### PR TITLE
Refactor Status tag styles into UI component #8656 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,6 +42,7 @@ Changelog
  * Maintenance: Remove unneeded float styles on 404 page (Fabien Le Frapper)
  * Maintenance: Convert userbar implementation to TypeScript (Albina Starykova)
  * Maintenance: Migrate slug field behaviour to a Stimulus controller and create new `SlugInput` widget (Loveth Omokaro)
+ * Maintenance: Refactor `status` HTML usage to shared template tag (Aman Pandey, LB (Ben) Johnston)
 
 
 4.2.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -62,6 +62,7 @@ depth: 1
  * Remove unneeded float styles on 404 page (Fabien Le Frapper)
  * Convert userbar implementation to TypeScript (Albina Starykova)
  * Migrate slug field behaviour to a Stimulus controller and create new `SlugInput` widget (Loveth Omokaro)
+ * Refactor `status` HTML usage to shared template tag (Aman Pandey, LB (Ben) Johnston)
 
 ## Upgrade considerations
 

--- a/wagtail/admin/templates/wagtailadmin/chooser/tables/page_title_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/tables/page_title_cell.html
@@ -1,4 +1,4 @@
-{% load l10n %}
+{% load l10n wagtailadmin_tags %}
 <td class="{% if column.classname %}{{ column.classname }} {% endif %}title">
     <div class="title-wrapper">
         {% if page.can_choose %}
@@ -11,7 +11,7 @@
             {{ value }}
         {% endif %}
         {% if column.show_locale_labels and page.depth == 2 %}
-            <span class="status-tag status-tag--label">{{ page.locale.get_display_name }}</span>
+            {% status page.locale.get_display_name classname="status-tag--label" %}
         {% endif %}
 
         {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}

--- a/wagtail/admin/templates/wagtailadmin/chooser/tables/parent_page_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/tables/parent_page_cell.html
@@ -1,6 +1,7 @@
+{% load wagtailadmin_tags %}
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
     {% if value %}
         <a href="{% url 'wagtailadmin_choose_page_child' value.id %}" class="navigate-parent">{{ value.get_admin_display_title }}</a>
-        {% if column.show_locale_labels %}<span class="status-tag status-tag--label">{{ value.locale.get_display_name }}</span>{% endif %}
+        {% if column.show_locale_labels %}{% status value.locale.get_display_name classname="status-tag--label" %}{% endif %}
     {% endif %}
 </td>

--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -24,7 +24,7 @@
                                 {% i18n_enabled as show_locale_labels %}
                                 {% if show_locale_labels and page.locale_id %}
                                     {% locale_label_from_id page.locale_id as locale_label %}
