### PR TITLE
Restore autocomplete behaviour of search in chooser modals

### DIFF
--- a/wagtail/admin/forms/choosers.py
+++ b/wagtail/admin/forms/choosers.py
@@ -76,7 +76,24 @@ class SearchFilterMixin(forms.Form):
         search_query = self.cleaned_data.get("q")
         if search_query:
             search_backend = get_search_backend()
-            objects = search_backend.search(search_query, objects)
+
+            # The search should work as an autocomplete by preference, but only if
+            # there are AutocompleteFields set up for this model in the search index;
+            # if not, fall back on a standard search so that we get results at all
+            if objects.model.get_autocomplete_search_fields():
+                try:
+                    objects = search_backend.autocomplete(search_query, objects)
+                except NotImplementedError:
+                    # Older search backends do not implement .autocomplete() but do support
+                    # partial_match on .search(). Newer ones will ignore partial_match.
+                    objects = search_backend.search(
+                        search_query, objects, partial_match=True
+                    )
+            else:
+                objects = search_backend.search(
+                    search_query, objects, partial_match=True
+                )
+
             self.is_searching = True
             self.search_query = search_query
         return objects

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -327,6 +327,13 @@ class TestChooserSearch(TestCase, WagtailTestUtils):
         self.assertContains(response, "There is 1 match")
         self.assertContains(response, "foobarbaz")
 
