### PR TITLE
Fixed error in the url to be cloned in forked copy of Wagtail in docu…

### DIFF
--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -22,7 +22,7 @@ You will also need to install the **libjpeg** and **zlib** libraries, if you hav
 Fork the [the Wagtail codebase](https://github.com/wagtail/wagtail) and clone the forked copy:
 
 ```sh
-git clone https://github.com/username/wagtail/wagtail.git
+git clone https://github.com/username/wagtail.git
 cd wagtail
 ```
 


### PR DESCRIPTION
…mentation

Fixed the clone url error in the developing documentation for when Wagtail has been forked and the forked copy is to be cloned