### PR TITLE
Use util method to construct util dummy requests

### DIFF
--- a/wagtail/admin/tests/test_jinja2.py
+++ b/wagtail/admin/tests/test_jinja2.py
@@ -1,8 +1,8 @@
 from django.contrib.auth.models import AnonymousUser
-from django.http import HttpRequest
 from django.template import engines
 from django.test import TestCase
 
+from wagtail.coreutils import get_dummy_request
 from wagtail.models import PAGE_TEMPLATE_VAR, Page, Site
 from wagtail.test.utils import WagtailTestUtils
 
@@ -25,10 +25,7 @@ class TestCoreJinja(TestCase, WagtailTestUtils):
 
     def dummy_request(self, user=None):
         site = Site.objects.get(is_default_site=True)
-
-        request = HttpRequest()
-        request.META["HTTP_HOST"] = site.hostname
-        request.META["SERVER_PORT"] = site.port
+        request = get_dummy_request(site=site)
         request.user = user or AnonymousUser()
         return request
 

--- a/wagtail/contrib/settings/tests/generic/base.py
+++ b/wagtail/contrib/settings/tests/generic/base.py
@@ -1,5 +1,4 @@
-from django.http import HttpRequest
-
+from wagtail.coreutils import get_dummy_request
 from wagtail.models import Page, Site
 from wagtail.test.testapp.models import TestGenericSetting
 
@@ -20,7 +19,4 @@ class GenericSettingsTestMixin:
     def get_request(self, site=None):
         if site is None:
             site = self.default_site
-        request = HttpRequest()
-        request.META["HTTP_HOST"] = site.hostname
-        request.META["SERVER_PORT"] = site.port
-        return request
+        return get_dummy_request(site=site)

--- a/wagtail/contrib/settings/tests/generic/test_templates.py
+++ b/wagtail/contrib/settings/tests/generic/test_templates.py
@@ -1,8 +1,8 @@
-from django.http import HttpRequest
 from django.template import Context, RequestContext, Template, engines
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from wagtail.coreutils import get_dummy_request
 from wagtail.models import Site
 from wagtail.test.utils import WagtailTestUtils
 
@@ -136,10 +136,7 @@ class GenericSettingJinjaContextProcessorTestCase(GenericSettingTemplateTestCase
         # Add a request to the template, to simulate a RequestContext
         if request_context:
             site = Site.objects.get(is_default_site=True)
-            request = HttpRequest()
-            request.META["HTTP_HOST"] = site.hostname
-            request.META["SERVER_PORT"] = site.port
-            context["request"] = request
+            context["request"] = get_dummy_request(site=site)
 
         template = self.engine.from_string(string)
         return template.render(context)

--- a/wagtail/contrib/settings/tests/site_specific/base.py
+++ b/wagtail/contrib/settings/tests/site_specific/base.py
@@ -1,5 +1,4 @@
-from django.http import HttpRequest
-
+from wagtail.coreutils import get_dummy_request
 from wagtail.models import Page, Site
 from wagtail.test.testapp.models import TestSiteSetting
 
@@ -23,7 +22,4 @@ class SiteSettingsTestMixin:
     def get_request(self, site=None):
         if site is None:
             site = self.default_site
-        request = HttpRequest()
-        request.META["HTTP_HOST"] = site.hostname
-        request.META["SERVER_PORT"] = site.port
-        return request
+        return get_dummy_request(site=site)

--- a/wagtail/contrib/settings/tests/site_specific/test_templates.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_templates.py
@@ -1,8 +1,8 @@
-from django.http import HttpRequest
 from django.template import Context, RequestContext, Template, engines
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from wagtail.coreutils import get_dummy_request
 from wagtail.models import Site
 from wagtail.test.utils import WagtailTestUtils
 
@@ -204,10 +204,7 @@ class TestSiteSettingsJinja(TemplateTestCase):
                 site = context["site"]
             else:
                 site = Site.objects.get(is_default_site=True)
-            request = HttpRequest()
-            request.META["HTTP_HOST"] = site.hostname
-            request.META["SERVER_PORT"] = site.port
-            context["request"] = request
+            context["request"] = get_dummy_request(site=site)
 
         template = self.engine.from_string(string)
         return template.render(context)

--- a/wagtail/tests/test_jinja2.py
+++ b/wagtail/tests/test_jinja2.py
@@ -1,10 +1,10 @@
-from django.http import HttpRequest
 from django.template import engines
 from django.template.loader import render_to_string
 from django.test import TestCase
 from django.utils.safestring import mark_safe
 
 from wagtail import __version__, blocks
+from wagtail.coreutils import get_dummy_request
 from wagtail.models import Page, Site
 from wagtail.test.testapp.blocks import SectionBlock
 
@@ -20,10 +20,7 @@ class TestCoreGlobalsAndFilters(TestCase):
         # Add a request to the template, to simulate a RequestContext
         if request_context:
             site = Site.objects.get(is_default_site=True)
-            request = HttpRequest()
-            request.META["HTTP_HOST"] = site.hostname
-            request.META["SERVER_PORT"] = site.port
-            context["request"] = request
+            context["request"] = get_dummy_request(site=site)
 
         template = self.engine.from_string(string)
         return template.render(context)

--- a/wagtail/tests/test_sites.py
+++ b/wagtail/tests/test_sites.py
@@ -120,33 +120,35 @@ class TestFindSiteForRequest(TestCase):
 
     def test_with_host(self):
         request = get_dummy_request()
-        request.META = {"HTTP_HOST": "example.com", "SERVER_PORT": 80}
+        request.META.update({"HTTP_HOST": "example.com", "SERVER_PORT": 80})
         self.assertEqual(Site.find_for_request(request), self.site)
 
     def test_with_unknown_host(self):
         request = get_dummy_request()
-        request.META = {"HTTP_HOST": "unknown.com", "SERVER_PORT": 80}
+        request.META.update({"HTTP_HOST": "unknown.com", "SERVER_PORT": 80})
         self.assertEqual(Site.find_for_request(request), self.default_site)
 
     def test_with_server_name(self):
         request = get_dummy_request()
-        request.META = {"SERVER_NAME": "example.com", "SERVER_PORT": 80}
+        request.META.update({"SERVER_NAME": "example.com", "SERVER_PORT": 80})
         self.assertEqual(Site.find_for_request(request), self.site)
 
     def test_with_x_forwarded_host(self):
         with self.settings(USE_X_FORWARDED_HOST=True):
             request = get_dummy_request()
-            request.META = {"HTTP_X_FORWARDED_HOST": "example.com", "SERVER_PORT": 80}
+            request.META.update(
+                {"HTTP_X_FORWARDED_HOST": "example.com", "SERVER_PORT": 80}
+            )
             self.assertEqual(Site.find_for_request(request), self.site)
 
     def test_ipv4_host(self):
         request = get_dummy_request()
-        request.META = {"SERVER_NAME": "127.0.0.1", "SERVER_PORT": 80}
+        request.META.update({"SERVER_NAME": "127.0.0.1", "SERVER_PORT": 80})
         self.assertEqual(Site.find_for_request(request), self.default_site)
 
     def test_ipv6_host(self):
         request = get_dummy_request()
-        request.META = {"SERVER_NAME": "[::1]", "SERVER_PORT": 80}
+        request.META.update({"SERVER_NAME": "[::1]", "SERVER_PORT": 80})
         self.assertEqual(Site.find_for_request(request), self.default_site)
 
 

--- a/wagtail/tests/test_sites.py
+++ b/wagtail/tests/test_sites.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ValidationError
-from django.http.request import HttpRequest
 from django.test import TestCase, override_settings
 
+from wagtail.coreutils import get_dummy_request
 from wagtail.models import Page, Site
 
 
@@ -114,34 +114,38 @@ class TestFindSiteForRequest(TestCase):
             hostname="example.com", port=80, root_page=Page.objects.get(pk=2)
         )
 
