### PR TITLE
Fix warning message in icon template tag and update obsolete `class_name` usages

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -51,7 +51,7 @@
     </template>
     <template id="w-a11y-result-selector-template">
         <button class="w-a11y-result__selector" data-a11y-result-selector type="button">
-            {% icon name="crosshairs" class_name="w-a11y-result__icon" %}
+            {% icon name="crosshairs" classname="w-a11y-result__icon" %}
             <span data-a11y-result-selector-text></span>
         </button>
     </template>

--- a/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_content_types_checkbox.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_content_types_checkbox.html
@@ -3,7 +3,7 @@
 {% for id, errors in errors_by_id.items %}
     {% if id == widget.value %}
         <div class="w-field__errors" data-field-errors>
-            {% icon name="warning" class_name="w-field__errors-icon" %}
+            {% icon name="warning" classname="w-field__errors-icon" %}
             <p class="error-message">
                 {% for error in errors %}{{ error.message }} {% endfor %}
             </p>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -764,8 +764,8 @@ def icon(name=None, classname=None, title=None, wrapped=False, class_name=None):
 
         warn(
             (
-                "Icon template tag `class_name` has been renamed to `classname`, please adopt the new usage instead.",
-                f'Replace `{{% icon ... class_name="{class_name}" %}}` with `{{% icon ... classname="{class_name}" %}}`',
+                "Icon template tag `class_name` has been renamed to `classname`, please adopt the new usage instead. "
+                f'Replace `{{% icon ... class_name="{class_name}" %}}` with `{{% icon ... classname="{class_name}" %}}`'
             ),
             category=RemovedInWagtail50Warning,
         )

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -27,6 +27,7 @@ from wagtail.images.tests.utils import get_test_image_file
 from wagtail.models import Locale
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.users.models import UserProfile
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
 
 
 class TestAvatarTemplateTag(TestCase, WagtailTestUtils):
@@ -483,3 +484,62 @@ class ClassnamesTagTest(TestCase):
         actual = Template(template).render(context)
 
         self.assertEqual(expected.strip(), actual.strip())
+
+
+class IconTagTest(TestCase):
+    def test_basic(self):
+        template = """
+            {% load wagtailadmin_tags %}
+            {% icon "wagtail" %}
+        """
+
+        expected = """
+            <svg aria-hidden="true" class="icon icon-wagtail icon"><use href="#icon-wagtail"></svg>
+        """
+
+        self.assertHTMLEqual(expected, Template(template).render(Context()))
+
+    def test_with_classes_positional(self):
+        template = """
+            {% load wagtailadmin_tags %}
+            {% icon "cogs" "myclass" %}
+        """
+
+        expected = """
+            <svg aria-hidden="true" class="icon icon-cogs myclass"><use href="#icon-cogs"></svg>
+        """
+
+        self.assertHTMLEqual(expected, Template(template).render(Context()))
+
+    def test_with_classes_keyword(self):
+        template = """
+            {% load wagtailadmin_tags %}
+            {% icon "warning" classname="myclass" %}
+        """
+
+        expected = """
+            <svg aria-hidden="true" class="icon icon-warning myclass"><use href="#icon-warning"></svg>
+        """
+
+        self.assertHTMLEqual(expected, Template(template).render(Context()))
+
+    def test_with_classes_obsolete_keyword(self):
+        template = """
+            {% load wagtailadmin_tags %}
+            {% icon "doc-empty" class_name="myclass" %}
+        """
+
+        expected = """
+            <svg aria-hidden="true" class="icon icon-doc-empty myclass"><use href="#icon-doc-empty"></svg>
+        """
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail50Warning,
+            (
+                "Icon template tag `class_name` has been renamed to `classname`, "
+                "please adopt the new usage instead. Replace "
+                '`{% icon ... class_name="myclass" %}` with '
+                '`{% icon ... classname="myclass" %}`'
+            ),
+        ):
+            self.assertHTMLEqual(expected, Template(template).render(Context()))


### PR DESCRIPTION
Fixes #9917.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
