### PR TITLE
Add `{% fullpageurl %}` for resolving absolute URLs to pages

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Snippet models extending `DraftStateMixin` now automatically define a "Publish" permission type (Sage Abdullah)
  * Users now remain on the edit page after saving a snippet as draft (Sage Abdullah)
  * Base project template now populates the meta description tag from the search description field (Aman Pandey)
+ * Create `{% fullpageurl %}` for getting the absolute URL of a page (Jake Howard)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/docs/advanced_topics/performance.md
+++ b/docs/advanced_topics/performance.md
@@ -62,7 +62,7 @@ To fully resolve the URL of a page, Wagtail requires information from a few diff
 
 The methods used to get the URL of a `Page` such as `Page.get_url` and `Page.get_full_url` optionally accept extra arguments for `request` and `current_site`. Passing these arguments enable much of underlying site-level URL information to be reused for the current request. In situations such as navigation menu generation, plus any links that appear in page content, providing `request` or `current_site` can result in a drastic reduction in the number of cache or database queries your site will generate for a given page load.
 
-When using the [`{% pageurl %}`](page_urls) template tag, the request is automatically passed in, so no further optimisation is needed.
+When using the [`{% pageurl %}`](pageurl_tag) or [`{% fullpageurl %}`](fullpageurl_tag) template tags, the request is automatically passed in, so no further optimisation is needed.
 
 ## Search
 

--- a/docs/reference/jinja2.md
+++ b/docs/reference/jinja2.md
@@ -38,9 +38,19 @@ In Django templates, `self` can be used to refer to the current page, stream blo
 
 ## Template tags, functions & filters
 
+### `fullpageurl()`
+
+Generate an absolute URL (`http://example.com/foo/bar/`) for a Page instance:
+
+```html+jinja
+<meta property="og:url" content="{{ fullpageurl(page) }}" />
+```
+
+See [](fullpageurl_tag) for more information.
+
 ### `pageurl()`
 
-Generate a URL for a Page instance:
+Generate a URL (`/foo/bar/`) for a Page instance:
 
 ```html+jinja
 <a href="{{ pageurl(page.more_information) }}">More information</a>

--- a/docs/topics/pages.md
+++ b/docs/topics/pages.md
@@ -179,7 +179,7 @@ class LandingPage(Page):
 
 ### Page URLs
 
-The most common method of retrieving page URLs is by using the `{% pageurl %}` template tag. Since it's called from a template, `pageurl` automatically includes the optimizations mentioned below. For more information, see [pageurl](pageurl_tag).
+The most common method of retrieving page URLs is by using the [`{% pageurl %}`](pageurl_tag) or [`{% fullpageurl %}`](fullpageurl_tag) template tags. Since it's called from a template, these automatically includes the optimizations mentioned below.
 
 Page models also include several low-level methods for overriding or accessing page URLs.
 

--- a/docs/topics/writing_templates.md
+++ b/docs/topics/writing_templates.md
@@ -177,7 +177,7 @@ A `fallback` keyword argument can be provided - this can be a URL string, a name
 
 ### `fullpageurl`
 
-Takes a Page object and returns its absolute (`http://example.com/foo/bar/`).
+Takes a Page object and returns its absolute URL (`http://example.com/foo/bar/`).
 
 ```html+django
 {% load wagtailcore_tags %}

--- a/docs/topics/writing_templates.md
+++ b/docs/topics/writing_templates.md
@@ -173,6 +173,20 @@ A `fallback` keyword argument can be provided - this can be a URL string, a name
 {% endfor %}
 ```
 
+(fullpageurl_tag)=
+
+### `fullpageurl`
+
+Takes a Page object and returns its absolute (`http://example.com/foo/bar/`).
+
+```html+django
+{% load wagtailcore_tags %}
+...
+<meta property="og:url" content="{% fullpageurl page %}" />
+```
+
+Much like `pageurl`, a `fallback` keyword argument may be provided.
+
 (slugurl_tag)=
 
 ### `slugurl`

