### PR TITLE
Allow header search to be empty on load without 'required' warning

### DIFF
--- a/wagtail/admin/forms/search.py
+++ b/wagtail/admin/forms/search.py
@@ -9,4 +9,8 @@ class SearchForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields["q"].widget.attrs = {"placeholder": placeholder}
 
-    q = forms.CharField(label=gettext_lazy("Search term"), widget=forms.TextInput())
+    q = forms.CharField(
+        label=gettext_lazy("Search term"),
+        widget=forms.TextInput(),
+        required=False,
+    )


### PR DESCRIPTION
- Secondary fix on #9918
- More of a UX improvement though but agree with @laymonage  that we should not make this search field required