### PR TITLE
Disconnect signal handlers that are connected during tests

### DIFF
--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_publish.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_publish.py
@@ -142,30 +142,33 @@ class TestBulkPublish(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         page_published.connect(mock_handler)
 
-        # Post to the publish page
-        response = self.client.post(self.url)
+        try:
+            # Post to the publish page
+            response = self.client.post(self.url)
 
-        # Should be redirected to explorer page
-        self.assertEqual(response.status_code, 302)
+            # Should be redirected to explorer page
+            self.assertEqual(response.status_code, 302)
 
-        # Check that the child pages were published
-        for child_page in self.pages_to_be_published:
-            published_page = SimplePage.objects.get(id=child_page.id)
-            self.assertTrue(published_page.live)
-            self.assertIn("Hello published", published_page.content)
+            # Check that the child pages were published
+            for child_page in self.pages_to_be_published:
+                published_page = SimplePage.objects.get(id=child_page.id)
+                self.assertTrue(published_page.live)
+                self.assertIn("Hello published", published_page.content)
 
-        # Check that the child pages not to be published remain
-        for child_page in self.pages_not_to_be_published:
-            self.assertFalse(Page.objects.get(id=child_page.id).live)
+            # Check that the child pages not to be published remain
+            for child_page in self.pages_not_to_be_published:
+                self.assertFalse(Page.objects.get(id=child_page.id).live)
 
-        # Check that the page_published signal was fired
-        self.assertEqual(mock_handler.call_count, len(self.pages_to_be_published))
+            # Check that the page_published signal was fired
+            self.assertEqual(mock_handler.call_count, len(self.pages_to_be_published))
 
-        for i, child_page in enumerate(self.pages_to_be_published):
-            mock_call = mock_handler.mock_calls[i][2]
-            self.assertEqual(mock_call["sender"], child_page.specific_class)
-            self.assertEqual(mock_call["instance"], child_page)
-            self.assertIsInstance(mock_call["instance"], child_page.specific_class)
+            for i, child_page in enumerate(self.pages_to_be_published):
+                mock_call = mock_handler.mock_calls[i][2]
+                self.assertEqual(mock_call["sender"], child_page.specific_class)
+                self.assertEqual(mock_call["instance"], child_page)
+                self.assertIsInstance(mock_call["instance"], child_page.specific_class)
+        finally:
+            page_published.disconnect(mock_handler)
 
     def test_after_publish_page(self):
         def hook_func(request, action_type, pages, action_class_instance):

--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_unpublish.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_unpublish.py
@@ -117,28 +117,31 @@ class TestBulkUnpublish(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         page_unpublished.connect(mock_handler)
 
-        # Post to the unpublish page
-        response = self.client.post(self.url)
+        try:
+            # Post to the unpublish page
+            response = self.client.post(self.url)
 
-        # Should be redirected to explorer page
-        self.assertEqual(response.status_code, 302)
+            # Should be redirected to explorer page
+            self.assertEqual(response.status_code, 302)
 
-        # Check that the child pages were unpublished
-        for child_page in self.pages_to_be_unpublished:
-            self.assertFalse(SimplePage.objects.get(id=child_page.id).live)
+            # Check that the child pages were unpublished
+            for child_page in self.pages_to_be_unpublished:
+                self.assertFalse(SimplePage.objects.get(id=child_page.id).live)
 
-        # Check that the child pages not to be unpublished remain
-        for child_page in self.pages_not_to_be_unpublished:
-            self.assertTrue(SimplePage.objects.get(id=child_page.id).live)
+            # Check that the child pages not to be unpublished remain
+            for child_page in self.pages_not_to_be_unpublished:
+                self.assertTrue(SimplePage.objects.get(id=child_page.id).live)
 
-        # Check that the page_unpublished signal was fired
-        self.assertEqual(mock_handler.call_count, len(self.pages_to_be_unpublished))
+            # Check that the page_unpublished signal was fired
+            self.assertEqual(mock_handler.call_count, len(self.pages_to_be_unpublished))
 
-        for i, child_page in enumerate(self.pages_to_be_unpublished):
-            mock_call = mock_handler.mock_calls[i][2]
-            self.assertEqual(mock_call["sender"], child_page.specific_class)
-            self.assertEqual(mock_call["instance"], child_page)
-            self.assertIsInstance(mock_call["instance"], child_page.specific_class)
+            for i, child_page in enumerate(self.pages_to_be_unpublished):
+                mock_call = mock_handler.mock_calls[i][2]
+                self.assertEqual(mock_call["sender"], child_page.specific_class)
+                self.assertEqual(mock_call["instance"], child_page)
+                self.assertIsInstance(mock_call["instance"], child_page.specific_class)
+        finally:
+            page_unpublished.disconnect(mock_handler)
 
     def test_after_unpublish_page(self):
         def hook_func(request, action_type, pages, action_class_instance):

--- a/wagtail/admin/tests/pages/test_delete_page.py
+++ b/wagtail/admin/tests/pages/test_delete_page.py
@@ -166,36 +166,39 @@ class TestPageDelete(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         page_unpublished.connect(mock_handler)
 
-        # Post
-        response = self.client.post(
-            reverse("wagtailadmin_pages:delete", args=(self.child_page.id,))
-        )
+        try:
+            # Post
+            response = self.client.post(
+                reverse("wagtailadmin_pages:delete", args=(self.child_page.id,))
+            )
 
-        # Should be redirected to explorer page
-        self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=(self.root_page.id,))
-        )
+            # Should be redirected to explorer page
+            self.assertRedirects(
+                response, reverse("wagtailadmin_explore", args=(self.root_page.id,))
+            )
 
-        # treebeard should report no consistency problems with the tree
-        self.assertFalse(
-            any(Page.find_problems()), msg="treebeard found consistency problems"
-        )
+            # treebeard should report no consistency problems with the tree
+            self.assertFalse(
+                any(Page.find_problems()), msg="treebeard found consistency problems"
+            )
 
-        # Check that the page is gone
-        self.assertEqual(
-            Page.objects.filter(
-                path__startswith=self.root_page.path, slug="hello-world"
-            ).count(),
-            0,
-        )
+            # Check that the page is gone
+            self.assertEqual(
+                Page.objects.filter(
+                    path__startswith=self.root_page.path, slug="hello-world"
+                ).count(),
+                0,
+            )
 
-        # Check that the page_unpublished signal was fired
-        self.assertEqual(mock_handler.call_count, 1)
-        mock_call = mock_handler.mock_calls[0][2]
+            # Check that the page_unpublished signal was fired
+            self.assertEqual(mock_handler.call_count, 1)
+            mock_call = mock_handler.mock_calls[0][2]
 
-        self.assertEqual(mock_call["sender"], self.child_page.specific_class)
-        self.assertEqual(mock_call["instance"], self.child_page)
-        self.assertIsInstance(mock_call["instance"], self.child_page.specific_class)
+            self.assertEqual(mock_call["sender"], self.child_page.specific_class)
+            self.assertEqual(mock_call["instance"], self.child_page)
+            self.assertIsInstance(mock_call["instance"], self.child_page.specific_class)
+        finally:
+            page_unpublished.disconnect(mock_handler)
 
     def test_page_delete_notlive_post(self):
         # Same as above, but this makes sure the page_unpublished signal is not fired
@@ -209,31 +212,34 @@ class TestPageDelete(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         page_unpublished.connect(mock_handler)
 
-        # Post
-        response = self.client.post(
-            reverse("wagtailadmin_pages:delete", args=(self.child_page.id,))
-        )
+        try:
+            # Post
+            response = self.client.post(
+                reverse("wagtailadmin_pages:delete", args=(self.child_page.id,))
+            )
 
-        # Should be redirected to explorer page
-        self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=(self.root_page.id,))
-        )
+            # Should be redirected to explorer page
+            self.assertRedirects(
+                response, reverse("wagtailadmin_explore", args=(self.root_page.id,))
+            )
 
