### PR TITLE
Update guide.wagtail.org links to point to v4.2.x pages

### DIFF
--- a/docs/advanced_topics/deploying.md
+++ b/docs/advanced_topics/deploying.md
@@ -68,7 +68,7 @@ If you would like to serve your images from a separate asset server or CDN, you 
 Document serving is controlled by the [WAGTAILDOCS_SERVE_METHOD](wagtaildocs_serve_method) method.
 When using `FileSystemStorage`, documents are stored in a `documents` subdirectory within your site's `MEDIA_ROOT`.
 If all your documents are public, you can set the `WAGTAILDOCS_SERVE_METHOD` to `direct` and configure your web server to serve the files itself.
-However, if you use Wagtail's [Collection Privacy settings](https://guide.wagtail.org/en-latest/how-to/managing-collections/#privacy-settings) to restrict access to some or all of your documents, you may or may not want to configure your web server to serve the documents directly.
+However, if you use Wagtail's [Collection Privacy settings](https://guide.wagtail.org/en-4.2.x/how-to-guides/manage-collections/#privacy-settings) to restrict access to some or all of your documents, you may or may not want to configure your web server to serve the documents directly.
 The default setting is `redirect` which allows Wagtail to perform any configured privacy checks before offloading serving the actual document to your web server or CDN.
 This means that Wagtail constructs document links that pass through Wagtail, but the final url in the user's browser is served directly by your web server.
 If a user bookmarks this url, they will be able to access the file without passing through Wagtail's privacy checks.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ If you'd like to get a quick feel for Wagtail, try spinning up a `temporary deve
 
 * **For editors**
 
-  * `Editors guide (separate site) <https://guide.wagtail.org/>`_
+  * `Editors guide (separate site) <https://guide.wagtail.org/4.2.x/>`_
 
 
 Index

--- a/docs/reference/contrib/redirects.md
+++ b/docs/reference/contrib/redirects.md
@@ -33,7 +33,7 @@ This app contains migrations so make sure you run the `migrate` django-admin com
 
 Once installed, a new menu item called "Redirects" should appear in the "Settings" menu. This is where you can add arbitrary redirects to your site.
 
-For an editor's guide to the interface, see [Managing redirects](https://guide.wagtail.org/en-latest/how-to/managing-redirects/).
+For an editor's guide to the interface, see our how-to guide: [Manage redirects](https://guide.wagtail.org/en-4.2.x/how-to-guides/manage-redirects/).
 
 ## Automatic redirect creation
 

--- a/docs/reference/pages/panels.md
+++ b/docs/reference/pages/panels.md
@@ -47,7 +47,7 @@ Here are some Wagtail-specific types that you might include as fields in your mo
 
     .. attribute:: FieldPanel.disable_comments (optional)
 
-        This allows you to prevent a field level comment button showing for this panel if set to ``True``. See `Commenting <https://guide.wagtail.org/en-latest/how-to/creating-and-editing-pages/#commenting>`_.
+        This allows you to prevent a field level comment button showing for this panel if set to ``True``. See `Create and edit comments <https://guide.wagtail.org/en-4.2.x/how-to-guides/manage-pages/#create-and-edit-comments>`_.
 
     .. attribute:: FieldPanel.permission (optional)
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -387,7 +387,7 @@ You can use it to specify or override the widgets to use in the admin form.
 WAGTAILDOCS_SERVE_METHOD = 'redirect'
 ```
 
-Determines how document downloads will be linked to and served. Normally, requests for documents are sent through a Django view, to perform privacy checks (see [Collection Privacy settings](https://guide.wagtail.org/en-latest/how-to/managing-collections/#privacy-settings)) and potentially other housekeeping tasks such as hit counting. To fully protect against users bypassing this check, it needs to happen in the same request where the document is served; however, this incurs a performance hit as the document then needs to be served by the Django server. In particular, this cancels out much of the benefit of hosting documents on external storage, such as S3 or a CDN.
+Determines how document downloads will be linked to and served. Normally, requests for documents are sent through a Django view, to perform privacy checks (see [Collection Privacy settings](https://guide.wagtail.org/en-4.2.x/how-to-guides/manage-collections/#privacy-settings)) and potentially other housekeeping tasks such as hit counting. To fully protect against users bypassing this check, it needs to happen in the same request where the document is served; however, this incurs a performance hit as the document then needs to be served by the Django server. In particular, this cancels out much of the benefit of hosting documents on external storage, such as S3 or a CDN.
 
 For this reason, Wagtail provides a number of serving methods which trade some of the strictness of the permission check for performance:
 

--- a/docs/releases/2.10.rst
+++ b/docs/releases/2.10.rst
@@ -17,7 +17,7 @@ Moderation workflow
 
 This release introduces a configurable moderation workflow system to replace the single-step "submit for moderation" feature. Workflows can be set up on specific subsections of the page tree and consist of any number of tasks to be completed by designated user groups. To support this, numerous UI improvements have been made to Wagtail's page editor, including a new log viewer to track page history.
 
-For further details, see `Managing Workflows <https://guide.wagtail.org/en-latest/how-to/configuring-moderation-workflows/>`_ and :doc:`../extending/custom_tasks`.
+For further details, see our How-to: `Configure workflows for moderation <https://guide.wagtail.org/en-4.2.x/how-to-guides/configure-workflows-for-moderation/>`_ and :doc:`../extending/custom_tasks`.
 
 This feature was developed by Jacob Topp-Mugglestone, Karl Hobley, Matt Westcott and Dan Braghis, and sponsored by `The Motley Fool <https://www.fool.com/>`_.
 
