### PR TITLE
Fix issue where header search would fail on initial empty values

### DIFF
--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -268,9 +268,9 @@ $(() => {
 
     // eslint-disable-next-line func-names
     const search = function () {
-      const newQuery = $input.val();
+      const newQuery = $input.val() || '';
       const searchParams = new URLSearchParams(window.location.search);
-      const currentQuery = searchParams.get('q');
+      const currentQuery = searchParams.get('q') || '';
       // only do the query if it has changed for trimmed queries
       // for example - " " === "" and "firstword " ==== "firstword"
       if (currentQuery.trim() !== newQuery.trim()) {


### PR DESCRIPTION
- Regression from #9768
- Fixes #9918 (see for steps to reproduce)