### PR TITLE
POC: Move `wagtailConfig` values to `wagtail_config` template tag

### DIFF
--- a/client/src/config/wagtailConfig.js
+++ b/client/src/config/wagtailConfig.js
@@ -1,20 +1,4 @@
-export const { ADMIN_API } = global.wagtailConfig;
-export const { ADMIN_URLS } = global.wagtailConfig;
-
-// Maximum number of pages to load inside the explorer menu.
-export const MAX_EXPLORER_PAGES = 200;
-
-export const LOCALE_NAMES = new Map();
-
-/* eslint-disable-next-line camelcase */
-global.wagtailConfig.LOCALES.forEach(({ code, display_name }) => {
-  LOCALE_NAMES.set(code, display_name);
-});
-
 function getWagtailConfig() {
-  // TODO: Move window.wagtailConfig from the base HTML template
-  // to the wagtail-config JSON script.
-
   try {
     return JSON.parse(document.getElementById('wagtail-config')?.textContent);
   } catch (err) {
@@ -31,3 +15,18 @@ function getWagtailConfig() {
 }
 
 export const WAGTAIL_CONFIG = getWagtailConfig();
+
+global.wagtailConfig = WAGTAIL_CONFIG;
+
+export const { ADMIN_API } = WAGTAIL_CONFIG;
+export const { ADMIN_URLS } = WAGTAIL_CONFIG;
+
+// Maximum number of pages to load inside the explorer menu.
+export const MAX_EXPLORER_PAGES = 200;
+
+export const LOCALE_NAMES = new Map();
+
+/* eslint-disable-next-line camelcase */
+WAGTAIL_CONFIG.LOCALES.forEach(({ code, display_name }) => {
+  LOCALE_NAMES.set(code, display_name);
+});

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -15,34 +15,6 @@
 {% endblock %}
 
 {% block js %}
-    <script>
-        (function(document, window) {
-            window.wagtailConfig = window.wagtailConfig || {};
-            wagtailConfig.ADMIN_API = {
-                PAGES: '{% url "wagtailadmin_api:pages:listing" %}',
-                DOCUMENTS: '{% url "wagtailadmin_api:documents:listing" %}',
-                IMAGES: '{% url "wagtailadmin_api:images:listing" %}',
-                {# // Use this to add an extra query string on all API requests. #}
-                {# // Example value: '&order=-id' #}
-                EXTRA_CHILDREN_PARAMETERS: '',
-            };
-
-            {% i18n_enabled as i18n_enabled %}
-            {% locales as locales %}
-            wagtailConfig.I18N_ENABLED = {% if i18n_enabled %}true{% else %}false{% endif %};
-            wagtailConfig.LOCALES = {{ locales|safe }};
-
-            {% if locale %}
-                wagtailConfig.ACTIVE_CONTENT_LOCALE = '{{ locale.language_code }}'
-            {% endif %}
-
-            wagtailConfig.STRINGS = {% js_translation_strings %};
-
-            wagtailConfig.ADMIN_URLS = {
-                PAGES: '{% url "wagtailadmin_explore_root" %}'
-            };
-        })(document, window);
-    </script>
     {% wagtail_config as config %}
     {{ config|json_script:"wagtail-config" }}
     <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery-3.6.0.min.js' %}"></script>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -793,16 +793,15 @@ def i18n_enabled():
 
 
 @register.simple_tag
-def locales():
-    return json.dumps(
-        [
-            {
-                "code": locale.language_code,
-                "display_name": force_str(locale.get_display_name()),
-            }
-            for locale in Locale.objects.all()
-        ]
-    )
+def locales(serialize=True):
+    result = [
+        {
+            "code": locale.language_code,
+            "display_name": force_str(locale.get_display_name()),
+        }
+        for locale in Locale.objects.all()
+    ]
+    return json.dumps(result) if serialize else result
 
 
 @register.simple_tag
@@ -870,10 +869,23 @@ def wagtail_config(context):
         "CSRF_HEADER_NAME": HttpHeaders.parse_header_name(
             getattr(settings, "CSRF_HEADER_NAME")
         ),
+        "ADMIN_API": {
+            "PAGES": reverse("wagtailadmin_api:pages:listing"),
+            "DOCUMENTS": reverse("wagtailadmin_api:documents:listing"),
+            "IMAGES": reverse("wagtailadmin_api:images:listing"),
+            "EXTRA_CHILDREN_PARAMETERS": "",
+        },
         "ADMIN_URLS": {
             "DISMISSIBLES": reverse("wagtailadmin_dismissibles"),
+            "PAGES": reverse("wagtailadmin_explore_root"),
         },
+        "I18N_ENABLED": i18n_enabled(),
+        "LOCALES": locales(serialize=False),
+        "STRINGS": get_js_translation_strings(),
     }
+
+    if context.get("locale"):
+        config["ACTIVE_CONTENT_LOCALE"] = context["locale"].language_code
 
     default_settings = {
         "WAGTAIL_AUTO_UPDATE_PREVIEW": True,


### PR DESCRIPTION
This is just a POC of the first step on cleaning up our client-side metadata configuration. With this approach, the values are computed in the `wagtail_config` template tag and passed into the template using Django's `json_script`. Then, it's parsed on the client-side and set as `global.wagtailConfig` to retain compatibility with existing code that rely on `window.wagtailConfig`.

This allows us to remove our existing approach of putting metadata values in a `<script>` tag using Django templates directly in the HTML, without changing too much of the existing code, and allowing new code to import the values as `WAGTAIL_CONFIG` from `wagtailConfig.js` instead of using `window.wagtailConfig`.