@@ -155,7 +155,7 @@ Key points:
   this should simply create a task approvable by anybody in the `Moderators` group, and assign a workflow with this task to the root page, creating a standard workflow
   for the entire page tree. However, if you have a complex nested set of publish page permissions, the created set of workflows will be more complex as well - you may wish to
   inspect the created workflows and tasks in the new ``Settings/Workflows`` admin area and potentially simplify them.
-  See `Managing Workflows <https://guide.wagtail.org/en-latest/how-to/configuring-moderation-workflows/>`_ for the administrator guide.
+  See our How-to: `Configure workflows for moderation <https://guide.wagtail.org/en-4.2.x/how-to-guides/configure-workflows-for-moderation/>`_ for the administrator guide.
 
 
 ``<div class="rich-text">`` wrappers removed from rich text

--- a/docs/topics/snippets.md
+++ b/docs/topics/snippets.md
@@ -502,7 +502,7 @@ class Advert(WorkflowMixin, DraftStateMixin, LockableMixin, RevisionMixin, model
 
 The other mixins required by `WorkflowMixin` includes additional fields that need to be added to your database table. Make sure to run the `makemigrations` and `migrate` management commands after making the above changes to apply the changes to your database.
 
-After enabling the mixin, you can assign a workflow to the snippet models through the workflow settings. For more information, see [Configuring moderation workflows](https://guide.wagtail.org/en-latest/how-to/configuring-moderation-workflows).
+After enabling the mixin, you can assign a workflow to the snippet models through the workflow settings. For more information, see how to [configure workflows for moderation](https://guide.wagtail.org/en-4.2.x/how-to-guides/configure-workflows-for-moderation/).
 
 The admin dashboard and workflow reports will also show you snippets (alongside pages) that have been submitted to workflows.
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -974,7 +974,7 @@ def register_reports_menu():
 
 @hooks.register("register_help_menu_item")
 def register_whats_new_in_wagtail_version_menu_item():
-    version = "4.1"
+    version = "4.2"
     return DismissibleMenuItem(
         _("What's new in Wagtail %(version)s") % {"version": version},
         wagtail_feature_release_whats_new_link(),

--- a/wagtail/templatetags/wagtailcore_tags.py
+++ b/wagtail/templatetags/wagtailcore_tags.py
@@ -98,12 +98,12 @@ def wagtail_release_notes_path():
 
 @register.simple_tag
 def wagtail_feature_release_whats_new_link():
-    return "https://guide.wagtail.org/en-latest/releases/new-in-wagtail-4-1/"
+    return "https://guide.wagtail.org/en-4.2.x/releases/new-in-wagtail-4-2/"
 
 
 @register.simple_tag
 def wagtail_feature_release_editor_guide_link():
-    return "https://guide.wagtail.org/"
+    return "https://guide.wagtail.org/4.2.x/"
 
 
 @register.filter


### PR DESCRIPTION
**Targets `stable/4.12x`.** See #10014. Includes the changes from that pull request, cherry-picked on `stable/4.2.x`, with the correct `4.2.x` release number.

Worth mentioning the "New in Wagtail 4.2" article doesn’t exist yet – it points to a page but the page is empty. I or someone else will be populating that page some time between now and Monday evening.