### PR TITLE
Fix two spacing typos in docs/reference/hooks.md

### DIFF
--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -1210,7 +1210,7 @@ def before_snippet_delete(request, instances):
 Add an item to the popup menu of actions on the snippet creation and edit views.
 The callable passed to this hook must return an instance of `wagtail.snippets.action_menu.ActionMenuItem`. `ActionMenuItem` is a subclass of [Component](creating_template_components) and so the rendering of the menu item can be customised through `template_name`, `get_context_data`, `render_html` and `Media`. In addition, the following attributes and methods are available to be overridden:
 
--   `order`- an integer (default 100) which determines the item's position in the menu. Can also be passed as a keyword argument to the object constructor. The lowest-numbered item in this sequence will be selected as the default menu item; as standard, this is "Save draft" (which has an`order` of 0).
+-   `order` - an integer (default 100) which determines the item's position in the menu. Can also be passed as a keyword argument to the object constructor. The lowest-numbered item in this sequence will be selected as the default menu item; as standard, this is "Save draft" (which has an `order` of 0).
 -   `label` - the displayed text of the menu item
 -   `get_url` - a method which returns a URL for the menu item to link to; by default, returns `None` which causes the menu item to behave as a form submit button instead
 -   `name` - value of the `name` attribute of the submit button if no URL is specified


### PR DESCRIPTION
This PR adds exactly two otherwise missing spaces into the `register_snippet_action_menu_item` hooks reference material.

Before:
<img width="753" alt="image" src="https://user-images.githubusercontent.com/1977376/224455048-d460d863-6a5e-412d-b8f7-4877a32e2bea.png">

After:
<img width="736" alt="image" src="https://user-images.githubusercontent.com/1977376/224455084-7479944f-f0b9-4d29-b70c-fdd0d292ee72.png">


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.
Build docs and test as per the developer instructions, and check at [http://localhost:8080/reference/hooks.html#register-snippet-action-menu-item](http://localhost:8080/reference/hooks.html#register-snippet-action-menu-item)

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
