### PR TITLE
Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Fix: Support creating `StructValue` copies (Tidiane Dia)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp)
+ * Docs: Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)
  * Maintenance: Removed features deprecated in Wagtail 3.0 and 4.0 (Matt Westcott)
  * Maintenance: Update djhtml (html formatting) library to v 1.5.2 (Loveth Omokaro)
  * Maintenance: Re-enable `strictPropertyInitialization` in tsconfig (Thibaud Colas)

--- a/docs/reference/pages/panels.md
+++ b/docs/reference/pages/panels.md
@@ -74,9 +74,8 @@ Here are some Wagtail-specific types that you might include as fields in your mo
         Help text to be displayed against the panel.
 
     .. attribute:: MultiFieldPanel.permission (optional)
-        Allows a panel to be selectively shown to users with sufficient permission. Accepts a permission codename such as ``'myapp.change_blog_category'`` - if the logged-in user does not have that permission, the field will be omitted from the form.
-        Similar to `FieldPanel.permission`
-        The panel group will not be visible if the permission check does not pass.
+
+        Allows a panel to be selectively shown to users with sufficient permission. Accepts a permission codename such as ``'myapp.change_blog_category'`` - if the logged-in user does not have that permission, the panel will be omitted from the form. Similar to ``FieldPanel.permission``.
 ```
 
 ### InlinePanel
@@ -115,9 +114,8 @@ Note that you can use `classname="collapsed"` to load the panel collapsed under 
         Help text to be displayed against the panel.
 
     .. attribute:: FieldRowPanel.permission (optional)
-        Allows a panel to be selectively shown to users with sufficient permission. Accepts a permission codename such as ``'myapp.change_blog_category'`` - if the logged-in user does not have that permission, the field will be omitted from the form.
-        Similar to `FieldPanel.permission`
-        The panel group will not be visible if the permission check does not pass.
+
+        Allows a panel to be selectively shown to users with sufficient permission. Accepts a permission codename such as ``'myapp.change_blog_category'`` - if the logged-in user does not have that permission, the panel will be omitted from the form. Similar to ``FieldPanel.permission``.
 ```
 
 ### HelpPanel

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -31,6 +31,7 @@ depth: 1
 
  * Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp)
+ * Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)
 
 ### Maintenance
 


### PR DESCRIPTION
Fix formatting on https://docs.wagtail.org/en/latest/reference/pages/panels.html#wagtail.admin.panels.MultiFieldPanel.permission - this was missing a line break, causing the description to be formatted as a title. Also fix some other formatting issues here, including removing the sentence "The panel group will not be visible if the permission check does not pass.", which just seems to be repeating the explanation above.