### PR TITLE
Clean up un-intentional whitespace in documentation

### DIFF
--- a/docs/contributing/committing.md
+++ b/docs/contributing/committing.md
@@ -72,11 +72,11 @@ The `CHANGELOG.txt` contains a short summary of each new feature, refactoring, o
 Each summary should be a single line.
 To easily identify the most relevant changes to users, items are grouped together in the following order:
 
-* Major features (no prefix) - things that will inspire users to upgrade to a new release
-* Minor enhancements (no prefix) - other improvements to the developer or end user experience
-* Bug fixes (prefixed with "Fix:") - things that address broken behaviour from previous releases
-* Documentation (prefixed with "Docs:") - changes to documentation that do not accompany a specific code change; reorganisations, tutorials, recipes and so on
-* Maintenance (prefixed with "Maintenance:") - cleanup, refactoring and other changes to code or tooling that are not intended to have a visible effect to developers or end users
+-   Major features (no prefix) - things that will inspire users to upgrade to a new release
+-   Minor enhancements (no prefix) - other improvements to the developer or end user experience
+-   Bug fixes (prefixed with "Fix:") - things that address broken behaviour from previous releases
+-   Documentation (prefixed with "Docs:") - changes to documentation that do not accompany a specific code change; reorganisations, tutorials, recipes and so on
+-   Maintenance (prefixed with "Maintenance:") - cleanup, refactoring and other changes to code or tooling that are not intended to have a visible effect to developers or end users
 
 The name of the contributor should be added at the end of the summary, in brackets.
 For example:

--- a/docs/reference/streamfield/blocks.md
+++ b/docs/reference/streamfield/blocks.md
@@ -59,9 +59,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.CharBlock
     :show-inheritance:
-    
+
     A single-line text input. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param required: If true (the default), the field cannot be left blank.
     :param max_length: The maximum allowed length of the field.
     :param min_length: The minimum allowed length of the field.
@@ -72,9 +72,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.TextBlock
     :show-inheritance:
-    
+
     A multi-line text input. As with ``CharBlock``, the following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param required: If true (the default), the field cannot be left blank.
     :param max_length: The maximum allowed length of the field.
     :param min_length: The minimum allowed length of the field.
@@ -86,7 +86,7 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.EmailBlock
     :show-inheritance:
-    
+
     A single-line email input that validates that the value is a valid e-mail address. The following keyword arguments are accepted in addition to the standard ones:
 
     :param required: If true (the default), the field cannot be left blank.
@@ -97,9 +97,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.IntegerBlock
     :show-inheritance:
-    
+
     A single-line integer input that validates that the value is a valid whole number. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param required: If true (the default), the field cannot be left blank.
     :param max_value: The maximum allowed numeric value of the field.
     :param min_value: The minimum allowed numeric value of the field.
@@ -110,9 +110,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.FloatBlock
     :show-inheritance:
-    
+
     A single-line Float input that validates that the value is a valid floating point number. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param required: If true (the default), the field cannot be left blank.
     :param max_value: The maximum allowed numeric value of the field.
     :param min_value: The minimum allowed numeric value of the field.
@@ -122,9 +122,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.DecimalBlock
     :show-inheritance:
-    
+
     A single-line decimal input that validates that the value is a valid decimal number. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param required: If true (the default), the field cannot be left blank.
     :param help_text: Help text to display alongside the field.
     :param max_value: The maximum allowed numeric value of the field.
@@ -137,17 +137,17 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.RegexBlock
     :show-inheritance:
-    
+
     A single-line text input that validates a string against a regular expression. The regular expression used for validation must be supplied as the first argument, or as the keyword argument ``regex``.
-    
+
     .. code-block:: python
 
        blocks.RegexBlock(regex=r'^[0-9]{3}$', error_messages={
            'invalid': "Not a valid library card number."
        })
-    
+
     The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param regex: Regular expression to validate against.
     :param error_messages: Dictionary of error messages, containing either or both of the keys ``required`` (for the message shown on an empty value) or ``invalid`` (for the message shown on a non-matching value).
     :param required: If true (the default), the field cannot be left blank.
