### PR TITLE
Documentation - fix white space issues

### DIFF
--- a/docs/advanced_topics/icons.md
+++ b/docs/advanced_topics/icons.md
@@ -6,11 +6,11 @@ Wagtail comes with an SVG icon set. The icons are used throughout the admin inte
 
 Elements that use icons are:
 
-- [Register Admin Menu Item](register_admin_menu_item)
-- [Client-side components](extending_clientside_components)
-- [Rich text editor toolbar buttons](extending_the_draftail_editor)
-- [ModelAdmin menu](modeladmin_menu_icon)
-- [StreamField blocks](custom_streamfield_blocks)
+-   [Register Admin Menu Item](register_admin_menu_item)
+-   [Client-side components](extending_clientside_components)
+-   [Rich text editor toolbar buttons](extending_the_draftail_editor)
+-   [ModelAdmin menu](modeladmin_menu_icon)
+-   [StreamField blocks](custom_streamfield_blocks)
 
 This document describes how to choose, add and customise icons.
 
@@ -18,7 +18,7 @@ This document describes how to choose, add and customise icons.
 
 An icon name corresponds with the value of `id` in the SVG file: `<svg id="<name>"`.
 
-Icons are SVG files in the [Wagtail admin template folder](https://github.com/wagtail/wagtail/tree/main/wagtail/admin/templates/wagtailadmin/icons). 
+Icons are SVG files in the [Wagtail admin template folder](https://github.com/wagtail/wagtail/tree/main/wagtail/admin/templates/wagtailadmin/icons).
 
 Alternatively, enable the [styleguide](styleguide) to view the available icons and their names.
 
@@ -38,10 +38,10 @@ Draw or download an icon and save it in a template folder:
 
 The `svg` tag should:
 
-- Set the `id="icon-<name>"` attribute, icons are referenced by this name
-- Set the `xmlns="http://www.w3.org/2000/svg"` attribute
-- Set the `viewBox="..."` attribute
-- Include license information, if applicable.
+-   Set the `id="icon-<name>"` attribute, icons are referenced by this name
+-   Set the `xmlns="http://www.w3.org/2000/svg"` attribute
+-   Set the `viewBox="..."` attribute
+-   Include license information, if applicable.
 
 Set `<path fill="currentColor"` to give the icon the current color.
 

--- a/docs/advanced_topics/reference_index.md
+++ b/docs/advanced_topics/reference_index.md
@@ -1,4 +1,5 @@
 (managing_the_reference_index)=
+
 # Managing the Reference Index
 
 Wagtail maintains a reference index, which records references between objects whenever those objects are saved. The index allows Wagtail to efficiently report the usage of images, documents and snippets within pages, including within StreamField and rich text fields.

--- a/docs/reference/pages/panels.md
+++ b/docs/reference/pages/panels.md
@@ -175,6 +175,7 @@ Note that you can use `classname="collapsed"` to load the panel collapsed under 
         PageChooserPanel('related_page', ['demo.PublisherPage', 'demo.AuthorPage'])
 
     Passing ``can_choose_root=True`` will allow the editor to choose the tree root as a page. Normally this would be undesirable, since the tree root is never a usable page, but in some specialised cases it may be appropriate; for example, a page with an automatic "related articles" feed could use a PageChooserPanel to select which subsection articles will be taken from, with the root corresponding to 'everywhere'.
+```
 
 ### FormSubmissionsPanel
 


### PR DESCRIPTION
- A few white space clean up items.
- It appears that the pages/panel page is missing a closing __```__ code block but the deployed docs seem ok, fixed up nonetheless.

**Will merge once CI runs**