### PR TITLE
Fix tests to work across all search backends

### DIFF
--- a/wagtail/admin/tests/api/test_documents.py
+++ b/wagtail/admin/tests/api/test_documents.py
@@ -2,7 +2,11 @@ import json
 
 from django.urls import reverse
 
-from wagtail.api.v2.tests.test_documents import TestDocumentDetail, TestDocumentListing
+from wagtail.api.v2.tests.test_documents import (
+    TestDocumentDetail,
+    TestDocumentListing,
+    TestDocumentListingSearch,
+)
 from wagtail.documents.models import Document
 
 from .utils import AdminAPITestCase
@@ -78,6 +82,16 @@ class TestAdminDocumentListing(AdminAPITestCase, TestDocumentListing):
                 set(document["meta"].keys()),
                 {"type", "detail_url", "download_url", "tags"},
             )
+
+
+class TestAdminDocumentListingSearch(AdminAPITestCase, TestDocumentListingSearch):
+    fixtures = ["demosite.json"]
+
+    def get_response(self, **params):
+        return self.client.get(reverse("wagtailadmin_api:documents:listing"), params)
+
+    def get_document_id_list(self, content):
+        return [document["id"] for document in content["items"]]
 
 
 class TestAdminDocumentDetail(AdminAPITestCase, TestDocumentDetail):

--- a/wagtail/admin/tests/api/test_images.py
+++ b/wagtail/admin/tests/api/test_images.py
@@ -2,7 +2,11 @@ import json
 
 from django.urls import reverse
 
-from wagtail.api.v2.tests.test_images import TestImageDetail, TestImageListing
+from wagtail.api.v2.tests.test_images import (
+    TestImageDetail,
+    TestImageListing,
+    TestImageListingSearch,
+)
 from wagtail.images import get_image_model
 from wagtail.images.tests.utils import get_test_image_file
 
@@ -173,6 +177,16 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
                 {"type", "detail_url", "tags", "download_url"},
             )
             self.assertIsInstance(image["meta"]["tags"], list)
+
+
+class TestAdminImageListingSearch(AdminAPITestCase, TestImageListingSearch):
+    fixtures = ["demosite.json"]
+
+    def get_response(self, **params):
+        return self.client.get(reverse("wagtailadmin_api:images:listing"), params)
+
+    def get_image_id_list(self, content):
+        return [image["id"] for image in content["items"]]
 
 
 class TestAdminImageDetail(AdminAPITestCase, TestImageDetail):

--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -4,12 +4,17 @@ import json
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
+from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
 from wagtail import hooks
-from wagtail.api.v2.tests.test_pages import TestPageDetail, TestPageListing
+from wagtail.api.v2.tests.test_pages import (
+    TestPageDetail,
+    TestPageListing,
+    TestPageListingSearch,
+)
 from wagtail.models import GroupPagePermission, Locale, Page, PageLogEntry
 from wagtail.test.demosite import models
 from wagtail.test.testapp.models import (
@@ -650,8 +655,8 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
                 set(page.keys()), {"id", "meta", "title", "admin_display_title"}
             )
 
-        self.assertTrue(blog_page_seen, "No blog pages were found in the items")
-        self.assertTrue(event_page_seen, "No event pages were found in the items")
+        self.assertTrue(blog_page_seen, msg="No blog pages were found in the items")
+        self.assertTrue(event_page_seen, msg="No event pages were found in the items")
 
     # Not applicable to the admin API
     test_site_filter_same_hostname_returns_error = None
@@ -1100,7 +1105,20 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         )
 
 
-class TestAdminPageDetailWithStreamField(AdminAPITestCase):
+class TestAdminPageListingSearch(AdminAPITestCase, TestPageListingSearch):
+    fixtures = ["demosite.json"]
+
+    def get_response(self, **params):
+        return self.client.get(reverse("wagtailadmin_api:pages:listing"), params)
+
+    def get_page_id_list(self, content):
+        return [page["id"] for page in content["items"]]
+
+    def get_homepage(self):
+        return Page.objects.get(slug="home-page")
+
+
+class TestAdminPageDetailWithStreamField(AdminAPITestCase, TestCase):
     fixtures = ["test.json"]
 
     def setUp(self):
@@ -1143,7 +1161,7 @@ class TestAdminPageDetailWithStreamField(AdminAPITestCase):
         self.assertEqual(content["body"][0]["value"], 1)
 
 
-class TestCustomAdminDisplayTitle(AdminAPITestCase):
+class TestCustomAdminDisplayTitle(AdminAPITestCase, TestCase):
     fixtures = ["test.json"]
 
     def setUp(self):
@@ -1174,7 +1192,7 @@ class TestCustomAdminDisplayTitle(AdminAPITestCase):
         )
 
 
-class TestCopyPageAction(AdminAPITestCase):
+class TestCopyPageAction(AdminAPITestCase, TestCase):
     fixtures = ["test.json"]
 
     def get_response(self, page_id, data):
@@ -1389,7 +1407,7 @@ class TestCopyPageAction(AdminAPITestCase):
         )
 
 
-class TestConvertAliasPageAction(AdminAPITestCase):
+class TestConvertAliasPageAction(AdminAPITestCase, TestCase):
     fixtures = ["test.json"]
 
     def setUp(self):
@@ -1462,7 +1480,7 @@ class TestConvertAliasPageAction(AdminAPITestCase):
         self.assertEqual(response.status_code, 403)
 
 
-class TestDeletePageAction(AdminAPITestCase):
+class TestDeletePageAction(AdminAPITestCase, TestCase):
     fixtures = ["test.json"]
 
     def get_response(self, page_id):
@@ -1500,7 +1518,7 @@ class TestDeletePageAction(AdminAPITestCase):
         self.assertTrue(Page.objects.filter(id=4).exists())
 
 
-class TestPublishPageAction(AdminAPITestCase):
+class TestPublishPageAction(AdminAPITestCase, TestCase):
     fixtures = ["test.json"]
 
     def get_response(self, page_id):
@@ -1563,7 +1581,7 @@ class TestPublishPageAction(AdminAPITestCase):
         )
 
 
-class TestUnpublishPageAction(AdminAPITestCase):
+class TestUnpublishPageAction(AdminAPITestCase, TestCase):
     fixtures = ["test.json"]
 
     def get_response(self, page_id, data):
@@ -1635,7 +1653,7 @@ class TestUnpublishPageAction(AdminAPITestCase):
         )
 
 
-class TestMovePageAction(AdminAPITestCase):
+class TestMovePageAction(AdminAPITestCase, TestCase):
     fixtures = ["test.json"]
 
     def get_response(self, page_id, data):
@@ -1674,7 +1692,7 @@ class TestMovePageAction(AdminAPITestCase):
         self.assertEqual(content, {"destination_page_id": ["This field is required."]})
 
 
-class TestCopyForTranslationAction(AdminAPITestCase):
+class TestCopyForTranslationAction(AdminAPITestCase, TestCase):
     fixtures = ["test.json"]
 
     def get_response(self, page_id, data):
@@ -1758,7 +1776,7 @@ class TestCopyForTranslationAction(AdminAPITestCase):
         self.assertEqual(content, {"message": "No Locale matches the given query."})
 
 
-class TestCreatePageAliasAction(AdminAPITestCase):
+class TestCreatePageAliasAction(AdminAPITestCase, TestCase):
     fixtures = ["test.json"]
 
     def setUp(self):
@@ -1870,7 +1888,7 @@ class TestCreatePageAliasAction(AdminAPITestCase):
         )
 
 
-class TestRevertToPageRevisionAction(AdminAPITestCase):
+class TestRevertToPageRevisionAction(AdminAPITestCase, TestCase):
     fixtures = ["test.json"]
 
     def setUp(self):

--- a/wagtail/admin/tests/api/utils.py
+++ b/wagtail/admin/tests/api/utils.py
@@ -1,8 +1,9 @@
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 from wagtail.test.utils import WagtailTestUtils
 
 
-class AdminAPITestCase(WagtailTestUtils, TestCase):
+class AdminAPITestCase(WagtailTestUtils, TransactionTestCase):
     def setUp(self):
+        super().setUp()
         self.user = self.login()

--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_delete.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_delete.py
@@ -261,13 +261,13 @@ class TestBulkDelete(WagtailTestUtils, TestCase):
         post_delete_signals_received = []
 
         def page_unpublished_handler(sender, instance, **kwargs):