@@ -160,9 +160,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.URLBlock
     :show-inheritance:
-    
+
     A single-line text input that validates that the string is a valid URL. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param required: If true (the default), the field cannot be left blank.
     :param max_length: The maximum allowed length of the field.
     :param min_length: The minimum allowed length of the field.
@@ -173,9 +173,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.BooleanBlock
     :show-inheritance:
-    
+
     A checkbox. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param required: If true (the default), the checkbox must be ticked to proceed. As with Django's ``BooleanField``, a checkbox that can be left ticked or unticked must be explicitly denoted with ``required=False``.
     :param help_text: Help text to display alongside the field.
     :param form_classname: A value to add to the form field's ``class`` attribute when rendered on the page editing form.
@@ -183,9 +183,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.DateBlock
     :show-inheritance:
-    
+
     A date picker. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param format: Date format. This must be one of the recognised formats listed in the `DATE_INPUT_FORMATS <https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-DATE_INPUT_FORMATS>`_ setting. If not specified Wagtail will use the ``WAGTAIL_DATE_FORMAT`` setting with fallback to '%Y-%m-%d'.
     :param required: If true (the default), the field cannot be left blank.
     :param help_text: Help text to display alongside the field.
@@ -195,9 +195,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.TimeBlock
     :show-inheritance:
-    
+
     A time picker. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param required: If true (the default), the field cannot be left blank.
     :param help_text: Help text to display alongside the field.
     :param validators: A list of validation functions for the field (see `Django Validators <https://docs.djangoproject.com/en/stable/ref/validators/>`__).
@@ -206,9 +206,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.DateTimeBlock
     :show-inheritance:
-    
+
     A combined date / time picker. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param format: Date/time format. This must be one of the recognised formats listed in the `DATETIME_INPUT_FORMATS <https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-DATETIME_INPUT_FORMATS>`_ setting. If not specified Wagtail will use the ``WAGTAIL_DATETIME_FORMAT`` setting with fallback to '%Y-%m-%d %H:%M'.
     :param required: If true (the default), the field cannot be left blank.
     :param help_text: Help text to display alongside the field.
@@ -218,9 +218,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.RichTextBlock
     :show-inheritance:
-    
+
     A WYSIWYG editor for creating formatted text including links, bold / italics etc. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param editor: The rich text editor to be used (see :ref:`wagtailadmin_rich_text_editors`).
     :param features: Specifies the set of features allowed (see :ref:`rich_text_features`).
     :param required: If true (the default), the field cannot be left blank.
@@ -232,25 +232,25 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.RawHTMLBlock
     :show-inheritance:
-    
+
     A text area for entering raw HTML which will be rendered unescaped in the page output. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param required: If true (the default), the field cannot be left blank.
     :param max_length: The maximum allowed length of the field.
     :param min_length: The minimum allowed length of the field.
     :param help_text: Help text to display alongside the field.
     :param validators: A list of validation functions for the field (see `Django Validators <https://docs.djangoproject.com/en/stable/ref/validators/>`__).
     :param form_classname: A value to add to the form field's ``class`` attribute when rendered on the page editing form.
-    
+
     .. WARNING::
       When this block is in use, there is nothing to prevent editors from inserting malicious scripts into the page, including scripts that would allow the editor to acquire administrator privileges when another administrator views the page. Do not use this block unless your editors are fully trusted.
 
 
 .. autoclass:: wagtail.blocks.BlockQuoteBlock
     :show-inheritance:
-    
+
     A text field, the contents of which will be wrapped in an HTML `<blockquote>` tag pair in the page output. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param required: If true (the default), the field cannot be left blank.
     :param max_length: The maximum allowed length of the field.
     :param min_length: The minimum allowed length of the field.
@@ -261,29 +261,29 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.ChoiceBlock
     :show-inheritance:
-    
+
     A dropdown select box for choosing one item from a list of choices. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param choices: A list of choices, in any format accepted by Django's :attr:`~django.db.models.Field.choices` parameter for model fields, or a callable returning such a list.
     :param required: If true (the default), the field cannot be left blank.
     :param help_text: Help text to display alongside the field.
     :param widget: The form widget to render the field with (see `Django Widgets <https://docs.djangoproject.com/en/stable/ref/forms/widgets/>`__).
     :param validators: A list of validation functions for the field (see `Django Validators <https://docs.djangoproject.com/en/stable/ref/validators/>`__).
     :param form_classname: A value to add to the form field's ``class`` attribute when rendered on the page editing form.
-    
+
     ``ChoiceBlock`` can also be subclassed to produce a reusable block with the same list of choices everywhere it is used. For example, a block definition such as:
-    
+
     .. code-block:: python
 
        blocks.ChoiceBlock(choices=[
            ('tea', 'Tea'),
            ('coffee', 'Coffee'),
        ], icon='cup')
-    
-    
+
+
     Could be rewritten as a subclass of ChoiceBlock:
-    
-    
+
+
     .. code-block:: python
 
        class DrinksChoiceBlock(blocks.ChoiceBlock):
@@ -294,8 +294,8 @@ All block definitions accept the following optional keyword arguments:
 
            class Meta:
                icon = 'cup'
-               
-               
+
+
     ``StreamField`` definitions can then refer to ``DrinksChoiceBlock()`` in place of the full ``ChoiceBlock`` definition. Note that this only works when ``choices`` is a fixed list, not a callable.
 ```
 
@@ -305,9 +305,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.MultipleChoiceBlock
     :show-inheritance:
-    
+
     A select box for choosing multiple items from a list of choices. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param choices: A list of choices, in any format accepted by Django's :attr:`~django.db.models.Field.choices` parameter for model fields, or a callable returning such a list.
     :param required: If true (the default), the field cannot be left blank.
     :param help_text: Help text to display alongside the field.
@@ -318,9 +318,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.PageChooserBlock
     :show-inheritance:
-    
+
     A control for selecting a page object, using Wagtail's page browser. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param required: If true (the default), the field cannot be left blank.
     :param page_type: Restrict choices to one or more specific page types; by default, any page type may be selected. Can be specified as a page model class, model name (as a string), or a list or tuple of these.
     :param can_choose_root: Defaults to false. If true, the editor can choose the tree root as a page. Normally this would be undesirable, since the tree root is never a usable page, but in some specialised cases it may be appropriate. For example, a block providing a feed of related articles could use a PageChooserBlock to select which subsection of the site articles will be taken from, with the root corresponding to 'everywhere'.
@@ -328,33 +328,33 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.documents.blocks.DocumentChooserBlock
     :show-inheritance:
-    
+
     A control to allow the editor to select an existing document object, or upload a new one. The following additional keyword argument is accepted:
-    
+
     :param required: If true (the default), the field cannot be left blank.
 
 
 .. autoclass:: wagtail.images.blocks.ImageChooserBlock
     :show-inheritance:
-    
+
     A control to allow the editor to select an existing image, or upload a new one. The following additional keyword argument is accepted:
-    
+
     :param required: If true (the default), the field cannot be left blank.
 
 
 .. autoclass:: wagtail.snippets.blocks.SnippetChooserBlock
     :show-inheritance:
-    
+
     A control to allow the editor to select a snippet object. Requires one positional argument: the snippet class to choose from. The following additional keyword argument is accepted:
-    
+
     :param required: If true (the default), the field cannot be left blank.
 
 
 .. autoclass:: wagtail.embeds.blocks.EmbedBlock
     :show-inheritance:
-    
+
     A field for the editor to enter a URL to a media item (such as a YouTube video) to appear as embedded media on the page. The following keyword arguments are accepted in addition to the standard ones:
-    
+
     :param required: If true (the default), the field cannot be left blank.
     :param max_width: The maximum width of the embed, in pixels; this will be passed to the provider when requesting the embed.
     :param max_height: The maximum height of the embed, in pixels; this will be passed to the provider when requesting the embed.:param max_length: The maximum allowed length of the field.
@@ -369,21 +369,21 @@ All block definitions accept the following optional keyword arguments:
 ```{eval-rst}
 .. autoclass:: wagtail.blocks.StaticBlock
     :show-inheritance:
-    
+
     A block which doesn't have any fields, thus passes no particular values to its template during rendering. This can be useful if you need the editor to be able to insert some content which is always the same or doesn't need to be configured within the page editor, such as an address, embed code from third-party services, or more complex pieces of code if the template uses template tags. The following additional keyword argument is accepted:
-    
+
     :param admin_text: A text string to display in the admin when this block is used. By default, some default text (which contains the ``label`` keyword argument if you pass it) will be displayed in the editor interface, so that the block doesn't look empty, but this can be customised by passing ``admin_text``:
-    
+
     .. code-block:: python
 
        blocks.StaticBlock(
            admin_text='Latest posts: no configuration needed.',
            # or admin_text=mark_safe('<b>Latest posts</b>: no configuration needed.'),
            template='latest_posts.html')
-           
+
     ``StaticBlock`` can also be subclassed to produce a reusable block with the same configuration everywhere it is used:
-    
-    
+
+
     .. code-block:: python
 
        class LatestPostsStaticBlock(blocks.StaticBlock):
@@ -396,9 +396,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.StructBlock
     :show-inheritance:
-    
+
     A block consisting of a fixed group of sub-blocks to be displayed together. Takes a list of ``(name, block_definition)`` tuples as its first argument:
-    
+
     .. code-block:: python
 
        body = StreamField([
@@ -410,11 +410,11 @@ All block definitions accept the following optional keyword arguments:
                ('biography', blocks.RichTextBlock()),
            ], icon='user')),
        ], use_json_field=True)
-       
-    
+
+
     Alternatively, StructBlock can be subclassed to specify a reusable set of sub-blocks:
-    
-    
+
+
     .. code-block:: python
 
        class PersonBlock(blocks.StructBlock):
@@ -425,12 +425,12 @@ All block definitions accept the following optional keyword arguments:
 
            class Meta:
                icon = 'user'
-               
+
     The ``Meta`` class supports the properties ``default``, ``label``, ``icon`` and ``template``, which have the same meanings as when they are passed to the block's constructor.
-    
-    
+
+
     This defines ``PersonBlock()`` as a block type for use in StreamField definitions:
-    
+
     .. code-block:: python
 
        body = StreamField([
@@ -439,10 +439,10 @@ All block definitions accept the following optional keyword arguments:
            ('image', ImageChooserBlock()),
            ('person', PersonBlock()),
        ], use_json_field=True)
-       
-    
+
+
     The following additional options are available as either keyword arguments or Meta class attributes:
-    
+
     :param form_classname: An HTML ``class`` attribute to set on the root element of this block as displayed in the editing interface. Defaults to ``struct-block``; note that the admin interface has CSS styles defined on this class, so it is advised to include ``struct-block`` in this value when overriding. See :ref:`custom_editing_interfaces_for_structblock`.
     :param form_template: Path to a Django template to use to render this block's form. See :ref:`custom_editing_interfaces_for_structblock`.
     :param value_class: A subclass of ``wagtail.blocks.StructValue`` to use as the type of returned values for this block. See :ref:`custom_value_class_for_structblock`.
@@ -452,20 +452,20 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.ListBlock
     :show-inheritance:
-    
+
     A block consisting of many sub-blocks, all of the same type. The editor can add an unlimited number of sub-blocks, and re-order and delete them. Takes the definition of the sub-block as its first argument:
-    
+
     .. code-block:: python
 
        body = StreamField([
            # ...
            ('ingredients_list', blocks.ListBlock(blocks.CharBlock(label="Ingredient"))),
        ], use_json_field=True)
-       
-       
-       
+
+
+
     Any block type is valid as the sub-block type, including structural types:
-    
+
     .. code-block:: python
 
        body = StreamField([
@@ -475,10 +475,10 @@ All block definitions accept the following optional keyword arguments:
                ('amount', blocks.CharBlock(required=False)),
            ]))),
        ], use_json_field=True)
