### PR TITLE
Allow url punctuation as defined in RFC 3986 section 2.3

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -87,6 +87,7 @@ Changelog
  * Fix: Search bar in chooser modals now performs autocomplete searches under PostgreSQL (Matt Westcott)
  * Fix: Server-side document filenames are preserved when replacing a document file (Suyash Singh, Matt Westcott)
  * Fix: Add missing wagtailadmin_tags in `workflow_state_approved.html` template (Alex Tomkins)
+ * Fix: Change url serving mechanism to allow url punctuations from RFC 3986 section 2.3 (https://www.ietf.org/rfc/rfc3986.txt) (Storm Heg and Jake Howard)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)

--- a/wagtail/contrib/routable_page/tests.py
+++ b/wagtail/contrib/routable_page/tests.py
@@ -83,6 +83,18 @@ class TestRoutablePage(TestCase):
         self.assertEqual(args, ())
         self.assertEqual(kwargs, {})
 
+    def test_get_external_view_allows_punctuation(self):
+        response = self.client.get(self.routable_page.url + "external/joe-._~bloggs/")
+
+        self.assertContains(response, "EXTERNAL VIEW: joe-._~bloggs")
+
+    @override_settings(WAGTAIL_APPEND_SLASH=False, APPEND_SLASH=False)
+    def test_get_external_view_allows_punctuation_no_append_slash_with_slash(self):
+        # We are testing this with a slash because of this issue: https://github.com/wagtail/wagtail/issues/2871
+        response = self.client.get(self.routable_page.url + "external/joe-._~bloggs/")
+
+        self.assertContains(response, "EXTERNAL VIEW: joe-._~bloggs")
+
     def test_reverse_index_route_view(self):
         url = self.routable_page.reverse_subpage("index_route")
 

--- a/wagtail/urls.py
+++ b/wagtail/urls.py
@@ -5,16 +5,19 @@ from django.urls import path, re_path
 from wagtail import views
 from wagtail.coreutils import WAGTAIL_APPEND_SLASH
 
+# Allowed punctuation from RFC 3986 Section 2.3
+ALLOWED_PUNCTUATION = r"\-._~"
+
 if WAGTAIL_APPEND_SLASH:
     # If WAGTAIL_APPEND_SLASH is True (the default value), we match a
     # (possibly empty) list of path segments ending in slashes.
     # CommonMiddleware will redirect requests without a trailing slash to
     # a URL with a trailing slash
-    serve_pattern = r"^((?:[\w\-]+/)*)$"
+    serve_pattern = r"^((?:[\w{}\-]+/)*)$".format(ALLOWED_PUNCTUATION)
 else:
     # If WAGTAIL_APPEND_SLASH is False, allow Wagtail to serve pages on URLs
     # with and without trailing slashes
-    serve_pattern = r"^([\w\-/]*)$"
+    serve_pattern = r"^([\w{}\-/]*)$".format(ALLOWED_PUNCTUATION)
 
 
 WAGTAIL_FRONTEND_LOGIN_TEMPLATE = getattr(


### PR DESCRIPTION
This is a re-implementation of https://github.com/wagtail/wagtail/pull/5806, where most of the code was copied from.

Fixes #3653.

Currently, pages aren't allowed to have `.`s in them, which is especially annoying when combined with `RoutablePageMixin`.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
