### PR TITLE
Always use concrete model content types for revisions

### DIFF
--- a/wagtail/admin/views/pages/revisions.py
+++ b/wagtail/admin/views/pages/revisions.py
@@ -1,4 +1,3 @@
-from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
@@ -34,10 +33,7 @@ def revisions_revert(request, page_id, revision_id):
     revision = get_object_or_404(page.revisions, id=revision_id)
     revision_page = revision.as_object()
 
-    content_type = ContentType.objects.get_for_model(page)
-    page_class = content_type.model_class()
-
-    edit_handler = page_class.get_edit_handler()
+    edit_handler = page.specific_class.get_edit_handler()
     form_class = edit_handler.get_form_class()
 
     form = form_class(instance=revision_page, for_user=request.user)
@@ -86,7 +82,7 @@ def revisions_revert(request, page_id, revision_id):
             "page": page,
             "revision": revision,
             "is_revision": True,
-            "content_type": content_type,
+            "content_type": page.get_content_type(),
             "edit_handler": edit_handler,
             "errors_debug": None,
             "action_menu": action_menu,

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2610,10 +2610,14 @@ class RevisionQuerySet(models.QuerySet):
         return self.filter(submitted_for_moderation=True)
 
     def for_instance(self, instance):
-        # For proxy model instances, use the concrete model ContentType
-        content_type = ContentType.objects.get_for_model(
-            instance, for_concrete_model=True
-        )
+        try:
+            # Utilise RevisionMixin.get_content_type() where available
+            content_type = instance.get_content_type()
+        except AttributeError:
+            # For proxy model instances, use the concrete model ContentType
+            content_type = ContentType.objects.get_for_model(
+                instance, for_concrete_model=True
+            )
         return self.filter(
             content_type=content_type,
             object_id=str(instance.pk),


### PR DESCRIPTION
As mentioned on #9255:

If a revision is published for a proxy model, those changes are technically applied to the concrete instance AND any proxy subclasses of it, because they are technically the same row in the database. With this in mind, I feel the correct behaviour is to always use the `ContentType` of the nearest concrete model when saving (or looking up) revisions for proxy model instances. 

