### PR TITLE
Use checkbox input for lock/unlock toggle and make lock message level more friendly

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Ensure selected collection is kept when navigating from documents or images listings to add multiple views & upon upload (Aman Pandey, Bojan Mihelac)
  * Keep applied filters when downloading form submissions (Suyash Srivastava)
  * Messages added dynamically via JavaScript now have an icon to be consistent with those supplied in the page's HTML (Aman Pandey)
+ * Switch lock/unlock side panel toggle to a switch, with more appropriate confirmation message status (Sage Abdullah)
  * Fix: Ensure `label_format` on StructBlock gracefully handles missing variables (Aadi jindal)
  * Fix: Adopt a no-JavaScript and more accessible solution for the 'Reset to default' switch to Gravatar when editing user profile (Loveth Omokaro)
  * Fix: Ensure `Site.get_site_root_paths` works on cache backends that do not preserve Python objects (Jaap Roes)

--- a/client/scss/components/_messages.scss
+++ b/client/scss/components/_messages.scss
@@ -60,6 +60,10 @@
     background-color: theme('colors.warning.100');
   }
 
+  .info {
+    background-color: theme('colors.info.100');
+  }
+
   .success {
     background-color: theme('colors.positive.100');
 

--- a/client/scss/components/forms/_switch.scss
+++ b/client/scss/components/forms/_switch.scss
@@ -89,8 +89,15 @@ $switch-border-radius: math.div(($switch-height + $switch-border * 2), 2);
     opacity: 0.3;
   }
 
