### PR TITLE
Adopt the Stimulus `SwapController` in the modal task chooser

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/chooser.html
@@ -30,7 +30,16 @@
                 aria-labelledby="tab-label-existing"
                 hidden
             >
-                <form class="task-search" action="{% url 'wagtailadmin_workflows:task_chooser_results' %}" method="GET" novalidate>
+                <form
+                    class="task-search"
+                    action="{% url 'wagtailadmin_workflows:task_chooser_results' %}"
+                    method="GET"
+                    novalidate
+                    data-controller="w-swap"
+                    data-action="navigate->w-swap#replace submit->w-swap#submit:stop:prevent input->w-swap#submitLazy"
+                    data-w-swap-target-value="#search-results"
+                    data-w-swap-wait-value="50"
+                >
                     <ul class="fields">
                         {% for field in search_form %}
                             <li>


### PR DESCRIPTION
Adopt the HTML Stimulus approach for the task chooser modal (Workflow). This is a standalone use case of the other implementation of a search controller that is in place currently. Instead of updating all usages I thought it would be simpler to get feedback on an isolated case initially.

- Builds on #9952
- Partial progress on #9950
- Uses event dispatching to communicate with the controller instances from outside the controller (when the page link is clicked) - this is the recommended approach in the Stimulus docs but does add a small bit of indirection where the `'navigate'` event must be listened to explicitly. It is quite powerful though and gives room for a lot of flexibility for doing this.

---

-   [X] Do the tests still pass?
-   [X] Does the code comply with the style guide?
-   [X] For front-end changes: Did you test on all of Wagtail’s supported environments? Chrome 109, Firefox 109, Safari 16.1 on macOS 13.0
