### PR TITLE
Added more configuration (that is supported by all the browsers) to tsconfig file 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,10 @@
 // Rules which have been enforced in configuration upgrades and flag issues in existing code.
 // We need to consider whether to disable those rules permanently, or fix the issues.
 const legacyCode = {
-  'constructor-super': 'off',
   'default-param-last': 'off',
   'no-continue': 'off',
   'no-else-return': 'off',
   'no-restricted-syntax': 'off',
-  'no-this-before-super': 'off',
 };
 
 module.exports = {
@@ -69,7 +67,6 @@ module.exports = {
     {
       files: [
         'client/src/entrypoints/admin/core.js',
-        'client/src/entrypoints/admin/page-chooser.js',
         'client/src/entrypoints/admin/page-editor.js',
         'client/src/entrypoints/admin/telepath/widgets.js',
         'client/src/entrypoints/contrib/typed_table_block/typed_table_block.js',

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -83,6 +83,7 @@ Changelog
  * Maintenance: Extracted generic lock / unlock views from page lock / unlock views (Sage Abdullah)
  * Maintenance: Move `identity` JavaScript util into shared utils folder (LB (Ben Johnston))
  * Maintenance: Remove unnecessary declaration of function to determine URL query params, instead use `URLSearchParams` (Loveth Omokaro)
+ * Maintenance: Update `tsconfig` to better support modern TypeScript development and clean up some code quality issues via Eslint (Loveth Omokaro)
 
 
 4.1.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -118,6 +118,7 @@ export class BaseSequenceChild extends EventEmitter {
     sequence,
     opts,
   ) {
+    super();
     this.blockDef = blockDef;
     this.type = blockDef.name;
     this.prefix = prefix;

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -97,6 +97,7 @@ class InsertPosition extends BaseInsertionControl {
 
 export class ListBlock extends BaseSequenceBlock {
   constructor(blockDef, placeholder, prefix, initialState, initialError) {
+    super();
     this.blockDef = blockDef;
     this.type = blockDef.name;
     this.prefix = prefix;

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -213,6 +213,7 @@ class StreamBlockMenu extends BaseInsertionControl {
 
 export class StreamBlock extends BaseSequenceBlock {
   constructor(blockDef, placeholder, prefix, initialState, initialError) {
+    super();
     this.blockDef = blockDef;
     this.type = blockDef.name;
     this.prefix = prefix;

--- a/client/src/entrypoints/admin/page-chooser.js
+++ b/client/src/entrypoints/admin/page-chooser.js
@@ -8,9 +8,9 @@ class PageChooser extends Chooser {
   chosenResponseName = 'pageChosen';
 
   constructor(id, parentId, options) {
+    super(id);
     this.initialParentId = parentId;
     this.options = options;
-    super(id);
   }
 
   getStateFromHTML() {

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -420,6 +420,7 @@ window.telepath.register(
 
 class BaseDateTimeWidget extends Widget {
   constructor(options) {
+    super();
     this.options = options;
   }
 

--- a/client/src/entrypoints/contrib/table_block/table.test.js
+++ b/client/src/entrypoints/contrib/table_block/table.test.js
@@ -66,6 +66,7 @@ describe('telepath: wagtail.widgets.TableInput', () => {
   let testStrings;
   let testValue;
   let handsontableConstructorMock;
+  let renderMock;
 
   // Call this to render the table block with the current settings
   const render = () => {
@@ -82,10 +83,19 @@ describe('telepath: wagtail.widgets.TableInput', () => {
 
   beforeEach(() => {
     handsontableConstructorMock = jest.fn();
-    window.Handsontable = (...args) => {
-      handsontableConstructorMock(...args);
-    };
-    window.Handsontable.prototype.render = jest.fn();
+    renderMock = jest.fn();
+
+    class HandsontableMock {
+      constructor(...args) {
+        handsontableConstructorMock(...args);
+      }
+
+      render() {
+        renderMock();
+      }
+    }
+
+    window.Handsontable = HandsontableMock;
 
     // Reset options, strings, and value for each test
     testOptions = JSON.parse(JSON.stringify(TEST_OPTIONS));
@@ -131,8 +141,8 @@ describe('telepath: wagtail.widgets.TableInput', () => {
 
   test('Handsontable.render is called', () => {
     render();
-    expect(window.Handsontable.prototype.render.mock.calls.length).toBe(1);
-    expect(window.Handsontable.prototype.render.mock.calls[0].length).toBe(0);
+    expect(renderMock.mock.calls.length).toBe(1);
+    expect(renderMock.mock.calls[0].length).toBe(0);
   });
 
   test('translation', () => {

--- a/client/src/utils/version.js
+++ b/client/src/utils/version.js
@@ -1,11 +1,13 @@
 class VersionNumberFormatError extends Error {
   constructor(versionString) {
+    super(versionString);
     this.message = `Version number '${versionString}' is not formatted correctly.`;
   }
 }
 
 class CanOnlyComparePreReleaseVersionsError extends Error {
   constructor() {
+    super();
     this.message = 'Can only compare prerelease versions';
   }
 }

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -102,6 +102,7 @@ Wagtail now provides a set of utilities for creating data migrations on StreamFi
  * Extracted generic lock / unlock views from page lock / unlock views (Sage Abdullah)
  * Move `identity` JavaScript util into shared utils folder (LB (Ben Johnston))
  * Remove unnecessary declaration of function to determine URL query params, instead use `URLSearchParams` (Loveth Omokaro)
+ * Update `tsconfig` to better support modern TypeScript development and clean up some code quality issues via Eslint (Loveth Omokaro)
 
 ## Upgrade considerations
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,18 @@
 {
   "compilerOptions": {
+    "allowJs": true,
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
     "jsx": "react",
-    "lib": ["es2015", "dom"],
+    "lib": ["DOM", "DOM.iterable"],
+    "moduleResolution": "node",
     "noImplicitAny": false, // TODO: Enable once all existing code is typed
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strictNullChecks": true,
-    "esModuleInterop": true,
-    "allowJs": true,
-    "downlevelIteration": true
+    "strictPropertyInitialization": true, // Requires `--strictNullChecks` be enabled in order to take effect
+    "target": "ES2021" // Since lowest browser support is for Safari 14
   },
   "files": [
     "client/src/index.ts",


### PR DESCRIPTION
Fixes  #9748 

## Fix Summary

-  Added the `target : es2021` option because least browser support is safari 14.  

- Added the `dom.iterable` option in order for the spread operator to work on DOM elements.

- Added the `"strictPropertyInitialization": true` option. This ensures that any class constructor property that is declared must be initialized or set. [Link to an example here](https://www.typescriptlang.org/tsconfig#strictPropertyInitialization)

- Added the `"forceConsistentCasingInFileNames": true` option. This might not be so important but I feel it's just an extra thing that can be added.  Since Typesecript follows the case sensitivity of the file system it is been used on, this can cause some issues when `import` is been used. More info [here](https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames)