-            unpublish_signals_received.append((sender, instance.id))
+            unpublish_signals_received.append((sender, instance.pk))
 
         def pre_delete_handler(sender, instance, **kwargs):
-            pre_delete_signals_received.append((sender, instance.id))
+            pre_delete_signals_received.append((sender, instance.pk))
 
         def post_delete_handler(sender, instance, **kwargs):
-            post_delete_signals_received.append((sender, instance.id))
+            post_delete_signals_received.append((sender, instance.pk))
 
         page_unpublished.connect(page_unpublished_handler)
         pre_delete.connect(pre_delete_handler)

--- a/wagtail/admin/tests/pages/test_delete_page.py
+++ b/wagtail/admin/tests/pages/test_delete_page.py
@@ -248,13 +248,13 @@ class TestPageDelete(WagtailTestUtils, TestCase):
         post_delete_signals_received = []
 
         def page_unpublished_handler(sender, instance, **kwargs):
-            unpublish_signals_received.append((sender, instance.id))
+            unpublish_signals_received.append((sender, instance.pk))
 
         def pre_delete_handler(sender, instance, **kwargs):
-            pre_delete_signals_received.append((sender, instance.id))
+            pre_delete_signals_received.append((sender, instance.pk))
 
         def post_delete_handler(sender, instance, **kwargs):
-            post_delete_signals_received.append((sender, instance.id))
+            post_delete_signals_received.append((sender, instance.pk))
 
         page_unpublished.connect(page_unpublished_handler)
         pre_delete.connect(pre_delete_handler)

--- a/wagtail/admin/tests/pages/test_page_search.py
+++ b/wagtail/admin/tests/pages/test_page_search.py
@@ -3,7 +3,6 @@ from django.test import TestCase
 from django.urls import reverse
 
 from wagtail.models import Page
