### PR TITLE
Keep applied filters when downloading form submissions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ Changelog
  * Add usage view for pages (Sage Abdullah)
  * Copy page form now updates the slug field dynamically with a slugified value on blur (Loveth Omokaro)
  * Ensure selected collection is kept when navigating from documents or images listings to add multiple views & upon upload (Aman Pandey, Bojan Mihelac)
+ * Keep applied filters when downloading form submissions (Suyash Srivastava)
  * Fix: Ensure `label_format` on StructBlock gracefully handles missing variables (Aadi jindal)
  * Fix: Adopt a no-JavaScript and more accessible solution for the 'Reset to default' switch to Gravatar when editing user profile (Loveth Omokaro)
  * Fix: Ensure `Site.get_site_root_paths` works on cache backends that do not preserve Python objects (Jaap Roes)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -25,6 +25,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Add usage view for pages (Sage Abdullah)
  * Copy page form now updates the slug field dynamically with a slugified value on blur (Loveth Omokaro)
  * Ensure selected collection is kept when navigating from documents or images listings to add multiple views & upon upload (Aman Pandey, Bojan Mihelac)
+ * Keep applied filters when downloading form submissions (Suyash Srivastava)
 
 ### Bug fixes
 

--- a/wagtail/contrib/forms/templates/wagtailforms/submissions_index.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/submissions_index.html
@@ -83,13 +83,13 @@
 {% block content %}
     {% fragment as form_actions %}
         <div class="dropdown dropdown-button">
-            <a href="?export=xlsx" class="button bicolor button--icon">
+            <a href="{{ view.xlsx_export_url }}" class="button bicolor button--icon">
                 {% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}
             </a>
             <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
             <ul>
                 <li>
-                    <a class="button bicolor button--icon" href="?export=csv">
+                    <a class="button bicolor button--icon" href="{{ view.csv_export_url }}">
                         {% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}
                     </a>
                 </li>

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -6,6 +6,8 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
+from django.utils.html import escape
+from django.utils.http import urlencode
 from openpyxl import load_workbook
 
 from wagtail.admin.forms import WagtailAdminPageForm
@@ -360,6 +362,17 @@ class TestFormsSubmissionsList(WagtailTestUtils, TestCase):
 
         # Login
         self.login()
+
+    def test_export_urls_include_filters(self):
+        list_url = reverse("wagtailforms:list_submissions", args=(self.form_page.id,))
+
+        # Ensure that the download URLs include the filter parameters
+        response = self.client.get(list_url, {"name": "Alice"})
+        for format in ("xlsx", "csv"):
+            with self.subTest(format=format):
+                params = urlencode({"name": "Alice", "export": format})
+                expected_url = f"{list_url}?{params}"
+                self.assertContains(response, escape(expected_url))
 
     def make_list_submissions(self):
         """


### PR DESCRIPTION
This PR solves issue #10101  , where I Made use of the `xlsx_export_url` and the `csv_export_url` instead of hardcoding the urls in the template, and added test cases in the test block `TestFormsSubmissionsList`, 
with all the help provided by @laymonage and @lb- 