### PR TITLE
Update PR template to prompt for a description of the PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,12 @@
-<!--
-Thanks for contributing to Wagtail! 🎉
+<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->
 
-Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
--->
+Fixes #...
+
+
+
+
+
+
 
 _Please check the following:_
 


### PR DESCRIPTION
Just proposing a small iterative change to the PR template, so that we're explicitly prompting contributors to fill in a description (and adding some whitespace to combat the "here is a page full of text I don't understand" effect) - while there are some bigger improvements to the new contributor messaging in progress (#10070 / #10071), I figure it's worth getting this in now (and seeing if it makes a difference to forthcoming PRs) rather than holding out for perfection.

Have removed the link in the opening comment, as it's really just a less helpful version of the links further down in the checklist and adds clutter.