-from wagtail.search.index import SearchField
 from wagtail.test.testapp.models import SimplePage, SingleEventPage
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.timestamps import local_datetime
@@ -36,8 +35,8 @@ class TestPageSearch(WagtailTestUtils, TestCase):
         # Create a page
         root_page.add_child(
             instance=SimplePage(
-                title="Hi there!",
-                slug="hello-world",
+                title="Greetings!",
+                slug="hello",
                 content="good morning",
                 live=True,
                 has_unpublished_changes=False,
@@ -47,19 +46,10 @@ class TestPageSearch(WagtailTestUtils, TestCase):
         # Confirm the slug is not being searched
         response = self.get({"q": "hello"})
         self.assertNotContains(response, "There is one matching page")
-        search_fields = Page.search_fields
 
-        # Add slug to the search_fields
-        Page.search_fields = Page.search_fields + [
-            SearchField("slug", partial_match=True)
-        ]
-
-        # Confirm the slug is being searched
-        response = self.get({"q": "hello"})
+        # Confirm the title is being searched
+        response = self.get({"q": "greetings"})
         self.assertContains(response, "There is one matching page")
-
-        # Reset the search fields
-        Page.search_fields = search_fields
 
     def test_ajax(self):
         response = self.get({"q": "Hello"}, HTTP_X_REQUESTED_WITH="XMLHttpRequest")

--- a/wagtail/admin/tests/pages/test_page_search.py
+++ b/wagtail/admin/tests/pages/test_page_search.py
@@ -1,4 +1,7 @@
+from io import StringIO
+
 from django.contrib.auth.models import Permission
+from django.core import management
 from django.test import TestCase
 from django.urls import reverse
 
@@ -9,6 +12,15 @@ from wagtail.test.utils.timestamps import local_datetime
 
 
 class TestPageSearch(WagtailTestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        management.call_command(
+            "update_index",
+            backend_name="default",
+            stdout=StringIO(),
+            chunk_size=50,
+        )
+
     def setUp(self):
         self.user = self.login()
 
@@ -66,7 +78,7 @@ class TestPageSearch(WagtailTestUtils, TestCase):
             self.assertTemplateUsed(response, "wagtailadmin/pages/search.html")
 
     def test_root_can_appear_in_search_results(self):
-        response = self.get({"q": "roo"})
+        response = self.get({"q": "root"})
         self.assertEqual(response.status_code, 200)
         # 'pages' list in the response should contain root
         results = response.context["pages"]

--- a/wagtail/admin/tests/pages/test_page_search.py
+++ b/wagtail/admin/tests/pages/test_page_search.py
@@ -2,7 +2,7 @@ from io import StringIO
 
 from django.contrib.auth.models import Permission
 from django.core import management
-from django.test import TestCase
+from django.test import TransactionTestCase
 from django.urls import reverse
 
 from wagtail.models import Page
@@ -11,17 +11,17 @@ from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.timestamps import local_datetime
 
 
-class TestPageSearch(WagtailTestUtils, TestCase):
-    @classmethod
-    def setUpTestData(cls):
+class TestPageSearch(WagtailTestUtils, TransactionTestCase):
+    fixtures = ["test_empty.json"]
+
+    def setUp(self):
+        super().setUp()
         management.call_command(
             "update_index",
             backend_name="default",
             stdout=StringIO(),
             chunk_size=50,
         )
-
-    def setUp(self):
         self.user = self.login()
 
     def get(self, params=None, **extra):

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -328,6 +328,8 @@ class TestChooserSearch(WagtailTestUtils, TestCase):
         self.assertContains(response, "foobarbaz")
 
     def test_partial_match(self):
+        # FIXME: SQLite and MySQL FTS backends don't support autocomplete searches
+        # https://github.com/wagtail/wagtail/issues/9903
         response = self.get({"q": "fooba"})
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/chooser/_search_results.html")
@@ -357,7 +359,7 @@ class TestChooserSearch(WagtailTestUtils, TestCase):
     def test_with_page_type(self):
         # Add a page that is not a SimplePage
         event_page = EventPage(
-            title="foo",
+            title="foobarbaz again",
             location="the moon",
             audience="public",
             cost="free",
@@ -366,7 +368,7 @@ class TestChooserSearch(WagtailTestUtils, TestCase):
         self.root_page.add_child(instance=event_page)
 
         # Send request
-        response = self.get({"q": "foo", "page_type": "tests.simplepage"})
+        response = self.get({"q": "foobarbaz", "page_type": "tests.simplepage"})
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/chooser/_search_results.html")
         self.assertEqual(response.context["page_type_string"], "tests.simplepage")
@@ -390,7 +392,7 @@ class TestChooserSearch(WagtailTestUtils, TestCase):
     def test_with_multiple_page_types(self):
         # Add a page that is not a SimplePage
         event_page = EventPage(
-            title="foo",
+            title="foobarbaz again",
             location="the moon",
             audience="public",
             cost="free",
@@ -400,7 +402,7 @@ class TestChooserSearch(WagtailTestUtils, TestCase):
 
         # Send request
         response = self.get(
-            {"q": "foo", "page_type": "tests.simplepage,tests.eventpage"}
+            {"q": "foobarbaz", "page_type": "tests.simplepage,tests.eventpage"}
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/chooser/_search_results.html")

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -1,7 +1,7 @@
 import json
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase, override_settings
+from django.test import TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 from django.utils.http import urlencode
 
@@ -307,7 +307,9 @@ class TestChooserBrowseChild(WagtailTestUtils, TestCase):
         self.assertEqual(response.context["pagination_page"].number, 5)
 
 
-class TestChooserSearch(WagtailTestUtils, TestCase):
+class TestChooserSearch(WagtailTestUtils, TransactionTestCase):
+    fixtures = ["test_empty.json"]
+
     def setUp(self):
         self.root_page = Page.objects.get(id=2)
 

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -1,7 +1,7 @@
 import json
 from unittest import mock
 
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 
@@ -359,7 +359,15 @@ class TestDocumentListing(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {"message": "offset must be a positive integer"})
 
-    # SEARCH
+
+class TestDocumentListingSearch(TransactionTestCase):
+    fixtures = ["demosite.json"]
+
+    def get_response(self, **params):
+        return self.client.get(reverse("wagtailapi_v2:documents:listing"), params)
+
+    def get_document_id_list(self, content):
+        return [document["id"] for document in content["items"]]
 
     def test_search_for_james_joyce(self):
         response = self.get_response(search="james")

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -1,7 +1,7 @@
 import json
 from unittest import mock
 
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 
@@ -362,7 +362,15 @@ class TestImageListing(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {"message": "offset must be a positive integer"})
 
-    # SEARCH
+
+class TestImageListingSearch(TransactionTestCase):
+    fixtures = ["demosite.json"]
+
+    def get_response(self, **params):
+        return self.client.get(reverse("wagtailapi_v2:images:listing"), params)
+
+    def get_image_id_list(self, content):
+        return [image["id"] for image in content["items"]]
 
     def test_search_for_james_joyce(self):
         response = self.get_response(search="james")

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1163,7 +1163,9 @@ class TestPageListingSearch(WagtailTestUtils, TestCase):
 
     def test_search_operator_and(self):
         response = self.get_response(
-            type="demosite.BlogEntryPage", search="blog again", search_operator="and"
+            type="demosite.BlogEntryPage",
+            search="blog elephants",
+            search_operator="and",
         )
         content = json.loads(response.content.decode("UTF-8"))
 
@@ -1173,7 +1175,7 @@ class TestPageListingSearch(WagtailTestUtils, TestCase):
 
     def test_search_operator_or(self):
         response = self.get_response(
-            type="demosite.BlogEntryPage", search="blog again", search_operator="or"
+            type="demosite.BlogEntryPage", search="blog elephants", search_operator="or"
         )
         content = json.loads(response.content.decode("UTF-8"))
 

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -89,7 +89,8 @@ class TestBookIndexView(WagtailTestUtils, TestCase):
             data_lines[1], "Charlie and the Chocolate Factory,Roald Dahl,1916-09-13\r"
         )
         self.assertEqual(
-            data_lines[2], "The Chronicles of Narnia,Roald Dahl,1898-11-29\r"
+            data_lines[2],
+            "The Chronicles of the Lord of Narnia,Roald Dahl,1898-11-29\r",
         )
         self.assertEqual(data_lines[3], "The Hobbit,J. R. R. Tolkien,1892-01-03\r")
         self.assertEqual(
@@ -117,7 +118,8 @@ class TestBookIndexView(WagtailTestUtils, TestCase):
             ["Charlie and the Chocolate Factory", "Roald Dahl", "1916-09-13"],
         )
         self.assertEqual(
-            cell_array[2], ["The Chronicles of Narnia", "Roald Dahl", "1898-11-29"]
+            cell_array[2],
+            ["The Chronicles of the Lord of Narnia", "Roald Dahl", "1898-11-29"],
         )
         self.assertEqual(
             cell_array[3], ["The Hobbit", "J. R. R. Tolkien", "1892-01-03"]
@@ -179,11 +181,11 @@ class TestBookIndexView(WagtailTestUtils, TestCase):
         self.assertEqual(data_lines[3], "")
 
     def test_search_indexed(self):
-        response = self.get(q="of")
+        response = self.get(q="lord")
 
         self.assertEqual(response.status_code, 200)
 
-        # There are two books where the title contains 'of'
+        # There are two books where the title contains 'lord'
         self.assertEqual(response.context["result_count"], 2)
 
         # The result count content is shown in the header

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -5,7 +5,7 @@ from unittest import mock
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core import checks
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.utils.timezone import make_aware
 from openpyxl import load_workbook
@@ -180,19 +180,6 @@ class TestBookIndexView(WagtailTestUtils, TestCase):
         )
         self.assertEqual(data_lines[3], "")
 
-    def test_search_indexed(self):
-        response = self.get(q="lord")
-
-        self.assertEqual(response.status_code, 200)
-
-        # There are two books where the title contains 'lord'
-        self.assertEqual(response.context["result_count"], 2)
-
-        # The result count content is shown in the header
-        self.assertContains(
-            response, '<span class="result-count">2 out of 4</span>', html=True
-        )
-
     def test_search_form_present(self):
         # Test the backend search handler allows the search form to render
         response = self.get()
@@ -233,6 +220,37 @@ class TestBookIndexView(WagtailTestUtils, TestCase):
 
         # There are four books in the test data
         self.assertEqual(response.context["result_count"], 4)
+
+
+class TestBookIndexViewSearch(WagtailTestUtils, TransactionTestCase):
+    fixtures = ["modeladmintest_test.json"]
+
+    def setUp(self):
+        self.login()
+
+        img = Image.objects.create(
+            title="LOTR cover",
+            file=get_test_image_file(),
+        )
+        book = Book.objects.get(title="The Lord of the Rings")
+        book.cover_image = img
+        book.save()
+
+    def get(self, **params):
+        return self.client.get("/admin/modeladmintest/book/", params)
+
+    def test_search_indexed(self):
+        response = self.get(q="lord")
+
+        self.assertEqual(response.status_code, 200)
+
+        # There are two books where the title contains 'lord'
+        self.assertEqual(response.context["result_count"], 2)
+
+        # The result count content is shown in the header
+        self.assertContains(
+            response, '<span class="result-count">2 out of 4</span>', html=True
+        )
 
 
 class TestAuthorIndexView(WagtailTestUtils, TestCase):

--- a/wagtail/documents/tests/test_models.py
+++ b/wagtail/documents/tests/test_models.py
@@ -18,7 +18,9 @@ from wagtail.test.testapp.models import CustomDocument, ReimportedDocumentModel
 from wagtail.test.utils import WagtailTestUtils
 
 
-class TestDocumentQuerySet(TestCase):
+class TestDocumentQuerySet(TransactionTestCase):
+    fixtures = ["test_empty.json"]
+
     def test_search_method(self):
         # Make a test document
         document = models.Document.objects.create(title="Test document")
@@ -163,17 +165,7 @@ class TestFilesDeletedForDefaultModels(TransactionTestCase):
         https://docs.djangoproject.com/en/1.10/topics/db/transactions/#use-in-tests
     """
 
-    def setUp(self):
-        # Required to create root collection because the TransactionTestCase
-        # does not make initial data loaded in migrations available and
-        # serialized_rollback=True causes other problems in the test suite.
-        # ref: https://docs.djangoproject.com/en/1.10/topics/testing/overview/#rollback-emulation
-        Collection.objects.get_or_create(
-            name="Root",
-            path="0001",
-            depth=1,
-            numchild=0,
-        )
+    fixtures = ["test_empty.json"]
 
     def test_document_file_deleted_oncommit(self):
         with transaction.atomic():

--- a/wagtail/documents/tests/test_models.py
+++ b/wagtail/documents/tests/test_models.py
@@ -42,9 +42,13 @@ class TestDocumentQuerySet(TestCase):
         aaa_document = models.Document.objects.create(title="AAA Test document")
         zzz_document = models.Document.objects.create(title="ZZZ Test document")
 
-        results = models.Document.objects.order_by("title").search("Test")
+        results = models.Document.objects.order_by("title").search(
+            "Test", order_by_relevance=False
+        )
         self.assertEqual(list(results), [aaa_document, zzz_document])
-        results = models.Document.objects.order_by("-title").search("Test")
+        results = models.Document.objects.order_by("-title").search(
+            "Test", order_by_relevance=False
+        )
         self.assertEqual(list(results), [zzz_document, aaa_document])
 
 

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import Group, Permission
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.template.defaultfilters import filesizeformat
 from django.template.loader import render_to_string
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import RequestFactory, TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 from django.utils.encoding import force_str
 from django.utils.html import escape, escapejs
@@ -75,55 +75,6 @@ class TestImageIndexView(WagtailTestUtils, TestCase):
         # all results should be returned
         self.assertContains(response, "a cute kitten")
         self.assertContains(response, "a cute puppy")
-
-    def test_search(self):
-        response = self.get({"q": "kitten"})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["query_string"], "kitten")
-        self.assertContains(response, "a cute kitten")
-        self.assertNotContains(response, "a cute puppy")
-
-    def test_search_partial_match(self):
-        response = self.get({"q": "kit"})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["query_string"], "kit")
-        self.assertContains(response, "a cute kitten")
-        self.assertNotContains(response, "a cute puppy")
-
-    def test_collection_query_search(self):
-        root_collection = Collection.get_first_root_node()
-        child_collection = [
-            root_collection.add_child(name="Baker Collection"),
-            root_collection.add_child(name="Other Collection"),
-        ]
-        title_list = ["Baker", "Other"]
-        answer_list = []
-        for i in range(10):
-            self.image = Image.objects.create(
-                title=f"{title_list[i%2]} {i}",
-                file=get_test_image_file(size=(1, 1)),
-                collection=child_collection[i % 2],
-            )
-            if i % 2 == 0:
-                answer_list.append(self.image)
-        response = self.get({"q": "Baker", "collection_id": child_collection[0].id})
-        status_code = response.status_code
-        query_string = response.context["query_string"]
-        response_list = response.context["images"].object_list
-        response_body = response.content.decode("utf-8")
-
-        self.assertEqual(status_code, 200)
-        self.assertEqual(query_string, "Baker")
-        self.assertCountEqual(answer_list, response_list)
-        for i in range(0, 10, 2):
-            self.assertIn("Baker %i" % i, response_body)
-
-        # should append the correct params to the add images button
-        url = reverse("wagtailimages:add_multiple")
-        self.assertContains(
-            response,
-            f'<a href="{url}?q=Baker&amp;collection_id={child_collection[0].pk}"',
-        )
 
     def test_pagination(self):
         pages = ["0", "1", "-1", "9999", "Not a page"]
@@ -344,29 +295,6 @@ class TestImageIndexView(WagtailTestUtils, TestCase):
             "?p=3&amp;tag=even" in response_body or "?tag=even&amp;p=3" in response_body
         )
 
-    def test_tag_filtering_with_search_term(self):
-        Image.objects.create(
-            title="Test image with no tags",
-            file=get_test_image_file(),
-        )
-
-        image_one_tag = Image.objects.create(
-            title="Test image with one tag",
-            file=get_test_image_file(),
-        )
-        image_one_tag.tags.add("one")
-
-        image_two_tags = Image.objects.create(
-            title="Test image with two tags",
-            file=get_test_image_file(),
-        )
-        image_two_tags.tags.add("one", "two")
-
-        # The tag gets ignored, if a valid search term is present, so this will find all
-        # images, as all of them contain "test" in their titles.
-        response = self.get({"tag": "one", "q": "test"})
-        self.assertEqual(response.context["images"].paginator.count, 3)
-
     def test_search_form_rendered(self):
         response = self.get()
         html = response.content.decode()
@@ -406,7 +334,101 @@ class TestImageIndexView(WagtailTestUtils, TestCase):
             self.get()
 
 
-class TestImageListingResultsView(WagtailTestUtils, TestCase):
+class TestImageIndexViewSearch(WagtailTestUtils, TransactionTestCase):
+    fixtures = ["test_empty.json"]
+
+    def setUp(self):
+        self.login()
+        self.kitten_image = Image.objects.create(
+            title="a cute kitten",
+            file=get_test_image_file(size=(1, 1)),
+            created_at=datetime.datetime(2020, 1, 1),
+        )
+        self.puppy_image = Image.objects.create(
+            title="a cute puppy",
+            file=get_test_image_file(size=(1, 1)),
+            created_at=datetime.datetime(2022, 2, 2),
+        )
+
+    def get(self, params={}):
+        return self.client.get(reverse("wagtailimages:index"), params)
+
+    def test_search(self):
+        response = self.get({"q": "kitten"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["query_string"], "kitten")
+        self.assertContains(response, "a cute kitten")
+        self.assertNotContains(response, "a cute puppy")
+
+    def test_search_partial_match(self):
+        response = self.get({"q": "kit"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["query_string"], "kit")
+        self.assertContains(response, "a cute kitten")
+        self.assertNotContains(response, "a cute puppy")
+
+    def test_collection_query_search(self):
+        root_collection = Collection.get_first_root_node()
+        child_collection = [
+            root_collection.add_child(name="Baker Collection"),
+            root_collection.add_child(name="Other Collection"),
+        ]
+        title_list = ["Baker", "Other"]
+        answer_list = []
+        for i in range(10):
+            self.image = Image.objects.create(
+                title=f"{title_list[i%2]} {i}",
+                file=get_test_image_file(size=(1, 1)),
+                collection=child_collection[i % 2],
+            )
+            if i % 2 == 0:
+                answer_list.append(self.image)
+        response = self.get({"q": "Baker", "collection_id": child_collection[0].id})
+        status_code = response.status_code
+        query_string = response.context["query_string"]
+        response_list = response.context["images"].object_list
+        response_body = response.content.decode("utf-8")
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(query_string, "Baker")
+        self.assertCountEqual(answer_list, response_list)
+        for i in range(0, 10, 2):
+            self.assertIn("Baker %i" % i, response_body)
+
+        # should append the correct params to the add images button
+        url = reverse("wagtailimages:add_multiple")
+        self.assertContains(
+            response,
+            f'<a href="{url}?q=Baker&amp;collection_id={child_collection[0].pk}"',
+        )
+
+    def test_tag_filtering_with_search_term(self):
+        Image.objects.create(
+            title="Test image with no tags",
+            file=get_test_image_file(),
+        )
+
+        image_one_tag = Image.objects.create(
+            title="Test image with one tag",
+            file=get_test_image_file(),
+        )
+        image_one_tag.tags.add("one")
+
+        image_two_tags = Image.objects.create(
+            title="Test image with two tags",
+            file=get_test_image_file(),
+        )
+        image_two_tags.tags.add("one", "two")
+
+        # The tag gets ignored, if a valid search term is present, so this will find all
+        # images, as all of them contain "test" in their titles.
+        response = self.get({"tag": "one", "q": "test"})
+        self.assertEqual(response.context["images"].paginator.count, 3)
+
+
+class TestImageListingResultsView(WagtailTestUtils, TransactionTestCase):
+    fixtures = ["test_empty.json"]
+
     def setUp(self):
         self.login()
 
@@ -1571,27 +1593,6 @@ class TestImageChooserView(WagtailTestUtils, TestCase):
         self.assertEqual(len(response.context["results"]), 1)
         self.assertEqual(response.context["results"][0], image)
 
-    def test_construct_queryset_hook_search(self):
-        image = Image.objects.create(
-            title="Test image shown",
-            file=get_test_image_file(),
-            uploaded_by_user=self.user,
-        )
-        Image.objects.create(
-            title="Test image not shown",
-            file=get_test_image_file(),
-        )
-
-        def filter_images(images, request):
-            # Filter on `uploaded_by_user` because it is
-            # the only default FilterField in search_fields
-            return images.filter(uploaded_by_user=self.user)
-
-        with self.register_hook("construct_image_chooser_queryset", filter_images):
-            response = self.get({"q": "Test"})
-        self.assertEqual(len(response.context["results"]), 1)
-        self.assertEqual(response.context["results"][0], image)
-
     def test_num_queries(self):
         # Initial number of queries.
         with self.assertNumQueries(8):
@@ -1612,6 +1613,37 @@ class TestImageChooserView(WagtailTestUtils, TestCase):
             # No extra additional queries since renditions exist and are saved in
             # the prefetched objects cache.
             self.get()
+
+
+class TestImageChooserViewSearch(WagtailTestUtils, TransactionTestCase):
+    fixtures = ["test_empty.json"]
+
+    def setUp(self):
+        self.user = self.login()
+
+    def get(self, params={}):
+        return self.client.get(reverse("wagtailimages_chooser:choose"), params)
+
+    def test_construct_queryset_hook_search(self):
+        image = Image.objects.create(
+            title="Test image shown",
+            file=get_test_image_file(),
+            uploaded_by_user=self.user,
+        )
+        Image.objects.create(
+            title="Test image not shown",
+            file=get_test_image_file(),
+        )
+
+        def filter_images(images, request):
+            # Filter on `uploaded_by_user` because it is
+            # the only default FilterField in search_fields
+            return images.filter(uploaded_by_user=self.user)
+
+        with self.register_hook("construct_image_chooser_queryset", filter_images):
+            response = self.get({"q": "Test"})
+        self.assertEqual(len(response.context["results"]), 1)
+        self.assertEqual(response.context["results"][0], image)
 
 
 class TestImageChooserChosenView(WagtailTestUtils, TestCase):

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -152,9 +152,13 @@ class TestImageQuerySet(TestCase):
             file=get_test_image_file(),
         )
 
-        results = Image.objects.order_by("title").search("Test")
+        results = Image.objects.order_by("title").search(
+            "Test", order_by_relevance=False
+        )
         self.assertEqual(list(results), [aaa_image, zzz_image])
-        results = Image.objects.order_by("-title").search("Test")
+        results = Image.objects.order_by("-title").search(
+            "Test", order_by_relevance=False
+        )
         self.assertEqual(list(results), [zzz_image, aaa_image])
 
     def test_search_indexing_prefetches_tags(self):

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -7,7 +7,7 @@ from django.core.files.storage import DefaultStorage, Storage
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models import Prefetch
 from django.db.utils import IntegrityError
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from willow.image import Image as WillowImage
@@ -113,7 +113,9 @@ class TestImage(TestCase):
             self.image.get_file_size()
 
 
-class TestImageQuerySet(TestCase):
+class TestImageQuerySet(TransactionTestCase):
+    fixtures = ["test_empty.json"]
+
     def test_search_method(self):
         # Create an image for running tests on
         image = Image.objects.create(

--- a/wagtail/search/backends/database/sqlite/query.py
+++ b/wagtail/search/backends/database/sqlite/query.py
@@ -197,6 +197,9 @@ class MatchExpression(Expression):
         ]  # Build the full MATCH search query. It will be a parameter to the template, so no SQL injections are possible here.
         return (self.template, params)
 
+    def __repr__(self):
+        return "<MatchExpression: %r = %r>" % (self.columns, self.query)
+
 
 class AndNot(SearchQuery):
     """

--- a/wagtail/search/tests/test_indexed_class.py
+++ b/wagtail/search/tests/test_indexed_class.py
@@ -6,7 +6,11 @@ from django.test import TestCase
 from wagtail.models import Page
 from wagtail.search import index
 from wagtail.test.search import models
-from wagtail.test.testapp.models import EventPage, SingleEventPage
+from wagtail.test.testapp.models import (
+    TaggedChildPage,
+    TaggedGrandchildPage,
+    TaggedPage,
+)
 
 
 @contextmanager
@@ -116,13 +120,16 @@ class TestSearchFields(TestCase):
     def test_checking_core_page_fields_are_indexed(self):
         """Run checks to ensure that when core page fields are missing we get a warning"""
 
-        # first confirm that errors show as EventPage (in test models) has no Page.search_fields
+        # first confirm that errors show as TaggedPage (in test models) has no Page.search_fields
         errors = [
             error for error in checks.run_checks() if error.id == "wagtailsearch.W001"
         ]
 
         # should only ever get this warning on the sub-classes of the page model
-        self.assertEqual([EventPage, SingleEventPage], [error.obj for error in errors])
+        self.assertEqual(
+            [TaggedPage, TaggedChildPage, TaggedGrandchildPage],
+            [error.obj for error in errors],
+        )
 
         for error in errors:
             self.assertEqual(
@@ -136,7 +143,7 @@ class TestSearchFields(TestCase):
 
         # second check that we get no errors when setting up the models correctly
         with patch_search_fields(
-            EventPage, Page.search_fields + EventPage.search_fields
+            TaggedPage, Page.search_fields + TaggedPage.search_fields
         ):
             errors = [
                 error
@@ -146,7 +153,7 @@ class TestSearchFields(TestCase):
             self.assertEqual([], errors)
 
         # third check that we get no errors when disabling all model search
-        with patch_search_fields(EventPage, []):
+        with patch_search_fields(TaggedPage, []):
             errors = [
                 error
                 for error in checks.run_checks()

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -13,7 +13,7 @@ from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpRequest, HttpResponse
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.timezone import make_aware, now
@@ -453,7 +453,7 @@ class TestListViewOrdering(WagtailTestUtils, TestCase):
         self.assertContains(response, list_url + "?ordering=live")
 
 
-class TestSnippetListViewWithSearchableSnippet(WagtailTestUtils, TestCase):
+class TestSnippetListViewWithSearchableSnippet(WagtailTestUtils, TransactionTestCase):
     def setUp(self):
         self.login()
 
@@ -605,6 +605,25 @@ class TestSnippetListViewWithFilterSet(WagtailTestUtils, TestCase):
             response,
             '<label for="id_country_code_1"><input type="radio" name="country_code" value="ID" id="id_country_code_1" checked>Indonesia</label>',
             html=True,
+        )
+
+
+class TestSnippetListViewWithFilterSetSearch(WagtailTestUtils, TransactionTestCase):
+    def setUp(self):
+        self.login()
+
+    def get(self, params={}):
+        return self.client.get(
+            reverse("wagtailsnippets_snippetstests_filterablesnippet:list"),
+            params,
+        )
+
+    def create_test_snippets(self):
+        FilterableSnippet.objects.create(
+            text="Nasi goreng from Indonesia", country_code="ID"
+        )
+        FilterableSnippet.objects.create(
+            text="Fish and chips from the UK", country_code="UK"
         )
 
     def test_filtered_searched_no_results(self):
@@ -4611,7 +4630,7 @@ class TestSnippetChooseStatus(WagtailTestUtils, TestCase):
         )
 
 
-class TestSnippetChooseWithSearchableSnippet(WagtailTestUtils, TestCase):
+class TestSnippetChooseWithSearchableSnippet(WagtailTestUtils, TransactionTestCase):
     def setUp(self):
         self.login()
 

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -529,8 +529,12 @@ class TestSnippetListViewWithFilterSet(WagtailTestUtils, TestCase):
         )
 
     def create_test_snippets(self):
-        FilterableSnippet.objects.create(text="From Indonesia", country_code="ID")
-        FilterableSnippet.objects.create(text="From the UK", country_code="UK")
+        FilterableSnippet.objects.create(
+            text="Nasi goreng from Indonesia", country_code="ID"
+        )
+        FilterableSnippet.objects.create(
+            text="Fish and chips from the UK", country_code="UK"
+        )
 
     def test_get_include_filters_form_media(self):
         response = self.get()
@@ -558,8 +562,8 @@ class TestSnippetListViewWithFilterSet(WagtailTestUtils, TestCase):
         self.create_test_snippets()
         response = self.get()
         self.assertTemplateUsed(response, "wagtailadmin/shared/filters.html")
-        self.assertContains(response, "From Indonesia")
-        self.assertContains(response, "From the UK")
+        self.assertContains(response, "Nasi goreng from Indonesia")
+        self.assertContains(response, "Fish and chips from the UK")
         self.assertNotContains(response, "There are 2 matches")
         self.assertContains(
             response,
@@ -571,8 +575,8 @@ class TestSnippetListViewWithFilterSet(WagtailTestUtils, TestCase):
         self.create_test_snippets()
         response = self.get({"country_code": ""})
         self.assertTemplateUsed(response, "wagtailadmin/shared/filters.html")
-        self.assertContains(response, "From Indonesia")
-        self.assertContains(response, "From the UK")
+        self.assertContains(response, "Nasi goreng from Indonesia")
+        self.assertContains(response, "Fish and chips from the UK")
         self.assertNotContains(response, "There are 2 matches")
         self.assertContains(
             response,
@@ -595,7 +599,7 @@ class TestSnippetListViewWithFilterSet(WagtailTestUtils, TestCase):
         self.create_test_snippets()
         response = self.get({"country_code": "ID"})
         self.assertTemplateUsed(response, "wagtailadmin/shared/filters.html")
-        self.assertContains(response, "From Indonesia")
+        self.assertContains(response, "Nasi goreng from Indonesia")
         self.assertContains(response, "There is 1 match")
         self.assertContains(
             response,
@@ -605,7 +609,7 @@ class TestSnippetListViewWithFilterSet(WagtailTestUtils, TestCase):
 
     def test_filtered_searched_no_results(self):
         self.create_test_snippets()
-        response = self.get({"country_code": "ID", "q": "the"})
+        response = self.get({"country_code": "ID", "q": "chips"})
         self.assertTemplateUsed(response, "wagtailadmin/shared/filters.html")
         self.assertContains(response, "Sorry, no filterable snippets match your query")
         self.assertContains(
@@ -616,9 +620,9 @@ class TestSnippetListViewWithFilterSet(WagtailTestUtils, TestCase):
 
     def test_filtered_searched_with_results(self):
         self.create_test_snippets()
-        response = self.get({"country_code": "UK", "q": "the"})
+        response = self.get({"country_code": "UK", "q": "chips"})
         self.assertTemplateUsed(response, "wagtailadmin/shared/filters.html")
-        self.assertContains(response, "From the UK")
+        self.assertContains(response, "Fish and chips from the UK")
         self.assertContains(response, "There is 1 match")
         self.assertContains(
             response,

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -308,7 +308,7 @@ class TestModelOrdering(WagtailTestUtils, TestCase):
             reverse("wagtailsnippetchoosers_tests_advertwithtabbedinterface:choose")
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["items"][0].text, "aaaadvert")
+        self.assertEqual(response.context["results"][0].text, "aaaadvert")
 
 
 class TestListViewOrdering(WagtailTestUtils, TestCase):
@@ -4481,7 +4481,7 @@ class TestSnippetChoose(WagtailTestUtils, TestCase):
             Advert.objects.create(pk=i, text="advert %d" % i)
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["items"][0].text, "advert 1")
+        self.assertEqual(response.context["results"][0].text, "advert 1")
 
     def test_simple_pagination(self):
 
@@ -4528,15 +4528,15 @@ class TestSnippetChoose(WagtailTestUtils, TestCase):
         self.assertIn('name="locale"', response_html)
 
         # Check both snippets are shown
-        self.assertEqual(len(response.context["items"]), 2)
-        self.assertEqual(response.context["items"][0].text, "English snippet")
-        self.assertEqual(response.context["items"][1].text, "French snippet")
+        self.assertEqual(len(response.context["results"]), 2)
+        self.assertEqual(response.context["results"][0].text, "English snippet")
+        self.assertEqual(response.context["results"][1].text, "French snippet")
 
         # Now test with a locale selected
         response = self.get({"locale": "en"})
 
-        self.assertEqual(len(response.context["items"]), 1)
-        self.assertEqual(response.context["items"][0].text, "English snippet")
+        self.assertEqual(len(response.context["results"]), 1)
+        self.assertEqual(response.context["results"][0].text, "English snippet")
 
 
 class TestSnippetChooseResults(WagtailTestUtils, TestCase):
@@ -4627,7 +4627,7 @@ class TestSnippetChooseWithSearchableSnippet(WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailadmin/generic/chooser/chooser.html")
 
         # All snippets should be in items
-        items = list(response.context["items"].object_list)
+        items = list(response.context["results"].object_list)
         self.assertIn(self.snippet_a, items)
         self.assertIn(self.snippet_b, items)
         self.assertIn(self.snippet_c, items)
@@ -4640,7 +4640,7 @@ class TestSnippetChooseWithSearchableSnippet(WagtailTestUtils, TestCase):
         response = self.get({"q": "Hello"})
 
         # Just snippets with "Hello" should be in items
-        items = list(response.context["items"].object_list)
+        items = list(response.context["results"].object_list)
         self.assertIn(self.snippet_a, items)
         self.assertNotIn(self.snippet_b, items)
         self.assertIn(self.snippet_c, items)
@@ -4649,7 +4649,7 @@ class TestSnippetChooseWithSearchableSnippet(WagtailTestUtils, TestCase):
         response = self.get({"q": "World"})
 
         # Just snippets with "World" should be in items
-        items = list(response.context["items"].object_list)
+        items = list(response.context["results"].object_list)
         self.assertNotIn(self.snippet_a, items)
         self.assertIn(self.snippet_b, items)
         self.assertIn(self.snippet_c, items)
@@ -4658,7 +4658,7 @@ class TestSnippetChooseWithSearchableSnippet(WagtailTestUtils, TestCase):
         response = self.get({"q": "hello wo"})
 
         # should perform partial matching and return "Hello World"
-        items = list(response.context["items"].object_list)
+        items = list(response.context["results"].object_list)
         self.assertNotIn(self.snippet_a, items)
         self.assertNotIn(self.snippet_b, items)
         self.assertIn(self.snippet_c, items)
@@ -5321,7 +5321,7 @@ class TestSnippetChooseWithCustomPrimaryKey(WagtailTestUtils, TestCase):
             AdvertWithCustomPrimaryKey.objects.create(pk=i, text="advert %d" % i)
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["items"][0].text, "advert 1")
+        self.assertEqual(response.context["results"][0].text, "advert 1")
 
 
 class TestSnippetChosenWithCustomPrimaryKey(WagtailTestUtils, TestCase):

--- a/wagtail/test/demosite/fixtures/demosite.json
+++ b/wagtail/test/demosite/fixtures/demosite.json
@@ -283,8 +283,8 @@
     "pk": 18,
     "model": "wagtailcore.page",
     "fields": {
-      "title": "Blog post again",
-      "draft_title": "Blog post again",
+      "title": "Blog post about elephants",
+      "draft_title": "Blog post about elephants",
       "numchild": 0,
       "show_in_menus": false,
       "live": true,

--- a/wagtail/test/demosite/fixtures/demosite.json
+++ b/wagtail/test/demosite/fixtures/demosite.json
@@ -1,6 +1,23 @@
 [
   {
     "pk": 1,
+    "model": "wagtailcore.locale",
+    "fields": {
+      "language_code": "en"
+    }
+  },
+  {
+    "model": "wagtailcore.collection",
+    "pk": 1,
+    "fields": {
+      "path": "0001",
+      "depth": 1,
+      "numchild": 0,
+      "name": "Root"
+    }
+  },
+  {
+    "pk": 1,
     "model": "wagtailcore.page",
     "fields": {
       "title": "Root",
@@ -16,6 +33,7 @@
       "owner": null,
       "path": "0001",
       "url_path": "/",
+      "locale": 1,
       "slug": "root"
     }
   },
@@ -36,6 +54,7 @@
       "owner": null,
       "path": "00010002",
       "url_path": "/home-page/",
+      "locale": 1,
       "slug": "home-page"
     }
   },
@@ -56,6 +75,7 @@
       "owner": null,
       "path": "000100020001",
       "url_path": "/home-page/events-index/",
+      "locale": 1,
       "slug": "events-index"
     }
   },
@@ -76,6 +96,7 @@
       "owner": null,
       "path": "000100020002",
       "url_path": "/home-page/blog-index/",
+      "locale": 1,
       "slug": "blog-index"
     }
   },
@@ -96,6 +117,7 @@
       "owner": null,
       "path": "000100020003",
       "url_path": "/home-page/standard-index/",
+      "locale": 1,
       "slug": "standard-index"
     }
   },
@@ -116,6 +138,7 @@
       "owner": null,
       "path": "0001000200010001",
       "url_path": "/home-page/events-index/event-1/",
+      "locale": 1,
       "slug": "event-1"
     }
   },
