### PR TITLE
Messages Controller - ensure we add a unit test for XSS checks

### DIFF
--- a/client/src/controllers/MessagesController.test.js
+++ b/client/src/controllers/MessagesController.test.js
@@ -210,5 +210,25 @@ describe('MessagesController', () => {
 
       expect(item.lastElementChild.textContent).toEqual(text);
     });
+
+    it('should not allow HTML to be added unescaped to any content', () => {
+      document.dispatchEvent(
+        new CustomEvent('w-messages:add', {
+          detail: {
+            clear: true,
+            text: '<script>window.alert("Secure?");</script>',
+            type: 'error',
+          },
+        }),
+      );
+
+      const items = document.querySelectorAll('li');
+      expect(items).toHaveLength(1);
+
+      // should escape any text that is passed through
+      expect(items[0].outerHTML).toEqual(
+        '<li class="error"><strong>&lt;script&gt;window.alert("Secure?");&lt;/script&gt;</strong></li>',
+      );
+    });
   });
 });


### PR DESCRIPTION
- While this new approach is much more secure than the previous and relies only on building DOM out of `template` elements, I thought it would be good to ensure we have an explicit test against any content being injected via the new DOM event listener.
- Relates to #9493 & #10182