-                                    <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                    {% status locale_label classname="status-tag--label" %}
                                 {% endif %}
                                 {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
                                 {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}

--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -1,5 +1,3 @@
-
-
 {% load i18n wagtailadmin_tags %}
 {% if page_revisions_for_moderation %}
     {% trans "Pages awaiting moderation" as heading %}
@@ -34,7 +32,7 @@
                                 {% i18n_enabled as show_locale_labels %}
                                 {% if show_locale_labels and revision.content_object.locale_id %}
                                     {% locale_label_from_id revision.content_object.locale_id as locale_label %}
-                                    <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                    {% status locale_label classname="status-tag--label" %}
                                 {% endif %}
                                 {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.content_object %}
                                 {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=revision.content_object %}

--- a/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
@@ -25,7 +25,7 @@
                                 {% i18n_enabled as show_locale_labels %}
                                 {% if show_locale_labels and page.locale_id %}
                                     {% locale_label_from_id page.locale_id as locale_label %}
-                                    <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                    {% status locale_label classname="status-tag--label" %}
                                 {% endif %}
                                 {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
                                 {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}

--- a/wagtail/admin/templates/wagtailadmin/home/user_objects_in_workflow_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/user_objects_in_workflow_moderation.html
@@ -35,7 +35,7 @@
                                     {% i18n_enabled as show_locale_labels %}
                                     {% if show_locale_labels and obj.locale_id %}
                                         {% locale_label_from_id obj.locale_id as locale_label %}
-                                        <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                        {% status locale_label classname="status-tag--label" %}
                                     {% endif %}
                                     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=obj %}
                                     {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=obj %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -35,7 +35,7 @@
                                     {% i18n_enabled as show_locale_labels %}
                                     {% if show_locale_labels and obj.locale_id %}
                                         {% locale_label_from_id obj.locale_id as locale_label %}
-                                        <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                        {% status locale_label classname="status-tag--label" %}
                                     {% endif %}
                                     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=obj %}
                                     {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=obj %}

--- a/wagtail/admin/templates/wagtailadmin/pages/history.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/history.html
@@ -36,9 +36,9 @@
                             {% endif %}
                             {% if entry.revision %}
                                 {% if entry.action == 'wagtail.publish' %}
-                                    {% if entry.revision_id == page.live_revision_id %}<span class="status-tag primary">{% trans 'Live version' %}</span>{% endif %}
+                                    {% if entry.revision_id == page.live_revision_id %}{% trans 'Live version' as status_label %}{% status status_label classname="primary" %}{% endif %}
                                 {% elif entry.content_changed %}
-                                    {% if entry.revision == page_latest_revision %}<span class="status-tag primary">{% trans 'Current draft' %}</span>{% endif %}
+                                    {% if entry.revision == page_latest_revision %}{% trans 'Current draft' as status_label %}{% status status_label classname="primary" %}{% endif %}
                                     {% include "wagtailadmin/pages/revisions/_actions.html" with revision=entry.revision %}
                                 {% endif %}
                             {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -16,7 +16,7 @@
     {% endif %}
 
     {% if show_locale_labels %}
-        <span class="status-tag status-tag--label">{{ page.locale.get_display_name }}</span>
+        {% status page.locale.get_display_name classname="status-tag--label" %}
     {% endif %}
 
     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}

--- a/wagtail/admin/templates/wagtailadmin/reports/aging_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/aging_pages.html
@@ -31,7 +31,7 @@
                             {% i18n_enabled as show_locale_labels %}
                             {% if show_locale_labels %}
                                 {% locale_label_from_id page.locale_id as locale_label %}
-                                <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                {% status locale_label classname="status-tag--label" %}
                             {% endif %}
                         </td>
                         <td class="status" valign="top">

--- a/wagtail/admin/templates/wagtailadmin/reports/workflow.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/workflow.html
@@ -46,7 +46,7 @@
                             {% i18n_enabled as show_locale_labels %}
                             {% if show_locale_labels and workflow_state.content_object.locale_id %}
                                 {% locale_label_from_id workflow_state.content_object.locale_id as locale_label %}
-                                <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                {% status locale_label classname="status-tag--label" %}
                             {% endif %}
                         </td>
                         <td>

--- a/wagtail/admin/templates/wagtailadmin/reports/workflow_tasks.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/workflow_tasks.html
@@ -44,14 +44,12 @@
                                 {% i18n_enabled as show_locale_labels %}
                                 {% if show_locale_labels and object.locale_id %}
                                     {% locale_label_from_id object.locale_id as locale_label %}
-                                    <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                    {% status locale_label classname="status-tag--label" %}
                                 {% endif %}
                             {% endwith %}
                         </td>
                         <td>
-                            <div class="status-tag primary">
-                                {{ task_state.get_status_display }}
-                            </div>
+                            {% status task_state.get_status_display classname="primary" %}
                         </td>
                         <td>{{ task_state.started_at }}</td>
                         <td>{{ task_state.finished_at }}</td>

--- a/wagtail/admin/templates/wagtailadmin/shared/page_status_tag.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/page_status_tag.html
@@ -1,18 +1,14 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% if page.live %}
     {% with page_url=page.url %}
