### PR TITLE
Decimal value block null causes server to crash. See issue #9777

### DIFF
--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -252,8 +252,8 @@ class DecimalBlock(FieldBlock):
 
     def to_python(self, value):
         if value is None:
-             return value
-         else:
+            return value
+        else:
             return Decimal(value)
 
     class Meta:

--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -251,7 +251,10 @@ class DecimalBlock(FieldBlock):
         super().__init__(*args, **kwargs)
 
     def to_python(self, value):
-        return Decimal(value)
+        if value is None:
+             return value
+         else:
+            return Decimal(value)
 
     class Meta:
         icon = "plus-inverse"

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -422,7 +422,7 @@ class TestDecimalBlock(TestCase):
     def test_type_to_python_decimal_none_value(self):
         block = blocks.DecimalBlock()
         block_val = block.to_python(None)
-        self.assertEqual(block_val, None)
+        self.assertIsNone(block_val)
 
     def test_render(self):
         block = blocks.DecimalBlock()

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -419,6 +419,11 @@ class TestDecimalBlock(TestCase):
         )  # decimals get saved as string in JSON field
         self.assertEqual(type(block_val), Decimal)
 
+    def test_type_to_python_decimal_none_value(self):
+        block = blocks.DecimalBlock()
+        block_val = block.to_python(None)
+        self.assertEqual(block_val, None)
+
     def test_render(self):
         block = blocks.DecimalBlock()
         test_val = Decimal(1.63)


### PR DESCRIPTION
-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

Please see issue #9777

DecimalBlock value when Null forces a conveersion to null which crashes the server. Fixed it by returning null when the value is null and decimal when a value is other than null

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)