### PR TITLE
Fix JS error in dirty form checks from NodeList - array API differences

### DIFF
--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -164,8 +164,8 @@ function enableDirtyFormCheck(formSelector, options) {
       const observer = new MutationObserver((mutationList) => {
         const hasMutationWithValidInputNode = mutationList.some(
           (mutation) =>
-            mutation.addedNodes.some(isValidInputNode) ||
-            mutation.removedNodes.some(isValidInputNode),
+            Array.from(mutation.addedNodes).some(isValidInputNode) ||
+            Array.from(mutation.removedNodes).some(isValidInputNode),
         );
 
         if (hasMutationWithValidInputNode) {


### PR DESCRIPTION
Follow-up to #9805, similar to #9878. We refactored this code to no longer use `for…of` loops. The new version only works if we convert the NodeLists to arrays first.

A similar fix has been done elsewhere in the code: #9878. Those are the only two places where this needed fixing.

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Safari 16 on macOS 12, Firefox 108 + Chrome 108 on macOS 13.1
    -   [x] **Please list which assistive technologies [^3] you tested**: N/A
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

**Please describe additional details for testing this change**.

- Trigger "dirty form check" when adding an element (e.g. rich text content)
- Trigger "dirty form check" when removing an element (e.g. rich text content)