### PR TITLE
Make audit log tests ordering-agnostic

### DIFF
--- a/wagtail/admin/tests/test_audit_log.py
+++ b/wagtail/admin/tests/test_audit_log.py
@@ -221,11 +221,11 @@ class TestAuditLogAdmin(TestCase, WagtailTestUtils):
 
         self.assertListEqual(
             list(
-                PageLogEntry.objects.filter(page=page_id).values_list(
-                    "action", flat=True
-                )
+                PageLogEntry.objects.filter(page=page_id)
+                .values_list("action", flat=True)
+                .order_by("action")
             ),
-            ["wagtail.publish", "wagtail.create"],
+            ["wagtail.create", "wagtail.publish"],
         )
 
     def test_revert_and_publish_logs_reversion_and_publish(self):
@@ -246,10 +246,12 @@ class TestAuditLogAdmin(TestCase, WagtailTestUtils):
         )
         self.assertEqual(response.status_code, 200)
 
-        entries = PageLogEntry.objects.filter(page=self.hello_page).values_list(
-            "action", flat=True
+        entries = (
+            PageLogEntry.objects.filter(page=self.hello_page)
+            .values_list("action", flat=True)
+            .order_by("action")
         )
         self.assertListEqual(
             list(entries),
-            ["wagtail.publish", "wagtail.rename", "wagtail.revert", "wagtail.create"],
+            ["wagtail.create", "wagtail.publish", "wagtail.rename", "wagtail.revert"],
         )


### PR DESCRIPTION
While running tests for an unrelated fix I received a one-off random test failure, where the 'create' and 'publish' log entries were returned in the wrong order. Since these log entries are created at the same time, it's possible that the timestamps will be closer together than the database's resolution - this should not be considered a test failure. Avoid this by explicitly ordering by action codename instead.
