### PR TITLE
Upgrade config for API v3

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,123 +1,124 @@
 [main]
-host = https://www.transifex.com
-lang_map = zh_CN:zh_Hans, zh-Hant:zh_Hant
+host     = https://www.transifex.com
+lang_map = zh-Hant: zh_Hant, zh_CN: zh_Hans
 
-[wagtail.wagtailadmin]
+[o:torchbox:p:wagtail:r:wagtailadmin]
 file_filter = wagtail/admin/locale/<lang>/LC_MESSAGES/django.po
 source_file = wagtail/admin/locale/en/LC_MESSAGES/django.po
 source_lang = en
-type = PO
+type        = PO
 
-[wagtail.wagtailadminjs]
+[o:torchbox:p:wagtail:r:wagtailadminjs]
 file_filter = wagtail/admin/locale/<lang>/LC_MESSAGES/djangojs.po
 source_file = wagtail/admin/locale/en/LC_MESSAGES/djangojs.po
 source_lang = en
-type = PO
+type        = PO
 
-[wagtail.wagtailcore]
+[o:torchbox:p:wagtail:r:wagtailcore]
 file_filter = wagtail/locale/<lang>/LC_MESSAGES/django.po
 source_file = wagtail/locale/en/LC_MESSAGES/django.po
 source_lang = en
-type = PO
+type        = PO
 
-[wagtail.wagtaildocs]
+[o:torchbox:p:wagtail:r:wagtaildocs]
 file_filter = wagtail/documents/locale/<lang>/LC_MESSAGES/django.po
 source_file = wagtail/documents/locale/en/LC_MESSAGES/django.po
 source_lang = en
-type = PO
+type        = PO
 
-[wagtail.wagtailimages]
-file_filter = wagtail/images/locale/<lang>/LC_MESSAGES/django.po
-source_file = wagtail/images/locale/en/LC_MESSAGES/django.po
-source_lang = en
-type = PO
-
-[wagtail.wagtailembeds]
+[o:torchbox:p:wagtail:r:wagtailembeds]
 file_filter = wagtail/embeds/locale/<lang>/LC_MESSAGES/django.po
 source_file = wagtail/embeds/locale/en/LC_MESSAGES/django.po
 source_lang = en
-type = PO
+type        = PO
 
-[wagtail.wagtailredirects]
-file_filter = wagtail/contrib/redirects/locale/<lang>/LC_MESSAGES/django.po
-source_file = wagtail/contrib/redirects/locale/en/LC_MESSAGES/django.po
-source_lang = en
-type = PO
-
-[wagtail.wagtailsearch]
-file_filter = wagtail/search/locale/<lang>/LC_MESSAGES/django.po
-source_file = wagtail/search/locale/en/LC_MESSAGES/django.po
-source_lang = en
-type = PO
-
-[wagtail.wagtailsnippets]
-file_filter = wagtail/snippets/locale/<lang>/LC_MESSAGES/django.po
-source_file = wagtail/snippets/locale/en/LC_MESSAGES/django.po
-source_lang = en
-type = PO
-
-[wagtail.wagtailusers]
-file_filter = wagtail/users/locale/<lang>/LC_MESSAGES/django.po
-source_file = wagtail/users/locale/en/LC_MESSAGES/django.po
-source_lang = en
-type = PO
-
-[wagtail.wagtailforms]
+[o:torchbox:p:wagtail:r:wagtailforms]
 file_filter = wagtail/contrib/forms/locale/<lang>/LC_MESSAGES/django.po
 source_file = wagtail/contrib/forms/locale/en/LC_MESSAGES/django.po
 source_lang = en
-type = PO
+type        = PO
 
-[wagtail.wagtailsites]
-file_filter = wagtail/sites/locale/<lang>/LC_MESSAGES/django.po
-source_file = wagtail/sites/locale/en/LC_MESSAGES/django.po
+[o:torchbox:p:wagtail:r:wagtailimages]
+file_filter = wagtail/images/locale/<lang>/LC_MESSAGES/django.po
+source_file = wagtail/images/locale/en/LC_MESSAGES/django.po
 source_lang = en
-type = PO
+type        = PO
 
-[wagtail.wagtaillocales]
+[o:torchbox:p:wagtail:r:wagtaillocales]
 file_filter = wagtail/locales/locale/<lang>/LC_MESSAGES/django.po
 source_file = wagtail/locales/locale/en/LC_MESSAGES/django.po
 source_lang = en
-type = PO
+type        = PO
 
-[wagtail.wagtailsearchpromotions]
-file_filter = wagtail/contrib/search_promotions/locale/<lang>/LC_MESSAGES/django.po
-source_file = wagtail/contrib/search_promotions/locale/en/LC_MESSAGES/django.po
-source_lang = en
-type = PO
-
-[wagtail.wagtailstyleguide]
-file_filter = wagtail/contrib/styleguide/locale/<lang>/LC_MESSAGES/django.po
-source_file = wagtail/contrib/styleguide/locale/en/LC_MESSAGES/django.po
-source_lang = en
-type = PO
-
-[wagtail.wagtailsettings]
-file_filter = wagtail/contrib/settings/locale/<lang>/LC_MESSAGES/django.po
-source_file = wagtail/contrib/settings/locale/en/LC_MESSAGES/django.po
-source_lang = en
-type = PO
-
-[wagtail.wagtailmodeladmin]
+[o:torchbox:p:wagtail:r:wagtailmodeladmin]
 file_filter = wagtail/contrib/modeladmin/locale/<lang>/LC_MESSAGES/django.po
 source_file = wagtail/contrib/modeladmin/locale/en/LC_MESSAGES/django.po
 source_lang = en
