### PR TITLE
Turn on strictPropertyInitialization and use declare for existing Stimulus controllers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~~~~~
 
 * Maintenance: Update djhtml (html formatting) library to v 1.5.2 (Loveth Omokaro)
+* Maintenance: Re-enable `strictPropertyInitialization` in tsconfig (Thibaud Colas)
 
 
 4.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/controllers/ActionController.ts
+++ b/client/src/controllers/ActionController.ts
@@ -20,8 +20,8 @@ export class ActionController extends Controller {
     url: String,
   };
 
-  continueValue: boolean;
-  urlValue: string;
+  declare continueValue: boolean;
+  declare urlValue: string;
 
   post(event: Event) {
     event.preventDefault();

--- a/client/src/controllers/UpgradeController.ts
+++ b/client/src/controllers/UpgradeController.ts
@@ -28,12 +28,12 @@ export class UpgradeController extends Controller<HTMLElement> {
     url: { default: 'https://releases.wagtail.org/latest.txt', type: String },
   };
 
-  currentVersionValue: string;
-  hiddenClass: string;
-  latestVersionTarget: HTMLElement;
-  linkTarget: HTMLElement;
-  ltsOnlyValue: any;
-  urlValue: string;
+  declare currentVersionValue: string;
+  declare hiddenClass: string;
+  declare latestVersionTarget: HTMLElement;
+  declare linkTarget: HTMLElement;
+  declare ltsOnlyValue: any;
+  declare urlValue: string;
 
   connect() {
     this.checkVersion();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strictNullChecks": true,
-    "strictPropertyInitialization": false,
+    "strictPropertyInitialization": true,
     "target": "ES2021" // Since lowest browser support is for Safari 14
   },
   "files": [


### PR DESCRIPTION


_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?
