### PR TITLE
Reduce memory exhaustion when updating many image renditions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,7 @@ Changelog
  * Fix: Avoid `ValueError` when extending `PagesAPIViewSet` and setting `meta_fields` to an empty list (Henry Harutyunyan, Alex Morega)
  * Fix: Improve accessibility for header search, remove autofocus on page load, advise screen readers that content has changed when results update (LB (Ben) Johnston)
  * Fix: Fix incorrect override of `PagePermissionHelper.user_can_unpublish_obj()` in ModelAdmin (Sébastien Corbin)
+ * Fix: Prevent memory exhaustion when updating a large number of image renditions (Jake Howard)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)

--- a/wagtail/images/management/commands/wagtail_update_image_renditions.py
+++ b/wagtail/images/management/commands/wagtail_update_image_renditions.py
@@ -70,4 +70,4 @@ class Command(BaseCommand):
                     self.style.ERROR(f"Failed to operate on rendition {rendition.id}")
                 )
 
-        self.stdout.write(self.style.SUCCESS("Success"))
+        self.stdout.write(self.style.SUCCESS("Done"))

--- a/wagtail/images/management/commands/wagtail_update_image_renditions.py
+++ b/wagtail/images/management/commands/wagtail_update_image_renditions.py
@@ -49,6 +49,8 @@ class Command(BaseCommand):
             )
 
         for rendition in (
+            # Pre-calculate the ids of the renditions to change, otherwise `.iterator` never
+            # ends.
             renditions.filter(id__in=rendition_ids)
             .select_related("image")
             .iterator(chunk_size=options["chunk_size"])

--- a/wagtail/images/management/commands/wagtail_update_image_renditions.py
+++ b/wagtail/images/management/commands/wagtail_update_image_renditions.py
@@ -1,7 +1,11 @@
+import logging
+
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from wagtail.images import get_image_model
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -15,37 +19,41 @@ class Command(BaseCommand):
             action="store_true",
             help="Purge all image renditions without regenerating them",
         )
+        parser.add_argument(
+            "--chunk-size",
+            type=int,
+            default=50,
+            help="Operate in x size chunks (default: %(default)s)",
+        )
 
     def handle(self, *args, **options):
         Rendition = get_image_model().get_rendition_model()
 
         renditions = Rendition.objects.all()
 
+        purge_only = options["purge_only"]
+
         if not renditions.exists():
             self.stdout.write("No image renditions found.")
             return
 
-        if options["purge_only"]:
-            rendition_count = renditions.count()
-            renditions.delete()
+        rendition_ids = list(renditions.values_list("id", flat=True))
+
+        if purge_only:
             self.stdout.write(
-                self.style.SUCCESS(
-                    f"Successfully purged {rendition_count} image rendition(s)"
-                )
+                self.style.HTTP_INFO(f"Purging {len(rendition_ids)} rendition(s)")
             )
         else:
             self.stdout.write(
-                self.style.HTTP_INFO(f"Regenerating {renditions.count()} rendition(s)")
+                self.style.HTTP_INFO(f"Regenerating {len(rendition_ids)} rendition(s)")
             )
-            # Pre-calculate the ids of the renditions to change, otherwise `.iterator` never
-            # ends.
-            rendition_ids = list(renditions.values_list("id", flat=True))
 
-            for rendition in (
-                renditions.filter(id__in=rendition_ids)
-                .select_related("image")
-                .iterator(chunk_size=10)
-            ):
+        for rendition in (
+            renditions.filter(id__in=rendition_ids)
+            .select_related("image")
+            .iterator(chunk_size=options["chunk_size"])
+        ):
+            try:
                 with transaction.atomic():
                     rendition_filter = rendition.filter
                     rendition_image = rendition.image
@@ -53,10 +61,13 @@ class Command(BaseCommand):
                     # Delete the existing rendition
                     rendition.delete()
 
