### PR TITLE
Fix/headless wagtail page url

### DIFF
--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2103,7 +2103,15 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                     "wagtail_serve", args=(self.url_path[len(root_path) :],)
                 )
         except NoReverseMatch:
-            return (site_id, None, None)
+            """
+            wagtail_serve is not mounted, this is most likely a headless Wagtail,
+            use the path rather than processsing through wagtail_serve -1 maintains
+            the leading slash needed to create a root relative URL Path.
+
+            TODO: review whether additional work is needed to support Multisite and i18n
+            url generation in headless Wagtail.
+            """
+            page_path = self.url_path[len(root_path) - 1 :]
 
         # Remove the trailing slash from the URL reverse generates if
         # WAGTAIL_APPEND_SLASH is False and we're not trying to serve

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -429,11 +429,18 @@ class TestRouting(TestCase):
         default_site = Site.objects.get(is_default_site=True)
         homepage = Page.objects.get(url_path="/home/")
 
-        # The page should not be routable because wagtail_serve is not registered
-        # However it is still associated with a site
-        self.assertEqual(homepage.get_url_parts(), (default_site.id, None, None))
-        self.assertIsNone(homepage.full_url)
-        self.assertIsNone(homepage.url)
+        # for now headless installations will return the url relative to the default site.
+        # additional work probably needs to be done to enable multisite in headless modes
+        # without this page links in richtext blocks have href=None
+        self.assertEqual(homepage.get_url_parts(), (default_site.id, "http://localhost", "/"))
+        self.assertEqual(homepage.full_url, "http://localhost/")
+        self.assertEqual(homepage.url, "/")
+
+        events_page = Page.objects.get(url_path="/home/events/")
+        self.assertEqual(events_page.get_url_parts(), (default_site.id, "http://localhost", "/events/"))
+        self.assertEqual(events_page.full_url, "http://localhost/events/")
+        self.assertEqual(events_page.url, "/events/")
+
 
     def test_request_routing(self):
         homepage = Page.objects.get(url_path="/home/")

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -432,15 +432,19 @@ class TestRouting(TestCase):
         # for now headless installations will return the url relative to the default site.
         # additional work probably needs to be done to enable multisite in headless modes
         # without this page links in richtext blocks have href=None
-        self.assertEqual(homepage.get_url_parts(), (default_site.id, "http://localhost", "/"))
+        self.assertEqual(
+            homepage.get_url_parts(), (default_site.id, "http://localhost", "/")
+        )
         self.assertEqual(homepage.full_url, "http://localhost/")
         self.assertEqual(homepage.url, "/")
 
         events_page = Page.objects.get(url_path="/home/events/")
-        self.assertEqual(events_page.get_url_parts(), (default_site.id, "http://localhost", "/events/"))
+        self.assertEqual(
+            events_page.get_url_parts(),
+            (default_site.id, "http://localhost", "/events/"),
+        )
         self.assertEqual(events_page.full_url, "http://localhost/events/")
         self.assertEqual(events_page.url, "/events/")
-
 
     def test_request_routing(self):
         homepage = Page.objects.get(url_path="/home/")

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -23,6 +23,13 @@ class TestPageLinktypeHandler(TestCase):
         )
         self.assertEqual(result, '<a href="/events/christmas/">')
 
+    @override_settings(ROOT_URLCONF="wagtail.test.headless_urls")
+    def test_expand_db_attributes_headless(self):
+        result = PageLinkHandler.expand_db_attributes(
+            {"id": Page.objects.get(url_path="/home/events/christmas/").id}
+        )
+        self.assertEqual(result, '<a href="/events/christmas/">')
+
     def test_expand_db_attributes_page_does_not_exist(self):
         result = PageLinkHandler.expand_db_attributes({"id": 0})
         self.assertEqual(result, "<a>")


### PR DESCRIPTION
When creating page links in RichTextBlocks on my headless site I am getting `<a href=None />` in the rendered output. This update returns a URL relative to the site for headless sites. This is currently a bug for a site I am developing. It is also potentially an enabler for implementing multisite support in grapple where there are plans brewing to allow pages for multisite installations to be queried with the following. 

```graphql
{ 
  site(hostname: "mysite.com") {
    pages {
       title
       url
   }
}
```


-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For new features: Has the documentation been updated accordingly? 

    I'm not sure url generation for headless sites are documented anywhere and I wouldn't know where to start adding something like that. 
