### PR TITLE
Ability to support outer double quotes in `wagtail.search.utils.parse_query_string` 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Switch lock/unlock side panel toggle to a switch, with more appropriate confirmation message status (Sage Abdullah)
  * Ensure that changed or cleared selection from choosers will dispatch a DOM `change` event (George Sakkis)
  * Add the ability to disable model indexing by setting `search_fields = []` (Daniel Kirkham)
+ * Enhance `wagtail.search.utils.parse_query_string` to allow inner single quotes for key/value parsing (Aman Pandey)
  * Fix: Ensure `label_format` on StructBlock gracefully handles missing variables (Aadi jindal)
  * Fix: Adopt a no-JavaScript and more accessible solution for the 'Reset to default' switch to Gravatar when editing user profile (Loveth Omokaro)
  * Fix: Ensure `Site.get_site_root_paths` works on cache backends that do not preserve Python objects (Jaap Roes)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -31,6 +31,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Switch lock/unlock side panel toggle to a switch, with more appropriate confirmation message status (Sage Abdullah)
  * Ensure that changed or cleared selection from choosers will dispatch a DOM `change` event (George Sakkis)
  * Add the ability to [disable model indexing](wagtailsearch_disable_indexing) by setting `search_fields = []` (Daniel Kirkham)
+ * Enhance `wagtail.search.utils.parse_query_string` to allow inner single quotes for key/value parsing (Aman Pandey)
 
 ### Bug fixes
 

--- a/docs/topics/search/searching.md
+++ b/docs/topics/search/searching.md
@@ -272,11 +272,14 @@ For example:
 
 ```python
 >>> from wagtail.search.utils import parse_query_string
->>> filters, query = parse_query_string('my query string "this is a phrase" this-is-a:filter', operator='and')
+>>> filters, query = parse_query_string('my query string "this is a phrase" this_is_a:filter', operator='and')
+
+# Alternatively..
+# filters, query = parse_query_string("my query string 'this is a phrase' this_is_a:filter", operator='and')
 
 >>> filters
 {
-    'this-is-a': 'filter',
+    'this_is_a': 'filter',
 }
 
 >>> query

--- a/wagtail/search/utils.py
+++ b/wagtail/search/utils.py
@@ -82,12 +82,14 @@ def normalise_query_string(query_string):
 
 
 def separate_filters_from_query(query_string):
-    filters_regexp = r'(\w+):(\w+|"[^"]+")'
+    filters_regexp = r'(\w+):(\w+|"[^"]+"|\'[^\']+\')'
 
     filters = {}
     for match_object in re.finditer(filters_regexp, query_string):
         key, value = match_object.groups()
-        filters[key] = value.strip('"')
+        filters[key] = (
+            value.strip('"') if value.strip('"') is not value else value.strip("'")
+        )
 
     query_string = re.sub(filters_regexp, "", query_string).strip()
 
@@ -112,7 +114,12 @@ def parse_query_string(query_string, operator=None, zero_terms=MATCH_NONE):
 
     is_phrase = False
     tokens = []
-    for part in query_string.split('"'):
+    if '"' in query_string:
+        parts = query_string.split('"')
+    else:
+        parts = query_string.split("'")
+
+    for part in parts:
         part = part.strip()
 
         if part:


### PR DESCRIPTION
_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.
Fixes https://github.com/wagtail/wagtail/issues/9951

additionally 
improved the docs https://docs.wagtail.org/en/stable/topics/search/searching.html#query-string-parsing
![image](https://user-images.githubusercontent.com/74553951/214550466-2173ab35-d591-4328-8e2d-e4a7cb14939e.png)
`this-is-a` to `this_is_a`
added tests 
some additional context and notes been added to docs to, direct the users 
to only use a one of the 2 types of query string patterns `" hello 'world' "` or `'hello "world" '`

after changes:
![image](https://user-images.githubusercontent.com/74553951/214553592-bd910189-e7e5-43f6-b3b7-ce0c027735d3.png)
