### PR TITLE
Adding verbosity to rebuild_references_index

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,7 +14,6 @@ Changelog
  * Mention the importance of passing `request` and `current_site` to `get_url` on the [performance](performance) documentation page (Jake Howard)
  * Run Python tests with coverage and upload coverage data to codecov (Sage Abdullah)
  * Clean up duplicate JavaScript for the `escapeHtml` function (Jordan Rob)
- * Ensure that the `rebuild_references_index` command can run without console output if called with `--verbosity 0` (Omerzahid Ali, Aman Pandey)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Changelog
  * Add documentation for `register_user_listing_buttons` hook (LB (Ben Johnston))
  * Clean up Prettier & Eslint usage for search promotions formset JS file (LB (Ben Johnston))
  * Ensure that translation file generation ignores JavaScript unit tests and clean up unit tests for Django gettext utils (LB (Ben Johnston))
+ * Ensure that the `rebuild_references_index` command can run without console output if called with `--verbosity 0` (Omerzahid Ali, Aman Pandey)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Changelog
  * Mention the importance of passing `request` and `current_site` to `get_url` on the [performance](performance) documentation page (Jake Howard)
  * Run Python tests with coverage and upload coverage data to codecov (Sage Abdullah)
  * Clean up duplicate JavaScript for the `escapeHtml` function (Jordan Rob)
+ * Ensure that the `rebuild_references_index` command can run without console output if called with `--verbosity 0` (Omerzahid Ali, Aman Pandey)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/docs/reference/management_commands.md
+++ b/docs/reference/management_commands.md
@@ -123,6 +123,14 @@ An alias for the `update_index` command that can be used when another installed 
 
 This command populates the table that tracks cross-references between objects, used for the usage reports on images, documents and snippets. This table is updated automatically saving objects, but it is recommended to run this command periodically to ensure that the data remains consistent.
 
