### PR TITLE
Remain on the edit view when saving a snippet draft

### DIFF
--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -253,6 +253,14 @@ class CreateEditViewOptionalFeaturesMixin:
             "object": object,
         }
 
+    def get_success_url(self):
+        if not self.draftstate_enabled or self.action == "publish":
+            return super().get_success_url()
+
+        # If DraftStateMixin is enabled and the action isn't publish,
+        # remain on the edit view
+        return self.get_edit_url()
+
     def save_instance(self):
         """
         Called after the form is successfully validated - saves the object to the db

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -398,6 +398,14 @@ class CreateView(
             )
         return reverse(self.add_url_name)
 
+    def get_edit_url(self):
+        if not self.edit_url_name:
+            raise ImproperlyConfigured(
+                "Subclasses of wagtail.admin.views.generic.models.CreateView must provide an "
+                "edit_url_name attribute or a get_edit_url method"
+            )
+        return reverse(self.edit_url_name, args=(quote(self.object.pk),))
+
     def get_success_url(self):
         if not self.index_url_name:
             raise ImproperlyConfigured(
@@ -412,11 +420,7 @@ class CreateView(
         return self.success_message % {"object": instance}
 
     def get_success_buttons(self):
-        return [
-            messages.button(
-                reverse(self.edit_url_name, args=(quote(self.object.pk),)), _("Edit")
-            )
-        ]
+        return [messages.button(self.get_edit_url(), _("Edit"))]
 
     def get_error_message(self):
         if self.error_message is None:

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -487,7 +487,13 @@ class DraftStateMixin(models.Model):
                 return _("live")
 
     def publish(
-        self, revision, user=None, changed=True, log_action=True, previous_revision=None
+        self,
+        revision,
+        user=None,
+        changed=True,
+        log_action=True,
+        previous_revision=None,
+        skip_permission_checks=False,
     ):
         """
         Publish a revision of the object by applying the changes in the revision to the live object.
@@ -506,7 +512,7 @@ class DraftStateMixin(models.Model):
             changed=changed,
             log_action=log_action,
             previous_revision=previous_revision,
-        ).execute()
+        ).execute(skip_permission_checks=skip_permission_checks)
 
     def unpublish(self, set_expired=False, commit=True, user=None, log_action=True):
         """
@@ -1721,7 +1727,13 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
     update_aliases.alters_data = True
 
     def publish(
-        self, revision, user=None, changed=True, log_action=True, previous_revision=None
+        self,
+        revision,
+        user=None,
+        changed=True,
+        log_action=True,
+        previous_revision=None,
+        skip_permission_checks=False,
     ):
         return PublishPageRevisionAction(
             revision,
@@ -1729,7 +1741,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             changed=changed,
             log_action=log_action,
             previous_revision=previous_revision,
-        ).execute()
+        ).execute(skip_permission_checks=skip_permission_checks)
 
     def unpublish(self, set_expired=False, commit=True, user=None, log_action=True):
         return UnpublishPageAction(
@@ -2826,13 +2838,21 @@ class Revision(models.Model):
 
         return super().delete()
 
-    def publish(self, user=None, changed=True, log_action=True, previous_revision=None):
+    def publish(
+        self,
+        user=None,
+        changed=True,
+        log_action=True,
+        previous_revision=None,
+        skip_permission_checks=False,
+    ):
         return self.content_object.publish(
             self,
             user=user,
             changed=changed,
             log_action=log_action,
             previous_revision=previous_revision,
+            skip_permission_checks=skip_permission_checks,
         )
 
     def get_previous(self):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -224,6 +224,10 @@ class CreateView(generic.CreateEditViewOptionalFeaturesMixin, generic.CreateView
         return url
 
     def get_success_url(self):
+        if self.draftstate_enabled and self.action != "publish":
+            return super().get_success_url()
+
+        # Make sure the redirect to the listing view uses the correct locale
         urlquery = ""
         if self.locale and self.object.locale is not Locale.get_default():
             urlquery = "?locale=" + self.object.locale.language_code


### PR DESCRIPTION
Fixes #9725, requires #9709 ~~and #9711~~.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
