### PR TITLE
Always use concrete model content types for reference index records

### DIFF
--- a/wagtail/models/reference_index.py
+++ b/wagtail/models/reference_index.py
@@ -165,15 +165,20 @@ class ReferenceIndex(models.Model):
         that contains the primary key. For example, for any page object, this
         will return the content type of the Page model.
         """
-        parents = model_or_object._meta.get_parent_list()
-        if parents:
+        try:
+            # Get the last concrete parent in the MRO
+            base_concrete_model = model_or_object._meta.get_parent_list()[-1]
+        except IndexError:
+            # Model has no concrete parents, so return the content type for
+            # the model itself
             return ContentType.objects.get_for_model(
-                parents[-1], for_concrete_model=False
+                model_or_object, for_concrete_model=True
             )
-        else:
-            return ContentType.objects.get_for_model(
-                model_or_object, for_concrete_model=False
-            )
+        # NOTE: base_concrete_model is ALWAYS concrete, so 'for_concrete_model'
+        # is unnecessary here, but is included for consistency
+        return ContentType.objects.get_for_model(
+            base_concrete_model, for_concrete_model=True
+        )
 
     @classmethod
     def model_is_indexable(cls, model, allow_child_models=False):

--- a/wagtail/models/reference_index.py
+++ b/wagtail/models/reference_index.py
@@ -371,12 +371,12 @@ class ReferenceIndex(models.Model):
         # Find content types for this model and all of its ancestor classes,
         # ordered from most to least specific
         content_types = [
-            ContentType.objects.get_for_model(model_or_object, for_concrete_model=False)
+            ContentType.objects.get_for_model(model_or_object, for_concrete_model=True)
             for model_or_object in ([object] + object._meta.get_parent_list())
         ]
         content_type = content_types[0]
         base_content_type = content_types[-1]
-        known_content_type_ids = [ct.id for ct in content_types]
+        known_content_type_ids = {ct.id for ct in content_types}
 
         # Find existing references in the database so we know what to add/delete.
         # Construct a dict mapping reference records to the (content_type_id, id) pair that the


### PR DESCRIPTION
As mentioned on #9255:

Any references to other objects from a proxy model instance are really from the concrete model instances that come before it in the inheritance chain, as the proxy model doesn't have its own database table. References found on different proxy representations of the same object should not count as individual/separate references.

