### PR TITLE
Switch TableBlock’s header controls to a field that requires user input

### DIFF
--- a/client/src/entrypoints/contrib/table_block/__snapshots__/table.test.js.snap
+++ b/client/src/entrypoints/contrib/table_block/__snapshots__/table.test.js.snap
@@ -3,24 +3,27 @@
 exports[`telepath: wagtail.widgets.TableInput it renders correctly 1`] = `
 "<div>
       <div classname=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
-        <label class=\\"w-field__label\\" for=\\"the-id-handsontable-header\\">Row header</label>
+      <label class=\\"w-field__label\\" for=\\"the-id-table-header-choice\\">Table headers</label>
         <div class=\\"w-field w-field--boolean_field w-field--checkbox_input\\" data-field=\\"\\">
           <div classname=\\"w-field__input\\" data-field-input=\\"\\">
-            <input type=\\"checkbox\\" id=\\"the-id-handsontable-header\\" name=\\"handsontable-header\\" aria-describedby=\\"the-id-handsontable-header-helptext\\">
+            <select id=\\"the-id-table-header-choice\\" name=\\"table-header-choice\\">
+              <option value=\\"\\">Select a header option</option>
+              <option value=\\"row\\">
+                  Display the first row as a header
+              </option>
+              <option value=\\"column\\">
+                  Display the first column as a header
+              </option>
+              <option value=\\"both\\">
+                  Display the first row AND first column as headers
+              </option>
+              <option value=\\"neither\\">
+                  No headers
+              </option>
+            </select>
           </div>
           <div id=\\"the-id-handsontable-header-helptext\\" data-field-help=\\"\\">
-            <div class=\\"help\\">Display the first row as a header.</div>
-          </div>
-        </div>
-      </div>
-      <div classname=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
-        <label class=\\"w-field__label\\" for=\\"the-id-handsontable-col-header\\">Column header</label>
-        <div class=\\"w-field w-field--boolean_field w-field--checkbox_input\\" data-field=\\"\\">
-          <div classname=\\"w-field__input\\" data-field-input=\\"\\">
-            <input type=\\"checkbox\\" id=\\"the-id-handsontable-col-header\\" name=\\"handsontable-col-header\\" aria-describedby=\\"the-id-handsontable-col-header-helptext\\">
-          </div>
-          <div id=\\"the-id-handsontable-col-header-helptext\\" data-field-help=\\"\\">
-            <div class=\\"help\\">Display the first column as a header.</div>
+            <div class=\\"help\\">Which cells should be displayed as headers?</div>
           </div>
         </div>
       </div>
@@ -43,24 +46,27 @@ exports[`telepath: wagtail.widgets.TableInput it renders correctly 1`] = `
 exports[`telepath: wagtail.widgets.TableInput translation 1`] = `
 "<div>
       <div classname=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
-        <label class=\\"w-field__label\\" for=\\"the-id-handsontable-header\\">En-tête de ligne</label>
+      <label class=\\"w-field__label\\" for=\\"the-id-table-header-choice\\">En-têtes de tableau</label>
         <div class=\\"w-field w-field--boolean_field w-field--checkbox_input\\" data-field=\\"\\">
           <div classname=\\"w-field__input\\" data-field-input=\\"\\">
-            <input type=\\"checkbox\\" id=\\"the-id-handsontable-header\\" name=\\"handsontable-header\\" aria-describedby=\\"the-id-handsontable-header-helptext\\">
+            <select id=\\"the-id-table-header-choice\\" name=\\"table-header-choice\\">
+              <option value=\\"\\">Select a header option</option>
+              <option value=\\"row\\">
+                  Afficher la première ligne sous forme d'en-tête
+              </option>
+              <option value=\\"column\\">
+                  Afficher la première colonne sous forme d'en-tête
+              </option>
+              <option value=\\"both\\">
+                  Afficher la première ligne ET la première colonne sous forme d'en-têtes
+              </option>
+              <option value=\\"neither\\">
+                  Pas d'en-têtes
+              </option>
+            </select>
           </div>
           <div id=\\"the-id-handsontable-header-helptext\\" data-field-help=\\"\\">
-            <div class=\\"help\\">Affichez la première ligne sous forme d'en-tête.</div>
-          </div>
-        </div>
-      </div>
-      <div classname=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
-        <label class=\\"w-field__label\\" for=\\"the-id-handsontable-col-header\\">En-tête de colonne</label>
-        <div class=\\"w-field w-field--boolean_field w-field--checkbox_input\\" data-field=\\"\\">
-          <div classname=\\"w-field__input\\" data-field-input=\\"\\">
-            <input type=\\"checkbox\\" id=\\"the-id-handsontable-col-header\\" name=\\"handsontable-col-header\\" aria-describedby=\\"the-id-handsontable-col-header-helptext\\">
-          </div>
-          <div id=\\"the-id-handsontable-col-header-helptext\\" data-field-help=\\"\\">
-            <div class=\\"help\\">Affichez la première colonne sous forme d'en-tête.</div>
+            <div class=\\"help\\">Quelles cellules doivent être affichées en tant qu'en-têtes?</div>
           </div>
         </div>
       </div>

--- a/client/src/entrypoints/contrib/table_block/table.js
+++ b/client/src/entrypoints/contrib/table_block/table.js
@@ -7,12 +7,14 @@ import { hasOwn } from '../../../utils/hasOwn';
 
 function initTable(id, tableOptions) {
   const containerId = id + '-handsontable-container';
-  const tableHeaderCheckboxId = id + '-handsontable-header';
-  const colHeaderCheckboxId = id + '-handsontable-col-header';
+  var tableHeaderId = id + '-handsontable-header';
+  var colHeaderId = id + '-handsontable-col-header';
+  var headerChoiceId = id + '-table-header-choice';
   const tableCaptionId = id + '-handsontable-col-caption';
   const hiddenStreamInput = $('#' + id);
-  const tableHeaderCheckbox = $('#' + tableHeaderCheckboxId);
-  const colHeaderCheckbox = $('#' + colHeaderCheckboxId);
+  var tableHeader = $('#' + tableHeaderId);
+  var colHeader = $('#' + colHeaderId);
+  var headerChoice = $('#' + headerChoiceId);
   const tableCaption = $('#' + tableCaptionId);
   const finalOptions = {};
   let hot = null;
@@ -24,10 +26,7 @@ function initTable(id, tableOptions) {
   };
   const getHeight = function () {
     const tableParent = $('#' + id).parent();
-    return (
-      tableParent.find('.htCore').height() +
-      tableParent.find('[data-field]').height() * 2
-    );
+    return tableParent.find('.htCore').height();
   };
   const resizeTargets = [
     '[data-field] > .handsontable',
@@ -55,15 +54,10 @@ function initTable(id, tableOptions) {
   }
 
   if (dataForForm !== null) {
-    if (hasOwn(dataForForm, 'first_row_is_table_header')) {
-      tableHeaderCheckbox.prop(
-        'checked',
-        dataForForm.first_row_is_table_header,
-      );
+    if (hasOwn(dataForForm, 'table_header_choice')) {
+      headerChoice.prop('value', dataForForm.table_header_choice);
     }
-    if (hasOwn(dataForForm, 'first_col_is_header')) {
-      colHeaderCheckbox.prop('checked', dataForForm.first_col_is_header);
-    }
+
     if (hasOwn(dataForForm, 'table_caption')) {
       tableCaption.prop('value', dataForForm.table_caption);
     }
@@ -100,8 +94,9 @@ function initTable(id, tableOptions) {
       JSON.stringify({
         data: hot.getData(),
         cell: getCellsClassnames(),
-        first_row_is_table_header: tableHeaderCheckbox.prop('checked'),
-        first_col_is_header: colHeaderCheckbox.prop('checked'),
+        first_row_is_table_header: tableHeader.val(),
+        first_col_is_header: colHeader.val(),
+        table_header_choice: headerChoice.val(),
         table_caption: tableCaption.val(),
       }),
     );
@@ -132,11 +127,7 @@ function initTable(id, tableOptions) {
     persist();
   };
 
-  tableHeaderCheckbox.on('change', () => {
-    persist();
-  });
-
-  colHeaderCheckbox.on('change', () => {
+  headerChoice.on('change', () => {
     persist();
   });
 
@@ -195,24 +186,27 @@ class TableInput {
     const container = document.createElement('div');
     container.innerHTML = `
       <div className="w-field__wrapper" data-field-wrapper>
