### PR TITLE
Pin `semgrep` version to 1.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ testing_extras = [
     "flake8-print==5.0.0",
     "doc8==0.8.1",
     "flake8-assertive==2.0.0",
-    "semgrep",
+    # For enforcing string formatting mechanism in source files
+    "semgrep==1.3.0",
     # For templates linting
     "curlylint==0.13.1",
     # For template indenting


### PR DESCRIPTION
Latest version (1.5.1 at time of writing) is incompatible with curlylint due to conflicting versions of parsy required by both packages. This causes issues with our CircleCI setup when Pipenv tries to lock the dependencies.