### PR TITLE
Redirect to `next` parameter in `RevisionsUnscheduleView`

### DIFF
--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -31,9 +31,8 @@ from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.search import admin_search_areas
 from wagtail.admin.staticfiles import versioned_static as versioned_static_func
 from wagtail.admin.ui import sidebar
-from wagtail.admin.utils import get_admin_base_url
+from wagtail.admin.utils import get_admin_base_url, get_valid_next_url_from_request
 from wagtail.admin.views.bulk_action.registry import bulk_action_registry
-from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
 from wagtail.admin.widgets import ButtonWithDropdown, PageListingButton
 from wagtail.coreutils import camelcase_to_underscore
 from wagtail.coreutils import cautious_slugify as _cautious_slugify

--- a/wagtail/admin/tests/pages/test_revisions.py
+++ b/wagtail/admin/tests/pages/test_revisions.py
@@ -538,6 +538,35 @@ class TestRevisionsUnschedule(TestCase, WagtailTestUtils):
             ).approved_go_live_at
         )
 
+    def test_unschedule_view_post_with_next_url(self):
+        """
+        This tests that the redirect response follows the "next" parameter
+        """
+
+        unschedule_url = reverse(
+            "wagtailadmin_pages:revisions_unschedule",
+            args=(self.christmas_event.id, self.this_christmas_revision.id),
+        )
+        edit_url = reverse("wagtailadmin_pages:edit", args=(self.christmas_event.id,))
+
+        # Post to the unschedule page
+        response = self.client.post(f"{unschedule_url}?next={edit_url}")
+
+        # Should be redirected to edit page
+        self.assertRedirects(response, edit_url)
+
+        # Check that the page has no approved_schedule
+        self.assertFalse(
+            EventPage.objects.get(id=self.christmas_event.id).approved_schedule
+        )
+
+        # Check that the approved_go_live_at has been cleared from the revision
+        self.assertIsNone(
+            self.christmas_event.revisions.get(
+                id=self.this_christmas_revision.id
+            ).approved_go_live_at
+        )
+
 
 class TestRevisionsUnscheduleForUnpublishedPages(TestCase, WagtailTestUtils):
     fixtures = ["test.json"]

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -1,6 +1,7 @@
 from warnings import warn
 
 from django.conf import settings
+from django.utils.http import url_has_allowed_host_and_scheme
 
 from wagtail.utils.deprecation import RemovedInWagtail50Warning
 
@@ -20,3 +21,12 @@ def get_admin_base_url():
         admin_base_url = settings.BASE_URL
 
     return admin_base_url
+
+
+def get_valid_next_url_from_request(request):
+    next_url = request.POST.get("next") or request.GET.get("next")
+    if not next_url or not url_has_allowed_host_and_scheme(
+        url=next_url, allowed_hosts={request.get_host()}
+    ):
+        return ""
+    return next_url

--- a/wagtail/admin/views/bulk_action/base_bulk_action.py
+++ b/wagtail/admin/views/bulk_action/base_bulk_action.py
@@ -7,7 +7,7 @@ from django.views.generic import FormView
 
 from wagtail import hooks
 from wagtail.admin import messages
-from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
+from wagtail.admin.utils import get_valid_next_url_from_request
 
 
 class BulkAction(ABC, FormView):

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -24,6 +24,7 @@ from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.panels import get_edit_handler
 from wagtail.admin.templatetags.wagtailadmin_tags import user_display_name
 from wagtail.admin.ui.tables import Column, Table, TitleColumn, UpdatedAtColumn
+from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.log_actions import log
 from wagtail.log_actions import registry as log_registry
 from wagtail.models import DraftStateMixin, RevisionMixin
@@ -1018,6 +1019,10 @@ class RevisionsUnscheduleView(TemplateView):
         ]
 
     def get_next_url(self):
