### PR TITLE
migrate initSlugCleaning to Stimulus

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Implement new simplified userbar designs (Albina Starykova)
  * Add more Axe rules to the accessibility checker (Albina Starykova)
  * Add usage view for pages (Sage Abdullah)
+ * Copy page form now updates the slug field dynamically with a slugified value on blur (Loveth Omokaro)
  * Fix: Ensure `label_format` on StructBlock gracefully handles missing variables (Aadi jindal)
  * Fix: Adopt a no-JavaScript and more accessible solution for the 'Reset to default' switch to Gravatar when editing user profile (Loveth Omokaro)
  * Fix: Ensure `Site.get_site_root_paths` works on cache backends that do not preserve Python objects (Jaap Roes)
@@ -39,6 +40,7 @@ Changelog
  * Maintenance: Replace `script` tags with `template` tag for image/document bulk uploads (Rishabh Kumar Bahukhandi)
  * Maintenance: Remove unneeded float styles on 404 page (Fabien Le Frapper)
  * Maintenance: Convert userbar implementation to TypeScript (Albina Starykova)
+ * Maintenance: Migrate slug field behaviour to a Stimulus controller and create new `SlugInput` widget (Loveth Omokaro)
 
 
 4.2.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/controllers/SlugController.test.js
+++ b/client/src/controllers/SlugController.test.js
@@ -1,0 +1,62 @@
+import { Application } from '@hotwired/stimulus';
+import { SlugController } from './SlugController';
+
+describe('SlugController', () => {
+  let application;
+
+  beforeEach(() => {
+    application?.stop();
+
+    document.body.innerHTML = `
+    <input
+      id="id_slug"
+      name="slug"
+      type="text"
+      data-controller="w-slug"
+      data-action="blur->w-slug#slugify"
+    />`;
+
+    application = Application.start();
+    application.register('w-slug', SlugController);
+  });
+
+  it('should trim and slugify the input value when focus is moved away from it', () => {
+    const slugInput = document.querySelector('#id_slug');
+    slugInput.value = '    slug  testing on     edit page ';
+
+    slugInput.dispatchEvent(new CustomEvent('blur'));
+
+    expect(document.querySelector('#id_slug').value).toEqual(
+      'slug-testing-on-edit-page',
+    );
+  });
+
+  it('should not allow unicode characters by default', () => {
+    const slugInput = document.querySelector('#id_slug');
+
+    expect(
+      slugInput.hasAttribute('data-w-slug-allow-unicode-value'),
+    ).toBeFalsy();
+
+    slugInput.value = 'Visiter Toulouse en été 2025';
+
+    slugInput.dispatchEvent(new CustomEvent('blur'));
+
+    expect(slugInput.value).toEqual('visiter-toulouse-en-t-2025');
+  });
+
+  it('should now allow unicode characters by default', () => {
+    const slugInput = document.querySelector('#id_slug');
+    slugInput.setAttribute('data-w-slug-allow-unicode-value', 'true');
+
+    expect(
+      slugInput.hasAttribute('data-w-slug-allow-unicode-value'),
+    ).toBeTruthy();
+
+    slugInput.value = 'Visiter Toulouse en été 2025';
+
+    slugInput.dispatchEvent(new CustomEvent('blur'));
+
+    expect(slugInput.value).toEqual('visiter-toulouse-en-été-2025');
+  });
+});

--- a/client/src/controllers/SlugController.ts
+++ b/client/src/controllers/SlugController.ts
@@ -1,0 +1,22 @@
+import { Controller } from '@hotwired/stimulus';
+import { cleanForSlug } from '../utils/text';
+
+/**
+ * Adds ability to slugify the value of an input element.
+ *
+ * @example
+ * <input type="text" name="slug" data-controller="w-slug" data-action="blur->w-slug#slugify" />
+ */
+export class SlugController extends Controller<HTMLInputElement> {
+  static values = {
+    allowUnicode: { default: false, type: Boolean },
+  };
+
+  declare allowUnicodeValue: boolean;
+
+  slugify() {
+    this.element.value = cleanForSlug(this.element.value.trim(), false, {
+      unicodeSlugsEnabled: this.allowUnicodeValue,
+    });
+  }
+}

