### PR TITLE
Fix 9613 allow long lines to wrap

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ Changelog
  * Fix: Make sure minimap error indicators follow the minimap scrolling (Thibaud Colas)
  * Fix: Remove the ability to view or add comments to `InlinePanel` inner fields to avoid lost or incorrectly linked comments (Jacob Topp-Mugglestone)
  * Fix: Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
+ * Fix: Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)
@@ -55,6 +56,7 @@ Changelog
  * Fix: Make "Cancel scheduled publish" button correctly redirect back to the edit view (Sage Abdullah)
  * Fix: Prevent crash when reverting revisions on a snippet with `PreviewableMixin` applied (Sage Abdullah)
  * Fix: Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
+ * Fix: Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
 
 
 4.1.1 (11.11.2022)

--- a/client/scss/components/_footer.scss
+++ b/client/scss/components/_footer.scss
@@ -175,6 +175,7 @@ footer .preview {
 
     .icon {
       margin-inline-end: theme('spacing.2');
+      flex-shrink: 0;
     }
   }
 }
@@ -182,7 +183,7 @@ footer .preview {
 footer .actions {
   .button {
     font-weight: 600;
-    text-overflow: ellipsis;
+    white-space: initial;
   }
 }
 

--- a/docs/releases/4.1.2.md
+++ b/docs/releases/4.1.2.md
@@ -16,3 +16,4 @@ depth: 1
  * Make "Cancel scheduled publish" button correctly redirect back to the edit view (Sage Abdullah)
  * Prevent crash when reverting revisions on a snippet with `PreviewableMixin` applied (Sage Abdullah)
  * Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
+ * Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -39,6 +39,7 @@ depth: 1
  * Make sure minimap error indicators follow the minimap scrolling (Thibaud Colas)
  * Remove the ability to view or add comments to `InlinePanel` inner fields to avoid lost or incorrectly linked comments (Jacob Topp-Mugglestone)
  * Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
+ * Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
 
 ### Documentation
 


### PR DESCRIPTION
Ref: #9613 

-   [x] Do the tests still pass? YES
-   [x] Does the code comply with the style guide? YES
    -   [x] Run `make lint` from the Wagtail root. YES
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour? N/A
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments? NO, not yet.
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly? N/A

In accordance with https://github.com/wagtail/wagtail/issues/9613#issuecomment-1309919343
I don't think we need to support more then two lines.

## Desktop (test content)

<img width="1280" alt="Screenshot 2022-11-10 at 16 14 02" src="https://user-images.githubusercontent.com/1969342/201133149-4fd7db0d-cb71-45fd-81d5-af838339b14a.png">

## Mobile

<img width="458" alt="Screenshot 2022-11-10 at 16 15 42" src="https://user-images.githubusercontent.com/1969342/201133388-8ab6adb4-ff68-423f-9bc7-903f3e27b369.png">

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
