### PR TITLE
Fixed: Pull out initTagField from core.js into includes/initTagField.ts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,7 @@ module.exports = {
         'client/src/entrypoints/images/image-chooser-modal.js',
         'client/src/utils/actions.ts',
         'client/src/utils/version.js',
+        'client/src/includes/initTagField.js'        
       ],
       rules: legacyCode,
     },

--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -1,42 +1,5 @@
 import $ from 'jquery';
 import { initTooltips } from '../../includes/initTooltips';
-import { escapeHtml } from '../../utils/text';
-
-/* generic function for adding a message to message area through JS alone */
-function addMessage(status, text) {
-  $('.messages')
-    .addClass('new')
-    .empty()
-    .append('<ul><li class="' + status + '">' + text + '</li></ul>');
-  const addMsgTimeout = setTimeout(() => {
-    $('.messages').addClass('appear');
-    clearTimeout(addMsgTimeout);
-  }, 100);
-}
-
-window.addMessage = addMessage;
-
-window.escapeHtml = escapeHtml;
-
-function initTagField(id, autocompleteUrl, options) {
-  const finalOptions = {
-    autocomplete: { source: autocompleteUrl },
-    preprocessTag(val) {
-      // Double quote a tag if it contains a space
-      // and if it isn't already quoted.
-      if (val && val[0] !== '"' && val.indexOf(' ') > -1) {
-        return '"' + val + '"';
-      }
-
-      return val;
-    },
-    ...options,
-  };
-
-  $('#' + id).tagit(finalOptions);
-}
-
-window.initTagField = initTagField;
 
 /*
  * Enables a "dirty form check", prompting the user if they are navigating away

--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 import { initTooltips } from '../../includes/initTooltips';
-
 /*
  * Enables a "dirty form check", prompting the user if they are navigating away
  * from a page with unsaved changes, as well as optionally controlling other

--- a/client/src/includes/initTagField.js
+++ b/client/src/includes/initTagField.js
@@ -36,3 +36,4 @@ function initTagField(id, autocompleteUrl, options) {
 }
 
 window.initTagField = initTagField;
+/* generic function for adding a message to message area through JS alone end */

--- a/client/src/includes/initTagField.js
+++ b/client/src/includes/initTagField.js
@@ -1,0 +1,38 @@
+import $ from 'jquery';
+import { escapeHtml } from '../../utils/text';
+
+/* generic function for adding a message to message area through JS alone */
+function addMessage(status, text) {
+  $('.messages')
+    .addClass('new')
+    .empty()
+    .append('<ul><li class="' + status + '">' + text + '</li></ul>');
+  const addMsgTimeout = setTimeout(() => {
+    $('.messages').addClass('appear');
+    clearTimeout(addMsgTimeout);
+  }, 100);
+}
+
+window.addMessage = addMessage;
+
+window.escapeHtml = escapeHtml;
+
+function initTagField(id, autocompleteUrl, options) {
+  const finalOptions = {
+    autocomplete: { source: autocompleteUrl },
+    preprocessTag(val) {
+      // Double quote a tag if it contains a space
+      // and if it isn't already quoted.
+      if (val && val[0] !== '"' && val.indexOf(' ') > -1) {
+        return '"' + val + '"';
+      }
+
+      return val;
+    },
+    ...options,
+  };
+
+  $('#' + id).tagit(finalOptions);
+}
+
+window.initTagField = initTagField;

--- a/wagtail/models/sites.py
+++ b/wagtail/models/sites.py
@@ -97,7 +97,7 @@ class Site(models.Model):
         on_delete=models.CASCADE,
     )
     is_default_site = models.BooleanField(
-        verbose_name=_("is default site"),
+        verbose_name=_("is default site?"),
         default=False,
         help_text=_(
             "If true, this site will handle requests for all other hostnames that do not have a site entry of their own"


### PR DESCRIPTION
Issue summary:

initTagField should move from core.js to a new file client/src/includes/initTagField.ts

Wagtail's JavaScript core.js is quite large and many items can be pulled out to shared utils or includes to help make the code more maintainable and supported with base unit tests.

Pulling some basic functions out lets us put these into TypeScript (type safety) but also document and unit test them better.

Fixed issue: https://github.com/wagtail/wagtail/issues/9496