### PR TITLE
Fix - Documentation on Images>Alternative HTML tags

### DIFF
--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -267,8 +267,9 @@ For example, to use the `<picture>` tag:
 ```html+django
 <picture>
     {% image page.photo width-800 as wide_photo %}
+    {% image page.photo width-400 as small_photo %}
     <source srcset="{{ wide_photo.url }}" media="(min-width: 800px)">
-    {% image page.photo width-400 %}
+    <img src="{{ small_photo.url }}">
 </picture>
 ```
 


### PR DESCRIPTION
After checking the example in the doc about using Alternative HTML tags, I found that the example maybe it's not working as expected.

Using the the template tag `image`, I saw that the generated HTML code for the image template tag, sets a hard coded value to the attributes `width` and `height` for the image, and for this reason, I think that the re-size of the image using the `source` tag it's not working.

Old generated HTML code with setted height and width:
![imagen](https://user-images.githubusercontent.com/79451874/208419233-661f3d9f-8f55-4362-a6a6-2da8bafcedfb.png)

My proposal is to define the two images using the `as` keyword, and then using the `img` HTML tag itself to set the alternative image. Doing it this way, any value for width and height is setted and it can check the condition inside `source` tag as expected.

New generated HTML code:
![imagen](https://user-images.githubusercontent.com/79451874/208419157-adcb7267-1f7d-45ba-b6ae-fc976dc05279.png)

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
