### PR TITLE
Refactor ListBlockValidationError to use a dict for block_errors

### DIFF
--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -267,12 +267,9 @@ export class ListBlock extends BaseSequenceBlock {
     }
 
     if (error.blockErrors) {
-      // error.blockErrors = a list with the same length as the data,
-      // with nulls for items without errors
-      error.blockErrors.forEach((blockError, blockIndex) => {
-        if (blockError) {
-          this.children[blockIndex].setError(blockError);
-        }
+      // error.blockErrors = a dict of errors, keyed by block index
+      Object.entries(error.blockErrors).forEach(([index, blockError]) => {
+        this.children[index].setError(blockError);
       });
     }
   }

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -299,7 +299,7 @@ describe('telepath: wagtail.blocks.ListBlock', () => {
 
   test('setError passes error messages to children', () => {
     boundBlock.setError({
-      blockErrors: [null, { messages: ['Not as good as the first one'] }],
+      blockErrors: { 1: { messages: ['Not as good as the first one'] } },
     });
     expect(document.body.innerHTML).toMatchSnapshot();
   });

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -164,6 +164,8 @@ Stimulus [targets](https://stimulus.hotwired.dev/reference/targets) and [actions
 * `<button ... data-action="readystatechange@document->w-progress#activate:once" data-w-progress-duration-value="5000" disabled ...>` - disabled on load (once JS starts) and becomes enabled after 5s duration
 
 
-### Client-side `BlockValidationError` classes removed
+### Changes to StreamField `ValidationError` classes
 
 The client-side handling of StreamField validation errors has been updated. The JavaScript classes `StreamBlockValidationError`, `ListBlockValidationError`, `StructBlockValidationError` and `TypedTableBlockValidationError` have been removed, and the corresponding Python classes can no longer be serialised using Telepath. Instead, the `setError` methods on client-side block objects now accept a plain JSON representation of the error, obtained from the `as_json_data` method on the Python class. Custom JavaScript code that works with these objects must be updated accordingly.
+
+Additionally, the Python `ListBlockValidationError` class no longer provides a `params` dict with `block_errors` and `non_block_errors` items; these are now available as the attributes `block_errors` and `non_block_errors` on the exception itself.


### PR DESCRIPTION
Part of #7250. The internal and `as_json_data` representation of block errors in ListBlockValidationError is now a dict of ValidationError instances keyed by block index. This replaces the old format, of a list mapping to the ListBlock value where items are either None or an ErrorList.

The constructor has been revised to be as liberal as possible in what it accepts: `block_errors` can be passed in either the list or dict format (or None), and the list/dict elements can now be ValidationError instances, either unwrapped or wrapped as a single-item list or ErrorList.

This doesn't directly fix any existing issues, but makes the ListBlockValidationError API more developer-friendly for when we come to document it.

As part of this change, ListBlockValidationError no longer writes `block_errors` / `non_block_errors` to the `params` attribute. This wasn't used anywhere (except a couple of test assertions), and the Django docs indicate that `params` is [primarily for doing variable interpolation on the error message string](https://docs.djangoproject.com/en/4.1/ref/forms/validation/#raising-validationerror) - I think this was a hangover from ancient code from before we had dedicated ValidationError subclasses, and `params` was one of the few places we could stash data without `ErrorList` mangling it...