-        <label class="w-field__label" for="${id}-handsontable-header">${this.strings['Row header']}</label>
+      <label class="w-field__label" for="${id}-table-header-choice">${this.strings['Table headers']}</label>
         <div class="w-field w-field--boolean_field w-field--checkbox_input" data-field>
           <div className="w-field__input" data-field-input>
-            <input type="checkbox" id="${id}-handsontable-header" name="handsontable-header" aria-describedby="${id}-handsontable-header-helptext" />
+            <select id="${id}-table-header-choice" name="table-header-choice">
+              <option value="">Select a header option</option>
+              <option value="row">
+                  ${this.strings['Display the first row as a header']}
+              </option>
+              <option value="column">
+                  ${this.strings['Display the first column as a header']}
+              </option>
+              <option value="both">
+                  ${this.strings['Display the first row AND first column as headers']}
+              </option>
+              <option value="neither">
+                  ${this.strings['No headers']}
+              </option>
+            </select>
           </div>
           <div id="${id}-handsontable-header-helptext" data-field-help>
-            <div class="help">${this.strings['Display the first row as a header.']}</div>
-          </div>
-        </div>
-      </div>
-      <div className="w-field__wrapper" data-field-wrapper>
-        <label class="w-field__label" for="${id}-handsontable-col-header">${this.strings['Column header']}</label>
-        <div class="w-field w-field--boolean_field w-field--checkbox_input" data-field>
-          <div className="w-field__input" data-field-input>
-            <input type="checkbox" id="${id}-handsontable-col-header" name="handsontable-col-header" aria-describedby="${id}-handsontable-col-header-helptext" />
-          </div>
-          <div id="${id}-handsontable-col-header-helptext" data-field-help>
-            <div class="help">${this.strings['Display the first column as a header.']}</div>
+            <div class="help">${this.strings['Which cells should be displayed as headers?']}</div>
           </div>
         </div>
       </div>

