### PR TITLE
Fix Typo

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ Changelog
  * Docs: Add helpful troubleshooting links and refine wording for getting started with development (Loveth Omokaro)
  * Docs: Ensure search autocomplete overlay on mobile does not overflow the viewport (Ayman Makroo)
  * Docs: Improve documentation for InlinePanel (Vallabh Tiwari)
+ * Docs: Fix typo in "Extending Draftail" documentation (Hans Kelson)
  * Maintenance: Removed features deprecated in Wagtail 3.0 and 4.0 (Matt Westcott)
  * Maintenance: Update djhtml (html formatting) library to v 1.5.2 (Loveth Omokaro)
  * Maintenance: Re-enable `strictPropertyInitialization` in tsconfig (Thibaud Colas)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -696,6 +696,7 @@ Contributors
 * Himanshu Garg
 * Christopher Wardle
 * Jatin Kumar
+* Hans Kelson
 
 Translators
 ===========

--- a/docs/extending/extending_draftail.md
+++ b/docs/extending/extending_draftail.md
@@ -142,7 +142,7 @@ Here are the main requirements to create a new entity feature:
 -   Like for inline styles and blocks, set up the to/from DB conversion.
 -   The conversion usually is more involved, since entities contain data that needs to be serialised to HTML.
 
-To write the React components, Wagtail exposes its own React, Draft.js, and Draftail dependencies as global variables. Read more about this in [ectending clientside components](extending_clientside_components).
+To write the React components, Wagtail exposes its own React, Draft.js, and Draftail dependencies as global variables. Read more about this in [extending clientside components](extending_clientside_components).
 To go further, please look at the [Draftail documentation](https://www.draftail.org/docs/formatting-options) as well as the [Draft.js exporter documentation](https://github.com/springload/draftjs_exporter).
 
 Here is a detailed example to showcase how those tools are used in the context of Wagtail.

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -53,6 +53,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Ensure search autocomplete overlay on mobile does not overflow the viewport (Ayman Makroo)
  * Improve documentation for InlinePanel (Vallabh Tiwari)
  * Remove confusing `SettingsPanel` reference in the page editing `TabbedInterface` example as `SettingsPanel` no longer shows anything as of 4.1 (Kenny Wolf, Julian Bigler)
+ * Fix typo in "Extending Draftail" documentation (Hans Kelson)
 
 ### Maintenance
 


### PR DESCRIPTION
"Extending" was misspelled as "Ectending"

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes a typo I saw in the docs. Didn't run tests or anything else, as this changes one letter in a manually-typed documentation link.







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
