### PR TITLE
Clean up tests in gettext.test.js & ignore translations in test files (extract-translatable-strings.js)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Changelog
  * Clean up duplicate JavaScript for the `escapeHtml` function (Jordan Rob)
  * Add documentation for `register_user_listing_buttons` hook (LB (Ben Johnston))
  * Clean up Prettier & Eslint usage for search promotions formset JS file (LB (Ben Johnston))
+ * Ensure that translation file generation ignores JavaScript unit tests and clean up unit tests for Django gettext utils (LB (Ben Johnston))
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/client/extract-translatable-strings.js
+++ b/client/extract-translatable-strings.js
@@ -24,7 +24,7 @@ extractor
       },
     }),
   ])
-  .parseFilesGlob('./src/**/*.@(ts|js|tsx)');
+  .parseFilesGlob('./src/**/!(*.test).@(ts|js|tsx)');
 
 extractor.savePotFile('../wagtail/admin/locale/en/LC_MESSAGES/djangojs.po');
 

--- a/client/src/utils/gettext.test.js
+++ b/client/src/utils/gettext.test.js
@@ -9,68 +9,74 @@ import {
 const STRING =
   'The name wagtail stems from the constant sideways wagging of the tail.';
 
+afterEach(() => {
+  // clear any mocked globals after each test
+  if (window.django) {
+    delete window.django;
+  }
+});
+
 describe('gettext', () => {
-  beforeEach(() => {
-    window.django = { gettext: jest.fn((val) => val) };
+  it('should return the provided string if Django gettext is not loaded', () => {
+    expect(gettext(STRING)).toEqual(STRING);
   });
 
-  it('should return the value based on the django util', () => {
-    expect(window.django.gettext).not.toHaveBeenCalled();
-    expect(gettext(STRING)).toEqual(STRING);
-    expect(window.django.gettext).toHaveBeenCalledWith(STRING);
+  it('should call the global Django util if loaded', () => {
+    const gettextMock = jest.fn();
+    window.django = { gettext: gettextMock };
+    gettext(STRING);
+    expect(gettextMock).toHaveBeenCalledWith(STRING);
   });
 });
 
 describe('ngettext', () => {
-  beforeEach(() => {
-    window.django = { ngettext: jest.fn((val) => val) };
+  it('should return the first param if Django ngettext is not loaded', () => {
+    expect(ngettext('One bird', 'Many birds', 2)).toEqual('One bird');
   });
 
-  it('should return the value based on the django util', () => {
-    expect(window.django.ngettext).not.toHaveBeenCalled();
-    expect(ngettext('One bird', 'Many birds', 2)).toEqual('One bird');
-    expect(window.django.ngettext).toHaveBeenCalledWith(
-      'One bird',
-      'Many birds',
-      2,
-    );
+  it('should call the global Django util if loaded', () => {
+    const ngettextMock = jest.fn();
+    window.django = { ngettext: ngettextMock };
+    ngettext('One bird', 'Many birds', 2);
+    expect(ngettextMock).toHaveBeenCalledWith('One bird', 'Many birds', 2);
   });
 });
 
 describe('getFormat', () => {
-  beforeEach(() => {
-    window.django = { get_format: jest.fn(() => 1) };
+  it('should return an empty string if Django get_format is not loaded', () => {
+    expect(getFormat('FIRST_DAY_OF_WEEK')).toEqual('');
   });
 
-  it('should return the value based on the django util', () => {
-    expect(window.django.get_format).not.toHaveBeenCalled();
-    expect(getFormat('FIRST_DAY_OF_WEEK')).toEqual(1);
-    expect(window.django.get_format).toHaveBeenCalledWith('FIRST_DAY_OF_WEEK');
+  it('should call the global Django util if loaded', () => {
+    const getFormatMock = jest.fn();
+    window.django = { get_format: getFormatMock };
+    getFormat('FIRST_DAY_OF_WEEK');
+    expect(getFormatMock).toHaveBeenCalledWith('FIRST_DAY_OF_WEEK');
   });
 });
 
 describe('gettextNoop', () => {
-  beforeEach(() => {
-    window.django = { gettext_noop: jest.fn((val) => val) };
+  it('should return the provided string if Django gettext_noop is not loaded', () => {
+    expect(gettextNoop(STRING)).toEqual(STRING);
   });
 
-  it('should return the value based on the django util', () => {
-    expect(window.django.gettext_noop).not.toHaveBeenCalled();
-    expect(gettextNoop(STRING)).toEqual(STRING);
-    expect(window.django.gettext_noop).toHaveBeenCalledWith(STRING);
+  it('should call the global Django util if loaded', () => {
+    const gettextNoopMock = jest.fn();
+    window.django = { gettext_noop: gettextNoopMock };
+    gettextNoop(STRING);
+    expect(gettextNoopMock).toHaveBeenCalledWith(STRING);
   });
 });
 
 describe('pluralIdx', () => {
-  beforeEach(() => {
-    window.django = {
-      pluralidx: jest.fn((val) => ({ 0: true, 1: false }[val] || true)),
-    };
+  it('should return false if if Django pluralidx is not loaded', () => {
+    expect(pluralIdx(3)).toEqual(false);
   });
 
-  it('should return the value based on the django util', () => {
-    expect(window.django.pluralidx).not.toHaveBeenCalled();
-    expect(pluralIdx(0)).toEqual(true);
-    expect(window.django.pluralidx).toHaveBeenCalledWith(0);
+  it('should call the global Django util if loaded', () => {
+    const pluralidxMock = jest.fn();
+    window.django = { pluralidx: pluralidxMock };
+    pluralIdx(5);
+    expect(pluralidxMock).toHaveBeenCalledWith(5);
   });
 });

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -25,6 +25,7 @@ depth: 1
  * Run Python tests with coverage and upload coverage data to codecov (Sage Abdullah)
  * Clean up duplicate JavaScript for the `escapeHtml` function (Jordan Rob)
  * Add documentation for [`register_user_listing_buttons`](register_user_listing_buttons) hook (LB (Ben Johnston))
+ * Ensure that translation file generation ignores JavaScript unit tests and clean up unit tests for Django gettext utils (LB (Ben Johnston))
 
 ### Bug fixes
 


### PR DESCRIPTION
As per https://github.com/wagtail/wagtail/pull/8747#issuecomment-1294852488 - the existing unit test for the `gettest` util seemed to make no sense.

However, the purpose of this test file was originally created as we found that the `ngettext` was not actually using the Django global util the correct way by passing all the params through to the global. See https://github.com/wagtail/wagtail/pull/8747

Although, in hindsight, this created two further problems, firstly it meant we got useless translations and secondly we ended up mocking the Django globals which was not really needed.

I propose a different approach to just deleting the file - https://github.com/wagtail/wagtail/pull/9537

1. Update the extract text util to ignore test files
2. Update the unit test file to be more clear about what it's testing; a. the 'default' behaviour if the global does not exist and b. that when the globals exist it calls the global with the correct params (without caring about the output of these mocks).

Note: To test the extract translation strings, do the following:

* Load the branch locally
* `cd client/`
* `node extract-translatable-strings.js`
* Expected result: There should be no new string for the `gettext.test.js` file added to `...admin/locale/en/LC_MESSAGES/djangojs.po` (note: There will be a line change for an unrelated translation usage)


### Checklist

- [X] Do the tests still pass?
- [X] Does the code comply with the style guide?