### PR TITLE
Fix failing workflow tests due to revision creation date collision

### DIFF
--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -1044,7 +1044,6 @@ class BasePageWorkflowTests(TestCase, WagtailTestUtils):
             has_unpublished_changes=True,
         )
         root_page.add_child(instance=self.object)
-        self.object.save_revision()
         self.object_class = self.object.specific_class
 
         # Assign to workflow
@@ -1112,8 +1111,11 @@ class BaseSnippetWorkflowTests(BasePageWorkflowTests):
         return self.model._meta.verbose_name
 
     def setup_object(self):
-        self.object = self.model.objects.create(text="Hello world!", live=False)
-        self.object.save_revision()
+        self.object = self.model.objects.create(
+            text="Hello world!",
+            live=False,
+            has_unpublished_changes=True,
+        )
         self.object_class = type(self.object)
 
         # Assign to workflow
@@ -1139,6 +1141,11 @@ class BaseSnippetWorkflowTests(BasePageWorkflowTests):
 
 
 class TestSubmitPageToWorkflow(BasePageWorkflowTests):
+    def setUp(self):
+        super().setUp()
+        # Ensure a revision exists
+        self.object.save_revision()
+
     def test_submit_for_approval_creates_states(self):
         """Test that WorkflowState and TaskState objects are correctly created when an object is submitted for approval"""
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2944,15 +2944,16 @@ class Revision(models.Model):
             # newer than any revision that might exist in the database
             return True
 
-        return (
-            not Revision.objects.filter(
+        latest_revision_id = (
+            Revision.objects.filter(
                 base_content_type_id=self.base_content_type_id,
                 object_id=self.object_id,
-                created_at__gte=self.created_at,
             )
-            .exclude(id=self.id)
-            .exists()
+            .order_by("-created_at", "-id")
+            .values_list("id", flat=True)
+            .first()
         )
+        return latest_revision_id == self.id
 
     def delete(self):
         # Update revision_created fields for comments that reference the current revision, if applicable.


### PR DESCRIPTION
Fixes #9917. For real!

## The real reason

The `self.page` object in the original `TestApproveRejectWorkflow` didn't have an initial revision (see no `save_revision()` call):

https://github.com/wagtail/wagtail/blob/c7da2988d51ca057cf5b2e23cb00cc485984ca29/wagtail/admin/tests/test_workflows.py#L1079-L1125

The original `TestSubmitToWorkflow` did:

https://github.com/wagtail/wagtail/blob/c7da2988d51ca057cf5b2e23cb00cc485984ca29/wagtail/admin/tests/test_workflows.py#L828-L868

Given how similar the setup code is, and in an effort to reduce code duplicity, I extracted a base class where the setup always calls `save_revision()`.

https://github.com/wagtail/wagtail/blob/c50982f062575222bace8c7d00ab94e5b75034e5/wagtail/admin/tests/test_workflows.py#L1036-L1051

Unfortunately, because our tests are wrapped in `freeze_time()` this results in the initial revision and the ones made by the workflow having the same creation date. The changes introduced in #9881 made the `is_latest_revision()` method return a different value when there are two revisions with the same creation date.

This PR fixes the tests by only adding `save_revision()` where they exist in the original test cases. Another way to fix this is to wrap the initial `save_revision()` in a `freeze_time()` with an earlier date.

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
