### PR TITLE
Document the policy needed to create invalidations in CloudFront

### DIFF
--- a/docs/reference/contrib/frontendcache.md
+++ b/docs/reference/contrib/frontendcache.md
@@ -105,7 +105,21 @@ WAGTAILFRONTENDCACHE = {
 }
 ```
 
-Configuration of credentials can done in multiple ways. You won't need to store them in your Django settings file. You can read more about this here: [Boto 3 Docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html).
+Configuration of credentials can done in multiple ways. You won't need to store them in your Django settings file. You can read more about this here: [Boto 3 Docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html). The user will need a policy similar to:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowWagtailFrontendInvalidation",
+            "Effect": "Allow",
+            "Action": "cloudfront:CreateInvalidation",
+            "Resource": "arn:aws:cloudfront::<account id>:distribution/<distribution id>"
+        }
+    ]
+}
+```
 
 In case you run multiple sites with Wagtail and each site has its CloudFront distribution, provide a mapping instead of a single distribution. Make sure the mapping matches with the hostnames provided in your site settings.
 


### PR DESCRIPTION
_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

When configuring frontend invalidation with Cloudfront, the authenticating user needs to be given permission to create an invalidation in Cloudfront. If someone has just configured AWS IAM with access to S3 (such as with [`buckup`](https://github.com/torchbox/buckup)), then the invalidation won't work.

This documents the (albeit small and simple) policy that needs to be added to the IAM user to give them the ability to create invalidations.

I realise this policy may be opaque to review, but we've been running this policy in production for a while without issue.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