@@ -136,6 +159,7 @@
       "owner": null,
       "path": "0001000200010002",
       "url_path": "/home-page/events-index/event-2/",
+      "locale": 1,
       "slug": "event-2"
     }
   },
@@ -156,6 +180,7 @@
       "owner": null,
       "path": "0001000200030001",
       "url_path": "/home-page/standard-index/standard-page-1/",
+      "locale": 1,
       "slug": "standard-page-1"
     }
   },
@@ -176,6 +201,7 @@
       "owner": null,
       "path": "000100020005",
       "url_path": "/home-page/contact-page/",
+      "locale": 1,
       "slug": "contact-page"
     }
   },
@@ -196,6 +222,7 @@
       "owner": null,
       "path": "0001000200040001",
       "url_path": "/home-page/people/james-joyce/",
+      "locale": 1,
       "slug": "james-joyce"
     }
   },
@@ -216,6 +243,7 @@
       "owner": null,
       "path": "0001000200040002",
       "url_path": "/home-page/people/david-mitchell/",
+      "locale": 1,
       "slug": "david-mitchell"
     }
   },
@@ -236,6 +264,7 @@
       "owner": null,
       "path": "0001000200030002",
       "url_path": "/home-page/standard-index/standard-page-2/",
+      "locale": 1,
       "slug": "standard-page-2"
     }
   },
