### PR TITLE
Consistent rendering of ValidationErrors across all StreamField blocks

### DIFF
--- a/client/src/components/StreamField/blocks/FieldBlock.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.js
@@ -50,13 +50,11 @@ export class FieldBlock {
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error(e);
-      this.setError([
-        {
-          messages: [
-            'This widget failed to render, please check the console for details',
-          ],
-        },
-      ]);
+      this.setError({
+        messages: [
+          'This widget failed to render, please check the console for details',
+        ],
+      });
       return;
     }
 
@@ -115,26 +113,26 @@ export class FieldBlock {
     }
   }
 
-  setError(errorList) {
-    const errors = this.field.querySelector('[data-field-errors]');
+  setError(error) {
+    const errorContainer = this.field.querySelector('[data-field-errors]');
 
-    errors
+    errorContainer
       .querySelectorAll('.error-message')
       .forEach((element) => element.remove());
 
-    if (errorList) {
+    if (error) {
       this.field.classList.add('w-field--error');
-      errors.querySelector('.icon').removeAttribute('hidden');
+      errorContainer.querySelector('.icon').removeAttribute('hidden');
 
       const errorElement = document.createElement('p');
       errorElement.classList.add('error-message');
-      errorElement.innerHTML = errorList
-        .map((error) => `<span>${h(error.messages[0])}</span>`)
+      errorElement.innerHTML = error.messages
+        .map((message) => `<span>${h(message)}</span>`)
         .join('');
-      errors.appendChild(errorElement);
+      errorContainer.appendChild(errorElement);
     } else {
       this.field.classList.remove('w-field--error');
-      errors.querySelector('.icon').setAttribute('hidden', 'true');
+      errorContainer.querySelector('.icon').setAttribute('hidden', 'true');
     }
   }
 

--- a/client/src/components/StreamField/blocks/FieldBlock.test.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.test.js
@@ -51,12 +51,6 @@ class DummyWidgetDefinition {
   }
 }
 
-class ValidationError {
-  constructor(messages) {
-    this.messages = messages;
-  }
-}
-
 describe('telepath: wagtail.blocks.FieldBlock', () => {
   let boundBlock;
 
@@ -135,10 +129,12 @@ describe('telepath: wagtail.blocks.FieldBlock', () => {
   });
 
   test('setError() renders errors', () => {
-    boundBlock.setError([
-      new ValidationError(['Field must not contain the letter E']),
-      new ValidationError(['Field must contain a story about kittens']),
-    ]);
+    boundBlock.setError({
+      messages: [
+        'Field must not contain the letter E',
+        'Field must contain a story about kittens',
+      ],
+    });
     expect(document.body.innerHTML).toMatchSnapshot();
   });
 });

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -258,11 +258,8 @@ export class ListBlock extends BaseSequenceBlock {
     }
   }
 