+        {% trans "Current page status:" as status_hidden_label %}
         {% if page_url is not None %}
-            <a href="{{ page_url }}" target="_blank" rel="noreferrer" class="status-tag primary" title="{% trans 'Visit the live page' %}">
-                <span class="visuallyhidden">{% trans "Current page status:" %}</span> {{ page.status_string }}
-            </a>
+            {% trans 'Visit the live page' as status_title %}
+            {% status page.status_string url=page_url title=status_title hidden_label=status_hidden_label classname="primary" attrs='target="_blank" rel="noreferrer"' %}
         {% else %}
-            <span class="status-tag primary">
-                <span class="visuallyhidden">{% trans "Current page status:" %}</span> {{ page.status_string }}
-            </span>
+            {% status page.status_string hidden_label=status_hidden_label classname="primary" %}
         {% endif %}
     {% endwith %}
 {% else %}
-    <span class="status-tag">
-        <span class="visuallyhidden">{% trans "Current page status:" %}</span> {{ page.status_string }}
-    </span>
+    {% status page.status_string hidden_label=status_hidden_label %}
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/status_tag.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/status_tag.html
@@ -1,0 +1,15 @@
+{% load wagtailadmin_tags %}
+{% if url %}
+    <a href="{{ url }}" class="{% classnames 'status-tag' classname %}"{% if title %} title="{{ title }}" {% endif %}{% if attrs %} {{ attrs }}{% endif %}>
+        {% if hidden_label %}
+            <span class="visuallyhidden">{{ hidden_label }}</span> {% if label %}{{ label }}{% endif %}
+        {% else %}
+            {% if label %}{{ label }}{% endif %}
+        {% endif %}
+    </a>
+{% else %}
+    <span class="{% classnames 'status-tag' classname %}"{% if attrs %} {{ attrs }}{% endif %}>
+        {% if hidden_label %}<span class="visuallyhidden">{{ hidden_label }}</span>{% endif %}
+        {% if label %}{{ label }}{% endif %}
+    </span>
+{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/status_tag.stories.tsx
+++ b/wagtail/admin/templates/wagtailadmin/shared/status_tag.stories.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Pattern, generateDocs } from 'storybook-django/src/react';
+
+import template from './status_tag.html';
+
+const { docs, argTypes } = generateDocs(template);
+
+export default {
+  parameters: { docs },
+  argTypes: {
+    ...argTypes,
+    classname: {
+      options: [null, 'primary', 'status-tag--label'],
+    },
+    url: {
+      options: [null, 'https://wagtail.org/'],
+    },
+    title: {
+      options: [null, 'wagtail live url'],
+    },
+    hidden_label: {
+      options: [null, 'current status:'],
+    },
+  },
+};
+
+const Template = (args) => <Pattern filename={__filename} context={args} />;
+export const Live = Template.bind({});
+
+Live.args = {
+  label: 'live',
+  classname: null,
+  url: null,
+  title: null,
+  hidden_label: null,
+};

--- a/wagtail/admin/templates/wagtailadmin/shared/workflow_history/detail.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/workflow_history/detail.html
@@ -26,7 +26,8 @@
         </p>
 
         <p>
-            {% blocktrans trimmed with workflow_state.get_status_display as status %}Status <span class="status-tag primary"> {{ status }}</span>{% endblocktrans %}
+            {% fragment as status_tag_variable %}{% status workflow_state.get_status_display classname="primary" %}{% endfragment %}
+            {% blocktrans trimmed with status_tag_variable as status %}Status {{ status }}{% endblocktrans %}
         </p>
 
 

--- a/wagtail/admin/templates/wagtailadmin/shared/workflow_history/list.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/workflow_history/list.html
@@ -23,9 +23,8 @@
             {% for workflow_state in workflow_states %}
                 <tr>
                     <td>
