### PR TITLE
Respect selected collection when adding documents or images (NEW)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Add more Axe rules to the accessibility checker (Albina Starykova)
  * Add usage view for pages (Sage Abdullah)
  * Copy page form now updates the slug field dynamically with a slugified value on blur (Loveth Omokaro)
+ * Ensure selected collection is kept when navigating from documents or images listings to add multiple views & upon upload (Aman Pandey, Bojan Mihelac)
  * Fix: Ensure `label_format` on StructBlock gracefully handles missing variables (Aadi jindal)
  * Fix: Adopt a no-JavaScript and more accessible solution for the 'Reset to default' switch to Gravatar when editing user profile (Loveth Omokaro)
  * Fix: Ensure `Site.get_site_root_paths` works on cache backends that do not preserve Python objects (Jaap Roes)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -22,6 +22,7 @@ depth: 1
  * Add more Axe rules to the accessibility checker (Albina Starykova)
  * Add usage view for pages (Sage Abdullah)
  * Copy page form now updates the slug field dynamically with a slugified value on blur (Loveth Omokaro)
+ * Ensure selected collection is kept when navigating from documents or images listings to add multiple views & upon upload (Aman Pandey, Bojan Mihelac)
 
 ### Bug fixes
 

--- a/wagtail/admin/views/generic/multiple_upload.py
+++ b/wagtail/admin/views/generic/multiple_upload.py
@@ -171,6 +171,7 @@ class AddView(PermissionCheckedMixin, TemplateView):
         # actual rendering of forms will happen on AJAX POST rather than here
         upload_form_class = self.get_upload_form_class()
         self.form = upload_form_class(user=self.request.user)
+        selected_collection_id = self.request.GET.get("collection_id")
 
         collections = self.permission_policy.collections_user_has_permission_for(
             self.request.user, "add"
@@ -184,6 +185,7 @@ class AddView(PermissionCheckedMixin, TemplateView):
                 "help_text": self.form.fields["file"].help_text,
                 "collections": collections,
                 "form_media": self.form.media,
+                "selected_collection_id": selected_collection_id,
             }
         )
 

--- a/wagtail/documents/templates/wagtaildocs/documents/index.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/index.html
@@ -22,7 +22,8 @@
     {% if user_can_add %}
         {% trans "Add a document" as add_doc_str %}
         {% url "wagtaildocs:add_multiple" as add_link %}
-        {% include "wagtailadmin/shared/header.html" with title=doc_str action_url=add_link icon="doc-full-inverse" action_text=add_doc_str search_url="wagtaildocs:index" %}
+        {% querystring as querystring %}
+        {% include "wagtailadmin/shared/header.html" with title=doc_str action_url=add_link|add:querystring icon="doc-full-inverse" action_text=add_doc_str search_url="wagtaildocs:index" %}
     {% else %}
         {% include "wagtailadmin/shared/header.html" with title=doc_str icon="doc-full-inverse" search_url="wagtaildocs:index" %}
     {% endif %}

--- a/wagtail/documents/templates/wagtaildocs/documents/index.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/index.html
@@ -38,7 +38,7 @@
         {% endif %}
 
         <div id="document-results" class="documents">
-            {% include "wagtaildocs/documents/results.html" %}
+            {% include "wagtaildocs/documents/results.html" with querystring=querystring %}
         </div>
     </div>
     {% trans "Select all documents in listing" as select_all_text %}

--- a/wagtail/documents/templates/wagtaildocs/documents/results.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/results.html
@@ -22,10 +22,12 @@
         {% search_other %}
     {% else %}
         {% url 'wagtaildocs:add_multiple' as wagtaildocs_add_document_url %}
-        {% if current_collection %}
-            <p>{% blocktrans trimmed %}You haven't uploaded any documents in this collection. Why not <a href="{{ wagtaildocs_add_document_url }}">upload one now</a>?{% endblocktrans %}</p>
-        {% else %}
-            <p>{% blocktrans trimmed %}You haven't uploaded any documents. Why not <a href="{{ wagtaildocs_add_document_url }}">upload one now</a>?{% endblocktrans %}</p>
-        {% endif %}
+        {% with wagtaildocs_add_document_url|add:querystring as wagtaildocs_add_document_url %}
+            {% if current_collection %}
+                <p>{% blocktrans trimmed %}You haven't uploaded any documents in this collection. Why not <a href="{{ wagtaildocs_add_document_url }}">upload one now</a>?{% endblocktrans %}</p>
+            {% else %}
+                <p>{% blocktrans trimmed %}You haven't uploaded any documents. Why not <a href="{{ wagtaildocs_add_document_url }}">upload one now</a>?{% endblocktrans %}</p>
+            {% endif %}
+        {% endwith %}
     {% endif %}
 {% endif %}

