### PR TITLE
Fix test failures on indexing document tags

### DIFF
--- a/wagtail/documents/forms.py
+++ b/wagtail/documents/forms.py
@@ -50,10 +50,11 @@ class BaseDocumentForm(BaseCollectionMemberForm):
                 self.original_file.storage.delete(self.original_file.name)
                 self.original_file = None
 
+        super().save(commit=commit)
+
+        if commit:
             # Reindex the image to make sure all tags are indexed
             search_index.insert_or_update_object(self.instance)
-
-        super().save(commit=commit)
 
         return self.instance
 


### PR DESCRIPTION
Fix regression caused by faf3e190f6631a0ee94e5242f443e7aa0daa04c6. The save() must happen before reindexing, so that the indexer sees the updated state of the tags.
