### PR TITLE
Axe accessibility checker: sorting violations based on their place in DOM

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Migrate `.button-longrunning` behaviour to a Stimulus controller with support for custom label element & duration (Loveth Omokaro)
  * Implement new simplified userbar designs (Albina Starykova)
  * Add more Axe rules to the accessibility checker (Albina Starykova)
+ * Sort accessibility checker results by position on the page (Albina Starykova)
  * Add usage view for pages (Sage Abdullah)
  * Copy page form now updates the slug field dynamically with a slugified value on blur (Loveth Omokaro)
  * Ensure selected collection is kept when navigating from documents or images listings to add multiple views & upon upload (Aman Pandey, Bojan Mihelac)

--- a/client/src/includes/userbar.test.ts
+++ b/client/src/includes/userbar.test.ts
@@ -1,0 +1,55 @@
+import { AxeResults } from 'axe-core';
+import { sortAxeViolations } from './userbar';
+
+const mockDocument = `
+<div id="a"></div>
+<div id="b"></div>
+<div id="c"></div>
+<div id="d"></div>
+`;
+
+// Multiple selectors per violation, multiple violations per selector
+const mockViolations = {
+  a: { id: 'axe-1', nodes: [{ target: ['#d'] }, { target: ['#a'] }] },
+  b: { id: 'axe-2', nodes: [{ target: ['#d'] }, { target: ['#b'] }] },
+  c: { id: 'axe-3', nodes: [{ target: ['#c'] }] },
+};
+
+it('works with no nodes', () => {
+  const violations = [
+    { id: 'axe-1', nodes: [] },
+    { id: 'axe-2', nodes: [] },
+  ] as unknown as AxeResults['violations'];
+  expect(sortAxeViolations(violations)).toEqual([
+    { id: 'axe-1', nodes: [] },
+    { id: 'axe-2', nodes: [] },
+  ]);
+});
+
+it('preserves the existing order if correct', () => {
+  document.body.innerHTML = mockDocument;
+  const violations = [
+    mockViolations.a,
+    mockViolations.b,
+    mockViolations.c,
+  ] as AxeResults['violations'];
+  expect(sortAxeViolations(violations)).toEqual([
+    mockViolations.a,
+    mockViolations.b,
+    mockViolations.c,
+  ]);
+});
+
+it('changes the order to match the DOM', () => {
+  document.body.innerHTML = mockDocument;
+  const violations = [
+    mockViolations.c,
+    mockViolations.b,
+    mockViolations.a,
+  ] as AxeResults['violations'];
+  expect(sortAxeViolations(violations)).toEqual([
+    mockViolations.a,
+    mockViolations.b,
+    mockViolations.c,
+  ]);
+});

--- a/client/src/includes/userbar.test.ts
+++ b/client/src/includes/userbar.test.ts
@@ -10,46 +10,48 @@ const mockDocument = `
 
 // Multiple selectors per violation, multiple violations per selector
 const mockViolations = {
-  a: { id: 'axe-1', nodes: [{ target: ['#d'] }, { target: ['#a'] }] },
-  b: { id: 'axe-2', nodes: [{ target: ['#d'] }, { target: ['#b'] }] },
+  da: { id: 'axe-1', nodes: [{ target: ['#d'] }, { target: ['#a'] }] },
+  db: { id: 'axe-2', nodes: [{ target: ['#d'] }, { target: ['#b'] }] },
   c: { id: 'axe-3', nodes: [{ target: ['#c'] }] },
 };
 
-it('works with no nodes', () => {
-  const violations = [
-    { id: 'axe-1', nodes: [] },
-    { id: 'axe-2', nodes: [] },
-  ] as unknown as AxeResults['violations'];
-  expect(sortAxeViolations(violations)).toEqual([
-    { id: 'axe-1', nodes: [] },
-    { id: 'axe-2', nodes: [] },
-  ]);
-});
+describe('sortAxeViolations', () => {
+  it('works with no nodes', () => {
+    const violations = [
+      { id: 'axe-1', nodes: [] },
+      { id: 'axe-2', nodes: [] },
+    ] as unknown as AxeResults['violations'];
+    expect(sortAxeViolations(violations)).toEqual([
+      { id: 'axe-1', nodes: [] },
+      { id: 'axe-2', nodes: [] },
+    ]);
+  });
 
-it('preserves the existing order if correct', () => {
-  document.body.innerHTML = mockDocument;
-  const violations = [
-    mockViolations.a,
-    mockViolations.b,
-    mockViolations.c,
-  ] as AxeResults['violations'];
-  expect(sortAxeViolations(violations)).toEqual([
-    mockViolations.a,
-    mockViolations.b,
-    mockViolations.c,
-  ]);
-});
+  it('preserves the existing order if correct', () => {
+    document.body.innerHTML = mockDocument;
+    const violations = [
+      mockViolations.da,
+      mockViolations.db,
+      mockViolations.c,
+    ] as AxeResults['violations'];
+    expect(sortAxeViolations(violations)).toEqual([
+      mockViolations.da,
+      mockViolations.db,
+      mockViolations.c,
+    ]);
+  });
 
-it('changes the order to match the DOM', () => {
-  document.body.innerHTML = mockDocument;
-  const violations = [
-    mockViolations.c,
-    mockViolations.b,
-    mockViolations.a,
-  ] as AxeResults['violations'];
-  expect(sortAxeViolations(violations)).toEqual([
-    mockViolations.a,
-    mockViolations.b,
-    mockViolations.c,
-  ]);
+  it('changes the order to match the DOM', () => {
+    document.body.innerHTML = mockDocument;
+    const violations = [
+      mockViolations.c,
+      mockViolations.db,
+      mockViolations.da,
+    ] as AxeResults['violations'];
+    expect(sortAxeViolations(violations)).toEqual([
+      mockViolations.da,
+      mockViolations.db,
+      mockViolations.c,
+    ]);
+  });
 });

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -22,6 +22,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Migrate `.button-longrunning` behaviour to a Stimulus controller with support for custom label element & duration (Loveth Omokaro)
  * Implement new simplified userbar designs (Albina Starykova)
  * Add more Axe rules to the accessibility checker (Albina Starykova)
+ * Sort accessibility checker results by position on the page (Albina Starykova)
  * Add usage view for pages (Sage Abdullah)
  * Copy page form now updates the slug field dynamically with a slugified value on blur (Loveth Omokaro)
  * Ensure selected collection is kept when navigating from documents or images listings to add multiple views & upon upload (Aman Pandey, Bojan Mihelac)


### PR DESCRIPTION
Sorting violations based on their place in DOM:
- sort all nodes with compareDocumentPosition()
- sort violations based on the min index of contained nodes
- manually tested on 8 rules with multiple nodes in some of them (#10011)
- added unit tests
- fixed the scrolling bug for iframe element (#10011)