### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,7 +157,7 @@ jobs:
           MYSQL_DATABASE: wagtail
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 --cap-add=sys_nice
 
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: 5.6.4
     hooks:
       - id: isort
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     # flake8 config is in setup.cfg
     rev: 3.8.4
     hooks:


### PR DESCRIPTION
- flake8 repository has been moved from GitLab to GitHub:
  - https://www.youtube.com/watch?v=1FIgj9Q5e6A
- Try to add `CAP_SYS_NICE` to suppress the `mbind: Operation not permitted` errors when running MySQL tests on GitHub Actions as per https://stackoverflow.com/questions/55559386/how-to-fix-mbind-operation-not-permitted-in-mysql-error-log and https://wagtailcms.slack.com/archives/C04AETFDD6J/p1676376156360539