### PR TITLE
Re-label StreamField blocks option in block picker to "Blocks"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Changelog
  * Allow customising icons for snippets via `SnippetViewSet.icon` (Daniel Kirkham, Sage Abdullah)
  * Allow customising the base URL and URL namespace for snippet views (Sage Abdullah)
  * Allow customising the number of items per page for snippet listing views (Sage Abdullah)
+ * Re-label "StreamField blocks" option in block picker to "Blocks" (Thibaud Colas)
  * Fix: Ensure `label_format` on StructBlock gracefully handles missing variables (Aadi jindal)
  * Fix: Adopt a no-JavaScript and more accessible solution for the 'Reset to default' switch to Gravatar when editing user profile (Loveth Omokaro)
  * Fix: Ensure `Site.get_site_root_paths` works on cache backends that do not preserve Python objects (Jaap Roes)

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -326,7 +326,7 @@ class BoundDraftailWidget {
             new DraftailInsertBlockCommand(this, blockDef, addSibling, split),
         );
         return {
-          label: group || gettext('StreamField blocks'),
+          label: group || gettext('Blocks'),
           type: `streamfield-${group}`,
           items: blockControls,
         };

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -40,6 +40,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Allow customising icons for snippets via `SnippetViewSet.icon` (Daniel Kirkham, Sage Abdullah)
  * Allow customising the base URL and URL namespace for snippet views (Sage Abdullah)
  * Allow customising the number of items per page for snippet listing views (Sage Abdullah)
+ * Re-label "StreamField blocks" option in block picker to "Blocks" (Thibaud Colas)
 
 ### Bug fixes
 


### PR DESCRIPTION
Based upon design review. We believe "Blocks" might be less confusing for users – "StreamField" as a term is rarely (never?) used in the UI, and only very occasionally mentioned in user documentation.