### PR TITLE
Make sure minimap error indicators follow the scrolling

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ Changelog
  * Fix: Ensure new tooltips & tooltip menus have visible borders and tip triangle in Windows high-contrast mode (Juliet Adeboye)
  * Fix: Ensure there is a visual difference of 'active/current link' vs normal links in Windows high-contrast mode (Mohammad Areeb)
  * Fix: Avoid issues where trailing whitespace could be accidentally removed in translations for new page & snippet headers (Florian Vogt)
+ * Fix: Make sure minimap error indicators follow the minimap scrolling (Thibaud Colas)
 
 
 4.1.1 (xx.xx.xxxx) - IN DEVELOPMENT
@@ -52,6 +53,7 @@ Changelog
  * Fix: Exclude tags from the reference index (Matt Westcott)
  * Fix: Fix errors in handling generic foreign keys when populating the reference index (Matt Westcott)
  * Fix: Prevent error in handling null ParentalKeys when populating the reference index (Matt Westcott)
+ * Fix: Make sure minimap error indicators follow the minimap scrolling (Thibaud Colas)
 
 
 4.1 LTS (01.11.2022)

--- a/client/src/components/Minimap/Minimap.scss
+++ b/client/src/components/Minimap/Minimap.scss
@@ -21,7 +21,6 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   transform: translateX(calc(100% - $minimap-collapsed-width-mobile));
 
   @include media-breakpoint-up(sm) {
-    padding-inline-start: $minimap-overflow;
     transform: translateX(
       calc(100% - $minimap-collapsed-width - $minimap-overflow)
     );
@@ -97,6 +96,7 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   min-height: 70px;
 
   :where(.w-minimap--expanded) & {
+    margin-inline-start: $minimap-overflow;
     border-inline-start: 1px solid theme('colors.grey.100');
   }
 }
@@ -104,6 +104,7 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
 .w-minimap__list {
   margin: 0;
   padding: 0;
+  padding-inline-start: $minimap-overflow;
   overflow-y: auto;
   overflow-x: hidden;
   list-style-type: none;
@@ -117,6 +118,7 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   flex-grow: 1;
 
   :where(.w-minimap--expanded) & {
+    margin-inline-start: $minimap-overflow;
     border-inline-start: 1px solid theme('colors.grey.100');
   }
 }

--- a/client/src/components/Minimap/MinimapItem.scss
+++ b/client/src/components/Minimap/MinimapItem.scss
@@ -76,7 +76,6 @@
 .w-minimap-item__errors {
   $border-width: 1px;
   $badge-size: theme('spacing.4');
-  position: absolute;
   width: $badge-size;
   height: $badge-size;
   flex-shrink: 0;
@@ -93,5 +92,6 @@
     margin-inline-start: calc(-1 * (theme('spacing.8') + $badge-size / 2));
     // Improve the alignment of "1" with the item’s border.
     padding-inline-end: theme('spacing.px');
+    margin-inline-end: calc($badge-size - theme('spacing.px'));
   }
 }

--- a/docs/releases/4.1.1.md
+++ b/docs/releases/4.1.1.md
@@ -22,3 +22,4 @@ depth: 1
  * Exclude tags from the reference index (Matt Westcott)
  * Fix errors in handling generic foreign keys when populating the reference index (Matt Westcott)
  * Prevent error in handling null ParentalKeys when populating the reference index (Matt Westcott)
+ * Make sure minimap error indicators follow the minimap scrolling (Thibaud Colas)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -51,6 +51,7 @@ depth: 1
  * Ensure new tooltips & tooltip menus have visible borders and tip triangle in Windows high-contrast mode (Juliet Adeboye)
  * Ensure there is a visual difference of 'active/current link' vs normal links in Windows high-contrast mode (Mohammad Areeb)
  * Avoid issues where trailing whitespace could be accidentally removed in translations for new page & snippet headers (Florian Vogt)
+ * Make sure minimap error indicators follow the minimap scrolling (Thibaud Colas)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
Fixes an issue reported by @laymonage with the minimap’s error indicator, which were stuck to their initial rendering position and not following along as the minimap scrolls. This was due to usage of absolute positioning based on the position of the parent.

`position: absolute;` usage was only so the indicators would overflow their parent – so I removed it, and changed where the left-edge external padding of the minimap is defined, so the error indicators technically aren’t overflowing their parent element.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 106, Firefox 104, Safari 15.6 on macOS. Safari 16 on iOS
    -   [x] **Please list which assistive technologies [^3] you tested**: Full-page zoom, keyboard.
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

**Please describe additional details for testing this change**.

Make a long page where the minimap would overflow the viewport, create validation errors, save as draft. Then upon reviewing the validation errors, scroll the minimap, and observe the error indicators keep their position next to the correct field label.