--- a/client/src/controllers/index.ts
+++ b/client/src/controllers/index.ts
@@ -4,6 +4,7 @@ import type { Definition } from '@hotwired/stimulus';
 import { ActionController } from './ActionController';
 import { ProgressController } from './ProgressController';
 import { SkipLinkController } from './SkipLinkController';
+import { SlugController } from './SlugController';
 import { SubmitController } from './SubmitController';
 import { UpgradeController } from './UpgradeController';
 
@@ -15,6 +16,7 @@ export const coreControllerDefinitions: Definition[] = [
   { controllerConstructor: ActionController, identifier: 'w-action' },
   { controllerConstructor: ProgressController, identifier: 'w-progress' },
   { controllerConstructor: SkipLinkController, identifier: 'w-skip-link' },
+  { controllerConstructor: SlugController, identifier: 'w-slug' },
   { controllerConstructor: SubmitController, identifier: 'w-submit' },
   { controllerConstructor: UpgradeController, identifier: 'w-upgrade' },
 ];

--- a/client/src/entrypoints/admin/page-editor.js
+++ b/client/src/entrypoints/admin/page-editor.js
@@ -30,16 +30,6 @@ function initSlugAutoPopulate() {
 
 window.initSlugAutoPopulate = initSlugAutoPopulate;
 
-function initSlugCleaning() {
-  // eslint-disable-next-line func-names
-  $('#id_slug').on('blur', function () {
-    // if a user has just set the slug themselves, don't remove stop words etc, just illegal characters
-    $(this).val(cleanForSlug($(this).val(), false));
-  });
-}
-
-window.initSlugCleaning = initSlugCleaning;
-
 function initErrorDetection() {
   const errorSections = {};
 
@@ -107,7 +97,6 @@ $(() => {
     initSlugAutoPopulate();
   }
 
-  initSlugCleaning();
   initErrorDetection();
   initKeyboardShortcuts();
 });

--- a/client/src/utils/text.test.js
+++ b/client/src/utils/text.test.js
@@ -47,8 +47,8 @@ describe('cleanForSlug', () => {
         'on-this-day-in-november',
       );
       expect(cleanForSlug('This & That', false)).toBe('this--that');
-      expect(cleanForSlug('The Price is $72.00!', false)).toBe(
-        'the-price-is-7200',
+      expect(cleanForSlug('Lisboa é ótima à beira-mar', false)).toBe(
+        'lisboa--tima--beira-mar',
       );
     });
   });
@@ -62,8 +62,8 @@ describe('cleanForSlug', () => {
       /* true triggers to use django's urlify */
 
       expect(cleanForSlug('This & That', true)).toBe('this-that');
-      expect(cleanForSlug('The Price is $72.00!', false)).toBe(
-        'the-price-is-7200',
+      expect(cleanForSlug('Lisboa é ótima à beira-mar', false)).toBe(
+        'lisboa-é-ótima-à-beira-mar',
       );
     });
 
@@ -71,8 +71,8 @@ describe('cleanForSlug', () => {
       /* false triggers ignores django's urlify */
 
       expect(cleanForSlug('This & That', false)).toBe('this--that');
-      expect(cleanForSlug('The Price is $72.00!', false)).toBe(
-        'the-price-is-7200',
+      expect(cleanForSlug('Lisboa é ótima à beira-mar', false)).toBe(
+        'lisboa-é-ótima-à-beira-mar',
       );
     });
   });

