### PR TITLE
Update to latest pre-release of Draftail. Fixes #9937, #9942

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "axe-core": "^4.6.2",
         "downshift": "^7.2.0",
         "draft-js": "^0.10.5",
-        "draftail": "^2.0.0-rc.5",
+        "draftail": "^2.0.0-rc.6",
         "draftjs-filters": "^3.0.1",
         "focus-trap-react": "^8.4.2",
         "immer": "^9.0.6",
@@ -18029,9 +18029,9 @@
       }
     },
     "node_modules/draftail": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/draftail/-/draftail-2.0.0-rc.5.tgz",
-      "integrity": "sha512-t4o+483o7DY+7taNP6adgh2FAp4VBi0WxcteilPZdRZaotv3ePsLV5TPtfLiQtS4KGgGyP+RiGmPfPjJ/Ycbvg==",
+      "version": "2.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/draftail/-/draftail-2.0.0-rc.6.tgz",
+      "integrity": "sha512-1Moe87oMhcR0C36H9wjgDo4n9kfv73s8+XKviaxVBopSK6HbZaHiEZu9T68wmYzOnUmAr9G59h0b+sSAGPiBlg==",
       "dependencies": {
         "@tippyjs/react": "^4.2.6",
         "decorate-component-with-props": "^1.0.2",
@@ -44140,9 +44140,9 @@
       }
     },
     "draftail": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/draftail/-/draftail-2.0.0-rc.5.tgz",
-      "integrity": "sha512-t4o+483o7DY+7taNP6adgh2FAp4VBi0WxcteilPZdRZaotv3ePsLV5TPtfLiQtS4KGgGyP+RiGmPfPjJ/Ycbvg==",
+      "version": "2.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/draftail/-/draftail-2.0.0-rc.6.tgz",
+      "integrity": "sha512-1Moe87oMhcR0C36H9wjgDo4n9kfv73s8+XKviaxVBopSK6HbZaHiEZu9T68wmYzOnUmAr9G59h0b+sSAGPiBlg==",
       "requires": {
         "@tippyjs/react": "^4.2.6",
         "decorate-component-with-props": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "axe-core": "^4.6.2",
     "downshift": "^7.2.0",
     "draft-js": "^0.10.5",
-    "draftail": "^2.0.0-rc.5",
+    "draftail": "^2.0.0-rc.6",
     "draftjs-filters": "^3.0.1",
     "focus-trap-react": "^8.4.2",
     "immer": "^9.0.6",


### PR DESCRIPTION
Fixes #9937 and fixes #9942. There are three separate issues here.

## Block toolbar toggle

See #9942.

Clicking the trigger to the left of the editor now correctly closes the toolbar. This previously wasn’t an issue due to the tooltip’s backdrop element receiving those click events, but became apparent without the backdrop.

The logic to handle clicks wasn’t correct, with the "click outside to close" event handling incorrectly used for clicks to the button too.

Commit: https://github.com/springload/draftail/commit/6734075b8e48d25e66d8f8085faab10cd1d8d6fa

## Return key handling in editor

See #9937.

The logic to handle Return/Enter key events was too basic, preventing certain key presses. Now the special "command palette" delegated event handling of the return/enter key only occurs when the command palette is open and there is a selected element within.

Commit: https://github.com/springload/draftail/commit/f4d955a39d9950ee8664fc2300cf4376ac78bef9

## Command prompt dismissal

See #9942.

The dismissing of the command prompt was too restrictive, particularly when users dismiss the command palette on just "/". The new logic is more permissive, only dismissing if there the last-dismissed prompt matches on position (same block and selection focus offset) and starts with the same text. To compensate I’ve made the auto-dismissing happen once a single space is typed within text.

Commit: https://github.com/springload/draftail/commit/b8c0d11b7a589a3df8d40ed1c6918b6920ef3bc8

---

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 109 macOS 13.1
    -   [x] **Please list which assistive technologies [^3] you tested**: N/A
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

Here is a recording of the different scenarios now handled differently:

![9937-9942](https://user-images.githubusercontent.com/877585/216272626-5d740af1-fe5a-4f26-acf8-e46f60ecfaeb.gif)