+    def test_dummy_request(self):
+        request = get_dummy_request(site=self.site)
+        self.assertEqual(Site.find_for_request(request), self.site)
+
     def test_with_host(self):
-        request = HttpRequest()
+        request = get_dummy_request()
         request.META = {"HTTP_HOST": "example.com", "SERVER_PORT": 80}
         self.assertEqual(Site.find_for_request(request), self.site)
 
     def test_with_unknown_host(self):
-        request = HttpRequest()
+        request = get_dummy_request()
         request.META = {"HTTP_HOST": "unknown.com", "SERVER_PORT": 80}
         self.assertEqual(Site.find_for_request(request), self.default_site)
 
     def test_with_server_name(self):
-        request = HttpRequest()
+        request = get_dummy_request()
         request.META = {"SERVER_NAME": "example.com", "SERVER_PORT": 80}
         self.assertEqual(Site.find_for_request(request), self.site)
 
     def test_with_x_forwarded_host(self):
         with self.settings(USE_X_FORWARDED_HOST=True):
-            request = HttpRequest()
+            request = get_dummy_request()
             request.META = {"HTTP_X_FORWARDED_HOST": "example.com", "SERVER_PORT": 80}
             self.assertEqual(Site.find_for_request(request), self.site)
 
     def test_ipv4_host(self):
-        request = HttpRequest()
+        request = get_dummy_request()
         request.META = {"SERVER_NAME": "127.0.0.1", "SERVER_PORT": 80}
         self.assertEqual(Site.find_for_request(request), self.default_site)
 
     def test_ipv6_host(self):
-        request = HttpRequest()
+        request = get_dummy_request()
         request.META = {"SERVER_NAME": "[::1]", "SERVER_PORT": 80}
         self.assertEqual(Site.find_for_request(request), self.default_site)
 


### PR DESCRIPTION
_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

Use `wagtail.coreutils.get_dummy_request` when constructing a request. This ensures it's correctly detected as a given site, and that it has the attributes expected by Wagtail. This removes quite a lot of duplicated and brittle code from the tests.

I considered moving it out of `coreutils`, but turns out it's being used as part of some of the redirect logic.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
