### PR TITLE
Support creating `StructValue` copies

### DIFF
--- a/wagtail/blocks/struct_block.py
+++ b/wagtail/blocks/struct_block.py
@@ -70,6 +70,9 @@ class StructValue(collections.OrderedDict):
             ]
         )
 
+    def __reduce__(self):
+        return (self.__class__, (self.block,), None, None, iter(self.items()))
+
 
 class PlaceholderBoundBlock(BoundBlock):
     """

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*
 import base64
 import collections
+import copy
 import json
 import unittest
 from decimal import Decimal
@@ -2156,6 +2157,19 @@ class TestStructBlock(SimpleTestCase):
         value = block.to_python({"title": "Bonjour", "body": "monde <i>italique</i>"})
         result = value.render_as_block(context={"language": "fr"})
         self.assertEqual(result, """<h1 lang="fr">Bonjour</h1>monde <i>italique</i>""")
+
+    def test_copy_structvalue(self):
+        block = SectionBlock()
+        value = block.to_python({"title": "Hello", "body": "world"})
+        copied = copy.copy(value)
+
+        # Ensure we have a new object
+        self.assertIsNot(value, copied)
+
+        # Check copy operation
+        self.assertIsInstance(copied, blocks.StructValue)
+        self.assertIs(value.block, copied.block)
+        self.assertEqual(value, copied)
 
 
 class TestStructBlockWithCustomStructValue(SimpleTestCase):


### PR DESCRIPTION
Fixes #9788.

If we look at the implementation of the [__reduce__ method of `collections.OrderedDict`](https://github.com/python/cpython/blob/main/Lib/collections/__init__.py#L272), the parent class of `StructValue`, we can see that the first item in the tuple returned is the class itself (in our case the `StructValue` class) and the second one is an empty tuple. According to the [Python docs on the `__reduce__` method](https://docs.python.org/3/library/pickle.html#object.__reduce__), this means that when an `OrderedDict` is unpickled, it will be instantiated as such:
```
unpickled = klass() # where klass = StructValue
```

That's why we hit the `TypeError: StructValue.__init__() missing 1 required positional argument: 'block'`

I've added a custom implementation of the `__reduce__` method so the `block` is passed as a positional argument instead of using a keyword.