### PR TITLE
Control non-Wagtail models indexing - Reference Index Ignore Hook

### DIFF
--- a/docs/advanced_topics/index.md
+++ b/docs/advanced_topics/index.md
@@ -22,4 +22,5 @@ boundblocks_and_values
 multi_site_multi_instance_multi_tenancy
 formbuilder_routablepage_redirect
 streamfield_migrations
+reference_index
 ```

--- a/docs/advanced_topics/reference_index.md
+++ b/docs/advanced_topics/reference_index.md
@@ -1,0 +1,49 @@
+# Managing the Reference Index
+
+Wagtail maintains a reference index, which records references between objects whenever those objects are saved. The index allows Wagtail to efficiently report the usage of images, documents and snippets within pages, including within StreamField and rich text fields.
+
+## Configuration
+
+The reference index does not require any configuration. It will by default index every model, unless configured to prevent this. Some of the models within Wagtail (such as revisions) are not indexed, so that object counts remain accurate.
+
+There are two ways to prevent indexing of your own models.
+
+### wagtail_reference_index_ignore
+
+The `wagtail_reference_index_ignore` attribute can be used to prevent indexing with a particular model or model field.
+
+-  set the `wagtail_reference_index_ignore` attribute to `True` within any model class where you want to prevent indexing of all fields in the model; or
+-  set the `wagtail_reference_index_ignore` attribute to `True` within any model field, to prevent that field or the related model field from being indexed:
+
+```python
+class CentralPage(Page):
+    ...
+    reference = models.ForeignKey(
+        "doc",
+        on_delete=models.SET_NULL,
+        related_name="page_ref",
+    )
+    reference.wagtail_reference_index_ignore = True
+    ...
+```
+
+### register_reference_index_ignore hook
+
+For models in third-party apps, the `register_reference_index_ignore` hook can be used to prevent indexing, without needing to change the app code. Simply list the apps or specific app models that should not be indexed in a `wagtail_hooks.py` module:
+
+```python
+from wagtail import hooks
+@hooks.register("register_reference_index_ignore")
+def reference_index_ignore(ignore_list):
+    ignore_list.extend([
+        "my_app",
+        "my_second_app.data_entry",
+    ])
+    return ignore_list
+```
+
+In this example, all the models in `my_app` will added to the ignore list, as will the model `data_entry` within the app `my_second_app`.
+
+## Maintenance
+
+The index can be rebuilt with the `rebuild_references_index` management command. This will repopulate the references table and ensure that reference counts are displayed accurately. This should be done if models are manipulated outside of Wagtail.

--- a/wagtail/models/reference_index.py
+++ b/wagtail/models/reference_index.py
@@ -1,13 +1,17 @@
+import itertools
 import uuid
 
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRel
 from django.contrib.contenttypes.models import ContentType
+from django.core.checks import Warning, register
 from django.db import models
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel, get_all_child_relations
 from taggit.models import ItemBase
+
+from wagtail import hooks
 
 
 class ReferenceGroups:
@@ -190,6 +194,9 @@ class ReferenceIndex(models.Model):
         if getattr(model, "wagtail_reference_index_ignore", False):
             return False
 
+        if reference_index_ignore(model):
+            return False
+
         # Don't check any models that have a parental key, references from these will be collected from the parent
         if not allow_child_models and any(
             [isinstance(field, ParentalKey) for field in model._meta.get_fields()]
@@ -204,6 +211,9 @@ class ReferenceIndex(models.Model):
                 if getattr(
                     field.related_model, "wagtail_reference_index_ignore", False
                 ):
+                    continue
+
+                if reference_index_ignore(field.related_model):
                     continue
 
                 if isinstance(field, (ParentalKey, GenericRel)):
@@ -257,6 +267,9 @@ class ReferenceIndex(models.Model):
                 if getattr(
                     field.related_model, "wagtail_reference_index_ignore", False
                 ):
+                    continue
+
+                if reference_index_ignore(field.related_model):
                     continue
 
                 if isinstance(field, (ParentalKey, GenericRel)):
@@ -515,3 +528,73 @@ class ReferenceIndex(models.Model):
 # correctly will require support for ManyToMany relations with through models:
 # https://github.com/wagtail/wagtail/issues/9629
 ItemBase.wagtail_reference_index_ignore = True
+
+
+# Ignore relations in models where adding the wagtail_reference_index_ignore attribute
+# is problematic
+_wagtail_reference_index_ignore_set = None
+
+
+def compile_ignore_list(check=False):
+    global _wagtail_reference_index_ignore_set
+    _wagtail_reference_index_ignore_set = set()
+    errors = []
+
+    ignore_hooks = hooks.get_hooks("register_reference_index_ignore")
+    ignore_list = sorted(
+        itertools.chain.from_iterable(hook([]) for hook in ignore_hooks)
+    )
+
+    for entry in ignore_list:
+        elements = entry.split(".")
+        parts = len(elements)
+        if parts > 2:
+            errors.append(
+                Warning(
+                    f"ReferenceIndex ignore entry '{entry}' has too many elements. Skipping entry.",
+                    obj=ReferenceIndex,
+                    id="wagtailcore.W002",
+                )
+            )
+            continue
+
+        if parts == 1:
+            content_types = ContentType.objects.filter(app_label=elements[0])
+            if len(content_types) == 0:
+                errors.append(
+                    Warning(
+                        f"ReferenceIndex ignore entry '{entry}' doesn't match an app label. Skipping entry.",
+                        obj=ReferenceIndex,
+                        id="wagtailcore.W002",
+                    )
+                )
+        else:
+            content_types = ContentType.objects.filter(
+                app_label=elements[0], model=elements[1]
+            )
+            if len(content_types) == 0:
+                errors.append(
+                    Warning(
+                        f"ReferenceIndex ignore entry '{entry}' doesn't match a model. Skipping entry.",
+                        obj=ReferenceIndex,
+                        id="wagtailcore.W002",
+                    )
+                )
+
+        for ct in content_types:
+            _wagtail_reference_index_ignore_set.add(ct.model_class())
+
+    if check:
+        return errors
+
+
+def reference_index_ignore(object):
+    global _wagtail_reference_index_ignore_set
+    if _wagtail_reference_index_ignore_set is None:
+        compile_ignore_list()
+    return object in _wagtail_reference_index_ignore_set
+
+
+@register("reference_index_ignore")
+def wagtail_model_reference_index_ignore(app_configs, **kwargs):
+    return compile_ignore_list(check=True)


### PR DESCRIPTION
Addresses #9731. Split from #9819.

This PR adds a new Wagtail hook enabling (typically) non-Wagtail models in a project to be ignored when updating and maintaining the Wagtail `ReferenceIndex`. 

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

To test in a project, ideally one with several non-Wagtail apps, set up a `wagtail_hooks.py` with something like this:

```python
from wagtail import hooks

@hooks.register("register_reference_index_ignore")
def reference_index_ignore(ignore_list):
    ignore_list.extend([
        "my_app",
        "my_second_app.data_entry",
    ])
    return ignore_list
```

where the entries are either app_label or app_label.model, as recorded in the Django ContentTypes registry.

Note: I expect this PR will have merge conflicts in the documentation once its companion PR #9935 is merged. I'll rebase when that arises.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