-  [type='checkbox']:focus + &__toggle {
+  [type='checkbox']:focus-visible + &__toggle {
     outline: $color-focus-outline solid $switch-outline;
+  }
+
+  @supports not selector(:focus-visible) {
+    /* Fallback for browsers without :focus-visible support */
+    [type='checkbox']:focus + &__toggle {
+      outline: $color-focus-outline solid $switch-outline;
+    }
   }
 
   [type='checkbox'] {

--- a/client/scss/components/forms/_switch.scss
+++ b/client/scss/components/forms/_switch.scss
@@ -94,7 +94,6 @@ $switch-border-radius: math.div(($switch-height + $switch-border * 2), 2);
   }
 
   @supports not selector(:focus-visible) {
-    /* Fallback for browsers without :focus-visible support */
     [type='checkbox']:focus + &__toggle {
       outline: $color-focus-outline solid $switch-outline;
     }

--- a/client/src/controllers/ActionController.ts
+++ b/client/src/controllers/ActionController.ts
@@ -16,7 +16,9 @@ import { WAGTAIL_CONFIG } from '../config/wagtailConfig';
  *  Enable
  * </button>
  */
-export class ActionController extends Controller<HTMLButtonElement> {
+export class ActionController extends Controller<
+  HTMLButtonElement | HTMLInputElement
+> {
   static values = {
     continue: { type: Boolean, default: false },
     url: String,

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -27,6 +27,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Ensure selected collection is kept when navigating from documents or images listings to add multiple views & upon upload (Aman Pandey, Bojan Mihelac)
  * Keep applied filters when downloading form submissions (Suyash Srivastava)
  * Messages added dynamically via JavaScript now have an icon to be consistent with those supplied in the page's HTML (Aman Pandey)
+ * Switch lock/unlock side panel toggle to a switch, with more appropriate confirmation message status (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/shared/action_switch.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/action_switch.html
@@ -1,0 +1,22 @@
+{% load wagtailadmin_tags %}
+{% comment %}
+    This is a switch (checkbox) input that is hooked into the ActionController
+    to allow for a POST request to be made when the switch is toggled.
+
+    Variables this template accepts:
+
+    data_url - A URL for ActionController to use
+    checked - Whether the switch is checked (active) or not
+    label_text - The text that shows up beside the switch
+    sr_only_label - Make the label invisible for all but screen reader users
+    classname - Custom CSS classes for styling
+{% endcomment %}
+<label class="switch w-my-0 {{ classname }}">
+    {% if label_text %}
+        <span class="w-mr-1 {% if sr_only_label %}w-sr-only{% endif %}">{{ label_text }}</span>
+    {% endif %}
+    <input type="checkbox" {% if checked %}checked{% endif %} data-controller="w-action" data-action="click->w-action#post" data-w-action-url-value="{{ data_url }}">
+    <span class="switch__toggle">
+        {% icon name="tick" classname="switch__tick" %}
+    </span>
+</label>

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/locked.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/locked.html
@@ -28,12 +28,11 @@
 {% endblock %}
 
 {% block action %}
+    {% trans 'Lock' as lock_text %}
     {% if user_can_unlock %}
-        {% trans 'Unlock' as unlock_text %}
-        {% include 'wagtailadmin/shared/side_panels/includes/side_panel_button.html' with data_url=unlock_url text=unlock_text %}
+        {% include 'wagtailadmin/shared/action_switch.html' with data_url=unlock_url label_text=lock_text checked=True %}
     {% endif %}
     {% if user_can_lock %}
-        {% trans 'Lock' as lock_text %}
-        {% include 'wagtailadmin/shared/side_panels/includes/side_panel_button.html' with data_url=lock_url text=lock_text %}
+        {% include 'wagtailadmin/shared/action_switch.html' with data_url=lock_url label_text=lock_text checked=False %}
     {% endif %}
 {% endblock %}

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -637,10 +637,13 @@ class CreateEditViewOptionalFeaturesMixin:
                     _("Cancel scheduled publish"),
                 )
 
-            if self.locked_for_user:
-                messages.error(self.request, lock_message, extra_tags="lock")
-            else:
+            if (
+                not isinstance(self.lock, ScheduledForPublishLock)
+                and self.locked_for_user
+            ):
                 messages.warning(self.request, lock_message, extra_tags="lock")
+            else:
+                messages.info(self.request, lock_message, extra_tags="lock")
 
         return context
 

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -411,10 +411,13 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
                         _("Cancel scheduled publish"),
                     )
 
-                if self.locked_for_user:
-                    messages.error(self.request, lock_message, extra_tags="lock")
-                else:
+                if (
+                    not isinstance(self.lock, ScheduledForPublishLock)
+                    and self.locked_for_user
+                ):
                     messages.warning(self.request, lock_message, extra_tags="lock")
+                else:
+                    messages.info(self.request, lock_message, extra_tags="lock")
 
         self.form = self.form_class(
             instance=self.page,

--- a/wagtail/snippets/tests/test_locking.py
+++ b/wagtail/snippets/tests/test_locking.py
@@ -447,11 +447,18 @@ class TestEditLockedSnippet(BaseLockingTestCase):
                     f"Only you can make changes while the {self.model_name} is locked",
                 )
 
-                # Should show unlock buttons, one in the message and one in the side panel
+                # Should show unlock toggle in the side panel
+                self.assertTagInHTML(
+                    f'<input type="checkbox" checked data-action="click->w-action#post" data-controller="w-action" data-w-action-url-value="{unlock_url}">',
+                    html,
+                    count=1,
+                    allow_extra_attrs=True,
+                )
+                # Should show unlock button in the message
                 self.assertTagInHTML(
                     f'<button type="button" data-action="w-action#post" data-controller="w-action" data-w-action-url-value="{unlock_url}">Unlock</button>',
                     html,
-                    count=2,
+                    count=1,
                     allow_extra_attrs=True,
                 )
 
@@ -497,11 +504,18 @@ class TestEditLockedSnippet(BaseLockingTestCase):
             allow_extra_attrs=True,
         )
 
-        # Should show unlock buttons, one in the message and one in the side panel
+        # Should show unlock toggle in the side panel
+        self.assertTagInHTML(
+            f'<input type="checkbox" checked data-action="click->w-action#post" data-controller="w-action" data-w-action-url-value="{unlock_url}">',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+        # Should show unlock button in the message
         self.assertTagInHTML(
             f'<button type="button" data-action="w-action#post" data-controller="w-action" data-w-action-url-value="{unlock_url}">Unlock</button>',
             html,
-            count=2,
+            count=1,
             allow_extra_attrs=True,
         )
 
@@ -552,7 +566,14 @@ class TestEditLockedSnippet(BaseLockingTestCase):
             allow_extra_attrs=True,
         )
 
-        # Should not show unlock buttons
+        # Should not show unlock toggle in the side panel
+        self.assertTagInHTML(
+            f'<input type="checkbox" checked data-action="click->w-action#post" data-controller="w-action" data-w-action-url-value="{unlock_url}">',
+            html,
+            count=0,
+            allow_extra_attrs=True,
+        )
+        # Should not show unlock button in the message
         self.assertTagInHTML(
             f'<button type="button" data-action="w-action#post" data-controller="w-action" data-w-action-url-value="{unlock_url}">Unlock</button>',
             html,
@@ -603,7 +624,14 @@ class TestEditLockedSnippet(BaseLockingTestCase):
             allow_extra_attrs=True,
         )
 
-        # Should not show the lock button
+        # Should not show lock toggle in the side panel
+        self.assertTagInHTML(
+            f'<input type="checkbox" data-action="click->w-action#post" data-controller="w-action" data-w-action-url-value="{lock_url}">',
+            html,
+            count=0,
+            allow_extra_attrs=True,
+        )
+        # Should not show lock button in the message
         self.assertTagInHTML(
             f'<button type="button" data-action="w-action#post" data-controller="w-action" data-w-action-url-value="{lock_url}">Lock</button>',
             html,
@@ -648,9 +676,9 @@ class TestEditLockedSnippet(BaseLockingTestCase):
             allow_extra_attrs=True,
         )
 
-        # Should show the lock button
+        # Should show lock toggle in the side panel
         self.assertTagInHTML(
-            f'<button type="button" data-action="w-action#post" data-controller="w-action" data-w-action-url-value="{lock_url}">Lock</button>',
+            f'<input type="checkbox" data-action="click->w-action#post" data-controller="w-action" data-w-action-url-value="{lock_url}">',
             html,
             count=1,
             allow_extra_attrs=True,


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Follow up to #9946. See [Figma](https://www.figma.com/file/h67EsVXdWsfu38WGGxWfpi/Wagtail-CMS?node-id=10861%3A133304&t=eB2SttDD8H25QBtU-1) for more details.

How to test the toggle:

- Open the edit view for a page (or snippet that has LockableMixin enabled) and open the status side panel
- If the user has the permission, the "Lock" toggle should be shown as a switch component 
- The lock button in the status side panel should be replaced by the switch component using a checkbox input element
- Click on the toggle to lock and unlock the page/snippet, the UI should follow the designs


The changes to the message banner are not exactly as shown in the designs. If I'm not mistaken, when I discussed this with Nick, he wasn't sure what/when the current messages are shown, and that we should just use the messages we already have. The main thing we're concerned about here is the background colour: the red (error) message seems a bit "harsh" to the user, because the lock is not an error. He proposed that we should use the blue (info) colour if the user can still edit, and use the yellow (warning) otherwise. Basically, reducing the "severity" level of the message by one.

How to test the message banner:

- The message banner should use the blue (info) background if the page/snippet is locked but the lock does not apply for the user (e.g. the user is the one who locked it)
- If the lock applies for the user (e.g. sign in with a different user), then the yellow (warning) background should be used
- For other types of locks:
  - If a user submitted a page/snippet to a workflow and the user has no review access for the task, then the lock message should be shown with the warning background.
    - For reviewers, the designs show that there's a message shown, but we have never done this before. I feel like we should just leave this as-is, but if we want to add the message we can do that in a separate PR.
  - If the page/snippet has been scheduled for publishing (set schedule and click publish), the info background should be used, regardless whether the user can unschedule or not.

<img width="498" alt="image" src="https://user-images.githubusercontent.com/6379424/222107613-5bd856ca-9472-43c0-8ef6-7a5b5d99355d.png">

<img width="498" alt="image" src="https://user-images.githubusercontent.com/6379424/222107676-5cdb635e-bdaa-40ea-8ae8-dc7f8a2dc5d8.png">

<img width="521" alt="image" src="https://user-images.githubusercontent.com/6379424/222107720-f28bf5f7-56ad-4261-af7c-6cce3ac1f161.png">

<img width="737" alt="image" src="https://user-images.githubusercontent.com/6379424/222116596-85026846-4c01-4a64-a8fa-bee95aff979e.png">

<img width="521" alt="image" src="https://user-images.githubusercontent.com/6379424/222107914-04387670-97c0-4edf-a4ea-f2106f8fbdfb.png">


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
