### PR TITLE
Documentation: Adding return statement to process_form_submission

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -694,6 +694,7 @@ Contributors
 * Julian Bigler
 * Kenny Wolf
 * Himanshu Garg
+* Christopher Wardle
 
 Translators
 ===========

--- a/docs/reference/contrib/forms/customisation.md
+++ b/docs/reference/contrib/forms/customisation.md
@@ -93,7 +93,7 @@ class FormPage(AbstractEmailForm):
         return CustomFormSubmission
 
     def process_form_submission(self, form):
-        self.get_submission_class().objects.create(
+        return self.get_submission_class().objects.create(
             form_data=form.cleaned_data,
             page=self, user=form.user
         )

--- a/docs/reference/contrib/forms/customisation.md
+++ b/docs/reference/contrib/forms/customisation.md
@@ -160,7 +160,7 @@ class FormPage(AbstractEmailForm):
         return CustomFormSubmission
 
     def process_form_submission(self, form):
-        self.get_submission_class().objects.create(
+        return self.get_submission_class().objects.create(
             form_data=form.cleaned_data,
             page=self, user=form.user
         )
@@ -235,7 +235,7 @@ class FormPage(AbstractEmailForm):
         return CustomFormSubmission
 
     def process_form_submission(self, form):
-        self.get_submission_class().objects.create(
+        return self.get_submission_class().objects.create(
             form_data=form.cleaned_data,
             page=self, user=form.user
         )


### PR DESCRIPTION
Adding missing return statement to FormPage.process_form_submission in the "Custom form submission model" example of the [Form builder customization documentation page](https://docs.wagtail.org/en/stable/reference/contrib/forms/customisation.html#custom-form-submission-model).

This makes the custom submission available to FormPage.render_landing_page, among other methods, just like the original in wagtail.contrib.forms.models.FormMixin.

Since this change does not change any application code, no new tests were added (I hope that's ok for this kind of pull request).