### PR TITLE
Migrate initErrorDetection to a Stimulus Controller w-count (tabs)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -48,6 +48,7 @@ Changelog
  * Maintenance: Add curlylint and update djhtml, semgrep versions in pre-commit config (Himanshu Garg)
  * Maintenance: Use shared header template for `ModelAdmin` header (Aman Pandey)
  * Maintenance: Move models and forms for `wagtailsearch.Query` to `wagtail.contrib.search_promotions` (Karl Hobley)
+ * Maintenance: Migrate `initErrorDetection` (tabs error counts) to a Stimulus Controller `w-count` (Aman Pandey)
 
 
 4.2.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/controllers/CountController.test.js
+++ b/client/src/controllers/CountController.test.js
@@ -1,0 +1,165 @@
+import { Application } from '@hotwired/stimulus';
+import { CountController } from './CountController';
+
+describe('CountController', () => {
+  let application;
+
+  describe('basic behaviour', () => {
+    beforeAll(() => {
+      application?.stop();
+
+      document.body.innerHTML = `
+  <body>
+    <div id="element" data-controller="w-count" data-action="recount@document->w-count#count">
+      <span id="total" data-w-count-target="total"></span>
+      <span id="label" data-w-count-target="label"></span>
+    </div>
+    <ul id="items"></ul>
+  </body>`;
+
+      application = Application.start();
+      application.register('w-count', CountController);
+    });
+
+    it('should run the count on connect', () => {
+      expect(
+        document.getElementById('element').dataset.wCountTotalValue,
+      ).toEqual('0');
+    });
+
+    it('should count the items if present', async () => {
+      document.getElementById('items').innerHTML = `
+      <li class="error-message"></li>
+      <li class="help-critical"></li>
+      <li class="error-message"></li>`;
+
+      document.dispatchEvent(new CustomEvent('recount'));
+      await Promise.resolve();
+
+      expect(
+        document.getElementById('element').dataset.wCountTotalValue,
+      ).toEqual('3');
+      expect(document.getElementById('total').innerHTML).toEqual('3');
+      expect(document.getElementById('label').innerHTML).toEqual('3 errors');
+    });
+
+    it('should update the targets based on the min value set', async () => {
+      document.getElementById('element').dataset.wCountMinValue = '3';
+
+      await Promise.resolve();
+
+      expect(document.getElementById('total').innerHTML).toEqual('');
+      expect(document.getElementById('label').innerHTML).toEqual('');
+    });
+
+    it('should support a custom find value for different elements', async () => {
+      document.getElementById('items').innerHTML = `
+      <li class="count-me"></li>
+      <li class="count-me"></li>
+      <li class="count-me"></li>
+      <li id="me-also"></li>`;
+
+      document.getElementById('element').dataset.wCountFindValue =
+        '.count-me,#me-also';
+
+      document.dispatchEvent(new CustomEvent('recount'));
+      await Promise.resolve();
+
+      expect(document.getElementById('total').innerHTML).toEqual('4');
+      expect(document.getElementById('label').innerHTML).toEqual('4 errors');
+    });
+
+    it('should support a custom translation labels value', async () => {
+      document.getElementById('element').dataset.wCountLabelsValue =
+        JSON.stringify(['One __total__', '__total__ items']);
+      document.getElementById('element').dataset.wCountMinValue = '0';
+
+      document.dispatchEvent(new CustomEvent('recount'));
+      await Promise.resolve();
+
+      expect(document.getElementById('label').innerHTML).toEqual('4 items');
+    });
+  });
+
+  describe('when one item exists in specified container', () => {
+    beforeAll(() => {
+      application?.stop();
+
+      document.body.innerHTML = `
+  <section>
+    <div class="w-tabs__errors" data-controller="w-count" data-w-count-active-class="!w-flex" data-w-count-container-value="#tab">
+      <span id="total" data-w-count-target="total"></span>
+      <span id="label" data-w-count-target="label"></span>
+    </div>
+    <div id="tab"></div>
+  </section>`;
+
+      application = Application.start();
+      application.register('w-count', CountController);
+    });
+
+    it('should count the errors if one exists', () => {
+      expect(document.getElementById('total').innerHTML).toEqual('');
+      expect(document.getElementById('label').innerHTML).toEqual('');
+      expect(
+        document.querySelector('.w-tabs__errors').classList.contains('!w-flex'),
+      ).toBe(false);
+    });
+  });
+
+  describe('when one item exists in specified container', () => {
+    beforeAll(() => {
+      application?.stop();
+
+      document.body.innerHTML = `
+  <section>
+    <div class="w-tabs__errors" data-controller="w-count" data-w-count-active-class="!w-flex" data-w-count-container-value="#tab">
+      <span id="total" data-w-count-target="total"></span>
+      <span id="label" data-w-count-target="label"></span>
+    </div>
+    <div id="tab"><div class="error-message"></div></div>
+  </section>`;
+
+      application = Application.start();
+      application.register('w-count', CountController);
+    });
+
+    it('should count the errors if one exists', () => {
+      expect(document.getElementById('total').innerHTML).toEqual('1');
+      expect(document.getElementById('label').innerHTML).toEqual('1 error');
+      expect(
+        document.querySelector('.w-tabs__errors').classList.contains('!w-flex'),
+      ).toBe(true);
+    });
+  });
+
+  describe('when more than one item exists in specified container', () => {
+    beforeAll(() => {
+      application?.stop();
+
+      document.body.innerHTML = `
+  <section>
+    <div class="w-tabs__errors" data-controller="w-count" data-w-count-active-class="!w-flex" data-w-count-container-value="#tab">
+      <span id="total" data-w-count-target="total"></span>
+      <span id="label" data-w-count-target="label"></span>
+    </div>
+    <div id="tab">
+      <div class="error-message"></div>
+      <div class="error-message"></div>
+      <span class="help-critical"></span>
+    </div>
+  </section>`;
+
+      application = Application.start();
+      application.register('w-count', CountController);
+    });
+
+    it('should count the errors if one exists', () => {
+      expect(document.getElementById('total').innerHTML).toEqual('3');
+      expect(document.getElementById('label').innerHTML).toEqual('3 errors');
+      expect(
+        document.querySelector('.w-tabs__errors').classList.contains('!w-flex'),
+      ).toBe(true);
+    });
+  });
+});

