### PR TITLE
Cleanup - Remove commented out scss in _listing.scss

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -11,7 +11,6 @@ ul.listing {
   ul {
     list-style-type: none;
     padding-inline-start: 0;
-    // @include unlist();
   }
 
   > li {


### PR DESCRIPTION
* Small clean up item - I do not think we need this commented out scss as it creates a bit of confusion.