### PR TITLE
Indicate that md5 is not being used for secure purposes—and that's okay (FIPS fix)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ Changelog
 5.1 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~
 
+ * Mark calls to `md5` as not being used for secure purposes, to avoid flagging on FIPS-mode systems (Sean Kelly)
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -15,7 +15,7 @@ depth: 1
 
 ### Other features
 
- * ...
+ * Mark calls to `md5` as not being used for secure purposes, to avoid flagging on FIPS-mode systems (Sean Kelly)
 
 ### Bug fixes
 

--- a/wagtail/coreutils.py
+++ b/wagtail/coreutils.py
@@ -20,6 +20,7 @@ from django.utils.encoding import force_str
 from django.utils.text import capfirst, slugify
 from django.utils.translation import check_for_language, get_supported_language_variant
 from django.utils.translation import gettext_lazy as _
+from hashlib import md5
 
 if TYPE_CHECKING:
     from wagtail.models import Site
@@ -419,6 +420,27 @@ def get_dummy_request(*, path: str = "/", site: "Site" = None) -> HttpRequest:
 
     # `SERVER_PORT` doesn't work when passed to the constructor
     return RequestFactory(SERVER_NAME=server_name).get(path, SERVER_PORT=server_port)
+
+
+def safe_md5(data=b"", usedforsecurity=True):
+    """
+    Safely use the MD5 hash algorithm with the given ``data`` and a flag
+    indicating if the purpose of the digest is for security or not.
+
+    On security-restricted systems (such as FIPS systems), insecure hashes
+    like MD5 are disabled by default. But passing ``usedforsecurity`` as
+    ``False`` tells the underlying security implementation we're not trying
+    to use the digest for secure purposes and to please just go ahead and
+    allow it to happen.
+    """
+
+    # Although ``accepts_kwarg`` works great on Python 3.8+, on Python 3.7 it
+    # raises a ValueError, saying "no signature found for builtin". So, back
+    # to the try/except.
+    try:
+        return md5(data, usedforsecurity=usedforsecurity)
+    except TypeError:
+        return md5(data)
 
 
 class BatchProcessor:

--- a/wagtail/embeds/embeds.py
+++ b/wagtail/embeds/embeds.py
@@ -1,9 +1,8 @@
 from datetime import datetime
-from hashlib import md5
 
 from django.utils.timezone import now
 
-from wagtail.coreutils import accepts_kwarg
+from wagtail.coreutils import accepts_kwarg, safe_md5
 
 from .exceptions import EmbedUnsupportedProviderException
 from .finders import get_finders
@@ -66,8 +65,7 @@ def get_embed(url, max_width=None, max_height=None, finder=None):
 
 
 def get_embed_hash(url, max_width=None, max_height=None):
-    h = md5()
-    h.update(url.encode("utf-8"))
+    h = safe_md5(url.encode("utf-8"), usedforsecurity=False)
     if max_width is not None:
         h.update(b"\n")
         h.update(str(max_width).encode("utf-8"))

--- a/wagtail/users/utils.py
+++ b/wagtail/users/utils.py
@@ -1,10 +1,10 @@
-import hashlib
-
 from django.conf import settings
 from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
+from wagtail.coreutils import safe_md5
+
 
 delete_user_perm = "{0}.delete_{1}".format(
     AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME.lower()
@@ -38,9 +38,11 @@ def get_gravatar_url(email, size=50):
     if (not email) or (gravatar_provider_url is None):
         return None
 
+    email_bytes = email.lower().encode("utf-8")
+    hash = safe_md5(email_bytes, usedforsecurity=False).hexdigest()
     gravatar_url = "{gravatar_provider_url}/{hash}?{params}".format(
         gravatar_provider_url=gravatar_provider_url.rstrip("/"),
-        hash=hashlib.md5(email.lower().encode("utf-8")).hexdigest(),
+        hash=hash,
         params=urlencode({"s": size, "d": default}),
     )
 


### PR DESCRIPTION
Merge this to fix #10184 wherein calls to `hashlib.md5` would raise an exception on security-restricted systems (such as FIPS mode systems used in newer U.S. Government computers). MD5 is disabled by default on such systems but a flag may be passed to indicate that it's being used for non-secure reasons (such as fingerprinting).
