### PR TITLE
Adopt core shared header for Snippet type listing header

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -67,7 +67,7 @@ Changelog
  * Maintenance: Migrate slug field behaviour to a Stimulus controller and create new `SlugInput` widget (Loveth Omokaro)
  * Maintenance: Refactor `status` HTML usage to shared template tag (Aman Pandey, LB (Ben) Johnston, Himanshu Garg)
  * Maintenance: Add curlylint and update djhtml, semgrep versions in pre-commit config (Himanshu Garg)
- * Maintenance: Use shared header template for `ModelAdmin` header (Aman Pandey)
+ * Maintenance: Use shared header template for `ModelAdmin` and Snippets type index header (Aman Pandey)
  * Maintenance: Move models and forms for `wagtailsearch.Query` to `wagtail.contrib.search_promotions` (Karl Hobley)
  * Maintenance: Migrate `initErrorDetection` (tabs error counts) to a Stimulus Controller `w-count` (Aman Pandey)
  * Maintenance: Migrate `window.addMessage` behaviour to a global event listener & Stimulus Controller approach with `w-messages` (Aman Pandey)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -88,7 +88,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Migrate slug field behaviour to a Stimulus controller and create new `SlugInput` widget (Loveth Omokaro)
  * Refactor `status` HTML usage to shared template tag (Aman Pandey, LB (Ben) Johnston, Himanshu Garg)
  * Add curlylint and update djhtml, semgrep versions in pre-commit config (Himanshu Garg)
- * Use shared header template for `ModelAdmin` header (Aman Pandey)
+ * Use shared header template for `ModelAdmin` and Snippets type index header (Aman Pandey)
  * Move models and forms for `wagtailsearch.Query` to `wagtail.contrib.search_promotions` (Karl Hobley)
  * Migrate `initErrorDetection` (tabs error counts) to a Stimulus Controller `w-count` (Aman Pandey)
  * Migrate `window.addMessage` behaviour to a global event listener & Stimulus Controller approach with `w-messages` (Aman Pandey)

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -16,45 +16,11 @@
 {% endblock %}
 
 {% block content %}
-    {% include 'wagtailsnippets/snippets/headers/list_header.html' %}
-
-    <header class="w-header">
-        <div class="row">
-            <div class="left">
-                <div class="col">
-                    <h1 class="w-header__title">
-                        {% icon classname="w-header__glyph" name="snippet" %} {{ model_opts.verbose_name_plural|capfirst }}
-                    </h1>
-                </div>
-                {% if is_searchable and search_url %}
-                    <form class="col search-form" action="{% url search_url %}" method="get" novalidate>
-                        {% for field in search_form %}
-                            {% include "wagtailadmin/shared/field.html" with field=field classname="w-mb-0" sr_only_label=True icon="search" %}
-                        {% endfor %}
-                        <div class="submit visuallyhidden"><input type="submit" value="Search" class="button" /></div>
-                    </form>
-                {% endif %}
-                {% if locales %}
-                    <div class="col">
-
-                    </div>
-                {% endif %}
-            </div>
-            <div class="right col">
-                <form>
-                    {% if locale %}
-                        {% include 'wagtailadmin/shared/locale_selector.html' with class='c-dropdown--large' %}
-                    {% endif %}
-                    {% if can_add_snippet %}
-                        <a href="{% url view.add_url_name %}{% if locale %}?locale={{ locale.language_code }}{% endif %}" class="button bicolor button--icon">
-                            {% icon name="plus" wrapped=1 %}
-                            {% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}</a>
-                        {# TODO: figure out a way of saying "Add a/an [foo]" #}
-                    {% endif %}
-                </form>
-            </div>
-        </div>
-    </header>
+    {% fragment as breadcrumb %}{% include 'wagtailsnippets/snippets/headers/list_header.html' %}{% endfragment %}
+    {% fragment as extra_actions_locale %}{% if locale %}{% include 'wagtailadmin/shared/locale_selector.html' with class='c-dropdown--large' %}{% endif %}{% endfragment %}
+    {% fragment as action_url_add_snippet %}{% if can_add_snippet %}{% url view.add_url_name %}{% if locale %}?locale={{ locale.language_code }}{% endif %}{% endif %}{% endfragment %}
+    {% fragment as action_text_snippet %}{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}{% endfragment %}
+    {% include 'wagtailadmin/shared/header.html' with breadcrumb=breadcrumb title=model_opts.verbose_name_plural|capfirst icon="snippet" search_url=search_url  extra_actions=extra_actions_locale action_url=action_url_add_snippet action_icon="plus" action_text=action_text_snippet %}
 
     <div class="nice-padding{% if filters %} filterable{% endif %}">
         <div id="snippet-results" class="snippets">


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/9227
adoptions of `wagtailadmin/shared/header.html` to snippets.
done directly using the `wagtailadmin/shared/header.html` without inheriting it 
as https://github.com/wagtail/wagtail/pull/9993 has already set up the most of it.

_Please check the following:_
-   [x] Do the tests still pass?[^1]
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]


**Please describe additional details for testing this change**.
### AFTER CHANGES:

![image](https://user-images.githubusercontent.com/74553951/221783644-d77a7403-17f3-4718-b090-42c348c6c2cf.png)
![image](https://user-images.githubusercontent.com/74553951/221783702-b9298f68-8620-4aea-850c-6aad4acc8dd3.png)
![image](https://user-images.githubusercontent.com/74553951/221783764-d6532014-51ee-4a9f-9a66-14af07b7413f.png)
![image](https://user-images.githubusercontent.com/74553951/221783909-9a87f8d4-7761-494b-a4ad-cb6b489e921c.png)