-        # treebeard should report no consistency problems with the tree
-        self.assertFalse(
-            any(Page.find_problems()), msg="treebeard found consistency problems"
-        )
+            # treebeard should report no consistency problems with the tree
+            self.assertFalse(
+                any(Page.find_problems()), msg="treebeard found consistency problems"
+            )
 
-        # Check that the page is gone
-        self.assertEqual(
-            Page.objects.filter(
-                path__startswith=self.root_page.path, slug="hello-world"
-            ).count(),
-            0,
-        )
+            # Check that the page is gone
+            self.assertEqual(
+                Page.objects.filter(
+                    path__startswith=self.root_page.path, slug="hello-world"
+                ).count(),
+                0,
+            )
 
-        # Check that the page_unpublished signal was not fired
-        self.assertEqual(mock_handler.call_count, 0)
+            # Check that the page_unpublished signal was not fired
+            self.assertEqual(mock_handler.call_count, 0)
+        finally:
+            page_unpublished.disconnect(mock_handler)
 
     def test_subpage_deletion(self):
         # Connect mock signal handlers to page_unpublished, pre_delete and post_delete signals
@@ -254,48 +260,59 @@ class TestPageDelete(WagtailTestUtils, TestCase):
         pre_delete.connect(pre_delete_handler)
         post_delete.connect(post_delete_handler)
 
-        # Post
-        response = self.client.post(
-            reverse("wagtailadmin_pages:delete", args=(self.child_index.id,))
-        )
+        try:
+            # Post
+            response = self.client.post(
+                reverse("wagtailadmin_pages:delete", args=(self.child_index.id,))
+            )
 
-        # Should be redirected to explorer page
-        self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=(self.root_page.id,))
-        )
+            # Should be redirected to explorer page
+            self.assertRedirects(
+                response, reverse("wagtailadmin_explore", args=(self.root_page.id,))
+            )
 
-        # treebeard should report no consistency problems with the tree
-        self.assertFalse(
-            any(Page.find_problems()), msg="treebeard found consistency problems"
-        )
+            # treebeard should report no consistency problems with the tree
+            self.assertFalse(
+                any(Page.find_problems()), msg="treebeard found consistency problems"
+            )
 
-        # Check that the page is gone
-        self.assertFalse(StandardIndex.objects.filter(id=self.child_index.id).exists())
-        self.assertFalse(Page.objects.filter(id=self.child_index.id).exists())
+            # Check that the page is gone
+            self.assertFalse(
+                StandardIndex.objects.filter(id=self.child_index.id).exists()
+            )
+            self.assertFalse(Page.objects.filter(id=self.child_index.id).exists())
 
-        # Check that the subpage is also gone
-        self.assertFalse(
-            StandardChild.objects.filter(id=self.grandchild_page.id).exists()
-        )
-        self.assertFalse(Page.objects.filter(id=self.grandchild_page.id).exists())
+            # Check that the subpage is also gone
+            self.assertFalse(
+                StandardChild.objects.filter(id=self.grandchild_page.id).exists()
+            )
+            self.assertFalse(Page.objects.filter(id=self.grandchild_page.id).exists())
 
-        # Check that the signals were fired for both pages
-        self.assertIn((StandardIndex, self.child_index.id), unpublish_signals_received)
-        self.assertIn(
-            (StandardChild, self.grandchild_page.id), unpublish_signals_received
-        )
+            # Check that the signals were fired for both pages
+            self.assertIn(
+                (StandardIndex, self.child_index.id), unpublish_signals_received
+            )
+            self.assertIn(
+                (StandardChild, self.grandchild_page.id), unpublish_signals_received
+            )
 
-        self.assertIn((StandardIndex, self.child_index.id), pre_delete_signals_received)
-        self.assertIn(
-            (StandardChild, self.grandchild_page.id), pre_delete_signals_received
-        )
+            self.assertIn(
+                (StandardIndex, self.child_index.id), pre_delete_signals_received
+            )
+            self.assertIn(
+                (StandardChild, self.grandchild_page.id), pre_delete_signals_received
+            )
 
-        self.assertIn(
-            (StandardIndex, self.child_index.id), post_delete_signals_received
-        )
-        self.assertIn(
-            (StandardChild, self.grandchild_page.id), post_delete_signals_received
-        )
+            self.assertIn(
+                (StandardIndex, self.child_index.id), post_delete_signals_received
+            )
+            self.assertIn(
+                (StandardChild, self.grandchild_page.id), post_delete_signals_received
+            )
+        finally:
+            page_unpublished.disconnect(page_unpublished_handler)
+            pre_delete.disconnect(pre_delete_handler)
+            post_delete.disconnect(post_delete_handler)
 
     def test_before_delete_page_hook(self):
         def hook_func(request, page):

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -519,57 +519,60 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         page_published.connect(mock_handler)
 
-        # Set has_unpublished_changes=True on the existing record to confirm that the publish action
-        # is resetting it (and not just leaving it alone)
-        self.child_page.has_unpublished_changes = True
-        self.child_page.save()
+        try:
+            # Set has_unpublished_changes=True on the existing record to confirm that the publish action
+            # is resetting it (and not just leaving it alone)
+            self.child_page.has_unpublished_changes = True
+            self.child_page.save()
 
-        # Save current value of first_published_at so we can check that it doesn't change
-        first_published_at = SimplePage.objects.get(
-            id=self.child_page.id
-        ).first_published_at
+            # Save current value of first_published_at so we can check that it doesn't change
+            first_published_at = SimplePage.objects.get(
+                id=self.child_page.id
+            ).first_published_at
 
-        # Tests publish from edit page
-        post_data = {
-            "title": "I've been edited!",
-            "content": "Some content",
-            "slug": "hello-world-new",
-            "action-publish": "Publish",
-        }
-        response = self.client.post(
-            reverse("wagtailadmin_pages:edit", args=(self.child_page.id,)),
-            post_data,
-            follow=True,
-        )
+            # Tests publish from edit page
+            post_data = {
+                "title": "I've been edited!",
+                "content": "Some content",
+                "slug": "hello-world-new",
+                "action-publish": "Publish",
+            }
+            response = self.client.post(
+                reverse("wagtailadmin_pages:edit", args=(self.child_page.id,)),
+                post_data,
+                follow=True,
+            )
 
