### PR TITLE
Fix RichTextField - StreamField migration example code

### DIFF
--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -643,7 +643,7 @@ def pagerevision_to_streamfield(revision_data):
         except ValueError:
             revision_data['body'] = json.dumps(
                 [{
-                    "value": {"rich_text": body},
+                    "value": body,
                     "type": "rich_text"
                 }],
                 cls=DjangoJSONEncoder)
@@ -658,7 +658,7 @@ def page_to_richtext(page):
     changed = False
     if page.body.raw_text is None:
         raw_text = ''.join([
-            child.value['rich_text'].source for child in page.body
+            child.value.source for child in page.body
             if child.block_type == 'rich_text'
         ])
         page.body = raw_text
@@ -677,7 +677,7 @@ def pagerevision_to_richtext(revision_data):
             pass
         else:
             raw_text = ''.join([
-                child['value']['rich_text'] for child in body_data
+                child['value'] for child in body_data
                 if child['type'] == 'rich_text'
             ])
             revision_data['body'] = raw_text


### PR DESCRIPTION
Follow-up to #8307. It appears that the original code was designed for a StreamField setup where the `rich_text` block is not a RichTextBlock, but a StructBlock with a RichTextBlock child also named `rich_text`. #8307 correctly removed this redundant wrapper from page_to_streamfield, but there are corresponding changes required for the rest of the helper methods.
