### PR TITLE
Ensure the ngettext (JS) util emulates the Django global if not present

### DIFF
--- a/client/src/utils/gettext.test.js
+++ b/client/src/utils/gettext.test.js
@@ -30,8 +30,9 @@ describe('gettext', () => {
 });
 
 describe('ngettext', () => {
-  it('should return the first param if Django ngettext is not loaded', () => {
-    expect(ngettext('One bird', 'Many birds', 2)).toEqual('One bird');
+  it('should emulate the Django ngettext function if it is not loaded', () => {
+    expect(ngettext('One bird', 'Many birds', 1)).toEqual('One bird');
+    expect(ngettext('One bird', 'Many birds', 2)).toEqual('Many birds');
   });
 
   it('should call the global Django util if loaded', () => {

--- a/client/src/utils/gettext.ts
+++ b/client/src/utils/gettext.ts
@@ -48,7 +48,7 @@ export function ngettext(
     return djangoNgettext(singular, plural, count);
   }
 
-  return singular;
+  return count === 1 ? singular : plural;
 }
 
 /**


### PR DESCRIPTION
Follow up from #9617

A reminder - this fallback variant should never really be used except for cases where something has gone wrong (Django translation JS is not loaded) or in unit tests / Storybook edge cases. However, we want to align the fallback of `ngettext` to be closer to the real util (without the actual translations) so that we can avoid confusion and have closer to real output in unit tests.

> I think the "make it error loudly" approach would probably just make life difficult for us :-) We're best served by having a simple fallback implementation that doesn't have any external dependencies, but is close enough to the "real" behaviour that our tests don't have to be contrived to work around the differences (e.g. being able to assert that the output contains "2 Errors" rather than "2 Error").

_Originally posted by @gasman in https://github.com/wagtail/wagtail/pull/9617#discussion_r1015347673_
      