### PR TITLE
Fixes #10177

### DIFF
--- a/client/scss/components/_dialog.scss
+++ b/client/scss/components/_dialog.scss
@@ -157,6 +157,13 @@
   .w-dialog__box {
     pointer-events: auto;
     box-shadow: theme('boxShadow.md');
+    overflow: hidden;
+    border-top-left-radius: 10px;
+    border-top-right-radius: 10px;
+  }
+  .w-dialog__message{
+    border-top-left-radius: 10px;
+    border-top-right-radius: 10px;
   }
 
   .w-dialog__overlay {

--- a/client/scss/components/_userbar.scss
+++ b/client/scss/components/_userbar.scss
@@ -258,6 +258,7 @@ $positions: (
     border: 2px solid theme('colors.primary.DEFAULT');
     background: theme('colors.white.DEFAULT');
   }
+  .w-dialog__box { overflow: visible; }
 
   .w-dialog__content {
     padding: 0;


### PR DESCRIPTION
Fixes #10177

- added overflow: hidden; to the .w-dialog__box styles in _dialog.scss

- added .w-dialog__box { overflow: visible; } to the userbar's dialog override in _userbar.scss

- added border-top-left-radius and border-top-right-radius to .w-dialog__message with the same value as the one set in .w-dialog__box