### PR TITLE
Fix handling of tags in reference index

### DIFF
--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1168,6 +1168,16 @@ class TestUsage(TestCase, WagtailTestUtils):
         # There's no usage so there should be no table rows
         self.assertRegex(response.content.decode("utf-8"), r"<tbody>(\s|\n)*</tbody>")
 
+    def test_usage_no_tags(self):
+        # tags should not count towards an image's references
+        self.image.tags.add("illustration")
+        self.image.save()
+        response = self.client.get(
+            reverse("wagtailimages:image_usage", args=[self.image.id])
+        )
+        # There's no usage so there should be no table rows
+        self.assertRegex(response.content.decode("utf-8"), r"<tbody>(\s|\n)*</tbody>")
+
     def test_usage_page_with_only_change_permission(self):
         home_page = Page.objects.get(id=2)
         home_page.add_child(

--- a/wagtail/models/reference_index.py
+++ b/wagtail/models/reference_index.py
@@ -7,6 +7,7 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel, get_all_child_relations
+from taggit.models import ItemBase
 
 
 class ReferenceGroups:
@@ -495,3 +496,11 @@ class ReferenceIndex(models.Model):
                 # https://github.com/django/django/blob/7b94847e384b1a8c05a7d4c8778958c0290bdf9a/django/db/models/fields/__init__.py#L858
                 field_name = field.name.replace("_", " ")
             return capfirst(field_name)
+
+
+# Ignore relations formed by any django-taggit 'through' model, as this causes any tag attached to
+# a tagged object to appear as a reference to that object. Ideally we would follow the reference to
+# the Tag model so that we can use the references index to find uses of a tag, but doing that
+# correctly will require support for ManyToMany relations with through models:
+# https://github.com/wagtail/wagtail/issues/9629
+ItemBase.wagtail_reference_index_ignore = True

--- a/wagtail/models/reference_index.py
+++ b/wagtail/models/reference_index.py
@@ -488,4 +488,10 @@ class ReferenceIndex(models.Model):
             child_field = field.related_model._meta.get_field(model_path_components[2])
             return capfirst(child_field.verbose_name)
         else:
-            return capfirst(field.verbose_name)
+            try:
+                field_name = field.verbose_name
+            except AttributeError:
+                # generate verbose name from field name in the same way that Django does:
+                # https://github.com/django/django/blob/7b94847e384b1a8c05a7d4c8778958c0290bdf9a/django/db/models/fields/__init__.py#L858
+                field_name = field.name.replace("_", " ")
+            return capfirst(field_name)

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -60,6 +60,7 @@ from wagtail.test.testapp.models import (
     AdvertWithTabbedInterface,
     DraftStateCustomPrimaryKeyModel,
     DraftStateModel,
+    GenericSnippetPage,
     RevisableChildModel,
     RevisableModel,
     SnippetChooserModel,
@@ -3161,6 +3162,12 @@ class TestSnippetUsageView(TestCase, WagtailTestUtils):
         page = Page.objects.get(pk=2)
         page.save()
 
+        gfk_page = GenericSnippetPage(
+            title="Generic snippet page",
+            snippet_content_object=Advert.objects.get(pk=1),
+        )
+        page.add_child(instance=gfk_page)
+
         response = self.client.get(
             reverse(
                 "wagtailsnippets_tests_advert:usage",
@@ -3168,6 +3175,8 @@ class TestSnippetUsageView(TestCase, WagtailTestUtils):
             )
         )
         self.assertContains(response, "Welcome to the Wagtail test site!")
+        self.assertContains(response, "Generic snippet page")
+        self.assertContains(response, "Snippet content object")
 
     def test_usage_without_edit_permission_on_snippet(self):
         # Create a user with basic admin backend access


### PR DESCRIPTION
Fixes #9616.
Use field name as a fallback for fields that don't provide a `verbose_name` property (such as `GenericForeignKey`), and mark the django-taggit 'through' model (`TaggedItem` as well as any custom ones subclassing `ItemBase`) as ignored for reference indexing, since it doesn't really make sense to include a document's tags on its own usage report.

(Ideally we'd be a bit cleverer with the tag relation, and index the reference to the Tag model so that we can use it to find uses of a tag, but that really needs us to implement proper M2M handling including through models first, and that's out of scope for a 4.1.1 bugfix - #9629)