### PR TITLE
Assorted page editor refinements from design review

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,8 @@ Changelog
  * Allow configuring Axe accessibility checker integration via `construct_wagtail_userbar` hook (Sage Abdullah)
  * Support pinning and un-pinning the rich text editor toolbar depending on user preference (Thibaud Colas)
  * Make the rich text block trigger and slash-commands always available regardless of where the cursor is (Thibaud Colas)
+ * Adjust the size of panel labels on the "Account" form (Thibaud Colas)
+ * Delay hiding the contents of the side panels when closing, so the animation is smoother (Thibaud Colas)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/client/scss/components/_form-side.scss
+++ b/client/scss/components/_form-side.scss
@@ -92,12 +92,11 @@
     @apply w-w-0 w-h-0 w-opacity-0 w-absolute w-pointer-events-none;
   }
 
-  &--open .form-side__close-button,
-  &--open .form-side__panel {
+  &--open .form-side__close-button {
     @apply w-block;
   }
 
   &__panel {
-    @apply w-px-5 xl:w-px-10 w-py-4 w-w-full w-h-full w-overflow-y-auto w-scrollbar-thin w-hidden;
+    @apply w-px-5 xl:w-px-10 w-py-4 w-w-full w-h-full w-overflow-y-auto w-scrollbar-thin;
   }
 }

--- a/client/src/includes/sidePanel.js
+++ b/client/src/includes/sidePanel.js
@@ -23,7 +23,11 @@ export default function initSidePanel() {
     return { minWidth, maxWidth, width, range, percentage };
   };
 
+  let hidePanelTimeout;
+
   const setPanel = (panelName) => {
+    clearTimeout(hidePanelTimeout);
+
     const body = document.querySelector('body');
     const selectedPanel = document.querySelector(
       `[data-side-panel-toggle="${panelName}"]`,
@@ -62,13 +66,18 @@ export default function initSidePanel() {
           body.classList.add('side-panel-open');
         }
       } else if (!panel.hidden) {
-        // eslint-disable-next-line no-param-reassign
-        panel.hidden = true;
-        panel.dispatchEvent(new CustomEvent('hide'));
-        sidePanelWrapper.classList.remove(`form-side--${name}`);
+        const hidePanel = () => {
+          // eslint-disable-next-line no-param-reassign
+          panel.hidden = true;
+          panel.dispatchEvent(new CustomEvent('hide'));
+          sidePanelWrapper.classList.remove(`form-side--${name}`);
+        };
 
         if (panelName === '') {
           body.classList.remove('side-panel-open');
+          hidePanelTimeout = setTimeout(hidePanel, 500);
+        } else {
+          hidePanel();
         }
       }
     });

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -63,6 +63,8 @@ This feature was developed by Matt Westcott, and sponsored by [YouGov](https://y
  * Implement latest design for the admin dashboard header (Thibaud Colas, Steven Steinwand)
  * Add base Axe accessibility checker integration within userbar, with count and list of errors (Albina Starykova)
  * Allow configuring Axe accessibility checker integration via `construct_wagtail_userbar` hook (Sage Abdullah)
+ * Adjust the size of panel labels on the "Account" form (Thibaud Colas)
+ * Delay hiding the contents of the side panels when closing, so the animation is smoother (Thibaud Colas)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/account/account.html
+++ b/wagtail/admin/templates/wagtailadmin/account/account.html
@@ -33,7 +33,7 @@
                         aria-labelledby="tab-label-{{ tab.name|cautious_slugify }}"
                     >
                         {% for panel in panels %}
-                            {% panel id=panel.name heading=panel.title %}
+                            {% panel id=panel.name heading=panel.title heading_size="label" %}
                                 {{ panel.render }}
                             {% endpanel %}
                         {% endfor %}


### PR DESCRIPTION
Two completely unrelated tweaks to the page editor UX based on our v4.0 changes:

- Adjust the size of panel labels on the "Account" form
- Delay hiding the contents of the side panels when closing, so the animation is smoother

They’re only grouped together because they were reported from design review together, and there are no larger changes in those two parts of the UI to associate them with.

---

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Safari 16.2, Firefox 108, Chrome 108 on macOS 13.1
    -   [x] **Please list which assistive technologies [^3] you tested**: None
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

---

To test this,

- Head to http://localhost:8000/admin/account/ and see the panels’ labels are smaller, matching the size in use for top-level panels in the page editor form
- Head to the page editor, open/close the "Info" side panel and note the panel’s contents remain visible for the duration of the closing animation