--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -29,7 +29,7 @@
                     {% field label_text=label_text id_for_label="id_adddocument_collection" classname="w-mx-auto w-mt-4 w-grid w-justify-center"  %}
                         <select id="id_adddocument_collection" name="collection">
                             {% for pk, display_name in collections.get_indented_choices %}
-                                <option value="{{ pk|unlocalize }}">
+                                <option value="{{ pk|unlocalize }}"{% if pk|unlocalize == selected_collection_id %} selected{% endif %}>
                                     {{ display_name }}
                                 </option>
                             {% endfor %}

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -823,6 +823,17 @@ class TestMultipleDocumentUploader(WagtailTestUtils, TestCase):
         self.assertContains(response, "id_adddocument_collection")
         self.assertContains(response, "Evil plans")
 
+    def test_add_with_selected_collection(self):
+        root_collection = Collection.get_first_root_node()
+        collection = root_collection.add_child(name="Evil plans")
+
+        response = self.client.get(
+            reverse("wagtaildocs:add_multiple") + f"?collection_id={collection.pk}"
+        )
+        self.assertEqual(response.status_code, 200)
+        # collection chooser should have selected collection passed with parameter
+        self.assertContains(response, f'<option value="{collection.pk}" selected>')
+
     def test_add_post(self):
         """
         This tests that a POST request to the add view saves the document and returns an edit form

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -132,6 +132,19 @@ class TestDocumentIndexView(WagtailTestUtils, TestCase):
             ["Root", "Evil plans", "Good plans"],
         )
 
+    def test_index_with_collection_filtered(self):
+        root_collection = Collection.get_first_root_node()
+        travel_plans = root_collection.add_child(name="Travel plans")
+
+        self.make_docs()
+
+        response = self.get({"collection_id": travel_plans.pk})
+        # should append the correct params to the add document button
+        url = reverse("wagtaildocs:add_multiple")
+        self.assertContains(
+            response, f'<a href="{url}?collection_id={travel_plans.pk}"'
+        )
+
     def test_collection_nesting(self):
         root_collection = Collection.get_first_root_node()
         evil_plans = root_collection.add_child(name="Evil plans")
@@ -819,7 +832,7 @@ class TestMultipleDocumentUploader(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtaildocs/multiple/add.html")
 
-        # collection chooser should exisst
+        # collection chooser should exist
         self.assertContains(response, "id_adddocument_collection")
         self.assertContains(response, "Evil plans")
 

--- a/wagtail/images/templates/wagtailimages/images/index.html
+++ b/wagtail/images/templates/wagtailimages/images/index.html
@@ -79,7 +79,7 @@
         </form>
 
         <div id="image-results">
-            {% include "wagtailimages/images/results.html" %}
+            {% include "wagtailimages/images/results.html" with querystring=querystring %}
         </div>
         {% trans "Select all images in listing" as select_all_text %}
         {% include 'wagtailadmin/bulk_actions/footer.html' with select_all_obj_text=select_all_text app_label=app_label model_name=model_name objects=images parent=current_collection.id %}

--- a/wagtail/images/templates/wagtailimages/images/index.html
+++ b/wagtail/images/templates/wagtailimages/images/index.html
@@ -25,7 +25,8 @@
     {% if user_can_add %}
         {% trans "Add an image" as add_img_str %}
         {% url "wagtailimages:add_multiple" as add_link %}
-        {% include "wagtailadmin/shared/header.html" with title=im_str action_url=add_link icon="image" action_text=add_img_str search_url="wagtailimages:index" %}
+        {% querystring as querystring %}
+        {% include "wagtailadmin/shared/header.html" with title=im_str action_url=add_link|add:querystring icon="image" action_text=add_img_str search_url="wagtailimages:index" %}
     {% else %}
         {% include "wagtailadmin/shared/header.html" with title=im_str icon="image" search_url="wagtailimages:index" %}
     {% endif %}

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -43,10 +43,12 @@
         {% search_other %}
     {% else %}
         {% url 'wagtailimages:add_multiple' as wagtailimages_add_image_url %}
-        {% if current_collection %}
-            <p>{% blocktrans trimmed %}You haven't uploaded any images in this collection. Why not <a href="{{ wagtailimages_add_image_url }}">upload one now</a>?{% endblocktrans %}</p>
-        {% else %}
-            <p>{% blocktrans trimmed %}You haven't uploaded any images. Why not <a href="{{ wagtailimages_add_image_url }}">upload one now</a>?{% endblocktrans %}</p>
-        {% endif %}
+        {% with wagtailimages_add_image_url|add:querystring as wagtailimages_add_image_url %}
+            {% if current_collection %}
+                <p>{% blocktrans trimmed %}You haven't uploaded any images in this collection. Why not <a href="{{ wagtailimages_add_image_url }}">upload one now</a>?{% endblocktrans %}</p>
+            {% else %}
+                <p>{% blocktrans trimmed %}You haven't uploaded any images. Why not <a href="{{ wagtailimages_add_image_url }}">upload one now</a>?{% endblocktrans %}</p>
+            {% endif %}
+        {% endwith %}
     {% endif %}
 {% endif %}

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -29,7 +29,7 @@
                     {% field label_text=label_text id_for_label="id_addimage_collection" classname="w-mx-auto w-mt-4 w-grid w-justify-center" %}
                         <select id="id_addimage_collection" name="collection">
                             {% for pk, display_name in collections.get_indented_choices %}
-                                <option value="{{ pk|unlocalize }}">
+                                <option value="{{ pk|unlocalize }}"{% if pk|unlocalize == selected_collection_id %} selected{% endif %} >
                                     {{ display_name }}
                                 </option>
                             {% endfor %}

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -106,6 +106,13 @@ class TestImageIndexView(WagtailTestUtils, TestCase):
         for i in range(0, 10, 2):
             self.assertIn("Baker %i" % i, response_body)
 
+        # should append the correct params to the add images button
+        url = reverse("wagtailimages:add_multiple")
+        self.assertContains(
+            response,
+            f'<a href="{url}?q=Baker&amp;collection_id={child_collection[0].pk}"',
+        )
+
     def test_pagination(self):
         pages = ["0", "1", "-1", "9999", "Not a page"]
         for page in pages:
@@ -611,6 +618,19 @@ class TestImageAddView(WagtailTestUtils, TestCase):
         # Test that it was placed in the Evil Plans collection
         image = images.first()
         self.assertEqual(image.collection, evil_plans_collection)
+
+    def test_add_with_selected_collection(self):
+
+        root_collection = Collection.get_first_root_node()
+        collection = root_collection.add_child(name="Travel pics")
+
+        response = self.client.get(
+            reverse("wagtailimages:add_multiple") + f"?collection_id={collection.pk}"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # collection chooser should have selected collection passed with parameter
+        self.assertContains(response, f'option value="{collection.pk}" selected')
 
     @override_settings(WAGTAILIMAGES_IMAGE_MODEL="tests.CustomImage")
     def test_unique_together_validation_error(self):


### PR DESCRIPTION
-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]


Fixes https://github.com/wagtail/wagtail/issues/7160

taken over https://github.com/wagtail/wagtail/pull/7756 by the permission of the author 

rebased along with https://github.com/wagtail/wagtail/pull/7810
regarding https://github.com/wagtail/wagtail/pull/7810, as working through the concept of  `next_url and next`  as to remember the complete url for previous index page along with selected collection_id 
so that after actions like edit/delete it redirects back, however using next in this issue seems like an extra work to get collection_id from the whole `next url` as for multiple add view it just needs `collection_id` , this PR keeps the approach simple, and also works along with https://github.com/wagtail/wagtail/pull/7810. refactored.

![image](https://user-images.githubusercontent.com/74553951/213911097-9fdb3fe5-9608-4bf3-a811-64d173971a09.png)
![image](https://user-images.githubusercontent.com/74553951/213911106-3cc8c1db-cb60-4bd3-9c83-c51dcaff0bea.png)
![image](https://user-images.githubusercontent.com/74553951/213911117-10941867-3f4c-4439-a50a-35eaed45c211.png)
![image](https://user-images.githubusercontent.com/74553951/213911119-5b0b7ff6-0e4b-4d02-999c-bd05da50bcfc.png)
![image](https://user-images.githubusercontent.com/74553951/213911141-1cdb9d01-9185-4d6a-9dec-117236429538.png)
![image](https://user-images.githubusercontent.com/74553951/213911156-fa67936c-63d5-4efb-99a8-651ecae1db51.png)


