### PR TITLE
Allow StructBlock to have non-block validation errors

### DIFF
--- a/client/src/components/StreamField/blocks/StructBlock.test.js
+++ b/client/src/components/StreamField/blocks/StructBlock.test.js
@@ -178,9 +178,19 @@ describe('telepath: wagtail.blocks.StructBlock', () => {
 
   test('setError passes error messages to children', () => {
     boundBlock.setError([
-      new StructBlockValidationError({
+      new StructBlockValidationError(null, {
         size: [new ValidationError(['This is too big'])],
       }),
+    ]);
+    expect(document.body.innerHTML).toMatchSnapshot();
+  });
+
+  test('setError shows non-block errors', () => {
+    boundBlock.setError([
+      new StructBlockValidationError(
+        [new ValidationError(['This is just generally wrong'])],
+        null,
+      ),
     ]);
     expect(document.body.innerHTML).toMatchSnapshot();
   });

--- a/client/src/components/StreamField/blocks/__snapshots__/StructBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StructBlock.test.js.snap
@@ -74,6 +74,43 @@ exports[`telepath: wagtail.blocks.StructBlock setError passes error messages to 
           </div></div>"
 `;
 
+exports[`telepath: wagtail.blocks.StructBlock setError shows non-block errors 1`] = `
+"<div class=\\"struct-block\\"><p class=\\"help-block help-critical\\">This is just generally wrong</p>
+        
+          <div class=\\"c-sf-help\\">
+            <div class=\\"help\\">
+              use <strong>lots</strong> of these
+            </div>
+          </div>
+        <div data-contentpath=\\"heading_text\\">
+          <label class=\\"w-field__label\\" for=\\"the-prefix-heading_text\\">Heading text<span class=\\"w-required-mark\\">*</span></label>
+            <div class=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
+        <div class=\\"w-field w-field--char_field w-field--text_input\\" data-field=\\"\\">
+          <div class=\\"w-field__errors\\" id=\\"the-prefix-heading_text-errors\\" data-field-errors=\\"\\">
+            <svg class=\\"icon icon-warning w-field__errors-icon\\" aria-hidden=\\"true\\" hidden=\\"\\"><use href=\\"#icon-warning\\"></use></svg>
+          </div>
+          <div class=\\"w-field__input\\" data-field-input=\\"\\">
+            <p name=\\"the-prefix-heading_text\\" id=\\"the-prefix-heading_text\\">Heading widget</p>
+          </div>
+          <div id=\\"the-prefix-heading_text-helptext\\" data-field-help=\\"\\"></div>
+        </div>
+      </div>
+          </div><div data-contentpath=\\"size\\">
+          <label class=\\"w-field__label\\" for=\\"the-prefix-size\\">Size</label>
+            <div class=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
+        <div class=\\"w-field w-field--choice_field w-field--select\\" data-field=\\"\\">
+          <div class=\\"w-field__errors\\" id=\\"the-prefix-size-errors\\" data-field-errors=\\"\\">
+            <svg class=\\"icon icon-warning w-field__errors-icon\\" aria-hidden=\\"true\\" hidden=\\"\\"><use href=\\"#icon-warning\\"></use></svg>
+          </div>
+          <div class=\\"w-field__input\\" data-field-input=\\"\\">
+            <p name=\\"the-prefix-size\\" id=\\"the-prefix-size\\">Size widget</p>
+          </div>
+          <div id=\\"the-prefix-size-helptext\\" data-field-help=\\"\\"></div>
+        </div>
+      </div>
+          </div></div>"
+`;
+
 exports[`telepath: wagtail.blocks.StructBlock with formTemplate it renders correctly 1`] = `
 "<div class=\\"custom-form-template\\">
         <p>here comes the first field:</p>


### PR DESCRIPTION
Part of #7250. Documentation to follow when the rest of the updates are in place.

To test against Bakerydemo, add the following to bakerydemo/base/blocks.py:

```python
from wagtail.blocks import PageChooserBlock, URLBlock
from wagtail.blocks.struct_block import StructBlockValidationError
from django.forms.utils import ErrorList


class LinkBlock(StructBlock):
    page = PageChooserBlock(required=False)
    url = URLBlock(required=False)

    def clean(self, value):
        result = super().clean(value)
        if not(result['page'] or result['url']):
            raise StructBlockValidationError(
                non_block_errors=ErrorList(["Either page or URL must be specified"])
            )
        return result


class BaseStreamBlock(StreamBlock):
    # ...
    link = LinkBlock()
```

Edit a blog page, and try adding a link block with both fields left blank.