--- a/client/src/controllers/CountController.ts
+++ b/client/src/controllers/CountController.ts
@@ -1,0 +1,88 @@
+import { Controller } from '@hotwired/stimulus';
+import { ngettext } from '../utils/gettext';
+
+const DEFAULT_ERROR_SELECTOR = '.error-message,.help-critical';
+
+/**
+ * Adds the ability for a controlled element to update the total count
+ * of selected elements within the provided container selector, defaults
+ * do `body.`
+ *
+ * @example
+ * <div data-controller="w-count">
+ *  <span data-w-count-target="label"></span>
+ *  <span class="error-message">An error</span>
+ * </div>
+ */
+export class CountController extends Controller<HTMLFormElement> {
+  static classes = ['active'];
+  static targets = ['label', 'total'];
+  static values = {
+    container: { default: 'body', type: String },
+    find: { default: DEFAULT_ERROR_SELECTOR, type: String },
+    labels: { default: [], type: Array },
+    min: { default: 0, type: Number },
+    total: { default: 0, type: Number },
+  };
+
+  /** selector string, used to determine the container/s to search through */
+  declare containerValue: string;
+  /** selector string, used to find the elements to count within the container */
+  declare findValue: string;
+  /** override pluralisation strings, e.g. `data-w-count-labels-value='["One item","Many items"]'` */
+  declare labelsValue: string[];
+  /** minimum value, anything equal or below will trigger blank labels in the UI */
+  declare minValue: number;
+  /** total current count of found elements */
+  declare totalValue: number;
+
+  declare readonly activeClass: string;
+  declare readonly hasActiveClass: boolean;
+  declare readonly hasLabelTarget: boolean;
+  declare readonly hasTotalTarget: boolean;
+  declare readonly labelTarget: HTMLElement;
+  declare readonly totalTarget: HTMLElement;
+
+  connect() {
+    this.count();
+  }
+
+  count() {
+    this.totalValue = [
+      ...document.querySelectorAll(this.containerValue || 'body'),
+    ]
+      .map((element) => element.querySelectorAll(this.findValue).length)
+      .reduce((total, subTotal) => total + subTotal, 0);
+
+    return this.totalValue;
+  }
+
+  getLabel(total: number) {
+    const defaultText = ngettext('%(num)s error', '%(num)s errors', total);
+
+    if (this.labelsValue.length > 1) {
+      const [single, plural = this.labelsValue[1], key = '__total__'] =
+        this.labelsValue;
+      return ngettext(single, plural, total).replace(key, `${total}`);
+    }
+
+    return defaultText.replace('%(num)s', `${total}`);
+  }
+
+  minValueChanged() {
+    this.totalValueChanged(this.count());
+  }
+
+  totalValueChanged(total: number) {
+    const min = this.minValue;
+    if (this.hasActiveClass) {
+      this.element.classList.toggle(this.activeClass, total > min);
+    }
+    if (this.hasLabelTarget) {
+      this.labelTarget.innerHTML = total > min ? this.getLabel(total) : '';
+    }
+    if (this.hasTotalTarget) {
+      this.totalTarget.innerHTML = total > min ? `${total}` : '';
+    }
+  }
+}

--- a/client/src/controllers/index.ts
+++ b/client/src/controllers/index.ts
@@ -2,6 +2,7 @@ import type { Definition } from '@hotwired/stimulus';
 
 // Order controller imports alphabetically.
 import { ActionController } from './ActionController';
+import { CountController } from './CountController';
 import { ProgressController } from './ProgressController';
 import { SkipLinkController } from './SkipLinkController';
 import { SlugController } from './SlugController';
