### PR TITLE
Allow manual lock even if `WorkflowLock` is currently applied

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Changelog
  * Fix: Prevent audit log report from failing on missing models (Andy Chosak)
  * Fix: Ensure that the privacy collection privacy edit button is styled as a button (Jatin Kumar)
  * Fix: Fix page/snippet cannot proceed a `GroupApprovalTask` if it's locked by someone outside of the group (Sage Abdullah)
+ * Fix: Allow manual lock even if `WorkflowLock` is currently applied (Sage Abdullah)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp)
  * Docs: Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -38,6 +38,7 @@ depth: 1
  * Prevent audit log report from failing on missing models (Andy Chosak)
  * Ensure that the privacy collection privacy edit button is styled as a button (Jatin Kumar)
  * Fix page/snippet cannot proceed a `GroupApprovalTask` if it's locked by someone outside of the group (Sage Abdullah)
+ * Allow manual lock even if `WorkflowLock` is currently applied (Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/locked.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/locked.html
@@ -5,27 +5,7 @@
     {% trans 'Locking: ' as screen_reader_title_prefix %}
 
     {% if lock %}
-        {% trans 'Locked' as title %}
-
-        {% if not locked_for_user and user_can_unlock %}
-            {% blocktrans trimmed with model_name=base_model_name|lower asvar help_text %}
-                You can edit this {{ model_name }}, but others may not. Unlock it to allow others to edit.
-            {% endblocktrans %}
-        {% elif not locked_for_user %}
-            {% blocktrans trimmed with model_name=base_model_name|lower asvar help_text %}
-                You can edit this {{ model_name }}, but others may not.
-            {% endblocktrans %}
-        {% elif user_can_unlock %}
-            {% blocktrans trimmed with model_name=base_model_name|lower asvar help_text %}
-                You cannot edit this {{ model_name }}. Unlock it to edit.
-            {% endblocktrans %}
-        {% else %}
-            {% blocktrans trimmed with model_name=base_model_name|lower asvar help_text %}
-                You cannot edit this {{ model_name }}.
-            {% endblocktrans %}
-        {% endif %}
-
-        {% with icon_name='lock' %}
+        {% with icon_name=lock_context.icon title=lock_context.locked_by help_text=lock_context.description %}
             {{ block.super }}
         {% endwith %}
     {% else %}
@@ -33,11 +13,11 @@
 
         {% if user_can_lock %}
             {% blocktrans trimmed with model_name=base_model_name|lower asvar help_text %}
-                Anyone can edit this {{ model_name }}. Lock it to prevent others from editing.
+                Anyone can edit this {{ model_name }} – lock it to prevent others from editing
             {% endblocktrans %}
         {% else %}
             {% blocktrans trimmed with model_name=base_model_name|lower asvar help_text %}
-                Anyone can edit this {{ model_name }}.
+                Anyone can edit this {{ model_name }}
             {% endblocktrans %}
         {% endif %}
 

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/locked.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/locked.html
@@ -28,11 +28,11 @@
 {% endblock %}
 
 {% block action %}
-    {% if user_can_unlock and lock %}
+    {% if user_can_unlock %}
         {% trans 'Unlock' as unlock_text %}
         {% include 'wagtailadmin/shared/side_panels/includes/side_panel_button.html' with data_url=unlock_url text=unlock_text %}
     {% endif %}
-    {% if user_can_lock and not lock %}
+    {% if user_can_lock %}
         {% trans 'Lock' as lock_text %}
         {% include 'wagtailadmin/shared/side_panels/includes/side_panel_button.html' with data_url=lock_url text=lock_text %}
     {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/locked.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/locked.html
@@ -2,47 +2,27 @@
 {% load wagtailadmin_tags i18n %}
 
 {% block content %}
-    {% if page %}
-        {% trans 'Page locking: ' as screen_reader_title_prefix %}
-    {% else %}
-        {% trans 'Locking: ' as screen_reader_title_prefix %}
-    {% endif %}
+    {% trans 'Locking: ' as screen_reader_title_prefix %}
 
     {% if lock %}
         {% trans 'Locked' as title %}
 
         {% if not locked_for_user and user_can_unlock %}
-            {% if page %}
-                {% trans 'You can edit this page, but others may not. Unlock it to allow others to edit.' as help_text %}
-            {% else %}
-                {% blocktrans trimmed with model_name=model_name|lower asvar help_text %}
-                    You can edit this {{ model_name }}, but others may not. Unlock it to allow others to edit.
-                {% endblocktrans %}
-            {% endif %}
+            {% blocktrans trimmed with model_name=base_model_name|lower asvar help_text %}
+                You can edit this {{ model_name }}, but others may not. Unlock it to allow others to edit.
+            {% endblocktrans %}
         {% elif not locked_for_user %}
-            {% if page %}
-                {% trans 'You can edit this page, but others may not.' as help_text %}
-            {% else %}
-                {% blocktrans trimmed with model_name=model_name|lower asvar help_text %}
-                    You can edit this {{ model_name }}, but others may not.
-                {% endblocktrans %}
-            {% endif %}
+            {% blocktrans trimmed with model_name=base_model_name|lower asvar help_text %}
+                You can edit this {{ model_name }}, but others may not.
+            {% endblocktrans %}
         {% elif user_can_unlock %}
-            {% if page %}
-                {% trans 'You cannot edit this page. Unlock it to edit.' as help_text %}
-            {% else %}
-                {% blocktrans trimmed with model_name=model_name|lower asvar help_text %}
-                    You cannot edit this {{ model_name }}. Unlock it to edit.
-                {% endblocktrans %}
-            {% endif %}
+            {% blocktrans trimmed with model_name=base_model_name|lower asvar help_text %}
+                You cannot edit this {{ model_name }}. Unlock it to edit.
+            {% endblocktrans %}
         {% else %}
-            {% if page %}
-                {% trans 'You cannot edit this page.' as help_text %}
-            {% else %}
-                {% blocktrans trimmed with model_name=model_name|lower asvar help_text %}
-                    You cannot edit this {{ model_name }}.
-                {% endblocktrans %}
-            {% endif %}
+            {% blocktrans trimmed with model_name=base_model_name|lower asvar help_text %}
+                You cannot edit this {{ model_name }}.
+            {% endblocktrans %}
         {% endif %}
 
         {% with icon_name='lock' %}
@@ -52,21 +32,13 @@
         {% trans 'Unlocked' as title %}
 
         {% if user_can_lock %}
-            {% if page %}
-                {% trans 'Anyone can edit this page. Lock it to prevent others from editing.' as help_text %}
-            {% else %}
-                {% blocktrans trimmed with model_name=model_name|lower asvar help_text %}
-                    Anyone can edit this {{ model_name }}. Lock it to prevent others from editing.
-                {% endblocktrans %}
-            {% endif %}
+            {% blocktrans trimmed with model_name=base_model_name|lower asvar help_text %}
+                Anyone can edit this {{ model_name }}. Lock it to prevent others from editing.
+            {% endblocktrans %}
         {% else %}
-            {% if page %}
-                {% trans 'Anyone can edit this page.' as help_text %}
-            {% else %}
-                {% blocktrans trimmed with model_name=model_name|lower asvar help_text %}
-                    Anyone can edit this {{ model_name }}.
-                {% endblocktrans %}
-            {% endif %}
+            {% blocktrans trimmed with model_name=base_model_name|lower asvar help_text %}
+                Anyone can edit this {{ model_name }}.
+            {% endblocktrans %}
         {% endif %}
 
         {% with icon_name='lock-open' help_text=help_text|capfirst %}

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/workflow.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/workflow.html
@@ -48,7 +48,7 @@
                                         {{ live_expire_at }}
                                     </div>
                                 </div>
-                                {% if show_schedule_publishing_toggle and not has_draft_publishing_schedule and not locked_for_user %}
+                                {% if show_schedule_publishing_toggle and not has_draft_publishing_schedule and not lock_context.locked %}
                                     {% trans 'Edit schedule' as edit_schedule_text %}
                                     {% dialog_toggle classname='w-bg-transparent w-text-14 w-p-0 w-text-secondary hover:w-text-secondary-600 w-inline-flex w-justify-center w-transition' dialog_id="schedule-publishing-dialog" text=edit_schedule_text %}
                                 {% endif %}
@@ -157,7 +157,7 @@
                             {% endif %}
                         {% endif %}
                     </div>
-                    {% if show_schedule_publishing_toggle and not locked_for_user %}
+                    {% if show_schedule_publishing_toggle and not lock_context.locked %}
                         {% trans 'Edit schedule' as edit_schedule_text %}
                         {% dialog_toggle classname='w-bg-transparent w-text-14 w-p-0 w-text-secondary hover:w-text-secondary-600 w-inline-flex w-justify-center w-transition' dialog_id="schedule-publishing-dialog" text=edit_schedule_text %}
                     {% endif %}
@@ -166,7 +166,7 @@
         {% elif draftstate_enabled and not has_live_publishing_schedule %}
             <div class="w-flex w-justify-between w-items-center w-w-full">
                 <div class="w-ml-8 w-pr-4 w-label-3">{% trans 'No publishing schedule set' %}</div>
-                {% if show_schedule_publishing_toggle and not locked_for_user %}
+                {% if show_schedule_publishing_toggle and not lock_context.locked %}
                     {% trans 'Set schedule' as set_schedule_text %}
                     {% dialog_toggle classname='w-bg-transparent w-text-14 w-p-0 w-text-secondary hover:w-text-secondary-600 w-inline-flex w-justify-center w-transition' dialog_id="schedule-publishing-dialog" text=set_schedule_text %}
                 {% endif %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -36,6 +36,7 @@ from wagtail.admin.ui import sidebar
 from wagtail.admin.utils import (
     get_admin_base_url,
     get_latest_str,
+    get_user_display_name,
     get_valid_next_url_from_request,
 )
 from wagtail.admin.views.bulk_action.registry import bulk_action_registry
@@ -888,23 +889,7 @@ def timesince_last_update(
 
 @register.filter
 def user_display_name(user):
-    """
-    Returns the preferred display name for the given user object: the result of
-    user.get_full_name() if implemented and non-empty, or user.get_username() otherwise.
-    """
-    try:
-        full_name = user.get_full_name().strip()
-        if full_name:
-            return full_name
-    except AttributeError:
-        pass
-
-    try:
-        return user.get_username()
-    except AttributeError:
-        # we were passed None or something else that isn't a valid user object; return
-        # empty string to replicate the behaviour of {{ user.get_full_name|default:user.get_username }}
-        return ""
+    return get_user_display_name(user)
 
 
 @register.filter

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -154,15 +154,14 @@ class BaseStatusSidePanel(BaseSidePanel):
 
     def get_lock_context(self):
         self.lock = None
-        self.locked_for_user = False
+        lock_context = {}
         if self.locking_enabled:
             self.lock = self.object.get_lock()
-            self.locked_for_user = self.lock and self.lock.for_user(self.request.user)
-
+            if self.lock:
+                lock_context = self.lock.get_context_for_user(self.request.user)
         return {
             "lock": self.lock,
-            "locked_for_user": self.locked_for_user,
-            "locking_enabled": self.locking_enabled,
+            "lock_context": lock_context,
         }
 
     def get_usage_context(self):

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -176,6 +176,7 @@ class BaseStatusSidePanel(BaseSidePanel):
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)
         context["model_name"] = capfirst(self.model._meta.verbose_name)
+        context["base_model_name"] = context["model_name"]
         context["status_templates"] = self.get_status_templates(context)
         context.update(self.get_scheduled_publishing_context())
         context.update(self.get_lock_context())
@@ -265,6 +266,7 @@ class PageStatusSidePanel(BaseStatusSidePanel):
         context.update(
             {
                 "model_name": self.model.get_verbose_name(),
+                "base_model_name": Page._meta.verbose_name,
                 "model_description": self.model.get_page_description(),
                 "status_templates": self.get_status_templates(context),
             }

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -32,3 +32,23 @@ def get_latest_str(obj):
     if isinstance(obj, DraftStateMixin) and obj.latest_revision:
         return obj.latest_revision.object_str
     return str(obj)
+
+
+def get_user_display_name(user):
+    """
+    Returns the preferred display name for the given user object: the result of
+    user.get_full_name() if implemented and non-empty, or user.get_username() otherwise.
+    """
+    try:
+        full_name = user.get_full_name().strip()
+        if full_name:
+            return full_name
+    except AttributeError:
+        pass
+
+    try:
+        return user.get_username()
+    except AttributeError:
+        # we were passed None or something else that isn't a valid user object; return
+        # empty string to replicate the behaviour of {{ user.get_full_name|default:user.get_username }}
+        return ""

--- a/wagtail/locks.py
+++ b/wagtail/locks.py
@@ -6,7 +6,7 @@ from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
 from django.utils.translation import gettext as _
 
-from wagtail.admin.utils import get_latest_str
+from wagtail.admin.utils import get_latest_str, get_user_display_name
 from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
@@ -36,6 +36,36 @@ class BaseLock:
         Returns a message to display to the given user describing the lock.
         """
         return None
+
+    def get_icon(self, user):
+        """
+        Returns the name of the icon to use for the lock.
+        """
+        return "lock"
+
+    def get_locked_by(self, user):
+        """
+        Returns a string that represents the user or mechanism that locked the object.
+        """
+        return _("Locked")
+
+    def get_description(self, user):
+        """
+        Returns a description of the lock to display to the given user.
+        """
+        return capfirst(_("No one can make changes while the %(model_name)s is locked"))
+
+    def get_context_for_user(self, user):
+        """
+        Returns a context dictionary to use in templates for the given user.
+        """
+        return {
+            "locked": self.for_user(user),
+            "message": self.get_message(user),
+            "icon": self.get_icon(user),
+            "locked_by": self.get_locked_by(user),
+            "description": self.get_description(user),
+        }
 
 
 class BasicLock(BaseLock):
@@ -88,7 +118,7 @@ class BasicLock(BaseLock):
                         "<b>'{title}' was locked</b> by <b>{user}</b> on <b>{datetime}</b>."
                     ),
                     title=title,
-                    user=str(self.object.locked_by),
+                    user=get_user_display_name(self.object.locked_by),
                     datetime=self.object.locked_at.strftime("%d %b %Y %H:%M"),
                 )
             else:
@@ -98,6 +128,29 @@ class BasicLock(BaseLock):
                     _("<b>'{title}' is locked</b>."),
                     title=title,
                 )
+
+    def get_locked_by(self, user):
+        if self.object.locked_by_id == user.pk:
+            return _("Locked by you")
+        if self.object.locked_by_id:
+            return _("Locked by another user")
+        return super().get_locked_by(user)
+
+    def get_description(self, user):
+        if self.object.locked_by_id == user.pk:
+            return capfirst(
+                _("Only you can make changes while the %(model_name)s is locked")
+                % {"model_name": self.model_name}
+            )
+        if self.object.locked_by_id:
+            return capfirst(
+                _("Only %(user)s can make changes while the %(model_name)s is locked")
+                % {
+                    "user": get_user_display_name(self.object.locked_by),
+                    "model_name": self.model_name,
+                }
+            )
+        return super().get_description(user)
 
 
 class WorkflowLock(BaseLock):
@@ -145,6 +198,18 @@ class WorkflowLock(BaseLock):
 
             return mark_safe(workflow_info + " " + reviewers_info)
 
+    def get_icon(self, user):
+        return super().get_icon(user)
+
+    def get_locked_by(self, user):
+        return _("Locked by workflow")
+
+    def get_description(self, user):
+        return capfirst(
+            _("Only reviewers can edit and approve the %(model_name)s")
+            % {"model_name": self.model_name}
+        )
+
 
 class ScheduledForPublishLock(BaseLock):
     """
@@ -170,3 +235,9 @@ class ScheduledForPublishLock(BaseLock):
             datetime=scheduled_revision.approved_go_live_at.strftime("%d %b %Y %H:%M"),
         )
         return mark_safe(capfirst(message))
+
+    def get_locked_by(self, user):
+        return _("Locked by schedule")
+
+    def get_description(self, user):
+        return _("Currently locked and will go live on the scheduled date")

--- a/wagtail/snippets/tests/test_locking.py
+++ b/wagtail/snippets/tests/test_locking.py
@@ -5,6 +5,7 @@ from django.test import TestCase, override_settings
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 
+from wagtail.admin.utils import get_user_display_name
 from wagtail.locks import WorkflowLock
 from wagtail.models import GroupApprovalTask, Workflow, WorkflowTask
 from wagtail.test.testapp.models import (
@@ -443,10 +444,7 @@ class TestEditLockedSnippet(BaseLockingTestCase):
                 # Should show lock information in the side panel
                 self.assertContains(
                     response,
-                    (
-                        f"You can edit this {self.model_name}, but others may not. "
-                        "Unlock it to allow others to edit."
-                    ),
+                    f"Only you can make changes while the {self.model_name} is locked",
                 )
 
                 # Should show unlock buttons, one in the message and one in the side panel
@@ -470,6 +468,7 @@ class TestEditLockedSnippet(BaseLockingTestCase):
         response = self.client.get(self.get_url("edit"))
         html = response.content.decode()
         unlock_url = self.get_url("unlock")
+        display_name = get_user_display_name(user)
 
         # Should show lock message
         self.assertContains(
@@ -480,7 +479,7 @@ class TestEditLockedSnippet(BaseLockingTestCase):
         # Should show lock information in the side panel
         self.assertContains(
             response,
-            f"You cannot edit this {self.model_name}. Unlock it to edit.",
+            f"Only {display_name} can make changes while the {self.model_name} is locked",
         )
 
         # Should not show Save action menu item
@@ -521,6 +520,7 @@ class TestEditLockedSnippet(BaseLockingTestCase):
         response = self.client.get(self.get_url("edit"))
         html = response.content.decode()
         unlock_url = self.get_url("unlock")
+        display_name = get_user_display_name(user)
 
         # Should show lock message
         self.assertContains(
@@ -531,11 +531,11 @@ class TestEditLockedSnippet(BaseLockingTestCase):
         # Should show lock information in the side panel
         self.assertContains(
             response,
-            f"You cannot edit this {self.model_name}.",
+            f"Only {display_name} can make changes while the {self.model_name} is locked",
         )
 
         # Should not show instruction to unlock
-        self.assertNotContains(response, "Unlock it to edit.")
+        self.assertNotContains(response, "Unlock")
 
         # Should not show Save action menu item
         self.assertNotContains(
@@ -579,13 +579,13 @@ class TestEditLockedSnippet(BaseLockingTestCase):
         # Should show unlocked information in the side panel
         self.assertContains(
             response,
-            f"Anyone can edit this {self.model_name}.",
+            f"Anyone can edit this {self.model_name}",
         )
 
         # Should not show info to lock the object in the side panel
         self.assertNotContains(
             response,
-            "Lock it to prevent others from editing.",
+            "lock it to prevent others from editing",
         )
 
         # Should show Save action menu item
@@ -630,7 +630,7 @@ class TestEditLockedSnippet(BaseLockingTestCase):
         # Should show unlocked information in the side panel
         self.assertContains(
             response,
-            f"Anyone can edit this {self.model_name}. Lock it to prevent others from editing.",
+            f"Anyone can edit this {self.model_name} – lock it to prevent others from editing",
         )
 
         # Should show Save action menu item

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -3041,9 +3041,10 @@ class TestScheduledForPublishLock(BaseTestSnippetEditView):
         )
 
         # Should show the lock information in the status side panel
+        self.assertContains(response, "Locked by schedule")
         self.assertContains(
             response,
-            '<div class="w-help-text">You cannot edit this draft state model.</div>',
+            '<div class="w-help-text">Currently locked and will go live on the scheduled date</div>',
             html=True,
             count=1,
         )
@@ -3107,9 +3108,10 @@ class TestScheduledForPublishLock(BaseTestSnippetEditView):
         )
 
         # Should show the lock information in the status side panel
+        self.assertContains(response, "Locked by schedule")
         self.assertContains(
             response,
-            '<div class="w-help-text">You cannot edit this draft state model.</div>',
+            '<div class="w-help-text">Currently locked and will go live on the scheduled date</div>',
             html=True,
             count=1,
         )
@@ -3168,9 +3170,10 @@ class TestScheduledForPublishLock(BaseTestSnippetEditView):
         )
 
         # Should show the lock information in the status side panel
+        self.assertContains(response, "Locked by schedule")
         self.assertContains(
             response,
-            '<div class="w-help-text">You cannot edit this draft state model.</div>',
+            '<div class="w-help-text">Currently locked and will go live on the scheduled date</div>',
             html=True,
             count=1,
         )

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -3572,11 +3572,11 @@ class TestGetLock(TestCase):
         self.assertFalse(lock.for_user(moderator))
         self.assertEqual(
             lock.get_message(christmas_event.owner),
-            f"<b>Page 'Christmas' was locked</b> by <b>{str(moderator)}</b> on <b>29 Jul 2022 12:19</b>.",
+            f"<b>'Christmas' was locked</b> by <b>{str(moderator)}</b> on <b>29 Jul 2022 12:19</b>.",
         )
         self.assertEqual(
             lock.get_message(moderator),
-            "<b>Page 'Christmas' was locked</b> by <b>you</b> on <b>29 Jul 2022 12:19</b>.",
+            "<b>'Christmas' was locked</b> by <b>you</b> on <b>29 Jul 2022 12:19</b>.",
         )
 
     def test_when_locked_without_locked_at(self):
@@ -3589,11 +3589,11 @@ class TestGetLock(TestCase):
         lock = christmas_event.get_lock()
         self.assertEqual(
             lock.get_message(christmas_event.owner),
-            "<b>Page 'Christmas' is locked</b>.",
+            "<b>'Christmas' is locked</b>.",
         )
         self.assertEqual(
             lock.get_message(moderator),
-            "<b>Page 'Christmas' is locked</b> by <b>you</b>.",
+            "<b>'Christmas' is locked</b> by <b>you</b>.",
         )
 
     @override_settings(WAGTAILADMIN_GLOBAL_EDIT_LOCK=True)
@@ -3611,11 +3611,11 @@ class TestGetLock(TestCase):
         self.assertTrue(lock.for_user(moderator))
         self.assertEqual(
             lock.get_message(christmas_event.owner),
-            f"<b>Page 'Christmas' was locked</b> by <b>{str(moderator)}</b> on <b>29 Jul 2022 12:19</b>.",
+            f"<b>'Christmas' was locked</b> by <b>{str(moderator)}</b> on <b>29 Jul 2022 12:19</b>.",
         )
         self.assertEqual(
             lock.get_message(moderator),
-            "<b>Page 'Christmas' was locked</b> by <b>you</b> on <b>29 Jul 2022 12:19</b>.",
+            "<b>'Christmas' was locked</b> by <b>you</b> on <b>29 Jul 2022 12:19</b>.",
         )
 
     @override_settings(WAGTAILADMIN_GLOBAL_PAGE_EDIT_LOCK=True)
@@ -3640,11 +3640,11 @@ class TestGetLock(TestCase):
 
         self.assertEqual(
             lock.get_message(christmas_event.owner),
-            f"<b>Page 'Christmas' was locked</b> by <b>{str(moderator)}</b> on <b>29 Jul 2022 12:19</b>.",
+            f"<b>'Christmas' was locked</b> by <b>{str(moderator)}</b> on <b>29 Jul 2022 12:19</b>.",
         )
         self.assertEqual(
             lock.get_message(moderator),
-            "<b>Page 'Christmas' was locked</b> by <b>you</b> on <b>29 Jul 2022 12:19</b>.",
+            "<b>'Christmas' was locked</b> by <b>you</b> on <b>29 Jul 2022 12:19</b>.",
         )
 
     def test_when_locked_by_workflow(self):


### PR DESCRIPTION
Fix #9943.

Other than the lock descriptions, the main difference here is that the "Lock" button is shown (provided the user has the permission to do so) when a page/snippet is in a workflow. Previously, the button has been missing since Wagtail 4.0.

<img width="461" alt="image" src="https://user-images.githubusercontent.com/6379424/221629744-f1b25080-178a-4b58-a5c6-0a6506bf7dab.png">

How to test:

- Spin up bakerydemo
- Sign in as an editor
- Submit a page/snippet to a workflow
  - For snippets, configure it first. One way to do this is by making the `Person` snippet extend both `LockableMixin` and `WorkflowMixin` (see [docs](https://docs.wagtail.org/en/stable/topics/snippets.html#enabling-workflows-for-snippets)), running the migrations, then assigning the default "Moderators approval" workflow to the `Person` model.
- The status side panel should say "Locked by workflow", with no option to unlock it
- Sign in with a user account that has an edit and lock permission on the page or snippet, e.g. a moderator
- The status side panel should say "Unlocked" with an option to lock it. The description should say `"Reviewers can edit this %(model_name)s, lock it to prevent other reviewers from editing"`
- Once locked, for users with review permissions on the task, the behaviour should be the same as if the page was locked with the manual lock outside of a workflow. This means that other reviewers cannot edit the page. If they want to, they need to unlock it first (if they have the permissions to do so)

## Notes

- Our designers have broken down the main possible scenarios on [Figma](https://www.figma.com/file/h67EsVXdWsfu38WGGxWfpi/Wagtail-CMS?node-id=10861%3A133304&t=eB2SttDD8H25QBtU-1)
- The messages in the side panel mostly follow the designs, but I've taken a few liberties:
  - Locked by other user -> Locked by another user
  - Removing periods from the lock description to be more consistent with other status side panel items
- Some design updates, notably the use of the switch toggle component and changes to the message banner colours, will be done in a separate PR.
  - #10171

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
