### PR TITLE
Remove react-axe package usage

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -102,6 +102,7 @@ Changelog
  * Maintenance: Refactor userbar stylesheets to use the same CSS loading as the rest of the admin (Albina Starykova)
  * Maintenance: Remove unused search-bar and button-filter styles (Thibaud Colas)
  * Maintenance: Use util method to construct dummy requests in tests (Jake Howard)
+ * Maintenance: Remove unused dev-only react-axe integration (Thibaud Colas)
 
 
 4.1.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/entrypoints/admin/wagtailadmin.js
+++ b/client/src/entrypoints/admin/wagtailadmin.js
@@ -18,14 +18,6 @@ import {
 } from '../../includes/panels';
 import { initMinimap } from '../../components/Minimap';
 
-if (process.env.NODE_ENV === 'development') {
-  // Run react-axe in development only, so it does not affect performance
-  // in production, and does not break unit tests either.
-  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires, import/no-extraneous-dependencies
-  const axe = require('react-axe');
-  axe(React, ReactDOM, 1000);
-}
-
 // Expose components as globals for third-party reuse.
 window.wagtail.components = {
   Icon,

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -241,7 +241,6 @@ We want to make Wagtail accessible for users of a wide variety of assistive tech
 
 We aim for Wagtail to work in those environments. Our development standards ensure that the site is usable with other assistive technologies. In practice, testing with assistive technology can be a daunting task that requires specialised training – here are tools we rely on to help identify accessibility issues, to use during development and code reviews:
 
--   [react-axe](https://github.com/dequelabs/react-axe) integrated directly into our build tools, to identify actionable issues. Logs its results in the browser console.
 -   [@wordpress/jest-puppeteer-axe](https://github.com/WordPress/gutenberg/tree/trunk/packages/jest-puppeteer-axe) running Axe checks as part of integration tests.
 -   [Axe](https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd) Chrome extension for more comprehensive automated tests of a given page.
 -   [Accessibility Insights for Web](https://accessibilityinsights.io/docs/en/web/overview) Chrome extension for semi-automated tests, and manual audits.

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -133,6 +133,7 @@ This feature was developed by Jake Howard.
  * Refactor userbar stylesheets to use the same CSS loading as the rest of the admin (Albina Starykova)
  * Remove unused search-bar and button-filter styles (Thibaud Colas)
  * Use util method to construct dummy requests in tests (Jake Howard)
+ * Remove unused dev-only react-axe integration (Thibaud Colas)
 
 ## Upgrade considerations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
         "postcss": "^8.4.7",
         "postcss-loader": "^6.2.1",
         "prettier": "^2.5.1",
-        "react-axe": "^3.5.4",
         "react-test-renderer": "^16.14.0",
         "redux-mock-store": "^1.3.0",
         "sass": "^1.45.1",
@@ -26651,23 +26650,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-axe": {
-      "version": "3.5.4",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "axe-core": "^3.5.0",
-        "requestidlecallback": "^0.3.0"
-      }
-    },
-    "node_modules/react-axe/node_modules/axe-core": {
-      "version": "3.5.6",
-      "dev": true,
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/react-colorful": {
       "version": "5.5.1",
       "dev": true,
@@ -27476,11 +27458,6 @@
       "engines": {
         "node": ">=0.10"
       }
-    },
-    "node_modules/requestidlecallback": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -49734,20 +49711,6 @@
         "prop-types": "^15.6.2"
       }
     },
-    "react-axe": {
-      "version": "3.5.4",
-      "dev": true,
-      "requires": {
-        "axe-core": "^3.5.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "dependencies": {
-        "axe-core": {
-          "version": "3.5.6",
-          "dev": true
-        }
-      }
-    },
     "react-colorful": {
       "version": "5.5.1",
       "dev": true,
@@ -50307,10 +50270,6 @@
     },
     "repeat-string": {
       "version": "1.6.1",
-      "dev": true
-    },
-    "requestidlecallback": {
-      "version": "0.3.0",
       "dev": true
     },
     "require-directory": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "postcss": "^8.4.7",
     "postcss-loader": "^6.2.1",
     "prettier": "^2.5.1",
-    "react-axe": "^3.5.4",
     "react-test-renderer": "^16.14.0",
     "redux-mock-store": "^1.3.0",
     "sass": "^1.45.1",


### PR DESCRIPTION
We’ve had Axe set up like this for a while now, but I don’t think many people use it. Its integration with React is useful in theory (re-runs the tests whenever React re-renders), but in practice reporting issues in the browser console means they’re too easy to ignore.

With an Axe integration in the works, I thought this would be a good time to remove react-axe, so we don’t run any risks of having two different versions of Axe conflicting on a page.