-        # Should be redirected to explorer
-        self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=(self.root_page.id,))
-        )
+            # Should be redirected to explorer
+            self.assertRedirects(
+                response, reverse("wagtailadmin_explore", args=(self.root_page.id,))
+            )
 
-        # Check that the page was edited
-        child_page_new = SimplePage.objects.get(id=self.child_page.id)
-        self.assertEqual(child_page_new.title, post_data["title"])
-        self.assertEqual(child_page_new.draft_title, post_data["title"])
+            # Check that the page was edited
+            child_page_new = SimplePage.objects.get(id=self.child_page.id)
+            self.assertEqual(child_page_new.title, post_data["title"])
+            self.assertEqual(child_page_new.draft_title, post_data["title"])
 
-        # Check that the page_published signal was fired
-        self.assertEqual(mock_handler.call_count, 1)
-        mock_call = mock_handler.mock_calls[0][2]
+            # Check that the page_published signal was fired
+            self.assertEqual(mock_handler.call_count, 1)
+            mock_call = mock_handler.mock_calls[0][2]
 
-        self.assertEqual(mock_call["sender"], child_page_new.specific_class)
-        self.assertEqual(mock_call["instance"], child_page_new)
-        self.assertIsInstance(mock_call["instance"], child_page_new.specific_class)
+            self.assertEqual(mock_call["sender"], child_page_new.specific_class)
+            self.assertEqual(mock_call["instance"], child_page_new)
+            self.assertIsInstance(mock_call["instance"], child_page_new.specific_class)
 
-        # The page shouldn't have "has_unpublished_changes" flag set
-        self.assertFalse(child_page_new.has_unpublished_changes)
+            # The page shouldn't have "has_unpublished_changes" flag set
+            self.assertFalse(child_page_new.has_unpublished_changes)
 
-        # first_published_at should not change as it was already set
-        self.assertEqual(first_published_at, child_page_new.first_published_at)
+            # first_published_at should not change as it was already set
+            self.assertEqual(first_published_at, child_page_new.first_published_at)
 
