### PR TITLE
Implement ConvertedValueField.get_prep_value

### DIFF
--- a/wagtail/test/customuser/fields.py
+++ b/wagtail/test/customuser/fields.py
@@ -54,6 +54,13 @@ class ConvertedValueField(models.IntegerField):
             value = ConvertedValue(value)
         return value
 
+    def get_prep_value(self, value):
+        if value is None:
+            return None
+        if not isinstance(value, ConvertedValue):
+            value = ConvertedValue(value)
+        return super().get_prep_value(value.db_value)
+
     def from_db_value(self, value, expression, connection):
         if not value:
             return

--- a/wagtail/test/customuser/tests.py
+++ b/wagtail/test/customuser/tests.py
@@ -42,3 +42,6 @@ class TestConvertedValueField(WagtailTestUtils, TestCase):
 
     def test_custom_user_primary_key_is_converted_value_field(self):
         self.assertIsInstance(self.pk_field, ConvertedValueField)
+
+    def test_get_prep_value_returns_integer_for_db_query(self):
+        self.assertIsInstance(self.pk_field.get_prep_value(1234), int)


### PR DESCRIPTION
Fixes #10200.

Per [the Django docs](https://docs.djangoproject.com/en/dev/howto/custom-model-fields/#converting-python-objects-to-query-values), "if you override `from_db_value()` you also have to override `get_prep_value()` to convert Python objects back to query values."

The ConvertedValueField inherits from IntegerField, which means that it stores its data as an integer. But its Python value is of type ConvertedValue, which is actually a string. The representation of that string is (potentially) a shifted version of the actual field value.

For example, given a ConvertedValue of 320333593, its string representation is actually "92467817240" due to the logic [here](https://github.com/wagtail/wagtail/blob/d5e4ac5590c3bc7fb6c49d3f0aa377724c369654/wagtail/test/customuser/fields.py#L11-L22) (which, to be honest, I am not sure I understand the rationale behind).

Because ConvertedValueField wasn't implementing `get_prep_value`, the parent IntegerField `get_prep_value()` logic was being called, which tried to cast `int()` on the field's value, which is actually the string representation. So instead of the actual integer value being stored in the database, it's this shifted value that gets stored.

But, with [this recent commit to Django](https://github.com/django/django/commit/dde2537fbb04ad78a673092a931b449245a2d6ae), that value could potentially overflow the supported integer field range in the database -- whereas the actual integer ConvertedValue value should always be okay.

So, this commit implements `ConvertedValueField.get_prep_value` to ensure that the real integer value gets stored, not the shifted string value.