### PR TITLE
Move snippet choosers and model check registration to `SnippetViewSet.on_register()`

### DIFF
--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -91,7 +91,6 @@ def _register_snippet_immediately(model, viewset=None):
         # Do not create duplicate registrations of the same model
         return
 
-    from wagtail.snippets.views.chooser import SnippetChooserViewSet
     from wagtail.snippets.views.snippets import SnippetViewSet
 
     model.get_usage = lambda obj: ReferenceIndex.get_references_to(
@@ -112,14 +111,7 @@ def _register_snippet_immediately(model, viewset=None):
         url_prefix=model.get_admin_base_path(),
     )
 
-    chooser_viewset = SnippetChooserViewSet(
-        f"wagtailsnippetchoosers_{model._meta.app_label}_{model._meta.model_name}",
-        model=model,
-        url_prefix=f"snippets/choose/{model._meta.app_label}/{model._meta.model_name}",
-    )
-
     viewsets.register(admin_viewset)
-    viewsets.register(chooser_viewset)
 
     SNIPPET_MODELS.append(model)
     SNIPPET_MODELS.sort(key=lambda x: x._meta.verbose_name)

--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -6,16 +6,12 @@ from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core import checks
 from django.db import DEFAULT_DB_ALIAS
-from django.db.models import ForeignKey
 from django.urls import reverse
 from django.utils.module_loading import import_string
 
 from wagtail.admin.checks import check_panels_in_model
-from wagtail.admin.forms.models import register_form_field_override
 from wagtail.admin.viewsets import viewsets
 from wagtail.models import DraftStateMixin, LockableMixin, ReferenceIndex, WorkflowMixin
-
-from .widgets import AdminSnippetChooser
 
 SNIPPET_MODELS = []
 
@@ -120,11 +116,6 @@ def _register_snippet_immediately(model, viewset=None):
     def modeladmin_model_check(app_configs, **kwargs):
         errors = check_panels_in_model(model, "snippets")
         return errors
-
-    # Set up admin model forms to use AdminSnippetChooser for any ForeignKey to this model
-    register_form_field_override(
-        ForeignKey, to=model, override={"widget": AdminSnippetChooser(model=model)}
-    )
 
 
 def get_snippet_usage_url(self):

--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -4,12 +4,10 @@ from django.contrib.admin.utils import quote
 from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.core import checks
 from django.db import DEFAULT_DB_ALIAS
 from django.urls import reverse
 from django.utils.module_loading import import_string
 
-from wagtail.admin.checks import check_panels_in_model
 from wagtail.admin.viewsets import viewsets
 from wagtail.models import DraftStateMixin, LockableMixin, ReferenceIndex, WorkflowMixin
 
@@ -111,11 +109,6 @@ def _register_snippet_immediately(model, viewset=None):
 
     SNIPPET_MODELS.append(model)
     SNIPPET_MODELS.sort(key=lambda x: x._meta.verbose_name)
-
-    @checks.register("panels")
-    def modeladmin_model_check(app_configs, **kwargs):
-        errors = check_panels_in_model(model, "snippets")
-        return errors
 
 
 def get_snippet_usage_url(self):

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -1,3 +1,4 @@
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.ui.tables import LiveStatusTagColumn
@@ -11,6 +12,7 @@ from wagtail.admin.views.generic.chooser import (
 )
 from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.models import DraftStateMixin
+from wagtail.snippets.widgets import AdminSnippetChooser
 
 
 class BaseSnippetChooseView(BaseChooseView):
@@ -64,8 +66,11 @@ class SnippetChosenMultipleView(ChosenMultipleView):
 
 
 class SnippetChooserViewSet(ChooserViewSet):
-    register_widget = False  # registering the snippet chooser widget for a given model is done in register_snippet
     choose_view_class = ChooseView
     choose_results_view_class = ChooseResultsView
     chosen_view_class = SnippetChosenView
     chosen_multiple_view_class = SnippetChosenMultipleView
+
+    @cached_property
+    def widget_class(self):
+        return AdminSnippetChooser(model=self.model)

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -1054,6 +1054,12 @@ class SnippetViewSet(ViewSet):
             url_prefix=f"snippets/choose/{self.app_label}/{self.model_name}",
         )
 
+    @property
+    def url_finder_class(self):
+        return type(
+            "_SnippetAdminURLFinder", (SnippetAdminURLFinder,), {"model": self.model}
+        )
+
     def get_urlpatterns(self):
         urlpatterns = super().get_urlpatterns() + [
             path("", self.index_view, name="list"),
@@ -1168,6 +1174,9 @@ class SnippetViewSet(ViewSet):
 
         return urlpatterns + legacy_redirects
 
+    def register_admin_url_finder(self):
+        register_admin_url_finder(self.model, self.url_finder_class)
+
     def register_model_check(self):
         def snippets_model_check(app_configs, **kwargs):
             return check_panels_in_model(self.model, "snippets")
@@ -1176,11 +1185,6 @@ class SnippetViewSet(ViewSet):
 
     def on_register(self):
         super().on_register()
-        url_finder_class = type(
-            "_SnippetAdminURLFinder", (SnippetAdminURLFinder,), {"model": self.model}
-        )
-        register_admin_url_finder(self.model, url_finder_class)
-
         viewsets.register(self.chooser_viewset)
-
+        self.register_admin_url_finder()
         self.register_model_check()


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

As part of #10206.

This brings us one step closer to making `SnippetViewSet` be the one place to customise all things snippets. For example, we can define an `icon` attribute on `SnippetViewSet` and pass it down to `SnippetChooserViewSet` and `AdminSnippetChooser`, allowing us to configure the icon from one place.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
