### PR TITLE
Fix horizontal positioning of rich text inline toolbar

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,6 +47,7 @@ Changelog
  * Fix: Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
  * Fix: Use the correct padding for autocomplete block picker (Umar Farouk Yunusa)
  * Fix: Ensure that short content pages (such as editing snippets) do not show an inconsistent background (Sage Abdullah)
+ * Fix: Fix horizontal positioning of rich text inline toolbar (Thibaud Colas)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)

--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -76,7 +76,9 @@ $draftail-editor-font-family: $font-sans;
 }
 
 .Draftail-Editor {
-  --draftail-offset-inline-start: 0;
+  // Number used inside a `calc` function, which doesn’t support unitless zero.
+  // stylelint-disable-next-line length-zero-no-unit
+  --draftail-offset-inline-start: 0px;
 }
 
 .Draftail-Editor__wrapper {

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -61,6 +61,7 @@ Wagtail now provides a set of utilities for creating data migrations on StreamFi
  * Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
  * Use the correct padding for autocomplete block picker (Umar Farouk Yunusa)
  * Ensure that short content pages (such as editing snippets) do not show an inconsistent background (Sage Abdullah)
+ * Fix horizontal positioning of rich text inline toolbar (Thibaud Colas)
 
 ### Documentation
 


### PR DESCRIPTION
Ahem. Took me quite a while to figure this one out, this is the first time I hear of unitless zero being a bad thing in CSS. `0` is invalid in `calc`, it has to have a unit.

This fixes the horizontal position of the inline toolbar in Draftail, which was always left-aligned with the left edge of the editor. Now it should be centered with the left side of the text selection:

![toolbar-horizontal-pos](https://user-images.githubusercontent.com/877585/206655970-2965d8b5-c3f5-4561-8b63-5cb331e5b43f.png)

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 108, Firefox 106, Safari 16.1 on macOS 13.0.1
    -   [x] **Please list which assistive technologies [^3] you tested**:  None
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

To test this, make a text selection in any editor and check where the inline toolbar is placed on the horizontal axis.