### PR TITLE
Update Algolia DocSearch to use new application and correct versioning setup

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -66,6 +66,7 @@ Changelog
  * Maintenance: Move models and forms for `wagtailsearch.Query` to `wagtail.contrib.search_promotions` (Karl Hobley)
  * Maintenance: Migrate `initErrorDetection` (tabs error counts) to a Stimulus Controller `w-count` (Aman Pandey)
  * Maintenance: Migrate `window.addMessage` behaviour to a global event listener & Stimulus Controller approach with `w-messages` (Aman Pandey)
+ * Maintenance: Update Algolia DocSearch to use new application and correct versioning setup (Thibaud Colas)
 
 
 4.2.1 (xx.xx.xxxx) - IN DEVELOPMENT
@@ -81,6 +82,7 @@ Changelog
  * Fix: Fix dialog component's message to have rounded corners at the top side (Sam)
  * Fix: Prevent matches from unrelated models from leaking into SQLite FTS searches (Matt Westcott)
  * Fix: Prevent duplicate addition of StreamField blocks with the new block picker (Deepam Priyadarshi)
+ * Maintenance: Update Algolia DocSearch to use new application and correct versioning setup (Thibaud Colas)
 
 
 4.2 (06.02.2023)
@@ -246,6 +248,7 @@ Changelog
  * Fix: Add missing log information for `wagtail.schedule.cancel` (Stefan Hammer)
  * Fix: Fix timezone activation leaking into subsequent requests in `require_admin_access()` (Stefan Hammer)
  * Fix: Prevent matches from unrelated models from leaking into SQLite FTS searches (Matt Westcott)
+ * Maintenance: Update Algolia DocSearch to use new application and correct versioning setup (Thibaud Colas)
 
 
 4.1.2 (06.02.2023)

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -4,6 +4,8 @@
 {% set docsearch_base = 'https://cdn.jsdelivr.net/npm/docsearch.js@' ~ docsearch_version ~ '/dist/cdn/' %}
 
 {% block extrahead %}
+    <meta name="docsearch:version" content="{% if READTHEDOCS and current_version %}{{ current_version }}{% else %}unknown{% endif %}" />
+
     <link rel="stylesheet" href="{{ docsearch_base ~ 'docsearch.min.css' }}"/>
     <link rel="stylesheet" href="{{ pathto('_static/css/docsearch.overrides.css', 1) }}" />
     <link rel="stylesheet" href="{{ pathto('_static/css/pagination.css', 1) }}" />
@@ -18,13 +20,14 @@
          * Get version of the currently served docs.
          *
          * PR builds have their version set to the PR ID (for example "6753").
