### PR TITLE
Move initTagField function from core.js to a initTagField.ts & add un…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ Changelog
  * Add full support for secondary buttons with icons in the Wagtail design system - `button bicolor button--icon button-secondary` including the `button-small` variant (Seremba Patrick)
  * Migrated `initTooltips` to TypeScript add JSDoc and unit tests (Fatuma Abdullahi)
  * Add `purge_embeds` management command to delete all the cached embed objects in the database (Aman Pandey)
+ * Migrated `initTagField` from core.js to own TypesScript file and add unit tests (Chisom Okeoma)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)
@@ -144,7 +145,7 @@ Changelog
  * Fix: Fully remove the obsolete `wagtailsearch_editorspick` table that prevents flushing the database (Matt Westcott)
  * Fix: Update latest version message on Dashboard to accept dev build version format used on nlightly builds (Sam Moran)
  * Fix: references extraction for ChooserBlock (Alex Tomkins)
- * Fix: Regression in field width for authentication pages (log in / password reset) (Chisom)
+ * Fix: Regression in field width for authentication pages (log in / password reset) (Chisom Okeoma)
  * Fix: Ensure the new minimap correctly pluralises error counts for `aria-label`s (Matt Westcott)
 
 

--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import { escapeHtml } from '../../utils/text';
 import { initButtonSelects } from '../../includes/initButtonSelects';
+import { initTagField } from '../../includes/initTagField';
 import { initTooltips } from '../../includes/initTooltips';
 
 /* generic function for adding a message to message area through JS alone */
@@ -18,24 +19,6 @@ function addMessage(status, text) {
 window.addMessage = addMessage;
 
 window.escapeHtml = escapeHtml;
-
-function initTagField(id, autocompleteUrl, options) {
-  const finalOptions = {
-    autocomplete: { source: autocompleteUrl },
-    preprocessTag(val) {
-      // Double quote a tag if it contains a space
-      // and if it isn't already quoted.
-      if (val && val[0] !== '"' && val.indexOf(' ') > -1) {
-        return '"' + val + '"';
-      }
-
-      return val;
-    },
-    ...options,
-  };
-
-  $('#' + id).tagit(finalOptions);
-}
 
 window.initTagField = initTagField;
 

--- a/client/src/includes/initTagField.test.js
+++ b/client/src/includes/initTagField.test.js
@@ -1,0 +1,62 @@
+import $ from 'jquery';
+
+window.$ = $;
+
+import { initTagField } from './initTagField';
+
+describe('initTagField', () => {
+  let element;
+
+  const tagitMock = jest.fn(function tagitMockInner() {
+    element = this;
+  });
+
+  window.$.fn.tagit = tagitMock;
+
+  beforeEach(() => {
+    element = null;
+    jest.clearAllMocks();
+  });
+
+  it('should not call jQuery tagit if the element is not found', () => {
+    expect(tagitMock).not.toHaveBeenCalled();
+
+    initTagField('not-present');
+
+    expect(tagitMock).not.toHaveBeenCalled();
+  });
+
+  it('should call jQuery tagit if the element is found', () => {
+    expect(tagitMock).not.toHaveBeenCalled();
+
+    document.body.innerHTML = `
+    <main>
+      <input id="tag-input" type="text" value="abc" />
+    </main>
+    `;
+
+    initTagField('tag-input', '/path/to/autocomplete/', {
+      someOther: 'option',
+    });
+
+    // check the jQuery instance is the correct element
+    expect(element).toContain(document.getElementById('tag-input'));
+
+    // check the tagit util was called correctly with supplied params
+    expect(tagitMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        autocomplete: { source: '/path/to/autocomplete/' },
+        someOther: 'option',
+      }),
+    );
+
+    // check the supplied preprocessTag function
+    const [{ preprocessTag }] = tagitMock.mock.calls[0];
+
+    expect(preprocessTag).toBeInstanceOf(Function);
+
+    expect(preprocessTag()).toEqual();
+    expect(preprocessTag('"flat white"')).toEqual(`"flat white"`);
+    expect(preprocessTag("'long black'")).toEqual(`"'long black'"`);
+  });
+});

