### PR TITLE
Fix lint issue in `side_panels.html` template

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels.html
@@ -9,11 +9,11 @@
         <label class="form-side__resize-grip" data-form-side-resize-grip>
             {% comment %}
                 By default, the `dir` attribute is inherited from the ancestor
-                (i.e. the root `<html>` element in our case).
+                (i.e. the root `html` element in our case).
                 On Chrome and Firefox, moving the slider with left-right arrow keys
                 is correctly reversed when dir="rtl". On Safari, this isn't the case.
                 So, we explicitly set the `dir` attribute to "ltr" on the input and handle the correct
-                direction in the JS code based on the `dir` attribute of the root `<html>`.
+                direction in the JS code based on the `dir` attribute of the root `html`.
             {% endcomment %}
             <input type="range" step="10" dir="ltr" class="form-side__width-input" name="wagtail-side-panel-width" data-form-side-width-input />
             <span class="w-sr-only">{% trans 'Side panel width' %}</span>


### PR DESCRIPTION
`curlylint` doesn't like the `<html>` in the comment.