### PR TITLE
Refresh lock object before returning a response when cancelling a workflow

### DIFF
--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -1055,7 +1055,7 @@ class BasePageWorkflowTests(TestCase, WagtailTestUtils):
             args=(self.object.id,) if args is None else args,
         )
 
-    def post(self, action, data=None):
+    def post(self, action, data=None, **kwargs):
         post_data = {
             "title": str(self.object.title),
             "slug": str(self.object.slug),
@@ -1064,7 +1064,7 @@ class BasePageWorkflowTests(TestCase, WagtailTestUtils):
         }
         if data:
             post_data.update(data)
-        return self.client.post(self.get_url("edit"), post_data)
+        return self.client.post(self.get_url("edit"), post_data, **kwargs)
 
     def workflow_action(self, action, data=None, **kwargs):
         return self.client.post(
@@ -1130,14 +1130,14 @@ class BaseSnippetWorkflowTests(BasePageWorkflowTests):
             args=(quote(self.object.pk),) if args is None else args,
         )
 
-    def post(self, action, data=None):
+    def post(self, action, data=None, **kwargs):
         post_data = {
             "text": self.object.text,
             f"action-{action}": "True",
         }
         if data:
             post_data.update(data)
-        return self.client.post(self.get_url("edit"), post_data)
+        return self.client.post(self.get_url("edit"), post_data, **kwargs)
 
 
 class TestSubmitPageToWorkflow(BasePageWorkflowTests):
@@ -1191,11 +1191,15 @@ class TestSubmitPageToWorkflow(BasePageWorkflowTests):
         self.assertNotContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save " disabled>',
+        )
 
         # submit for approval
         self.post("submit")
 
-        # After submit, as a submitter, should only see cancel button
+        # After submit, as a submitter, should only see cancel and locked buttons
         response = self.client.get(edit_url)
         self.assertNotContains(response, "Save draft")
         self.assertNotContains(response, "Submit to test_workflow")
@@ -1203,6 +1207,10 @@ class TestSubmitPageToWorkflow(BasePageWorkflowTests):
         self.assertNotContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertContains(
+            response,
+            '<button type="submit" class="button action-save " disabled>',
+        )
 
         # After submit, as a moderator, should only see save, approve, and reject buttons
         self.login(self.moderator)
@@ -1213,6 +1221,10 @@ class TestSubmitPageToWorkflow(BasePageWorkflowTests):
         self.assertNotContains(response, "Restart workflow")
         self.assertContains(response, "Approve")
         self.assertContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save " disabled>',
+        )
 
         self.reject()
 
@@ -1225,6 +1237,23 @@ class TestSubmitPageToWorkflow(BasePageWorkflowTests):
         self.assertContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save " disabled>',
+        )
+
+        # After cancel, as a submitter, should only see save and submit buttons
+        response = self.post("cancel-workflow", follow=True)
+        self.assertContains(response, "Save draft")
+        self.assertContains(response, "Submit to test_workflow")
+        self.assertNotContains(response, "Cancel workflow")
+        self.assertNotContains(response, "Restart workflow")
+        self.assertNotContains(response, "Approve")
+        self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save " disabled>',
+        )
 
     def test_workflow_action_menu_items_when_reverting(self):
         old_revision = self.object.latest_revision
@@ -1241,11 +1270,15 @@ class TestSubmitPageToWorkflow(BasePageWorkflowTests):
         self.assertNotContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save warning" disabled>',
+        )
 
         # submit for approval
         self.post("submit")
 
-        # After submit, as a submitter, should not see any buttons
+        # After submit, as a submitter, should only see locked button
         response = self.client.get(revert_url)
         self.assertNotContains(response, "Replace current draft")
         self.assertNotContains(response, "Submit to test_workflow")
@@ -1253,6 +1286,10 @@ class TestSubmitPageToWorkflow(BasePageWorkflowTests):
         self.assertNotContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertContains(
+            response,
+            '<button type="submit" class="button action-save warning" disabled>',
+        )
 
         # After submit, as a moderator, should only see save button
         self.login(self.moderator)
@@ -1263,6 +1300,10 @@ class TestSubmitPageToWorkflow(BasePageWorkflowTests):
         self.assertNotContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save warning" disabled>',
+        )
 
         self.reject()
 
@@ -1275,6 +1316,24 @@ class TestSubmitPageToWorkflow(BasePageWorkflowTests):
         self.assertNotContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save warning" disabled>',
+        )
+
+        # After cancel, as a submitter, should only see save button
+        self.post("cancel-workflow")
+        response = self.client.get(revert_url)
+        self.assertContains(response, "Replace current draft")
+        self.assertNotContains(response, "Submit to test_workflow")
+        self.assertNotContains(response, "Cancel workflow")
+        self.assertNotContains(response, "Restart workflow")
+        self.assertNotContains(response, "Approve")
+        self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save warning" disabled>',
+        )
 
     @override_settings(WAGTAILADMIN_BASE_URL="http://admin.example.com")
     def test_submit_sends_mail(self):
