### PR TITLE
Prevent memory exhaustion when purging a large number of revisions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -70,6 +70,7 @@ Changelog
  * Fix: Prevent obstructing the outline around rich text fields (Thibaud Colas)
  * Fix: Page editor dropdowns now use indigo backgrounds like elsewhere in the admin interface (Thibaud Colas)
  * Fix: Allow parsing of multiple key/value pairs from string in `wagtail.search.utils.parse_query_string` (Beniamin Bucur)
+ * Fix: Prevent memory exhaustion when purging a large number of revisions (Jake Howard)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -107,6 +107,7 @@ This feature was developed by Matt Westcott, and sponsored by [YouGov](https://y
  * Prevent obstructing the outline around rich text fields (Thibaud Colas)
  * Page editor dropdowns now use indigo backgrounds like elsewhere in the admin interface (Thibaud Colas)
  * Allow parsing of multiple key/value pairs from string in `wagtail.search.utils.parse_query_string` (Beniamin Bucur)
+ * Prevent memory exhaustion when purging a large number of revisions (Jake Howard)
 
 ### Documentation
 

--- a/wagtail/management/commands/purge_revisions.py
+++ b/wagtail/management/commands/purge_revisions.py
@@ -60,7 +60,7 @@ def purge_revisions(days=None):
 
     deleted_revisions_count = 0
 
-    for revision in purgeable_revisions:
+    for revision in purgeable_revisions.iterator():
         # don't delete the latest revision for any page
         if not revision.is_latest_revision():
             revision.delete()

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2835,15 +2835,16 @@ class Revision(models.Model):
             # special case: a revision without an ID is presumed to be newly-created and is thus
             # newer than any revision that might exist in the database
             return True
-        latest_revision = (
-            Revision.objects.filter(
+
+        return (
+            not Revision.objects.filter(
                 base_content_type_id=self.base_content_type_id,
                 object_id=self.object_id,
+                created_at__gte=self.created_at,
             )
-            .order_by("-created_at", "-id")
-            .first()
+            .exclude(id=self.id)
+            .exists()
         )
-        return latest_revision == self
 
     def delete(self):
         # Update revision_created fields for comments that reference the current revision, if applicable.


### PR DESCRIPTION
_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

When running `manage.py purge_revisions` with lots of revisions to purge (millions), the system can run out of memory as it tries to load all these revisions into memory. This PR improves things in 2 ways:

1. Uses `.iterator` to prevent loading _all_ revisions into memory at once. Instead, it loads them in chunks, which Python's GC should then clean up. This also has the benefit of starting the delete sooner, before waiting for the DB to return all the results.
2. Optimise `is_latest_revision` slightly. It still does a query, but said query should now be much faster, as it doesn't need to load the latest revision into memory. Instead, we just check whether any future revisions exist, all inside the DB.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
