### PR TITLE
Documentation - remove legacy docs references

### DIFF
--- a/docs/releases/1.8.rst
+++ b/docs/releases/1.8.rst
@@ -30,8 +30,6 @@ Restrictions on bulk-deletion of pages
 
 Previously, any user with edit permission over a page and its descendants was able to delete them all as a single action, which led to the risk of accidental deletions. To guard against this, the permission rules have been revised so that a user with basic permissions can only delete pages that have no children; in order to delete a whole subtree, they must individually delete each child page first. A new "bulk delete" permission type has been added which allows a user to delete pages with children, as before; superusers receive this permission implicitly, and so there is no change of behaviour for them.
 
-See: :ref:`permissions`
-
 This feature was developed by Matt Westcott.
 
 

--- a/docs/releases/2.13.rst
+++ b/docs/releases/2.13.rst
@@ -31,7 +31,7 @@ This module was contributed by Coen van der Kamp.
 Commenting
 ~~~~~~~~~~
 
-The page editor now supports :ref:`leaving comments on fields and StreamField blocks <commenting>`, by entering commenting mode (using the button in the top right of the editor). Inline comments are available in rich text fields using the Draftail editor.
+The page editor now supports leaving comments on fields and StreamField blocks, by entering commenting mode (using the button in the top right of the editor). Inline comments are available in rich text fields using the Draftail editor.
 
 This feature was developed by Jacob Topp-Mugglestone, Karl Hobley and Simon Evans and sponsored by `The Motley Fool <https://www.fool.com/>`_.
 


### PR DESCRIPTION
- Permissions/commenting links no longer exist in the documentation and have moved to the user guide
- As these are quite old releases now, remove the references to avoid build errors in docs
