### PR TITLE
Add deprecation warnings to wagtail.core and other modules deprecated in Wagtail 3

### DIFF
--- a/docs/reference/pages/model_recipes.md
+++ b/docs/reference/pages/model_recipes.md
@@ -258,7 +258,7 @@ To add the tag interface, add the following block of code to a `wagtail_hooks.py
 
 ```python
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
-from wagtail.admin.edit_handlers import FieldPanel
+from wagtail.admin.panels import FieldPanel
 from taggit.models import Tag
 
 

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.admin.panels import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.admin.edit_handlers is deprecated. "
+    "Use wagtail.admin.panels instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/admin/tests/pages/test_reorder_page.py
+++ b/wagtail/admin/tests/pages/test_reorder_page.py
@@ -1,9 +1,9 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from wagtail.core.models import Page
+from wagtail.models import Page
 from wagtail.test.testapp.models import BusinessChild, BusinessIndex, SimplePage
-from wagtail.tests.utils import WagtailTestUtils
+from wagtail.test.utils import WagtailTestUtils
 
 
 class TestPageReorder(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_upgrade_notification.py
+++ b/wagtail/admin/tests/test_upgrade_notification.py
@@ -1,7 +1,7 @@
 from django.test import RequestFactory, TestCase, override_settings
 
 from wagtail.admin.views.home import UpgradeNotificationPanel
-from wagtail.tests.utils import WagtailTestUtils
+from wagtail.test.utils import WagtailTestUtils
 
 
 class TestUpgradeNotificationPanel(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_whats_new.py
+++ b/wagtail/admin/tests/test_whats_new.py
@@ -2,7 +2,7 @@ from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
 from wagtail.admin.views.home import WhatsNewInWagtailVersionPanel
-from wagtail.tests.utils import WagtailTestUtils
+from wagtail.test.utils import WagtailTestUtils
 from wagtail.users.models import UserProfile
 
 

--- a/wagtail/contrib/forms/edit_handlers.py
+++ b/wagtail/contrib/forms/edit_handlers.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.contrib.forms.panels import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.contrib.forms.edit_handlers is deprecated. "
+    "Use wagtail.contrib.forms.panels instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/__init__.py
+++ b/wagtail/core/__init__.py
@@ -1,0 +1,7 @@
+def load_tests(loader, tests, pattern):
+    # As standard the unittest framework will recurse through this module, importing submodules to
+    # discover tests. We don't want it to do that for wagtail.core, because it will trigger our
+    # deprecation warnings. This standard behaviour can be overridden by defining a load_tests
+    # function that returns a TestSuite to run; return None so that no tests are run and no
+    # recursive importing happens.
+    return None

--- a/wagtail/core/apps.py
+++ b/wagtail/core/apps.py
@@ -1,3 +1,13 @@
+from warnings import warn
+
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
 from ..apps import WagtailAppConfig as WagtailCoreAppConfig  # noqa
 
-# TODO: Deprecation warning
+warn(
+    "Importing from wagtail.core.apps is deprecated. "
+    "Use wagtail.apps instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/blocks/__init__.py
+++ b/wagtail/core/blocks/__init__.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 # Import block types defined in submodules into the wagtail.blocks namespace
 from wagtail.blocks.base import *  # NOQA
 from wagtail.blocks.field_block import *  # NOQA
@@ -5,3 +7,12 @@ from wagtail.blocks.list_block import *  # NOQA
 from wagtail.blocks.static_block import *  # NOQA
 from wagtail.blocks.stream_block import *  # NOQA
 from wagtail.blocks.struct_block import *  # NOQA
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.blocks is deprecated. "
+    "Use wagtail.blocks instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.blocks.base import *  # NOQA
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.blocks.base is deprecated. "
+    "Use wagtail.blocks.base instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.blocks.field_block import *  # NOQA
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.blocks.field_block is deprecated. "
+    "Use wagtail.blocks.field_block instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.blocks.list_block import *  # NOQA
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.blocks.list_block is deprecated. "
+    "Use wagtail.blocks.list_block instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/blocks/static_block.py
+++ b/wagtail/core/blocks/static_block.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.blocks.static_block import *  # NOQA
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.blocks.static_block is deprecated. "
+    "Use wagtail.blocks.static_block instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.blocks.stream_block import *  # NOQA
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.blocks.stream_block is deprecated. "
+    "Use wagtail.blocks.stream_block instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/blocks/struct_block.py
+++ b/wagtail/core/blocks/struct_block.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.blocks.struct_block import *  # NOQA
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.blocks.struct_block is deprecated. "
+    "Use wagtail.blocks.struct_block instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/fields.py
+++ b/wagtail/core/fields.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.fields import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.fields is deprecated. "
+    "Use wagtail.fields instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/hooks.py
+++ b/wagtail/core/hooks.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.hooks import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.hooks is deprecated. "
+    "Use wagtail.hooks instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/log_actions.py
+++ b/wagtail/core/log_actions.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.log_actions import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.log_actions is deprecated. "
+    "Use wagtail.log_actions instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from wagtail.models import (  # noqa
     COMMENTS_RELATION_NAME,
     PAGE_MODEL_CLASSES,
@@ -39,6 +41,7 @@ from wagtail.models import (  # noqa
     logger,
     reassign_root_page_locale_on_delete,
 )
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
 
 from .audit_log import (  # noqa
     BaseLogEntry,
@@ -67,3 +70,11 @@ from .i18n import (  # noqa
     get_translatable_models,
 )
 from .sites import Site, SiteManager, SiteRootPath  # noqa
+
+warn(
+    "Importing from wagtail.core.models is deprecated. "
+    "Use wagtail.models instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/models/audit_log.py
+++ b/wagtail/core/models/audit_log.py
@@ -1,6 +1,17 @@
+from warnings import warn
+
 from wagtail.models.audit_log import (  # noqa
     BaseLogEntry,
     BaseLogEntryManager,
     LogEntryQuerySet,
     ModelLogEntry,
+)
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.models.audit_log is deprecated. "
+    "Use wagtail.models.audit_log instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
 )

--- a/wagtail/core/models/collections.py
+++ b/wagtail/core/models/collections.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from wagtail.models.collections import (  # noqa
     BaseCollectionManager,
     Collection,
@@ -7,4 +9,13 @@ from wagtail.models.collections import (  # noqa
     GroupCollectionPermission,
     GroupCollectionPermissionManager,
     get_root_collection_id,
+)
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.models.collections is deprecated. "
+    "Use wagtail.models.collections instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
 )

--- a/wagtail/core/models/copying.py
+++ b/wagtail/core/models/copying.py
@@ -1,5 +1,16 @@
+from warnings import warn
+
 from wagtail.models.copying import (  # noqa
     _copy,
     _copy_m2m_relations,
     _extract_field_data,
+)
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.models.copying is deprecated. "
+    "Use wagtail.models.copying instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
 )

--- a/wagtail/core/models/i18n.py
+++ b/wagtail/core/models/i18n.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from wagtail.models.i18n import (  # noqa
     BootstrapTranslatableMixin,
     BootstrapTranslatableModel,
@@ -6,4 +8,13 @@ from wagtail.models.i18n import (  # noqa
     TranslatableMixin,
     bootstrap_translatable_model,
     get_translatable_models,
+)
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.models.i18n is deprecated. "
+    "Use wagtail.models.i18n instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
 )

--- a/wagtail/core/models/sites.py
+++ b/wagtail/core/models/sites.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.models.sites import Site, SiteManager, SiteRootPath  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.models.sites is deprecated. "
+    "Use wagtail.models.sites instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/permission_policies/__init__.py
+++ b/wagtail/core/permission_policies/__init__.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.permission_policies import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.permission_policies is deprecated. "
+    "Use wagtail.permission_policies instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/permission_policies/base.py
+++ b/wagtail/core/permission_policies/base.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.permission_policies.base import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.permission_policies.base is deprecated. "
+    "Use wagtail.permission_policies.base instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/permission_policies/collections.py
+++ b/wagtail/core/permission_policies/collections.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.permission_policies.collections import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.permission_policies.collections is deprecated. "
+    "Use wagtail.permission_policies.collections instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/permissions.py
+++ b/wagtail/core/permissions.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.permissions import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.permissions is deprecated. "
+    "Use wagtail.permissions instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/rich_text/__init__.py
+++ b/wagtail/core/rich_text/__init__.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.rich_text import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.rich_text is deprecated. "
+    "Use wagtail.rich_text instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/rich_text/feature_registry.py
+++ b/wagtail/core/rich_text/feature_registry.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.rich_text.feature_registry import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.rich_text.feature_registry is deprecated. "
+    "Use wagtail.rich_text.feature_registry instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/rich_text/rewriters.py
+++ b/wagtail/core/rich_text/rewriters.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.rich_text.rewriters import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.rich_text.rewriters is deprecated. "
+    "Use wagtail.rich_text.rewriters instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/signals.py
+++ b/wagtail/core/signals.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.signals import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.signals is deprecated. "
+    "Use wagtail.signals instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/sites.py
+++ b/wagtail/core/sites.py
@@ -1,7 +1,18 @@
+from warnings import warn
+
 from wagtail.models.sites import (  # noqa
     MATCH_DEFAULT,
     MATCH_HOSTNAME,
     MATCH_HOSTNAME_DEFAULT,
     MATCH_HOSTNAME_PORT,
     get_site_for_hostname,
+)
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.sites is deprecated. "
+    "Use wagtail.models.sites instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
 )

--- a/wagtail/core/telepath.py
+++ b/wagtail/core/telepath.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.telepath import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.telepath is deprecated. "
+    "Use wagtail.telepath instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.templatetags.wagtailcore_tags import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.templatetags.wagtailcore_tags is deprecated. "
+    "Use wagtail.templatetags.wagtailcore_tags instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/urls.py
+++ b/wagtail/core/urls.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.urls import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.urls is deprecated. "
+    "Use wagtail.urls instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/utils.py
+++ b/wagtail/core/utils.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from wagtail.coreutils import (  # noqa
     SCRIPT_RE,
     SLUGIFY_RE,
@@ -16,4 +18,13 @@ from wagtail.coreutils import (  # noqa
     resolve_model_string,
     safe_snake_case,
     string_to_ascii,
+)
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.core.utils is deprecated. "
+    "Use wagtail.coreutils instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
 )

--- a/wagtail/core/whitelist.py
+++ b/wagtail/core/whitelist.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
 from wagtail.whitelist import *  # noqa
+
+warn(
+    "Importing from wagtail.core.whitelist is deprecated. "
+    "Use wagtail.whitelist instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/core/widget_adapters.py
+++ b/wagtail/core/widget_adapters.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
 from wagtail.widget_adapters import *  # noqa
+
+warn(
+    "Importing from wagtail.core.widget_adapters is deprecated. "
+    "Use wagtail.widget_adapters instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/tests/dummy_external_storage.py
+++ b/wagtail/tests/dummy_external_storage.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.test.dummy_external_storage import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.tests.dummy_external_storage is deprecated. "
+    "Use wagtail.test.dummy_external_storage instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.test.settings import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.tests.settings is deprecated. "
+    "Use wagtail.test.settings instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/tests/utils/__init__.py
+++ b/wagtail/tests/utils/__init__.py
@@ -1,1 +1,11 @@
 from wagtail.test.utils import *  # noqa
+
+# RemovedInWagtail50Warning: We would put a deprecation warning here to tell people to import from
+# wagtail.test.utils instead, but then the unittest framework would trigger the warning when
+# recursing through this module during test discovery, and there seems to be no good way to block
+# recursing into wagtail.test.utils without also blocking the real tests in wagtail.test.
+
+# Instead, when wagtail/test/utils/(form_data|page_tests|wagtail_tests).py are removed in Wagtail
+# 5.0, we will move this file to wagtail/test/utils.py. Since this does not match the standard
+# test_*.py pattern for test modules, unittest will no longer try to import it, and then we can
+# add a RemovedInWagtail60Warning to finally prompt people to update their imports.

--- a/wagtail/tests/utils/form_data.py
+++ b/wagtail/tests/utils/form_data.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.test.utils.form_data import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.tests.utils.form_data is deprecated. "
+    "Use wagtail.test.utils.form_data instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/tests/utils/page_tests.py
+++ b/wagtail/tests/utils/page_tests.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.test.utils.page_tests import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.tests.utils.page_tests is deprecated. "
+    "Use wagtail.test.utils.page_tests instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)

--- a/wagtail/tests/utils/wagtail_tests.py
+++ b/wagtail/tests/utils/wagtail_tests.py
@@ -1,1 +1,12 @@
+from warnings import warn
+
 from wagtail.test.utils.wagtail_tests import *  # noqa
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+warn(
+    "Importing from wagtail.tests.utils.wagtail_tests is deprecated. "
+    "Use wagtail.test.utils.wagtail_tests instead. "
+    "See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths",
+    category=RemovedInWagtail50Warning,
+    stacklevel=2,
+)


### PR DESCRIPTION
When we deprecated wagtail.core and several other modules in Wagtail 3, we didn't add any deprecation warnings. Add those now, so that developers have sufficient advance warning for us to remove them completely in Wagtail 5.

I've had to get a bit tricksy with `wagtail/core/__init__.py` to stop the unittest framework recursing into that module while discovering tests, and triggering the warnings in the process. `wagtail/tests/utils/__init__.py` would need similar treatment, but I can't find a good way of doing that without blocking the actual tests in `wagtail/tests`. However, once the other files in `wagtail/tests/utils/` are dropped in 5.0, I think we should be able to move it to `wagtail/tests/utils.py` and add a deprecation warning at that point - I figure it's not a big deal if that one file ends up sitting around for one more major release cycle :-)