### PR TITLE
Fix inconsistent heading styles on top-level fields in the page editor

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changelog
  * Fix: Avoid issues where trailing whitespace could be accidentally removed in translations for new page & snippet headers (Florian Vogt)
  * Fix: Make sure minimap error indicators follow the minimap scrolling (Thibaud Colas)
  * Fix: Remove the ability to view or add comments to `InlinePanel` inner fields to avoid lost or incorrectly linked comments (Jacob Topp-Mugglestone)
+ * Fix: Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)
@@ -53,6 +54,7 @@ Changelog
 
  * Fix: Make "Cancel scheduled publish" button correctly redirect back to the edit view (Sage Abdullah)
  * Fix: Prevent crash when reverting revisions on a snippet with `PreviewableMixin` applied (Sage Abdullah)
+ * Fix: Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
 
 
 4.1.1 (11.11.2022)

--- a/client/scss/components/_panel.scss
+++ b/client/scss/components/_panel.scss
@@ -32,6 +32,10 @@ $header-gap: theme('spacing.1');
   cursor: pointer;
   padding-inline-end: theme('spacing.2');
 
+  label {
+    cursor: pointer;
+  }
+
   @include media-breakpoint-up(md) {
     padding-inline-end: theme('spacing.5');
   }

--- a/client/scss/components/forms/_nested-panel.scss
+++ b/client/scss/components/forms/_nested-panel.scss
@@ -36,11 +36,6 @@ $panel-x-offset: calc($header-button-size-sm / 2 + $header-gap);
     // Mask the overlap with the parent panel’s guide line.
     background-color: $color-white;
   }
-
-  .w-panel__heading--label {
-    // Use smaller labels within nested panels in InlinePanel.
-    @apply w-label-2;
-  }
 }
 
 // Styles for nested panels excluding the top level.
@@ -59,6 +54,11 @@ $panel-x-offset: calc($header-button-size-sm / 2 + $header-gap);
     @include media-breakpoint-up(sm) {
       transform: translateX(theme('spacing.1'));
     }
+  }
+
+  .w-panel__heading--label {
+    // Use smaller labels within nested panels in InlinePanel.
+    @apply w-label-2;
   }
 
   // For nested panels, there is always enough space for the prefix anchor.

--- a/docs/releases/4.1.2.md
+++ b/docs/releases/4.1.2.md
@@ -15,3 +15,4 @@ depth: 1
 
  * Make "Cancel scheduled publish" button correctly redirect back to the edit view (Sage Abdullah)
  * Prevent crash when reverting revisions on a snippet with `PreviewableMixin` applied (Sage Abdullah)
+ * Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -38,6 +38,7 @@ depth: 1
  * Avoid issues where trailing whitespace could be accidentally removed in translations for new page & snippet headers (Florian Vogt)
  * Make sure minimap error indicators follow the minimap scrolling (Thibaud Colas)
  * Remove the ability to view or add comments to `InlinePanel` inner fields to avoid lost or incorrectly linked comments (Jacob Topp-Mugglestone)
+ * Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
 
 ### Documentation
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

Fixes #9658.

<img width="217" alt="image" src="https://user-images.githubusercontent.com/6379424/201658734-58538a47-f2c6-470a-bd03-b96081cafd37.png">


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