-type = PO
+type        = PO
 
-[wagtail.wagtailtableblock]
-file_filter = wagtail/contrib/table_block/locale/<lang>/LC_MESSAGES/django.po
-source_file = wagtail/contrib/table_block/locale/en/LC_MESSAGES/django.po
+[o:torchbox:p:wagtail:r:wagtailredirects]
+file_filter = wagtail/contrib/redirects/locale/<lang>/LC_MESSAGES/django.po
+source_file = wagtail/contrib/redirects/locale/en/LC_MESSAGES/django.po
 source_lang = en
-type = PO
+type        = PO
 
-[wagtail.wagtailsimpletranslation]
+[o:torchbox:p:wagtail:r:wagtailsearch]
+file_filter = wagtail/search/locale/<lang>/LC_MESSAGES/django.po
+source_file = wagtail/search/locale/en/LC_MESSAGES/django.po
+source_lang = en
+type        = PO
+
+[o:torchbox:p:wagtail:r:wagtailsearchpromotions]
+file_filter = wagtail/contrib/search_promotions/locale/<lang>/LC_MESSAGES/django.po
+source_file = wagtail/contrib/search_promotions/locale/en/LC_MESSAGES/django.po
+source_lang = en
+type        = PO
+
+[o:torchbox:p:wagtail:r:wagtailsettings]
+file_filter = wagtail/contrib/settings/locale/<lang>/LC_MESSAGES/django.po
+source_file = wagtail/contrib/settings/locale/en/LC_MESSAGES/django.po
+source_lang = en
+type        = PO
+
+[o:torchbox:p:wagtail:r:wagtailsimpletranslation]
 file_filter = wagtail/contrib/simple_translation/locale/<lang>/LC_MESSAGES/django.po
 source_file = wagtail/contrib/simple_translation/locale/en/LC_MESSAGES/django.po
 source_lang = en
-type = PO
+type        = PO
 
-[wagtail.wagtailtypedtableblock]
+[o:torchbox:p:wagtail:r:wagtailsites]
+file_filter = wagtail/sites/locale/<lang>/LC_MESSAGES/django.po
+source_file = wagtail/sites/locale/en/LC_MESSAGES/django.po
+source_lang = en
+type        = PO
+
+[o:torchbox:p:wagtail:r:wagtailsnippets]
+file_filter = wagtail/snippets/locale/<lang>/LC_MESSAGES/django.po
+source_file = wagtail/snippets/locale/en/LC_MESSAGES/django.po
+source_lang = en
+type        = PO
+
+[o:torchbox:p:wagtail:r:wagtailstyleguide]
+file_filter = wagtail/contrib/styleguide/locale/<lang>/LC_MESSAGES/django.po
+source_file = wagtail/contrib/styleguide/locale/en/LC_MESSAGES/django.po
+source_lang = en
+type        = PO
+
+[o:torchbox:p:wagtail:r:wagtailtableblock]
+file_filter = wagtail/contrib/table_block/locale/<lang>/LC_MESSAGES/django.po
+source_file = wagtail/contrib/table_block/locale/en/LC_MESSAGES/django.po
+source_lang = en
+type        = PO
+
+[o:torchbox:p:wagtail:r:wagtailtypedtableblock]
 file_filter = wagtail/contrib/typed_table_block/locale/<lang>/LC_MESSAGES/django.po
 source_file = wagtail/contrib/typed_table_block/locale/en/LC_MESSAGES/django.po
 source_lang = en
-type = PO
+type        = PO
+
+[o:torchbox:p:wagtail:r:wagtailusers]
+file_filter = wagtail/users/locale/<lang>/LC_MESSAGES/django.po
+source_file = wagtail/users/locale/en/LC_MESSAGES/django.po
+source_lang = en
+type        = PO
+


### PR DESCRIPTION
Transifex [deprecated their API v2 for Nov 30th 2022](https://community.transifex.com/t/reminder-deprecated-transifex-apis-and-transifex-client-to-be-discontinued-on-nov-30-2022/3079). Surprisingly though, our scripts are still working despite using [pypi/transifex-client](https://pypi.org/project/transifex-client/) which targets v2, but for how long?

As described in their [migration steps](https://github.com/transifex/cli/blob/3451ac1a8bc5fdec0fa9d0db64eaa8d5a85d4279/README.md#migrating-from-older-versions-of-the-client), _the client maintains backwards compatibility for the tx push and tx pull commands_ so the only thing needed it to update the config file (done in this PR).

Additionally, I created a revision on the translation management wiki page, to be merged/applied once this PR is merged, see [the changes](https://github.com/wagtail/wagtail/wiki/Managing-Wagtail-translations/_compare/dbefd8bc375cc8035c39e0f96640dcf4e50e3d2b...79afdd4e9430f226b38ba9601f5d2234191c355c).

I was able to test `tx pull` commands successfully, however I did not try `tx push` as it's always quite sensitive. I guess it will be done soon for the next release candidate and everything will be fine 🤞 