+        next_url = get_valid_next_url_from_request(self.request)
+        if next_url:
+            return next_url
+
         if not self.history_url_name:
             raise ImproperlyConfigured(
                 "Subclasses of wagtail.admin.views.generic.models.RevisionsUnscheduleView "

--- a/wagtail/admin/views/pages/convert_alias.py
+++ b/wagtail/admin/views/pages/convert_alias.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext as _
 from wagtail import hooks
 from wagtail.actions.convert_alias import ConvertAliasPageAction
 from wagtail.admin import messages
-from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
+from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.models import Page
 
 

--- a/wagtail/admin/views/pages/copy.py
+++ b/wagtail/admin/views/pages/copy.py
@@ -8,7 +8,7 @@ from wagtail.actions.create_alias import CreatePageAliasAction
 from wagtail.admin import messages
 from wagtail.admin.auth import user_has_any_page_permission, user_passes_test
 from wagtail.admin.forms.pages import CopyForm
-from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
+from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.models import Page
 
 

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -14,8 +14,8 @@ from django.views.generic.base import ContextMixin, TemplateResponseMixin, View
 from wagtail.admin import messages, signals
 from wagtail.admin.action_menu import PageActionMenu
 from wagtail.admin.ui.side_panels import PageSidePanels
+from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.admin.views.generic import HookResponseMixin
-from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
 from wagtail.models import Locale, Page, PageSubscription, UserPagePermissionsProxy
 
 

--- a/wagtail/admin/views/pages/delete.py
+++ b/wagtail/admin/views/pages/delete.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext as _
 from wagtail import hooks
 from wagtail.actions.delete_page import DeletePageAction
 from wagtail.admin import messages
-from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
+from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.models import Page
 
 

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -18,8 +18,8 @@ from wagtail.admin import messages
 from wagtail.admin.action_menu import PageActionMenu
 from wagtail.admin.mail import send_notification
 from wagtail.admin.ui.side_panels import PageSidePanels
+from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.admin.views.generic import HookResponseMixin
-from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
 from wagtail.exceptions import PageClassNotFoundError
 from wagtail.locks import BasicLock, ScheduledForPublishLock
 from wagtail.models import (

--- a/wagtail/admin/views/pages/revisions.py
+++ b/wagtail/admin/views/pages/revisions.py
@@ -12,12 +12,12 @@ from wagtail.admin import messages
 from wagtail.admin.action_menu import PageActionMenu
 from wagtail.admin.auth import user_has_any_page_permission, user_passes_test
 from wagtail.admin.ui.side_panels import PageSidePanels
+from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.admin.views.generic.models import (
     RevisionsCompareView,
     RevisionsUnscheduleView,
 )
 from wagtail.admin.views.generic.preview import PreviewRevision
-from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
 from wagtail.models import Page, UserPagePermissionsProxy
 
 

--- a/wagtail/admin/views/pages/revisions.py
+++ b/wagtail/admin/views/pages/revisions.py
@@ -12,7 +12,6 @@ from wagtail.admin import messages
 from wagtail.admin.action_menu import PageActionMenu
 from wagtail.admin.auth import user_has_any_page_permission, user_passes_test
 from wagtail.admin.ui.side_panels import PageSidePanels
-from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.admin.views.generic.models import (
     RevisionsCompareView,
     RevisionsUnscheduleView,
@@ -159,9 +158,3 @@ class RevisionsUnschedule(RevisionsUnscheduleView):
 
     def get_object_display_title(self):
         return self.object.get_admin_display_title()
-
-    def get_success_url(self):
-        next_url = get_valid_next_url_from_request(self.request)
-        if next_url:
-            return next_url
-        return super().get_success_url()

--- a/wagtail/admin/views/pages/unpublish.py
+++ b/wagtail/admin/views/pages/unpublish.py
@@ -6,8 +6,8 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.actions.unpublish_page import UnpublishPageAction
+from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.admin.views.generic.models import UnpublishView
-from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
 from wagtail.models import Page, UserPagePermissionsProxy
 
 

--- a/wagtail/admin/views/pages/utils.py
+++ b/wagtail/admin/views/pages/utils.py
@@ -1,10 +1,2 @@
-from django.utils.http import url_has_allowed_host_and_scheme
-
-
-def get_valid_next_url_from_request(request):
-    next_url = request.POST.get("next") or request.GET.get("next")
-    if not next_url or not url_has_allowed_host_and_scheme(
-        url=next_url, allowed_hosts={request.get_host()}
-    ):
-        return ""
-    return next_url
+# Retain backwards compatibility for imports
+from wagtail.admin.utils import get_valid_next_url_from_request  # noqa

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -15,7 +15,7 @@ from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.models import popular_tags_for_model
-from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
+from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.documents import get_document_model
 from wagtail.documents.forms import get_document_form
 from wagtail.documents.permissions import permission_policy

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -18,7 +18,7 @@ from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.models import popular_tags_for_model
-from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
+from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.images import get_image_model
 from wagtail.images.exceptions import InvalidFilterSpecError
 from wagtail.images.forms import URLGeneratorForm, get_image_form


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

Fixes #9671.

I've moved `get_valid_next_url_from_request` from `wagtail.admin.views.pages.utils` to `wagtail.admin.utils`, as it's not something that's specific to pages, and we use it in other places too (e.g. `wagtail.documents`). I added an import in `wagtail.admin.views.pages.utils` for backwards compatibility in case people depend on it, but I'm happy to remove it entirely.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
