### PR TITLE
Fix "Edit this page" missing from userbar

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,6 +33,7 @@ Changelog
 
  * Fix: Support creating `StructValue` copies (Tidiane Dia)
  * Fix: Fix image uploads on storage backends that require file pointer to be at the start of the file (Matt Westcott)
+ * Fix: Fix "Edit this page" missing from userbar (Satvik Vashisht)
 
 
 4.2 (06.02.2023)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Changelog
  * Fix: Resize in the correct direction for RTL languages with the side panel resizer (Sage Abdullah)
  * Fix: Support creating `StructValue` copies (Tidiane Dia)
  * Fix: Fix image uploads on storage backends that require file pointer to be at the start of the file (Matt Westcott)
+ * Fix: Fix "Edit this page" missing from userbar (Satvik Vashisht)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp)
  * Docs: Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -687,6 +687,7 @@ Contributors
 * Ananjan-R
 * Yosr Karoui
 * Aadi jindal
+* Satvik Vashisht
 
 Translators
 ===========

--- a/docs/releases/4.2.1.md
+++ b/docs/releases/4.2.1.md
@@ -15,3 +15,4 @@ depth: 1
 
  * Support creating `StructValue` copies (Tidiane Dia)
  * Fix image uploads on storage backends that require file pointer to be at the start of the file (Matt Westcott)
+ * Fix "Edit this page" missing from userbar (Satvik Vashisht)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -29,6 +29,7 @@ depth: 1
  * Ignore right clicks on side panel resizer (Sage Abdullah)
  * Resize in the correct direction for RTL languages with the side panel resizer (Sage Abdullah)
  * Fix image uploads on storage backends that require file pointer to be at the start of the file (Matt Westcott)
+ * Fix "Edit this page" missing from userbar (Satvik Vashisht)
 
 ### Documentation
 

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -811,6 +811,9 @@ class TestPageCreation(WagtailTestUtils, TestCase):
         self.assertTrue(response.context["self"].path.startswith(self.root_page.path))
         self.assertEqual(response.context["self"].get_parent(), self.root_page)
 
+        # Should not show edit link in the userbar
+        self.assertNotContains(response, "Edit this page")
+
     def test_preview_with_custom_validation(self):
         post_data = {
             "title": "New page!",

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1314,6 +1314,13 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "tests/simple_page.html")
         self.assertContains(response, "I&#39;ve been edited!", html=True)
 
