### PR TITLE
Fixed : Pull out initTagField from core.js into includes

### DIFF
--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -1,42 +1,5 @@
 import $ from 'jquery';
 import { initTooltips } from '../../includes/initTooltips';
-import { escapeHtml } from '../../utils/text';
-
-/* generic function for adding a message to message area through JS alone */
-function addMessage(status, text) {
-  $('.messages')
-    .addClass('new')
-    .empty()
-    .append('<ul><li class="' + status + '">' + text + '</li></ul>');
-  const addMsgTimeout = setTimeout(() => {
-    $('.messages').addClass('appear');
-    clearTimeout(addMsgTimeout);
-  }, 100);
-}
-
-window.addMessage = addMessage;
-
-window.escapeHtml = escapeHtml;
-
-function initTagField(id, autocompleteUrl, options) {
-  const finalOptions = {
-    autocomplete: { source: autocompleteUrl },
-    preprocessTag(val) {
-      // Double quote a tag if it contains a space
-      // and if it isn't already quoted.
-      if (val && val[0] !== '"' && val.indexOf(' ') > -1) {
-        return '"' + val + '"';
-      }
-
-      return val;
-    },
-    ...options,
-  };
-
-  $('#' + id).tagit(finalOptions);
-}
-
-window.initTagField = initTagField;
 
 /*
  * Enables a "dirty form check", prompting the user if they are navigating away

--- a/client/src/includes/initTagField.js
+++ b/client/src/includes/initTagField.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import { escapeHtml } from '../../utils/text';
+import { escapeHtml } from '../utils/text';
 
 /* generic function for adding a message to message area through JS alone */
 function addMessage(status, text) {

--- a/client/src/includes/initTagField.js
+++ b/client/src/includes/initTagField.js
@@ -1,0 +1,38 @@
+import $ from 'jquery';
+import { escapeHtml } from '../../utils/text';
+
+/* generic function for adding a message to message area through JS alone */
+function addMessage(status, text) {
+  $('.messages')
+    .addClass('new')
+    .empty()
+    .append('<ul><li class="' + status + '">' + text + '</li></ul>');
+  const addMsgTimeout = setTimeout(() => {
+    $('.messages').addClass('appear');
+    clearTimeout(addMsgTimeout);
+  }, 100);
+}
+
+window.addMessage = addMessage;
+
+window.escapeHtml = escapeHtml;
+
+function initTagField(id, autocompleteUrl, options) {
+  const finalOptions = {
+    autocomplete: { source: autocompleteUrl },
+    preprocessTag(val) {
+      // Double quote a tag if it contains a space
+      // and if it isn't already quoted.
+      if (val && val[0] !== '"' && val.indexOf(' ') > -1) {
+        return '"' + val + '"';
+      }
+
+      return val;
+    },
+    ...options,
+  };
+
+  $('#' + id).tagit(finalOptions);
+}
+
+window.initTagField = initTagField;


### PR DESCRIPTION
Issue summary 1:

> initTagField should move from core.js to a new file client/src/includes/initTagField.ts


Issue summary 2:

> addMessage should move from core.js to a new file client/src/includes/messages.ts

Fixed issue 1: https://github.com/wagtail/wagtail/issues/9496
Fixed issue 2: https://github.com/wagtail/wagtail/issues/9493


- If we are converting JavaScript to TypeScript so the function can not be moved/separated.(Because the TypeScript is used only for exporting function in Wagtail)
- Why I have not created separate PR's for :
- Issue 1 https://github.com/wagtail/wagtail/issues/9496
- Issue 2 https://github.com/wagtail/wagtail/issues/9493
Because these issues are single file function.