### PR TITLE
Fix assertCanCreate to publish by default

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,7 +9,7 @@ Changelog
  * Added ability to submit snippets for moderation with `WorkflowMixin` (Sage Abdullah)
  * Create `{% fullpageurl %}` tag for getting the absolute URL of a page (Jake Howard)
  * Added `MultipleChooserPanel`, a variant of `InlinePanel` with improved editor experience when inserting multiple linked objects (Matt Westcott)
- * Test assertion util `WagtailPageTestCase.assertCanCreate` now supports the kwarg `publish=True` to check publish redirection (Harry Percival, Akua Dokua Asiedu)
+ * Test assertion util `WagtailPageTestCase.assertCanCreate` now supports the kwarg `publish=True` to determine whether to publish the page (Harry Percival, Akua Dokua Asiedu, Matt Westcott)
  * Ensure that the `rebuild_references_index` command can run without console output if called with `--verbosity 0` (Omerzahid Ali, Aman Pandey)
  * Add full support for secondary buttons with icons in the Wagtail design system - `button bicolor button--icon button-secondary` including the `button-small` variant (Seremba Patrick)
  * Add `purge_embeds` management command to delete all the cached embed objects in the database (Aman Pandey)

--- a/docs/advanced_topics/testing.md
+++ b/docs/advanced_topics/testing.md
@@ -145,7 +145,7 @@ Assert that a child of the given Page type can be created under the parent, usin
 
 `parent` should be a Page instance, and `child_model` should be a Page subclass. `data` should be a dict that will be POSTed at the Wagtail admin Page creation method.
 
-`publish` specifies whether the page being created should be published or not, default is `False`. When `True`, it checks if the response url includes the url of the Wagtail Explorer Page, displaying an error if does not include that url. Otherwise it checks that the correct edit page loads.
+`publish` specifies whether the page being created should be published or not - default is `True`.
 
 ```python
 from wagtail.test.utils.form_data import nested_form_data, streamfield

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -65,7 +65,7 @@ This feature was developed by Matt Westcott, and sponsored by [YouGov](https://y
 
 ### Other features
 
- * Test assertion [`WagtailPageTestCase.assertCanCreate`](testing_reference) now supports the kwarg `publish=True` to check publish redirection (Harry Percival, Akua Dokua Asiedu)
+ * Test assertion [`WagtailPageTestCase.assertCanCreate`](testing_reference) now supports the kwarg `publish=True` to determine whether to publish the page (Harry Percival, Akua Dokua Asiedu, Matt Westcott)
  * Ensure that the `rebuild_references_index` command can run without console output if called with `--verbosity 0` (Omerzahid Ali, Aman Pandey)
  * Add full support for secondary buttons with icons in the Wagtail design system - `button bicolor button--icon button-secondary` including the `button-small` variant (Seremba Patrick)
  * Add [`purge_embeds`](purge_embeds) management command to delete all the cached embed objects in the database (Aman Pandey)

--- a/wagtail/test/utils/page_tests.py
+++ b/wagtail/test/utils/page_tests.py
@@ -69,7 +69,7 @@ class WagtailPageTestCase(WagtailTestUtils, TestCase):
             )
             raise self.failureException(msg)
 
-    def assertCanCreate(self, parent, child_model, data, msg=None, publish=False):
+    def assertCanCreate(self, parent, child_model, data, msg=None, publish=True):
         """
         Assert that a child of the given Page type can be created under the
         parent, using the supplied POST data.

--- a/wagtail/tests/test_tests.py
+++ b/wagtail/tests/test_tests.py
@@ -125,6 +125,7 @@ class TestWagtailPageTests(WagtailPageTests):
             },
         )
         self.assertTrue(EventIndex.objects.exists())
+        self.assertTrue(EventIndex.objects.get().live)
 
         self.assertCanCreate(
             self.root,
@@ -172,13 +173,15 @@ class TestWagtailPageTests(WagtailPageTests):
             },
         )
 
-    def test_assert_can_create_for_page_with_publish(self):
+    def test_assert_can_create_for_page_without_publish(self):
         self.assertCanCreate(
             self.root,
             SimplePage,
             {"title": "Simple Lorem Page", "content": "Lorem ipsum dolor sit amet"},
-            publish=True,
+            publish=False,
         )
+        created_page = Page.objects.get(title="Simple Lorem Page")
+        self.assertFalse(created_page.live)
 
     def test_assert_can_create_with_form_helpers(self):
         # same as test_assert_can_create, but using the helpers from wagtail.test.utils.form_data


### PR DESCRIPTION
Fixes #9939. There wasn't any discussion on #9458 about switching the behaviour away from how it was originally done in #4756 (publishing by default and explicitly setting `publish=False` to override that) so it looks like that change was made inadvertently in the final rebase.

Also remove the mentions of redirects from the documentation - the fact that the method has to check for a different redirect URL is an internal implementation detail, and not relevant to what the assertion is intending to test (namely that a page is successfully created).