@@ -256,6 +285,7 @@
       "owner": null,
       "path": "0001000200020001",
       "url_path": "/home-page/blog-index/blog-post/",
+      "locale": 1,
       "slug": "blog-post"
     }
   },
@@ -276,6 +306,7 @@
       "owner": null,
       "path": "0001000200030007",
       "url_path": "/home-page/standard-index/photo-credits/",
+      "locale": 1,
       "slug": "photo-credits"
     }
   },
@@ -296,6 +327,7 @@
       "owner": null,
       "path": "0001000200020002",
       "url_path": "/home-page/blog-index/blog-post-again/",
+      "locale": 1,
       "slug": "blog-post-again"
     }
   },
@@ -316,6 +348,7 @@
       "owner": null,
       "path": "0001000200020003",
       "url_path": "/home-page/blog-index/another-blog-post/",
+      "locale": 1,
       "slug": "another-blog-post"
     }
   },
@@ -336,6 +369,7 @@
       "owner": null,
       "path": "000100020004",
       "url_path": "/home-page/people/",
+      "locale": 1,
       "slug": "people"
     }
   },
@@ -356,6 +390,7 @@
       "owner": null,
       "path": "0001000200030008",
       "url_path": "/home-page/standard-index/a-deeper-menu-level/",
+      "locale": 1,
       "slug": "a-deeper-menu-level"
     }
   },
