### PR TITLE
fix issue undefined (reading 'getTextLabel')

### DIFF
--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -142,7 +142,7 @@ export class StructBlock {
         /\{(\w+)\}/g,
         (tag, blockName) => {
           const block = this.childBlocks[blockName];
-          if (block.getTextLabel) {
+          if (block && block.getTextLabel) {
             /* to be strictly correct, we should be adjusting opts.maxLength to account for the overheads
           in the format string, and dividing the remainder across all the placeholders in the string,
           rather than just passing opts on to the child. But that would get complicated, and this is


### PR DESCRIPTION
fixed Uncaught TypeError: Cannot read properties of undefined (reading 'getTextLabel') in admin and missing stream blocks. #9990

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**:
    -   [x] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
