### PR TITLE
removed the function for getURLParam and replaced with URLSearchParam method

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -82,6 +82,7 @@ Changelog
  * Maintenance: Extracted revision and draft state logic from generic views into mixins (Sage Abdullah)
  * Maintenance: Extracted generic lock / unlock views from page lock / unlock views (Sage Abdullah)
  * Maintenance: Move `identity` JavaScript util into shared utils folder (LB (Ben Johnston))
+ * Maintenance: Remove unnecessary declaration of function to determine URL query params, instead use `URLSearchParams` (Loveth Omokaro)
 
 
 4.1.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -268,8 +268,8 @@ $(() => {
     // eslint-disable-next-line func-names
     const search = function () {
       const newQuery = $input.val();
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      const currentQuery = getURLParam('q');
+      const searchParams = new URLSearchParams(window.location.search);
+      const currentQuery = searchParams.get('q');
       // only do the query if it has changed for trimmed queries
       // for example - " " === "" and "firstword " ==== "firstword"
       if (currentQuery.trim() !== newQuery.trim()) {
@@ -278,7 +278,6 @@ $(() => {
         const index = searchNextIndex;
 
         // Update q, reset to first page, and keep other query params
-        const searchParams = new URLSearchParams(window.location.search);
         searchParams.set('q', newQuery);
         searchParams.delete('p');
         const queryString = searchParams.toString();
@@ -302,17 +301,6 @@ $(() => {
           },
         });
       }
-    };
-
-    // eslint-disable-next-line func-names
-    const getURLParam = function (name) {
-      const results = new RegExp('[\\?&]' + name + '=([^]*)').exec(
-        window.location.search,
-      );
-      if (results) {
-        return results[1];
-      }
-      return '';
     };
   }
 

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -101,6 +101,7 @@ Wagtail now provides a set of utilities for creating data migrations on StreamFi
  * Extracted revision and draft state logic from generic views into mixins (Sage Abdullah)
  * Extracted generic lock / unlock views from page lock / unlock views (Sage Abdullah)
  * Move `identity` JavaScript util into shared utils folder (LB (Ben Johnston))
+ * Remove unnecessary declaration of function to determine URL query params, instead use `URLSearchParams` (Loveth Omokaro)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
Fixes #9765 

## Fix Summary

-  Removed the getURLParam function and replaced it with the URLSearchParams method.
- The function was called in a new variable (currentQuery) **line 272**, which I removed and replaced with the get method of the URLSearchParams.
- On running `npm run lint` line 307 gave me errors which I assume is because of this eslint rule `    // eslint-disable-next-line func-names`
- Since `newQuery`  local variable in line 270 was used in `searchParams.set()`, I had to remove it from that line and move it to line 267.
