### PR TITLE
Allow both horizontal and vertical manual resizing of TextFields. Fix #7210

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ Changelog
  * Fix: Remove the ability to view or add comments to `InlinePanel` inner fields to avoid lost or incorrectly linked comments (Jacob Topp-Mugglestone)
  * Fix: Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
  * Fix: Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
+ * Fix: Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)
@@ -65,6 +66,7 @@ Changelog
  * Fix: Prevent crash when reverting revisions on a snippet with `PreviewableMixin` applied (Sage Abdullah)
  * Fix: Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
  * Fix: Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
+ * Fix: Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
 
 
 4.1.1 (11.11.2022)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -670,6 +670,7 @@ Contributors
 * Temidayo Azeez
 * ChickenF622
 * Benita Anawonah
+* Anisha Singh
 
 Translators
 ===========

--- a/docs/releases/4.1.2.md
+++ b/docs/releases/4.1.2.md
@@ -17,3 +17,4 @@ depth: 1
  * Prevent crash when reverting revisions on a snippet with `PreviewableMixin` applied (Sage Abdullah)
  * Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
  * Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
+ * Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -41,6 +41,7 @@ depth: 1
  * Remove the ability to view or add comments to `InlinePanel` inner fields to avoid lost or incorrectly linked comments (Jacob Topp-Mugglestone)
  * Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
  * Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
+ * Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
 
 ### Documentation
 

--- a/wagtail/admin/static_src/wagtailadmin/js/vendor/jquery.autosize.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/vendor/jquery.autosize.js
@@ -37,7 +37,7 @@
 			if (style.resize === 'vertical') {
 				ta.style.resize = 'none';
 			} else if (style.resize === 'both') {
-				ta.style.resize = 'horizontal';
+				ta.style.resize = 'both';
 			}
 
 			if (style.boxSizing === 'content-box') {


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->
**Issue Summary:**

The admin widget for TextField allows vertical resize instead of vertical.

**Before:**

https://user-images.githubusercontent.com/76876709/201477894-52b38a35-35ae-47bb-8a55-d91e77f04874.mov

**After:**

https://user-images.githubusercontent.com/76876709/201477927-db1d2449-0a3c-4568-8a6a-16f7c49143da.mp4



**Fixes:** https://github.com/wagtail/wagtail/issues/7210

- The normal behavior of TextField only allows horizontal extension, and the recommended way is to implement the vertical resizing as well. 

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
    -   [x] **Please list the exact browser and operating system versions you tested**:
    -   [x] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
