### PR TITLE
Fix issue where notifications did not include the correct hash

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -57,6 +57,7 @@ Changelog
  * Fix: Make sure browser font resizing applies to the userbar (Albina Starykova)
  * Fix: Fix check for `delete_url_name` attribute in generic `DeleteView` (Alex Simpson)
  * Fix: Re-implement design system colors so HSL values exactly match the desired RGB (Albina Starykova)
+ * Fix: Resolve issue where workflow and other notification emails would not include the correct tab URL for account notification management (LB (Ben) Johnston)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -81,6 +81,7 @@ This feature was developed by Jake Howard.
  * Make sure browser font resizing applies to the userbar (Albina Starykova)
  * Fix check for `delete_url_name` attribute in generic `DeleteView` (Alex Simpson)
  * Re-implement design system colors so HSL values exactly match the desired RGB (Albina Starykova)
+ * Resolve issue where workflow and other notification emails would not include the correct tab URL for account notification management (LB (Ben) Johnston)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/notifications/base.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/base.html
@@ -119,7 +119,7 @@
 
                                         <div style="font-size: 10px; margin-top: 20px;">
                                             {% block preferences %}
-                                                {% trans "Edit your notification preferences here:" %} <a href="{{ base_url }}{% url 'wagtailadmin_account' %}#notifications">{{ base_url }}{% url 'wagtailadmin_account' %}#notifications</a>
+                                                {% trans "Edit your notification preferences here:" %} <a href="{{ base_url }}{% url 'wagtailadmin_account' %}#tab-notifications">{{ base_url }}{% url 'wagtailadmin_account' %}#tab-notifications</a>
                                             {% endblock %}
                                         </div>
                                     </td>

--- a/wagtail/admin/templates/wagtailadmin/notifications/base.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/base.txt
@@ -7,5 +7,5 @@
 {% block content %}
 {% endblock %}
 {% block preferences %}
-{% trans "Edit your notification preferences here:" %} {{ base_url }}{% url 'wagtailadmin_account' %}#notifications
+{% trans "Edit your notification preferences here:" %} {{ base_url }}{% url 'wagtailadmin_account' %}#tab-notifications
 {% endblock %}

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from freezegun import freeze_time
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
+from wagtail.admin.utils import get_admin_base_url
 from wagtail.models import (
     GroupApprovalTask,
     Page,
@@ -1616,6 +1617,7 @@ class TestNotificationPreferences(TestCase, WagtailTestUtils):
         workflow_submission_emailed_addresses = [
             address for email in workflow_submission_emails for address in email.to
         ]
+        workflow_submission_email_body = workflow_submission_emails[0].body
 
         self.assertEqual(len(task_submission_emails), 3)
         # the moderator is in the Group assigned to the GroupApproval task, so should get an email
@@ -1634,6 +1636,16 @@ class TestNotificationPreferences(TestCase, WagtailTestUtils):
         self.assertIn(self.superuser.email, workflow_submission_emailed_addresses)
         # as the submitter was the triggering user, the submitter should not get an email notification
         self.assertNotIn(self.submitter.email, workflow_submission_emailed_addresses)
+        # check that the email contains the ability to show the notifications tab in the admin account preferences
+        account_notifications_url = (
+            get_admin_base_url()
+            + reverse("wagtailadmin_account")
+            + "#tab-notifications"
+        )
+        self.assertIn(
+            "Edit your notification preferences here: %s" % account_notifications_url,
+            workflow_submission_email_body,
+        )
 
     @override_settings(WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS=False)
     def test_submitted_email_notifications_superuser_settings(self):


### PR DESCRIPTION
- Fixes #9873
- The Tab notification URL hash changed when adopting the new tabs system
-   [X] Do the tests still pass?
-   [X] Does the code comply with the style guide?
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For new features: Has the documentation been updated accordingly? **N/A**

**Please describe additional details for testing this change**.
See #9873

## Validation screenshot

<img width="1609" alt="Screen Shot 2023-01-11 at 7 33 14 am" src="https://user-images.githubusercontent.com/1396140/211667611-92684335-c583-4a71-b59b-1d65cbc31116.png">