@@ -376,6 +411,7 @@
       "owner": null,
       "path": "00010002000300080001",
       "url_path": "/home-page/standard-index/a-deeper-menu-level/a-grandchild-page/",
+      "locale": 1,
       "slug": "a-grandchild-page"
     }
   },
@@ -396,6 +432,7 @@
       "owner": null,
       "path": "00010002000300080002",
       "url_path": "/home-page/standard-index/a-deeper-menu-level/another-grandchild-page/",
+      "locale": 1,
       "slug": "another-grandchild-page"
     }
   },
@@ -416,6 +453,7 @@
       "owner": null,
       "path": "00010003",
       "url_path": "/home-page-multi-site/",
+      "locale": 1,
       "slug": "home-page-page-multi-site"
     }
   },
@@ -436,6 +474,7 @@
       "owner": null,
       "path": "000100030001",
       "url_path": "/home-page-multi-site/events-index-multi-site/",
+      "locale": 1,
       "slug": "events-index-multi-site"
     }
   },
@@ -468,6 +507,7 @@
       "height": 427,
       "width": 640,
       "file": "original_images/wagtail_by_markyharky.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -480,6 +520,7 @@
       "height": 392,
       "width": 500,
       "file": "original_images/James_Joyce_in_1915.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -492,6 +533,7 @@
       "height": 282,
       "width": 360,
       "file": "original_images/David_Mitchell_by_Kubik.JPG",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -504,6 +546,7 @@
       "height": 397,
       "width": 640,
       "file": "original_images/wagtail_by_joe_buckingham.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -516,6 +559,7 @@
       "height": 397,
       "width": 640,
       "file": "original_images/wagtail_by_fs-phil.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -528,6 +572,7 @@
       "height": 397,
       "width": 640,
       "file": "original_images/white_wagtail_by_Koshyk.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -540,6 +585,7 @@
       "height": 397,
       "width": 640,
       "file": "original_images/pied_wagtail_by_Marie_Hale.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -552,6 +598,7 @@
       "height": 397,
       "width": 640,
       "file": "original_images/wagtail_at_Borovoye_Kazakhstan_by_Ken_and_Nyetta.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -564,6 +611,7 @@
       "height": 397,
       "width": 640,
       "file": "original_images/wagtail_sproing_by_Jim_Bendon.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -576,6 +624,7 @@
       "height": 397,
       "width": 640,
       "file": "original_images/hopalong_wagtail_by_Ruth_Flickr.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -588,6 +637,7 @@
       "height": 397,
       "width": 640,
       "file": "original_images/wagtail_collects_insects_by_Maggi_94.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -600,6 +650,7 @@
       "height": 397,
       "width": 640,
       "file": "original_images/grey_wagtail_by_lip_kee.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -1054,6 +1105,7 @@
       "title": "Wagtail by mark Harkin",
       "created_at": "2014-02-06T10:14:47.173Z",
       "file": "original_images/wagtail_by_markyharky.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -1064,6 +1116,7 @@
       "title": "James Joyce",
       "created_at": "2014-02-06T10:37:10.518Z",
       "file": "original_images/James_Joyce_in_1915.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -1074,6 +1127,7 @@
       "title": "David Mitchell",
       "created_at": "2014-02-06T10:42:46.536Z",
       "file": "original_images/David_Mitchell_by_Kubik.JPG",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -1084,6 +1138,7 @@
       "title": "Wagtail by joe Buckingham",
       "created_at": "2014-02-06T10:49:29.579Z",
       "file": "original_images/wagtail_by_joe_buckingham.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -1094,6 +1149,7 @@
       "title": "Wagtail by fs-phil",
       "created_at": "2014-02-06T10:54:29.963Z",
       "file": "original_images/wagtail_by_fs-phil.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -1104,6 +1160,7 @@
       "title": "White wagtail by Koshy Koshy",
       "created_at": "2014-02-06T10:57:05.536Z",
       "file": "original_images/white_wagtail_by_Koshyk.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -1114,6 +1171,7 @@
       "title": "Pied wagtail by Marie Hale",
       "created_at": "2014-02-06T11:05:12.370Z",
       "file": "original_images/pied_wagtail_by_Marie_Hale.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -1124,6 +1182,7 @@
       "title": "Wagtail at Borovoye, Kazakhstan by Ken and Nyetta",
       "created_at": "2014-02-06T11:08:09.355Z",
       "file": "original_images/wagtail_at_Borovoye_Kazakhstan_by_Ken_and_Nyetta.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -1134,6 +1193,7 @@
       "title": "Wagtail sproing by Jim Bendon",
       "created_at": "2014-02-06T11:10:01.185Z",
       "file": "original_images/wagtail_sproing_by_Jim_Bendon.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -1144,6 +1204,7 @@
       "title": "Hopalong wagtail by Ruth Flickr",
       "created_at": "2014-02-06T11:15:32.454Z",
       "file": "original_images/hopalong_wagtail_by_Ruth_Flickr.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -1154,6 +1215,7 @@
       "title": "Wagtail collects insects by Margrit",
       "created_at": "2014-02-06T11:21:13.596Z",
       "file": "original_images/wagtail_collects_insects_by_Maggi_94.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   },
