### PR TITLE
Update the fields in the database while the object is in draft state

### DIFF
--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -473,7 +473,9 @@ class CreateEditViewOptionalFeaturesMixin:
         and returns the new object. Override this to implement custom save logic.
         """
         if self.draftstate_enabled:
-            instance = self.form.save(commit=False)
+            instance = self.form.save(
+                commit=self.view_name == "edit" and not self.object.live
+            )
 
             # If DraftStateMixin is applied, only save to the database in CreateView,
             # and make sure the live field is set to False.
@@ -739,7 +741,7 @@ class RevisionsRevertMixin:
         return self.revision.as_object()
 
     def save_instance(self):
-        commit = not issubclass(self.model, DraftStateMixin)
+        commit = not issubclass(self.model, DraftStateMixin) or not self.object.live
         instance = self.form.save(commit=commit)
 
         self.has_content_changes = self.form.has_changed()

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -522,7 +522,7 @@ class EditView(WagtailAdminTemplateMixin, HookResponseMixin, View):
             return self.save_action()
 
     def save_action(self):
-        self.page = self.form.save(commit=False)
+        self.page = self.form.save(commit=not self.page.live)
         self.subscription.save()
 
         # Save revision
@@ -547,7 +547,7 @@ class EditView(WagtailAdminTemplateMixin, HookResponseMixin, View):
         return self.redirect_and_remain()
 
     def publish_action(self):
-        self.page = self.form.save(commit=False)
+        self.page = self.form.save(commit=not self.page.live)
         self.subscription.save()
 
         # Save revision
@@ -643,7 +643,7 @@ class EditView(WagtailAdminTemplateMixin, HookResponseMixin, View):
         return self.redirect_away()
 
     def submit_action(self):
-        self.page = self.form.save(commit=False)
+        self.page = self.form.save(commit=not self.page.live)
         self.subscription.save()
 
         # Save revision
@@ -690,7 +690,7 @@ class EditView(WagtailAdminTemplateMixin, HookResponseMixin, View):
         return self.redirect_away()
 
     def restart_workflow_action(self):
-        self.page = self.form.save(commit=False)
+        self.page = self.form.save(commit=not self.page.live)
         self.subscription.save()
 
         # save revision
@@ -732,7 +732,7 @@ class EditView(WagtailAdminTemplateMixin, HookResponseMixin, View):
         return self.redirect_away()
 
     def perform_workflow_action(self):
-        self.page = self.form.save(commit=False)
+        self.page = self.form.save(commit=not self.page.live)
         self.subscription.save()
 
         if self.has_content_changes:
@@ -772,7 +772,7 @@ class EditView(WagtailAdminTemplateMixin, HookResponseMixin, View):
 
     def cancel_workflow_action(self):
         self.workflow_state.cancel(user=self.request.user)
-        self.page = self.form.save(commit=False)
+        self.page = self.form.save(commit=not self.page.live)
         self.subscription.save()
 
         # Save revision

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -1844,8 +1844,8 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
 
         self.assertRedirects(response, self.get_edit_url())
 
-        # The instance should not be updated
-        self.assertEqual(self.test_snippet.text, "Draft-enabled Foo")
+        # The instance should be updated, since it is still a draft
+        self.assertEqual(self.test_snippet.text, "Draft-enabled Bar")
 
         # The instance should be a draft
         self.assertFalse(self.test_snippet.live)
@@ -1960,8 +1960,8 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
             # Should remain on the edit page
             self.assertRedirects(response, self.get_edit_url())
 
-            # The instance should not be edited
-            self.assertEqual(self.test_snippet.text, "Draft-enabled Foo")
+            # The instance should be edited, since it is still a draft
+            self.assertEqual(self.test_snippet.text, "Edited draft Foo")
 
             # The instance should not be live
             self.assertFalse(self.test_snippet.live)
@@ -4548,8 +4548,8 @@ class TestSnippetRevisions(WagtailTestUtils, TestCase):
             object_id=self.snippet.pk,
         )
 
-        # The instance should not be updated
-        self.assertEqual(self.snippet.text, "Draft-enabled Foo")
+        # The instance should be updated, since it is still a draft
+        self.assertEqual(self.snippet.text, "Draft-enabled Foo reverted")
         # The initial revision, edited revision, and revert revision
         self.assertEqual(self.snippet.revisions.count(), 3)
         # The latest revision should be the revert revision


### PR DESCRIPTION
I would like to propose these changes, so that db fields of pages and snippets (with `DraftStateMixin`) are updated as long as those objects are not published.
It makes the logic of creation and editing a bit more consistent, because until now, the initial creation kind of manifests all fields until the objects gets published, all further edits only create revisions, and that's not really necessary. As soon as the object is `live`, the fields won't be edited anymore and only a revision gets created.
The actual changes are small, so I hope I haven't missed anything :pray: 

The tests of the generic snippet views already cover a lot, so I've only adapted the 3 failing cases.
No other tests failed, so I've started adding one specific test to the page admin. Theoretically, we could add tests for the other actions (submit, publish,...) too.

Fixes #9285

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
