### PR TITLE
Stop comments being added on inline panels

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Changelog
  * Fix: Ensure there is a visual difference of 'active/current link' vs normal links in Windows high-contrast mode (Mohammad Areeb)
  * Fix: Avoid issues where trailing whitespace could be accidentally removed in translations for new page & snippet headers (Florian Vogt)
  * Fix: Make sure minimap error indicators follow the minimap scrolling (Thibaud Colas)
+ * Fix: Remove the ability to view or add comments to `InlinePanel` inner fields to avoid lost or incorrectly linked comments (Jacob Topp-Mugglestone)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)

--- a/client/src/entrypoints/admin/comments.js
+++ b/client/src/entrypoints/admin/comments.js
@@ -19,7 +19,7 @@ window.comments = (() => {
 
   function getContentPath(fieldNode) {
     // Return the total contentpath for an element as a string, in the form field.streamfield_uid.block...
-    if (fieldNode.closest('data-contentpath-disabled')) {
+    if (fieldNode.closest('[data-contentpath-disabled]')) {
       return '';
     }
     let element = fieldNode.closest('[data-contentpath]');
@@ -163,10 +163,14 @@ window.comments = (() => {
         throw new MissingElementError(annotationTemplateNode);
       }
       this.annotationTemplateNode = annotationTemplateNode;
-      this.shown = false;
+      this.updateVisibility(false);
     }
 
     register() {
+      if (!this.contentpath) {
+        // The widget has no valid contentpath, skip subscriptions
+        return undefined;
+      }
       const { selectEnabled } = commentApp.selectors;
       const initialState = commentApp.store.getState();
       let currentlyEnabled = selectEnabled(initialState);
@@ -300,9 +304,7 @@ window.comments = (() => {
         commentAdditionNode: buttonElement,
         annotationTemplateNode: document.querySelector('#comment-icon'),
       });
-      if (widget.contentpath) {
-        widget.register();
-      }
+      widget.register();
     };
     // Our template node may not exist yet - let's hold off until comments are loaded and enabled
     onNextEnable(initWidget);

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -36,6 +36,7 @@ depth: 1
  * Ensure there is a visual difference of 'active/current link' vs normal links in Windows high-contrast mode (Mohammad Areeb)
  * Avoid issues where trailing whitespace could be accidentally removed in translations for new page & snippet headers (Florian Vogt)
  * Make sure minimap error indicators follow the minimap scrolling (Thibaud Colas)
+ * Remove the ability to view or add comments to `InlinePanel` inner fields to avoid lost or incorrectly linked comments (Jacob Topp-Mugglestone)
 
 ### Documentation
 
@@ -68,3 +69,11 @@ depth: 1
 The `AbstractImage` and `AbstractRendition` models use a Wagtail-specific `WagtailImageField` which extends Django's `ImageField` 
 to use [Willow](https://github.com/wagtail/Willow/) for image file handling. This will generate a new migration if you 
 are using a [custom image model](custom_image_model)
+
+### Comments within `InlinePanel` not supported
+
+When the commenting system was introduced, support for `InlinePanel` fields was incorrectly added. This has lead to issues
+where comments can be lost on save or in most cases will be added to the incorrect item within the `InlinePanel`. The ability
+to add comments here has now been removed and as such any existing comments that were added will no longer show.
+
+See https://github.com/wagtail/wagtail/issues/9685 for tracking of adding this back officially in the future.

--- a/wagtail/admin/templates/wagtailadmin/shared/field.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/field.html
@@ -66,7 +66,7 @@
             {% endblock %}
 
             {% if show_add_comment_button %}
-                <button class="w-field__comment-button w-field__comment-button--add" type="button" data-component="add-comment-button" data-comment-add aria-label="{% trans 'Add comment' %}" {% if label_for %}aria-describedby="{{ label_id }}"{% endif %}>
+                <button class="w-field__comment-button w-field__comment-button--add u-hidden" type="button" data-component="add-comment-button" data-comment-add aria-label="{% trans 'Add comment' %}" {% if label_for %}aria-describedby="{{ label_id }}"{% endif %}>
                     {% icon name="comment-add" %}
                     {% icon name="comment-add-reversed" %}
                 </button>


### PR DESCRIPTION
(they do not have stable ids when models are not persisted to the database)

Addresses https://github.com/wagtail/wagtail/issues/9641

This feature should was enabled unintentionally. It would be great to add the ability to comment on child models in the future, but just like ListBlock before the addition of ids, we need a stable way to calculate the id to attach a comment before we can do this. This is a problem we'll need to solve - potentially via a uuid field on the model to identify models that haven't yet been saved to the database outside revisions.

To test, use the `BlogPage` model in bakerydemo, which contains an author `InlinePanel`. Confirm the chooser is uncommentable, and any additional panel instances are likewise uncommentable.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
