### PR TITLE
Fix parsing of queries with multiple filters that contain quotes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -69,6 +69,7 @@ Changelog
  * Fix: Use the correct color for placeholders in rich text fields (Thibaud Colas)
  * Fix: Prevent obstructing the outline around rich text fields (Thibaud Colas)
  * Fix: Page editor dropdowns now use indigo backgrounds like elsewhere in the admin interface (Thibaud Colas)
+ * Fix: Allow parsing of multiple key/value pairs from string in `wagtail.search.utils.parse_query_string` (Beniamin Bucur)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -683,6 +683,7 @@ Contributors
 * Alex Simpson
 * GLEF1X
 * Nick Lee
+* Beniamin Bucur
 
 Translators
 ===========

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -106,6 +106,7 @@ This feature was developed by Matt Westcott, and sponsored by [YouGov](https://y
  * Use the correct color for placeholders in rich text fields (Thibaud Colas)
  * Prevent obstructing the outline around rich text fields (Thibaud Colas)
  * Page editor dropdowns now use indigo backgrounds like elsewhere in the admin interface (Thibaud Colas)
+ * Allow parsing of multiple key/value pairs from string in `wagtail.search.utils.parse_query_string` (Beniamin Bucur)
 
 ### Documentation
 

--- a/wagtail/search/tests/test_queries.py
+++ b/wagtail/search/tests/test_queries.py
@@ -248,6 +248,14 @@ class TestSeparateFiltersFromQuery(SimpleTestCase):
         self.assertDictEqual(filters, {"author": "foo bar", "bar": "beer"})
         self.assertEqual(query, "hello world")
 
+    def test_two_filters_with_quotation_marks_and_query(self):
+        filters, query = separate_filters_from_query(
+            'author:"foo bar" hello world bar:"two beers"'
+        )
+
+        self.assertDictEqual(filters, {"author": "foo bar", "bar": "two beers"})
+        self.assertEqual(query, "hello world")
+
 
 class TestParseQueryString(SimpleTestCase):
     def test_simple_query(self):

--- a/wagtail/search/utils.py
+++ b/wagtail/search/utils.py
@@ -82,7 +82,7 @@ def normalise_query_string(query_string):
 
 
 def separate_filters_from_query(query_string):
-    filters_regexp = r'(\w+):(\w+|".+")'
+    filters_regexp = r'(\w+):(\w+|"[^"]+")'
 
     filters = {}
     for match_object in re.finditer(filters_regexp, query_string):


### PR DESCRIPTION
This PR changes the `separate_filters_from_query` util to correctly parse queries with multiple filters that contain quotes. 
It fixes issue #7961

-   [X] Do the tests still pass?
-   [X] Does the code comply with the style guide?
    -   [X] Run `make lint` from the Wagtail root.
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
