### PR TITLE
Restrict images globally to certain types

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -316,6 +316,14 @@ WAGTAILIMAGES_MAX_IMAGE_PIXELS = 128000000  # 128 megapixels
 
 This setting lets you override the maximum number of pixels an image can have. If omitted, Wagtail will fall back to using its 128 megapixels default value. The pixel count takes animation frames into account - for example, a 25-frame animation of size 100x100 is considered to have 100 _ 100 _ 25 = 250000 pixels.
 
+### `WAGTAIL_IMAGES_ALLOWED_EXTENSIONS`
+
+```python
+WAGTAIL_IMAGES_ALLOWED_EXTENSIONS = ["gif", "jpg", "jpeg", "png", "webp"]
+```
+
+A list of allowed image extensions that will be validated during image upload. If this isn't supplied gif, jpg, jpeg, png and webp extensions are allowed. Warning: this doesn't always ensure that the uploaded image is valid as files can be renamed to have an extension no matter what data they contain.
+
 ### `WAGTAILIMAGES_FEATURE_DETECTION_ENABLED`
 
 ```python

--- a/wagtail/images/fields.py
+++ b/wagtail/images/fields.py
@@ -28,7 +28,7 @@ class WagtailImageField(ImageField):
         self.max_upload_size_text = filesizeformat(self.max_upload_size)
 
         self.images_allowed_extensions = getattr(
-            settings, "WAGTAIL_IMAGES_ALLOWED_EXTENSIONS ", ALLOWED_EXTENSIONS
+            settings, "WAGTAIL_IMAGES_ALLOWED_EXTENSIONS", ALLOWED_EXTENSIONS
         )
         # Help text
         if self.max_upload_size is not None:

--- a/wagtail/images/fields.py
+++ b/wagtail/images/fields.py
@@ -10,7 +10,6 @@ from django.template.defaultfilters import filesizeformat
 from django.utils.translation import gettext_lazy as _
 
 ALLOWED_EXTENSIONS = ["gif", "jpg", "jpeg", "png", "webp"]
-SUPPORTED_FORMATS_TEXT = _("GIF, JPEG, PNG, WEBP")
 
 
 class WagtailImageField(ImageField):
@@ -28,17 +27,20 @@ class WagtailImageField(ImageField):
         )
         self.max_upload_size_text = filesizeformat(self.max_upload_size)
 
+        self.images_allowed_extensions = getattr(
+            settings, "WAGTAIL_IMAGES_ALLOWED_EXTENSIONS ", ALLOWED_EXTENSIONS
+        )
         # Help text
         if self.max_upload_size is not None:
             self.help_text = _(
                 "Supported formats: %(supported_formats)s. Maximum filesize: %(max_upload_size)s."
             ) % {
-                "supported_formats": SUPPORTED_FORMATS_TEXT,
+                "supported_formats": self.images_allowed_extensions,
                 "max_upload_size": self.max_upload_size_text,
             }
         else:
             self.help_text = _("Supported formats: %(supported_formats)s.") % {
-                "supported_formats": SUPPORTED_FORMATS_TEXT,
+                "supported_formats": self.images_allowed_extensions,
             }
 
         # Error messages
@@ -46,7 +48,7 @@ class WagtailImageField(ImageField):
         # either right now if all values are known, otherwise when used.
         self.error_messages["invalid_image_extension"] = _(
             "Not a supported image format. Supported formats: %(supported_formats)s."
-        ) % {"supported_formats": SUPPORTED_FORMATS_TEXT}
+        ) % {"supported_formats": self.images_allowed_extensions}
 
         self.error_messages["invalid_image_known_format"] = _(
             "Not a valid .%(extension)s image. The extension does not match the file format (%(image_format)s)"
@@ -68,7 +70,7 @@ class WagtailImageField(ImageField):
         # Check file extension
         extension = os.path.splitext(f.name)[1].lower()[1:]
 
-        if extension not in ALLOWED_EXTENSIONS:
+        if extension not in self.images_allowed_extensions:
             raise ValidationError(
                 self.error_messages["invalid_image_extension"],
                 code="invalid_image_extension",


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [X] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
