### PR TITLE
Eslint - update config to allow enums to work correctly in TS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -75,6 +75,15 @@ module.exports = {
         'react/require-default-props': 'off',
       },
     },
+    // Rules for TypeScript files only
+    {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        // note you must disable the base rule as it can report incorrect errors
+        'no-shadow': 'off',
+        '@typescript-eslint/no-shadow': ['error'],
+      },
+    },
     // Rules we want to enforce or change for Stimulus Controllers
     {
       files: ['*Controller.ts'],


### PR DESCRIPTION
See https://github.com/typescript-eslint/tslint-to-eslint-config/issues/856

At the moment, using TS enums will fail the CI, as encountered when working on https://github.com/wagtail/wagtail/pull/9961

This PR is a single commit to fix up the linting, pulled out from that PR.