### PR TITLE
Fix Wagtail icons server-side caching

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -94,6 +94,8 @@ Changelog
  * Fix: Fix radio and checkbox elements shrinking when using a long label (Sage Abdullah)
  * Fix: Fix select elements expanding beyond their container when using a long option label (Sage Abdullah)
  * Fix: Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
+ * Fix: Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
+ * Fix: Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
 
 
 4.2.1 (13.03.2023)
@@ -270,6 +272,8 @@ Changelog
  * Fix: Fix radio and checkbox elements shrinking when using a long label (Sage Abdullah)
  * Fix: Fix select elements expanding beyond their container when using a long option label (Sage Abdullah)
  * Fix: Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
+ * Fix: Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
+ * Fix: Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
 
 
 4.1.3 (13.03.2023)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,6 +53,7 @@ Changelog
  * Fix: Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
  * Fix: Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
  * Fix: Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
+ * Fix: Fix server-side caching of the icons sprite (Thibaud Colas)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp)
  * Docs: Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)
@@ -96,6 +97,7 @@ Changelog
  * Fix: Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
  * Fix: Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
  * Fix: Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
+ * Fix: Fix server-side caching of the icons sprite (Thibaud Colas)
 
 
 4.2.1 (13.03.2023)
@@ -274,6 +276,7 @@ Changelog
  * Fix: Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
  * Fix: Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
  * Fix: Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
+ * Fix: Fix server-side caching of the icons sprite (Thibaud Colas)
 
 
 4.1.3 (13.03.2023)

--- a/docs/releases/4.1.4.md
+++ b/docs/releases/4.1.4.md
@@ -18,3 +18,4 @@ depth: 1
 * Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
 * Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
 * Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
+* Fix server-side caching of the icons sprite (Thibaud Colas)

--- a/docs/releases/4.1.4.md
+++ b/docs/releases/4.1.4.md
@@ -16,3 +16,5 @@ depth: 1
 * Fix radio and checkbox elements shrinking when using a long label (Sage Abdullah)
 * Fix select elements expanding beyond their container when using a long option label (Sage Abdullah)
 * Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
+* Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
+* Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)

--- a/docs/releases/4.2.2.md
+++ b/docs/releases/4.2.2.md
@@ -18,3 +18,4 @@ depth: 1
 * Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
 * Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
 * Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
+* Fix server-side caching of the icons sprite (Thibaud Colas)

--- a/docs/releases/4.2.2.md
+++ b/docs/releases/4.2.2.md
@@ -16,3 +16,5 @@ depth: 1
 * Fix radio and checkbox elements shrinking when using a long label (Sage Abdullah)
 * Fix select elements expanding beyond their container when using a long option label (Sage Abdullah)
 * Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
+* Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
+* Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -70,6 +70,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
  * Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
  * Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
+ * Fix server-side caching of the icons sprite (Thibaud Colas)
 
 ### Documentation
 

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -370,10 +370,10 @@ def icons():
                 .replace("svg", "symbol")
             )
 
-        _full_sprite_html = render_to_string(
+        _icons_html = render_to_string(
             "wagtailadmin/shared/icons.html", {"icons": combined_icon_markup}
         )
-    return _full_sprite_html
+    return _icons_html
 
 
 def sprite(request):


### PR DESCRIPTION
Spotted while working on #10262. Our in-memory cache of icons as a global variable isn’t working because we’ve renamed the local variable reference at some point.