### PR TITLE
Add the missing kwargs to the send_mail helper #5899

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@ Changelog
  * Fix: Ignore images added via fixtures when using `WAGTAILIMAGES_FEATURE_DETECTION_ENABLED` to avoid errors for images that do not exist (Aman Pandey)
  * Fix: Restore ability to perform JSONField query operations against StreamField when running against the Django 4.2 development branch (Sage Abdullah)
  * Fix: Ensure there is correct grammar and pluralisation for Tab error counts shown to screen readers (Aman Pandey)
+ * Fix: Pass through expected expected `cc`, `bcc` and `reply_to` to the Django mail helper from `wagtail.admin.mail.send_mail` (Ben Gosney)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -673,6 +673,7 @@ Contributors
 * Anisha Singh
 * Ivy Jeptoo
 * Jeremy Thompson
+* Ben Gosney
 
 Translators
 ===========

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -48,6 +48,7 @@ depth: 1
  * Ignore images added via fixtures when using `WAGTAILIMAGES_FEATURE_DETECTION_ENABLED` to avoid errors for images that do not exist (Aman Pandey)
  * Restore ability to perform JSONField query operations against StreamField when running against the Django 4.2 development branch (Sage Abdullah)
  * Ensure there is correct grammar and pluralisation for Tab error counts shown to screen readers (Aman Pandey)
+ * Pass through expected expected `cc`, `bcc` and `reply_to` to the Django mail helper from `wagtail.admin.mail.send_mail` (Ben Gosney)
 
 ### Documentation
 

--- a/wagtail/admin/mail.py
+++ b/wagtail/admin/mail.py
@@ -54,6 +54,9 @@ def send_mail(subject, message, recipient_list, from_email=None, **kwargs):
         "headers": {
             "Auto-Submitted": "auto-generated",
         },
+        "bcc": kwargs.get("bcc", None),
+        "cc": kwargs.get("cc", None),
+        "reply_to": kwargs.get("reply_to", None),
     }
     mail = EmailMultiAlternatives(
         subject, message, from_email, recipient_list, **multi_alt_kwargs

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -235,6 +235,78 @@ class TestSendMail(TestCase):
         self.assertEqual(email_message.body, "TEXT content")
         self.assertEqual(email_message.to, ["mr.plain.text@email.com"])
 
+    def test_send_cc(self):
+        send_mail(
+            "Test subject",
+            "Test content",
+            ["nobody@email.com"],
+            "test@email.com",
+            cc=["cc.test@email.com"],
+        )
+
+        # Check that the email was sent
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Test subject")
+        self.assertEqual(mail.outbox[0].body, "Test content")
+        self.assertEqual(mail.outbox[0].to, ["nobody@email.com"])
+        self.assertEqual(mail.outbox[0].from_email, "test@email.com")
+        self.assertEqual(mail.outbox[0].cc, ["cc.test@email.com"])
+
+    def test_send_bcc(self):
+        send_mail(
+            "Test subject",
+            "Test content",
+            ["nobody@email.com"],
+            "test@email.com",
+            bcc=["bcc.test@email.com"],
+        )
+
+        # Check that the email was sent
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Test subject")
+        self.assertEqual(mail.outbox[0].body, "Test content")
+        self.assertEqual(mail.outbox[0].to, ["nobody@email.com"])
+        self.assertEqual(mail.outbox[0].from_email, "test@email.com")
+        self.assertEqual(mail.outbox[0].bcc, ["bcc.test@email.com"])
+
+    def test_send_reply_to(self):
+        send_mail(
+            "Test subject",
+            "Test content",
+            ["nobody@email.com"],
+            "test@email.com",
+            reply_to=["reply_to.test@email.com"],
+        )
+
+        # Check that the email was sent
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Test subject")
+        self.assertEqual(mail.outbox[0].body, "Test content")
+        self.assertEqual(mail.outbox[0].to, ["nobody@email.com"])
+        self.assertEqual(mail.outbox[0].from_email, "test@email.com")
+        self.assertEqual(mail.outbox[0].reply_to, ["reply_to.test@email.com"])
+
+    def test_send_all_extra_fields(self):
+        send_mail(
+            "Test subject",
+            "Test content",
+            ["nobody@email.com"],
+            "test@email.com",
+            cc=["cc.test@email.com"],
+            bcc=["bcc.test@email.com"],
+            reply_to=["reply_to.test@email.com"],
+        )
+
+        # Check that the email was sent
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Test subject")
+        self.assertEqual(mail.outbox[0].body, "Test content")
+        self.assertEqual(mail.outbox[0].to, ["nobody@email.com"])
+        self.assertEqual(mail.outbox[0].from_email, "test@email.com")
+        self.assertEqual(mail.outbox[0].cc, ["cc.test@email.com"])
+        self.assertEqual(mail.outbox[0].bcc, ["bcc.test@email.com"])
+        self.assertEqual(mail.outbox[0].reply_to, ["reply_to.test@email.com"])
+
 
 class TestTagsAutocomplete(TestCase, WagtailTestUtils):
     def setUp(self):


### PR DESCRIPTION
This passes cc, bcc and reply_to to the Django mail helper

Fixes #5899