### PR TITLE
Fix image saving on backends that expect a rewound file pointer

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -214,6 +214,8 @@ class WagtailImageFieldFile(models.fields.files.ImageFieldFile):
         finally:
             if close:
                 self.close()
+            else:
+                self.seek(0)
 
 
 class WagtailImageField(models.ImageField):


### PR DESCRIPTION
Fixes #10046

_Please check the following:_

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