-                        <a href="{% url workflow_history_detail_url_name object.pk|admin_urlquote workflow_state.id %}" class="status-tag primary">
-                            {{ workflow_state.get_status_display }}
-                        </a>
+                        {% url workflow_history_detail_url_name object.pk|admin_urlquote workflow_state.id as status_url %}
+                        {% status workflow_state.get_status_display url=status_url classname="primary" %}
                     </td>
                     <td class="title">
                         <h2>

--- a/wagtail/admin/templates/wagtailadmin/tables/status_tag_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/status_tag_cell.html
@@ -1,3 +1,4 @@
+{% load wagtailadmin_tags %}
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
-    <div class="status-tag {% if primary %}primary{% endif %}">{{ value }}</div>
+    {% status value classname=primary|yesno:"primary," %}
 </td>

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -36,9 +36,8 @@
                             <td class="title">
                                 <div class="title-wrapper">
                                     <a href="{% url view.edit_url_name workflow.pk %}">{{ workflow }}</a>
-                                    {% if not workflow.active %}
-                                        <span class="status-tag">Disabled</span>
-                                    {% endif %}
+                                    {% trans "Disabled" as status_label %}
+                                    {% if not workflow.active %}{% status status_label %}{% endif %}
                                 </div>
                             </td>
                             <td class="title">

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -36,9 +36,8 @@
                             <td class="title">
                                 <div class="title-wrapper">
                                     <a href="{% url view.edit_url_name task.pk %}">{{ task }}</a>
-                                    {% if not task.active %}
-                                        <span class="status-tag">Disabled</span>
-                                    {% endif %}
+                                    {% trans "Disabled" as status_label %}
+                                    {% if not task.active %}{% status status_label %}{% endif %}
                                 </div>
                             </td>
                             <td>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -779,6 +779,41 @@ def icon(name=None, classname=None, title=None, wrapped=False, class_name=None):
     }
 
 
