### PR TITLE
Remove resize handles from autosize text areas

### DIFF
--- a/client/scss/components/forms/_input-text.scss
+++ b/client/scss/components/forms/_input-text.scss
@@ -34,6 +34,11 @@ textarea {
   padding: theme('spacing.5');
 }
 
+// Disable resize handle on textareas with auto-sizing behaviour
+.w-field__autosize {
+  resize: none;
+}
+
 // Make non-text field types with custom widgets have a smaller width.
 .w-field--date_field,
 .w-field--date_time_field,

--- a/wagtail/admin/static_src/wagtailadmin/js/vendor/jquery.autosize.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/vendor/jquery.autosize.js
@@ -37,7 +37,7 @@
 			if (style.resize === 'vertical') {
 				ta.style.resize = 'none';
 			} else if (style.resize === 'both') {
-				ta.style.resize = 'both';
+				ta.style.resize = 'horizontal';
 			}
 
 			if (style.boxSizing === 'content-box') {

--- a/wagtail/admin/widgets/auto_height_text.py
+++ b/wagtail/admin/widgets/auto_height_text.py
@@ -13,6 +13,12 @@ class AdminAutoHeightTextInput(widgets.Textarea):
         if attrs:
             default_attrs.update(attrs)
 
+        # add a w-field__autosize classname
+        try:
+            default_attrs["class"] += " w-field__autosize"
+        except KeyError:
+            default_attrs["class"] = "w-field__autosize"
+
         super().__init__(default_attrs)
 
 


### PR DESCRIPTION
Fixes #7210, replacing #9651 as per https://github.com/wagtail/wagtail/issues/7210#issuecomment-1325707942. AdminAutoHeightTextInput now inserts a w-field__autosize classname which explicitly disables the resizing handle, leaving resizing fully in control of the jquery.autosize plugin.
