### PR TITLE
Fix: Etag Behaviour in combination with Cache-Control Headers and update the tests

### DIFF
--- a/wagtail/documents/forms.py
+++ b/wagtail/documents/forms.py
@@ -42,8 +42,6 @@ class BaseDocumentForm(BaseCollectionMemberForm):
         if "file" in self.changed_data:
             self.instance._set_document_file_metadata()
 
-        super().save(commit=commit)
-
         if commit:
             if "file" in self.changed_data and self.original_file:
                 # If providing a new document file, delete the old one.
@@ -54,6 +52,8 @@ class BaseDocumentForm(BaseCollectionMemberForm):
 
             # Reindex the image to make sure all tags are indexed
             search_index.insert_or_update_object(self.instance)
+
+        super().save(commit=commit)
 
         return self.instance
 

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -603,9 +603,8 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
         )
         self.assertRedirects(response, reverse("wagtaildocs:index"))
         self.document.refresh_from_db()
-        self.assertFalse(self.document.file.storage.exists(old_filename))
-        self.assertTrue(self.document.file.storage.exists(self.document.file.name))
-        self.assertNotEqual(self.document.file.name, "documents/" + new_name)
+        self.assertEqual(old_filename, self.document.file.name)
+        self.assertEqual(self.document.file.name, "documents/" + new_name)
         self.assertEqual(self.document.file.read(), b"An updated test content.")
 
     def test_reupload_different_name(self):

--- a/wagtail/documents/tests/test_views.py
+++ b/wagtail/documents/tests/test_views.py
@@ -169,7 +169,7 @@ class TestServeView(TestCase):
     def test_has_cache_control_header(self):
         self.assertIn(
             self.get()["Cache-Control"],
-            ["max-age=3600, public", "public, max-age=3600"],
+            ["max-age=0, public", "public, max-age=0"],
         )
 
     def clear_sendfile_cache(self):

--- a/wagtail/documents/views/serve.py
+++ b/wagtail/documents/views/serve.py
@@ -28,7 +28,7 @@ def document_etag(request, document_id, document_filename):
         )
 
 
-@cache_control(max_age=0, public=True)
+@cache_control(max_age=0)
 @etag(document_etag)
 def serve(request, document_id, document_filename):
     # The cache control should be placed higher than the etag decorator as per the django documentation

--- a/wagtail/documents/views/serve.py
+++ b/wagtail/documents/views/serve.py
@@ -31,6 +31,12 @@ def document_etag(request, document_id, document_filename):
 @cache_control(max_age=0, public=True)
 @etag(document_etag)
 def serve(request, document_id, document_filename):
+    # The cache control should be placed higher than the etag decorator as per the django documentation
+    # The cache control with etag combination defines the following behaviour:
+    # E-Tag sends If-None-Match header with etag, if the document hasn't been modified status code 304
+    # is sent back, otherwise if the document has been updated, the updated document is sent with status code 200
+    # cache_control caches the respose of the etag in the local cache of the browser and a If-None-Match isn't
+    # sent until the max_age of the local cache expires
     Document = get_document_model()
     doc = get_object_or_404(Document, id=document_id)
 

--- a/wagtail/documents/views/serve.py
+++ b/wagtail/documents/views/serve.py
@@ -28,8 +28,8 @@ def document_etag(request, document_id, document_filename):
         )
 
 
+@cache_control(max_age=0, public=True)
 @etag(document_etag)
-@cache_control(max_age=3600, public=True)
 def serve(request, document_id, document_filename):
     Document = get_document_model()
     doc = get_object_or_404(Document, id=document_id)


### PR DESCRIPTION
Fixes #9776 

- Fix the caching behaviour in `wagtail.documents.views.serve`, wherein the etag sends a not-modified 304 response if the document hasn't updated. Previous behaviour cached the etag response where in even it sent potentially stale responses from the local cache.
- Reverted the change to `wagtail.documents.views.documents` that was made in https://github.com/wagtail/wagtail/pull/3821. Deletion now happens before saving the new document.
- Updated the tests to meet the requirements mentioned in https://github.com/wagtail/wagtail/pull/4567#issuecomment-555224245

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
