### PR TITLE
Convert PNG mode CMYK to RGB

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -743,6 +743,8 @@ class Filter:
                     output, quality=quality, progressive=True, optimize=True
                 )
             elif output_format == "png":
+                if willow.image.mode == "CMYK":
+                    willow.image = willow.image.convert("RGB")
                 return willow.save_as_png(output, optimize=True)
             elif output_format == "gif":
                 return willow.save_as_gif(output)


### PR DESCRIPTION
This PR fixes issue #9686.

When attempting to output a PNG image that is in mode `CMYK`, an OSError is thrown that can bring down an entire application's frontend. 

This PR simply checks the image mode when outputting a PNG and converts it to `RGB` if it is in mode `CMYK`.