-        # The "View Live" button should have the updated slug.
-        for message in response.context["messages"]:
-            self.assertIn("hello-world-new", message.message)
-            break
+            # The "View Live" button should have the updated slug.
+            for message in response.context["messages"]:
+                self.assertIn("hello-world-new", message.message)
+                break
+        finally:
+            page_published.disconnect(mock_handler)
 
     def test_first_published_at_editable(self):
         """Test that we can update the first_published_at via the Page edit form,

--- a/wagtail/admin/tests/pages/test_moderation.py
+++ b/wagtail/admin/tests/pages/test_moderation.py
@@ -48,30 +48,37 @@ class TestApproveRejectModeration(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         page_published.connect(mock_handler)
 
-        # Post
-        response = self.client.post(
-            reverse("wagtailadmin_pages:approve_moderation", args=(self.revision.id,))
-        )
+        try:
+            # Post
+            response = self.client.post(
+                reverse(
+                    "wagtailadmin_pages:approve_moderation", args=(self.revision.id,)
+                )
+            )
 
-        # Check that the user was redirected to the dashboard
-        self.assertRedirects(response, reverse("wagtailadmin_home"))
+            # Check that the user was redirected to the dashboard
+            self.assertRedirects(response, reverse("wagtailadmin_home"))
 
-        page = Page.objects.get(id=self.page.id)
-        # Page must be live
-        self.assertTrue(page.live, msg="Approving moderation failed to set live=True")
-        # Page should now have no unpublished changes
-        self.assertFalse(
-            page.has_unpublished_changes,
-            msg="Approving moderation failed to set has_unpublished_changes=False",
-        )
+            page = Page.objects.get(id=self.page.id)
+            # Page must be live
+            self.assertTrue(
+                page.live, msg="Approving moderation failed to set live=True"
+            )
+            # Page should now have no unpublished changes
+            self.assertFalse(
+                page.has_unpublished_changes,
+                msg="Approving moderation failed to set has_unpublished_changes=False",
+            )
 
-        # Check that the page_published signal was fired
-        self.assertEqual(mock_handler.call_count, 1)
-        mock_call = mock_handler.mock_calls[0][2]
+            # Check that the page_published signal was fired
+            self.assertEqual(mock_handler.call_count, 1)
+            mock_call = mock_handler.mock_calls[0][2]
 
-        self.assertEqual(mock_call["sender"], self.page.specific_class)
-        self.assertEqual(mock_call["instance"], self.page)
-        self.assertIsInstance(mock_call["instance"], self.page.specific_class)
+            self.assertEqual(mock_call["sender"], self.page.specific_class)
+            self.assertEqual(mock_call["instance"], self.page)
+            self.assertIsInstance(mock_call["instance"], self.page.specific_class)
+        finally:
+            page_published.disconnect(mock_handler)
 
     def test_approve_moderation_when_later_revision_exists(self):
         self.page.title = "Goodbye world!"
@@ -405,27 +412,34 @@ class TestApproveRejectModerationWithoutUser(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         page_published.connect(mock_handler)
 
-        # Post
-        response = self.client.post(
-            reverse("wagtailadmin_pages:approve_moderation", args=(self.revision.id,))
-        )
+        try:
+            # Post
+            response = self.client.post(
+                reverse(
+                    "wagtailadmin_pages:approve_moderation", args=(self.revision.id,)
+                )
+            )
 
-        # Check that the user was redirected to the dashboard
-        self.assertRedirects(response, reverse("wagtailadmin_home"))
+            # Check that the user was redirected to the dashboard
+            self.assertRedirects(response, reverse("wagtailadmin_home"))
 
-        page = Page.objects.get(id=self.page.id)
-        # Page must be live
-        self.assertTrue(page.live, msg="Approving moderation failed to set live=True")
-        # Page should now have no unpublished changes
-        self.assertFalse(
-            page.has_unpublished_changes,
-            msg="Approving moderation failed to set has_unpublished_changes=False",
-        )
+            page = Page.objects.get(id=self.page.id)
+            # Page must be live
+            self.assertTrue(
+                page.live, msg="Approving moderation failed to set live=True"
+            )
+            # Page should now have no unpublished changes
+            self.assertFalse(
+                page.has_unpublished_changes,
+                msg="Approving moderation failed to set has_unpublished_changes=False",
+            )
 
-        # Check that the page_published signal was fired
-        self.assertEqual(mock_handler.call_count, 1)
-        mock_call = mock_handler.mock_calls[0][2]
+            # Check that the page_published signal was fired
+            self.assertEqual(mock_handler.call_count, 1)
+            mock_call = mock_handler.mock_calls[0][2]
 
-        self.assertEqual(mock_call["sender"], self.page.specific_class)
-        self.assertEqual(mock_call["instance"], self.page)
-        self.assertIsInstance(mock_call["instance"], self.page.specific_class)
+            self.assertEqual(mock_call["sender"], self.page.specific_class)
+            self.assertEqual(mock_call["instance"], self.page)
+            self.assertIsInstance(mock_call["instance"], self.page.specific_class)
+        finally:
+            page_published.disconnect(mock_handler)

--- a/wagtail/admin/tests/pages/test_unpublish_page.py
+++ b/wagtail/admin/tests/pages/test_unpublish_page.py
@@ -80,26 +80,29 @@ class TestPageUnpublish(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         page_unpublished.connect(mock_handler)
 
-        # Post to the unpublish page
-        response = self.client.post(
-            reverse("wagtailadmin_pages:unpublish", args=(self.page.id,))
-        )
+        try:
+            # Post to the unpublish page
+            response = self.client.post(
+                reverse("wagtailadmin_pages:unpublish", args=(self.page.id,))
+            )
 
-        # Should be redirected to explorer page
-        self.assertRedirects(
-            response, reverse("wagtailadmin_explore", args=(self.root_page.id,))
-        )
+            # Should be redirected to explorer page
+            self.assertRedirects(
+                response, reverse("wagtailadmin_explore", args=(self.root_page.id,))
+            )
 
-        # Check that the page was unpublished
-        self.assertFalse(SimplePage.objects.get(id=self.page.id).live)
+            # Check that the page was unpublished
+            self.assertFalse(SimplePage.objects.get(id=self.page.id).live)
 
-        # Check that the page_unpublished signal was fired
-        self.assertEqual(mock_handler.call_count, 1)
-        mock_call = mock_handler.mock_calls[0][2]
+            # Check that the page_unpublished signal was fired
+            self.assertEqual(mock_handler.call_count, 1)
+            mock_call = mock_handler.mock_calls[0][2]
 
-        self.assertEqual(mock_call["sender"], self.page.specific_class)
-        self.assertEqual(mock_call["instance"], self.page)
-        self.assertIsInstance(mock_call["instance"], self.page.specific_class)
+            self.assertEqual(mock_call["sender"], self.page.specific_class)
+            self.assertEqual(mock_call["instance"], self.page)
+            self.assertIsInstance(mock_call["instance"], self.page.specific_class)
+        finally:
+            page_unpublished.disconnect(mock_handler)
 
     def test_after_unpublish_page(self):
         def hook_func(request, page):

--- a/wagtail/documents/tests/test_views.py
+++ b/wagtail/documents/tests/test_views.py
@@ -139,11 +139,14 @@ class TestServeView(TestCase):
         mock_handler = mock.MagicMock()
         models.document_served.connect(mock_handler)
 
-        self.get()
+        try:
+            self.get()
 
-        self.assertEqual(mock_handler.call_count, 1)
-        self.assertEqual(mock_handler.mock_calls[0][2]["sender"], models.Document)
-        self.assertEqual(mock_handler.mock_calls[0][2]["instance"], self.document)
+            self.assertEqual(mock_handler.call_count, 1)
+            self.assertEqual(mock_handler.mock_calls[0][2]["sender"], models.Document)
+            self.assertEqual(mock_handler.mock_calls[0][2]["instance"], self.document)
+        finally:
+            models.document_served.disconnect(mock_handler)
 
     def test_with_nonexistent_document(self):
         response = self.client.get(

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -1007,46 +1007,49 @@ class TestCreateDraftStateSnippet(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         published.connect(mock_handler)
 
-        timestamp = now()
-        with freeze_time(timestamp):
-            response = self.post(
-                post_data={
-                    "text": "Draft-enabled Foo, Published",
-                    "action-publish": "action-publish",
-                }
+        try:
+            timestamp = now()
+            with freeze_time(timestamp):
+                response = self.post(
+                    post_data={
+                        "text": "Draft-enabled Foo, Published",
+                        "action-publish": "action-publish",
+                    }
+                )
+            snippet = DraftStateModel.objects.get(text="Draft-enabled Foo, Published")
+
+            self.assertRedirects(
+                response, reverse("wagtailsnippets_tests_draftstatemodel:list")
             )
-        snippet = DraftStateModel.objects.get(text="Draft-enabled Foo, Published")
 
-        self.assertRedirects(
-            response, reverse("wagtailsnippets_tests_draftstatemodel:list")
-        )
+            # The instance should be created
+            self.assertEqual(snippet.text, "Draft-enabled Foo, Published")
 
-        # The instance should be created
-        self.assertEqual(snippet.text, "Draft-enabled Foo, Published")
+            # The instance should be live
+            self.assertTrue(snippet.live)
+            self.assertFalse(snippet.has_unpublished_changes)
+            self.assertEqual(snippet.first_published_at, timestamp)
+            self.assertEqual(snippet.last_published_at, timestamp)
 
-        # The instance should be live
-        self.assertTrue(snippet.live)
-        self.assertFalse(snippet.has_unpublished_changes)
-        self.assertEqual(snippet.first_published_at, timestamp)
-        self.assertEqual(snippet.last_published_at, timestamp)
+            # A revision should be created and set as both latest_revision and live_revision
+            self.assertIsNotNone(snippet.live_revision)
+            self.assertEqual(snippet.live_revision, snippet.latest_revision)
 
-        # A revision should be created and set as both latest_revision and live_revision
-        self.assertIsNotNone(snippet.live_revision)
-        self.assertEqual(snippet.live_revision, snippet.latest_revision)
+            # The revision content should contain the new data
+            self.assertEqual(
+                snippet.live_revision.content["text"],
+                "Draft-enabled Foo, Published",
+            )
 
-        # The revision content should contain the new data
-        self.assertEqual(
-            snippet.live_revision.content["text"],
-            "Draft-enabled Foo, Published",
-        )
+            # Check that the published signal was fired
+            self.assertEqual(mock_handler.call_count, 1)
+            mock_call = mock_handler.mock_calls[0][2]
 
-        # Check that the published signal was fired
-        self.assertEqual(mock_handler.call_count, 1)
-        mock_call = mock_handler.mock_calls[0][2]
-
-        self.assertEqual(mock_call["sender"], DraftStateModel)
-        self.assertEqual(mock_call["instance"], snippet)
-        self.assertIsInstance(mock_call["instance"], DraftStateModel)
+            self.assertEqual(mock_call["sender"], DraftStateModel)
+            self.assertEqual(mock_call["instance"], snippet)
+            self.assertIsInstance(mock_call["instance"], DraftStateModel)
+        finally:
+            published.disconnect(mock_handler)
 
     def test_publish_bad_permissions(self):
         # Only add create and edit permission
@@ -1074,42 +1077,45 @@ class TestCreateDraftStateSnippet(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         published.connect(mock_handler)
 
-        response = self.post(
-            post_data={
-                "text": "Draft-enabled Foo",
-                "action-publish": "action-publish",
-            }
-        )
-        snippet = DraftStateModel.objects.get(text="Draft-enabled Foo")
+        try:
+            response = self.post(
+                post_data={
+                    "text": "Draft-enabled Foo",
+                    "action-publish": "action-publish",
+                }
+            )
+            snippet = DraftStateModel.objects.get(text="Draft-enabled Foo")
 
-        # Should be taken to the edit page
-        self.assertRedirects(
-            response,
-            reverse(
-                "wagtailsnippets_tests_draftstatemodel:edit",
-                args=[snippet.pk],
-            ),
-        )
+            # Should be taken to the edit page
+            self.assertRedirects(
+                response,
+                reverse(
+                    "wagtailsnippets_tests_draftstatemodel:edit",
+                    args=[snippet.pk],
+                ),
+            )
 
-        # The instance should still be created
-        self.assertEqual(snippet.text, "Draft-enabled Foo")
+            # The instance should still be created
+            self.assertEqual(snippet.text, "Draft-enabled Foo")
 
-        # The instance should not be live
-        self.assertFalse(snippet.live)
-        self.assertTrue(snippet.has_unpublished_changes)
+            # The instance should not be live
+            self.assertFalse(snippet.live)
+            self.assertTrue(snippet.has_unpublished_changes)
 
-        # A revision should be created and set as latest_revision, but not live_revision
-        self.assertIsNotNone(snippet.latest_revision)
-        self.assertIsNone(snippet.live_revision)
+            # A revision should be created and set as latest_revision, but not live_revision
+            self.assertIsNotNone(snippet.latest_revision)
+            self.assertIsNone(snippet.live_revision)
 
-        # The revision content should contain the data
-        self.assertEqual(
-            snippet.latest_revision.content["text"],
-            "Draft-enabled Foo",
-        )
+            # The revision content should contain the data
+            self.assertEqual(
+                snippet.latest_revision.content["text"],
+                "Draft-enabled Foo",
+            )
 
-        # Check that the published signal was not fired
-        self.assertEqual(mock_handler.call_count, 0)
+            # Check that the published signal was not fired
+            self.assertEqual(mock_handler.call_count, 0)
+        finally:
+            published.disconnect(mock_handler)
 
     def test_publish_with_publish_permission(self):
         # Use create and publish permissions instead of relying on superuser flag
@@ -1137,46 +1143,49 @@ class TestCreateDraftStateSnippet(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         published.connect(mock_handler)
 
-        timestamp = now()
-        with freeze_time(timestamp):
-            response = self.post(
-                post_data={
-                    "text": "Draft-enabled Foo, Published",
-                    "action-publish": "action-publish",
-                }
+        try:
+            timestamp = now()
+            with freeze_time(timestamp):
+                response = self.post(
+                    post_data={
+                        "text": "Draft-enabled Foo, Published",
+                        "action-publish": "action-publish",
+                    }
+                )
+            snippet = DraftStateModel.objects.get(text="Draft-enabled Foo, Published")
+
+            self.assertRedirects(
+                response, reverse("wagtailsnippets_tests_draftstatemodel:list")
             )
-        snippet = DraftStateModel.objects.get(text="Draft-enabled Foo, Published")
 
-        self.assertRedirects(
-            response, reverse("wagtailsnippets_tests_draftstatemodel:list")
-        )
+            # The instance should be created
+            self.assertEqual(snippet.text, "Draft-enabled Foo, Published")
 
-        # The instance should be created
-        self.assertEqual(snippet.text, "Draft-enabled Foo, Published")
+            # The instance should be live
+            self.assertTrue(snippet.live)
+            self.assertFalse(snippet.has_unpublished_changes)
+            self.assertEqual(snippet.first_published_at, timestamp)
+            self.assertEqual(snippet.last_published_at, timestamp)
 
-        # The instance should be live
-        self.assertTrue(snippet.live)
-        self.assertFalse(snippet.has_unpublished_changes)
-        self.assertEqual(snippet.first_published_at, timestamp)
-        self.assertEqual(snippet.last_published_at, timestamp)
+            # A revision should be created and set as both latest_revision and live_revision
+            self.assertIsNotNone(snippet.live_revision)
+            self.assertEqual(snippet.live_revision, snippet.latest_revision)
 
-        # A revision should be created and set as both latest_revision and live_revision
-        self.assertIsNotNone(snippet.live_revision)
-        self.assertEqual(snippet.live_revision, snippet.latest_revision)
+            # The revision content should contain the new data
+            self.assertEqual(
+                snippet.live_revision.content["text"],
+                "Draft-enabled Foo, Published",
+            )
 
-        # The revision content should contain the new data
-        self.assertEqual(
-            snippet.live_revision.content["text"],
-            "Draft-enabled Foo, Published",
-        )
+            # Check that the published signal was fired
+            self.assertEqual(mock_handler.call_count, 1)
+            mock_call = mock_handler.mock_calls[0][2]
 
-        # Check that the published signal was fired
-        self.assertEqual(mock_handler.call_count, 1)
-        mock_call = mock_handler.mock_calls[0][2]
-
-        self.assertEqual(mock_call["sender"], DraftStateModel)
-        self.assertEqual(mock_call["instance"], snippet)
-        self.assertIsInstance(mock_call["instance"], DraftStateModel)
+            self.assertEqual(mock_call["sender"], DraftStateModel)
+            self.assertEqual(mock_call["instance"], snippet)
+            self.assertIsInstance(mock_call["instance"], DraftStateModel)
+        finally:
+            published.disconnect(mock_handler)
 
     def test_create_scheduled(self):
         go_live_at = now() + datetime.timedelta(days=1)
@@ -1708,64 +1717,69 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         mock_handler = mock.MagicMock()
         published.connect(mock_handler)
 
-        timestamp = now()
-        with freeze_time(timestamp):
-            response = self.post(
-                post_data={
-                    "text": "Draft-enabled Bar, Published",
-                    "action-publish": "action-publish",
-                }
+        try:
+            timestamp = now()
+            with freeze_time(timestamp):
+                response = self.post(
+                    post_data={
+                        "text": "Draft-enabled Bar, Published",
+                        "action-publish": "action-publish",
+                    }
+                )
+
+            self.test_snippet.refresh_from_db()
+            revisions = Revision.objects.for_instance(self.test_snippet)
+            latest_revision = self.test_snippet.latest_revision
+
+            log_entries = ModelLogEntry.objects.filter(
+                content_type=ContentType.objects.get_for_model(
+                    DraftStateCustomPrimaryKeyModel
+                ),
+                action="wagtail.publish",
+                object_id=self.test_snippet.pk,
+            )
+            log_entry = log_entries.first()
+
+            self.assertRedirects(
+                response,
+                reverse("wagtailsnippets_tests_draftstatecustomprimarykeymodel:list"),
             )
 
-        self.test_snippet.refresh_from_db()
-        revisions = Revision.objects.for_instance(self.test_snippet)
-        latest_revision = self.test_snippet.latest_revision
+            # The instance should be updated
+            self.assertEqual(self.test_snippet.text, "Draft-enabled Bar, Published")
 
-        log_entries = ModelLogEntry.objects.filter(
-            content_type=ContentType.objects.get_for_model(
-                DraftStateCustomPrimaryKeyModel
-            ),
-            action="wagtail.publish",
-            object_id=self.test_snippet.pk,
-        )
-        log_entry = log_entries.first()
+            # The instance should be live
+            self.assertTrue(self.test_snippet.live)
+            self.assertFalse(self.test_snippet.has_unpublished_changes)
+            self.assertEqual(self.test_snippet.first_published_at, timestamp)
+            self.assertEqual(self.test_snippet.last_published_at, timestamp)
+            self.assertEqual(self.test_snippet.live_revision, latest_revision)
 
-        self.assertRedirects(
-            response,
-            reverse("wagtailsnippets_tests_draftstatecustomprimarykeymodel:list"),
-        )
+            # The revision should be created and set as latest_revision
+            self.assertEqual(revisions.count(), 1)
+            self.assertEqual(latest_revision, revisions.first())
 
-        # The instance should be updated
-        self.assertEqual(self.test_snippet.text, "Draft-enabled Bar, Published")
+            # The revision content should contain the new data
+            self.assertEqual(
+                latest_revision.content["text"],
+                "Draft-enabled Bar, Published",
+            )
 
-        # The instance should be live
-        self.assertTrue(self.test_snippet.live)
-        self.assertFalse(self.test_snippet.has_unpublished_changes)
-        self.assertEqual(self.test_snippet.first_published_at, timestamp)
-        self.assertEqual(self.test_snippet.last_published_at, timestamp)
-        self.assertEqual(self.test_snippet.live_revision, latest_revision)
+            # A log entry with wagtail.publish action should be created
+            self.assertEqual(log_entries.count(), 1)
+            self.assertEqual(log_entry.timestamp, timestamp)
 
-        # The revision should be created and set as latest_revision
-        self.assertEqual(revisions.count(), 1)
-        self.assertEqual(latest_revision, revisions.first())
+            # Check that the published signal was fired
+            self.assertEqual(mock_handler.call_count, 1)
+            mock_call = mock_handler.mock_calls[0][2]
 
-        # The revision content should contain the new data
-        self.assertEqual(
-            latest_revision.content["text"],
-            "Draft-enabled Bar, Published",
-        )
-
-        # A log entry with wagtail.publish action should be created
-        self.assertEqual(log_entries.count(), 1)
-        self.assertEqual(log_entry.timestamp, timestamp)
-
-        # Check that the published signal was fired
-        self.assertEqual(mock_handler.call_count, 1)
-        mock_call = mock_handler.mock_calls[0][2]
-
-        self.assertEqual(mock_call["sender"], DraftStateCustomPrimaryKeyModel)
-        self.assertEqual(mock_call["instance"], self.test_snippet)
-        self.assertIsInstance(mock_call["instance"], DraftStateCustomPrimaryKeyModel)
+            self.assertEqual(mock_call["sender"], DraftStateCustomPrimaryKeyModel)
+            self.assertEqual(mock_call["instance"], self.test_snippet)
+            self.assertIsInstance(
+                mock_call["instance"], DraftStateCustomPrimaryKeyModel
+            )
+        finally:
+            published.disconnect(mock_handler)
 
     def test_publish_bad_permissions(self):
         # Only add edit permission
@@ -1785,36 +1799,39 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         mock_handler = mock.MagicMock()
         published.connect(mock_handler)
 
-        response = self.post(
-            post_data={
-                "text": "Edited draft Foo",
-                "action-publish": "action-publish",
-            }
-        )
-        self.test_snippet.refresh_from_db()
+        try:
+            response = self.post(
+                post_data={
+                    "text": "Edited draft Foo",
+                    "action-publish": "action-publish",
+                }
+            )
+            self.test_snippet.refresh_from_db()
 
-        # Should remain on the edit page
-        self.assertRedirects(response, self.get_edit_url())
+            # Should remain on the edit page
+            self.assertRedirects(response, self.get_edit_url())
 
-        # The instance should not be edited
-        self.assertEqual(self.test_snippet.text, "Draft-enabled Foo")
+            # The instance should not be edited
+            self.assertEqual(self.test_snippet.text, "Draft-enabled Foo")
 
-        # The instance should not be live
-        self.assertFalse(self.test_snippet.live)
-        self.assertTrue(self.test_snippet.has_unpublished_changes)
+            # The instance should not be live
+            self.assertFalse(self.test_snippet.live)
+            self.assertTrue(self.test_snippet.has_unpublished_changes)
 
-        # A revision should be created and set as latest_revision, but not live_revision
-        self.assertIsNotNone(self.test_snippet.latest_revision)
-        self.assertIsNone(self.test_snippet.live_revision)
+            # A revision should be created and set as latest_revision, but not live_revision
+            self.assertIsNotNone(self.test_snippet.latest_revision)
+            self.assertIsNone(self.test_snippet.live_revision)
 
-        # The revision content should contain the data
-        self.assertEqual(
-            self.test_snippet.latest_revision.content["text"],
-            "Edited draft Foo",
-        )
+            # The revision content should contain the data
+            self.assertEqual(
+                self.test_snippet.latest_revision.content["text"],
+                "Edited draft Foo",
+            )
 
-        # Check that the published signal was not fired
-        self.assertEqual(mock_handler.call_count, 0)
+            # Check that the published signal was not fired
+            self.assertEqual(mock_handler.call_count, 0)
+        finally:
+            published.disconnect(mock_handler)
 
     def test_publish_with_publish_permission(self):
         # Only add edit and publish permissions
@@ -1841,64 +1858,69 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         mock_handler = mock.MagicMock()
         published.connect(mock_handler)
 
-        timestamp = now()
-        with freeze_time(timestamp):
-            response = self.post(
-                post_data={
-                    "text": "Draft-enabled Bar, Published",
-                    "action-publish": "action-publish",
-                }
+        try:
+            timestamp = now()
+            with freeze_time(timestamp):
+                response = self.post(
+                    post_data={
+                        "text": "Draft-enabled Bar, Published",
+                        "action-publish": "action-publish",
+                    }
+                )
+
+            self.test_snippet.refresh_from_db()
+            revisions = Revision.objects.for_instance(self.test_snippet)
+            latest_revision = self.test_snippet.latest_revision
+
+            log_entries = ModelLogEntry.objects.filter(
+                content_type=ContentType.objects.get_for_model(
+                    DraftStateCustomPrimaryKeyModel
+                ),
+                action="wagtail.publish",
+                object_id=self.test_snippet.pk,
+            )
+            log_entry = log_entries.first()
+
+            self.assertRedirects(
+                response,
+                reverse("wagtailsnippets_tests_draftstatecustomprimarykeymodel:list"),
             )
 
-        self.test_snippet.refresh_from_db()
-        revisions = Revision.objects.for_instance(self.test_snippet)
-        latest_revision = self.test_snippet.latest_revision
+            # The instance should be updated
+            self.assertEqual(self.test_snippet.text, "Draft-enabled Bar, Published")
 
-        log_entries = ModelLogEntry.objects.filter(
-            content_type=ContentType.objects.get_for_model(
-                DraftStateCustomPrimaryKeyModel
-            ),
-            action="wagtail.publish",
-            object_id=self.test_snippet.pk,
-        )
-        log_entry = log_entries.first()
+            # The instance should be live
+            self.assertTrue(self.test_snippet.live)
+            self.assertFalse(self.test_snippet.has_unpublished_changes)
+            self.assertEqual(self.test_snippet.first_published_at, timestamp)
+            self.assertEqual(self.test_snippet.last_published_at, timestamp)
+            self.assertEqual(self.test_snippet.live_revision, latest_revision)
 
-        self.assertRedirects(
-            response,
-            reverse("wagtailsnippets_tests_draftstatecustomprimarykeymodel:list"),
-        )
+            # The revision should be created and set as latest_revision
+            self.assertEqual(revisions.count(), 1)
+            self.assertEqual(latest_revision, revisions.first())
 
-        # The instance should be updated
-        self.assertEqual(self.test_snippet.text, "Draft-enabled Bar, Published")
+            # The revision content should contain the new data
+            self.assertEqual(
+                latest_revision.content["text"],
+                "Draft-enabled Bar, Published",
+            )
 
-        # The instance should be live
-        self.assertTrue(self.test_snippet.live)
-        self.assertFalse(self.test_snippet.has_unpublished_changes)
-        self.assertEqual(self.test_snippet.first_published_at, timestamp)
-        self.assertEqual(self.test_snippet.last_published_at, timestamp)
-        self.assertEqual(self.test_snippet.live_revision, latest_revision)
+            # A log entry with wagtail.publish action should be created
+            self.assertEqual(log_entries.count(), 1)
+            self.assertEqual(log_entry.timestamp, timestamp)
 
-        # The revision should be created and set as latest_revision
-        self.assertEqual(revisions.count(), 1)
-        self.assertEqual(latest_revision, revisions.first())
+            # Check that the published signal was fired
+            self.assertEqual(mock_handler.call_count, 1)
+            mock_call = mock_handler.mock_calls[0][2]
 
-        # The revision content should contain the new data
-        self.assertEqual(
-            latest_revision.content["text"],
-            "Draft-enabled Bar, Published",
-        )
-
-        # A log entry with wagtail.publish action should be created
-        self.assertEqual(log_entries.count(), 1)
-        self.assertEqual(log_entry.timestamp, timestamp)
-
-        # Check that the published signal was fired
-        self.assertEqual(mock_handler.call_count, 1)
-        mock_call = mock_handler.mock_calls[0][2]
-
-        self.assertEqual(mock_call["sender"], DraftStateCustomPrimaryKeyModel)
-        self.assertEqual(mock_call["instance"], self.test_snippet)
-        self.assertIsInstance(mock_call["instance"], DraftStateCustomPrimaryKeyModel)
+            self.assertEqual(mock_call["sender"], DraftStateCustomPrimaryKeyModel)
+            self.assertEqual(mock_call["instance"], self.test_snippet)
+            self.assertIsInstance(
+                mock_call["instance"], DraftStateCustomPrimaryKeyModel
+            )
+        finally:
+            published.disconnect(mock_handler)
 
     def test_save_draft_then_publish(self):
         save_timestamp = now()
@@ -3405,28 +3427,31 @@ class TestSnippetUnpublish(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         unpublished.connect(mock_handler)
 
-        # Remove privileges from user
-        self.user.is_superuser = False
-        self.user.user_permissions.add(
-            Permission.objects.get(
-                content_type__app_label="wagtailadmin", codename="access_admin"
+        try:
+            # Remove privileges from user
+            self.user.is_superuser = False
+            self.user.user_permissions.add(
+                Permission.objects.get(
+                    content_type__app_label="wagtailadmin", codename="access_admin"
+                )
             )
-        )
-        self.user.save()
+            self.user.save()
 
-        # Post to the unpublish view
-        response = self.client.post(self.unpublish_url)
+            # Post to the unpublish view
+            response = self.client.post(self.unpublish_url)
 
-        # Should be redirected to the home page
-        self.assertRedirects(response, reverse("wagtailadmin_home"))
+            # Should be redirected to the home page
+            self.assertRedirects(response, reverse("wagtailadmin_home"))
 
-        # Check that the object was not unpublished
-        self.assertTrue(
-            DraftStateCustomPrimaryKeyModel.objects.get(pk=self.snippet.pk).live
-        )
+            # Check that the object was not unpublished
+            self.assertTrue(
+                DraftStateCustomPrimaryKeyModel.objects.get(pk=self.snippet.pk).live
+            )
 
-        # Check that the unpublished signal was not fired
-        self.assertEqual(mock_handler.call_count, 0)
+            # Check that the unpublished signal was not fired
+            self.assertEqual(mock_handler.call_count, 0)
+        finally:
+            unpublished.disconnect(mock_handler)
 
     def test_unpublish_view_post_with_publish_permission(self):
         """
