### PR TITLE
Fix timezone handling of `TemplateResponse`s for users with a custom timezone

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -45,6 +45,7 @@ Changelog
  * Fix: Ensure that document search results count shows the correct all matches, not the paginate total (Andy Chosak)
  * Fix: Fix radio and checkbox elements shrinking when using a long label (Sage Abdullah)
  * Fix: Fix select elements expanding beyond their container when using a long option label (Sage Abdullah)
+ * Fix: Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp)
  * Docs: Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)
@@ -85,6 +86,7 @@ Changelog
 
  * Fix: Fix radio and checkbox elements shrinking when using a long label (Sage Abdullah)
  * Fix: Fix select elements expanding beyond their container when using a long option label (Sage Abdullah)
+ * Fix: Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
 
 
 4.2.1 (13.03.2023)
@@ -260,6 +262,7 @@ Changelog
 
  * Fix: Fix radio and checkbox elements shrinking when using a long label (Sage Abdullah)
  * Fix: Fix select elements expanding beyond their container when using a long option label (Sage Abdullah)
+ * Fix: Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
 
 
 4.1.3 (13.03.2023)

--- a/docs/releases/4.1.4.md
+++ b/docs/releases/4.1.4.md
@@ -15,3 +15,4 @@ depth: 1
 
 * Fix radio and checkbox elements shrinking when using a long label (Sage Abdullah)
 * Fix select elements expanding beyond their container when using a long option label (Sage Abdullah)
+* Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)

--- a/docs/releases/4.2.2.md
+++ b/docs/releases/4.2.2.md
@@ -15,3 +15,4 @@ depth: 1
 
 * Fix radio and checkbox elements shrinking when using a long label (Sage Abdullah)
 * Fix select elements expanding beyond their container when using a long option label (Sage Abdullah)
+* Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -59,6 +59,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Ensure that document search results count shows the correct all matches, not the paginate total (Andy Chosak)
  * Fix radio and checkbox elements shrinking when using a long label (Sage Abdullah)
  * Fix select elements expanding beyond their container when using a long option label (Sage Abdullah)
+ * Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -182,29 +182,30 @@ def require_admin_access(view_func):
                     if preferred_language:
                         with override(preferred_language):
                             response = view_func(request, *args, **kwargs)
-
-                        if hasattr(response, "render"):
-                            # If the response has a render() method, Django treats it
-                            # like a TemplateResponse, so we should do the same
-                            # In this case, we need to guarantee that when the TemplateResponse
-                            # is rendered, it is done within the override context manager
-                            # or the user preferred_language will not be used
-                            # (this could be replaced with simply rendering the TemplateResponse
-                            # for simplicity but this does remove some of its middleware modification
-                            # potential)
-                            render = response.render
-
-                            def overridden_render(response):
-                                with override(preferred_language):
-                                    return render()
-
-                            response.render = types.MethodType(
-                                overridden_render, response
-                            )
-                            # decorate the response render method with the override context manager
-                        return response
                     else:
-                        return view_func(request, *args, **kwargs)
+                        response = view_func(request, *args, **kwargs)
+
+                    if hasattr(response, "render"):
+                        # If the response has a render() method, Django treats it
+                        # like a TemplateResponse, so we should do the same
+                        # In this case, we need to guarantee that when the TemplateResponse
+                        # is rendered, it is done within the override context manager
+                        # or the user preferred_language/timezone will not be used
+                        # (this could be replaced with simply rendering the TemplateResponse
+                        # for simplicity but this does remove some of its middleware modification
+                        # potential)
+                        render = response.render
+
+                        def overridden_render(response):
+                            with override_tz(time_zone):
+                                if preferred_language:
+                                    with override(preferred_language):
+                                        return render()
+                                return render()
+
+                        response.render = types.MethodType(overridden_render, response)
+                        # decorate the response render method with the override context manager
+                    return response
 
             except PermissionDenied:
                 if request.headers.get("x-requested-with") == "XMLHttpRequest":


### PR DESCRIPTION
The PR #9628 missed the cases, where a TemplateResponse is used, which defers the rendering to a point outside the override_tz() context manager. This change re-uses the existing handling for the user's preferred language.

Fixes #10243

Note: I haven't added tests for now, but I'm currently writing a testing guide for #9590, which led me to this issue. So I had the chance to test the fixed behaviour.


_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
