### PR TITLE
updated userbar.scss for fixing Wagtail 4.2 userbar is now sensitive to change in font size in parent DOM #10036

### DIFF
--- a/client/scss/components/_userbar.scss
+++ b/client/scss/components/_userbar.scss
@@ -82,7 +82,7 @@ $positions: (
   cursor: pointer;
   box-shadow: $box-shadow-props;
   transition: all 0.2s ease-in-out;
-  font-size: 1rem;
+  font-size: inherit;
   text-decoration: none;
   position: relative;
 


### PR DESCRIPTION
for fixing Wagtail 4.2 userbar is now sensitive to change in font size in parent DOM

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**:
    -   [x] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