+    def test_partial_match(self):
+        response = self.get({"q": "fooba"})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/chooser/_search_results.html")
+        self.assertContains(response, "There is 1 match")
+        self.assertContains(response, "foobarbaz")
+
     def test_result_uses_custom_admin_display_title(self):
         single_event_page = SingleEventPage(
             title="Lunar event",

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -451,7 +451,13 @@ class SearchView(View):
             pages = pages.exclude(depth=1)  # never include root
             pages = pages.type(*desired_classes)
             pages = pages.specific()
-            pages = pages.search(search_form.cleaned_data["q"])
+            try:
+                pages = pages.autocomplete(search_form.cleaned_data["q"])
+            except NotImplementedError:
+                # Older search backends do not implement .autocomplete() but do support
+                # partial_match on .search(). Newer ones will ignore partial_match.
+                pages = pages.search(search_form.cleaned_data["q"], partial_match=True)
+
         else:
             pages = pages.none()
 

--- a/wagtail/search/backends/database/mysql/mysql.py
+++ b/wagtail/search/backends/database/mysql/mysql.py
@@ -633,7 +633,11 @@ class MySQLSearchAtomicRebuilder(MySQLSearchRebuilder):
 
 class MySQLSearchBackend(BaseSearchBackend):
     query_compiler_class = MySQLSearchQueryCompiler
-    autocomplete_query_compiler_class = MySQLAutocompleteQueryCompiler
+
+    # FIXME: the implementation of MySQLAutocompleteQueryCompiler is incomplete -
+    # leave this undefined so that we get a clean NotImplementedError from BaseSearchBackend
+    # autocomplete_query_compiler_class = MySQLAutocompleteQueryCompiler
+
     results_class = MySQLSearchResults
     rebuilder_class = MySQLSearchRebuilder
     atomic_rebuilder_class = MySQLSearchAtomicRebuilder

--- a/wagtail/search/backends/database/sqlite/sqlite.py
+++ b/wagtail/search/backends/database/sqlite/sqlite.py
@@ -650,7 +650,11 @@ class SQLiteSearchResults(BaseSearchResults):
 
 class SQLiteSearchBackend(BaseSearchBackend):
     query_compiler_class = SQLiteSearchQueryCompiler
-    autocomplete_query_compiler_class = SQLiteAutocompleteQueryCompiler
+
+    # FIXME: the implementation of SQLiteAutocompleteQueryCompiler is incomplete -
+    # leave this undefined so that we get a clean NotImplementedError from BaseSearchBackend
+    # autocomplete_query_compiler_class = SQLiteAutocompleteQueryCompiler
+
     results_class = SQLiteSearchResults
     rebuilder_class = SQLiteSearchRebuilder
     atomic_rebuilder_class = SQLiteSearchAtomicRebuilder

--- a/wagtail/search/tests/test_mysql_backend.py
+++ b/wagtail/search/tests/test_mysql_backend.py
@@ -90,6 +90,10 @@ class TestMySQLSearchBackend(BackendTests, TransactionTestCase):
     def test_annotate_score_with_slice(self):
         return super().test_annotate_score_with_slice()
 
+    def test_autocomplete_raises_not_implemented_error(self):
+        with self.assertRaises(NotImplementedError):
+            self.backend.autocomplete("Py", models.Book)
+
     @skip("The MySQL backend doesn't support autocomplete.")
     def test_autocomplete(self):
         return super().test_autocomplete()

--- a/wagtail/search/tests/test_sqlite_backend.py
+++ b/wagtail/search/tests/test_sqlite_backend.py
@@ -8,6 +8,7 @@ from django.test.utils import override_settings
 
 from wagtail.search.backends.database.sqlite.utils import fts5_available
 from wagtail.search.tests.test_backends import BackendTests
+from wagtail.test.search import models
 
 
 @unittest.skipUnless(
@@ -42,6 +43,10 @@ class TestSQLiteSearchBackend(BackendTests, TestCase):
     @skip("The SQLite backend doesn't score annotations.")
     def test_annotate_score_with_slice(self):
         return super().test_annotate_score_with_slice()
+
+    def test_autocomplete_raises_not_implemented_error(self):
+        with self.assertRaises(NotImplementedError):
+            self.backend.autocomplete("Py", models.Book)
 
     @skip("The SQLite backend doesn't support autocomplete.")
     def test_autocomplete(self):

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -4733,6 +4733,15 @@ class TestSnippetChooseWithSearchableSnippet(TestCase, WagtailTestUtils):
         self.assertIn(self.snippet_b, items)
         self.assertIn(self.snippet_c, items)
 
+    def test_partial_match(self):
+        response = self.get({"q": "hello wo"})
+
+        # should perform partial matching and return "Hello World"
+        items = list(response.context["items"].object_list)
+        self.assertNotIn(self.snippet_a, items)
+        self.assertNotIn(self.snippet_b, items)
+        self.assertIn(self.snippet_c, items)
+
 
 class TestSnippetChosen(TestCase, WagtailTestUtils):
     fixtures = ["test.json"]

--- a/wagtail/test/snippets/models.py
+++ b/wagtail/test/snippets/models.py
@@ -57,6 +57,7 @@ class SearchableSnippet(index.Indexed, models.Model):
 
     search_fields = [
         index.SearchField("text"),
+        index.AutocompleteField("text"),
     ]
 
     def __str__(self):


### PR DESCRIPTION
Fixes #7720. Unfortunately the different search backends have diverged massively in the autocomplete APIs they support:

* Postgres FTS (and probably the other database FTS backends) ignores the `partial_match` kwarg on `.search()` and `SearchField`, and only supports the `.autocomplete()` / `AutocompleteField` API
* The database fallback backend (and probably Elasticsearch) accepts `partial_match` on `.search()` (in fact I think it always does partial matches regardless of that setting - untested), but raises `NotImplementedError` on `.autocomplete()`

As a result, to perform autocompletion across all backends, we need to try both methods, with a try/except. (Also, user-defined models such as snippets will need either or both of `AutocompleteField` or `SearchField(partial_match=True)` in `search_fields` depending on the backend in use.)

Additionally, while tests have been added to cover the autocomplete behaviour, the test suite only ever runs under the fallback backend (with the exception of the backend-specific tests in wagtail.search), and so these would have succeeded anyhow. Much more cleanup work is needed here, but this will serve as a stopgap solution to get the choosers working as intended again.

**Please describe additional details for testing this change**.

To test against bakerydemo:

* In `base/models.py`, change the `search_fields` definition on Person to
  ```python
    search_fields = [
        index.SearchField("first_name", partial_match=True),
        index.AutocompleteField("first_name"),
        index.SearchField("last_name", partial_match=True),
        index.AutocompleteField("last_name"),
    ]
  ```
* Run `./manage.py update_index`
* Edit the homepage, open the page chooser under "Hero CTA link", and enter `wild ye` in the search box - "Tracking Wild Yeast" appears in the results
* Edit a blog post, open the snippet chooser under the Authors section, and enter `oliv` in the search box - Olivia Ava appears in the results
* In `settings/base.py`, change WAGTAILSEARCH_BACKENDS to `"wagtail.search.backends.database.fallback"` and re-test