### PR TITLE
Defer snippet registration until models are loaded

### DIFF
--- a/wagtail/snippets/apps.py
+++ b/wagtail/snippets/apps.py
@@ -6,3 +6,11 @@ class WagtailSnippetsAppConfig(AppConfig):
     name = "wagtail.snippets"
     label = "wagtailsnippets"
     verbose_name = _("Wagtail snippets")
+
+    def ready(self):
+        # Register all snippets for which register_snippet was called up to this point -
+        # these registrations had to be deferred as we could not guarantee that models were
+        # fully loaded at that point (but now they are).
+        from .models import register_deferred_snippets
+
+        register_deferred_snippets()

--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -56,10 +56,19 @@ def register_snippet(model, viewset=None):
         # Models may not have been fully loaded yet, so defer registration until they are -
         # add it to the list of registrations to be processed by register_deferred_snippets
         DEFERRED_REGISTRATIONS.append((model, viewset))
-        return model
-    elif model in SNIPPET_MODELS:
+    else:
+        _register_snippet_immediately(model, viewset)
+
+    return model
+
+
+def _register_snippet_immediately(model, viewset=None):
+    # Register the viewset and formfield for this snippet model,
+    # skipping the check for whether models are loaded
+
+    if model in SNIPPET_MODELS:
         # Do not create duplicate registrations of the same model
-        return model
+        return
 
     from wagtail.snippets.views.chooser import SnippetChooserViewSet
     from wagtail.snippets.views.snippets import SnippetViewSet
@@ -104,8 +113,6 @@ def register_snippet(model, viewset=None):
         ForeignKey, to=model, override={"widget": AdminSnippetChooser(model=model)}
     )
 
-    return model
-
 
 def get_snippet_usage_url(self):
     return reverse(
@@ -132,4 +139,4 @@ def register_deferred_snippets():
     global DEFER_REGISTRATION
     DEFER_REGISTRATION = False
     for model, viewset in DEFERRED_REGISTRATIONS:
-        register_snippet(model, viewset)
+        _register_snippet_immediately(model, viewset)


### PR DESCRIPTION
Fixes #9586. All calls to `register_snippet` that happen before `WagtailSnippetsAppConfig.ready` are now queued up and processed once we are sure models are fully loaded. This avoids any issues with unloaded models during viewset construction, as seen when subclassing django-filters's FilterSet.

Unfortunately I can't see any good way of adding a test for this - it seems to me that this bug ought to have surfaced on our test environment already, given that the app defining the custom user model is [right at the end of INSTALLED_APPS](https://github.com/wagtail/wagtail/blob/main/wagtail/test/settings.py#L185-L191) and there are surely calls to `register_snippet` in models.py files before that point. In any case, this does resolve the issue when testing against the test case described in https://github.com/wagtail/wagtail/issues/9586#issuecomment-1302425868.