+@register.inclusion_tag("wagtailadmin/shared/status_tag.html")
+def status(
+    label=None,
+    classname=None,
+    url=None,
+    title=None,
+    hidden_label=None,
+    attrs=None,
+):
+    """
+    Generates a status-tag css with <span></span> or <a><a/> implementation.
+
+    Usage:
+
+        {% status label="live" url="/test/" title="title" hidden_label="current status:" classname="primary" %}
+
+    :param label: the status test, (string)
+    :param classname: defaults to 'status-tag' if not provided (string)
+    :param url: the status url(to specify the use of anchor tag instead of default span), (string)
+    :param title: accessible label intended for screen readers (string)
+    :param hidden_label : the to specify the additional visually hidden span text, (string)
+    :param attrs: any additional HTML attributes (as a string) to append to the root element
+    :return: Rendered template snippet (string)
+
+    """
+    return {
+        "label": label,
+        "attrs": attrs,
+        "classname": classname,
+        "hidden_label": hidden_label,
+        "title": title,
+        "url": url,
+    }
+
+
 @register.filter()
 def timesince_simple(d):
     """

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -543,3 +543,77 @@ class IconTagTest(TestCase):
             ),
         ):
             self.assertHTMLEqual(expected, Template(template).render(Context()))
+
+
+class StatusTagTest(TestCase):
+    def test_render_block_component_span_variations(self):
+        template = """
+            {% load wagtailadmin_tags i18n %}
+            {% status "live" classname="primary" %}
+            {% status "live" %}
+            {% trans "hidden translated label" as trans_hidden_label %}
+            {% status "live" hidden_label=trans_hidden_label classname="primary" %}
+            {% status %}
+        """
+
+        expected = """
+            <span class="status-tag primary">live</span>
+            <span class="status-tag">live</span>
+            <span class="status-tag primary"><span class="visuallyhidden">hidden translated label</span>live</span>
+            <span class="status-tag"></span>
+        """
+
+        self.assertHTMLEqual(expected, Template(template).render(Context()))
+
+    def test_render_block_component_anchor_variations(self):
+        template = """
+            {% load wagtailadmin_tags i18n %}
+            {% trans "title" as trans_title %}
+            {% trans "hidden label" as trans_hidden_label %}
+            {% status "live" url="/test-url/" title=trans_title hidden_label=trans_hidden_label classname="primary" attrs='target="_blank" rel="noreferrer"' %}
+            {% status "live" url="/test-url/" title=trans_title classname="primary" %}
+            {% status "live" url="/test-url/" title=trans_title %}
+            {% status  url="/test-url/" title=trans_title attrs='id="my-status"' %}
+        """
+
+        expected = """
+            <a href="/test-url/" class="status-tag primary" title="title" target="_blank" rel="noreferrer">
+                <span class="visuallyhidden">hidden label</span>
+                live
+            </a>
+            <a href="/test-url/" class="status-tag primary" title="title">
+                live
+            </a>
+            <a href="/test-url/" class="status-tag" title="title">
+                live
+            </a>
+            <a href="/test-url/" class="status-tag" title="title" id="my-status">
+            </a>
+        """
+
+        self.assertHTMLEqual(expected, Template(template).render(Context()))
+
+    def test_render_as_fragment(self):
+        template = """
+            {% load wagtailadmin_tags i18n %}
+            {% fragment as var %}
+                {% trans "title" as trans_title %}
+                {% trans "hidden label" as trans_hidden_label %}
+                {% status "live" url="/test-url/" title=trans_title hidden_label=trans_hidden_label classname="primary" attrs='target="_blank" rel="noreferrer"' %}
+                {% status "live" hidden_label=trans_hidden_label classname="primary" attrs="data-example='present'" %}
+            {% endfragment %}
+            {{var}}
+        """
+
+        expected = """
+            <a href="/test-url/" class="status-tag primary" title="title" target="_blank" rel="noreferrer">
+                <span class="visuallyhidden">hidden label</span>
+                live
+            </a>
+            <span class="status-tag primary" data-example='present'>
+                <span class="visuallyhidden">hidden label</span>
+                live
+            </span>
+        """
+
+        self.assertHTMLEqual(expected, Template(template).render(Context()))

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -617,9 +617,10 @@
             <p>{% avatar size="small" %} Avatar small</p>
 
             <h3>Status tags</h3>
-            <div class="status-tag primary">Primary tag</div>
-
-            <div class="status-tag">Secondary tag</div>
+            <div>{% status "status tag primary" classname="primary" %}</div>
+            <div>{% status "status tag secondary" %}</div>
+            <div>{% status "status tag label" classname="status-tag--label" %}</div>
+            <div>{% status "status tag link" url="https://wagtail.org/" title="wagtail.org" hidden_label="current status" classname="primary" %}</div>
 
             <h3>Loading mask</h3>
             <p>Add the following <code>div</code> around any items you wish to display with a spinner overlay and fading out</p>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/revisions/_actions.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/revisions/_actions.html
@@ -5,8 +5,8 @@
         {% with revision=instance.revision latest_revision=object.get_latest_revision previous_revision=instance.revision.get_previous %}
             <span>{{ value }}</span>
             {% if draftstate_enabled %}
-                {% if instance.action == 'wagtail.publish' and revision == object.live_revision %}<span class="status-tag primary">{% trans 'Live version' %}</span>
-                {% elif instance.content_changed and revision == latest_revision %}<span class="status-tag primary">{% trans 'Current draft' %}</span>{% endif %}
+                {% if instance.action == 'wagtail.publish' and revision == object.live_revision %}{% trans 'Live version' as status_label %}{% status status_label classname="primary" %}
+                {% elif instance.content_changed and revision == latest_revision %}{% trans 'Current draft' as status_label %}{% status status_label classname="primary" %}{% endif %}
             {% endif %}
             <ul class="actions">
                 {% if preview_enabled and object.is_previewable %}

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -4100,12 +4100,18 @@ class TestSnippetHistory(WagtailTestUtils, TestCase):
 
         # Should show the "live version" status tag for the published revision
         self.assertContains(
-            response, '<span class="status-tag primary">Live version</span>', count=1
+            response,
+            '<span class="status-tag primary">Live version</span>',
+            count=1,
+            html=True,
         )
 
         # Should show the "current draft" status tag for the draft revision
         self.assertContains(
-            response, '<span class="status-tag primary">Current draft</span>', count=1
+            response,
+            '<span class="status-tag primary">Current draft</span>',
+            count=1,
+            html=True,
         )
 
         # Should use the latest draft title in the header subtitle
@@ -4685,19 +4691,25 @@ class TestSnippetChooseStatus(WagtailTestUtils, TestCase):
         response = self.get("choose")
         html = response.json()["html"]
         self.assertTagInHTML("<th>Status</th>", html)
-        self.assertTagInHTML('<div class="status-tag ">draft</div>', html)
-        self.assertTagInHTML('<div class="status-tag primary">live</div>', html)
-        self.assertTagInHTML('<div class="status-tag primary">live + draft</div>', html)
+        self.assertTagInHTML('<span class="status-tag">draft</span>', html)
+        self.assertTagInHTML('<span class="status-tag primary">live</span>', html)
+        self.assertTagInHTML(
+            '<span class="status-tag primary">live + draft</span>', html
+        )
 
     def test_choose_results_view_shows_status_column(self):
         response = self.get("choose_results")
         self.assertContains(response, "<th>Status</th>", html=True)
-        self.assertContains(response, '<div class="status-tag ">draft</div>', html=True)
         self.assertContains(
-            response, '<div class="status-tag primary">live</div>', html=True
+            response, '<span class="status-tag">draft</span>', html=True
         )
         self.assertContains(
-            response, '<div class="status-tag primary">live + draft</div>', html=True
+            response, '<span class="status-tag primary">live</span>', html=True
+        )
+        self.assertContains(
+            response,
+            '<span class="status-tag primary">live + draft</span>',
+            html=True,
         )
 
 

--- a/wagtail/users/templates/wagtailusers/users/list.html
+++ b/wagtail/users/templates/wagtailusers/users/list.html
@@ -45,7 +45,15 @@
                 </td>
                 <td class="username" valign="top">{{ user.get_username }}</td>
                 <td class="level" valign="top">{% if user.is_superuser %}{% trans "Admin" %}{% endif %}</td>
-                <td class="status" valign="top"><div class="status-tag {% if user.is_active %}primary{% endif %}">{% if user.is_active %}{% trans "Active" %}{% else %}{% trans "Inactive" %}{% endif %}</div></td>
+                <td class="status" valign="top">
+                    {% if user.is_active %}
+                        {% trans "Active" as status_label %}
+                        {% status status_label classname="primary" %}
+                    {% else %}
+                        {% trans "Inactive" as status_label %}
+                        {% status status_label %}
+                    {% endif %}
+                </td>
                 <td>{% if user.last_login %}{% human_readable_date user.last_login %}{% endif %}</td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]

addresses issue #8656 
-added a new status_tag.html as UI component 
-using inclusion tag created a new tag called status_tag , args( page, classname )
-created a status_tag.stories.tsx for ```LIVE```  and ```DRAFT``` variations

### DIFFERENCE ### 
as in  case if page is not live it still renders a span in an anchor tag like the live condition 
but with disabled css class
### OUTPUT ### 

**New test **
![image](https://user-images.githubusercontent.com/74553951/208293273-78422ada-683a-471e-824a-7a77938de65f.png)

**Styleguide**

![image](https://user-images.githubusercontent.com/74553951/208292963-8e01d072-31e8-4a2e-b8f9-8429a2014d9f.png)

**Story**

![ezgif-5-67376ee7a6](https://user-images.githubusercontent.com/74553951/207421659-3c5cd3bc-e662-4c0b-88db-2541243df3cc.gif)
