### PR TITLE
Add `StreamField.get_db_prep_value()` to delegate serialisation of `JSONField` lookup values in Django >= 4.2

### DIFF
--- a/wagtail/fields.py
+++ b/wagtail/fields.py
@@ -212,7 +212,17 @@ class StreamField(models.Field):
             )
         else:
             # When querying with JSONField features, the rhs might not be a StreamValue.
+            # Note: when Django 4.2 is the minimum supported version, this can be removed
+            # as the serialisation is handled in get_db_prep_value instead.
             return self.json_field.get_prep_value(value)
+
+    def get_db_prep_value(self, value, connection, prepared=False):
+        if self.use_json_field and not isinstance(value, StreamValue):
+            # When querying with JSONField features, the rhs might not be a StreamValue.
+            # As of Django 4.2, JSONField value serialisation is handled in
+            # get_db_prep_value instead of get_prep_value.
+            return self.json_field.get_db_prep_value(value, connection, prepared)
+        return super().get_db_prep_value(value, connection, prepared)
 
     def from_db_value(self, value, expression, connection):
         if self.use_json_field and isinstance(expression, KeyTransform):


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

Fixes #9692. See the issue for more details on the rationale.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