@@ -3437,47 +3462,52 @@ class TestSnippetUnpublish(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         unpublished.connect(mock_handler)
 
-        # Only add edit and publish permissions
-        self.user.is_superuser = False
-        edit_permission = Permission.objects.get(
-            content_type__app_label="tests",
-            codename="change_draftstatecustomprimarykeymodel",
-        )
-        publish_permission = Permission.objects.get(
-            content_type__app_label="tests",
-            codename="publish_draftstatecustomprimarykeymodel",
-        )
-        admin_permission = Permission.objects.get(
-            content_type__app_label="wagtailadmin", codename="access_admin"
-        )
-        self.user.user_permissions.add(
-            edit_permission,
-            publish_permission,
-            admin_permission,
-        )
-        self.user.save()
+        try:
+            # Only add edit and publish permissions
+            self.user.is_superuser = False
+            edit_permission = Permission.objects.get(
+                content_type__app_label="tests",
+                codename="change_draftstatecustomprimarykeymodel",
+            )
+            publish_permission = Permission.objects.get(
+                content_type__app_label="tests",
+                codename="publish_draftstatecustomprimarykeymodel",
+            )
+            admin_permission = Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            )
+            self.user.user_permissions.add(
+                edit_permission,
+                publish_permission,
+                admin_permission,
+            )
+            self.user.save()
 
