### PR TITLE
Add GitHub FUNDING with custom link for Wagtail sponsorship

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ['https://wagtail.org/sponsor/']


### PR DESCRIPTION
- While Wagtail is funded primarily through Torchbox (thanks!), it might be good to call out that there is a way for companies to contribute financially towards direct features or through a support to Torchbox.
- After doing some research into sponsoring for my work, I found that the Sponsor button on a GitHub repo is a great way to make this known and actually reflects that the project is mature as they have a plan for sustainability. It would be great to see this on Wagtail's GitHub a bit more pronounced.
- Further enabling may be needed in the Repo settings - https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository