### PR TITLE
Ensure icon template tag can use `classname` instead of `class_name` by default

### DIFF
--- a/docs/advanced_topics/customisation/streamfield_blocks.md
+++ b/docs/advanced_topics/customisation/streamfield_blocks.md
@@ -71,7 +71,7 @@ A form template for a StructBlock must include the output of `render_form` for e
     {% if help_text %}
         <span>
             <div class="help">
-                {% icon name="help" class_name="default" %}
+                {% icon name="help" classname="default" %}
                 {{ help_text }}
             </div>
         </span>

--- a/docs/contributing/general_guidelines.md
+++ b/docs/contributing/general_guidelines.md
@@ -34,15 +34,7 @@ Examples:
 
 #### Django template tag
 
-```django+html
-{% dialog_toggle classname='button button-primary' %}
-```
-
-```django+html
-<button type="button" class="{{ classname }}" data-a11y-dialog-show="{{ dialog_id }}">
-    {{ text }}
-</button>
-```
+Example template tag definition
 
 ```python
 @register.inclusion_tag("wagtailadmin/shared/dialog/dialog_toggle.html")
@@ -51,6 +43,29 @@ def dialog_toggle(dialog_id, classname="", text=None):
         "classname": classname,
         "text": text,
     }
+```
+
+Example template
+
+```html+django
+{% comment "text/markdown" %}
+
+    Variables accepted by this template:
+
+    - `classname` - {string?} if present, adds classname to button
+    - `dialog_id` - {string} unique id to use to reference the modal which will be triggered
+
+{% endcomment %}
+
+<button type="button" class="{{ classname }}" data-a11y-dialog-show="{{ dialog_id }}">
+    {{ text }}
+</button>
+```
+
+Example usage
+
+```html+django
+{% dialog_toggle classname='button button-primary' %}
 ```
 
 ### Python / Django class driven content
@@ -69,7 +84,7 @@ class Panel:
 | `classname`   | ✅ Preferred for any new code.                                                                                      |
 | `class`       | ✳️ Only if used as part of a generic `attrs`-like dict; however avoid due to conflicts with Python `class` keyword. |
 | `classnames`  | ❌ Avoid for new code.                                                                                              |
-| `class_name`  | ✳️ Some existing code may use this; avoid for new code.                                                             |
+| `class_name`  | ❌ Avoid for new code.                                                                                              |
 | `class_names` | ❌ Avoid for new code.                                                                                              |
 | `className`   | ❌ Avoid for new code.                                                                                              |
 | `classNames`  | ❌ Avoid for new code.                                                                                              |

--- a/wagtail/admin/templates/wagtailadmin/shared/icon.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/icon.html
@@ -1,7 +1,7 @@
 {% spaceless %}
     {# Reference implementation: components/Icon.tsx #}
     {% if wrapped %}<span class="icon-wrapper">{% endif %}
-    <svg class="icon icon-{{ name }} {{ class_name }}" aria-hidden="true">
+    <svg class="icon icon-{{ name }} {{ classname }}" aria-hidden="true">
         <use href="#icon-{{ name }}"></use>
     </svg>
     {% if title %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -669,24 +669,30 @@ def versioned_static(path):
 
 
 @register.inclusion_tag("wagtailadmin/shared/icon.html", takes_context=False)
-def icon(name=None, class_name="icon", title=None, wrapped=False):
+def icon(name=None, classname=None, title=None, wrapped=False, class_name=None):
     """
     Abstracts away the actual icon implementation.
 
     Usage:
         {% load wagtailadmin_tags %}
         ...
-        {% icon name="cogs" class_name="icon--red" title="Settings" %}
+        {% icon name="cogs" classname="icon--red" title="Settings" %}
 
     :param name: the icon name/id, required (string)
-    :param class_name: default 'icon' (string)
+    :param classname: defaults to 'icon' if not provided (string)
     :param title: accessible label intended for screen readers (string)
     :return: Rendered template snippet (string)
     """
     if not name:
         raise ValueError("You must supply an icon name")
 
-    return {"name": name, "class_name": class_name, "title": title, "wrapped": wrapped}
+    return {
+        "name": name,
+        # supporting class_name for backwards compatibility
+        "classname": classname or class_name or "icon",
+        "title": title,
+        "wrapped": wrapped,
+    }
 
 
 @register.filter()

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -604,7 +604,7 @@ class BlockField(forms.Field):
 @lru_cache(maxsize=1)
 def get_help_icon():
     return render_to_string(
-        "wagtailadmin/shared/icon.html", {"name": "help", "class_name": "default"}
+        "wagtailadmin/shared/icon.html", {"name": "help", "classname": "default"}
     )
 
 

--- a/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
+++ b/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
@@ -118,7 +118,7 @@ def pagination_link_previous(current_page, view):
     if current_page.has_previous():
         previous_page_number0 = current_page.previous_page_number() - 1
         tpl = get_template("wagtailadmin/shared/icon.html")
-        icon_svg = tpl.render({"name": "arrow-left", "class_name": "default"})
+        icon_svg = tpl.render({"name": "arrow-left", "classname": "default"})
         return format_html(
             '<li class="prev"><a href="{}">{} {}</a></li>',
             view.get_query_string({view.PAGE_VAR: previous_page_number0}),
@@ -133,7 +133,7 @@ def pagination_link_next(current_page, view):
     if current_page.has_next():
         next_page_number0 = current_page.next_page_number() - 1
         tpl = get_template("wagtailadmin/shared/icon.html")
-        icon_svg = tpl.render({"name": "arrow-right", "class_name": "default"})
+        icon_svg = tpl.render({"name": "arrow-right", "classname": "default"})
         return format_html(
             '<li class="next"><a href="{}">{} {}</a></li>',
             view.get_query_string({view.PAGE_VAR: next_page_number0}),


### PR DESCRIPTION
This contains the minimum change possible to ensure that the `{% icon ...` template tag can use `classname` as per the work in docs on #6028 & also ensures that we can go out with 4.2 having a very consistent approach to `classname` usage across all templates.

This PR does not add any 5.0 removal warning, nor upgrade considerations as technically the icon template tag is not yet 'official', I have updated one use case though in the docs. I will prepare a follow up PR (see #9770 ) on top of this one that updates all usage and adds the warnings.

## Details

- Update icon template to allow `classname`
- Preserve the existing `class_name` usage in most other icon cases
- Update only docs reference to use `classname`
- Update development docs template example for `classname` convention to be in a more logical order & use the correct template syntax
- Update `class_name` as no longer preferred as we have adopted a normalised approach for icon
- Relates to #6107 & #6028

## Checklist

-   [X] Do the tests still pass?
-   [X] Does the code comply with the style guide?
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [X] For new features: Has the documentation been updated accordingly?
