### PR TITLE
Use `CSRF_HEADER_NAME` from global config for preview panel `DELETE` request

### DIFF
--- a/client/src/entrypoints/admin/preview-panel.js
+++ b/client/src/entrypoints/admin/preview-panel.js
@@ -1,3 +1,4 @@
+import { WAGTAIL_CONFIG } from '../../config/wagtailConfig';
 import { gettext } from '../../utils/gettext';
 
 function initPreview() {
@@ -143,16 +144,11 @@ function initPreview() {
     newIframe.addEventListener('load', handleLoad);
   };
 
-  const clearPreviewData = () => {
-    const csrfToken = document.querySelector(
-      'input[name="csrfmiddlewaretoken"]',
-    ).value;
-
-    return fetch(previewUrl, {
-      headers: { 'X-CSRFToken': csrfToken },
+  const clearPreviewData = () =>
+    fetch(previewUrl, {
+      headers: { [WAGTAIL_CONFIG.CSRF_HEADER_NAME]: WAGTAIL_CONFIG.CSRF_TOKEN },
       method: 'DELETE',
     });
-  };
 
   const setPreviewData = () => {
     // Bail out if there is already a pending update

--- a/client/src/entrypoints/admin/preview-panel.js
+++ b/client/src/entrypoints/admin/preview-panel.js
@@ -9,11 +9,6 @@ function initPreview() {
   // Preview side panel is not shown if the object does not have any preview modes
   if (!previewSidePanel) return;
 
-  // Get settings from the preview_settings template tag
-  const settings = JSON.parse(
-    document.getElementById('wagtail-preview-settings').textContent,
-  );
-
   // The previewSidePanel is a generic container for side panels,
   // the content of the preview panel itself is in a child element
   const previewPanel = previewSidePanel.querySelector('[data-preview-panel]');
@@ -218,7 +213,7 @@ function initPreview() {
     refreshButton.addEventListener('click', handlePreview);
   }
 
-  if (settings.WAGTAIL_AUTO_UPDATE_PREVIEW) {
+  if (WAGTAIL_CONFIG.WAGTAIL_AUTO_UPDATE_PREVIEW) {
     let oldPayload = new URLSearchParams(new FormData(form)).toString();
     let updateInterval;
 
@@ -244,7 +239,7 @@ function initPreview() {
       // Only set the interval while the panel is shown
       updateInterval = setInterval(
         checkAndUpdatePreview,
-        settings.WAGTAIL_AUTO_UPDATE_PREVIEW_INTERVAL,
+        WAGTAIL_CONFIG.WAGTAIL_AUTO_UPDATE_PREVIEW_INTERVAL,
       );
     });
 

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/preview.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/preview.html
@@ -1,7 +1,6 @@
 {% load i18n wagtailadmin_tags %}
 
-{% preview_settings as settings %}
-{{ settings|json_script:"wagtail-preview-settings" }}
+{% wagtail_config as settings %}
 
 <div class="preview-panel preview-panel--mobile" data-preview-panel data-action="{{ preview_url }}">
     <div class="preview-panel__sizes">

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -863,19 +863,6 @@ def get_comments_enabled():
     return getattr(settings, "WAGTAILADMIN_COMMENTS_ENABLED", True)
 
 
-@register.simple_tag
-def preview_settings():
-    default_options = {
-        "WAGTAIL_AUTO_UPDATE_PREVIEW": True,
-        "WAGTAIL_AUTO_UPDATE_PREVIEW_INTERVAL": 500,
-    }
-
-    return {
-        option: getattr(settings, option, default)
-        for option, default in default_options.items()
-    }
-
-
 @register.simple_tag(takes_context=True)
 def wagtail_config(context):
     request = context["request"]
@@ -888,6 +875,17 @@ def wagtail_config(context):
             "DISMISSIBLES": reverse("wagtailadmin_dismissibles"),
         },
     }
+
+    default_settings = {
+        "WAGTAIL_AUTO_UPDATE_PREVIEW": True,
+        "WAGTAIL_AUTO_UPDATE_PREVIEW_INTERVAL": 500,
+    }
+    config.update(
+        {
+            option: getattr(settings, option, default)
+            for option, default in default_settings.items()
+        }
+    )
 
     return config
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

Fixes #9635. The config is defined in here:

https://github.com/wagtail/wagtail/blob/2af187127100e92c6792cdcc6f5e0803f86e22ab/wagtail/admin/templatetags/wagtailadmin_tags.py#L879-L892

I've also added a small refactoring to move the settings in the `preview_settings` template tag to the `wagtail_config` template tag.

## Notes

After this PR, I'd like to move the global settings we have in here:

https://github.com/wagtail/wagtail/blob/2af187127100e92c6792cdcc6f5e0803f86e22ab/wagtail/admin/templates/wagtailadmin/admin_base.html#L18-L45

to the `wagtail_config` template tag so that we don't inject JS values using Django templates directly and use the `json_script` filter instead:

https://github.com/wagtail/wagtail/blob/2af187127100e92c6792cdcc6f5e0803f86e22ab/wagtail/admin/templates/wagtailadmin/admin_base.html#L46-L47

https://github.com/wagtail/wagtail/blob/2af187127100e92c6792cdcc6f5e0803f86e22ab/client/src/config/wagtailConfig.js#L14-L19

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
