### PR TITLE
Remove unnecessary exists() query from PageLogEntryQuerySet.get_content_type_ids()

### DIFF
--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -4381,10 +4381,7 @@ class PageLogEntryQuerySet(LogEntryQuerySet):
     def get_content_type_ids(self):
         # for reporting purposes, pages of all types are combined under a single "Page"
         # object type
-        if self.exists():
-            return {ContentType.objects.get_for_model(Page).pk}
-        else:
-            return set()
+        return {ContentType.objects.get_for_model(Page).pk}
 
     def filter_on_content_type(self, content_type):
         if content_type == ContentType.objects.get_for_model(Page):


### PR DESCRIPTION
Since most `ContentType.objects.get_for_model()` lookups are served by local memory, we shouldn't try to guard against a query here (especially not by making a database query)