--- a/client/src/utils/text.ts
+++ b/client/src/utils/text.ts
@@ -39,13 +39,13 @@ export function cleanForSlug(
   // just do the "replace"
   if (unicodeSlugsEnabled) {
     return val
-      .replace(/\s/g, '-')
+      .replace(/\s+/g, '-')
       .replace(/[&/\\#,+()$~%.'":`@^!*?<>{}]/g, '')
       .toLowerCase();
   }
 
   return val
-    .replace(/\s/g, '-')
+    .replace(/\s+/g, '-')
     .replace(/[^A-Za-z0-9\-_]/g, '')
     .toLowerCase();
 }

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -21,6 +21,7 @@ depth: 1
  * Implement new simplified userbar designs (Albina Starykova)
  * Add more Axe rules to the accessibility checker (Albina Starykova)
  * Add usage view for pages (Sage Abdullah)
+ * Copy page form now updates the slug field dynamically with a slugified value on blur (Loveth Omokaro)
 
 ### Bug fixes
 
@@ -59,6 +60,7 @@ depth: 1
  * Replace `script` tags with `template` tag for image/document bulk uploads (Rishabh Kumar Bahukhandi)
  * Remove unneeded float styles on 404 page (Fabien Le Frapper)
  * Convert userbar implementation to TypeScript (Albina Starykova)
+ * Migrate slug field behaviour to a Stimulus controller and create new `SlugInput` widget (Loveth Omokaro)
 
 ## Upgrade considerations
 
@@ -88,6 +90,37 @@ The following features deprecated in Wagtail 4.0 have been fully removed. See [W
 ### `Page.get_static_site_paths` method removed
 
 The undocumented `Page.get_static_site_paths` method (which returns a generator of URL paths for use by static site generator packages) has been removed. Packages relying on this functionality should provide their own fallback implementation.
+
+### Slug field widget required for auto-formatting
+
+The slug field JavaScript behaviour was previously attached to any field with an ID of `id_slug`, this has now changed to be any field with the appropriate HTML data attributes.
+
+If using a custom edit handler or set of panels for page models, the correct widget will now need to be used for these data attributes to be included. This widget will use the `WAGTAIL_ALLOW_UNICODE_SLUGS` Django setting.
+
+```python
+from wagtail.admin.widgets.slug import SlugInput
+# ... other imports
+
+class MyPage(Page):
+    promote_panels = [
+        FieldPanel("slug", widget=SlugInput),
+        # ... other panels
+    ]
+```
+
+Additionally, the slug behaviour can be attached to any field easily by including the following attributes in HTML or via Django's widget `attrs`.
+
+```html
+<input type="text" name="slug" data-controller="w-slug" data-action="blur->w-slug#slugify" />
+```
+
+To allow unicode values, add the data attribute value;
+
+```html
+<input type="text" name="slug" data-controller="w-slug" data-action="blur->w-slug#slugify" data-w-slug-allow-unicode="true" />
+```
+
+
 
 ### Progress button (`button-longrunning`) now implemented with Stimulus
 

--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -22,7 +22,10 @@ class CopyForm(forms.Form):
         )
         allow_unicode = getattr(settings, "WAGTAIL_ALLOW_UNICODE_SLUGS", True)
         self.fields["new_slug"] = forms.SlugField(
-            initial=self.page.slug, label=_("New slug"), allow_unicode=allow_unicode
+            initial=self.page.slug,
+            label=_("New slug"),
+            allow_unicode=allow_unicode,
+            widget=widgets.slug.SlugInput,
         )
         self.fields["new_parent_page"] = forms.ModelChoiceField(
             initial=self.page.get_parent(),

--- a/wagtail/admin/panels/page_utils.py
+++ b/wagtail/admin/panels/page_utils.py
@@ -4,6 +4,7 @@ from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy
 
 from wagtail.admin.forms.pages import WagtailAdminPageForm
+from wagtail.admin.widgets.slug import SlugInput
 from wagtail.models import Page
 from wagtail.utils.decorators import cached_classmethod
 
@@ -31,7 +32,7 @@ def set_default_page_edit_handlers(cls):
     cls.promote_panels = [
         MultiFieldPanel(
             [
-                FieldPanel("slug"),
+                FieldPanel("slug", widget=SlugInput),
                 FieldPanel("seo_title"),
                 FieldPanel("search_description"),
             ],

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1482,8 +1482,8 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             reverse("wagtailadmin_pages:edit", args=(self.child_page.id,))
         )
 
-        input_field_for_draft_slug = '<input type="text" name="slug" value="revised-slug-in-draft-only" aria-describedby="panel-child-promote-child-for_search_engines-child-slug-helptext" id="id_slug" maxlength="255" required />'
-        input_field_for_live_slug = '<input type="text" name="slug" value="hello-world" aria-describedby="panel-child-promote-child-for_search_engines-child-slug-helptext" id="id_slug" maxlength="255" required />'
+        input_field_for_draft_slug = '<input type="text" name="slug" value="revised-slug-in-draft-only" data-controller="w-slug" data-action="blur-&gt;w-slug#slugify" data-w-slug-allow-unicode-value maxlength="255" aria-describedby="panel-child-promote-child-for_search_engines-child-slug-helptext" required id="id_slug">'
+        input_field_for_live_slug = '<input type="text" name="slug" value="hello-world" maxlength="255" aria-describedby="panel-child-promote-child-for_search_engines-child-slug-helptext" required id="id_slug" />'
 
         # Status Link should be the live page (not revision)
         self.assertNotContains(
@@ -1508,8 +1508,8 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             reverse("wagtailadmin_pages:edit", args=(self.single_event_page.id,))
         )
 
-        input_field_for_draft_slug = '<input type="text" name="slug" value="revised-slug-in-draft-only" aria-describedby="panel-child-promote-child-common_page_configuration-child-slug-helptext" id="id_slug" maxlength="255" required />'
-        input_field_for_live_slug = '<input type="text" name="slug" value="mars-landing" aria-describedby="panel-child-promote-child-common_page_configuration-child-slug-helptext" id="id_slug" maxlength="255" required />'
+        input_field_for_draft_slug = '<input type="text" name="slug" value="revised-slug-in-draft-only" maxlength="255" aria-describedby="panel-child-promote-child-common_page_configuration-child-slug-helptext" required id="id_slug" />'
+        input_field_for_live_slug = '<input type="text" name="slug" value="mars-landing" maxlength="255" aria-describedby="panel-child-promote-child-common_page_configuration-child-slug-helptext" required id="id_slug" />'
 
         # Status Link should be the live page (not revision)
         self.assertNotContains(

--- a/wagtail/admin/tests/test_widgets.py
+++ b/wagtail/admin/tests/test_widgets.py
@@ -642,3 +642,23 @@ class TestFilteredSelect(TestCase):
             </select>
         """,
         )
+
+
+class TestSlugInput(TestCase):
+    def test_has_data_attr(self):
+        widget = widgets.slug.SlugInput()
+
+        html = widget.render("test", None, attrs={"id": "test-id"})
+
+        self.assertInHTML(
+            '<input type="text" name="test" data-controller="w-slug" data-action="blur-&gt;w-slug#slugify" data-w-slug-allow-unicode-value id="test-id">',
+            html,
+        )
+
+    @override_settings(WAGTAIL_ALLOW_UNICODE_SLUGS=False)
+    def test_render_data_atrrs_from_settings(self):
+        widget = widgets.slug.SlugInput()
+
+        html = widget.render("test", None, attrs={"id": "test-id"})
+
+        self.assertNotIn("data-w-slug-allow-unicode-value", html)

--- a/wagtail/admin/widgets/slug.py
+++ b/wagtail/admin/widgets/slug.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+from django.forms import widgets
+
+
+class SlugInput(widgets.TextInput):
+    def __init__(self, attrs=None):
+        default_attrs = {
+            "data-controller": "w-slug",
+            "data-action": "blur->w-slug#slugify",
+            "data-w-slug-allow-unicode-value": getattr(
+                settings, "WAGTAIL_ALLOW_UNICODE_SLUGS", True
+            ),
+        }
+        if attrs:
+            default_attrs.update(attrs)
+        super().__init__(default_attrs)


### PR DESCRIPTION
Fixes #10086

## Fix summary

- Converted initSlugCleaning to TypeScript
- Wrote test for when the input element value is slugified
- Added trim method to the `text` utils  and changed the regex to match one or more whitespace


### Before conversion with multiple whitespace

![image](https://user-images.githubusercontent.com/38161296/219864903-a42882e4-ed44-418a-ac4b-a2006c23add7.png)

### After conversion

![image](https://user-images.githubusercontent.com/38161296/219864982-8f6bb981-c945-4970-a044-e2b0d6d18cda.png)


![image](https://user-images.githubusercontent.com/38161296/219865001-d1d983c1-2028-420b-851e-d2f8a092dfde.png)


## Issues I have 

- > * and passing in the option `unicodeSlugsEnabled` based on the controller's value

I don't understand this part @lb- . Do I need to create a value attribute for this or I only need to pass the  `{ unicodeSlugsEnabled: true }` as the third argument>

