### PR TITLE
Fix Storybook build issues + set up Storybook build in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
           root: ~/project
           paths:
             - wagtail
+      - run: npm run build-storybook
       - run: npm run lint:js
       - run: npm run lint:css
       - run: npm run lint:format

--- a/client/storybook/main.js
+++ b/client/storybook/main.js
@@ -14,6 +14,18 @@ module.exports = {
   core: {
     builder: 'webpack5',
   },
+  // Redefine Babel config to allow TypeScript class fields `declare`.
+  // See https://github.com/storybookjs/storybook/issues/12479.
+  // The resulting configuration is closer to Wagtail’s Webpack + TypeScript setup,
+  // preventing other potential issues with JS transpilation differences.
+  babel: async (options) => ({
+    ...options,
+    plugins: [],
+    presets: [
+      ['@babel/preset-typescript', { allowDeclareFields: true }],
+      ['@babel/preset-react', { runtime: 'automatic' }],
+    ],
+  }),
   webpackFinal: (config) => {
     /* eslint-disable no-param-reassign */
 

--- a/client/storybook/middleware.js
+++ b/client/storybook/middleware.js
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires, import/no-extraneous-dependencies */
 const middleware = require('storybook-django/src/middleware');
 
-const origin = process.env.TEST_ORIGIN ?? 'http://localhost:8000';
+// Target the Django server with IPV4 address explicitly to avoid DNS resolution of localhost to IPV6.
+const origin = process.env.TEST_ORIGIN ?? 'http://127.0.0.1:8000';
 
 module.exports = middleware.createDjangoAPIMiddleware({
   origin,

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -32,9 +32,11 @@ global.wagtailConfig = {
   ACTIVE_LOCALE: 'en',
 };
 
-document.body.innerHTML = `<script id="wagtail-config">${JSON.stringify({
-  CSRF_TOKEN: 'potato',
-})}</script>`;
+const script = document.createElement('script');
+script.type = 'application/json';
+script.id = 'wagtail-config';
+script.textContent = JSON.stringify({ CSRF_TOKEN: 'potato' });
+document.body.appendChild(script);
 
 global.wagtailVersion = '1.6a1';
 

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -200,7 +200,7 @@ npm --prefix client/tests/integration install
 npm run test:integration
 ```
 
-Integration tests target `http://localhost:8000` by default. Use the `TEST_ORIGIN` environment variable to use a different port, or test a remote Wagtail instance: `TEST_ORIGIN=http://localhost:9000 npm run test:integration`.
+Integration tests target `http://127.0.0.1:8000` by default. Use the `TEST_ORIGIN` environment variable to use a different port, or test a remote Wagtail instance: `TEST_ORIGIN=http://127.0.0.1:9000 npm run test:integration`.
 
 ### Browser and device support
 

--- a/wagtail/test/settings_ui.py
+++ b/wagtail/test/settings_ui.py
@@ -9,6 +9,9 @@ INSTALLED_APPS += [  # noqa
     "pattern_library",
 ]
 
+# Allow loopback address to access the server without DNS resolution (lack of Happy Eyeballs in Node 18).
+ALLOWED_HOSTS += ["127.0.0.1"]  # noqa
+
 TEMPLATES[0]["OPTIONS"]["builtins"] = ["pattern_library.loader_tags"]  # noqa
 
 PATTERN_LIBRARY = {


### PR DESCRIPTION
Fixes three issues with our Storybook setup:

- The way I added our `wagtail-config` JSON script was good enough to support unit tests but not Storybook usage. It’s now set up to work for both use cases.
- Storybook’s default Babel configuration was incompatible with the `declare` keyword in TypeScript for class fields. This needs to be manually enabled in the Babel configuration.
- Our proxying to Django failed in some circumstances. On Node 18 (at least on macOS with a default `/etc/hosts` file), DNS resolution for `localhost` favoured the IPv6 `::1` rather than IPv4 `127.0.0.1`). So until Node introduces support for Happy Eyeballs (apparently in Node 20, see https://github.com/nodejs/node/issues/41625), we need to explicitly use the IPv4 address when proxying requests via Node to Django (which only listens on [one of the two addresses](https://code.djangoproject.com/ticket/24864))

I also added the Storybook build to CircleCI. This won’t prevent all issues as it only does a static build of the stories without rendering anything dependent on Django, but would at least have prevented the first two points here.