### PR TITLE
Extract revision and draft state logic from generic views into mixins

### DIFF
--- a/wagtail/admin/views/generic/__init__.py
+++ b/wagtail/admin/views/generic/__init__.py
@@ -1,6 +1,7 @@
 from .base import WagtailAdminTemplateMixin  # noqa
 from .mixins import (  # noqa
     BeforeAfterHookMixin,
+    CreateViewOptionalFeaturesMixin,
     HookResponseMixin,
     IndexViewOptionalFeaturesMixin,
     LocaleMixin,

--- a/wagtail/admin/views/generic/__init__.py
+++ b/wagtail/admin/views/generic/__init__.py
@@ -2,6 +2,7 @@ from .base import WagtailAdminTemplateMixin  # noqa
 from .mixins import (  # noqa
     BeforeAfterHookMixin,
     CreateViewOptionalFeaturesMixin,
+    EditViewOptionalFeaturesMixin,
     HookResponseMixin,
     IndexViewOptionalFeaturesMixin,
     LocaleMixin,

--- a/wagtail/admin/views/generic/__init__.py
+++ b/wagtail/admin/views/generic/__init__.py
@@ -1,8 +1,7 @@
 from .base import WagtailAdminTemplateMixin  # noqa
 from .mixins import (  # noqa
     BeforeAfterHookMixin,
-    CreateViewOptionalFeaturesMixin,
-    EditViewOptionalFeaturesMixin,
+    CreateEditViewOptionalFeaturesMixin,
     HookResponseMixin,
     IndexViewOptionalFeaturesMixin,
     LocaleMixin,

--- a/wagtail/admin/views/generic/__init__.py
+++ b/wagtail/admin/views/generic/__init__.py
@@ -2,8 +2,10 @@ from .base import WagtailAdminTemplateMixin  # noqa
 from .mixins import (  # noqa
     BeforeAfterHookMixin,
     HookResponseMixin,
+    IndexViewOptionalFeaturesMixin,
     LocaleMixin,
     PanelMixin,
+    RevisionsRevertMixin,
 )
 from .models import (  # noqa
     CreateView,

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -201,7 +201,7 @@ class IndexView(generic.IndexViewOptionalFeaturesMixin, generic.IndexView):
             return ["wagtailsnippets/snippets/type_index.html"]
 
 
-class CreateView(generic.CreateViewOptionalFeaturesMixin, generic.CreateView):
+class CreateView(generic.CreateEditViewOptionalFeaturesMixin, generic.CreateView):
     view_name = "create"
     preview_url_name = None
     permission_required = "add"
@@ -287,7 +287,7 @@ class CreateView(generic.CreateViewOptionalFeaturesMixin, generic.CreateView):
         return context
 
 
-class EditView(generic.EditViewOptionalFeaturesMixin, generic.EditView):
+class EditView(generic.CreateEditViewOptionalFeaturesMixin, generic.EditView):
     view_name = "edit"
     history_url_name = None
     preview_url_name = None

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -203,7 +203,7 @@ class IndexView(generic.IndexViewOptionalFeaturesMixin, generic.IndexView):
             return ["wagtailsnippets/snippets/type_index.html"]
 
 
-class CreateView(generic.CreateView):
+class CreateView(generic.CreateViewOptionalFeaturesMixin, generic.CreateView):
     view_name = "create"
     preview_url_name = None
     permission_required = "add"
@@ -231,31 +231,6 @@ class CreateView(generic.CreateView):
             urlquery = "?locale=" + self.object.locale.language_code
 
         return reverse(self.index_url_name) + urlquery
-
-    def get_success_message(self, instance):
-        message = _("%(model_name)s '%(object)s' created.")
-        if isinstance(instance, DraftStateMixin) and self.action == "publish":
-            message = _("%(model_name)s '%(object)s' created and published.")
-            if instance.go_live_at and instance.go_live_at > timezone.now():
-                message = _(
-                    "%(model_name)s '%(object)s' created and scheduled for publishing."
-                )
-
-        return message % {
-            "model_name": capfirst(self.model._meta.verbose_name),
-            "object": instance,
-        }
-
-    def get_success_buttons(self):
-        return [
-            messages.button(
-                reverse(
-                    self.edit_url_name,
-                    args=[quote(self.object.pk)],
-                ),
-                _("Edit"),
-            )
-        ]
 
     def _get_action_menu(self):
         return SnippetActionMenu(self.request, view=self.view_name, model=self.model)


### PR DESCRIPTION
Fixes #9710.

An alternate approach to #9190. I initially tried to create a separate mixin for each corresponding model mixin, and dynamically applying the view mixins in `SnippetViewSet` based on the model class. However, that seems to add more complexity as we'll need to have one view mixin for each model, for each view (e.g. `CreateViewDraftStateMixin`, `EditViewDraftStateMixin`). It will be very hard to make sure all the combinations work correctly, especially with the upcoming `LockableMixin` (and soon `WorkflowMixin`) integrations.

After tinkering around, I think it's worth to just combine all the model mixins logic into a single mixin for each view (`XViewOptionalFeaturesMixin`). This allows us to handle the model mixin combinations in each method in a simpler way (using `if` checks), while still removing the model mixin logic from the generic views.

I'd suggest reviewing each individual commit. The last commit combines the mixins for `CreateView` and `EditView` into a single mixin as some methods are exactly the same (`publish_action()`, `form_valid()`, etc.). Not sure if the reusability vs readability tradeoff is worth it, though. I'd be happy to remove that commit if desired.

I also noticed some method overrides in snippets views are no longer necessary as of #9221, so I removed them.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
