### PR TITLE
Make empty search field on image / document index return all results

### DIFF
--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -273,3 +273,7 @@ In addition, some methods on the base {class}`~wagtail.models.Task` model have b
 To accommodate workflows support for snippets, the `WorkflowState.page` foreign key has been replaced with a `GenericForeignKey` as `WorkflowState.content_object`. The generic foreign key is defined using a combination of the new `WorkflowState.base_content_type` and `WorkflowState.object_id` fields.
 
 The `TaskState.page_revision` foreign key has been renamed to `TaskState.revision`.
+
+### `wagtail.admin.forms.search.SearchForm` validation logic
+
+The `wagtail.admin.forms.search.SearchForm` class (which is internal and undocumented, but may be in use by applications that extend the Wagtail admin) no longer treats an empty search field as invalid. Any code that checks `form.is_valid` to determine whether or not to apply a `search()` filter to a queryset should now explicitly check that `form.cleaned_data["q"]` is non-empty.

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -30,15 +30,34 @@ class TestDocumentIndexView(TestCase, WagtailTestUtils):
         return self.client.get(reverse("wagtaildocs:index"), params)
 
     def test_simple(self):
+        models.Document.objects.create(title="Hello document")
+        models.Document.objects.create(title="Bonjour document")
+
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtaildocs/documents/index.html")
         self.assertContains(response, "Add a document")
+        self.assertContains(response, "Hello document")
+        self.assertContains(response, "Bonjour document")
 
     def test_search(self):
+        models.Document.objects.create(title="Hello document")
+        models.Document.objects.create(title="Bonjour document")
+
         response = self.get({"q": "Hello"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["query_string"], "Hello")
+        self.assertContains(response, "Hello document")
+        self.assertNotContains(response, "Bonjour document")
+
+    def test_empty_q(self):
+        models.Document.objects.create(title="Hello document")
+        models.Document.objects.create(title="Bonjour document")
+
+        response = self.get({"q": ""})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Hello document")
+        self.assertContains(response, "Bonjour document")
 
     def make_docs(self):
         for i in range(50):

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -63,7 +63,8 @@ class BaseListingView(TemplateView):
             self.form = SearchForm(self.request.GET, placeholder=_("Search documents"))
             if self.form.is_valid():
                 query_string = self.form.cleaned_data["q"]
-                documents = documents.search(query_string)
+                if query_string:
+                    documents = documents.search(query_string)
         else:
             self.form = SearchForm(placeholder=_("Search documents"))
 

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -103,8 +103,8 @@ class BaseListingView(TemplateView):
             self.form = SearchForm(self.request.GET, placeholder=_("Search images"))
             if self.form.is_valid():
                 query_string = self.form.cleaned_data["q"]
-
-                images = images.search(query_string)
+                if query_string:
+                    images = images.search(query_string)
         else:
             self.form = SearchForm(placeholder=_("Search images"))
 


### PR DESCRIPTION
Fixes #9953

(Ended up going down a bit of a rabbit-hole fixing the tests for the images index view - previously most of them were only testing against an empty set of results, which obviously isn't very representative... Notably, checking `page.object_list.query` on a Paginator page object that has been iterated over has not worked since Django 1.6, thanks to https://github.com/django/django/commit/31f6421b134e4e83a459d2faa1009b33fefd6276.)

Also manually checked the other views that use `wagtail.admin.forms.search.SearchForm` to confirm that they are unaffected by this issue.