--- a/client/src/includes/initTagField.ts
+++ b/client/src/includes/initTagField.ts
@@ -1,0 +1,42 @@
+import $ from 'jquery';
+
+declare global {
+  interface JQuery {
+    tagit(...args): void;
+  }
+}
+
+/**
+ * Initialises the tag fields using the jQuery tagit widget
+ *
+ * @param id - element id to initialise against
+ * @param source -  auto complete URL source
+ * @param options - Other options passed to jQuery tagit
+ */
+const initTagField = (
+  id: string,
+  source: string,
+  options: Record<string, any>,
+): void => {
+  const tagFieldElement = document.getElementById(id);
+
+  if (!tagFieldElement) return;
+
+  const finalOptions = {
+    autocomplete: { source },
+    preprocessTag(val: any) {
+      // Double quote a tag if it contains a space
+      // and if it isn't already quoted.
+      if (val && val[0] !== '"' && val.indexOf(' ') > -1) {
+        return '"' + val + '"';
+      }
+
+      return val;
+    },
+    ...options,
+  };
+
+  $('#' + id).tagit(finalOptions);
+};
+
+export { initTagField };

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -136,7 +136,7 @@ There are multiple improvements to the documentation theme this release, here ar
  * Fully remove the obsolete `wagtailsearch_editorspick` table that prevents flushing the database (Matt Westcott)
  * Update latest version message on Dashboard to accept dev build version format used on nlightly builds (Sam Moran)
  * Ensure `ChooserBlock.extract_references` uses the model class, not the model string (Alex Tomkins)
- * Regression in field width for authentication pages (log in / password reset) (Chisom)
+ * Regression in field width for authentication pages (log in / password reset) (Chisom Okeoma)
  * Ensure the new minimap correctly pluralises error counts for `aria-label`s (Matt Westcott)
 
 ## Upgrade considerations

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -36,6 +36,7 @@ depth: 1
  * Add full support for secondary buttons with icons in the Wagtail design system - `button bicolor button--icon button-secondary` including the `button-small` variant (Seremba Patrick)
  * Migrated `initTooltips` to TypeScript add JSDoc and unit tests (Fatuma Abdullahi)
  * Add [`purge_embeds`](purge_embeds) management command to delete all the cached embed objects in the database (Aman Pandey)
+ * Migrated `initTagField` from core.js to own TypesScript file and add unit tests (Chisom Okeoma)
 
 ### Bug fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@storybook/react": "^6.4.19",
         "@types/draft-js": "^0.10.45",
         "@types/jest": "^26.0.24",
+        "@types/jquery": "^3.5.14",
         "@types/react": "^16.14.21",
         "@types/react-dom": "^16.0",
         "@types/react-redux": "^7.1.20",
@@ -13347,6 +13348,15 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "node_modules/@types/jquery": {
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
+      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
+      "dev": true,
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "dev": true,
@@ -13477,6 +13487,12 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "license": "MIT"
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
     },
     "node_modules/@types/source-list-map": {
       "version": "0.1.2",
@@ -40821,6 +40837,15 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/jquery": {
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
+      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "dev": true
@@ -40932,6 +40957,12 @@
     },
     "@types/scheduler": {
       "version": "0.16.2"
+    },
+    "@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
     },
     "@types/source-list-map": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@storybook/react": "^6.4.19",
     "@types/draft-js": "^0.10.45",
     "@types/jest": "^26.0.24",
+    "@types/jquery": "^3.5.14",
     "@types/react": "^16.14.21",
     "@types/react-dom": "^16.0",
     "@types/react-redux": "^7.1.20",


### PR DESCRIPTION
 When complete closes at #9496
- [x] Move the function to the the new TypeScript file and set up correct types - https://www.typescriptlang.org/
- [x] Add a [JSDOC](https://jsdoc.app/) description to the function
- [x] Add a basic set unit test (just one is fine) for this function in a new client/src/includes/initTagField.test.js file using [Jest](https://jestjs.io/)
- [x] Ensure the util is imported in core.js correctly and the window variables window.initTagField works, take as screenshot of a tag field working after your change for the PR


…it test

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [x] Run `make lint` from the Wagtail root.
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
-   [x] **Please list the exact browser and operating system versions you tested**: Chrome version


**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
