### PR TITLE
conditional display of meta description

### DIFF
--- a/wagtail/project_template/project_name/templates/base.html
+++ b/wagtail/project_template/project_name/templates/base.html
@@ -13,7 +13,9 @@
             {% templatetag openblock %} if current_site and current_site.site_name %}- {% templatetag openvariable %} current_site.site_name {% templatetag closevariable %}{% templatetag openblock %} endif %}
             {% templatetag openblock %} endblock %}
         </title>
-        <meta name="description" content="" />
+        {% templatetag openblock %} if page.search_description {% templatetag closeblock %}
+        <meta name="description" content="{% templatetag openvariable %} page.search_description {% templatetag closevariable %}" />
+        {% templatetag openblock %} endif {% templatetag closeblock %}
         <meta name="viewport" content="width=device-width, initial-scale=1" />
 
         {% templatetag opencomment %} Force all links in the live preview panel to be opened in a new tab {% templatetag closecomment %}


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)

Addresses issue https://github.com/wagtail/wagtail/issues/9656

added a conditional check for meta
if no meta description added then there won't be any meta tag
![image](https://user-images.githubusercontent.com/74553951/206281080-2e3c8ff8-acf1-4843-b906-988376993aad.png)

if meta description is added it adapts and put the tag
![image](https://user-images.githubusercontent.com/74553951/206281280-f65e48dc-b959-41e0-9f35-27a2ca0d30b4.png)
### This is how the new projects base.html would look like ### 
![image](https://user-images.githubusercontent.com/74553951/206281484-e5c0b16b-cc21-481c-ae7a-56c4dceec864.png)