--- a/client/src/entrypoints/contrib/table_block/table.test.js
+++ b/client/src/entrypoints/contrib/table_block/table.test.js
@@ -33,11 +33,15 @@ const TEST_OPTIONS = {
 };
 
 const TEST_STRINGS = {
-  'Row header': 'Row header',
-  'Display the first row as a header.': 'Display the first row as a header.',
-  'Column header': 'Column header',
-  'Display the first column as a header.':
-    'Display the first column as a header.',
+  'Table headers': 'Table headers',
+  'Display the first row as a header': 'Display the first row as a header',
+  'Display the first column as a header':
+    'Display the first column as a header',
+  'Display the first row AND first column as headers':
+    'Display the first row AND first column as headers',
+  'No headers': 'No headers',
+  'Which cells should be displayed as headers?':
+    'Which cells should be displayed as headers?',
   'Table caption': 'Table caption',
 
   'A heading that identifies the overall topic of the table, and is useful for screen reader users':
@@ -137,12 +141,16 @@ describe('telepath: wagtail.widgets.TableInput', () => {
 
   test('translation', () => {
     testStrings = {
-      'Row header': 'En-tête de ligne',
-      'Display the first row as a header.':
-        "Affichez la première ligne sous forme d'en-tête.",
-      'Column header': 'En-tête de colonne',
-      'Display the first column as a header.':
-        "Affichez la première colonne sous forme d'en-tête.",
+      'Table headers': 'En-têtes de tableau',
+      'Display the first row as a header':
+        "Afficher la première ligne sous forme d'en-tête",
+      'Display the first column as a header':
+        "Afficher la première colonne sous forme d'en-tête",
+      'Display the first row AND first column as headers':
+        "Afficher la première ligne ET la première colonne sous forme d'en-têtes",
+      'No headers': "Pas d'en-têtes",
+      'Which cells should be displayed as headers?':
+        "Quelles cellules doivent être affichées en tant qu'en-têtes?",
       'Table caption': 'Légende du tableau',
 
       'A heading that identifies the overall topic of the table, and is useful for screen reader users':

--- a/wagtail/contrib/table_block/tests.py
+++ b/wagtail/contrib/table_block/tests.py
@@ -116,10 +116,9 @@ class TestTableBlock(TestCase):
         """
         self.assertHTMLEqual(result, expected)
 
-    def test_do_not_render_html(self):
+    def test_do_not_render_html_by_default(self):
         """
-        Ensure that raw html doesn't render
-        by default.
+        Ensure that raw html doesn't render by default.
         """
         value = {
             "first_row_is_table_header": False,
@@ -142,6 +141,36 @@ class TestTableBlock(TestCase):
         """
 
         block = TableBlock()
+        result = block.render(value)
+        self.assertHTMLEqual(result, expected)
+
+    def test_does_render_html_if_allowed(self):
+        """
+        Ensure html renders if table_options set renderer to allow html
+        """
+        value = {
+            "first_row_is_table_header": False,
+            "first_col_is_header": False,
+            "data": [
+                ["<p><strong>Test</strong></p>", None, None],
+                [None, None, None],
+                [None, None, None],
+            ],
+        }
+
+        expected = """
+            <table>
+                <tbody>
+                    <tr><td><p><strong>Test</strong></p></td><td></td><td></td></tr>
+                    <tr><td></td><td></td><td></td></tr>
+                    <tr><td></td><td></td><td></td></tr>
+                </tbody>
+            </table>
+        """
+
+        new_options = self.default_table_options.copy()
+        new_options["renderer"] = "html"
+        block = TableBlock(table_options=new_options)
         result = block.render(value)
         self.assertHTMLEqual(result, expected)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)

for issue #9673 