### PR TITLE
Always show the page editor title field’s border when the field is empty. Fix #9318

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ Changelog
  * Add ability to include `form_fields` as an APIField on `FormPage` (Sævar Öfjörð Magnússon, Suyash Singh, LB (Ben) Johnston)
  * Ensure that images listings are more consistently aligned when there are fewer images uploaded (Theresa Okoro)
  * Add more informative validation error messages for non-unique slugs within the admin interface and for programmatic page creation (Benjamin Bach)
+ * Always show the page editor title field’s border when the field is empty (Thibaud Colas)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/client/scss/components/forms/_title.scss
+++ b/client/scss/components/forms/_title.scss
@@ -32,7 +32,9 @@
     padding-inline-start: theme('spacing[1.5]');
     margin-inline-start: calc(-1 * theme('spacing[1.5]'));
 
-    &:not(:hover, :focus, [aria-invalid='true']) {
+    // Avoid calling attention to the field _unless_ it’s in one of those states.
+    &:not(:hover, :focus, :placeholder-shown, [aria-invalid='true']) {
+      // Hide w/ transparency to preserve border size and show it in forced-colors mode.
       border-color: transparent;
     }
   }

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -23,6 +23,7 @@ depth: 1
  * Add ability to include [`form_fields` as an APIField](form_page_fields_api_field) on `FormPage` (Sævar Öfjörð Magnússon, Suyash Singh, LB (Ben) Johnston)
  * Ensure that images listings are more consistently aligned when there are fewer images uploaded (Theresa Okoro)
  * Add more informative validation error messages for non-unique slugs within the admin interface and for programmatic page creation (Benjamin Bach)
+ * Always show the page editor title field’s border when the field is empty (Thibaud Colas)
 
 ### Bug fixes
 


### PR DESCRIPTION
Fixes #9318. Tweaks our special page editor title field, so its border is visible when the field is empty. This uses `:placeholder-shown`, which works in all our supported browsers. Technically just using this would cause the border to disappear once the user starts typing, but we’re already showing the border on `:focus`, so we’re good.

I added a lot of comments to explain this code because how the selector is written is critical to making sure the border changes as expected across all of the field’s states.

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 107, Firefox 106, Safari 16.1, on macOS 13
    -   [x] **Please list which assistive technologies [^3] you tested**: forced-colors mode only
-   [ ] For new features: Has the documentation been updated accordingly?

Testing should just be a matter of opening the page editor on a existing page, and checking:

- Absence of border when the field contains a value (same as before)
- Presence of border when the field is in the different interaction states (same as before)
- Presence of border when the field is empty and not interacted with (new)