### PR TITLE
Fix dismissible `SubMenuItem` not showing the number badge when there's a new item

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -104,6 +104,7 @@ Changelog
  * Fix: Fix initialisation of commenting widgets within StreamField (Thibaud Colas)
  * Fix: Fix various regressions in the commenting UI (Thibaud Colas)
  * Fix: Prevent TableBlock from becoming uneditable after save (Sage Abdullah)
+ * Fix: Correctly show the "new item" badge within menu sections previously dismissed (Sage Abdullah)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp, Thibaud Colas)
  * Docs: Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -147,6 +147,7 @@ We hope this new theme will bring accessibility improvements for users who perfe
  * Fix initialisation of commenting widgets within StreamField (Thibaud Colas)
  * Fix various regressions in the commenting UI (Thibaud Colas)
  * Prevent TableBlock from becoming uneditable after save (Sage Abdullah)
+ * Correctly show the "new item" badge within menu sections previously dismissed (Sage Abdullah)
 
 ### Documentation
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Previously, we rely on the fact that the `SubMenuItem` itself is a dismissible. So, we decide how to show/hide the number badge based on the value for the `SubMenuItem`'s dismissible ID on the server.

However, this means that if the user has dismissed the `SubMenuItem` and we add new dismissible child items within it (e.g. update the ID for the 'What's new in Wagtail version' child item), the number badge will not show up.

This PR changes the logic to show/hide the number badge based on whether there are any undismissed items within the `SubMenuItem` and whether the `SubMenuItem` has been opened or not.

How to reproduce the issue:
- Spin up bakerydemo
- Make sure you've dismissed the Help menu item by clicking it at least once
- Reload the page and confirm it's been dismissed
- Change the version string here: https://github.com/wagtail/wagtail/blob/8c006a16c9e8259a81999069644ba3e02a6deecb/wagtail/admin/wagtail_hooks.py#L976-L977
  e.g. to `"5.1"`
- Reload the page
- The number badge doesn't show up on the Help menu, but if you open it, the "What's new in Wagtail 5.1" item has the "new" badge
- With this PR applied, change the version string again, e.g. to `"5.2"`, then load the admin again
- The number badge should show up on the Help menu.
- Clicking on the Help menu will make the number badge disappear, but the "What's new in Wagtail 5.2" still has the "new" badge
- On the next page load, the Help menu will not have the number badge, and none of the items inside it has the "new" badge

To ease testing, follow the instructions at https://github.com/wagtail/wagtail/issues/10166#issuecomment-1494163362 to reset the dismissibles state.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 112, Firefox 112, Safari 16.4 on macOS Ventura 13.3.1
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
