### PR TITLE
make streamfield migration names from operations

### DIFF
--- a/docs/advanced_topics/streamfield_migrations.md
+++ b/docs/advanced_topics/streamfield_migrations.md
@@ -483,7 +483,15 @@ Block ids are not preserved here since the new blocks are structurally different
 
 #### Basic usage
 
-While this package comes with a set of operations for common use cases, there may be many instances where you need to define your own operation for mapping data. Making a custom operation is fairly straightforward. All you need to do is extend the `BaseBlockOperation` class and define the `apply` method.
+While this package comes with a set of operations for common use cases, there may be many instances where you need to define your own operation for mapping data. Making a custom operation is fairly straightforward. All you need to do is extend the `BaseBlockOperation` class and define the required methods,
+
+-   `apply`  
+    This applies the actual changes on the existing block value and returns the new block value.
+-   `operation_name_fragment`  
+    (`@property`) Returns a name to be used for generating migration names.
+
+(**NOTE:** `BaseBlockOperation` inherits from `abc.ABC`, so all of the required methods
+mentioned above have to be defined on any class inheriting from it.)
 
 For example, if we want to truncate the string in a `CharBlock` to a given length,
 
@@ -500,6 +508,11 @@ class MyBlockOperation(BaseBlockOperation):
         # block value is the string value of the CharBlock
         new_block_value = block_value[:self.length]
         return new_block_value
+
+    
+    @property
+    def operation_name_fragment(self):
+        return "truncate_{}".format(self.length)
 
 ```
 

--- a/wagtail/blocks/migrations/migrate_operation.py
+++ b/wagtail/blocks/migrations/migrate_operation.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from collections import OrderedDict
 from django.db.models import JSONField, F, Q, Subquery, OuterRef
 from django.db.models.functions import Cast
 from django.db.migrations import RunPython
@@ -77,6 +78,16 @@ class MigrateStreamData(RunPython):
         kwargs["chunk_size"] = self.chunk_size
 
         return (self.__class__.__qualname__, args, kwargs)
+
+    @property
+    def migration_name_fragment(self):
+        # We are using an OrderedDict here to essentially get the functionality of an ordered set
+        # so that names generated will be consistent.
+        fragments = OrderedDict(
+            (op.operation_name_fragment, None)
+            for op, _ in self.operations_and_block_paths
+        )
+        return "_".join(fragments.keys())
 
     def migrate_stream_data_forward(self, apps, schema_editor):
         model = apps.get_model(self.app_name, self.model_name)

--- a/wagtail/test/streamfield_migrations/testutils.py
+++ b/wagtail/test/streamfield_migrations/testutils.py
@@ -10,11 +10,7 @@ class MigrationTestMixin:
     default_operation_and_block_path = []
     app_name = None
 
-    def apply_migration(
-        self,
-        revisions_from=None,
-        operations_and_block_path=None,
-    ):
+    def init_migration(self, revisions_from=None, operations_and_block_path=None):
         migration = Migration(
             "test_migration", "wagtail_streamfield_migration_toolkit_test"
         )
@@ -27,6 +23,18 @@ class MigrationTestMixin:
             revisions_from=revisions_from,
         )
         migration.operations = [migration_operation]
+
+        return migration
+
+    def apply_migration(
+        self,
+        revisions_from=None,
+        operations_and_block_path=None,
+    ):
+        migration = self.init_migration(
+            revisions_from=revisions_from,
+            operations_and_block_path=operations_and_block_path,
+        )
 
         loader = MigrationLoader(connection=connection)
         loader.build_graph()

--- a/wagtail/tests/streamfield_migrations/test_migration_names.py
+++ b/wagtail/tests/streamfield_migrations/test_migration_names.py
@@ -1,0 +1,59 @@
+from django.test import TestCase
+
+from wagtail.blocks.migrations.operations import (
+    RemoveStreamChildrenOperation,
+    RenameStreamChildrenOperation,
+)
+from wagtail.test.streamfield_migrations import models
+from wagtail.test.streamfield_migrations.testutils import MigrationTestMixin
+
+
+class MigrationNameTest(TestCase, MigrationTestMixin):
+    model = models.SamplePage
+    app_name = "wagtail_streamfield_migration_toolkit_test"
+
+    def test_rename(self):
+        operations_and_block_path = [
+            (
+                RenameStreamChildrenOperation(old_name="char1", new_name="renamed1"),
+                "",
+            )
+        ]
+        migration = self.init_migration(
+            operations_and_block_path=operations_and_block_path
+        )
+
+        suggested_name = migration.suggest_name()
+        self.assertEqual(suggested_name, "rename_char1_to_renamed1")
+
+    def test_remove(self):
+        operations_and_block_path = [
+            (
+                RemoveStreamChildrenOperation(name="char1"),
+                "",
+            )
+        ]
+        migration = self.init_migration(
+            operations_and_block_path=operations_and_block_path
+        )
+
+        suggested_name = migration.suggest_name()
+        self.assertEqual(suggested_name, "remove_char1")
+
+    def test_multiple(self):
+        operations_and_block_path = [
+            (
+                RenameStreamChildrenOperation(old_name="char1", new_name="renamed1"),
+                "",
+            ),
+            (
+                RemoveStreamChildrenOperation(name="char1"),
+                "simplestruct",
+            ),
+        ]
+        migration = self.init_migration(
+            operations_and_block_path=operations_and_block_path
+        )
+
+        suggested_name = migration.suggest_name()
+        self.assertEqual(suggested_name, "rename_char1_to_renamed1_remove_char1")


### PR DESCRIPTION
- `operation_name_fragment` property added to operations
- `migration_name_fragment` property added to MigrateStreamData
- added tests, docs updated
- BaseBlockOperation inherits from `abc.ABC`