-  setError(errorList) {
-    if (errorList.length !== 1) {
-      return;
-    }
-    const error = errorList[0];
+  setError(error) {
+    if (!error) return;
 
     // Non block errors
     const container = this.container[0];
@@ -270,24 +267,26 @@ export class ListBlock extends BaseSequenceBlock {
       .querySelectorAll(':scope > .help-block.help-critical')
       .forEach((element) => element.remove());
 
-    if (error.nonBlockErrors.length > 0) {
+    if (error.messages) {
       // Add a help block for each error raised
-      error.nonBlockErrors.forEach((nonBlockError) => {
+      error.messages.forEach((message) => {
         const errorElement = document.createElement('p');
         errorElement.classList.add('help-block');
         errorElement.classList.add('help-critical');
-        errorElement.innerHTML = h(nonBlockError.messages[0]);
+        errorElement.innerHTML = h(message);
         container.insertBefore(errorElement, container.childNodes[0]);
       });
     }
 
-    // error.blockErrors = a list with the same length as the data,
-    // with nulls for items without errors
-    error.blockErrors.forEach((blockError, blockIndex) => {
-      if (blockError) {
-        this.children[blockIndex].setError(blockError);
-      }
-    });
+    if (error.blockErrors) {
+      // error.blockErrors = a list with the same length as the data,
+      // with nulls for items without errors
+      error.blockErrors.forEach((blockError, blockIndex) => {
+        if (blockError) {
+          this.children[blockIndex].setError(blockError);
+        }
+      });
+    }
   }
 
   getBlockGroups() {

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -11,13 +11,6 @@ import { range } from '../../../utils/range';
 
 /* global $ */
 
-export class ListBlockValidationError {
-  constructor(blockErrors, nonBlockErrors) {
-    this.blockErrors = blockErrors;
-    this.nonBlockErrors = nonBlockErrors;
-  }
-}
-
 class ListChild extends BaseSequenceChild {
   /*
   wrapper for an item inside a ListBlock

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -8,6 +8,10 @@ import {
 } from './BaseSequenceBlock';
 import { escapeHtml as h } from '../../../utils/text';
 import { range } from '../../../utils/range';
+import {
+  addErrorMessages,
+  removeErrorMessages,
+} from '../../../includes/streamFieldErrors';
 
 /* global $ */
 
@@ -256,19 +260,10 @@ export class ListBlock extends BaseSequenceBlock {
 
     // Non block errors
     const container = this.container[0];
-    container
-      .querySelectorAll(':scope > .help-block.help-critical')
-      .forEach((element) => element.remove());
+    removeErrorMessages(container);
 
     if (error.messages) {
-      // Add a help block for each error raised
-      error.messages.forEach((message) => {
-        const errorElement = document.createElement('p');
-        errorElement.classList.add('help-block');
-        errorElement.classList.add('help-critical');
-        errorElement.innerHTML = h(message);
-        container.insertBefore(errorElement, container.childNodes[0]);
-      });
+      addErrorMessages(container, error.messages);
     }
 
     if (error.blockErrors) {

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import * as uuid from 'uuid';
 import { FieldBlock, FieldBlockDefinition } from './FieldBlock';
-import { ListBlockDefinition, ListBlockValidationError } from './ListBlock';
+import { ListBlockDefinition } from './ListBlock';
 import { StreamBlockDefinition } from './StreamBlock';
 
 // Mock uuid for consistent snapshot results
@@ -51,12 +51,6 @@ class DummyWidgetDefinition {
       },
       idForLabel: id,
     };
-  }
-}
-
-class ValidationError {
-  constructor(messages) {
-    this.messages = messages;
   }
 }
 
@@ -304,22 +298,16 @@ describe('telepath: wagtail.blocks.ListBlock', () => {
   });
 
   test('setError passes error messages to children', () => {
-    boundBlock.setError([
-      new ListBlockValidationError(
-        [null, [new ValidationError(['Not as good as the first one'])]],
-        [],
-      ),
-    ]);
+    boundBlock.setError({
+      blockErrors: [null, { messages: ['Not as good as the first one'] }],
+    });
     expect(document.body.innerHTML).toMatchSnapshot();
   });
 
   test('setError renders non-block errors', () => {
-    boundBlock.setError([
-      new ListBlockValidationError(
-        [null, null],
-        [new ValidationError(['At least three blocks are required'])],
-      ),
-    ]);
+    boundBlock.setError({
+      messages: ['At least three blocks are required'],
+    });
     expect(document.body.innerHTML).toMatchSnapshot();
   });
 });

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -403,34 +403,32 @@ export class StreamBlock extends BaseSequenceBlock {
     }
   }
 
-  setError(errorList) {
-    if (errorList.length !== 1) {
-      return;
-    }
-    const error = errorList[0];
+  setError(error) {
+    if (!error) return;
 
-    // Non block errors
+    // Non block errors (messages applying to the block as a whole)
     const container = this.container[0];
     container
       .querySelectorAll(':scope > .help-block.help-critical')
       .forEach((element) => element.remove());
 
-    if (error.nonBlockErrors.length > 0) {
+    if (error.messages) {
       // Add a help block for each error raised
-      error.nonBlockErrors.forEach((nonBlockError) => {
+      error.messages.forEach((message) => {
         const errorElement = document.createElement('p');
         errorElement.classList.add('help-block');
         errorElement.classList.add('help-critical');
-        errorElement.innerHTML = h(nonBlockError.messages[0]);
+        errorElement.innerHTML = h(message);
         container.insertBefore(errorElement, container.childNodes[0]);
       });
     }
 
-    // Block errors
-
-    for (const blockIndex in error.blockErrors) {
-      if (hasOwn(error.blockErrors, blockIndex)) {
-        this.children[blockIndex].setError(error.blockErrors[blockIndex]);
+    if (error.blockErrors) {
+      // Block errors (to be propagated to child blocks)
+      for (const blockIndex in error.blockErrors) {
+        if (hasOwn(error.blockErrors, blockIndex)) {
+          this.children[blockIndex].setError(error.blockErrors[blockIndex]);
+        }
       }
     }
   }

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -18,6 +18,10 @@ import ComboBox, {
   comboBoxTriggerLabel,
 } from '../../ComboBox/ComboBox';
 import { hideTooltipOnEsc } from '../../../includes/initTooltips';
+import {
+  addErrorMessages,
+  removeErrorMessages,
+} from '../../../includes/streamFieldErrors';
 
 /* global $ */
 
@@ -401,19 +405,10 @@ export class StreamBlock extends BaseSequenceBlock {
 
     // Non block errors (messages applying to the block as a whole)
     const container = this.container[0];
-    container
-      .querySelectorAll(':scope > .help-block.help-critical')
-      .forEach((element) => element.remove());
+    removeErrorMessages(container);
 
     if (error.messages) {
-      // Add a help block for each error raised
-      error.messages.forEach((message) => {
-        const errorElement = document.createElement('p');
-        errorElement.classList.add('help-block');
-        errorElement.classList.add('help-critical');
-        errorElement.innerHTML = h(message);
-        container.insertBefore(errorElement, container.childNodes[0]);
-      });
+      addErrorMessages(container, error.messages);
     }
 
     if (error.blockErrors) {

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -21,13 +21,6 @@ import { hideTooltipOnEsc } from '../../../includes/initTooltips';
 
 /* global $ */
 
-export class StreamBlockValidationError {
-  constructor(nonBlockErrors, blockErrors) {
-    this.nonBlockErrors = nonBlockErrors;
-    this.blockErrors = blockErrors;
-  }
-}
-
 class StreamChild extends BaseSequenceChild {
   /*
   wrapper for a block inside a StreamBlock, handling StreamBlock-specific metadata

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -1,11 +1,7 @@
 import $ from 'jquery';
 import * as uuid from 'uuid';
 import { FieldBlockDefinition } from './FieldBlock';
-import {
-  StreamBlockDefinition,
-  StreamBlockValidationError,
-} from './StreamBlock';
-import { StructBlockDefinition } from './StructBlock';
+import { StreamBlockDefinition } from './StreamBlock';
 
 // Mock uuid for consistent snapshot results
 jest.mock('uuid');
@@ -54,12 +50,6 @@ class DummyWidgetDefinition {
       },
       idForLabel: id,
     };
-  }
-}
-
-class ValidationError {
-  constructor(messages) {
-    this.messages = messages;
   }
 }
 
@@ -321,18 +311,16 @@ describe('telepath: wagtail.blocks.StreamBlock', () => {
   });
 
   test('setError renders error messages', () => {
-    boundBlock.setError([
-      new StreamBlockValidationError(
-        [
-          /* non-block error */
-          new ValidationError(['At least three blocks are required']),
-        ],
-        {
-          /* block error */
-          1: [new ValidationError(['Not as good as the first one'])],
-        },
-      ),
-    ]);
+    boundBlock.setError({
+      messages: [
+        /* non-block error */
+        'At least three blocks are required',
+      ],
+      blockErrors: {
+        /* block error */
+        1: { messages: ['Not as good as the first one'] },
+      },
+    });
     expect(document.body.innerHTML).toMatchSnapshot();
   });
 });

--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -2,6 +2,10 @@
 
 import { escapeHtml as h } from '../../../utils/text';
 import { hasOwn } from '../../../utils/hasOwn';
+import {
+  addErrorMessages,
+  removeErrorMessages,
+} from '../../../includes/streamFieldErrors';
 
 export class StructBlock {
   constructor(blockDef, placeholder, prefix, initialState, initialError) {
@@ -90,21 +94,12 @@ export class StructBlock {
 
   setError(error) {
     if (!error) return;
+
     // Non block errors
     const container = this.container[0];
-    container
-      .querySelectorAll(':scope > .help-block.help-critical')
-      .forEach((element) => element.remove());
-
+    removeErrorMessages(container);
     if (error.messages) {
-      // Add a help block for each error raised
-      error.messages.forEach((message) => {
-        const errorElement = document.createElement('p');
-        errorElement.classList.add('help-block');
-        errorElement.classList.add('help-critical');
-        errorElement.innerHTML = h(message);
-        container.insertBefore(errorElement, container.childNodes[0]);
-      });
+      addErrorMessages(container, error.messages);
     }
 
     if (error.blockErrors) {

--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -95,25 +95,21 @@ export class StructBlock {
     }
   }
 
-  setError(errorList) {
-    if (errorList.length !== 1) {
-      return;
-    }
-    const error = errorList[0];
-
+  setError(error) {
+    if (!error) return;
     // Non block errors
     const container = this.container[0];
     container
       .querySelectorAll(':scope > .help-block.help-critical')
       .forEach((element) => element.remove());
 
-    if (error.nonBlockErrors) {
+    if (error.messages) {
       // Add a help block for each error raised
-      error.nonBlockErrors.forEach((nonBlockError) => {
+      error.messages.forEach((message) => {
         const errorElement = document.createElement('p');
         errorElement.classList.add('help-block');
         errorElement.classList.add('help-critical');
-        errorElement.innerHTML = h(nonBlockError.messages[0]);
+        errorElement.innerHTML = h(message);
         container.insertBefore(errorElement, container.childNodes[0]);
       });
     }

--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -3,13 +3,6 @@
 import { escapeHtml as h } from '../../../utils/text';
 import { hasOwn } from '../../../utils/hasOwn';
 
-export class StructBlockValidationError {
-  constructor(nonBlockErrors, blockErrors) {
-    this.nonBlockErrors = nonBlockErrors;
-    this.blockErrors = blockErrors;
-  }
-}
-
 export class StructBlock {
   constructor(blockDef, placeholder, prefix, initialState, initialError) {
     const state = initialState || {};

--- a/client/src/components/StreamField/blocks/StructBlock.test.js
+++ b/client/src/components/StreamField/blocks/StructBlock.test.js
@@ -1,10 +1,7 @@
 import $ from 'jquery';
 import { FieldBlockDefinition } from './FieldBlock';
 import { StreamBlockDefinition } from './StreamBlock';
-import {
-  StructBlockDefinition,
-  StructBlockValidationError,
-} from './StructBlock';
+import { StructBlockDefinition } from './StructBlock';
 
 window.$ = $;
 
@@ -51,12 +48,6 @@ class DummyWidgetDefinition {
       },
       idForLabel: id,
     };
-  }
-}
-
-class ValidationError {
-  constructor(messages) {
-    this.messages = messages;
   }
 }
 
@@ -177,21 +168,18 @@ describe('telepath: wagtail.blocks.StructBlock', () => {
   });
 
   test('setError passes error messages to children', () => {
-    boundBlock.setError([
-      new StructBlockValidationError(null, {
-        size: [new ValidationError(['This is too big'])],
-      }),
-    ]);
+    boundBlock.setError({
+      blockErrors: {
+        size: { messages: ['This is too big'] },
+      },
+    });
     expect(document.body.innerHTML).toMatchSnapshot();
   });
 
   test('setError shows non-block errors', () => {
-    boundBlock.setError([
-      new StructBlockValidationError(
-        [new ValidationError(['This is just generally wrong'])],
-        null,
-      ),
-    ]);
+    boundBlock.setError({
+      messages: ['This is just generally wrong'],
+    });
     expect(document.body.innerHTML).toMatchSnapshot();
   });
 });

--- a/client/src/components/StreamField/blocks/StructBlock.test.js
+++ b/client/src/components/StreamField/blocks/StructBlock.test.js
@@ -178,9 +178,19 @@ describe('telepath: wagtail.blocks.StructBlock', () => {
 
   test('setError passes error messages to children', () => {
     boundBlock.setError([
-      new StructBlockValidationError({
+      new StructBlockValidationError(null, {
         size: [new ValidationError(['This is too big'])],
       }),
+    ]);
+    expect(document.body.innerHTML).toMatchSnapshot();
+  });
+
+  test('setError shows non-block errors', () => {
+    boundBlock.setError([
+      new StructBlockValidationError(
+        [new ValidationError(['This is just generally wrong'])],
+        null,
+      ),
     ]);
     expect(document.body.innerHTML).toMatchSnapshot();
   });

--- a/client/src/components/StreamField/blocks/__snapshots__/StructBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StructBlock.test.js.snap
@@ -74,6 +74,43 @@ exports[`telepath: wagtail.blocks.StructBlock setError passes error messages to 
           </div></div>"
 `;
 
+exports[`telepath: wagtail.blocks.StructBlock setError shows non-block errors 1`] = `
+"<div class=\\"struct-block\\"><p class=\\"help-block help-critical\\">This is just generally wrong</p>
+        
+          <div class=\\"c-sf-help\\">
+            <div class=\\"help\\">
+              use <strong>lots</strong> of these
+            </div>
+          </div>
+        <div data-contentpath=\\"heading_text\\">
+          <label class=\\"w-field__label\\" for=\\"the-prefix-heading_text\\">Heading text<span class=\\"w-required-mark\\">*</span></label>
+            <div class=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
+        <div class=\\"w-field w-field--char_field w-field--text_input\\" data-field=\\"\\">
+          <div class=\\"w-field__errors\\" id=\\"the-prefix-heading_text-errors\\" data-field-errors=\\"\\">
+            <svg class=\\"icon icon-warning w-field__errors-icon\\" aria-hidden=\\"true\\" hidden=\\"\\"><use href=\\"#icon-warning\\"></use></svg>
+          </div>
+          <div class=\\"w-field__input\\" data-field-input=\\"\\">
+            <p name=\\"the-prefix-heading_text\\" id=\\"the-prefix-heading_text\\">Heading widget</p>
+          </div>
+          <div id=\\"the-prefix-heading_text-helptext\\" data-field-help=\\"\\"></div>
+        </div>
+      </div>
+          </div><div data-contentpath=\\"size\\">
+          <label class=\\"w-field__label\\" for=\\"the-prefix-size\\">Size</label>
+            <div class=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
+        <div class=\\"w-field w-field--choice_field w-field--select\\" data-field=\\"\\">
+          <div class=\\"w-field__errors\\" id=\\"the-prefix-size-errors\\" data-field-errors=\\"\\">
+            <svg class=\\"icon icon-warning w-field__errors-icon\\" aria-hidden=\\"true\\" hidden=\\"\\"><use href=\\"#icon-warning\\"></use></svg>
+          </div>
+          <div class=\\"w-field__input\\" data-field-input=\\"\\">
+            <p name=\\"the-prefix-size\\" id=\\"the-prefix-size\\">Size widget</p>
+          </div>
+          <div id=\\"the-prefix-size-helptext\\" data-field-help=\\"\\"></div>
+        </div>
+      </div>
+          </div></div>"
+`;
+
 exports[`telepath: wagtail.blocks.StructBlock with formTemplate it renders correctly 1`] = `
 "<div class=\\"custom-form-template\\">
         <p>here comes the first field:</p>

--- a/client/src/entrypoints/admin/telepath/blocks.js
+++ b/client/src/entrypoints/admin/telepath/blocks.js
@@ -61,10 +61,10 @@ function initBlockWidget(id) {
   const blockDefData = JSON.parse(body.dataset.block);
   const blockDef = window.telepath.unpack(blockDefData);
   const blockValue = JSON.parse(body.dataset.value);
-  const blockErrors = window.telepath.unpack(JSON.parse(body.dataset.errors));
+  const blockError = JSON.parse(body.dataset.error);
 
   // replace the 'body' element with the populated HTML structure for the block
-  blockDef.render(body, id, blockValue, blockErrors);
+  blockDef.render(body, id, blockValue, blockError);
 }
 window.initBlockWidget = initBlockWidget;
 

--- a/client/src/entrypoints/admin/telepath/blocks.js
+++ b/client/src/entrypoints/admin/telepath/blocks.js
@@ -9,17 +9,14 @@ import {
 import {
   StructBlock,
   StructBlockDefinition,
-  StructBlockValidationError,
 } from '../../../components/StreamField/blocks/StructBlock';
 import {
   ListBlock,
   ListBlockDefinition,
-  ListBlockValidationError,
 } from '../../../components/StreamField/blocks/ListBlock';
 import {
   StreamBlock,
   StreamBlockDefinition,
-  StreamBlockValidationError,
 } from '../../../components/StreamField/blocks/StreamBlock';
 
 const wagtailStreamField = window.wagtailStreamField || {};
@@ -33,15 +30,12 @@ wagtailStreamField.blocks = {
 
   StructBlock,
   StructBlockDefinition,
-  StructBlockValidationError,
 
   ListBlock,
   ListBlockDefinition,
-  ListBlockValidationError,
 
   StreamBlock,
   StreamBlockDefinition,
-  StreamBlockValidationError,
 };
 
 function initBlockWidget(id) {
@@ -71,19 +65,7 @@ window.initBlockWidget = initBlockWidget;
 window.telepath.register('wagtail.blocks.FieldBlock', FieldBlockDefinition);
 window.telepath.register('wagtail.blocks.StaticBlock', StaticBlockDefinition);
 window.telepath.register('wagtail.blocks.StructBlock', StructBlockDefinition);
-window.telepath.register(
-  'wagtail.blocks.StructBlockValidationError',
-  StructBlockValidationError,
-);
 window.telepath.register('wagtail.blocks.ListBlock', ListBlockDefinition);
-window.telepath.register(
-  'wagtail.blocks.ListBlockValidationError',
-  ListBlockValidationError,
-);
 window.telepath.register('wagtail.blocks.StreamBlock', StreamBlockDefinition);
-window.telepath.register(
-  'wagtail.blocks.StreamBlockValidationError',
-  StreamBlockValidationError,
-);
 
 window.wagtailStreamField = wagtailStreamField;

--- a/client/src/entrypoints/contrib/typed_table_block/__snapshots__/typed_table_block.test.js.snap
+++ b/client/src/entrypoints/contrib/typed_table_block/__snapshots__/typed_table_block.test.js.snap
@@ -89,3 +89,183 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock it renders cor
         </div>
       </div>"
 `;
+
+exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError passes error messages to children 1`] = `
+"<div class=\\"typed-table-block \\">
+        <input type=\\"hidden\\" name=\\"mytable-column-count\\" data-column-count=\\"\\" value=\\"2\\">
+        <input type=\\"hidden\\" name=\\"mytable-row-count\\" data-row-count=\\"\\" value=\\"2\\">
+        <div data-deleted-fields=\\"\\"><input type=\\"hidden\\" name=\\"mytable-column-0-deleted\\" value=\\"\\"><input type=\\"hidden\\" name=\\"mytable-column-1-deleted\\" value=\\"\\"><input type=\\"hidden\\" name=\\"mytable-row-0-deleted\\" value=\\"\\"><input type=\\"hidden\\" name=\\"mytable-row-1-deleted\\" value=\\"\\"></div>
+        <div class=\\"typed-table-block__wrapper\\">
+          <table>
+            <thead>
+              <tr><th></th><th><input type=\\"hidden\\" name=\\"mytable-column-0-type\\" value=\\"test_block_a\\"><input type=\\"hidden\\" name=\\"mytable-column-0-order\\" value=\\"0\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace prepend-column\\" aria-label=\\"Insert column\\" title=\\"Insert column\\">
+        <svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
+      </button><input type=\\"text\\" name=\\"mytable-column-0-heading\\" class=\\"column-heading\\" placeholder=\\"Column heading\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace no delete-column\\" aria-label=\\"Delete column\\" title=\\"Delete column\\">
+        <svg class=\\"icon icon-bin icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-bin\\"></use></svg>
+      </button></th><th><input type=\\"hidden\\" name=\\"mytable-column-1-type\\" value=\\"test_block_b\\"><input type=\\"hidden\\" name=\\"mytable-column-1-order\\" value=\\"1\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace prepend-column\\" aria-label=\\"Insert column\\" title=\\"Insert column\\">
+        <svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
+      </button><input type=\\"text\\" name=\\"mytable-column-1-heading\\" class=\\"column-heading\\" placeholder=\\"Column heading\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace no delete-column\\" aria-label=\\"Delete column\\" title=\\"Delete column\\">
+        <svg class=\\"icon icon-bin icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-bin\\"></use></svg>
+      </button></th><th class=\\"control-cell\\">
+                  <button type=\\"button\\" class=\\"button button-small button-secondary append-column button--icon text-replace white\\" data-append-column=\\"\\" aria-label=\\"Add column\\" title=\\"Add column\\"><svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg></button>
+                </th></tr>
+            </thead>
+            <tbody><tr><td class=\\"control-cell\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace prepend-row\\" aria-label=\\"Insert row\\" title=\\"Insert row\\">
+        <svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
+      </button></td><td><div class=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
+        <div class=\\"w-field w-field--char_field w-field--text_input\\" data-field=\\"\\">
+          <div class=\\"w-field__errors\\" id=\\"mytable-cell-0-0-errors\\" data-field-errors=\\"\\">
+            <svg class=\\"icon icon-warning w-field__errors-icon\\" aria-hidden=\\"true\\" hidden=\\"\\"><use href=\\"#icon-warning\\"></use></svg>
+          </div>
+          <div class=\\"w-field__input\\" data-field-input=\\"\\">
+            <p name=\\"mytable-cell-0-0\\" id=\\"mytable-cell-0-0\\">Block A widget</p>
+          </div>
+          <div id=\\"mytable-cell-0-0-helptext\\" data-field-help=\\"\\"></div>
+        </div>
+      </div></td><td><div class=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
+        <div class=\\"w-field w-field--char_field w-field--admin_auto_height_text_input w-field--error\\" data-field=\\"\\">
+          <div class=\\"w-field__errors\\" id=\\"mytable-cell-0-1-errors\\" data-field-errors=\\"\\">
+            <svg class=\\"icon icon-warning w-field__errors-icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-warning\\"></use></svg>
+          <p class=\\"error-message\\"><span>This is not enough cheese</span></p></div>
+          <div class=\\"w-field__input\\" data-field-input=\\"\\">
+            <p name=\\"mytable-cell-0-1\\" id=\\"mytable-cell-0-1\\">Block B widget</p>
+          </div>
+          <div id=\\"mytable-cell-0-1-helptext\\" data-field-help=\\"\\"></div>
+        </div>
+      </div></td><td class=\\"control-cell\\"><input type=\\"hidden\\" name=\\"mytable-row-0-order\\" value=\\"0\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace no delete-row\\" aria-label=\\"Delete row\\" title=\\"Delete row\\">
+        <svg class=\\"icon icon-bin icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-bin\\"></use></svg>
+      </button></td></tr><tr><td class=\\"control-cell\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace prepend-row\\" aria-label=\\"Insert row\\" title=\\"Insert row\\">
+        <svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
+      </button></td><td><div class=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
+        <div class=\\"w-field w-field--char_field w-field--text_input\\" data-field=\\"\\">
+          <div class=\\"w-field__errors\\" id=\\"mytable-cell-1-0-errors\\" data-field-errors=\\"\\">
+            <svg class=\\"icon icon-warning w-field__errors-icon\\" aria-hidden=\\"true\\" hidden=\\"\\"><use href=\\"#icon-warning\\"></use></svg>
+          </div>
+          <div class=\\"w-field__input\\" data-field-input=\\"\\">
+            <p name=\\"mytable-cell-1-0\\" id=\\"mytable-cell-1-0\\">Block A widget</p>
+          </div>
+          <div id=\\"mytable-cell-1-0-helptext\\" data-field-help=\\"\\"></div>
+        </div>
+      </div></td><td><div class=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
+        <div class=\\"w-field w-field--char_field w-field--admin_auto_height_text_input\\" data-field=\\"\\">
+          <div class=\\"w-field__errors\\" id=\\"mytable-cell-1-1-errors\\" data-field-errors=\\"\\">
+            <svg class=\\"icon icon-warning w-field__errors-icon\\" aria-hidden=\\"true\\" hidden=\\"\\"><use href=\\"#icon-warning\\"></use></svg>
+          </div>
+          <div class=\\"w-field__input\\" data-field-input=\\"\\">
+            <p name=\\"mytable-cell-1-1\\" id=\\"mytable-cell-1-1\\">Block B widget</p>
+          </div>
+          <div id=\\"mytable-cell-1-1-helptext\\" data-field-help=\\"\\"></div>
+        </div>
+      </div></td><td class=\\"control-cell\\"><input type=\\"hidden\\" name=\\"mytable-row-1-order\\" value=\\"1\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace no delete-row\\" aria-label=\\"Delete row\\" title=\\"Delete row\\">
+        <svg class=\\"icon icon-bin icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-bin\\"></use></svg>
+      </button></td></tr></tbody>
+            <tfoot>
+              <tr>
+                <td class=\\"control-cell\\">
+                  <button type=\\"button\\" class=\\"button button-small button-secondary button--icon text-replace prepend-row\\" data-add-row=\\"\\" aria-label=\\"Add row\\" title=\\"Add row\\" style=\\"\\">
+                    <svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\">
+                      <use href=\\"#icon-plus\\"></use>
+                    </svg>
+                  </button></td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      
+        <div class=\\"c-sf-help\\">
+          <div class=\\"help\\">
+            use <strong>plenty</strong> of these
+          </div>
+        </div>
+      </div>"
+`;
+
+exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError shows non-block errors 1`] = `
+"<div class=\\"typed-table-block \\"><p class=\\"help-block help-critical\\">This is just generally wrong</p>
+        <input type=\\"hidden\\" name=\\"mytable-column-count\\" data-column-count=\\"\\" value=\\"2\\">
+        <input type=\\"hidden\\" name=\\"mytable-row-count\\" data-row-count=\\"\\" value=\\"2\\">
+        <div data-deleted-fields=\\"\\"><input type=\\"hidden\\" name=\\"mytable-column-0-deleted\\" value=\\"\\"><input type=\\"hidden\\" name=\\"mytable-column-1-deleted\\" value=\\"\\"><input type=\\"hidden\\" name=\\"mytable-row-0-deleted\\" value=\\"\\"><input type=\\"hidden\\" name=\\"mytable-row-1-deleted\\" value=\\"\\"></div>
+        <div class=\\"typed-table-block__wrapper\\">
+          <table>
+            <thead>
+              <tr><th></th><th><input type=\\"hidden\\" name=\\"mytable-column-0-type\\" value=\\"test_block_a\\"><input type=\\"hidden\\" name=\\"mytable-column-0-order\\" value=\\"0\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace prepend-column\\" aria-label=\\"Insert column\\" title=\\"Insert column\\">
+        <svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
+      </button><input type=\\"text\\" name=\\"mytable-column-0-heading\\" class=\\"column-heading\\" placeholder=\\"Column heading\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace no delete-column\\" aria-label=\\"Delete column\\" title=\\"Delete column\\">
+        <svg class=\\"icon icon-bin icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-bin\\"></use></svg>
+      </button></th><th><input type=\\"hidden\\" name=\\"mytable-column-1-type\\" value=\\"test_block_b\\"><input type=\\"hidden\\" name=\\"mytable-column-1-order\\" value=\\"1\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace prepend-column\\" aria-label=\\"Insert column\\" title=\\"Insert column\\">
+        <svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
+      </button><input type=\\"text\\" name=\\"mytable-column-1-heading\\" class=\\"column-heading\\" placeholder=\\"Column heading\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace no delete-column\\" aria-label=\\"Delete column\\" title=\\"Delete column\\">
+        <svg class=\\"icon icon-bin icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-bin\\"></use></svg>
+      </button></th><th class=\\"control-cell\\">
+                  <button type=\\"button\\" class=\\"button button-small button-secondary append-column button--icon text-replace white\\" data-append-column=\\"\\" aria-label=\\"Add column\\" title=\\"Add column\\"><svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg></button>
+                </th></tr>
+            </thead>
+            <tbody><tr><td class=\\"control-cell\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace prepend-row\\" aria-label=\\"Insert row\\" title=\\"Insert row\\">
+        <svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
+      </button></td><td><div class=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
+        <div class=\\"w-field w-field--char_field w-field--text_input\\" data-field=\\"\\">
+          <div class=\\"w-field__errors\\" id=\\"mytable-cell-0-0-errors\\" data-field-errors=\\"\\">
+            <svg class=\\"icon icon-warning w-field__errors-icon\\" aria-hidden=\\"true\\" hidden=\\"\\"><use href=\\"#icon-warning\\"></use></svg>
+          </div>
+          <div class=\\"w-field__input\\" data-field-input=\\"\\">
+            <p name=\\"mytable-cell-0-0\\" id=\\"mytable-cell-0-0\\">Block A widget</p>
+          </div>
+          <div id=\\"mytable-cell-0-0-helptext\\" data-field-help=\\"\\"></div>
+        </div>
+      </div></td><td><div class=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
+        <div class=\\"w-field w-field--char_field w-field--admin_auto_height_text_input\\" data-field=\\"\\">
+          <div class=\\"w-field__errors\\" id=\\"mytable-cell-0-1-errors\\" data-field-errors=\\"\\">
+            <svg class=\\"icon icon-warning w-field__errors-icon\\" aria-hidden=\\"true\\" hidden=\\"\\"><use href=\\"#icon-warning\\"></use></svg>
+          </div>
+          <div class=\\"w-field__input\\" data-field-input=\\"\\">
+            <p name=\\"mytable-cell-0-1\\" id=\\"mytable-cell-0-1\\">Block B widget</p>
+          </div>
+          <div id=\\"mytable-cell-0-1-helptext\\" data-field-help=\\"\\"></div>
+        </div>
+      </div></td><td class=\\"control-cell\\"><input type=\\"hidden\\" name=\\"mytable-row-0-order\\" value=\\"0\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace no delete-row\\" aria-label=\\"Delete row\\" title=\\"Delete row\\">
+        <svg class=\\"icon icon-bin icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-bin\\"></use></svg>
+      </button></td></tr><tr><td class=\\"control-cell\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace prepend-row\\" aria-label=\\"Insert row\\" title=\\"Insert row\\">
+        <svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
+      </button></td><td><div class=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
+        <div class=\\"w-field w-field--char_field w-field--text_input\\" data-field=\\"\\">
+          <div class=\\"w-field__errors\\" id=\\"mytable-cell-1-0-errors\\" data-field-errors=\\"\\">
+            <svg class=\\"icon icon-warning w-field__errors-icon\\" aria-hidden=\\"true\\" hidden=\\"\\"><use href=\\"#icon-warning\\"></use></svg>
+          </div>
+          <div class=\\"w-field__input\\" data-field-input=\\"\\">
+            <p name=\\"mytable-cell-1-0\\" id=\\"mytable-cell-1-0\\">Block A widget</p>
+          </div>
+          <div id=\\"mytable-cell-1-0-helptext\\" data-field-help=\\"\\"></div>
+        </div>
+      </div></td><td><div class=\\"w-field__wrapper\\" data-field-wrapper=\\"\\">
+        <div class=\\"w-field w-field--char_field w-field--admin_auto_height_text_input\\" data-field=\\"\\">
+          <div class=\\"w-field__errors\\" id=\\"mytable-cell-1-1-errors\\" data-field-errors=\\"\\">
+            <svg class=\\"icon icon-warning w-field__errors-icon\\" aria-hidden=\\"true\\" hidden=\\"\\"><use href=\\"#icon-warning\\"></use></svg>
+          </div>
+          <div class=\\"w-field__input\\" data-field-input=\\"\\">
+            <p name=\\"mytable-cell-1-1\\" id=\\"mytable-cell-1-1\\">Block B widget</p>
+          </div>
+          <div id=\\"mytable-cell-1-1-helptext\\" data-field-help=\\"\\"></div>
+        </div>
+      </div></td><td class=\\"control-cell\\"><input type=\\"hidden\\" name=\\"mytable-row-1-order\\" value=\\"1\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace no delete-row\\" aria-label=\\"Delete row\\" title=\\"Delete row\\">
+        <svg class=\\"icon icon-bin icon\\" aria-hidden=\\"true\\"><use href=\\"#icon-bin\\"></use></svg>
+      </button></td></tr></tbody>
+            <tfoot>
+              <tr>
+                <td class=\\"control-cell\\">
+                  <button type=\\"button\\" class=\\"button button-small button-secondary button--icon text-replace prepend-row\\" data-add-row=\\"\\" aria-label=\\"Add row\\" title=\\"Add row\\" style=\\"\\">
+                    <svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\">
+                      <use href=\\"#icon-plus\\"></use>
+                    </svg>
+                  </button></td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      
+        <div class=\\"c-sf-help\\">
+          <div class=\\"help\\">
+            use <strong>plenty</strong> of these
+          </div>
+        </div>
+      </div>"
+`;

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
@@ -3,6 +3,10 @@
 
 import { escapeHtml as h } from '../../../utils/text';
 import { range } from '../../../utils/range';
+import {
+  addErrorMessages,
+  removeErrorMessages,
+} from '../../../includes/streamFieldErrors';
 
 export class TypedTableBlock {
   constructor(blockDef, placeholder, prefix, initialState, initialError) {
@@ -458,19 +462,10 @@ export class TypedTableBlock {
 
     // Non block errors
     const container = this.container[0];
-    container
-      .querySelectorAll(':scope > .help-block.help-critical')
-      .forEach((element) => element.remove());
+    removeErrorMessages(container);
 
     if (error.messages) {
-      // Add a help block for each error raised
-      error.messages.forEach((message) => {
-        const errorElement = document.createElement('p');
-        errorElement.classList.add('help-block');
-        errorElement.classList.add('help-critical');
-        errorElement.innerHTML = h(message);
-        container.insertBefore(errorElement, container.childNodes[0]);
-      });
+      addErrorMessages(container, error.messages);
     }
 
     if (error.blockErrors) {

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
@@ -84,6 +84,7 @@ export class TypedTableBlock {
       </div>
     `);
     $(placeholder).replaceWith(dom);
+    this.container = dom;
     this.thead = dom.find('table > thead').get(0);
     this.tbody = dom.find('table > tbody').get(0);
 
@@ -452,15 +453,30 @@ export class TypedTableBlock {
     }
   }
 
-  setError(errorList) {
-    if (errorList.length !== 1) {
-      return;
+  setError(error) {
+    if (!error) return;
+
+    // Non block errors
+    const container = this.container[0];
+    container
+      .querySelectorAll(':scope > .help-block.help-critical')
+      .forEach((element) => element.remove());
+
+    if (error.messages) {
+      // Add a help block for each error raised
+      error.messages.forEach((message) => {
+        const errorElement = document.createElement('p');
+        errorElement.classList.add('help-block');
+        errorElement.classList.add('help-critical');
+        errorElement.innerHTML = h(message);
+        container.insertBefore(errorElement, container.childNodes[0]);
+      });
     }
-    const error = errorList[0];
-    if (error.cellErrors) {
-      for (const [rowIndex, rowErrors] of Object.entries(error.cellErrors)) {
+
+    if (error.blockErrors) {
+      for (const [rowIndex, rowErrors] of Object.entries(error.blockErrors)) {
         for (const [colIndex, cellError] of Object.entries(rowErrors)) {
-          this.rows[rowIndex].blocks[colIndex].setError([cellError]);
+          this.rows[rowIndex].blocks[colIndex].setError(cellError);
         }
       }
     }

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
@@ -584,13 +584,3 @@ window.telepath.register(
   'wagtail.contrib.typed_table_block.blocks.TypedTableBlock',
   TypedTableBlockDefinition,
 );
-
-export class TypedTableBlockValidationError {
-  constructor(cellErrors) {
-    this.cellErrors = cellErrors;
-  }
-}
-window.telepath.register(
-  'wagtail.contrib.typed_table_block.TypedTableBlockValidationError',
-  TypedTableBlockValidationError,
-);

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
@@ -191,6 +191,24 @@ describe('wagtail.contrib.typed_table_block.blocks.TypedTableBlock', () => {
     expect(boundBlock.rows.length).toBe(2);
     expect(document.getElementsByName('mytable-row-count')[0].value).toBe('3');
   });
+
+  test('setError passes error messages to children', () => {
+    boundBlock.setError({
+      blockErrors: {
+        0: {
+          1: { messages: ['This is not enough cheese'] },
+        },
+      },
+    });
+    expect(document.body.innerHTML).toMatchSnapshot();
+  });
+
+  test('setError shows non-block errors', () => {
+    boundBlock.setError({
+      messages: ['This is just generally wrong'],
+    });
+    expect(document.body.innerHTML).toMatchSnapshot();
+  });
 });
 
 describe('wagtail.contrib.typed_table_block.blocks.TypedTableBlock in StreamBlock', () => {

--- a/client/src/includes/streamFieldErrors.js
+++ b/client/src/includes/streamFieldErrors.js
@@ -1,0 +1,19 @@
+import { escapeHtml as h } from '../utils/text';
+
+const removeErrorMessages = (container) => {
+  container
+    .querySelectorAll(':scope > .help-block.help-critical')
+    .forEach((element) => element.remove());
+};
+
+const addErrorMessages = (container, messages) => {
+  messages.forEach((message) => {
+    const errorElement = document.createElement('p');
+    errorElement.classList.add('help-block');
+    errorElement.classList.add('help-critical');
+    errorElement.innerHTML = h(message);
+    container.insertBefore(errorElement, container.childNodes[0]);
+  });
+};
+
+export { removeErrorMessages, addErrorMessages };

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -124,3 +124,8 @@ Stimulus [targets](https://stimulus.hotwired.dev/reference/targets) and [actions
 * `<button ... data-action="w-progress#activate focus->w-progress#activate" ...>` - any event can be used to trigger the in progress behaviour
 * `<button ... data-action="w-progress#activate:once" ...>` - only trigger the progress behaviour once
 * `<button ... data-action="readystatechange@document->w-progress#activate:once" data-w-progress-duration-value="5000" disabled ...>` - disabled on load (once JS starts) and becomes enabled after 5s duration
+
+
+### Client-side `BlockValidationError` classes removed
+
+The client-side handling of StreamField validation errors has been updated. The JavaScript classes `StreamBlockValidationError`, `ListBlockValidationError`, `StructBlockValidationError` and `TypedTableBlockValidationError` have been removed, and the corresponding Python classes can no longer be serialised using Telepath. Instead, the `setError` methods on client-side block objects now accept a plain JSON representation of the error, obtained from the `as_json_data` method on the Python class. Custom JavaScript code that works with these objects must be updated accordingly.

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -535,13 +535,15 @@ class BlockWidget(forms.Widget):
         value_json = json.dumps(self.block_def.get_form_state(value))
 
         if errors:
-            errors_json = json.dumps(self.js_context.pack(errors.as_data()))
+            # errors is expected to be an ErrorList consisting of a single validation error
+            error = errors.as_data()[0]
+            error_json = json.dumps(get_error_json_data(error))
         else:
-            errors_json = "[]"
+            error_json = "null"
 
         return format_html(
             """
-                <div id="{id}" data-block="{block_json}" data-value="{value_json}" data-errors="{errors_json}"></div>
+                <div id="{id}" data-block="{block_json}" data-value="{value_json}" data-error="{error_json}"></div>
                 <script>
                     initBlockWidget('{id}');
                 </script>
@@ -549,7 +551,7 @@ class BlockWidget(forms.Widget):
             id=name,
             block_json=self.block_json,
             value_json=value_json,
-            errors_json=errors_json,
+            error_json=error_json,
         )
 
     def render(self, name, value, attrs=None, renderer=None):

--- a/wagtail/blocks/list_block.py
+++ b/wagtail/blocks/list_block.py
@@ -47,30 +47,6 @@ class ListBlockValidationError(ValidationError):
         return result
 
 
-class ListBlockValidationErrorAdapter(Adapter):
-    js_constructor = "wagtail.blocks.ListBlockValidationError"
-
-    def js_args(self, error):
-        return [
-            [
-                elist.as_data() if elist is not None else elist
-                for elist in error.block_errors
-            ],
-            error.non_block_errors.as_data(),
-        ]
-
-    @cached_property
-    def media(self):
-        return forms.Media(
-            js=[
-                versioned_static("wagtailadmin/js/telepath/blocks.js"),
-            ]
-        )
-
-
-register(ListBlockValidationErrorAdapter(), ListBlockValidationError)
-
-
 class ListValue(MutableSequence):
     """
     The native data type used by ListBlock. Behaves as a list of values, but also provides

--- a/wagtail/blocks/list_block.py
+++ b/wagtail/blocks/list_block.py
@@ -11,7 +11,13 @@ from django.utils.translation import gettext as _
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.telepath import Adapter, register
 
-from .base import Block, BoundBlock, get_help_icon
+from .base import (
+    Block,
+    BoundBlock,
+    get_error_json_data,
+    get_error_list_json_data,
+    get_help_icon,
+)
 
 __all__ = ["ListBlock", "ListBlockValidationError"]
 
@@ -27,6 +33,18 @@ class ListBlockValidationError(ValidationError):
         if non_block_errors:
             params["non_block_errors"] = non_block_errors
         super().__init__("Validation error in ListBlock", params=params)
+
+    def as_json_data(self):
+        result = {}
+        if self.non_block_errors:
+            result["messages"] = get_error_list_json_data(self.non_block_errors)
+        if self.block_errors:
+            result["blockErrors"] = [
+                get_error_json_data(error_list.as_data()[0]) if error_list else None
+                for error_list in self.block_errors
+            ]
+
+        return result
 
 
 class ListBlockValidationErrorAdapter(Adapter):

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -54,30 +54,6 @@ class StreamBlockValidationError(ValidationError):
         return result
 
 
-class StreamBlockValidationErrorAdapter(Adapter):
-    js_constructor = "wagtail.blocks.StreamBlockValidationError"
-
-    def js_args(self, error):
-        return [
-            error.non_block_errors.as_data(),
-            {
-                block_id: child_errors.as_data()
-                for block_id, child_errors in error.block_errors.items()
-            },
-        ]
-
-    @cached_property
-    def media(self):
-        return forms.Media(
-            js=[
-                versioned_static("wagtailadmin/js/telepath/blocks.js"),
-            ]
-        )
-
-
-register(StreamBlockValidationErrorAdapter(), StreamBlockValidationError)
-
-
 class BaseStreamBlock(Block):
     def __init__(self, local_blocks=None, **kwargs):
         self._constructor_kwargs = kwargs

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -13,7 +13,14 @@ from django.utils.translation import gettext as _
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.telepath import Adapter, register
 
-from .base import Block, BoundBlock, DeclarativeSubBlocksMetaclass, get_help_icon
+from .base import (
+    Block,
+    BoundBlock,
+    DeclarativeSubBlocksMetaclass,
+    get_error_json_data,
+    get_error_list_json_data,
+    get_help_icon,
+)
 
 __all__ = [
     "BaseStreamBlock",
@@ -34,6 +41,17 @@ class StreamBlockValidationError(ValidationError):
         if non_block_errors:
             params[NON_FIELD_ERRORS] = non_block_errors
         super().__init__("Validation error in StreamBlock", params=params)
+
+    def as_json_data(self):
+        result = {}
+        if self.non_block_errors:
+            result["messages"] = get_error_list_json_data(self.non_block_errors)
+        if self.block_errors:
+            result["blockErrors"] = {
+                k: get_error_json_data(error_list.as_data()[0])
+                for (k, error_list) in self.block_errors.items()
+            }
+        return result
 
 
 class StreamBlockValidationErrorAdapter(Adapter):

--- a/wagtail/blocks/struct_block.py
+++ b/wagtail/blocks/struct_block.py
@@ -11,7 +11,14 @@ from django.utils.safestring import mark_safe
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.telepath import Adapter, register
 
-from .base import Block, BoundBlock, DeclarativeSubBlocksMetaclass, get_help_icon
+from .base import (
+    Block,
+    BoundBlock,
+    DeclarativeSubBlocksMetaclass,
+    get_error_json_data,
+    get_error_list_json_data,
+    get_help_icon,
+)
 
 __all__ = ["BaseStructBlock", "StructBlock", "StructValue"]
 
@@ -27,6 +34,17 @@ class StructBlockValidationError(ValidationError):
         if non_block_errors:
             params[NON_FIELD_ERRORS] = non_block_errors
         super().__init__("Validation error in StructBlock", params=params)
+
+    def as_json_data(self):
+        result = {}
+        if self.non_block_errors:
+            result["messages"] = get_error_list_json_data(self.non_block_errors)
+        if self.block_errors:
+            result["blockErrors"] = {
+                k: get_error_json_data(error_list.as_data()[0])
+                for (k, error_list) in self.block_errors.items()
+            }
+        return result
 
 
 class StructBlockValidationErrorAdapter(Adapter):

--- a/wagtail/blocks/struct_block.py
+++ b/wagtail/blocks/struct_block.py
@@ -47,37 +47,6 @@ class StructBlockValidationError(ValidationError):
         return result
 
 
-class StructBlockValidationErrorAdapter(Adapter):
-    js_constructor = "wagtail.blocks.StructBlockValidationError"
-
-    def js_args(self, error):
-        if error.non_block_errors:
-            non_block_errors = error.non_block_errors.as_data()
-        else:
-            non_block_errors = None
-
-        if error.block_errors:
-            block_errors = {
-                name: error_list.as_data()
-                for name, error_list in error.block_errors.items()
-            }
-        else:
-            block_errors = None
-
-        return [non_block_errors, block_errors]
-
-    @cached_property
-    def media(self):
-        return forms.Media(
-            js=[
-                versioned_static("wagtailadmin/js/telepath/blocks.js"),
-            ]
-        )
-
-
-register(StructBlockValidationErrorAdapter(), StructBlockValidationError)
-
-
 class StructValue(collections.OrderedDict):
     """A class that generates a StructBlock value from provided sub-blocks"""
 

--- a/wagtail/contrib/typed_table_block/blocks.py
+++ b/wagtail/contrib/typed_table_block/blocks.py
@@ -43,35 +43,6 @@ class TypedTableBlockValidationError(ValidationError):
         return result
 
 
-class TypedTableBlockValidationErrorAdapter(Adapter):
-    js_constructor = "wagtail.contrib.typed_table_block.TypedTableBlockValidationError"
-
-    def js_args(self, error):
-        if error.cell_errors is None:
-            return [None]
-        else:
-            return [
-                {
-                    row_index: {
-                        col_index: cell_error
-                        for col_index, cell_error in row_errors.items()
-                    }
-                    for row_index, row_errors in error.cell_errors.items()
-                }
-            ]
-
-    @cached_property
-    def media(self):
-        return forms.Media(
-            js=[
-                versioned_static("typed_table_block/js/typed_table_block.js"),
-            ]
-        )
-
-
-register(TypedTableBlockValidationErrorAdapter(), TypedTableBlockValidationError)
-
-
 class TypedTable:
     template = "typed_table_block/typed_table_block.html"
 

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -17,10 +17,11 @@ from django.utils.safestring import SafeData, mark_safe
 from django.utils.translation import gettext_lazy as _
 
 from wagtail import blocks
+from wagtail.blocks.base import get_error_json_data
 from wagtail.blocks.field_block import FieldBlockAdapter
-from wagtail.blocks.list_block import ListBlockAdapter
+from wagtail.blocks.list_block import ListBlockAdapter, ListBlockValidationError
 from wagtail.blocks.static_block import StaticBlockAdapter
-from wagtail.blocks.stream_block import StreamBlockAdapter
+from wagtail.blocks.stream_block import StreamBlockAdapter, StreamBlockValidationError
 from wagtail.blocks.struct_block import StructBlockAdapter, StructBlockValidationError
 from wagtail.models import Page
 from wagtail.rich_text import RichText
@@ -5198,3 +5199,170 @@ class TestOverriddenGetTemplateBlockTag(TestCase):
         )
         template = block.get_template()
         self.assertEqual(template, block.my_new_template)
+
+
+class TestValidationErrorAsJsonData(TestCase):
+    def test_plain_validation_error(self):
+        error = ValidationError("everything is broken")
+        self.assertEqual(
+            get_error_json_data(error), {"messages": ["everything is broken"]}
+        )
+
+    def test_validation_error_with_multiple_messages(self):
+        error = ValidationError(
+            [
+                ValidationError("everything is broken"),
+                ValidationError("even more broken than before"),
+            ]
+        )
+        self.assertEqual(
+            get_error_json_data(error),
+            {"messages": ["everything is broken", "even more broken than before"]},
+        )
+
+    def test_structblock_validation_error(self):
+        error = StructBlockValidationError(
+            block_errors={
+                "name": ErrorList(
+                    [
+                        ValidationError("This field is required."),
+                    ]
+                )
+            },
+            non_block_errors=ErrorList(
+                [ValidationError("Either email or telephone number must be specified.")]
+            ),
+        )
+        self.assertEqual(
+            get_error_json_data(error),
+            {
+                "blockErrors": {
+                    "name": {"messages": ["This field is required."]},
+                },
+                "messages": [
+                    "Either email or telephone number must be specified.",
+                ],
+            },
+        )
+
+    def test_streamblock_validation_error(self):
+        error = StreamBlockValidationError(
+            block_errors={
+                2: ErrorList(
+                    [
+                        StructBlockValidationError(
+                            non_block_errors=ErrorList(
+                                [
+                                    ValidationError(
+                                        "Either email or telephone number must be specified."
+                                    )
+                                ]
+                            )
+                        )
+                    ]
+                ),
+                4: ErrorList([ValidationError("This field is required.")]),
+                6: ErrorList(
+                    [
+                        StructBlockValidationError(
+                            block_errors={
+                                "name": ErrorList(
+                                    [ValidationError("This field is required.")]
+                                ),
+                            }
+                        )
+                    ]
+                ),
+            },
+            non_block_errors=ErrorList(
+                [
+                    ValidationError("The minimum number of items is 2"),
+                    ValidationError("The maximum number of items is 5"),
+                ]
+            ),
+        )
+        self.assertEqual(
+            get_error_json_data(error),
+            {
+                "blockErrors": {
+                    2: {
+                        "messages": [
+                            "Either email or telephone number must be specified."
+                        ]
+                    },
+                    4: {"messages": ["This field is required."]},
+                    6: {
+                        "blockErrors": {
+                            "name": {
+                                "messages": ["This field is required."],
+                            }
+                        }
+                    },
+                },
+                "messages": [
+                    "The minimum number of items is 2",
+                    "The maximum number of items is 5",
+                ],
+            },
+        )
+
+    def test_listblock_validation_error(self):
+        error = ListBlockValidationError(
+            block_errors=[
+                None,
+                ErrorList(
+                    [
+                        StructBlockValidationError(
+                            non_block_errors=ErrorList(
+                                [
+                                    ValidationError(
+                                        "Either email or telephone number must be specified."
+                                    )
+                                ]
+                            )
+                        )
+                    ]
+                ),
+                ErrorList(
+                    [
+                        StructBlockValidationError(
+                            block_errors={
+                                "name": ErrorList(
+                                    [ValidationError("This field is required.")]
+                                ),
+                            }
+                        )
+                    ]
+                ),
+            ],
+            non_block_errors=ErrorList(
+                [
+                    ValidationError("The minimum number of items is 2"),
+                    ValidationError("The maximum number of items is 5"),
+                ]
+            ),
+        )
+        self.assertEqual(
+            get_error_json_data(error),
+            {
+                "blockErrors": [
+                    None,
+                    {
+                        "messages": [
+                            "Either email or telephone number must be specified."
+                        ]
+                    },
+                    {
+                        "blockErrors": {
+                            "name": {
+                                "messages": ["This field is required."],
+                            }
+                        }
+                    },
+                ],
+                "messages": [
+                    "The minimum number of items is 2",
+                    "The maximum number of items is 5",
+                ],
+            },
+        )


### PR DESCRIPTION
Part of #7250
Incorporates #10108; fixes #5663 and #7997

This PR drops the telepath serialisation mechanism from our `*BlockValidationError` subclasses, in favour of a standardised JSON serialisation (performed by `wagtail.blocks.base.get_error_json_data`, delegating to the exception's `as_json_data` method where available) consisting of a dict with one or both of the keys:

* `messages` - a list of error messages to be rendered on the block as a whole (otherwise known as non-block errors within the `*BlockValidationError` classes)
* `blockErrors` - some structure, specific to the corresponding block type, that contains error objects (also following this structure) to be propagated to the child blocks

This standardised format means that it's no longer necessary for validation errors triggered on ListBlock / StreamBlock / StructBlock / TypedTableBlock to match their respective `*BlockValidationError` classes - a plain `ValidationError` is sufficient to set an error against the block as a whole.

The following setup can be used to test against Bakerydemo, based on the one in #10108 - add to bakerydemo/base/blocks.py:

```python
from wagtail.blocks import PageChooserBlock, URLBlock
from wagtail.contrib.typed_table_block.blocks import TypedTableBlock
from django.forms.utils import ValidationError


class LinkBlock(StructBlock):
    page = PageChooserBlock(required=False)
    url = URLBlock(required=False)

    def clean(self, value):
        result = super().clean(value)
        if not(result['page'] or result['url']):
            raise ValidationError("Either page or URL must be specified")
        return result


class MyTableBlock(TypedTableBlock):
    text = CharBlock()
    url = URLBlock()

    def clean(self, value):
        result = super().clean(value)
        if len(result.row_data) > 3:
            raise ValidationError("The maximum number of rows is 3.")


class BaseStreamBlock(StreamBlock):
    # ...
    link = LinkBlock()
    table = MyTableBlock()
```