### PR TITLE
Create and show publish permissions for snippets with `DraftStateMixin` applied

### DIFF
--- a/docs/topics/snippets.md
+++ b/docs/topics/snippets.md
@@ -365,6 +365,12 @@ You can publish revisions programmatically by calling {meth}`instance.publish(re
 
 If you use the scheduled publishing feature, make sure that you run the [`publish_scheduled`](publish_scheduled) management command periodically. For more details, see [](scheduled_publishing).
 
+```{versionadded} 4.2
+For models that extend `DraftStateMixin`, `publish` permissions are automatically created.
+```
+
+Publishing a snippet instance requires `publish` permission on the snippet model. For models with `DraftStateMixin` applied, Wagtail automatically creates the corresponding `publish` permissions and display them in the 'Groups' area of the Wagtail admin interface. For more details on how to configure the permission, see [](permissions).
+
 ```{warning}
 Wagtail does not yet have a mechanism to prevent editors from including unpublished ("draft") snippets in pages. When including a `DraftStateMixin`-enabled snippet in pages, make sure that you add necessary checks to handle how a draft snippet should be rendered (e.g. by checking its `live` field). We are planning to improve this in the future.
 ```

--- a/wagtail/snippets/apps.py
+++ b/wagtail/snippets/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.db.models.signals import post_migrate
 from django.utils.translation import gettext_lazy as _
 
 
@@ -8,9 +9,20 @@ class WagtailSnippetsAppConfig(AppConfig):
     verbose_name = _("Wagtail snippets")
 
     def ready(self):
+        from .models import create_extra_permissions, register_deferred_snippets
+
         # Register all snippets for which register_snippet was called up to this point -
         # these registrations had to be deferred as we could not guarantee that models were
         # fully loaded at that point (but now they are).
-        from .models import register_deferred_snippets
-
         register_deferred_snippets()
+
+        # Models with certain mixins, e.g. DraftStateMixin, may require extra permissions
+        # in the admin. We need to make sure these are available without having to be
+        # created manually.
+        # Django also uses post_migrate signal to create permissions for models based on
+        # the model's Meta options:
+        # https://github.com/django/django/blob/64b3c413da011f55469165256261f406a277e822/django/contrib/auth/apps.py#L19-L22
+        # However, we cannot put the extra permissions in the model mixin's Meta class,
+        # as we do not know the concrete model's name. Thus, we use our own signal handler
+        # to create the extra permissions.
+        post_migrate.connect(create_extra_permissions, sender=self)

--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -1,5 +1,9 @@
 from django.contrib.admin.utils import quote
+from django.contrib.auth import get_permission_codename
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.core import checks
+from django.db import DEFAULT_DB_ALIAS
 from django.db.models import ForeignKey
 from django.urls import reverse
 from django.utils.module_loading import import_string
@@ -7,7 +11,7 @@ from django.utils.module_loading import import_string
 from wagtail.admin.checks import check_panels_in_model
 from wagtail.admin.forms.models import register_form_field_override
 from wagtail.admin.viewsets import viewsets
-from wagtail.models import ReferenceIndex
+from wagtail.models import DraftStateMixin, ReferenceIndex
 
 from .widgets import AdminSnippetChooser
 
@@ -140,3 +144,24 @@ def register_deferred_snippets():
     DEFER_REGISTRATION = False
     for model, viewset in DEFERRED_REGISTRATIONS:
         _register_snippet_immediately(model, viewset)
+
+
+def create_extra_permissions(*args, using=DEFAULT_DB_ALIAS, **kwargs):
+    model_cts = ContentType.objects.get_for_models(
+        *SNIPPET_MODELS, for_concrete_models=False
+    )
+
+    permissions = []
+    for model, ct in model_cts.items():
+        if issubclass(model, DraftStateMixin):
+            permissions.append(
+                Permission(
+                    content_type=ct,
+                    codename=get_permission_codename("publish", model._meta),
+                    name=f"Can publish {model._meta.verbose_name_raw}",
+                )
+            )
+
+    # Use bulk_create with ignore_conflicts instead of checking for existence
+    # prior to creation to avoid additional database query.
+    Permission.objects.using(using).bulk_create(permissions, ignore_conflicts=True)

--- a/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
@@ -6,20 +6,28 @@
         <legend class="w-sr-only">{% trans "Object permissions" %}</legend>
 
         <table class="listing">
-            <col />
-            <col width="15%" />
-            <col width="15%" />
-            <col width="15%" />
-            {% if custom_perms_exist %}
-                <col width="30%" />
-            {% endif %}
+            <colgroup>
+                <col />
+                <col width="10%" />
+                <col width="10%" />
+                <col width="10%" />
+                {% if extra_perms_exist.publish %}
+                    <col width="10%" />
+                {% endif %}
+                {% if extra_perms_exist.custom %}
+                    <col width="25%" />
+                {% endif %}
+            </colgroup>
             <thead>
                 <tr>
                     <th>{% trans "Name" %}</th>
                     <th>{% trans "Add" %}</th>
                     <th>{% trans "Change" %}</th>
                     <th>{% trans "Delete" %}</th>
-                    {% if custom_perms_exist %}
+                    {% if extra_perms_exist.publish %}
+                        <th>{% trans "Publish" %}</th>
+                    {% endif %}
+                    {% if extra_perms_exist.custom %}
                         <th>{% trans "Custom permissions" %}</th>
                     {% endif %}
                 </tr>
@@ -46,7 +54,15 @@
                                 {{ content_perms_dict.delete.checkbox.tag }}
                             {% endif %}
                         </td>
-                        {% if custom_perms_exist %}
+                        {% if extra_perms_exist.publish %}
+                            <td>
+                                {% if content_perms_dict.publish %}
+                                    <label for="{{ content_perms_dict.publish.checkbox.id_for_label }}" class="visuallyhidden">{{ content_perms_dict.publish.perm.name }}</label>
+                                    {{ content_perms_dict.publish.checkbox.tag }}
+                                {% endif %}
+                            </td>
+                        {% endif %}
+                        {% if extra_perms_exist.custom %}
                             <td>
                                 {% if content_perms_dict.custom %}
                                     <fieldset class="w-p-0">

--- a/wagtail/users/templatetags/wagtailusers_tags.py
+++ b/wagtail/users/templatetags/wagtailusers_tags.py
@@ -17,9 +17,10 @@ def format_permissions(permission_bound_field):
     'objects': [
         {
             'object': name_of_some_content_object,
-            'add': checkbox
-            'change': checkbox
-            'delete': checkbox
+            'add': checkbox,
+            'change': checkbox,
+            'delete': checkbox,
+            'publish': checkbox,  # only if the model extends DraftStateMixin
             'custom': list_of_checkboxes_for_custom_permissions
         },
     ]
@@ -50,7 +51,12 @@ def format_permissions(permission_bound_field):
 
     object_perms = []
     other_perms = []
-    custom_perms_exist = False
+
+    # Only show the columns for these permissions if any of the model has them.
+    extra_perms_exist = {
+        "publish": False,
+        "custom": False,
+    }
 
     for content_type_id in content_type_ids:
         content_perms = permissions.filter(content_type_id=content_type_id)
@@ -65,16 +71,18 @@ def format_permissions(permission_bound_field):
         for perm in content_perms:
             content_perms_dict["object"] = perm.content_type.name
             checkbox = checkboxes_by_id[perm.id]
-            # identify the three main categories of permission, and assign to
-            # the relevant dict key, else bung in the 'other_perms' list
+            # identify the four main categories of permission, and assign to
+            # the relevant dict key, else bung in the 'custom_perms' list
             permission_action = perm.codename.split("_")[0]
-            if permission_action in ["add", "change", "delete"]:
+            if permission_action in ["add", "change", "delete", "publish"]:
+                if permission_action == "publish":
+                    extra_perms_exist["publish"] = True
                 content_perms_dict[permission_action] = {
                     "perm": perm,
                     "checkbox": checkbox,
                 }
             else:
-                custom_perms_exist = True
+                extra_perms_exist["custom"] = True
                 custom_perms.append(
                     {
                         "perm": perm,
@@ -90,7 +98,7 @@ def format_permissions(permission_bound_field):
     return {
         "object_perms": object_perms,
         "other_perms": other_perms,
-        "custom_perms_exist": custom_perms_exist,
+        "extra_perms_exist": extra_perms_exist,
     }
 
 

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -1360,6 +1360,7 @@ class TestGroupCreateView(TestCase, WagtailTestUtils):
             Q(codename__startswith="add")
             | Q(codename__startswith="change")
             | Q(codename__startswith="delete")
+            | Q(codename__startswith="publish")
         ).delete()
 
         response = self.get()
@@ -1370,6 +1371,37 @@ class TestGroupCreateView(TestCase, WagtailTestUtils):
         response = self.get()
 
         self.assertInHTML("Custom permissions", str(response.content))
+
+    def test_show_publish_permissions(self):
+        response = self.get()
+        html = response.content.decode()
+
+        # Should show the Publish column
+        self.assertInHTML("<th>Publish</th>", html)
+
+        # Should show inputs for publish permissions on models with DraftStateMixin
+        self.assertInHTML("Can publish draft state model", html)
+        self.assertInHTML("Can publish draft state custom primary key model", html)
+
+        # Should not show inputs for publish permissions on models without DraftStateMixin
+        self.assertNotInHTML("Can publish advert", html)
+
+    def test_hide_publish_permissions(self):
+        # Remove all `publish` permissions
+        Permission.objects.filter(codename__startswith="publish").delete()
+
+        response = self.get()
+        html = response.content.decode()
+
+        # Should not show the Publish column
+        self.assertNotInHTML("<th>Publish</th>", html)
+
+        # Should not show inputs for publish permissions even on models with DraftStateMixin
+        self.assertNotInHTML("Can publish draft state model", html)
+        self.assertNotInHTML("Can publish draft state custom primary key model", html)
+
+        # Should not show inputs for publish permissions on models without DraftStateMixin
+        self.assertNotInHTML("Can publish advert", html)
 
 
 class TestGroupEditView(TestCase, WagtailTestUtils):
@@ -1775,6 +1807,37 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
             % custom_permission.id,
             str(response.content),
         )
+
+    def test_show_publish_permissions(self):
+        response = self.get()
+        html = response.content.decode()
+
+        # Should show the Publish column
+        self.assertInHTML("<th>Publish</th>", html)
+
+        # Should show inputs for publish permissions on models with DraftStateMixin
+        self.assertInHTML("Can publish draft state model", html)
+        self.assertInHTML("Can publish draft state custom primary key model", html)
+
+        # Should not show inputs for publish permissions on models without DraftStateMixin
+        self.assertNotInHTML("Can publish advert", html)
+
+    def test_hide_publish_permissions(self):
+        # Remove all `publish` permissions
+        Permission.objects.filter(codename__startswith="publish").delete()
+
+        response = self.get()
+        html = response.content.decode()
+
+        # Should not show the Publish column
+        self.assertNotInHTML("<th>Publish</th>", html)
+
+        # Should not show inputs for publish permissions even on models with DraftStateMixin
+        self.assertNotInHTML("Can publish draft state model", html)
+        self.assertNotInHTML("Can publish draft state custom primary key model", html)
+
+        # Should not show inputs for publish permissions on models without DraftStateMixin
+        self.assertNotInHTML("Can publish advert", html)
 
 
 class TestGroupViewSet(TestCase):


### PR DESCRIPTION
Fixes #9720.

Use the `post_migrate` signal to create `Permission` objects with the `publish_rawmodelname` codename for models with `DraftStateMixin` applied. This ensures that after a `migrate` run, such models have their corresponding permissions in the database. If developers have already created the permissions, then we ignore the creation.

In addition, we now show the "Publish" permission as part of the main permissions in the "Object permissions" section of the Group edit form, instead of being put in the "Custom permissions". This column only shows up if any of the models have the `publish` permission in the database, which means that it normally won't show up if none of the models extends `DraftStateMixin`.

## Before

(if the `publish` permissions haven't been created, or if none of the models has `DraftStateMixin`)

<img width="924" alt="image" src="https://user-images.githubusercontent.com/6379424/203982974-510c28f2-7b4f-4107-9da4-10bbe9a87016.png">

## After

<img width="924" alt="image" src="https://user-images.githubusercontent.com/6379424/203982899-826b383f-6c75-4c93-966b-73768730d074.png">

Refs:
- https://github.com/django/django/blob/d526d1569ca4a1e62bb6a1dd779d2068766d348c/django/contrib/auth/management/__init__.py#L21-L34
- https://github.com/django/django/blob/64b3c413da011f55469165256261f406a277e822/django/contrib/auth/apps.py#L19-L22
- https://github.com/django/django/blob/64b3c413da011f55469165256261f406a277e822/django/contrib/auth/management/__init__.py#L37-L106

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
