### PR TITLE
Update 4.2 release notes for `class_name` warning

### DIFF
--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -231,7 +231,7 @@ If these are used within packages or customisations they will need to be updated
 | `tab_nav_link`      | `{% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with classname="..." %}`                      | `{% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with classes="..." %}`                      |
 | `side_panel_button` | `{% include 'wagtailadmin/shared/side_panels/includes/side_panel_button.html' with classname="..." %}` | `{% include 'wagtailadmin/shared/side_panels/includes/side_panel_button.html' with classes="..." %}` |
 
-Note that the `icon` template tag will still support `class_name` until Wagtail version 5 but will trigger a deprecation warning.
+Note that the `icon` template tag will still support `class_name` with a deprecation warning, support will be dropped in a future release.
 
 ### `InlinePanel` JavaScript function is now a class
 

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -231,7 +231,7 @@ If these are used within packages or customisations they will need to be updated
 | `tab_nav_link`      | `{% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with classname="..." %}`                      | `{% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with classes="..." %}`                      |
 | `side_panel_button` | `{% include 'wagtailadmin/shared/side_panels/includes/side_panel_button.html' with classname="..." %}` | `{% include 'wagtailadmin/shared/side_panels/includes/side_panel_button.html' with classes="..." %}` |
 
-Note that the `icon` template tag will still support `class_name` with a deprecation warning, support will be dropped in a future release.
+Note that the `icon` template tag will still support `class_name` with a deprecation warning. Support will be dropped in a future release.
 
 ### `InlinePanel` JavaScript function is now a class
 


### PR DESCRIPTION
- Relates to #9770
- As the `class_name` deprecation will now happen in 6.0 - it seemed more appropriate to be generic with this release note item. See #9987