### PR TITLE
Add spellcheck=false attribute to ensure password isnt shared

### DIFF
--- a/wagtail/admin/forms/auth.py
+++ b/wagtail/admin/forms/auth.py
@@ -12,6 +12,7 @@ class LoginForm(AuthenticationForm):
         widget=forms.PasswordInput(
             attrs={
                 "placeholder": gettext_lazy("Enter password"),
+                "spellcheck": "false",
             }
         )
     )


### PR DESCRIPTION
Advanced spellcheck used by i.e. Chrome or Edge could enable sending sensitive data, like passwords, to servers that should never receive the data. Setting the attribute `spellcheck="false"` disallows sending said data.

See [here](https://www.androidpolice.com/google-chrome-servers-get-passwords-enhanced-spell-check/) or [here](https://www.spiceworks.com/it-security/network-security/news/spellcheck-threat-google-chrome-microsoft-edge/). 
