### PR TITLE
Fix workflow HTML email

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -86,6 +86,7 @@ Changelog
  * Fix: Center-align StreamField and rich text block picker buttons with the dotted guide line (Thibaud Colas)
  * Fix: Search bar in chooser modals now performs autocomplete searches under PostgreSQL (Matt Westcott)
  * Fix: Server-side document filenames are preserved when replacing a document file (Suyash Singh, Matt Westcott)
+ * Fix: Add missing wagtailadmin_tags in `workflow_state_approved.html` template (Alex Tomkins)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.html
@@ -1,5 +1,5 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% block content %}
     {% if page %}


### PR DESCRIPTION
Closes #9932

I've enabled HTML emails by default for testing - otherwise quite a few templates are missed out during CI.

To test:

- Set `WAGTAILADMIN_NOTIFICATION_USE_HTML = True` in your settings file
- With one user, submit a page for review
- With another user, approve the page
- Check your terminal output - the approval email should have HTML