@@ -1409,13 +1468,31 @@ class TestSubmitPageToWorkflow(BasePageWorkflowTests):
         workflow_state = self.object.current_workflow_state
         self.assertEqual(workflow_state.current_task_state.task.specific, self.task_1)
         self.assertEqual(workflow_state.status, WorkflowState.STATUS_IN_PROGRESS)
-        self.post("cancel-workflow")
+        response = self.post("cancel-workflow", follow=True)
         workflow_state.refresh_from_db()
 
         # check that the workflow state's status is now cancelled
         self.assertEqual(workflow_state.status, WorkflowState.STATUS_CANCELLED)
         self.assertEqual(
             workflow_state.current_task_state.status, TaskState.STATUS_CANCELLED
+        )
+
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save " disabled>',
+        )
+        self.assertNotContains(
+            response,
+            f"The {self.model_name} could not be saved as it is locked",
+        )
+        self.assertNotContains(
+            response,
+            f"The {self.model_name} could not be saved due to validation errors",
+        )
+        # Snippets have a custom error message that's not made generic yet
+        self.assertNotContains(
+            response,
+            "The snippet could not be saved due to errors",
         )
 
     def test_email_headers(self):
@@ -1466,6 +1543,10 @@ class TestSubmitSnippetToWorkflowNotLockable(TestSubmitSnippetToWorkflow):
         self.assertNotContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save warning" disabled>',
+        )
 
         # submit for approval
         self.post("submit")
@@ -1479,6 +1560,10 @@ class TestSubmitSnippetToWorkflowNotLockable(TestSubmitSnippetToWorkflow):
         self.assertNotContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save warning" disabled>',
+        )
 
         # After submit, as a moderator, should only see save, approve, and reject buttons
         self.login(self.moderator)
@@ -1489,6 +1574,10 @@ class TestSubmitSnippetToWorkflowNotLockable(TestSubmitSnippetToWorkflow):
         self.assertNotContains(response, "Restart workflow")
         self.assertContains(response, "Approve")
         self.assertContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save warning" disabled>',
+        )
 
         self.reject()
 
@@ -1501,6 +1590,10 @@ class TestSubmitSnippetToWorkflowNotLockable(TestSubmitSnippetToWorkflow):
         self.assertContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save warning" disabled>',
+        )
 
     def test_workflow_action_menu_items_when_reverting(self):
         old_revision = self.object.latest_revision
@@ -1517,6 +1610,10 @@ class TestSubmitSnippetToWorkflowNotLockable(TestSubmitSnippetToWorkflow):
         self.assertNotContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save warning" disabled>',
+        )
 
         # submit for approval
         self.post("submit")
@@ -1530,6 +1627,10 @@ class TestSubmitSnippetToWorkflowNotLockable(TestSubmitSnippetToWorkflow):
         self.assertNotContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save warning" disabled>',
+        )
 
         # After submit, as a moderator, should only see save button
         self.login(self.moderator)
@@ -1540,6 +1641,10 @@ class TestSubmitSnippetToWorkflowNotLockable(TestSubmitSnippetToWorkflow):
         self.assertNotContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save warning" disabled>',
+        )
 
         self.reject()
 
@@ -1552,6 +1657,10 @@ class TestSubmitSnippetToWorkflowNotLockable(TestSubmitSnippetToWorkflow):
         self.assertNotContains(response, "Restart workflow")
         self.assertNotContains(response, "Approve")
         self.assertNotContains(response, "Request changes")
+        self.assertNotContains(
+            response,
+            '<button type="submit" class="button action-save warning" disabled>',
+        )
 
 
 @freeze_time("2020-03-31 12:00:00")

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -438,9 +438,10 @@ class CreateEditViewOptionalFeaturesMixin:
         }
 
     def get_success_url(self):
-        if self.draftstate_enabled and self.action in ["create", "edit"]:
-            # If DraftStateMixin is enabled and the action is saving a draft,
-            # remain on the edit view
+        # If DraftStateMixin is enabled and the action is saving a draft
+        # or cancelling a workflow, remain on the edit view
+        remain_actions = {"create", "edit", "cancel-workflow"}
+        if self.draftstate_enabled and self.action in remain_actions:
             return self.get_edit_url()
         return super().get_success_url()
 

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -812,7 +812,12 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             self.workflow_state.cancel(user=self.request.user)
             self.add_cancel_workflow_confirmation_message()
 
-        if self.locked_for_user:
+            # Refresh the lock object as now WorkflowLock no longer applies
+            self.lock = self.page.get_lock()
+            self.locked_for_user = self.lock is not None and self.lock.for_user(
+                self.request.user
+            )
+        elif self.locked_for_user:
             messages.error(
                 self.request, _("The page could not be saved as it is locked")
             )


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

Fixes #9992.

_Please check the following:_

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
