### PR TITLE
Adopt core shared header for ModelAdmin headers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -45,6 +45,7 @@ Changelog
  * Maintenance: Migrate slug field behaviour to a Stimulus controller and create new `SlugInput` widget (Loveth Omokaro)
  * Maintenance: Refactor `status` HTML usage to shared template tag (Aman Pandey, LB (Ben) Johnston)
  * Maintenance: Add curlylint and update djhtml, semgrep versions in pre-commit config (Himanshu Garg)
+ * Maintenance: Use shared header template for `ModelAdmin` header (Aman Pandey)
 
 
 4.2.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -65,6 +65,7 @@ depth: 1
  * Migrate slug field behaviour to a Stimulus controller and create new `SlugInput` widget (Loveth Omokaro)
  * Refactor `status` HTML usage to shared template tag (Aman Pandey, LB (Ben) Johnston)
  * Add curlylint and update djhtml, semgrep versions in pre-commit config (Himanshu Garg)
+ * Use shared header template for `ModelAdmin` header (Aman Pandey)
 
 ## Upgrade considerations
 
@@ -94,6 +95,16 @@ The following features deprecated in Wagtail 4.0 have been fully removed. See [W
 ### `Page.get_static_site_paths` method removed
 
 The undocumented `Page.get_static_site_paths` method (which returns a generator of URL paths for use by static site generator packages) has been removed. Packages relying on this functionality should provide their own fallback implementation.
+
+### Changes to header CSS classes in `ModelAdmin` templates
+
+If there are custom styles in place for the `ModelAdmin`'s header content or more complex [template overrides](modeladmin_overriding_templates) in us, there are a few changes for the following classes to be aware of.
+
+| **Content**                      | **Old classes**       | **New classes** |
+| -------------------------------- | --------------------- | --------------- |
+| Heading & search (contains `h1`) | `.left.header-left`   | `.left`         |
+| Action buttons (`header_extra`)  | `.right.header-right` | `.right`        |
+
 
 ### Slug field widget required for auto-formatting
 

--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -16,21 +16,29 @@
     - `action_text` - text for the 'action' button
     - `action_icon` - icon for the 'action' button, default is 'icon-plus'
     - `extra_actions` - extra action buttons for the header. This is the HTML to be used for the extra buttons
+    - `breadcrumb` - Custom breadcrumbs content as a variable, displayed in place of breadcrumb block before the header content
+    - `header` - Replaces the header `h1` completely with custom variable content
+    - `search` - An alternative search content variable displayed if provided and search_url url is not present
+    - `extra_rows` - Shown at the end of the header container
 
 {% endcomment %}
 <header class="{% classnames "w-header" classname merged|yesno:"w-header--merged," search_form|yesno:"w-header--hasform," %}">
-    {% block breadcrumb %}{% endblock %}
+    {% block breadcrumb %}{{ breadcrumb }}{% endblock %}
     <div class="row">
         <div class="left">
             <div class="col">
-                <h1 class="w-header__title" id="header-title">
-                    {% if icon %}
-                        {% icon classname="w-header__glyph" name=icon %}
-                    {% elif avatar %}
-                        <div class="w-header__glyph avatar large"><img src="{{ avatar }}" alt="" /></div>
-                    {% endif %}
-                    {{ title }}{% if subtitle %} <span class="w-header__subtitle">{{ subtitle }}</span>{% endif %}
-                </h1>
+                {% if heading %}
+                    {{ heading }}
+                {% else %}
+                    <h1 class="w-header__title" id="header-title">
+                        {% if icon %}
+                            {% icon classname="w-header__glyph" name=icon %}
+                        {% elif avatar %}
+                            <div class="w-header__glyph avatar large"><img src="{{ avatar }}" alt="" /></div>
+                        {% endif %}
+                        {{ title }}{% if subtitle %} <span class="w-header__subtitle">{{ subtitle }}</span>{% endif %}
+                    </h1>
+                {% endif %}
                 {% if description %}<div class="w-header__description">{{ description }}</div>{% endif %}
             </div>
             {% if search_url %}
@@ -42,6 +50,8 @@
                     <div class="visuallyhidden"><input disabled type="submit" aria-hidden="true"/></div>
                     <div class="submit visuallyhidden"><input type="submit" value="Search" class="button" /></div>
                 </form>
+            {% elif search %}
+                {{ search }}
             {% endif %}
         </div>
         <div class="{% block right_column_classname %}right{% endblock %}">
@@ -59,5 +69,5 @@
             {% endif %}
         </div>
     </div>
-    {% block extra_rows %}{% endblock %}
+    {% block extra_rows %}{{ extra_rows }}{% endblock %}
 </header>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -17,45 +17,38 @@
 
 {% block content %}
     {% block header %}
-        <header class="w-header w-header--hasform">
-            {% block breadcrumb %}{% endblock %}
-            <div class="row">
-                <div class="left header-left">
-                    <div class="col">
-                        {% block h1 %}
-                            <h1 class="w-header__title">
-                                {% if view.header_icon %}{% icon classname="w-header__glyph" name=view.header_icon %}{% endif %}
-                                {{ view.get_page_title }}
-                                {% if view.get_page_subtitle %} <span class="w-header__subtitle">{{ view.get_page_subtitle }}</span> {% endif %}
-                                {% include 'modeladmin/includes/result_count.html' %}
-                            </h1>
-                        {% endblock %}
-                    </div>
-                    {% block search %}{% search_form %}{% endblock %}
-                </div>
-                {% block header_extra %}
-                    <div class="right header-right">
-                        {% if view.list_export or user_can_create %}
-                            <div class="actionbutton">
-                                {% if user_can_create %}
-                                    {% include 'modeladmin/includes/button.html' with button=view.button_helper.add_button %}
-                                {% endif %}
-                                {% if view.list_export %}
-                                    <div class="dropdown dropdown-button match-width col">
-                                        <a href="?export=xlsx&{{ request.GET.urlencode }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}</a>
-                                        <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
-                                        <ul>
-                                            <li><a  class="button bicolor button--icon" href="?export=csv&{{ request.GET.urlencode }}">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a></li>
-                                        </ul>
-                                    </div>
-                                {% endif %}
+        {% fragment as breadcrumb %}{% block breadcrumb %}{% endblock %}{% endfragment %}
+        {% fragment as heading %}{% block h1 %}{% endblock %}{% endfragment %}
+        {% fragment as description %}{% include 'modeladmin/includes/result_count.html' %}{% endfragment %}
+        {% fragment as extra_actions %}
+            {% block header_extra %}
+                {% if view.list_export or user_can_create %}
+                    <div class="actionbutton">
+                        {% if user_can_create %}
+                            {% include 'modeladmin/includes/button.html' with button=view.button_helper.add_button %}
+                        {% endif %}
+                        {% if view.list_export %}
+                            <div class="dropdown dropdown-button match-width col">
+                                <a href="?export=xlsx&{{ request.GET.urlencode }}" class="button bicolor button--icon">
+                                    {% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}
+                                </a>
+                                <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
+                                <ul>
+                                    <li>
+                                        <a class="button bicolor button--icon" href="?export=csv&{{ request.GET.urlencode }}">{% icon name="download" wrapped=1 %}
+                                            {% trans 'Download CSV' %}
+                                        </a>
+                                    </li>
+                                </ul>
                             </div>
                         {% endif %}
                     </div>
-                {% endblock %}
-            </div>
-            {% block extra_rows %}{% endblock %}
-        </header>
+                {% endif %}
+            {% endblock %}
+        {% endfragment %}
+        {% fragment as search %}{% block search %}{% search_form %}{% endblock %}{% endfragment %}
+        {% fragment as extra_rows %}{% block extra_rows %}{% endblock %}{% endfragment %}
+        {% include 'wagtailadmin/shared/header.html' with classname="w-header--hasform" breadcrumb=breadcrumb heading=heading title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon description=description search=search extra_actions=extra_actions extra_rows=extra_rows %}
     {% endblock %}
 
     {% block content_main %}


### PR DESCRIPTION
-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]

**Please describe additional details for testing this change**.

Fixes https://github.com/wagtail/wagtail/issues/8907

Adopts core header in modeladmin index view through `modeladmin/includes/header.html` (inherits/extends) core header 

BEFORE: 

![before](https://user-images.githubusercontent.com/74553951/215775462-745bfbff-e8ae-4df4-884a-bccb49f7ebe2.jpg)

AFTER:

![after](https://user-images.githubusercontent.com/74553951/215775516-01ebc717-f956-406c-927a-5620dcc22d07.jpg)