@@ -14,6 +15,7 @@ import { UpgradeController } from './UpgradeController';
 export const coreControllerDefinitions: Definition[] = [
   // Keep this list in alphabetical order
   { controllerConstructor: ActionController, identifier: 'w-action' },
+  { controllerConstructor: CountController, identifier: 'w-count' },
   { controllerConstructor: ProgressController, identifier: 'w-progress' },
   { controllerConstructor: SkipLinkController, identifier: 'w-skip-link' },
   { controllerConstructor: SlugController, identifier: 'w-slug' },

--- a/client/src/entrypoints/admin/page-editor.js
+++ b/client/src/entrypoints/admin/page-editor.js
@@ -2,7 +2,6 @@ import $ from 'jquery';
 import { cleanForSlug } from '../../utils/text';
 import { InlinePanel } from '../../components/InlinePanel';
 import { MultipleChooserPanel } from '../../components/MultipleChooserPanel';
-import { ngettext } from '../../utils/gettext';
 
 window.InlinePanel = InlinePanel;
 window.MultipleChooserPanel = MultipleChooserPanel;
@@ -30,48 +29,6 @@ function initSlugAutoPopulate() {
 
 window.initSlugAutoPopulate = initSlugAutoPopulate;
 
-function initErrorDetection() {
-  const errorSections = {};
-
-  // first count up all the errors
-  $('.error-message,.help-critical').each(function collectError() {
-    const parentSection = $(this).closest('section[role="tabpanel"]');
-
-    if (!errorSections[parentSection.attr('id')]) {
-      errorSections[parentSection.attr('id')] = 0;
-    }
-
-    errorSections[parentSection.attr('id')] =
-      errorSections[parentSection.attr('id')] + 1;
-  });
-
-  // now identify them on each tab
-  Object.entries(errorSections).forEach(([sectionId, errorCount]) => {
-    const tabErrorsElement = $(`[data-tabs] a[href="#${sectionId}"]`).find(
-      '[data-tabs-errors]',
-    );
-
-    // show and add error count
-    tabErrorsElement
-      .addClass('!w-flex')
-      .find('[data-tabs-errors-count]')
-      .text(errorCount);
-
-    // update label for screen readers
-    tabErrorsElement
-      .find('[data-tabs-errors-statement]')
-      .text(
-        ngettext(
-          '(%(errorCount)s error)',
-          '(%(errorCount)s errors)',
-          errorCount,
-        ).replace('%(errorCount)s', errorCount),
-      );
-  });
-}
-
-window.initErrorDetection = initErrorDetection;
-
 function initKeyboardShortcuts() {
   // eslint-disable-next-line no-undef
   Mousetrap.bind(['mod+p'], () => {
@@ -96,8 +53,6 @@ $(() => {
   if (!$('body').hasClass('page-is-live')) {
     initSlugAutoPopulate();
   }
-
-  initErrorDetection();
   initKeyboardShortcuts();
 });
 

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -68,6 +68,7 @@ depth: 1
  * Add curlylint and update djhtml, semgrep versions in pre-commit config (Himanshu Garg)
  * Use shared header template for `ModelAdmin` header (Aman Pandey)
  * Move models and forms for `wagtailsearch.Query` to `wagtail.contrib.search_promotions` (Karl Hobley)
+ * Migrate `initErrorDetection` (tabs error counts) to a Stimulus Controller `w-count` (Aman Pandey)
 
 ## Upgrade considerations
 

--- a/wagtail/admin/templates/wagtailadmin/shared/tabs/tab_nav_link.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/tabs/tab_nav_link.html
@@ -11,8 +11,8 @@
 
 <a id="tab-label-{{ tab_id }}" href="#tab-{{ tab_id }}" class="w-tabs__tab {{ classname }}" role="tab" aria-selected="false" tabindex="-1">
     {{ title }}
-    <div data-tabs-errors class="w-tabs__errors">
-        <span data-tabs-errors-count aria-hidden="true"></span>
-        <span data-tabs-errors-statement class="w-sr-only"></span>
+    <div class="w-tabs__errors" data-controller="w-count" data-w-count-active-class="!w-flex" data-w-count-container-value="#tab-{{ tab_id }}">
+        <span aria-hidden="true" data-w-count-target="total"></span>
+        <span class="w-sr-only">(<span data-w-count-target="label"></span>)</span>
     </div>
 </a>


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/10090

added tests, shifted `initErrorDetection` to `stimulus controller`.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]

Screen Shots after the changes. 

![image](https://user-images.githubusercontent.com/74553951/221405068-73bb0e7f-97b7-42ef-b2d1-9325aa7bccd2.png)
![image](https://user-images.githubusercontent.com/74553951/221405096-6cc975c4-bbb2-413f-83da-36cae9d47958.png)
![image](https://user-images.githubusercontent.com/74553951/221405107-785848c9-94c3-41cc-b834-68654cd636ec.png)
![image](https://user-images.githubusercontent.com/74553951/221405123-a642c464-0f08-4075-8bc9-32020089b4df.png)
![image](https://user-images.githubusercontent.com/74553951/221405135-3b75f176-4daa-4718-a195-fb2705c0767a.png)

test 
![image](https://user-images.githubusercontent.com/74553951/221407441-46c78411-4987-42d6-b013-f77ba1ddc207.png)

