### PR TITLE
Remove unused React / ReactDOM imports from wagtailadmin.js

### DIFF
--- a/client/src/entrypoints/admin/wagtailadmin.js
+++ b/client/src/entrypoints/admin/wagtailadmin.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
 import { Icon, Portal, initDismissibles, initUpgradeNotification } from '../..';
 import { initModernDropdown, initTooltips } from '../../includes/initTooltips';
 import { initTabs } from '../../includes/tabs';


### PR DESCRIPTION
These are no longer required as of d036f10e610044b91fa96521e43c1e55ab1ce3b8 and are raising eslint warnings.
