### PR TITLE
ChooserWidget: Trigger manually change event when input.value is set

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Changelog
  * Keep applied filters when downloading form submissions (Suyash Srivastava)
  * Messages added dynamically via JavaScript now have an icon to be consistent with those supplied in the page's HTML (Aman Pandey)
  * Switch lock/unlock side panel toggle to a switch, with more appropriate confirmation message status (Sage Abdullah)
+ * Ensure that changed or cleared selection from choosers will dispatch a DOM `change` event (George Sakkis)
  * Fix: Ensure `label_format` on StructBlock gracefully handles missing variables (Aadi jindal)
  * Fix: Adopt a no-JavaScript and more accessible solution for the 'Reset to default' switch to Gravatar when editing user profile (Loveth Omokaro)
  * Fix: Ensure `Site.get_site_root_paths` works on cache backends that do not preserve Python objects (Jaap Roes)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -700,6 +700,7 @@ Contributors
 * Sam
 * Deepam Priyadarshi
 * Mng
+* George Sakkis
 
 Translators
 ===========

--- a/client/src/components/ChooserWidget/index.js
+++ b/client/src/components/ChooserWidget/index.js
@@ -85,11 +85,13 @@ export class Chooser {
 
   renderEmptyState() {
     this.input.setAttribute('value', '');
+    this.input.dispatchEvent(new Event('change', { bubbles: true }));
     this.chooserElement.classList.add('blank');
   }
 
   renderState(newState) {
     this.input.setAttribute('value', newState.id);
+    this.input.dispatchEvent(new Event('change', { bubbles: true }));
     if (this.titleElement && this.titleStateKey) {
       this.titleElement.textContent = newState[this.titleStateKey];
     }

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -29,6 +29,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Keep applied filters when downloading form submissions (Suyash Srivastava)
  * Messages added dynamically via JavaScript now have an icon to be consistent with those supplied in the page's HTML (Aman Pandey)
  * Switch lock/unlock side panel toggle to a switch, with more appropriate confirmation message status (Sage Abdullah)
+ * Ensure that changed or cleared selection from choosers will dispatch a DOM `change` event (George Sakkis)
 
 ### Bug fixes
 


### PR DESCRIPTION
Fixes #10186







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