@@ -1164,6 +1226,7 @@
       "title": "Grey wagtail by Lip Kee",
       "created_at": "2014-02-06T11:23:36.409Z",
       "file": "original_images/grey_wagtail_by_lip_kee.jpg",
+      "collection": 1,
       "uploaded_by_user": null
     }
   }

--- a/wagtail/test/modeladmintest/fixtures/modeladmintest_test.json
+++ b/wagtail/test/modeladmintest/fixtures/modeladmintest_test.json
@@ -1,5 +1,22 @@
 [
   {
+    "model": "wagtailcore.locale",
+    "pk": 1,
+    "fields": {
+      "language_code": "en"
+    }
+  },
+  {
+    "model": "wagtailcore.collection",
+    "pk": 1,
+    "fields": {
+      "path": "0001",
+      "depth": 1,
+      "numchild": 0,
+      "name": "Root"
+    }
+  },
+  {
     "pk": 1,
     "model": "modeladmintest.author",
     "fields": {

--- a/wagtail/test/modeladmintest/fixtures/modeladmintest_test.json
+++ b/wagtail/test/modeladmintest/fixtures/modeladmintest_test.json
@@ -67,7 +67,7 @@
     "pk": 4,
     "model": "modeladmintest.book",
     "fields": {
-      "title": "The Chronicles of Narnia",
+      "title": "The Chronicles of the Lord of Narnia",
       "author_id": 3
     }
   },

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -177,7 +177,7 @@ ALLOWED_HOSTS = ["localhost", "testserver", "other.example.com"]
 
 WAGTAILSEARCH_BACKENDS = {
     "default": {
-        "BACKEND": "wagtail.search.backends.database.fallback",
+        "BACKEND": "wagtail.search.backends.database",
     }
 }
 

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -177,7 +177,7 @@ ALLOWED_HOSTS = ["localhost", "testserver", "other.example.com"]
 
 WAGTAILSEARCH_BACKENDS = {
     "default": {
-        "BACKEND": "wagtail.search.backends.database",
+        "BACKEND": "wagtail.search.backends.database.fallback",
     }
 }
 

--- a/wagtail/test/testapp/fixtures/test.json
+++ b/wagtail/test/testapp/fixtures/test.json
@@ -1,5 +1,22 @@
 [
   {
+    "model": "wagtailcore.locale",
+    "pk": 1,
+    "fields": {
+      "language_code": "en"
+    }
+  },
+  {
+    "model": "wagtailcore.collection",
+    "pk": 1,
+    "fields": {
+      "path": "0001",
+      "depth": 1,
+      "numchild": 3,
+      "name": "Root"
+    }
+  },
+  {
     "pk": 1,
     "model": "wagtailcore.page",
     "fields": {
@@ -922,16 +939,6 @@
       "restriction_type": "groups",
       "collection": 4,
       "groups": [["Event editors"]]
-    }
-  },
-  {
-    "model": "wagtailcore.collection",
-    "pk": 1,
-    "fields": {
-      "path": "0001",
-      "depth": 1,
-      "numchild": 3,
-      "name": "Root"
     }
   },
   {

--- a/wagtail/test/testapp/fixtures/test_empty.json
+++ b/wagtail/test/testapp/fixtures/test_empty.json
@@ -1,0 +1,54 @@
+[
+  {
+    "model": "wagtailcore.locale",
+    "pk": 1,
+    "fields": {
+      "language_code": "en"
+    }
+  },
+  {
+    "model": "wagtailcore.collection",
+    "pk": 1,
+    "fields": {
+      "path": "0001",
+      "depth": 1,
+      "numchild": 0,
+      "name": "Root"
+    }
+  },
+  {
+    "pk": 1,
+    "model": "wagtailcore.page",
+    "fields": {
+      "title": "Root",
+      "draft_title": "Root",
+      "numchild": 1,
+      "show_in_menus": false,
+      "live": true,
+      "depth": 1,
+      "content_type": ["wagtailcore", "page"],
+      "path": "0001",
+      "url_path": "/",
+      "slug": "root"
+    }
+  },
+
+  {
+    "pk": 2,
+    "model": "wagtailcore.page",
+    "fields": {
+      "title": "Welcome to the Wagtail test site!",
+      "draft_title": "Welcome to the Wagtail test site!",
+      "numchild": 0,
+      "show_in_menus": false,
+      "live": true,
+      "depth": 2,
+      "content_type": ["wagtailcore", "page"],
+      "path": "00010001",
+      "url_path": "/home/",
+      "slug": "home",
+      "first_published_at": "2014-01-01T12:00:00.000Z",
+      "last_published_at": "2014-02-01T12:00:00.000Z"
+    }
+  }
+]

--- a/wagtail/test/testapp/fixtures/test_specific.json
+++ b/wagtail/test/testapp/fixtures/test_specific.json
@@ -1,5 +1,22 @@
 [
   {
+    "model": "wagtailcore.locale",
+    "pk": 1,
+    "fields": {
+      "language_code": "en"
+    }
+  },
+  {
+    "model": "wagtailcore.collection",
+    "pk": 1,
+    "fields": {
+      "path": "0001",
+      "depth": 1,
+      "numchild": 3,
+      "name": "Root"
+    }
+  },
+  {
     "pk": 1,
     "model": "wagtailcore.page",
     "fields": {

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -372,7 +372,7 @@ class EventPage(Page):
     )
     categories = ParentalManyToManyField(EventCategory, blank=True)
 
-    search_fields = [
+    search_fields = Page.search_fields + [
         index.SearchField("get_audience_display"),
         index.SearchField("location"),
         index.SearchField("body"),
@@ -1302,6 +1302,11 @@ class TaggedPage(Page):
     content_panels = [
         FieldPanel("title", classname="title"),
         FieldPanel("tags"),
+    ]
+
+    # Page.search_fields intentionally omitted to test warning
+    search_fields = [
+        index.SearchField("tags"),
     ]
 
 

--- a/wagtail/tests/test_page_queryset.py
+++ b/wagtail/tests/test_page_queryset.py
@@ -4,7 +4,7 @@ from unittest import mock
 from django.contrib.contenttypes.models import ContentType
 from django.core import management
 from django.db.models import Count, Q
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 
 from wagtail.models import Locale, Page, PageViewRestriction, Site
 from wagtail.search.query import MATCH_ALL
@@ -623,7 +623,7 @@ class TestPageQueryInSite(TestCase):
         self.assertNotIn(self.about_us_page, site_2_pages)
 
 
-class TestPageQuerySetSearch(TestCase):
+class TestPageQuerySetSearch(TransactionTestCase):
     fixtures = ["test.json"]
 
     def test_search(self):
@@ -755,15 +755,6 @@ class TestSpecificQuery(WagtailTestUtils, TestCase):
 
     fixtures = ["test_specific.json"]
 
-    @classmethod
-    def setUpTestData(cls):
-        management.call_command(
-            "update_index",
-            backend_name="default",
-            stdout=StringIO(),
-            chunk_size=50,
-        )
-
     def setUp(self):
         self.live_pages = Page.objects.live().specific()
         self.live_pages_with_annotations = (
@@ -870,49 +861,6 @@ class TestSpecificQuery(WagtailTestUtils, TestCase):
 
         self.assertEqual(results.first().subscribers_count, 1)
         self.assertEqual(results.last().subscribers_count, 1)
-
-    def test_specific_query_with_match_all_search_and_annotation(self):
-        # Ensure annotations are reapplied to specific() page queries
-
-        results = (
-            Page.objects.live().specific().search(MATCH_ALL).annotate_score("_score")
-        )
-
-        self.assertGreater(len(results), 0)
-        for result in results:
-            self.assertTrue(hasattr(result, "_score"))
-
-    def test_specific_query_with_real_search_and_annotation(self):
-        # Ensure annotations are reapplied to specific() page queries
-
-        results = (
-            Page.objects.live().specific().search("event").annotate_score("_score")
-        )
-
-        self.assertGreater(len(results), 0)
-        for result in results:
-            self.assertTrue(hasattr(result, "_score"))
-
-    def test_specific_query_with_search(self):
-        # 1276 - The database search backend didn't return results with the
-        # specific type when searching a specific queryset.
-
-        pages = list(
-            Page.objects.specific()
-            .live()
-            .in_menu()
-            .search(MATCH_ALL, backend="wagtail.search.backends.database")
-        )
-
-        # Check that each page is in the queryset with the correct type.
-        # We don't care about order here
-        self.assertEqual(len(pages), 4)
-        self.assertIn(Page.objects.get(url_path="/home/other/").specific, pages)
-        self.assertIn(
-            Page.objects.get(url_path="/home/events/christmas/").specific, pages
-        )
-        self.assertIn(Page.objects.get(url_path="/home/events/").specific, pages)
-        self.assertIn(Page.objects.get(url_path="/home/about-us/").specific, pages)
 
     def test_specific_gracefully_handles_missing_models(self):
         # 3567 - PageQuerySet.specific should gracefully handle pages whose class definition
@@ -1096,6 +1044,66 @@ class TestSpecificQuery(WagtailTestUtils, TestCase):
         with self.assertNumQueries(5):
             result_2 = list(queryset.all().iterator(chunk_size=3))
             self.assertEqual(result_2, benchmark_result)
+
+
+class TestSpecificQuerySearch(WagtailTestUtils, TransactionTestCase):
+    fixtures = ["test_specific.json"]
+
+    def setUp(self):
+        management.call_command(
+            "update_index",
+            backend_name="default",
+            stdout=StringIO(),
+            chunk_size=50,
+        )
+
+        self.live_pages = Page.objects.live().specific()
+        self.live_pages_with_annotations = (
+            Page.objects.live().specific().annotate(count=Count("pk"))
+        )
+
+    def test_specific_query_with_match_all_search_and_annotation(self):
+        # Ensure annotations are reapplied to specific() page queries
+
+        results = (
+            Page.objects.live().specific().search(MATCH_ALL).annotate_score("_score")
+        )
+
+        self.assertGreater(len(results), 0)
+        for result in results:
+            self.assertTrue(hasattr(result, "_score"))
+
+    def test_specific_query_with_real_search_and_annotation(self):
+        # Ensure annotations are reapplied to specific() page queries
+
+        results = (
+            Page.objects.live().specific().search("event").annotate_score("_score")
+        )
+
+        self.assertGreater(len(results), 0)
+        for result in results:
+            self.assertTrue(hasattr(result, "_score"))
+
+    def test_specific_query_with_search(self):
+        # 1276 - The database search backend didn't return results with the
+        # specific type when searching a specific queryset.
+
+        pages = list(
+            Page.objects.specific()
+            .live()
+            .in_menu()
+            .search(MATCH_ALL, backend="wagtail.search.backends.database")
+        )
+
+        # Check that each page is in the queryset with the correct type.
+        # We don't care about order here
+        self.assertEqual(len(pages), 4)
+        self.assertIn(Page.objects.get(url_path="/home/other/").specific, pages)
+        self.assertIn(
+            Page.objects.get(url_path="/home/events/christmas/").specific, pages
+        )
+        self.assertIn(Page.objects.get(url_path="/home/events/").specific, pages)
+        self.assertIn(Page.objects.get(url_path="/home/about-us/").specific, pages)
 
 
 class TestFirstCommonAncestor(TestCase):


### PR DESCRIPTION
Early stages of addressing #9901, to make tests work against all search backends, not just the fallback one. So far it looks like the root causes of the failures are quite diverse, and it's not going to be a straightforward case of applying one fix everywhere.

Incorporates #10210 and #10211