### PR TITLE
Fix success messages that does not meet contrast guidelines

### DIFF
--- a/client/scss/components/_messages.scss
+++ b/client/scss/components/_messages.scss
@@ -61,7 +61,7 @@
   }
 
   .success {
-    background-color: theme('colors.positive.100');
+    background-color: theme('colors.secondary.DEFAULT');
 
     .button:hover {
       background-color: $color-teal-dark;


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

This fixes https://github.com/wagtail/wagtail/issues/9571

This PR rectifies the issue of success messages not meeting contrast guidelines according to AXE DevTools .

After adding a page, the success message has insufficient color contrast of 4.45 (foreground color: #ffffff, background color: #1c8767, font size: 10.2pt (13.6px), font weight: normal).

The following code was edited as the previous Foreground colour against the Background colour did not meet the guideline - Change the background to use the new secondary color background: theme('colors.secondary.DEFAULT');

Please see pictures below;

BEFORE

![wagsuccesscontrastaxetodo](https://user-images.githubusercontent.com/62052443/200354967-22d7a18f-6729-41c4-8057-fed3ccc48690.PNG)

![wagsuccesscontrastcodetodo](https://user-images.githubusercontent.com/62052443/200355113-4d65dba0-c847-4286-9858-4bd55f10d7b2.PNG)

AFTER

![wagsuccesscontrastaxe](https://user-images.githubusercontent.com/62052443/200355311-9464aebc-a5c4-46cf-a441-e17450314360.PNG)

![wagsuccesscontrastcode](https://user-images.githubusercontent.com/62052443/200355583-52c05922-0fca-4e02-a0cf-701715d46a9f.PNG)

