### PR TITLE
Fix missing `preview_url_name` in `SnippetViewSet.revisions_revert_view`

### DIFF
--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -881,6 +881,7 @@ class SnippetViewSet(ViewSet):
 
     @property
     def edit_view(self):
+        # Any parameters passed here must also be passed in revisions_revert_view.
         return self.edit_view_class.as_view(
             model=self.model,
             permission_policy=self.permission_policy,
@@ -938,6 +939,7 @@ class SnippetViewSet(ViewSet):
             edit_url_name=self.get_url_name("edit"),
             delete_url_name=self.get_url_name("delete"),
             history_url_name=self.get_url_name("history"),
+            preview_url_name=self.get_url_name("preview_on_edit"),
             revisions_revert_url_name=self.get_url_name("revisions_revert"),
         )
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

Fixes #9661. Sorry for not noticing this earlier 🙏 

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
