### PR TITLE
Fix indentation of the Telepath Adapter example code

### DIFF
--- a/docs/reference/streamfield/widget_api.md
+++ b/docs/reference/streamfield/widget_api.md
@@ -8,30 +8,30 @@ The [telepath](https://wagtail.github.io/telepath/) library is used to set up ma
 
 ```python
 from wagtail.telepath import register
-   from wagtail.widget_adapters import WidgetAdapter
+from wagtail.widget_adapters import WidgetAdapter
 
-   class FancyInputAdapter(WidgetAdapter):
-       # Identifier matching the one registered on the client side
-       js_constructor = 'myapp.widgets.FancyInput'
+class FancyInputAdapter(WidgetAdapter):
+      # Identifier matching the one registered on the client side
+      js_constructor = 'myapp.widgets.FancyInput'
 
-       # Arguments passed to the client-side object
-       def js_args(self, widget):
-           return [
-               # Arguments typically include the widget's HTML representation
-               # and label ID rendered with __NAME__ and __ID__ placeholders,
-               # for use in the client-side render() method
-               widget.render('__NAME__', None, attrs={'id': '__ID__'}),
-               widget.id_for_label('__ID__'),
-               widget.extra_options,
-           ]
+      # Arguments passed to the client-side object
+      def js_args(self, widget):
+         return [
+            # Arguments typically include the widget's HTML representation
+            # and label ID rendered with __NAME__ and __ID__ placeholders,
+            # for use in the client-side render() method
+            widget.render('__NAME__', None, attrs={'id': '__ID__'}),
+            widget.id_for_label('__ID__'),
+            widget.extra_options,
+         ]
 
-       class Media:
-           # JS / CSS includes required in addition to the widget's own media;
-           # generally this will include the client-side adapter definition
-           js = ['myapp/js/fancy-input-adapter.js']
+      class Media:
+         # JS / CSS includes required in addition to the widget's own media;
+         # generally this will include the client-side adapter definition
+         js = ['myapp/js/fancy-input-adapter.js']
 
 
-   register(FancyInputAdapter(), FancyInput)
+register(FancyInputAdapter(), FancyInput)
 ```
 
 The JavaScript object associated with a widget instance should provide a single method:


### PR DESCRIPTION
Fixes the indentation of the example Telepath Adapter code, in Docs->Reference->Streamfield->Form widget client-side API.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

- Build docs
- Check Docs->Reference->Streamfield->Form widget client-side API

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
