### PR TITLE
Use `SnippetViewSet.icon` in `SnippetChooserBlock`

### DIFF
--- a/wagtail/snippets/blocks.py
+++ b/wagtail/snippets/blocks.py
@@ -5,6 +5,12 @@ from wagtail.coreutils import resolve_model_string
 
 
 class SnippetChooserBlock(ChooserBlock):
+    # Blocks are instantiated before models are loaded, so we can't set
+    # self.meta.icon in __init__. We need to override the default value
+    # some time after the model is loaded, so we mark it as a mutable
+    # attribute and set it using set_meta_options.
+    MUTABLE_META_ATTRIBUTES = ["icon"]
+
     def __init__(self, target_model, **kwargs):
         super().__init__(**kwargs)
         self._target_model = target_model
@@ -17,7 +23,9 @@ class SnippetChooserBlock(ChooserBlock):
     def widget(self):
         from wagtail.snippets.widgets import AdminSnippetChooser
 
-        return AdminSnippetChooser(self.target_model)
+        # Override the default icon with the icon for the target model
+        self.set_meta_options({"icon": self.target_model.snippet_viewset.icon})
+        return AdminSnippetChooser(self.target_model, icon=self.meta.icon)
 
     class Meta:
         icon = "snippet"

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -4,8 +4,11 @@ from django.test import TestCase
 from django.urls import reverse
 
 from wagtail.admin.panels import get_edit_handler
+from wagtail.blocks.field_block import FieldBlockAdapter
 from wagtail.coreutils import get_dummy_request
 from wagtail.models import Workflow, WorkflowContentType
+from wagtail.snippets.blocks import SnippetChooserBlock
+from wagtail.snippets.widgets import AdminSnippetChooser
 from wagtail.test.testapp.models import Advert, FullFeaturedSnippet, SnippetChooserModel
 from wagtail.test.utils import WagtailTestUtils
 
@@ -83,6 +86,28 @@ class TestCustomIcon(WagtailTestUtils, TestCase):
         self.assertEqual(response.context["header_icon"], "list-ul")
         self.assertContains(response, "icon icon-list-ul")
         self.assertContains(response, "icon icon-cog")
+
+
+class TestSnippetChooserBlockWithIcon(TestCase):
+    def test_adapt(self):
+        block = SnippetChooserBlock(FullFeaturedSnippet)
+
+        block.set_name("test_snippetchooserblock")
+        js_args = FieldBlockAdapter().js_args(block)
+
+        self.assertEqual(js_args[0], "test_snippetchooserblock")
+        self.assertIsInstance(js_args[1], AdminSnippetChooser)
+        self.assertEqual(js_args[1].model, FullFeaturedSnippet)
+        # It should use the icon defined in the FullFeaturedSnippetViewSet
+        self.assertEqual(js_args[2]["icon"], "cog")
+
+    def test_deconstruct(self):
+        block = SnippetChooserBlock(FullFeaturedSnippet, required=False)
+        path, args, kwargs = block.deconstruct()
+        self.assertEqual(path, "wagtail.snippets.blocks.SnippetChooserBlock")
+        self.assertEqual(args, (FullFeaturedSnippet,))
+        # It should not add any extra kwargs for the icon
+        self.assertEqual(kwargs, {"required": False})
 
 
 class TestSnippetChooserPanelWithIcon(WagtailTestUtils, TestCase):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #4040 as a follow-up to #10178 and part of wagtail/rfcs#85. This PR can be reviewed separately from the other PRs.

## Before

<img width="408" alt="image" src="https://user-images.githubusercontent.com/6379424/227203555-51b8e2b1-2884-48ea-a358-b71505f377f5.png">

Note: #10178 removed the default `AdminSnippetChooser.icon` attribute, so you might see a plus icon instead of the snippet icon on the "Choose Person" button. This PR fixes it as it will always use the snippet's icon from the viewset (defaulting to the `"snippet"` icon)

## After

<img width="408" alt="image" src="https://user-images.githubusercontent.com/6379424/227202554-399aff92-8ac6-4015-b74f-fbd36c649968.png">


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