--- a/wagtail/jinja2tags.py
+++ b/wagtail/jinja2tags.py
@@ -4,6 +4,7 @@ from jinja2.ext import Extension
 from markupsafe import Markup, escape
 
 from .templatetags.wagtailcore_tags import (
+    fullpageurl,
     pageurl,
     richtext,
     slugurl,
@@ -20,6 +21,7 @@ class WagtailCoreExtension(Extension):
 
         self.environment.globals.update(
             {
+                "fullpageurl": jinja2.pass_context(fullpageurl),
                 "pageurl": jinja2.pass_context(pageurl),
                 "slugurl": jinja2.pass_context(slugurl),
                 "wagtail_site": jinja2.pass_context(wagtail_site),

--- a/wagtail/templatetags/wagtailcore_tags.py
+++ b/wagtail/templatetags/wagtailcore_tags.py
@@ -23,25 +23,10 @@ def pageurl(context, page, fallback=None):
     if page is None and fallback:
         return resolve_url(fallback)
 
-    if not hasattr(page, "relative_url"):
+    if not isinstance(page, Page):
         raise ValueError("pageurl tag expected a Page object, got %r" % page)
 
-    try:
-        site = Site.find_for_request(context["request"])
-        current_site = site
-    except KeyError:
-        # request not available in the current context; fall back on page.url
-        return page.url
-
-    if current_site is None:
-        # request does not correspond to a recognised site; fall back on page.url
-        return page.url
-
-    # Pass page.relative_url the request object, which may contain a cached copy of
-    # Site.get_site_root_paths()
-    # This avoids page.relative_url having to make a database/cache fetch for this list
-    # each time it's called.
-    return page.relative_url(current_site, request=context.get("request"))
+    return page.get_url(request=context.get("request"))
 
 
 @register.simple_tag(takes_context=True)

--- a/wagtail/templatetags/wagtailcore_tags.py
+++ b/wagtail/templatetags/wagtailcore_tags.py
@@ -30,6 +30,24 @@ def pageurl(context, page, fallback=None):
 
 
 @register.simple_tag(takes_context=True)
+def fullpageurl(context, page, fallback=None):
+    """
+    Outputs a page's absolute URL (http://example.com/foo/bar/)
+    If kwargs contains a fallback view name and page is None, the fallback view url will be returned.
+    """
+    if page is None and fallback:
+        fallback_url = resolve_url(fallback)
+        if fallback_url and "request" in context and fallback_url[0] == "/":
+            fallback_url = context["request"].build_absolute_uri(fallback_url)
+        return fallback_url
+
+    if not isinstance(page, Page):
+        raise ValueError("fullpageurl tag expected a Page object, got %r" % page)
+
+    return page.get_full_url(request=context.get("request"))
+
+
+@register.simple_tag(takes_context=True)
 def slugurl(context, slug):
     """
     Returns the URL for the page that has the given slug.

--- a/wagtail/tests/test_jinja2.py
+++ b/wagtail/tests/test_jinja2.py
@@ -39,6 +39,12 @@ class TestCoreGlobalsAndFilters(TestCase):
         page = Page.objects.get(pk=2)
         self.assertEqual(self.render("{{ pageurl(page) }}", {"page": page}), page.url)
 
+    def test_fullpageurl(self):
+        page = Page.objects.get(pk=2)
+        self.assertEqual(
+            self.render("{{ fullpageurl(page) }}", {"page": page}), page.full_url
+        )
+
     def test_slugurl(self):
         page = Page.objects.get(pk=2)
         self.assertEqual(

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -15,6 +15,7 @@ from django.utils import timezone, translation
 from freezegun import freeze_time
 
 from wagtail.actions.copy_for_translation import ParentNotTranslatedError
+from wagtail.coreutils import get_dummy_request
 from wagtail.locks import BasicLock, ScheduledForPublishLock, WorkflowLock
 from wagtail.models import (
     Comment,
@@ -465,9 +466,8 @@ class TestRouting(TestCase):
     def test_request_serving(self):
         christmas_page = EventPage.objects.get(url_path="/home/events/christmas/")
 
-        request = HttpRequest()
+        request = get_dummy_request(site=Site.objects.first())
         request.user = AnonymousUser()
-        request.META["HTTP_HOST"] = Site.objects.first().hostname
 
         response = christmas_page.serve(request)
         self.assertEqual(response.status_code, 200)

--- a/wagtail/tests/tests.py
+++ b/wagtail/tests/tests.py
@@ -210,12 +210,12 @@ class TestPageUrlTags(TestCase):
 
     def test_fullpageurl(self):
         tpl = template.Template(
-            """{% load wagtailcore_tags %}<a href="{% fullpageurl page %}">Fallback</a>"""
+            """{% load wagtailcore_tags %}<a href="{% fullpageurl page %}">Events</a>"""
         )
         page = Page.objects.get(url_path="/home/events/")
         with self.assertNumQueries(7):
             result = tpl.render(template.Context({"page": page}))
-        self.assertIn('<a href="http://localhost/events/">Fallback</a>', result)
+        self.assertIn('<a href="http://localhost/events/">Events</a>', result)
 
     def test_fullpageurl_with_named_url_fallback(self):
         tpl = template.Template(
@@ -234,6 +234,20 @@ class TestPageUrlTags(TestCase):
                 template.Context({"page": None, "request": get_dummy_request()})
             )
         self.assertIn('<a href="http://localhost/fallback/">Fallback</a>', result)
+
+    def test_fullpageurl_with_invalid_page(self):
+        tpl = template.Template(
+            """{% load wagtailcore_tags %}<a href="{% fullpageurl page %}">Events</a>"""
+        )
+        with self.assertRaises(ValueError):
+            tpl.render(template.Context({"page": 123}))
+
+    def test_pageurl_with_invalid_page(self):
+        tpl = template.Template(
+            """{% load wagtailcore_tags %}<a href="{% pageurl page %}">Events</a>"""
+        )
+        with self.assertRaises(ValueError):
+            tpl.render(template.Context({"page": 123}))
 
 
 class TestWagtailSiteTag(TestCase):

--- a/wagtail/tests/tests.py
+++ b/wagtail/tests/tests.py
@@ -202,6 +202,33 @@ class TestPageUrlTags(TestCase):
         result = slugurl(template.Context({"request": request}), "events")
         self.assertEqual(result, "/events/")
 
+    def test_fullpageurl(self):
+        tpl = template.Template(
+            """{% load wagtailcore_tags %}<a href="{% fullpageurl page %}">Fallback</a>"""
+        )
+        page = Page.objects.get(url_path="/home/events/")
+        with self.assertNumQueries(7):
+            result = tpl.render(template.Context({"page": page}))
+        self.assertIn('<a href="http://localhost/events/">Fallback</a>', result)
+
+    def test_fullpageurl_with_named_url_fallback(self):
+        tpl = template.Template(
+            """{% load wagtailcore_tags %}<a href="{% fullpageurl page fallback='fallback' %}">Fallback</a>"""
+        )
+        with self.assertNumQueries(0):
+            result = tpl.render(template.Context({"page": None}))
+        self.assertIn('<a href="/fallback/">Fallback</a>', result)
+
+    def test_fullpageurl_with_absolute_fallback(self):
+        tpl = template.Template(
+            """{% load wagtailcore_tags %}<a href="{% fullpageurl page fallback='fallback' %}">Fallback</a>"""
+        )
+        with self.assertNumQueries(0):
+            result = tpl.render(
+                template.Context({"page": None, "request": get_dummy_request()})
+            )
+        self.assertIn('<a href="http://localhost/fallback/">Fallback</a>', result)
+
 
 class TestWagtailSiteTag(TestCase):
     fixtures = ["test.json"]

--- a/wagtail/tests/tests.py
+++ b/wagtail/tests/tests.py
@@ -15,6 +15,12 @@ from wagtail.test.testapp.models import SimplePage
 class TestPageUrlTags(TestCase):
     fixtures = ["test.json"]
 
+    def setUp(self):
+        super().setUp()
+
+        # Clear caches
+        cache.clear()
+
     def test_pageurl_tag(self):
         response = self.client.get("/events/")
         self.assertEqual(response.status_code, 200)

--- a/wagtail/tests/tests.py
+++ b/wagtail/tests/tests.py
@@ -6,7 +6,7 @@ from django.test.utils import override_settings
 from django.urls.exceptions import NoReverseMatch
 from django.utils.safestring import SafeString
 
-from wagtail.coreutils import resolve_model_string
+from wagtail.coreutils import get_dummy_request, resolve_model_string
 from wagtail.models import Locale, Page, Site, SiteRootPath
 from wagtail.templatetags.wagtailcore_tags import richtext, slugurl
 from wagtail.test.testapp.models import SimplePage
@@ -24,7 +24,8 @@ class TestPageUrlTags(TestCase):
         tpl = template.Template(
             """{% load wagtailcore_tags %}<a href="{% pageurl page fallback='fallback' %}">Fallback</a>"""
         )
-        result = tpl.render(template.Context({"page": None}))
+        with self.assertNumQueries(0):
+            result = tpl.render(template.Context({"page": None}))
         self.assertIn('<a href="/fallback/">Fallback</a>', result)
 
     def test_pageurl_with_get_absolute_url_object_fallback(self):
@@ -81,11 +82,30 @@ class TestPageUrlTags(TestCase):
         )
 
         # no 'request' object in context
-        result = tpl.render(template.Context({"page": page}))
+        with self.assertNumQueries(7):
+            result = tpl.render(template.Context({"page": page}))
         self.assertIn('<a href="/events/">Events</a>', result)
 
         # 'request' object in context, but no 'site' attribute
-        result = tpl.render(template.Context({"page": page, "request": HttpRequest()}))
+        result = tpl.render(
+            template.Context({"page": page, "request": get_dummy_request()})
+        )
+        self.assertIn('<a href="/events/">Events</a>', result)
+
+    def test_pageurl_caches(self):
+        page = Page.objects.get(url_path="/home/events/")
+        tpl = template.Template(
+            """{% load wagtailcore_tags %}<a href="{% pageurl page %}">{{ page.title }}</a>"""
+        )
+
+        request = get_dummy_request()
+
+        with self.assertNumQueries(8):
+            result = tpl.render(template.Context({"page": page, "request": request}))
+        self.assertIn('<a href="/events/">Events</a>', result)
+
+        with self.assertNumQueries(0):
+            result = tpl.render(template.Context({"page": page, "request": request}))
         self.assertIn('<a href="/events/">Events</a>', result)
 
     @override_settings(ALLOWED_HOSTS=["testserver", "localhost", "unknown.example.com"])
@@ -99,7 +119,8 @@ class TestPageUrlTags(TestCase):
         request = HttpRequest()
         request.META["HTTP_HOST"] = "unknown.example.com"
         request.META["SERVER_PORT"] = 80
-        result = tpl.render(template.Context({"page": page, "request": request}))
+        with self.assertNumQueries(8):
+            result = tpl.render(template.Context({"page": page, "request": request}))
         self.assertIn('<a href="/events/">Events</a>', result)
 
     def test_bad_pageurl(self):
@@ -166,7 +187,10 @@ class TestPageUrlTags(TestCase):
         self.assertEqual(result, "/events/")
 
         # 'request' object in context, but no 'site' attribute
-        result = slugurl(template.Context({"request": HttpRequest()}), "events")
+        with self.assertNumQueries(3):
+            result = slugurl(
+                template.Context({"request": get_dummy_request()}), "events"
+            )
         self.assertEqual(result, "/events/")
 
     @override_settings(ALLOWED_HOSTS=["testserver", "localhost", "unknown.example.com"])


### PR DESCRIPTION
_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

A pattern I've seen quite a lot is concatenating a site's URL onto `{% pageurl page %}` - there should be a better way of doing that. This could be even more useful in multi-site environments where the current site may not be the page's site.

As shown in the example, this is mostly useful when interacting with external services where the absolute URL is needed, rather than just the most efficient way to get to a page as `{% pageurl %}` returns.

I also took the chance to reduce the boilerplate in `{% pageurl %}`, as much of its functionality was already being handled by `get_url`, so I just called that directly instead. It doesn't appear to notably improve performance or reduce queries, but less code is more better.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