-                    # Create a new one
-                    rendition_image.get_rendition(rendition_filter)
-            self.stdout.write(
-                self.style.SUCCESS(
-                    f"Successfully regenerated {len(rendition_ids)} image rendition(s)"
+                    if not purge_only:
+                        # Create a new one
+                        rendition_image.get_rendition(rendition_filter)
+            except:  # noqa:E722
+                logger.exception("Error operating on rendition %d", rendition.id)
+                self.stderr.write(
+                    self.style.ERROR(f"Failed to operate on rendition {rendition.id}")
                 )
-            )
+
+        self.stdout.write(self.style.SUCCESS("Success"))

--- a/wagtail/images/tests/test_management_commands.py
+++ b/wagtail/images/tests/test_management_commands.py
@@ -64,7 +64,7 @@ class TestUpdateImageRenditions(TestCase):
         # checking if the number of renditions regenerated equal total_renditions
         self.assertEqual(
             output_string,
-            f"Successfully regenerated {total_renditions} image rendition(s)\n",
+            f"Regenerating {total_renditions} rendition(s)\nDone\n",
         )
 
         # checking if the number of renditions now equal total_renditions
@@ -81,7 +81,7 @@ class TestUpdateImageRenditions(TestCase):
         # checking if the number of renditions purged equal total_renditions
         self.assertEqual(
             output_string,
-            f"Successfully purged {total_renditions} image rendition(s)\n",
+            f"Purging {total_renditions} rendition(s)\nDone\n",
         )
 
         # checking if the number of renditions now equal 0

--- a/wagtail/images/tests/test_management_commands.py
+++ b/wagtail/images/tests/test_management_commands.py
@@ -5,20 +5,22 @@ from io import StringIO
 from django.core import management
 from django.test import TestCase
 
-from wagtail.images import get_image_model
-
 from .utils import Image, get_test_image_file
+
+# note .utils.Image already does get_image_model()
+Rendition = Image.get_rendition_model()
 
 
 class TestUpdateImageRenditions(TestCase):
-    def setUp(self):
-        self.image = Image.objects.create(
+    @classmethod
+    def setUpTestData(cls):
+        cls.image = Image.objects.create(
             title="Test image",
             file=get_test_image_file(filename="test_image.png", colour="white"),
         )
 
-        self.rendition = Image.get_rendition_model().objects.create(
-            image=self.image,
+        cls.rendition = Rendition.objects.create(
+            image=cls.image,
             filter_spec="original",
             width=1000,
             height=1000,
@@ -27,8 +29,10 @@ class TestUpdateImageRenditions(TestCase):
             ),
         )
 
+        cls.reaesc = re.compile(r"\x1b[^m]*m")
+
     def delete_renditions(self):
-        renditions = get_image_model().get_rendition_model().objects.all()
+        renditions = Rendition.objects.all()
         for rendition in renditions:
             try:
                 rendition_image = rendition.image
@@ -49,42 +53,44 @@ class TestUpdateImageRenditions(TestCase):
         self.delete_renditions()
         # checking when command is called without any arguments
         output = self.run_command()
-        self.assertEqual(output.read(), "No image renditions found.\n")
+        output_string = self.reaesc.sub("", output.read())
+        self.assertEqual(output_string, "No image renditions found.\n")
 
         # checking when command is called with '--purge-only'
         output = self.run_command(purge_only=True)
-        self.assertEqual(output.read(), "No image renditions found.\n")
+        output_string = self.reaesc.sub("", output.read())
+        self.assertEqual(output_string, "No image renditions found.\n")
 
     def test_image_renditions(self):
-        renditions = get_image_model().get_rendition_model().objects.all()
+        renditions = Rendition.objects.all()
         total_renditions = len(renditions)
         output = self.run_command()
-        reaesc = re.compile(r"\x1b[^m]*m")
-        output_string = reaesc.sub("", output.read())
+        output_string = self.reaesc.sub("", output.read())
         # checking if the number of renditions regenerated equal total_renditions
         self.assertEqual(
             output_string,
-            f"Regenerating {total_renditions} rendition(s)\nDone\n",
+            f"Regenerating {total_renditions} rendition(s)\n"
+            f"Successfully processed {total_renditions} rendition(s)\n",
         )
 
         # checking if the number of renditions now equal total_renditions
-        renditions_now = get_image_model().get_rendition_model().objects.all()
+        renditions_now = Rendition.objects.all()
         total_renditions_now = len(renditions_now)
         self.assertEqual(total_renditions_now, total_renditions)
 
     def test_image_renditions_with_purge_only(self):
-        renditions = get_image_model().get_rendition_model().objects.all()
+        renditions = Rendition.objects.all()
         total_renditions = len(renditions)
         output = self.run_command(purge_only=True)
-        reaesc = re.compile(r"\x1b[^m]*m")
-        output_string = reaesc.sub("", output.read())
+        output_string = self.reaesc.sub("", output.read())
         # checking if the number of renditions purged equal total_renditions
         self.assertEqual(
             output_string,
-            f"Purging {total_renditions} rendition(s)\nDone\n",
+            f"Purging {total_renditions} rendition(s)\n"
+            f"Successfully processed {total_renditions} rendition(s)\n",
         )
 
         # checking if the number of renditions now equal 0
-        renditions_now = get_image_model().get_rendition_model().objects.all()
+        renditions_now = Rendition.objects.all()
         total_renditions_now = len(renditions_now)
         self.assertEqual(total_renditions_now, 0)


### PR DESCRIPTION
Off the back of #9881 

This reduces the memory overhead of the command, allowing it to be run on sites with lots of images. Whilst that may reduce performance, I've also added a `select_related` and massively simplified the `purge_only` path to counter

This also removes the exception handling, so the command errors loud. If this fails, it's something which needs attention, rather than just skipping the rendition and moving on.

I've also wrapped each operation in a transaction, to reduce the chance of a race and a duplicate rendition being stored.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
