### PR TITLE
Load Axe configuration and error messages defined in Python

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Changelog
  * Update admin focus outline color to have higher contrast against white backgrounds (Thibaud Colas)
  * Implement latest design for the admin dashboard header (Thibaud Colas, Steven Steinwand)
  * Add base Axe accessibility checker integration within userbar, with error count (Albina Starykova)
+ * Allow configuring Axe accessibility checker integration via `construct_wagtail_userbar` hook (Sage Abdullah)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -46,6 +46,7 @@ This feature was developed by Jake Howard.
  * Update admin focus outline color to have higher contrast against white backgrounds (Thibaud Colas)
  * Implement latest design for the admin dashboard header (Thibaud Colas, Steven Steinwand)
  * Add base Axe accessibility checker integration within userbar, with error count (Albina Starykova)
+ * Allow configuring Axe accessibility checker integration via `construct_wagtail_userbar` hook (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_accessibility.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_accessibility.html
@@ -6,4 +6,5 @@
         {% icon name="tick" class_name="w-action-icon" %}
         {% trans 'Accessibility' %}
     </button>
+    {{ axe_configuration|json_script:"accessibility-axe-configuration" }}
 {% endblock %}

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -146,6 +146,25 @@ class TestUserbarTag(TestCase, WagtailTestUtils):
         # Make sure nothing was rendered
         self.assertEqual(content, "")
 
+    def test_userbar_accessibility_configuration(self):
+        template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")
+        content = template.render(
+            Context(
+                {
+                    PAGE_TEMPLATE_VAR: self.homepage,
+                    "request": self.dummy_request(self.user),
+                }
+            )
+        )
+
+        # Should include the configuration as a JSON script with the specific id
+        self.assertIn(
+            '<script id="accessibility-axe-configuration" type="application/json">',
+            content,
+        )
+        # Should include the custom error message
+        self.assertIn("Use the correct heading order", content)
+
 
 class TestUserbarFrontend(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -1,4 +1,5 @@
 from django.template.loader import render_to_string
+from django.utils.translation import gettext_lazy as _
 
 
 class BaseItem:
@@ -25,13 +26,47 @@ class AdminItem(BaseItem):
 class AccessibilityItem(BaseItem):
     template = "wagtailadmin/userbar/item_accessibility.html"
 
+    def get_axe_configuration(self):
+        return {
+            # See https://github.com/dequelabs/axe-core/blob/develop/doc/context.md.
+            "context": {
+                "include": "body",
+                "exclude": {"fromShadowDOM": ["wagtail-userbar"]},
+            },
+            # See https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter.
+            "options": {
+                "runOnly": {
+                    "type": "rule",
+                    "values": [
+                        "empty-heading",
+                        "heading-order",
+                        "p-as-heading",
+                    ],
+                }
+            },
+            # Wagtail-specific translatable custom error messages.
+            "messages": {
+                "empty-heading": _("Avoid empty headings"),
+                "heading-order": _("Use the correct heading order"),
+                "p-as-heading": _("Use heading elements for headings"),
+            },
+        }
+
     def render(self, request):
 
         # Don't render if user doesn't have permission to access the admin area
         if not request.user.has_perm("wagtailadmin.access_admin"):
             return ""
 
-        return super().render(request)
+        return render_to_string(
+            self.template,
+            {
+                "self": self,
+                "request": request,
+                "axe_configuration": self.get_axe_configuration(),
+            },
+            request=request,
+        )
 
 
 class AddPageItem(BaseItem):


### PR DESCRIPTION
This allows the configuration to be customisable by subclassing `AccessibilityItem` and overriding `get_axe_configuration()`, then replacing the default `AccessibilityItem` instance with a custom one through the `construct_wagtail_userbar` hook.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

- Spin up bakerydemo
- Login to the admin
- Open the Breads page
- Click on the userbar > Accessibility
- Custom error message ("Use the correct heading order") should be shown instead of Axe's default

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
