### PR TITLE
Make audit log tests check order of creation

### DIFF
--- a/wagtail/admin/tests/test_audit_log.py
+++ b/wagtail/admin/tests/test_audit_log.py
@@ -223,9 +223,9 @@ class TestAuditLogAdmin(TestCase, WagtailTestUtils):
             list(
                 PageLogEntry.objects.filter(page=page_id)
                 .values_list("action", flat=True)
-                .order_by("action")
+                .order_by("-pk")
             ),
-            ["wagtail.create", "wagtail.publish"],
+            ["wagtail.publish", "wagtail.create"],
         )
 
     def test_revert_and_publish_logs_reversion_and_publish(self):
@@ -249,9 +249,9 @@ class TestAuditLogAdmin(TestCase, WagtailTestUtils):
         entries = (
             PageLogEntry.objects.filter(page=self.hello_page)
             .values_list("action", flat=True)
-            .order_by("action")
+            .order_by("-pk")
         )
         self.assertListEqual(
             list(entries),
-            ["wagtail.create", "wagtail.publish", "wagtail.rename", "wagtail.revert"],
+            ["wagtail.publish", "wagtail.rename", "wagtail.revert", "wagtail.create"],
         )


### PR DESCRIPTION
This is based on the findings of #9611, but uses "-pk" to mirror the sometimes unreliable "-timestamp" default ordering.

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
