### PR TITLE
Use blocktrans to remove trailing whitespace

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ Changelog
  * Fix: Ensure tag fields correctly show in both dark and light Windows high-contrast modes (Albina Starykova)
  * Fix: Ensure new tooltips & tooltip menus have visible borders and tip triangle in Windows high-contrast mode (Juliet Adeboye)
  * Fix: Ensure there is a visual difference of 'active/current link' vs normal links in Windows high-contrast mode (Mohammad Areeb)
+ * Fix: Avoid issues where trailing whitespace could be accidentally removed in translations for new page & snippet headers (Florian Vogt)
 
 
 4.1.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -663,6 +663,7 @@ Contributors
 * Aman Pandey
 * Doug Harris
 * Mohammad Areeb
+* Florian Vogt
 
 Translators
 ===========

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -46,6 +46,7 @@ depth: 1
  * Ensure tag fields correctly show in both dark and light Windows high-contrast modes (Albina Starykova)
  * Ensure new tooltips & tooltip menus have visible borders and tip triangle in Windows high-contrast mode (Juliet Adeboye)
  * Ensure there is a visual difference of 'active/current link' vs normal links in Windows high-contrast mode (Mohammad Areeb)
+ * Avoid issues where trailing whitespace could be accidentally removed in translations for new page & snippet headers (Florian Vogt)
 
 ## Upgrade considerations
 

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/page_create_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/page_create_header.html
@@ -2,7 +2,7 @@
 {% load wagtailadmin_tags i18n %}
 
 {% block header_content %}
-    {% trans 'New: '|add:content_type.model_class.get_verbose_name as title %}
+    {% blocktrans trimmed asvar title with model_name=content_type.model_class.get_verbose_name %}New: {{ model_name }}{% endblocktrans %}
     {% breadcrumbs parent_page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' include_self=True trailing_breadcrumb_title=title %}
 
     <h1 class="w-sr-only">

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/headers/create_header.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/headers/create_header.html
@@ -12,7 +12,7 @@
 
 {% block header_content %}
     {% with model_opts.verbose_name|capfirst as model_name %}
-        {% trans 'New: '|add:model_name as title %}
+        {% blocktrans trimmed asvar title %}New: {{ model_name }}{% endblocktrans %}
         {{ block.super }}
 
         <h1 class="w-sr-only">


### PR DESCRIPTION
Fixes #9596

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   ~~For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 107, Firefox 106
    -   [x] **Please list which assistive technologies [^3] you tested**: I checked with the browser development tools to see if the `w-sr-only` text is still there.
-   ~~For new features: Has the documentation been updated accordingly?~~

**Please describe additional details for testing this change**.

The Po files must be updated, translations must be added and then the Mo files must be updated. After changing the user language, the new translation will be displayed. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
