### PR TITLE
Fix paginated results count on document search

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ Changelog
  * Fix: Prevent duplicate addition of StreamField blocks with the new block picker (Deepam Priyadarshi)
  * Fix: Enable partial search on images and documents index view where available (Mng)
  * Fix: Adopt a no-JavaScript and more accessible solution for option selection in reporting, using HTML only `radio` input fields (Mehul Aggarwal)
+ * Fix: Ensure that document search results count shows the correct all matches, not the paginate total (Andy Chosak)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp)
  * Docs: Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -54,6 +54,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Prevent duplicate addition of StreamField blocks with the new block picker (Deepam Priyadarshi)
  * Enable partial search on images and documents index view where available (Mng)
  * Adopt a no-JavaScript and more accessible solution for option selection in reporting, using HTML only `radio` input fields (Mehul Aggarwal)
+ * Ensure that document search results count shows the correct all matches, not the paginate total (Andy Chosak)
 
 ### Documentation
 

--- a/wagtail/documents/templates/wagtaildocs/documents/results.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/results.html
@@ -2,7 +2,7 @@
 {% if documents %}
     {% if is_searching %}
         <h2 role="alert">
-            {% blocktrans trimmed count counter=documents|length %}
+            {% blocktrans trimmed count counter=documents.paginator.count %}
                 There is {{ counter }} match
             {% plural %}
                 There are {{ counter }} matches

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -114,6 +114,15 @@ class TestDocumentIndexView(WagtailTestUtils, TestCase):
             response.context["documents"].paginator.num_pages,
         )
 
+    def test_pagination_q(self):
+        self.make_docs()
+
+        response = self.get({"q": "Test"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtaildocs/documents/index.html")
+        self.assertContains(response, "There are 50 matches")
+
     def test_ordering(self):
         orderings = ["title", "-created_at"]
         for ordering in orderings:


### PR DESCRIPTION
Paginated document search results currently always show the number of documents per page instead of the total number of documents in the search results.

For example, if a document search (at http://localhost:8000/admin/documents/) returns 100 results, and the results are paginated by 20, the results view always says "There are 20 matches", when it should instead say "There are 100 matches".

This commit fixes that bug and adds a unit test to cover it.

_Please check the following:_

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

To test, add more than 20 documents to your site (for example "test-XX.txt") and then do a search that matches all documents (for example "test"). Current Wagtail behavior always shows 20 matches:

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/654645/224169960-bcc8fedb-1cd1-49ea-bd3a-880353924804.png">

With this branch, the correct number will be shown.