### PR TITLE
Clean up eslint usage `no-prototype-builtins`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,6 @@ const legacyCode = {
   'no-continue': 'off',
   'no-else-return': 'off',
   'no-plusplus': 'off',
-  'no-prototype-builtins': 'off',
   'no-restricted-syntax': 'off',
   'no-this-before-super': 'off',
 };
@@ -71,12 +70,9 @@ module.exports = {
       files: [
         'client/src/entrypoints/admin/comments.js',
         'client/src/entrypoints/admin/core.js',
-        'client/src/entrypoints/admin/expanding-formset.js',
-        'client/src/entrypoints/admin/filtered-select.js',
         'client/src/entrypoints/admin/page-chooser.js',
         'client/src/entrypoints/admin/page-editor.js',
         'client/src/entrypoints/admin/telepath/widgets.js',
-        'client/src/entrypoints/contrib/table_block/table.js',
         'client/src/entrypoints/contrib/typed_table_block/typed_table_block.js',
         'client/src/entrypoints/images/image-chooser-modal.js',
         'client/src/utils/actions.ts',

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Clean up some unused utility classes and migrate `unlist` to Tailwind utility class `w-list-none` (Loveth Omokaro)
  * Ensure that the `rebuild_references_index` command can run without console output if called with `--verbosity 0` (Omerzahid Ali, Aman Pandey)
  * Add development (contributing to Wagtail) documentation notes for development on Windows (Akua Dokua Asiedu)
+ * Clean up linting on legacy code and add shared util `hasOwn` in TypeScript (Loveth Omokaro)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -8,6 +8,7 @@ import {
   BaseInsertionControl,
 } from './BaseSequenceBlock';
 import { escapeHtml as h } from '../../../utils/text';
+import { hasOwn } from '../../../utils/hasOwn';
 
 /* global $ */
 
@@ -318,7 +319,7 @@ export class StreamBlock extends BaseSequenceBlock {
     // Check if there are any block types that have count limits
     this.disabledBlockTypes = new Set();
     for (const blockType in this.blockDef.meta.blockCounts) {
-      if (this.blockDef.meta.blockCounts.hasOwnProperty(blockType)) {
+      if (hasOwn(this.blockDef.meta.blockCounts, blockType)) {
         const maxNum = this.getBlockMax(blockType);
 
         if (typeof maxNum === 'number') {
@@ -459,7 +460,7 @@ export class StreamBlock extends BaseSequenceBlock {
     // Block errors
 
     for (const blockIndex in error.blockErrors) {
-      if (error.blockErrors.hasOwnProperty(blockIndex)) {
+      if (hasOwn(error.blockErrors, blockIndex)) {
         this.children[blockIndex].setError(error.blockErrors[blockIndex]);
       }
     }

--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -1,6 +1,7 @@
 /* global $ */
 
 import { escapeHtml as h } from '../../../utils/text';
+import { hasOwn } from '../../../utils/hasOwn';
 
 export class StructBlockValidationError {
   constructor(blockErrors) {
@@ -96,7 +97,7 @@ export class StructBlock {
     const error = errorList[0];
 
     for (const blockName in error.blockErrors) {
-      if (error.blockErrors.hasOwnProperty(blockName)) {
+      if (hasOwn(error.blockErrors, blockName)) {
         this.childBlocks[blockName].setError(error.blockErrors[blockName]);
       }
     }

--- a/client/src/entrypoints/admin/expanding-formset.js
+++ b/client/src/entrypoints/admin/expanding-formset.js
@@ -7,7 +7,7 @@ function buildExpandingFormset(prefix, opts = {}) {
   let formCount = parseInt(totalFormsInput.val(), 10);
 
   if (opts.onInit) {
-    for (let i = 0; i < formCount; i++) {
+    for (let i = 0; i < formCount; i += 1) {
       opts.onInit(i);
     }
   }
@@ -29,7 +29,7 @@ function buildExpandingFormset(prefix, opts = {}) {
     if (opts.onAdd) opts.onAdd(formCount);
     if (opts.onInit) opts.onInit(formCount);
 
-    formCount++;
+    formCount += 1;
     totalFormsInput.val(formCount);
   });
 }

--- a/client/src/entrypoints/admin/filtered-select.js
+++ b/client/src/entrypoints/admin/filtered-select.js
@@ -61,7 +61,7 @@ $(() => {
         filteredValues = optionData;
       } else {
         filteredValues = [];
-        for (let i = 0; i < optionData.length; i++) {
+        for (let i = 0; i < optionData.length; i += 1) {
           if (
             optionData[i].value === '' ||
             optionData[i].filterValue.indexOf(chosenFilter) !== -1
@@ -72,7 +72,7 @@ $(() => {
       }
 
       let foundValue = false;
-      for (let i = 0; i < filteredValues.length; i++) {
+      for (let i = 0; i < filteredValues.length; i += 1) {
         const option = $('<option>');
         option.attr('value', filteredValues[i].value);
         if (filteredValues[i].value === currentValue) foundValue = true;

--- a/client/src/entrypoints/contrib/table_block/table.js
+++ b/client/src/entrypoints/contrib/table_block/table.js
@@ -3,6 +3,7 @@
 /* global Handsontable */
 
 import $ from 'jquery';
+import { hasOwn } from '../../../utils/hasOwn';
 
 function initTable(id, tableOptions) {
   const containerId = id + '-handsontable-container';
@@ -54,24 +55,21 @@ function initTable(id, tableOptions) {
   }
 
   if (dataForForm !== null) {
-    if (dataForForm.hasOwnProperty('first_row_is_table_header')) {
+    if (hasOwn(dataForForm, 'first_row_is_table_header')) {
       tableHeaderCheckbox.prop(
         'checked',
         dataForForm.first_row_is_table_header,
       );
     }
-    if (dataForForm.hasOwnProperty('first_col_is_header')) {
+    if (hasOwn(dataForForm, 'first_col_is_header')) {
       colHeaderCheckbox.prop('checked', dataForForm.first_col_is_header);
     }
-    if (dataForForm.hasOwnProperty('table_caption')) {
+    if (hasOwn(dataForForm, 'table_caption')) {
       tableCaption.prop('value', dataForForm.table_caption);
     }
   }
 
-  if (
-    !tableOptions.hasOwnProperty('width') ||
-    !tableOptions.hasOwnProperty('height')
-  ) {
+  if (hasOwn(!tableOptions, 'width') || hasOwn(!tableOptions, 'height')) {
     // Size to parent .sequence-member-inner width if width is not given in tableOptions
     $(window).on('resize', () => {
       hot.updateSettings({
@@ -85,8 +83,8 @@ function initTable(id, tableOptions) {
   const getCellsClassnames = function () {
     const meta = hot.getCellsMeta();
     const cellsClassnames = [];
-    for (let i = 0; i < meta.length; i++) {
-      if (meta[i].hasOwnProperty('className')) {
+    for (let i = 0; i < meta.length; i += 1) {
+      if (hasOwn(meta[i], 'className')) {
         cellsClassnames.push({
           row: meta[i].row,
           col: meta[i].col,
@@ -159,10 +157,10 @@ function initTable(id, tableOptions) {
 
   if (dataForForm !== null) {
     // Overrides default value from tableOptions (if given) with value from database
-    if (dataForForm.hasOwnProperty('data')) {
+    if (hasOwn(dataForForm, 'data')) {
       defaultOptions.data = dataForForm.data;
     }
-    if (dataForForm.hasOwnProperty('cell')) {
+    if (hasOwn(dataForForm, 'cell')) {
       defaultOptions.cell = dataForForm.cell;
     }
   }

--- a/client/src/utils/hasOwn.test.js
+++ b/client/src/utils/hasOwn.test.js
@@ -1,0 +1,21 @@
+import { hasOwn } from './hasOwn';
+
+describe('hasOwn', () => {
+  it('should return false when not provided an object', () => {
+    expect(hasOwn()).toEqual(false);
+    expect(hasOwn(null)).toEqual(false);
+    expect(hasOwn([])).toEqual(false);
+    expect(hasOwn(undefined)).toEqual(false);
+  });
+
+  it('should return false if the object does not have the key', () => {
+    expect(hasOwn({}, 'a')).toEqual(false);
+    expect(hasOwn({ bb: true }, 'a')).toEqual(false);
+    expect(hasOwn({ AA: 'something' }, 'aa')).toEqual(false);
+  });
+
+  it('should return true if the object does  have the key', () => {
+    expect(hasOwn({ bb: true }, 'bb')).toEqual(true);
+    expect(hasOwn({ AA: 'something' }, 'AA')).toEqual(true);
+  });
+});

--- a/client/src/utils/hasOwn.ts
+++ b/client/src/utils/hasOwn.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns true if the specified object has the
+ * indicated property as its own property.
+ */
+const hasOwn = (object: Record<string, unknown>, key: string) =>
+  object ? Object.prototype.hasOwnProperty.call(object, key) : false;
+
+export { hasOwn };

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -31,6 +31,7 @@ depth: 1
  * Clean up some unused utility classes and migrate `unlist` to Tailwind utility class `w-list-none` (Loveth Omokaro)
  * Ensure that the `rebuild_references_index` command can run without console output if called with `--verbosity 0` (Omerzahid Ali, Aman Pandey)
  * Add development (contributing to Wagtail) documentation notes for [development on Windows](development_on_windows) (Akua Dokua Asiedu)
+ * Clean up linting on legacy code and add shared util `hasOwn` in TypeScript (Loveth Omokaro)
 
 ### Bug fixes
 


### PR DESCRIPTION
Fix for no-prototype-builtins rule for issue wagtail/wagtail#8731

- I removed the rule from the .eslintrc.js file and then ran `npm run lint`. This brought up issues in 3 files which are StreamBlock.js,  StructBlock.js and table.js

![eslintrc-errors](https://user-images.githubusercontent.com/38161296/200679554-28b3b816-3f1b-4f60-b084-7f0cc3cc7a0c.PNG)

- I fixed the errors that occurred and then ran tests for them. My fix was to remove `object.hasOwnProperty` and replace with `Object.prototype.hasOwnProperty.call(object, property)`

**This is the test result for StreamBlock.test.js**

![test-for-streamBlock](https://user-images.githubusercontent.com/38161296/200680179-c89bd430-94ef-48cf-abec-fc32020452f5.PNG)

**This is the test result for StructBlock.test.js**

![test-for-StructBlock](https://user-images.githubusercontent.com/38161296/200680271-c1200f31-ce46-4f43-bc0f-23fb85b255aa.PNG)

**This is the test result for table.test.js**

![test-for-table](https://user-images.githubusercontent.com/38161296/200680386-472bad47-f2ad-4d91-8373-d02397c23098.PNG)


- After I did that, I removed the table.js File from the override list of files in .eslintrc.js. This brought up this error

![error-after-removing-table-file](https://user-images.githubusercontent.com/38161296/200680736-7fe935b0-d2c5-42da-8b09-5e8c40a04d2d.PNG)

Which I fixed by replacing `i++` in the `for loop` with `i += 1`

And when I ran `npm run lint` again, everything was working fine and the tests passed.

![image](https://user-images.githubusercontent.com/38161296/200681218-291c8f0b-4680-4e2a-ac60-7ee9cd103822.png)