+### Silencing the command
+
+You can prevent logs to the console by providing `--verbosity 0` as an argument:
+
+```console
+$ python manage.py rebuild_references_index --verbosity 0
+```
+
 ## search_garbage_collect
 
 ```sh

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -26,6 +26,7 @@ depth: 1
  * Clean up duplicate JavaScript for the `escapeHtml` function (Jordan Rob)
  * Add documentation for [`register_user_listing_buttons`](register_user_listing_buttons) hook (LB (Ben Johnston))
  * Ensure that translation file generation ignores JavaScript unit tests and clean up unit tests for Django gettext utils (LB (Ben Johnston))
+ * Ensure that the `rebuild_references_index` command can run without console output if called with `--verbosity 0` (Omerzahid Ali, Aman Pandey)
 
 ### Bug fixes
 

--- a/wagtail/management/commands/rebuild_references_index.py
+++ b/wagtail/management/commands/rebuild_references_index.py
@@ -9,10 +9,13 @@ DEFAULT_CHUNK_SIZE = 1000
 
 class Command(BaseCommand):
     def write(self, *args, **kwargs):
-      """Helper function that writes based on verbosity parameter"""
-      if self.verbosity != 0:
-        self.stdout.write(*args, **kwargs)
+        """
+        Helper function that writes based on verbosity parameter
 
+        """
+
+        if self.verbosity != 0:
+            self.stdout.write(*args, **kwargs)
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -26,7 +29,7 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         self.verbosity = options["verbosity"]
-        
+
         chunk_size = options.get("chunk_size")
         object_count = 0
 

--- a/wagtail/management/commands/rebuild_references_index.py
+++ b/wagtail/management/commands/rebuild_references_index.py
@@ -79,7 +79,7 @@ class Command(BaseCommand):
             elif i % 10 == 0:
                 self.write(" ", ending="")
 
-            self.flush()
+            self.stdout.flush()
 
     # Atomic so the count of models doesn't change as it is iterated
     @transaction.atomic

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -913,16 +913,6 @@ class BackendTests(WagtailTestUtils):
         )
         self.assertFalse(stdout.read())
 
-    def test_rebuild_references_index_no_verbosity(self):
-        stdout = StringIO()
-        management.call_command(
-            "rebuild_references_index",
-            verbosity=0,
-            backend_name=self.backend_name,
-            stdout=stdout,
-        )
-        self.assertFalse(stdout.read())
-
 
 @override_settings(
     WAGTAILSEARCH_BACKENDS={"default": {"BACKEND": "wagtail.search.backends.database"}}

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -913,15 +913,6 @@ class BackendTests(WagtailTestUtils):
         )
         self.assertFalse(stdout.read())
 
-    def test_rebuild_references_index_no_verbosity(self):
-        stdout = StringIO()
-        management.call_command(
-            "rebuild_references_index",
-            verbosity=0,
-            stdout=stdout,
-        )
-        self.assertFalse(stdout.read())
-
 
 @override_settings(
     WAGTAILSEARCH_BACKENDS={"default": {"BACKEND": "wagtail.search.backends.database"}}

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -913,6 +913,16 @@ class BackendTests(WagtailTestUtils):
         )
         self.assertFalse(stdout.read())
 
+    def test_rebuild_references_index_no_verbosity(self):
+        stdout = StringIO()
+        management.call_command(
+            "rebuild_references_index",
+            verbosity=0,
+            backend_name=self.backend_name,
+            stdout=stdout,
+        )
+        self.assertFalse(stdout.read())
+
 
 @override_settings(
     WAGTAILSEARCH_BACKENDS={"default": {"BACKEND": "wagtail.search.backends.database"}}

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -912,11 +912,14 @@ class BackendTests(WagtailTestUtils):
             "update_index", verbosity=0, backend_name=self.backend_name, stdout=stdout
         )
         self.assertFalse(stdout.read())
-    
-     def test_rebuild_references_index_no_verbosity(self):
+
+    def test_rebuild_references_index_no_verbosity(self):
         stdout = StringIO()
         management.call_command(
-            "rebuild_references_index", verbosity=0, backend_name=self.backend_name, stdout=stdout
+            "rebuild_references_index",
+            verbosity=0,
+            backend_name=self.backend_name,
+            stdout=stdout,
         )
         self.assertFalse(stdout.read())
 

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -918,7 +918,6 @@ class BackendTests(WagtailTestUtils):
         management.call_command(
             "rebuild_references_index",
             verbosity=0,
-            backend_name=self.backend_name,
             stdout=stdout,
         )
         self.assertFalse(stdout.read())

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -912,6 +912,13 @@ class BackendTests(WagtailTestUtils):
             "update_index", verbosity=0, backend_name=self.backend_name, stdout=stdout
         )
         self.assertFalse(stdout.read())
+    
+     def test_rebuild_references_index_no_verbosity(self):
+        stdout = StringIO()
+        management.call_command(
+            "rebuild_references_index", verbosity=0, backend_name=self.backend_name, stdout=stdout
+        )
+        self.assertFalse(stdout.read())
 
 
 @override_settings(

--- a/wagtail/tests/test_reference_index.py
+++ b/wagtail/tests/test_reference_index.py
@@ -1,13 +1,10 @@
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
-from django.core import management
 
 from wagtail.images import get_image_model
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.models import Page, ReferenceIndex
 from wagtail.test.testapp.models import EventPage, EventPageCarouselItem
-
-from io import StringIO
 
 
 class TestCreateOrUpdateForObject(TestCase):
@@ -162,13 +159,3 @@ class TestCreateOrUpdateForObject(TestCase):
             ),
             self.expected_references,
         )
-
-    def test_rebuild_references_index_no_verbosity(self):
-        stdout = StringIO()
-        management.call_command(
-            "rebuild_references_index",
-            verbosity=0,
-            backend_name=self.backend_name,
-            stdout=stdout,
-        )
-        self.assertFalse(stdout.read())

--- a/wagtail/tests/test_reference_index.py
+++ b/wagtail/tests/test_reference_index.py
@@ -9,6 +9,7 @@ from wagtail.test.testapp.models import EventPage, EventPageCarouselItem
 
 from io import StringIO
 
+
 class TestCreateOrUpdateForObject(TestCase):
     def setUp(self):
         image_model = get_image_model()

--- a/wagtail/tests/test_reference_index.py
+++ b/wagtail/tests/test_reference_index.py
@@ -1,5 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
+from django.core import management
 
 from wagtail.images import get_image_model
 from wagtail.images.tests.utils import get_test_image_file
@@ -159,3 +160,14 @@ class TestCreateOrUpdateForObject(TestCase):
             ),
             self.expected_references,
         )
+
+    
+    def test_rebuild_references_index_no_verbosity(self):
+        stdout = StringIO()
+        management.call_command(
+            "rebuild_references_index",
+            verbosity=0,
+            backend_name=self.backend_name,
+            stdout=stdout,
+        )
+        self.assertFalse(stdout.read())

--- a/wagtail/tests/test_reference_index.py
+++ b/wagtail/tests/test_reference_index.py
@@ -171,4 +171,4 @@ class TestCreateOrUpdateForObject(TestCase):
             backend_name=self.backend_name,
             stdout=stdout,
         )
-        self.assertFalse(stdout)
+        self.assertFalse(stdout.read())

--- a/wagtail/tests/test_reference_index.py
+++ b/wagtail/tests/test_reference_index.py
@@ -7,6 +7,7 @@ from wagtail.images.tests.utils import get_test_image_file
 from wagtail.models import Page, ReferenceIndex
 from wagtail.test.testapp.models import EventPage, EventPageCarouselItem
 
+from io import StringIO
 
 class TestCreateOrUpdateForObject(TestCase):
     def setUp(self):
@@ -161,7 +162,6 @@ class TestCreateOrUpdateForObject(TestCase):
             self.expected_references,
         )
 
-    
     def test_rebuild_references_index_no_verbosity(self):
         stdout = StringIO()
         management.call_command(

--- a/wagtail/tests/test_reference_index.py
+++ b/wagtail/tests/test_reference_index.py
@@ -1,4 +1,7 @@
+from io import StringIO
+
 from django.contrib.contenttypes.models import ContentType
+from django.core import management
 from django.test import TestCase
 
 from wagtail.images import get_image_model
@@ -159,3 +162,12 @@ class TestCreateOrUpdateForObject(TestCase):
             ),
             self.expected_references,
         )
+
+    def test_rebuild_references_index_no_verbosity(self):
+        stdout = StringIO()
+        management.call_command(
+            "rebuild_references_index",
+            verbosity=0,
+            stdout=stdout,
+        )
+        self.assertFalse(stdout.read())

--- a/wagtail/tests/test_reference_index.py
+++ b/wagtail/tests/test_reference_index.py
@@ -1,7 +1,4 @@
-from io import StringIO
-
 from django.contrib.contenttypes.models import ContentType
-from django.core import management
 from django.test import TestCase
 
 from wagtail.images import get_image_model
@@ -162,13 +159,3 @@ class TestCreateOrUpdateForObject(TestCase):
             ),
             self.expected_references,
         )
-
-    def test_rebuild_references_index_no_verbosity(self):
-        stdout = StringIO()
-        management.call_command(
-            "rebuild_references_index",
-            verbosity=0,
-            backend_name=self.backend_name,
-            stdout=stdout,
-        )
-        self.assertFalse(stdout.read())

--- a/wagtail/tests/test_reference_index.py
+++ b/wagtail/tests/test_reference_index.py
@@ -1,4 +1,7 @@
+from io import StringIO
+
 from django.contrib.contenttypes.models import ContentType
+from django.core import management
 from django.test import TestCase
 
 from wagtail.images import get_image_model
@@ -159,3 +162,13 @@ class TestCreateOrUpdateForObject(TestCase):
             ),
             self.expected_references,
         )
+
+    def test_rebuild_references_index_no_verbosity(self):
+        stdout = StringIO()
+        management.call_command(
+            "rebuild_references_index",
+            verbosity=0,
+            backend_name=self.backend_name,
+            stdout=stdout,
+        )
+        self.assertFalse(stdout)


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
