### PR TITLE
Fixing duplicate addition of StreamFields

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ Changelog
  * Fix: Fix dialog component's message to have rounded corners at the top side (Sam)
  * Fix: When multiple documents are uploaded and then subsequently updated, ensure that existing success messages are cleared correctly (Aman Pandey)
  * Fix: Prevent matches from unrelated models from leaking into SQLite FTS searches (Matt Westcott)
+ * Fix: Prevent duplicate addition of StreamField blocks with the new block picker (Deepam Priyadarshi)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp)
  * Docs: Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -698,6 +698,7 @@ Contributors
 * Jatin Kumar
 * Hans Kelson
 * Sam
+* Deepam Priyadarshi
 
 Translators
 ===========

--- a/docs/releases/4.2.1.md
+++ b/docs/releases/4.2.1.md
@@ -22,3 +22,4 @@ depth: 1
  * Fix timezone activation leaking into subsequent requests in `require_admin_access()` (Stefan Hammer)
  * Fix dialog component's message to have rounded corners at the top side (Sam)
  * Prevent matches from unrelated models from leaking into SQLite FTS searches (Matt Westcott)
+ * Prevent duplicate addition of StreamField blocks with the new block picker (Deepam Priyadarshi)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -49,6 +49,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Fix dialog component's message to have rounded corners at the top side (Sam)
  * When multiple documents are uploaded and then subsequently updated, ensure that existing success messages are cleared correctly (Aman Pandey)
  * Prevent matches from unrelated models from leaking into SQLite FTS searches (Matt Westcott)
+ * Prevent duplicate addition of StreamField blocks with the new block picker (Deepam Priyadarshi)
 
 ### Documentation
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->
Fixes #10057 

This issue was related to Downshift ComboBox used to create combobox for adding stream fields.
2 of the weird behaviors were already discussed in the issue, a third was discovered while debugging. Before moving to the reasons of such behaviors, kindly go through this extract from [Downshift useCombobox doc](https://github.com/downshift-js/downshift/tree/master/src/hooks/useCombobox#onselecteditemchange)

![image](https://user-images.githubusercontent.com/65447610/221111163-9afd0e28-2fd4-4413-871d-80599ab5c473.png)

Wrt. our code, we have `onSelect` as a parameter to `ComoBox` functional component. Upon rendering of `ComboBox`, `onSelectBlock(change)` function of StreamChild class  is passed to `onSelect`, so basically we can say `onSelect` is an alias to onSelectBlock(change) of StreamChild class. Now this `onSelect` function is assigned to `onSelectedItemChange` prop of `useCombo` hook. 

<details>
  <summary>Click to toggle view</summary>

https://github.com/wagtail/wagtail/blob/5f6f640d0d8366a5cb05f8bd180883e7fafb4294/client/src/components/ComboBox/ComboBox.tsx#L105-L124
</details>

From the DownShift documentation we find that `onSelectedItemChange` is called each time the selected item is changed and selection of item happens from 3 events :- 
### Selection triggers <span id="place1"></span>
1. Clicking on the the item.
2. Pressing Enter Key while item is highlighted.
3. Blurring the menu while an item is highlighted

# Reasons for duplication of StreamFields
## Case 1
<details>
  <summary>Click to toggle view</summary>

![](https://user-images.githubusercontent.com/654645/218098159-44f2522b-5edd-458b-8703-a14ca2dee3a3.gif)

</details>

Discussed by @chosak. Here selection was triggered by clicking on the item which has an explicit eventlisterner for mouse down events as shown below. But this only overrides the default click event but not events like `onBlur`, `onKeyPress`, `onInputChange` etc. which triggers `onStateChange` and `onSelectedItemChange` hooks. So clicking on item make 2 calls to `onSelect`, first from the explicit eventhandler with custom object argument, and second from `onSelectedItemChange` with `changes` object as argument. Therefor 2 blocks are added.

<details>
  <summary>Click to toggle view</summary>

https://github.com/wagtail/wagtail/blob/5f6f640d0d8366a5cb05f8bd180883e7fafb4294/client/src/components/ComboBox/ComboBox.tsx#L203-L219

</details>

## Case 2
<details id="lk">
  <summary>Click to toggle view</summary>

![](https://user-images.githubusercontent.com/65447610/221127285-9bf1165f-41fc-4852-be37-125ac4026ea9.gif)
45/218098159-44f2522b-5edd-458b-8703-a14ca2dee3a3.gif)

</details>

Discussed by @wojcikmat. Same reason as Case1. Here the 3rd case of [Selection Triggers](#place1) applies. Here on clicking on the input makes the text box active and then clicking on the item triggers `onBlur` event for the text box. The first inserted block is due to the explicit `onSelect` function call and second is due to implicit call `onStateChange` and `onSelectedItemChange` hooks. **Note: As per the 3rd case of [Selection Triggers](#place1), if look closely at above gif, as the user moves the cursor over item it gets highlighted. Next click action is performed. This triggers click event for the item which is handled by [this](https://github.com/thibaudcolas/wagtail/blob/a7df17a50707413655f22ea62af170d8fb49b75c/client/src/components/ComboBox/ComboBox.tsx#L203-L209) and also blur event for input box which is internally handled by downshift.**

## Case 3
<details>
  <summary>Click to toggle view</summary>

![](https://user-images.githubusercontent.com/65447610/221174157-baad3cc6-8a6a-4577-ab61-ddf0f61fe272.mp4)

</details>

**Description**:- Found during debugging. Here after typing in the text box(something similar to available options in the list) and then changing the focus of the browser Window adds the highlighted item in the list without clicking on it. Here also 3rd case of [Selection Triggers](#place1) applies.


---


-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: All listed in [^2] except Mobile Safari-iOS Phone and Safari-macOS
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

---
**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
