### PR TITLE
Ensure all icon template tags use `classname` instead of `class_name` & add deprecation warning

### DIFF
--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -160,10 +160,13 @@ If these are used within packages or customisations they will need to be updated
 
 | Name                | New (`classname`)                                                                                      | Old (various)                                                                                        |
 | ------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `icon` (see note)   | `{% icon name='spinner' classname='...' %}`                                                            | `{% icon name='spinner class_name='...' %}`                                                          |
 | `dialog_toggle`     | `{% dialog_toggle classname='...' %}`                                                                  | `{% dialog_toggle class_name='...' %}`                                                               |
 | `paginate`          | `{% paginate pages classname="..." %}`                                                                 | `{% paginate pages classnames="..." %}`                                                              |
 | `tab_nav_link`      | `{% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with classname="..." %}`                      | `{% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with classes="..." %}`                      |
 | `side_panel_button` | `{% include 'wagtailadmin/shared/side_panels/includes/side_panel_button.html' with classname="..." %}` | `{% include 'wagtailadmin/shared/side_panels/includes/side_panel_button.html' with classes="..." %}` |
+
+Note that the `icon` template tag will still support `class_name` until Wagtail version 5 but will trigger a deprecation warning.
 
 ### `InlinePanel` JavaScript function is now a class
 

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -16,13 +16,13 @@
                             <li class="{% message_tags message %}">
                                 {% if level_tag == "error" %}
                                     {# There is no error icon, use warning icon instead #}
-                                    {% icon name="warning" class_name="messages-icon" %}
+                                    {% icon name="warning" classname="messages-icon" %}
                                 {% elif message.extra_tags == "lock" %}
-                                    {% icon name="lock" class_name="messages-icon" %}
+                                    {% icon name="lock" classname="messages-icon" %}
                                 {% elif message.extra_tags == "unlock" %}
-                                    {% icon name="lock-open" class_name="messages-icon" %}
+                                    {% icon name="lock-open" classname="messages-icon" %}
                                 {% else %}
-                                    {% icon name=level_tag class_name="messages-icon" %}
+                                    {% icon name=level_tag classname="messages-icon" %}
                                 {% endif %}
                                 {{ message|safe }}
                             </li>

--- a/wagtail/admin/templates/wagtailadmin/chooser/_browse_results.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/_browse_results.html
@@ -11,7 +11,7 @@
         {% else %}
             <div class="c-dropdown t-inverted {{ class }}" style="display: inline-block;">
                 <div class="c-dropdown__button u-btn-current">
-                    {% icon name="site" class_name="default" %}
+                    {% icon name="site" classname="default" %}
                     {{ parent_page.locale.get_display_name }}
                 </div>
             </div>

--- a/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
@@ -39,7 +39,7 @@
                             </td>
                             <td class="task" valign="top">
                                 {% if workflow_state.current_task_state.status == 'rejected' %}
-                                    {% icon name="warning" class_name="default" %}
+                                    {% icon name="warning" classname="default" %}
                                     {% trans "Changes requested at" %}
                                 {% elif workflow_state.current_task_state.status == 'in_progress' %}
                                     {% trans "Awaiting" %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
@@ -60,11 +60,11 @@
                                 {% for task in workflow_tasks %}
                                     <span data-wagtail-tooltip="{{ task.name }}: {{ task.status_display }}">
                                         {% if task.status == 'approved' %}
-                                            {% icon "success" title=task.status_display class_name="default" %}
+                                            {% icon "success" title=task.status_display classname="default" %}
                                         {% elif task.status == 'rejected' %}
-                                            {% icon "error" title=task.status_display class_name="default" %}
+                                            {% icon "error" title=task.status_display classname="default" %}
                                         {% else %}
-                                            {% icon "radio-empty" title=status_display class_name="default" %}
+                                            {% icon "radio-empty" title=status_display classname="default" %}
                                         {% endif %}
                                     </span>
                                 {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/publish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/publish.html
@@ -1,5 +1,5 @@
 {% load i18n wagtailadmin_tags %}
 <button type="submit" name="action-publish" value="action-publish" class="button button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Publishing…' %}">
-    {% if icon_name %}{% icon name=icon_name class_name="button-longrunning__icon" %}{% endif %}
+    {% if icon_name %}{% icon name=icon_name classname="button-longrunning__icon" %}{% endif %}
     {% icon name="spinner" %}<em>{% if is_revision %}{% trans 'Publish this version' %}{% else %}{% trans 'Publish' %}{% endif %}</em>
 </button>

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/save_draft.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/save_draft.html
@@ -1,5 +1,5 @@
 {% load i18n wagtailadmin_tags %}
 <button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Saving…' %}">
-    {% icon name="draft" class_name="button-longrunning__icon" %}
+    {% icon name="draft" classname="button-longrunning__icon" %}
     {% icon name="spinner" %}<em>{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}</em>
 </button>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_locked_indicator.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_locked_indicator.html
@@ -11,6 +11,6 @@
         class="indicator locked-indicator {% if page.locked_by == request.user %}indicator--is-inverse{% endif %}"
         title="{% if page.locked_by == request.user %}{% trans 'This page is locked, by you, to further editing' %}{% else %}{% trans 'This page is locked to further editing' %}{% endif %}"
     >
-        {% icon name="lock" class_name="initial" %}
+        {% icon name="lock" classname="initial" %}
     </span>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_modern_dropdown.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_modern_dropdown.html
@@ -3,7 +3,7 @@
 <div {{ self.attrs }} class="{{ classes|join:' ' }}" data-button-with-dropdown>
     <button class="{{ button_classes|join:' ' }}" data-button-with-dropdown-toggle data-hover-tooltip-content="{{ title }}" data-tippy-offset="[0, -2]">
         <span class="{% if hide_title %}w-sr-only{% endif %}">{{ title }}</span>
-        {% if icon_name %}{% icon name=icon_name class_name='w-w-5 w-h-5' %}{% endif %}
+        {% if icon_name %}{% icon name=icon_name classname='w-w-5 w-h-5' %}{% endif %}
     </button>
 
     <div data-button-with-dropdown-content class="w-hidden w-p-0">
@@ -13,7 +13,7 @@
                     <a href="{{ button.url }}" aria-label="{{ button.attrs.title }}"
                         class="w-group w-inline-flex w-items-center w-text-white hover:w-text-white hover:w-bg-primary-200 w-py-3 w-px-6 w-no-underline w-transition w-outline-offset-inside {{ button.classes|join:' ' }}">
                         {% if button.icon_name %}
-                            {% icon name=button.icon_name class_name='w-w-4 w-h-4 w-mr-3 w-transition w-opacity-50 group-hover:w-opacity-100' %}
+                            {% icon name=button.icon_name classname='w-w-4 w-h-4 w-mr-3 w-transition w-opacity-50 group-hover:w-opacity-100' %}
                         {% endif %}
                         {{ button.label }}
                     </a>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_pagination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_pagination.html
@@ -12,7 +12,7 @@ Pagination for page listings. Used by the `{% paginate %}` template tag.
         <li class="prev">
             {% if page.has_previous %}
                 <a data-page="{{ page.previous_page_number }}" href="{{ base_url }}{% pagination_querystring page.previous_page_number page_key=page_key %}" class="{{ classname }}">
-                    {% icon name="arrow-left" class_name="default" %}
+                    {% icon name="arrow-left" classname="default" %}
                     {% trans "Previous" %}
                 </a>
             {% endif %}
@@ -21,7 +21,7 @@ Pagination for page listings. Used by the `{% paginate %}` template tag.
             {% if page.has_next %}
                 <a data-page="{{ page.next_page_number }}" href="{{ base_url }}{% pagination_querystring page.next_page_number page_key=page_key %}" class="{{ classname }}">
                     {% trans "Next" %}
-                    {% icon name="arrow-right" class_name="default" %}
+                    {% icon name="arrow-right" classname="default" %}
                 </a>
             {% endif %}
         </li>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_privacy_indicator.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_privacy_indicator.html
@@ -12,6 +12,6 @@
         class="indicator privacy-indicator"
         title="{% trans "This page is protected from public view" %}"
     >
-        {% icon name="no-view" class_name="initial" %}
+        {% icon name="no-view" classname="initial" %}
     </span>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
@@ -26,7 +26,7 @@
                     data-tippy-placement="bottom"
                     aria-label="{% trans 'History' %}"
                 >
-                    {% icon name="history" class_name=nav_icon_classes %}
+                    {% icon name="history" classname=nav_icon_classes %}
                 </a>
             {% endif %}
 

--- a/wagtail/admin/templates/wagtailadmin/pages/workflow_history/detail.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/workflow_history/detail.html
@@ -8,13 +8,13 @@
     {% include "wagtailadmin/shared/header.html" with title=title_str %}
 
     <div class="nice-padding">
-        <h2>{% icon "doc-empty-inverse" class_name="initial" %} {{ page.specific_deferred.get_admin_display_title }}</h2>
+        <h2>{% icon "doc-empty-inverse" classname="initial" %} {{ page.specific_deferred.get_admin_display_title }}</h2>
         <p>
             <a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans "Edit / Review" %}</a>
             <a href="{% url 'wagtailadmin_pages:workflow_history' page.id %}" class="button button-small button-secondary">{% trans "Workflow history" %}</a>
         </p>
 
-        <h2>{% icon "clipboard-list" class_name="initial" %} {{ workflow_state.workflow.name }}</h2>
+        <h2>{% icon "clipboard-list" classname="initial" %} {{ workflow_state.workflow.name }}</h2>
 
         <p>
             {% blocktrans trimmed with modified_by=workflow_state.requested_by|user_display_name %}Requested by <b>{{ modified_by }}</b>{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/pages/workflow_history/list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/workflow_history/list.html
@@ -35,9 +35,9 @@
                         {% for task in workflow_state.all_tasks_with_status %}
                             <span data-wagtail-tooltip="{{ task.name }}: {{ task.status_display }}">
                                 {% if task.status == 'approved' %}
-                                    {% icon "success" title=approved_title class_name="initial" %}
+                                    {% icon "success" title=approved_title classname="initial" %}
                                 {% else %}
-                                    {% icon "radio-empty" title=incomplete_title class_name="initial" %}
+                                    {% icon "radio-empty" title=incomplete_title classname="initial" %}
                                 {% endif %}
                             </span>
                         {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/reports/workflow.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/workflow.html
@@ -60,11 +60,11 @@
                             {% for task in workflow_state.all_tasks_with_status %}
                                 <span data-wagtail-tooltip="{{ task.name }}: {{ task.status_display }}">
                                     {% if task.status == 'approved' %}
-                                        {% icon "success" title=task.status_display class_name="initial" %}
+                                        {% icon "success" title=task.status_display classname="initial" %}
                                     {% elif task.status == 'rejected' %}
-                                        {% icon "error" title=task.status_display class_name="initial" %}
+                                        {% icon "error" title=task.status_display classname="initial" %}
                                     {% else %}
-                                        {% icon "radio-empty" title=incomplete_title class_name="initial" %}
+                                        {% icon "radio-empty" title=incomplete_title classname="initial" %}
                                     {% endif %}
                                 </span>
                             {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/shared/ajax_pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/ajax_pagination_nav.html
@@ -8,7 +8,7 @@
         <li class="prev">
             {% if items.has_previous %}
                 <a href="#" data-page="{{ items.previous_page_number }}">
-                    {% icon name="arrow-left" class_name="default" %}
+                    {% icon name="arrow-left" classname="default" %}
                     {% trans 'Previous' %}
                 </a>
             {% endif %}
@@ -17,7 +17,7 @@
             {% if items.has_next %}
                 <a href="#" data-page="{{ items.next_page_number }}">
                     {% trans 'Next' %}
-                    {% icon name="arrow-right" class_name="default" %}
+                    {% icon name="arrow-right" classname="default" %}
                 </a>
             {% endif %}
         </li>

--- a/wagtail/admin/templates/wagtailadmin/shared/breadcrumbs.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/breadcrumbs.html
@@ -18,7 +18,7 @@
                 aria-label="{% trans 'Toggle breadcrumbs' %}"
                 aria-expanded="false"
             >
-                {% icon name="breadcrumb-expand" class_name="w-w-4 w-h-4" %}
+                {% icon name="breadcrumb-expand" classname="w-w-4 w-h-4" %}
             </button>
         {% endif %}
         <div class="w-relative w-h-slim-header w-mr-4 w-top-0 w-z-20 w-flex w-items-center w-flex-row w-flex-1 sm:w-flex-none w-transition w-duration-300">
@@ -43,7 +43,7 @@
                                 >
                                     {% trans "Root" %}
                                 </a>
-                                {% icon name="arrow-right" class_name=icon_classes %}
+                                {% icon name="arrow-right" classname=icon_classes %}
                             </li>
                         {% elif forloop.first %}
                             {# For limited-permission users whose breadcrumb starts further down from the root #}
@@ -55,7 +55,7 @@
                                 <a class="{{ breadcrumb_link_classes }}" href="{{ breadcrumb_url }}{{ querystring_value }}">
                                     {% trans "Root" %}
                                 </a>
-                                {% icon name="arrow-right" class_name=icon_classes %}
+                                {% icon name="arrow-right" classname=icon_classes %}
                             </li>
                         {% elif forloop.last %}
                             <li
@@ -68,7 +68,7 @@
                                     {{ page.get_admin_display_title }}
                                 </a>
                                 {% if trailing_breadcrumb_title %}
-                                    {% icon name="arrow-right" class_name=icon_classes %}
+                                    {% icon name="arrow-right" classname=icon_classes %}
                                 {% endif %}
                             </li>
                         {% else %}
@@ -80,7 +80,7 @@
                                 <a class="{{ breadcrumb_link_classes }}" href="{{ breadcrumb_url }}{{ querystring_value }}">
                                     {{ page.get_admin_display_title }}
                                 </a>
-                                {% icon name="arrow-right" class_name=icon_classes %}
+                                {% icon name="arrow-right" classname=icon_classes %}
                             </li>
                         {% endif %}
                     {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/shared/dialog/dialog.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/dialog/dialog.html
@@ -15,12 +15,12 @@
         <div data-a11y-dialog-hide class="w-dialog__overlay"></div>
         <div class="w-dialog__box">
             <button type="button" data-a11y-dialog-hide aria-label="{% trans 'Close dialog' %}" class="w-dialog__close-button">
-                {% icon name='cross' class_name="w-dialog__close-icon" %}
+                {% icon name='cross' classname="w-dialog__close-icon" %}
             </button>
 
             {% if message_heading and message_icon_name %}
                 <div class="w-dialog__message w-dialog__message--{{ message_status }}">
-                    {% icon name=message_icon_name class_name="w-dialog__message-icon" %}
+                    {% icon name=message_icon_name classname="w-dialog__message-icon" %}
                     <div class="w-dialog__message-header">
                         <strong class="w-dialog__message-heading">{{ message_heading }}</strong>
                         {% if message_description %}<p class="w-dialog__message-description ">{{ message_description }}</p>{% endif %}
@@ -30,7 +30,7 @@
 
             <div class="w-dialog__content">
                 <h2 class="w-dialog__title w-h1" id="title-{{ id }}">
-                    {% if icon_name %}{% icon name=icon_name class_name="w-dialog__icon" %}{% endif %}
+                    {% if icon_name %}{% icon name=icon_name classname="w-dialog__icon" %}{% endif %}
                     {{ title }}
                 </h2>
 

--- a/wagtail/admin/templates/wagtailadmin/shared/field.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/field.html
@@ -42,7 +42,7 @@
         <div class="w-field__errors" data-field-errors {% if error_message_id %}id="{{ error_message_id }}"{% endif %}>
             {# Avoid rendering errors here if the widget itself is taking responsibility for its error rendering. #}
             {% if field and field|has_unrendered_errors %}
-                {% icon name="warning" class_name="w-field__errors-icon" %}
+                {% icon name="warning" classname="w-field__errors-icon" %}
                 <p class="error-message">
                     {% for error in field.errors %}{{ error|escape }} {% endfor %}
                 </p>
@@ -52,7 +52,7 @@
         {# Separate container for the widget with prefix icon and suffix comment button #}
         <div class="w-field__input" data-field-input>
             {% if icon %}
-                {% icon name=icon class_name="w-field__icon" %}
+                {% icon name=icon classname="w-field__icon" %}
             {% endif %}
 
             {% block form_field %}

--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -25,7 +25,7 @@
             <div class="col">
                 <h1 class="w-header__title" id="header-title">
                     {% if icon %}
-                        {% icon class_name="w-header__glyph" name=icon %}
+                        {% icon classname="w-header__glyph" name=icon %}
                     {% elif avatar %}
                         <div class="w-header__glyph avatar"><img src="{{ avatar }}" alt="" /></div>
                     {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
@@ -27,7 +27,7 @@
                 data-tippy-placement="bottom"
                 aria-label="{% trans 'History' %}"
             >
-                {% icon name="history" class_name=nav_icon_classes %}
+                {% icon name="history" classname=nav_icon_classes %}
             </a>
         {% endif %}
 

--- a/wagtail/admin/templates/wagtailadmin/shared/locale_selector.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/locale_selector.html
@@ -3,7 +3,7 @@
 {% if translations %}
     <div class="c-dropdown t-inverted {{ class }}" style="display: inline-block;" data-dropdown>
         <a href="javascript:void(0)" aria-label="{{ locale.get_display_name }}" class="c-dropdown__button u-btn-current w-no-underline">
-            {% icon name="site" class_name="default" %}
+            {% icon name="site" classname="default" %}
             {{ locale.get_display_name }}
             <div data-dropdown-toggle class="o-icon c-dropdown__toggle c-dropdown__togle--icon [ icon icon-arrow-down ]">
                 {% icon name="arrow-down" %}{% icon name="arrow-up" %}
@@ -22,6 +22,6 @@
         </div>
     </div>
 {% else %}
-    {% icon name="site" class_name="default" %}
+    {% icon name="site" classname="default" %}
     {{ locale.get_display_name }}
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/page_status_tag_new.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/page_status_tag_new.html
@@ -38,9 +38,9 @@
 
         {% with icon_classes='privacy-indicator-icon w-w-4 w-h-4 w-mr-1' %}
             {% if is_public %}
-                {% icon name="view" class_name=icon_classes %}
+                {% icon name="view" classname=icon_classes %}
             {% else %}
-                {% icon name="no-view" class_name=icon_classes %}
+                {% icon name="no-view" classname=icon_classes %}
             {% endif %}
         {% endwith %}
 

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -14,7 +14,7 @@
         <li class="prev">
             {% if items.has_previous %}
                 <a href="{{ url_path }}{% querystring p=items.previous_page_number %}">
-                    {% icon name="arrow-left" class_name="default" %}
+                    {% icon name="arrow-left" classname="default" %}
                     {% trans 'Previous' %}
                 </a>
             {% endif %}
@@ -23,7 +23,7 @@
             {% if items.has_next %}
                 <a href="{{ url_path }}{% querystring p=items.next_page_number %}">
                     {% trans 'Next' %}
-                    {% icon name="arrow-right" class_name="default" %}
+                    {% icon name="arrow-right" classname="default" %}
                 </a>
             {% endif %}
         </li>

--- a/wagtail/admin/templates/wagtailadmin/shared/panel.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/panel.html
@@ -24,11 +24,11 @@
     {% if heading or header_controls %}
         <div class="w-panel__header">
             <a class="w-panel__anchor w-panel__anchor--prefix" href="#{{ panel_id }}" data-panel-anchor aria-labelledby="{{ heading_id }}">
-                {% icon name="link" class_name="w-panel__icon" %}
+                {% icon name="link" classname="w-panel__icon" %}
             </a>
             <button class="w-panel__toggle" type="button" aria-label="{% trans 'Toggle section' %}" aria-describedby="{{ heading_id }}" data-panel-toggle aria-controls="{{ content_id }}" aria-expanded="true">
                 {% firstof icon "arrow-down-big" as icon_name %}
-                {% icon name=icon_name class_name="w-panel__icon" %}
+                {% icon name=icon_name classname="w-panel__icon" %}
             </button>
             {% if heading %}
                 <h2 class="w-panel__heading {% if heading_size == "label" %}w-panel__heading--label{% endif %}" {% if heading_level %}aria-level="{{ heading_level }}"{% endif %} id="{{ heading_id }}" data-panel-heading>
@@ -40,13 +40,13 @@
                 </h2>
             {% endif %}
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#{{ panel_id }}" aria-labelledby="{{ heading_id }}">
-                {% icon name="link" class_name="w-panel__icon" %}
+                {% icon name="link" classname="w-panel__icon" %}
             </a>
             <div class="w-panel__divider"></div>
             {% if header_controls %}
                 <div class="w-panel__controls" data-panel-controls>
                     <div class="w-panel__controls-cue">
-                        {% icon name="dots-horizontal" class_name="w-panel__icon" %}
+                        {% icon name="dots-horizontal" classname="w-panel__icon" %}
                     </div>
                     {{ header_controls }}
                 </div>

--- a/wagtail/admin/templates/wagtailadmin/shared/search_area.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/search_area.html
@@ -1,4 +1,4 @@
 {% load wagtailadmin_tags %}
 <li>
-    <a href="{{ url }}?q={{ query_string|urlencode }}" class="{{ classnames }}{% if active %} nolink{% endif %}"{{ attr_string }}>{% if icon_name %}{% icon name=icon_name class_name="filter-options__icon" %}{% endif %}{{ label }}</a>
+    <a href="{{ url }}?q={{ query_string|urlencode }}" class="{{ classnames }}{% if active %} nolink{% endif %}"{{ attr_string }}>{% if icon_name %}{% icon name=icon_name classname="filter-options__icon" %}{% endif %}{{ label }}</a>
 </li>

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panel_toggles.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panel_toggles.html
@@ -10,6 +10,6 @@
         data-side-panel-toggle="{{ panel.name }}"
         aria-expanded="false"
     >
-        {% icon name=panel.toggle_icon_name class_name=nav_icon_classes %}
+        {% icon name=panel.toggle_icon_name classname=nav_icon_classes %}
     </button>
 {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/action_list_item.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/action_list_item.html
@@ -3,7 +3,7 @@
 
     {% block content %}
         <section class="w-flex w-space-x-3" aria-labelledby="status-sidebar-{{ title|cautious_slugify }}">
-            {% icon name=icon_name class_name='w-w-5 w-h-5 w-text-primary w-flex-shrink-0' %}
+            {% icon name=icon_name classname='w-w-5 w-h-5 w-text-primary w-flex-shrink-0' %}
 
             <div class="w-flex w-flex-1 w-items-start w-justify-between">
                 <div class="w-flex w-flex-col w-flex-1 w-pr-5">

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/side_panel_button.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/side_panel_button.html
@@ -12,7 +12,7 @@
     <button type="button" class="{{ classname }} w-bg-transparent w-text-14 w-p-0 w-text-secondary hover:w-text-secondary-600 w-inline-flex w-justify-center w-transition" {% if data_url %}data-url="{{ data_url }}" {% endif %}{% if has_toggle %}data-button-with-dropdown-toggle {% endif %}{{ attr }}>
         {{ text }}
         {% if has_toggle %}
-            {% icon name='arrow-down' class_name='w-w-4 w-h-4 w-transition motion-reduce:w-transition-none' %}
+            {% icon name='arrow-down' classname='w-w-4 w-h-4 w-transition motion-reduce:w-transition-none' %}
         {% endif %}
     </button>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/workflow.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/workflow.html
@@ -40,7 +40,7 @@
                             {% page_permissions object as page_perms %}
                         {% endif %}
                         <div class="w-p-4 w-bg-info-50 w-rounded w-flex w-space-x-3">
-                            {% icon name='calendar-check' class_name='w-w-4 w-h-4 w-text-info-100' %}
+                            {% icon name='calendar-check' classname='w-w-4 w-h-4 w-text-info-100' %}
                             <div class="w-flex w-flex-1 w-items-start w-justify-between">
                                 <div class="w-flex w-flex-col w-flex-1 w-pr-5 w-space-y-1 w-help-text">
                                     <div>
@@ -125,7 +125,7 @@
     {% with workflow_state=object.current_workflow_state draft_revision=object.get_latest_revision %}
         {% if workflow_state %}
             <div class="w-flex w-space-x-4">
-                {% icon name='info-circle' class_name='w-w-4 w-h-4 w-text-info-100 w-shrink-0' %}
+                {% icon name='info-circle' classname='w-w-4 w-h-4 w-text-info-100 w-shrink-0' %}
                 <div class="w-label-3 w-flex-1">
                     {% workflow_status_with_date workflow_state %}
                 </div>
@@ -136,9 +136,9 @@
         {% if has_draft_publishing_schedule %}
             <div class="w-p-4 w-bg-info-50 w-rounded w-flex w-space-x-3">
                 {% if scheduled_go_live_at or scheduled_expire_at %}
-                    {% icon name='calendar-check' class_name='w-w-4 w-h-4 w-text-info-100' %}
+                    {% icon name='calendar-check' classname='w-w-4 w-h-4 w-text-info-100' %}
                 {% else %}
-                    {% icon name='calendar' class_name='w-w-4 w-h-4 w-text-info-100' %}
+                    {% icon name='calendar' classname='w-w-4 w-h-4 w-text-info-100' %}
                 {% endif %}
                 <div class="w-flex w-flex-1 w-items-start w-justify-between">
                     <div class="w-flex w-flex-col w-flex-1 w-pr-5 w-space-y-1 w-help-text">

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/preview.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/preview.html
@@ -21,7 +21,7 @@
     </div>
 
     <div class="preview-panel__spinner w-hidden" data-preview-spinner>
-        {% icon name="spinner" class_name="default" %}
+        {% icon name="spinner" classname="default" %}
         <span class="w-sr-only">{% trans 'Loading'%}</span>
     </div>
 
@@ -32,7 +32,7 @@
     <div class="preview-panel__area">
         <div class="preview-panel__controls{% if has_multiple_modes %} preview-panel__controls--multiple{% endif %}">
             <div id="preview-panel-error-banner" class="preview-panel__error-banner">
-                {% icon name='warning' class_name='default' %}
+                {% icon name='warning' classname='default' %}
                 <div>
                     <h3 class="preview-panel__error-title">
                         {% trans 'Preview is out of date' %}

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_admin.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_admin.html
@@ -3,7 +3,7 @@
 
 {% block item_content %}
     <a href="{% url 'wagtailadmin_home' %}" target="_parent" role="menuitem">
-        {% icon name="wagtail-icon" class_name="w-action-icon" %}
+        {% icon name="wagtail-icon" classname="w-action-icon" %}
         {% trans 'Go to Wagtail admin' %}
     </a>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_add.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_add.html
@@ -3,7 +3,7 @@
 
 {% block item_content %}
     <a href="{% url 'wagtailadmin_pages:add_subpage' self.page.id %}" target="_parent" role="menuitem">
-        {% icon name="plus" class_name="w-action-icon" %}
+        {% icon name="plus" classname="w-action-icon" %}
         {% trans 'Add a child page' %}
     </a>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_approve.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_approve.html
@@ -5,7 +5,7 @@
     <form action="{% url 'wagtailadmin_pages:approve_moderation' self.revision.id %}" target="_parent" method="post">
         {% csrf_token %}
         <button type="submit" value="{% trans 'Approve' %}" class="button" role="menuitem">
-            {% icon name="tick" class_name="w-action-icon" %}
+            {% icon name="tick" classname="w-action-icon" %}
             {% trans 'Approve' %}
         </button>
     </form>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_edit.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_edit.html
@@ -3,7 +3,7 @@
 
 {% block item_content %}
     <a href="{% url 'wagtailadmin_pages:edit' self.page.id %}" target="_parent" role="menuitem">
-        {% icon name="edit" class_name="w-action-icon" %}
+        {% icon name="edit" classname="w-action-icon" %}
         {% trans 'Edit this page' %}
     </a>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_explore.html
@@ -3,7 +3,7 @@
 
 {% block item_content %}
     <a href="{% url 'wagtailadmin_explore' self.parent_page.id %}" target="_parent" role="menuitem">
-        {% icon name="folder-open-inverse" class_name="w-action-icon" %}
+        {% icon name="folder-open-inverse" classname="w-action-icon" %}
         {% trans 'Show in Explorer' %}
     </a>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_reject.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_reject.html
@@ -5,7 +5,7 @@
     <form action="{% url 'wagtailadmin_pages:reject_moderation' self.revision.id %}" target="_parent" method="post">
         {% csrf_token %}
         <button type="submit" value="{% trans 'Reject' %}" class="button" role="menuitem">
-            {% icon name="cross" class_name="w-action-icon" %}
+            {% icon name="cross" classname="w-action-icon" %}
             {% trans 'Reject' %}
         </button>
     </form>

--- a/wagtail/admin/templates/wagtailadmin/widgets/switch.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/switch.html
@@ -2,6 +2,6 @@
 <label class="switch">
     {% include "django/forms/widgets/input.html" %}
     <span class="switch__toggle">
-        {% icon name="tick" class_name="switch__tick" %}
+        {% icon name="tick" classname="switch__tick" %}
     </span>
 </label>

--- a/wagtail/admin/templates/wagtailadmin/workflows/workflow_status.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/workflow_status.html
@@ -4,7 +4,7 @@
 
     <li class="workflow-timeline__item workflow-timeline__item--approved">
         <div class="workflow-timeline__line"></div>
-        {% icon name="circle-check" class_name="workflow-timeline__icon" %}
+        {% icon name="circle-check" classname="workflow-timeline__icon" %}
         {% trans "Submitted" %}
     </li>
 
@@ -17,7 +17,7 @@
                     <div class="workflow-timeline__line"></div>
                     {% if status == "rejected" %}
                         <div class="w-flex">
-                            {% icon name="warning" class_name="workflow-timeline__icon" title=status_display %}
+                            {% icon name="warning" classname="workflow-timeline__icon" title=status_display %}
                             <div class="w-flex w-flex-col">
                                 <strong>{{ task.name }}</strong>
                                 {% if task.task_state.finished_by %}
@@ -30,7 +30,7 @@
                             </div>
                         </div>
                     {% else %}
-                        {% if status == "in_progress" %}{% icon name="radio-full" class_name="workflow-timeline__icon" title=status_display %}{% else %}{% icon name="radio-empty" class_name="workflow-timeline__icon" title=status_display %}{% endif %}
+                        {% if status == "in_progress" %}{% icon name="radio-full" classname="workflow-timeline__icon" title=status_display %}{% else %}{% icon name="radio-empty" classname="workflow-timeline__icon" title=status_display %}{% endif %}
                         {{ task.name }}
                         {% if task.task_state.finished_by %}
                             {% blocktrans trimmed with approved_by=task.task_state.finished_by|user_display_name %}
@@ -51,7 +51,7 @@
 
     {# Published status #}
     <li class="workflow-timeline__item workflow-timeline__item--pending">
-        {% icon name="radio-empty" class_name="workflow-timeline__icon" %}{% trans "Published" %}
+        {% icon name="radio-empty" classname="workflow-timeline__icon" %}{% trans "Published" %}
     </li>
 </ol>
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from urllib.parse import urljoin
+from warnings import warn
 
 from django import template
 from django.conf import settings
@@ -685,6 +686,17 @@ def icon(name=None, classname=None, title=None, wrapped=False, class_name=None):
     """
     if not name:
         raise ValueError("You must supply an icon name")
+
+    if class_name:
+        from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+        warn(
+            (
+                "Icon template tag `class_name` has been renamed to `classname`, please adopt the new usage instead.",
+                f'Replace `{{% icon ... class_name="{class_name}" %}}` with `{{% icon ... classname="{class_name}" %}}`',
+            ),
+            category=RemovedInWagtail50Warning,
+        )
 
     return {
         "name": name,

--- a/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
@@ -27,7 +27,7 @@
         <div class="nice-padding">
             <p class="back">
                 <a href="{{ view.index_url }}">
-                    {% icon name="arrow-left" class_name="default" %}
+                    {% icon name="arrow-left" classname="default" %}
                     {% blocktrans trimmed with view.verbose_name as model_name %}Back to {{ model_name }} list{% endblocktrans %}
                 </a>
             </p>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/header_with_history.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/header_with_history.html
@@ -11,7 +11,7 @@
                     {% include "wagtailadmin/shared/last_updated.html" with last_updated=latest_log_entry.timestamp show_time_prefix=True %}
                 </li>
                 {% if history_url %}
-                    <li><a href="{{ history_url }}">{% icon "history" class_name="default" %} {% trans "History" %}</a></li>
+                    <li><a href="{{ history_url }}">{% icon "history" classname="default" %} {% trans "History" %}</a></li>
                 {% endif %}
             </ul>
         {% endif %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -24,7 +24,7 @@
                     <div class="col">
                         {% block h1 %}
                             <h1 class="w-header__title">
-                                {% if view.header_icon %}{% icon class_name="w-header__glyph" name=view.header_icon %}{% endif %}
+                                {% if view.header_icon %}{% icon classname="w-header__glyph" name=view.header_icon %}{% endif %}
                                 {{ view.get_page_title }}
                                 {% if view.get_page_subtitle %} <span class="w-header__subtitle">{{ view.get_page_subtitle }}</span> {% endif %}
                                 {% include 'modeladmin/includes/result_count.html' %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
@@ -27,7 +27,7 @@
             <div class="nice-padding">
                 <p class="back">
                     <a href="{{ view.index_url }}">
-                        {% icon name="arrow-left" class_name="default" %}
+                        {% icon name="arrow-left" classname="default" %}
                         {% blocktrans trimmed with view.verbose_name as model_name %}Back to {{ model_name }} list{% endblocktrans %}
                     </a>
                 </p>

--- a/wagtail/locales/templates/wagtaillocales/_language_title_cell.html
+++ b/wagtail/locales/templates/wagtaillocales/_language_title_cell.html
@@ -5,7 +5,7 @@
         <a href="{{ link_url }}">{{ value }}</a>
         {% if not value.language_code_is_valid %}
             {% trans "This locale's language code is not supported" as error %}
-            {% icon name="warning" class_name="locale-error" title=error %}
+            {% icon name="warning" classname="locale-error" title=error %}
         {% endif %}
     </div>
 </td>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/_header_with_history.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/_header_with_history.html
@@ -11,9 +11,9 @@
                     {% include "wagtailadmin/shared/last_updated.html" with last_updated=latest_log_entry.timestamp show_time_prefix=True %}
                 </li>
                 {% if history_url %}
-                    <li><a href="{{ history_url }}">{% icon "history" class_name="default" %} {% trans "History" %}</a></li>
+                    <li><a href="{{ history_url }}">{% icon "history" classname="default" %} {% trans "History" %}</a></li>
                 {% endif %}
-                <li>{% icon "snippet" class_name="default" %} {{ model_opts.verbose_name|capfirst }}</li>
+                <li>{% icon "snippet" classname="default" %} {{ model_opts.verbose_name|capfirst }}</li>
             </ul>
         </div>
     {% endif %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/publish.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/publish.html
@@ -1,5 +1,5 @@
 {% load i18n wagtailadmin_tags %}
 <button type="submit" name="{{ name }}" value="{{ name }}" class="button action-save button-longrunning{% if is_revision %} warning{% endif %}" data-clicked-text="{% trans 'Publishing…' %}">
-    {% icon name=icon_name class_name="button-longrunning__icon" %}
+    {% icon name=icon_name classname="button-longrunning__icon" %}
     {% icon name="spinner" %}<em>{% if is_revision %}{% trans 'Publish this version' %}{% else %}{% trans 'Publish' %}{% endif %}</em>
 </button>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/save.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/save.html
@@ -1,6 +1,6 @@
 {% load i18n wagtailadmin_tags %}
 <button type="submit" class="button action-save button-longrunning{% if is_revision %} warning{% endif %}" data-clicked-text="{% trans 'Saving…' %}">
-    {% icon name=icon_name class_name="button-longrunning__icon" %}
+    {% icon name=icon_name classname="button-longrunning__icon" %}
     {% icon name="spinner" %}
     <em>
         {% if is_revision %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/headers/_base_header.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/headers/_base_header.html
@@ -14,7 +14,7 @@
                 aria-label="{% trans 'Toggle breadcrumbs' %}"
                 aria-expanded="false"
             >
-                {% icon name="breadcrumb-expand" class_name="w-w-4 w-h-4" %}
+                {% icon name="breadcrumb-expand" classname="w-w-4 w-h-4" %}
             </button>
 
             <div class="w-relative w-h-slim-header w-mr-4 w-top-0 w-z-20 w-flex w-items-center w-flex-row w-flex-1 sm:w-flex-none w-transition w-duration-300">
@@ -26,13 +26,13 @@
                                 <a class="{{ breadcrumb_link_classes }}" href="{% url 'wagtailsnippets:index' %}">
                                     {% trans "Snippets" %}
                                 </a>
-                                {% icon name="arrow-right" class_name=icon_classes %}
+                                {% icon name="arrow-right" classname=icon_classes %}
                             </li>
                             <li class="{{ breadcrumb_item_classes }} w-max-w-0" data-breadcrumb-item hidden>
                                 <a class="{{ breadcrumb_link_classes }}" href="{% url view.index_url_name %}">
                                     {{ model_opts.verbose_name_plural|capfirst }}
                                 </a>
-                                {% icon name="arrow-right" class_name=icon_classes %}
+                                {% icon name="arrow-right" classname=icon_classes %}
                             </li>
                         {% endblock %}
                     </ol>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/headers/edit_header.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/headers/edit_header.html
@@ -30,7 +30,7 @@
             data-tippy-placement="bottom"
             aria-label="{% trans 'History' %}"
         >
-            {% icon name="history" class_name=nav_icon_classes %}
+            {% icon name="history" classname=nav_icon_classes %}
         </a>
     {% endwith %}
 {% endblock %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/headers/history_header.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/headers/history_header.html
@@ -7,7 +7,7 @@
         <a class="{{ breadcrumb_link_classes }}" href="{% url view.edit_url_name object.pk|admin_urlquote %}">
             {{ object }}
         </a>
-        {% icon name="arrow-right" class_name=icon_classes %}
+        {% icon name="arrow-right" classname=icon_classes %}
     </li>
     <li class="{{ breadcrumb_item_classes }}">
         <div class="w-flex w-justify-start w-items-center">

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/headers/list_header.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/headers/list_header.html
@@ -6,7 +6,7 @@
         <a class="{{ breadcrumb_link_classes }}" href="{% url 'wagtailsnippets:index' %}">
             {% trans "Snippets" %}
         </a>
-        {% icon name="arrow-right" class_name=icon_classes %}
+        {% icon name="arrow-right" classname=icon_classes %}
     </li>
     <li class="{{ breadcrumb_item_classes }}">
         <a class="{{ breadcrumb_link_classes }}" href="{% url view.index_url_name %}">

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/headers/usage_header.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/headers/usage_header.html
@@ -7,7 +7,7 @@
         <a class="{{ breadcrumb_link_classes }}" href="{% url view.edit_url_name object.pk|admin_urlquote %}">
             {{ object }}
         </a>
-        {% icon name="arrow-right" class_name=icon_classes %}
+        {% icon name="arrow-right" classname=icon_classes %}
     </li>
     <li class="{{ breadcrumb_item_classes }}">
         <div class="w-flex w-justify-start w-items-center">

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -23,7 +23,7 @@
             <div class="left">
                 <div class="col">
                     <h1 class="w-header__title">
-                        {% icon class_name="w-header__glyph" name="snippet" %} {{ model_opts.verbose_name_plural|capfirst }}
+                        {% icon classname="w-header__glyph" name="snippet" %} {{ model_opts.verbose_name_plural|capfirst }}
                     </h1>
                 </div>
                 {% if is_searchable and search_url %}


### PR DESCRIPTION
This PR builds on top of #9769 and updates all `{% icon ...` template tag usage to `classname` instead of `class_name`. It also adds a deprecation warning & upgrade considerations to move away from using the previous approach.

- Relates to #6107 & #6028

## To validate

Within Bakerydemo, or even Wagtail admin code, change an icon template usage to use `class_name='...'` and you should see something like the following warning in the console.

    /code/wagtail/wagtail/admin/templatetags/wagtailadmin_tags.py:693: RemovedInWagtail50Warning: ('Icon template tag `class_name` has been renamed to `classname`, please adopt the new usage instead.', 'Replace `{% icon ... class_name="button-longrunning__icon" %}` with `{% icon ... classname="button-longrunning__icon" %}`')

## Checklist

-   [X] Do the tests still pass?
-   [X] Does the code comply with the style guide?
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [X] For new features: Has the documentation been updated accordingly?
