### PR TITLE
Remove LGTM badges from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,6 @@
     <a href="https://pypi.python.org/pypi/wagtail/">
         <img src="https://img.shields.io/pypi/v/wagtail.svg" alt="Version" />
     </a>
-    <a href="https://lgtm.com/projects/g/wagtail/wagtail/alerts/">
-        <img src="https://img.shields.io/lgtm/alerts/g/wagtail/wagtail.svg?logo=lgtm&logoWidth=18" alt="Total alerts" />
-    </a>
-    <a href="https://lgtm.com/projects/g/wagtail/wagtail/context:python">
-        <img src="https://img.shields.io/lgtm/grade/python/g/wagtail/wagtail.svg?logo=lgtm&logoWidth=18" alt="Language grade: Python" />
-    </a>
-    <a href="https://lgtm.com/projects/g/wagtail/wagtail/context:javascript">
-        <img src="https://img.shields.io/lgtm/grade/javascript/g/wagtail/wagtail.svg?logo=lgtm&logoWidth=18" alt="Language grade: JavaScript" />
-    </a>
     <a href="https://pypi.python.org/pypi/wagtail/">
         <img src="https://img.shields.io/pypi/dm/wagtail?logo=Downloads" alt="Monthly downloads" />
     </a>


### PR DESCRIPTION
LGTM is shutting down imminently (https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/), and badges will no longer be functional. We now use Github's native CodeQL scanner instead - https://github.com/wagtail/wagtail/blob/main/.github/workflows/codeql-analysis.yml