-        # Post to the unpublish view
-        response = self.client.post(self.unpublish_url)
+            # Post to the unpublish view
+            response = self.client.post(self.unpublish_url)
 
-        # Should be redirected to the listing page
-        self.assertRedirects(
-            response,
-            reverse("wagtailsnippets_tests_draftstatecustomprimarykeymodel:list"),
-        )
+            # Should be redirected to the listing page
+            self.assertRedirects(
+                response,
+                reverse("wagtailsnippets_tests_draftstatecustomprimarykeymodel:list"),
+            )
 
-        # Check that the object was unpublished
-        self.assertFalse(
-            DraftStateCustomPrimaryKeyModel.objects.get(pk=self.snippet.pk).live
-        )
+            # Check that the object was unpublished
+            self.assertFalse(
+                DraftStateCustomPrimaryKeyModel.objects.get(pk=self.snippet.pk).live
+            )
 
-        # Check that the unpublished signal was fired
-        self.assertEqual(mock_handler.call_count, 1)
-        mock_call = mock_handler.mock_calls[0][2]
+            # Check that the unpublished signal was fired
+            self.assertEqual(mock_handler.call_count, 1)
+            mock_call = mock_handler.mock_calls[0][2]
 
-        self.assertEqual(mock_call["sender"], DraftStateCustomPrimaryKeyModel)
-        self.assertEqual(mock_call["instance"], self.snippet)
-        self.assertIsInstance(mock_call["instance"], DraftStateCustomPrimaryKeyModel)
+            self.assertEqual(mock_call["sender"], DraftStateCustomPrimaryKeyModel)
+            self.assertEqual(mock_call["instance"], self.snippet)
+            self.assertIsInstance(
+                mock_call["instance"], DraftStateCustomPrimaryKeyModel
+            )
+        finally:
+            unpublished.disconnect(mock_handler)
 
     def test_unpublish_view_post(self):
         """
@@ -3487,27 +3517,32 @@ class TestSnippetUnpublish(WagtailTestUtils, TestCase):
         mock_handler = mock.MagicMock()
         unpublished.connect(mock_handler)
 
-        # Post to the unpublish view
-        response = self.client.post(self.unpublish_url)
+        try:
+            # Post to the unpublish view
+            response = self.client.post(self.unpublish_url)
 
-        # Should be redirected to the listing page
-        self.assertRedirects(
-            response,
-            reverse("wagtailsnippets_tests_draftstatecustomprimarykeymodel:list"),
-        )
+            # Should be redirected to the listing page
+            self.assertRedirects(
+                response,
+                reverse("wagtailsnippets_tests_draftstatecustomprimarykeymodel:list"),
+            )
 
-        # Check that the object was unpublished
-        self.assertFalse(
-            DraftStateCustomPrimaryKeyModel.objects.get(pk=self.snippet.pk).live
-        )
+            # Check that the object was unpublished
+            self.assertFalse(
+                DraftStateCustomPrimaryKeyModel.objects.get(pk=self.snippet.pk).live
+            )
 
-        # Check that the unpublished signal was fired
-        self.assertEqual(mock_handler.call_count, 1)
-        mock_call = mock_handler.mock_calls[0][2]
+            # Check that the unpublished signal was fired
+            self.assertEqual(mock_handler.call_count, 1)
+            mock_call = mock_handler.mock_calls[0][2]
 
-        self.assertEqual(mock_call["sender"], DraftStateCustomPrimaryKeyModel)
-        self.assertEqual(mock_call["instance"], self.snippet)
-        self.assertIsInstance(mock_call["instance"], DraftStateCustomPrimaryKeyModel)
+            self.assertEqual(mock_call["sender"], DraftStateCustomPrimaryKeyModel)
+            self.assertEqual(mock_call["instance"], self.snippet)
+            self.assertIsInstance(
+                mock_call["instance"], DraftStateCustomPrimaryKeyModel
+            )
+        finally:
+            unpublished.disconnect(mock_handler)
 
     def test_after_unpublish_hook(self):
         def hook_func(request, snippet):

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -2048,12 +2048,15 @@ class TestCopyPage(TestCase):
             signal_page = instance
 
         page_published.connect(page_published_handler)
-        copy_page = christmas_page.copy(
-            update_attrs={"title": "New christmas", "slug": "new-christmas"},
-        )
+        try:
+            copy_page = christmas_page.copy(
+                update_attrs={"title": "New christmas", "slug": "new-christmas"},
+            )
 
-        self.assertTrue(signal_fired)
-        self.assertEqual(signal_page, copy_page)
+            self.assertTrue(signal_fired)
+            self.assertEqual(signal_page, copy_page)
+        finally:
+            page_published.disconnect(page_published_handler)
 
     def test_copy_unpublished_not_emits_signal(self):
         """Test that copying of an unpublished page not emits a page_published signal."""
@@ -2069,8 +2072,11 @@ class TestCopyPage(TestCase):
 
         page_published.connect(page_published_handler)
 
-        homepage.copy(update_attrs={"slug": "new_slug"})
-        self.assertFalse(signal_fired)
+        try:
+            homepage.copy(update_attrs={"slug": "new_slug"})
+            self.assertFalse(signal_fired)
+        finally:
+            page_published.disconnect(page_published_handler)
 
     def test_copy_keep_live_false_not_emits_signal(self):
         """Test that copying of a live page with keep_live=False not emits a page_published signal."""
@@ -2081,10 +2087,13 @@ class TestCopyPage(TestCase):
             nonlocal signal_fired
             signal_fired = True
 
-        page_published.connect(page_published_handler)
+        try:
+            page_published.connect(page_published_handler)
 
-        homepage.copy(keep_live=False, update_attrs={"slug": "new_slug"})
-        self.assertFalse(signal_fired)
+            homepage.copy(keep_live=False, update_attrs={"slug": "new_slug"})
+            self.assertFalse(signal_fired)
+        finally:
+            page_published.disconnect(page_published_handler)
 
     def test_copy_alias_page(self):
         about_us = SimplePage.objects.get(url_path="/home/about-us/")

--- a/wagtail/tests/test_page_queryset.py
+++ b/wagtail/tests/test_page_queryset.py
@@ -701,28 +701,31 @@ class TestPageQuerySetSearch(TestCase):
 
         page_unpublished.connect(page_unpublished_handler)
 
-        events_index = Page.objects.get(url_path="/home/events/")
-        events_index.get_children().unpublish()
+        try:
+            events_index = Page.objects.get(url_path="/home/events/")
+            events_index.get_children().unpublish()
 
-        # Previously-live children of event index should now be non-live
-        christmas = EventPage.objects.get(url_path="/home/events/christmas/")
-        saint_patrick = SingleEventPage.objects.get(
-            url_path="/home/events/saint-patrick/"
-        )
-        unpublished_event = EventPage.objects.get(
-            url_path="/home/events/tentative-unpublished-event/"
-        )
+            # Previously-live children of event index should now be non-live
+            christmas = EventPage.objects.get(url_path="/home/events/christmas/")
+            saint_patrick = SingleEventPage.objects.get(
+                url_path="/home/events/saint-patrick/"
+            )
+            unpublished_event = EventPage.objects.get(
+                url_path="/home/events/tentative-unpublished-event/"
+            )
 
-        self.assertFalse(christmas.live)
-        self.assertFalse(saint_patrick.live)
+            self.assertFalse(christmas.live)
+            self.assertFalse(saint_patrick.live)
 
-        # Check that a signal was fired for each unpublished page
-        self.assertIn((EventPage, christmas), unpublish_signals_fired)
-        self.assertIn((SingleEventPage, saint_patrick), unpublish_signals_fired)
+            # Check that a signal was fired for each unpublished page
+            self.assertIn((EventPage, christmas), unpublish_signals_fired)
+            self.assertIn((SingleEventPage, saint_patrick), unpublish_signals_fired)
 
-        # a signal should not be fired for pages that were in the queryset
-        # but already unpublished
-        self.assertNotIn((EventPage, unpublished_event), unpublish_signals_fired)
+            # a signal should not be fired for pages that were in the queryset
+            # but already unpublished
+            self.assertNotIn((EventPage, unpublished_event), unpublish_signals_fired)
+        finally:
+            page_unpublished.disconnect(page_unpublished_handler)
 
 
 class TestSpecificQuery(WagtailTestUtils, TestCase):


### PR DESCRIPTION
Saves over 30 seconds on a full test run, in my not-so-scientific trial.