-         * If the docs are built for a PR, use the "latest" search index.
-         * Otherwise, use the search index for the current version.
+         * If the docs are built for a PR or local development, use the "latest" facet filter.
+         * Otherwise, use the facet filter for the current version.
          */
         function getReadTheDocsVersion() {
-            const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest'
-            const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version
-            return version
+            const meta = document.querySelector('meta[name="docsearch:version"]');
+            const rtd_version = meta ? meta.content : 'latest';
+            const version = rtd_version.match(/^(\d+|unknown)$/) ? 'latest' : rtd_version;
+            return version;
         }
 
         function getVersionFacetFilter() {
@@ -54,10 +57,11 @@
         function docSearchReady() {
             /**
              * Configure Algolia DocSearch.
-             * See https://github.com/algolia/docsearch-configs/blob/master/configs/wagtail.json for index configuration.
+             * See https://github.com/wagtail/wagtail/wiki/Documentation-search for index configuration.
              */
             const search = docsearch({
-                apiKey: '8325c57d16798633e29d211c26c7b6f9',
+                appId: 'XSYGEO7KMJ',
+                apiKey: 'd50a485660ed9280079aada4e09454b2',
                 indexName: 'wagtail',
                 inputSelector: '#searchbox [name="q"]',
                 algoliaOptions: {

--- a/docs/releases/4.1.3.md
+++ b/docs/releases/4.1.3.md
@@ -22,3 +22,4 @@ depth: 1
  * Add missing log information for `wagtail.schedule.cancel` (Stefan Hammer)
  * Fix timezone activation leaking into subsequent requests in `require_admin_access()` (Stefan Hammer)
  * Prevent matches from unrelated models from leaking into SQLite FTS searches (Matt Westcott)
+ * Update Algolia DocSearch to use new application and correct versioning setup (Thibaud Colas)

--- a/docs/releases/4.2.1.md
+++ b/docs/releases/4.2.1.md
@@ -23,3 +23,4 @@ depth: 1
  * Fix dialog component's message to have rounded corners at the top side (Sam)
  * Prevent matches from unrelated models from leaking into SQLite FTS searches (Matt Westcott)
  * Prevent duplicate addition of StreamField blocks with the new block picker (Deepam Priyadarshi)
+ * Update Algolia DocSearch to use new application and correct versioning setup (Thibaud Colas)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -87,6 +87,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Move models and forms for `wagtailsearch.Query` to `wagtail.contrib.search_promotions` (Karl Hobley)
  * Migrate `initErrorDetection` (tabs error counts) to a Stimulus Controller `w-count` (Aman Pandey)
  * Migrate `window.addMessage` behaviour to a global event listener & Stimulus Controller approach with `w-messages` (Aman Pandey)
+ * Update Algolia DocSearch to use new application and correct versioning setup (Thibaud Colas)
 
 ## Upgrade considerations
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 myst_parser==0.18.1
-sphinx-wagtail-theme==5.3.2
+sphinx-wagtail-theme==6.0.0
 sphinx-copybutton>=0.5,<1.0

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ documentation_extras = [
     "sphinxcontrib-spelling>=5.4.0,<6",
     "Sphinx>=1.5.2",
     "sphinx-autobuild>=0.6.0",
-    "sphinx-wagtail-theme==5.3.2",
+    "sphinx-wagtail-theme==6.0.0",
     "myst_parser==0.18.1",
     "sphinx_copybutton>=0.5,<1.0",
 ]


### PR DESCRIPTION
This addresses three issues:

- Outdated documentation search results due to a botched DocSearch migration. The new application `XSYGEO7KMJ` is on different infrastructure, which is more configurable for us – and actually runs regular crawls.
  - #10027
  - #9894
-  #8159 – mismatch in version identifiers between how we crawl / index the documentation site contents, and how we query.

To resolve this I made the following changes:

## Refactoring

- Via `sphinx-wagtail-theme` v6.0.0: remove meta tags that aren’t doing anything: `docsearch:name`, `docsearch:package_type`, `docsearch:release`.
- Via `sphinx-wagtail-theme` v6.0.0: move `docsearch:version` to this repository – it’s much easier to check its correct usage and update it if it’s all in one file.

## Fixes

- Switches to our new Algolia DocSearch app, as documented in our [Documentation search wiki page](https://github.com/wagtail/wagtail/wiki/Documentation-search). This new app is much more configurable, and has an up-to-date index.
- Sets `docsearch:version` based on the RTD data – currently it’s set to `4.2` for both `stable` and `v4.2`, which is problematic (duplicate content indexed under the same version).
- Changes our JavaScript widget initialisation to use the value of the meta tag to determine the correct filter, so there is less chance of the indexing and widget configuration using different sources of truth for versions in the future.

---

This will be impossible to fully test as-is, because the `docsearch:version` meta tag has to be picked up by the crawler / reflected in the index before we can see the results on the site.

Here is what can be tested on the [docs PR preview build](https://wagtail--10207.org.readthedocs.build/en/10207/):

1. Calling `getReadTheDocsVersion()` in the console should return `latest`
2. Calling `document.querySelector('meta[name="docsearch:version"]')` in the console should return the PR number (`10207`).

Finally, to test the new credentials work, we can copy-paste in the console:

```js
docsearch({
    appId: 'XSYGEO7KMJ',
    apiKey: 'd50a485660ed9280079aada4e09454b2',
    indexName: 'wagtail',
    inputSelector: '#searchbox [name="q"]',
    algoliaOptions: {
        facetFilters: ['version:5.0'],
    },
    autocompleteOptions: {
        autoSelect: false
    },
    debug: true,
})
```

This will initialise the search _twice_, leading to one list of results with no entries, and one with contents currently indexed as `version:5.0` (https://docs.wagtail.org/en/latest/). Try to search for example "LockableMixin" or "minimap".

Once we merge all of this _and run another crawl_, we can expect that:

- The `latest` build will work right after the crawl has completed, with both `getReadTheDocsVersion()` and `document.querySelector('meta[name="docsearch:version"]')` returning `latest`
- The `stable` build will work as soon as that branch is updated, with `stable` as the version
- The `v4.2` build will also work, with `v4.2` as the version.