+        # Should not show edit link in the userbar
+        # https://github.com/wagtail/wagtail/issues/8765
+        self.assertNotContains(response, "Edit this page")
+        self.assertNotContains(
+            response, reverse("wagtailadmin_pages:edit", args=(self.child_page.id,))
+        )
+
     def test_preview_on_edit_no_session_key(self):
         preview_url = reverse(
             "wagtailadmin_pages:preview_on_edit", args=(self.child_page.id,)

--- a/wagtail/admin/tests/pages/test_revisions.py
+++ b/wagtail/admin/tests/pages/test_revisions.py
@@ -68,6 +68,14 @@ class TestRevisions(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Last Christmas I gave you my heart")
 
+        # Should show edit link in the userbar
+        # https://github.com/wagtail/wagtail/issues/10002
+        self.assertContains(response, "Edit this page")
+        self.assertContains(
+            response,
+            reverse("wagtailadmin_pages:edit", args=(self.christmas_event.id,)),
+        )
+
     def test_preview_revision_with_no_page_permissions_redirects_to_admin(self):
         admin_only_user = self.create_user(
             username="admin_only", email="admin_only@email.com", password="password"

--- a/wagtail/admin/tests/pages/test_view_draft.py
+++ b/wagtail/admin/tests/pages/test_view_draft.py
@@ -100,3 +100,15 @@ class TestDraftAccess(WagtailTestUtils, TestCase):
             HTTP_USER_AGENT="EvilHacker",
         )
         self.assertEqual(response.status_code, 403)
+
+    def test_show_edit_link_in_userbar(self):
+        self.login()
+        response = self.client.get(
+            reverse("wagtailadmin_pages:view_draft", args=(self.child_page.id,))
+        )
+        # Should show edit link in the userbar
+        # https://github.com/wagtail/wagtail/issues/10002
+        self.assertContains(response, "Edit this page")
+        self.assertContains(
+            response, reverse("wagtailadmin_pages:edit", args=(self.child_page.id,))
+        )

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -17,11 +17,18 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
         self.homepage = Page.objects.get(id=2)
 
     def dummy_request(
-        self, user=None, *, is_preview=False, in_preview_panel=False, revision_id=None
+        self,
+        user=None,
+        *,
+        is_preview=False,
+        in_preview_panel=False,
+        revision_id=None,
+        is_editing=False,
     ):
         request = RequestFactory().get("/")
         request.user = user or AnonymousUser()
         request.is_preview = is_preview
+        request.is_editing = is_editing
         request.in_preview_panel = in_preview_panel
         if revision_id:
             request.revision_id = revision_id
@@ -117,7 +124,9 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
         self.assertIn("<!-- Wagtail user bar embed code -->", content)
         self.assertIn("Edit this page", content)
 
-    def test_userbar_edit_menu_not_in_preview(self):
+    def test_userbar_edit_menu_in_previews(self):
+        # The edit link should be visible on draft, revision, and workflow previews.
+        # https://github.com/wagtail/wagtail/issues/10002
         template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")
         content = template.render(
             Context(
@@ -128,7 +137,30 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
             )
         )
         self.assertIn("<!-- Wagtail user bar embed code -->", content)
+        self.assertIn("Edit this page", content)
+        self.assertIn(
+            reverse("wagtailadmin_pages:edit", args=(self.homepage.id,)), content
+        )
+
+    def test_userbar_edit_menu_not_in_preview(self):
+        # The edit link should not be visible on PreviewOnEdit/Create views.
+        # https://github.com/wagtail/wagtail/issues/8765
+        template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")
+        content = template.render(
+            Context(
+                {
+                    PAGE_TEMPLATE_VAR: self.homepage,
+                    "request": self.dummy_request(
+                        self.user, is_preview=True, is_editing=True
+                    ),
+                }
+            )
+        )
+        self.assertIn("<!-- Wagtail user bar embed code -->", content)
         self.assertNotIn("Edit this page", content)
+        self.assertNotIn(
+            reverse("wagtailadmin_pages:edit", args=(self.homepage.id,)), content
+        )
 
     def test_userbar_not_in_preview_panel(self):
         template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -1,7 +1,7 @@
 import io
 import json
 import logging
-from unittest import mock
+from unittest import expectedFailure, mock
 
 from django.conf import settings
 from django.contrib.admin.utils import quote
@@ -2763,6 +2763,20 @@ class TestPageWorkflowPreview(BasePageWorkflowTests):
         self.assertTemplateUsed(response, self.preview_template)
         self.assertContains(response, self.preview_content)
 
+    def test_preview_workflow_show_edit_link_in_userbar(self):
+        preview_url = self.get_url(
+            "workflow_preview",
+            args=(quote(self.object.pk), self.object.current_workflow_task.id),
+        )
+        response = self.client.get(preview_url)
+
+        # Should show edit link in the userbar
+        # https://github.com/wagtail/wagtail/issues/10002
+        self.assertContains(response, "Edit this page")
+        self.assertContains(
+            response, reverse("wagtailadmin_pages:edit", args=(quote(self.object.pk),))
+        )
+
     def test_preview_workflow_by_submitter(self):
         self.login(self.submitter)
         preview_url = self.get_url(
@@ -2810,6 +2824,11 @@ class TestSnippetWorkflowPreview(TestPageWorkflowPreview, BaseSnippetWorkflowTes
     def edit_object(self):
         self.object.text = self.new_content
         self.object.save_revision()
+
+    @expectedFailure
+    def test_preview_workflow_show_edit_link_in_userbar(self):
+        # TODO: Add edit link to userbar on snippet previews
+        super().test_preview_workflow_show_edit_link_in_userbar()
 
 
 class TestTaskChooserView(WagtailTestUtils, TestCase):

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -160,7 +160,7 @@ class EditPageItem(BaseItem):
         # Don't render if request is a preview. This is to avoid confusion that
         # might arise when the user clicks edit on a preview.
         try:
-            if request.is_preview:
+            if request.is_preview and request.is_editing:
                 return ""
         except AttributeError:
             pass

--- a/wagtail/admin/views/generic/preview.py
+++ b/wagtail/admin/views/generic/preview.py
@@ -106,7 +106,8 @@ class PreviewOnEdit(View):
             raise PermissionDenied
 
         extra_attrs = {
-            "in_preview_panel": request.GET.get("in_preview_panel") == "true"
+            "in_preview_panel": request.GET.get("in_preview_panel") == "true",
+            "is_editing": True,
         }
 
         return self.object.make_preview_request(request, preview_mode, extra_attrs)


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->
Resolves "Edit this Page" missing from userbar Fixes #10002

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

