### PR TITLE
Fixed: Wagtail userbar toggle doesn't close the userbar

### DIFF
--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -77,9 +77,9 @@ document.addEventListener('DOMContentLoaded', () => {
   function toggleUserbar(e2) {
     e2.stopPropagation();
     if (userbar.classList.contains(isActiveClass)) {
-      hideUserbar();
+      hideUserbar(true);
     } else {
-      showUserbar(true);
+      showUserbar();
     }
   }
 


### PR DESCRIPTION
**Issue Summary:**

When the user clicks on the user bar toggle button, the content displays fine. But when it's clicked again and the content is supposed to disappear, they don't. The content disappears for some seconds and then reappears again. Then also, the first list item of has a yellow border around it when the toggle event is triggered.

**Fixed:**https://github.com/wagtail/wagtail/issues/9342

- By setting the value to true in `hideUserbar(true)`.

**Before**


https://user-images.githubusercontent.com/76876709/202866459-311d4606-5823-452b-a01a-32dc37714238.mp4



**After**


https://user-images.githubusercontent.com/76876709/202866470-72cf6f89-627d-447e-b0d1-936e92b3b94f.mp4








_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