-       
-       
+
+
     The following additional options are available as either keyword arguments or Meta class attributes:
-    
+
     :param form_classname: An HTML ``class`` attribute to set on the root element of this block as displayed in the editing interface.
     :param min_num: Minimum number of sub-blocks that the list must have.
     :param max_num: Maximum number of sub-blocks that the list may have.
@@ -487,9 +487,9 @@ All block definitions accept the following optional keyword arguments:
 
 .. autoclass:: wagtail.blocks.StreamBlock
     :show-inheritance:
-    
+
     A block consisting of a sequence of sub-blocks of different types, which can be mixed and reordered at will. Used as the overall mechanism of the StreamField itself, but can also be nested or used within other structural block types. Takes a list of ``(name, block_definition)`` tuples as its first argument:
-    
+
     .. code-block:: python
 
        body = StreamField([
@@ -506,10 +506,10 @@ All block definitions accept the following optional keyword arguments:
                icon='cogs'
            )),
        ], use_json_field=True)
-       
-       
+
+
     As with StructBlock, the list of sub-blocks can also be provided as a subclass of StreamBlock:
-    
+
     .. code-block:: python
 
        class CarouselBlock(blocks.StreamBlock):

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -17,7 +17,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
 
 To help with onboarding new users, Wagtail now displays a banner on the dashboard, pointing users to our Editor Guide. The sidebar also contains a new "Help" menu item with a prominent indicator to call attention to the new content: a "What’s new" page showcasing new features, and a link to the Editor Guide.
 
-Users can dismiss the new banner and the sidebar items’ indicators by interacting with the corresponding UI element. We store the state in the user’s profile  so we only call attention to the content once.
+Users can dismiss the new banner and the sidebar items’ indicators by interacting with the corresponding UI element. We store the state in the user’s profile so we only call attention to the content once.
 
 To turn off the new banner, set [`WAGTAIL_ENABLE_WHATS_NEW_BANNER`](wagtail_enable_whats_new_banner) to `False` in your settings. The new menu items can be removed and customised with the following hooks:
 
@@ -43,7 +43,7 @@ Snippet models that inherit from `DraftStateMixin` can now be assigned go-live a
 
 ### Object usage reporting
 
-Images, documents and snippets now provide a usage report, listing the places where references to those objects appear.  This report is powered by a new `ReferenceIndex` model which records cross-references between objects whenever those objects to save; this allows it to work more efficiently than the old report available through the `WAGTAIL_USAGE_COUNT_ENABLED` setting, as well as handling references within StreamField and rich text fields.
+Images, documents and snippets now provide a usage report, listing the places where references to those objects appear. This report is powered by a new `ReferenceIndex` model which records cross-references between objects whenever those objects to save; this allows it to work more efficiently than the old report available through the `WAGTAIL_USAGE_COUNT_ENABLED` setting, as well as handling references within StreamField and rich text fields.
 
 Note that on first upgrading to Wagtail 4.1, you will need to run the `rebuild_references_index` management command to populate the references table and ensure that reference counts are displayed accurately.
 

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -84,8 +84,8 @@ depth: 1
 
 ### Wagtail-specific image field (`WagtailImageField`)
 
-The `AbstractImage` and `AbstractRendition` models use a Wagtail-specific `WagtailImageField` which extends Django's `ImageField` 
-to use [Willow](https://github.com/wagtail/Willow/) for image file handling. This will generate a new migration if you 
+The `AbstractImage` and `AbstractRendition` models use a Wagtail-specific `WagtailImageField` which extends Django's `ImageField`
+to use [Willow](https://github.com/wagtail/Willow/) for image file handling. This will generate a new migration if you
 are using a [custom image model](custom_image_model)
 
 ### Comments within `InlinePanel` not supported


### PR DESCRIPTION
Small clean up items - lots of new docs recently and a few small 'double space after period' leaking in.

Nitpicky but until we decide on Prettier for markdown, just cleaning these up when I find them.