### PR TITLE
Fix audit log display of deleted models

### DIFF
--- a/wagtail/coreutils.py
+++ b/wagtail/coreutils.py
@@ -19,6 +19,7 @@ from django.test import RequestFactory
 from django.utils.encoding import force_str
 from django.utils.text import capfirst, slugify
 from django.utils.translation import check_for_language, get_supported_language_variant
+from django.utils.translation import gettext_lazy as _
 
 if TYPE_CHECKING:
     from wagtail.models import Site
@@ -156,6 +157,9 @@ def get_content_type_label(content_type):
     Return a human-readable label for a content type object, suitable for display in the admin
     in place of the default 'wagtailcore | page' representation
     """
+    if content_type is None:
+        return _("Unknown content type")
+
     model = content_type.model_class()
     if model:
         return str(capfirst(model._meta.verbose_name))

--- a/wagtail/tests/test_utils.py
+++ b/wagtail/tests/test_utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*
 import pickle
 
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.utils.text import slugify
@@ -14,6 +15,7 @@ from wagtail.coreutils import (
     cautious_slugify,
     find_available_slug,
     get_content_languages,
+    get_content_type_label,
     get_dummy_request,
     get_supported_content_language_variant,
     multigetattr,
@@ -293,6 +295,21 @@ class TestGetContentLanguages(TestCase):
                 "The language zh is specified in WAGTAIL_CONTENT_LANGUAGES but not LANGUAGES. WAGTAIL_CONTENT_LANGUAGES must be a subset of LANGUAGES.",
             ),
         )
+
+
+def TestGetContentTypeLabel(TestCase):
+    def test_none(self):
+        self.assertEqual(get_content_type_label(None), "Unknown content type")
+
+    def test_valid_content_type(self):
+        page_content_type = ContentType.objects.get_for_model(Page)
+        self.assertEqual(get_content_type_label(page_content_type), "Page")
+
+    def test_stale_content_type(self):
+        stale_content_type = ContentType.objects.create(
+            app_label="fake_app", model="deleted model"
+        )
+        self.assertEqual(get_content_type_label(stale_content_type), "Deleted model")
 
 
 @override_settings(


### PR DESCRIPTION
Fixes #8699; please see that issue for PR testing instructions.

The audit log report currently raises an unhandled exception if it tries to display log entries for model instances where the model was deleted after the log entry was made. This PR fixes that bug.

If the model was deleted via a migration but the content type still exists in the database (a "stale content type" in Django parlance), the report will now display a capitalized version of the content type's "name" field, for example "Homepage" for the HomePage model:

<img width="878" alt="image" src="https://user-images.githubusercontent.com/654645/220390805-ee95b8e0-5c7c-4738-a64d-2c5dc02f9596.png">

If the content type has also been deleted (likely via Django's remove_stale_contenttypes management command), the report will now display the phrase "Unknown content type":

<img width="878" alt="image" src="https://user-images.githubusercontent.com/654645/220390297-4590ae97-db3b-4b64-9fa6-357bfe6d29e2.png">

There may be some better phrase to use here, as typical Wagtail content editors might not know what a "content type" is. We could also just say "Unknown", which sort of [already exists](https://github.com/wagtail/wagtail/blob/93077eaccd7b65a067f5f307a34b969fe6c6e37c/wagtail/locale/en/LC_MESSAGES/django.po#L676) in the translation files, [as does](https://github.com/wagtail/wagtail/blob/93077eaccd7b65a067f5f307a34b969fe6c6e37c/wagtail/locale/en/LC_MESSAGES/django.po#L285) "content type", although I don't think that is ever shown to users.