### PR TITLE
Fix up typo in slug field validation

### DIFF
--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -184,7 +184,7 @@ class WagtailAdminPageForm(WagtailAdminModelForm):
                     "slug",
                     forms.ValidationError(
                         _(
-                            "The slug '%(page_slug)s' is already in use in use within the parent page"
+                            "The slug '%(page_slug)s' is already in use within the parent page"
                         )
                         % {"page_slug": page_slug}
                     ),

--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -1383,7 +1383,7 @@ class TestCopyPageAction(AdminAPITestCase):
             content,
             {
                 "slug": [
-                    "The slug 'events' is already in use in use within the parent page at '/'"
+                    "The slug 'events' is already in use within the parent page at '/'"
                 ]
             },
         )

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -717,7 +717,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             response,
             "form",
             "slug",
-            "The slug 'hello-world' is already in use in use within the parent page",
+            "The slug 'hello-world' is already in use within the parent page",
         )
 
         # form should be marked as having unsaved changes for the purposes of the dirty-forms warning

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1285,7 +1285,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             response,
             "form",
             "slug",
-            "The slug 'hello-world' is already in use in use within the parent page",
+            "The slug 'hello-world' is already in use within the parent page",
         )
 
     def test_preview_on_edit(self):

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -1103,7 +1103,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             raise ValidationError(
                 {
                     "slug": _(
-                        "The slug '%(page_slug)s' is already in use in use within the parent page at '%(parent_url_path)s'"
+                        "The slug '%(page_slug)s' is already in use within the parent page at '%(parent_url_path)s'"
                     )
                     % {"page_slug": self.slug, "parent_url_path": parent_page.url}
                 }


### PR DESCRIPTION
- See #7730


> Looks like 'in use' is duplicated here (and in all the resulting test cases).
_Originally posted by @gasman in https://github.com/wagtail/wagtail/pull/7730#discussion_r1032245601_
      