### PR TITLE
Linting - clean up ignored file (search promotions)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,5 +13,4 @@ wagtail/search/static
 wagtail/snippets/static
 wagtail/users/static
 wagtail/contrib/*/static
-wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotions_formset.js
 .mypy_cache

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -136,6 +136,7 @@ module.exports = {
       files: [
         'docs/_static/**',
         'wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/js/prepopulate.js',
+        'wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotions_formset.js',
         'wagtail/contrib/settings/static_src/wagtailsettings/js/site-switcher.js',
         'wagtail/documents/static_src/wagtaildocs/js/add-multiple.js',
         'wagtail/embeds/static_src/wagtailembeds/js/embed-chooser-modal.js',

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,5 +11,4 @@ _build
 *.md
 # Files which contain incompatible syntax.
 *.html
-wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotions_formset.js
 .mypy_cache

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Run Python tests with coverage and upload coverage data to codecov (Sage Abdullah)
  * Clean up duplicate JavaScript for the `escapeHtml` function (Jordan Rob)
  * Add documentation for `register_user_listing_buttons` hook (LB (Ben Johnston))
+ * Clean up Prettier & Eslint usage for search promotions formset JS file (LB (Ben Johnston))
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotions_formset.js
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotions_formset.js
@@ -1,13 +1,15 @@
-$(function() {
-    var panel = InlinePanel({
-        formsetPrefix: "id_{{ formset.prefix }}",
-        emptyChildFormPrefix: "{{ formset.empty_form.prefix }}",
-        canOrder: true
-    });
+$(function () {
+  // eslint-disable-next-line no-undef
+  var panel = InlinePanel({
+    formsetPrefix: 'id_{{ formset.prefix }}',
+    emptyChildFormPrefix: '{{ formset.empty_form.prefix }}',
+    canOrder: true,
+  });
 
-    {% for form in formset.forms %}
-        panel.initChildControls('{{ formset.prefix }}-{{ forloop.counter0 }}');
-    {% endfor %}
+  // {# Ensure eslint/prettier ignore the Django template syntax by treating them as comments, template for loop will still be executed by Django #}
+  // {% for form in formset.forms %}
+  panel.initChildControls('{{ formset.prefix }}-{{ forloop.counter0 }}');
+  // {% endfor %}
 
-    panel.updateMoveButtonDisabledStates();
+  panel.updateMoveButtonDisabledStates();
 });


### PR DESCRIPTION
- Remove specific file in .prettierignore and add inline comments to allow for linting / formatting for the searchpromotions_formset
- This kind of template JS will likely be removed in the long term but for now it means that we no longer have specific files in .prettierignore and get the benefits of the JS file being parsed by prettier & eslint for any major issues.
- We also get a clearer picture of what code is still using jQuery as we prepare for the Stimulus RFC
- Split from #9522

I have validated that the JS works the same, below is a screenshot of what the resolved JS  looks like.

<img width="1230" alt="Screen Shot 2022-11-07 at 7 06 09 am" src="https://user-images.githubusercontent.com/1396140/200195160-4bd2fcbd-6b78-43ca-a01c-c47355f00a1e.png">
