### PR TITLE
Ensure datetimepicker widget overlay shows over modals & drop-downs

### DIFF
--- a/client/scss/overrides/_vendor.datetimepicker.scss
+++ b/client/scss/overrides/_vendor.datetimepicker.scss
@@ -8,7 +8,7 @@
   padding-inline-start: 0;
   padding-top: 2px;
   position: absolute;
-  z-index: 5;
+  z-index: 500;
   display: none;
 
   .w-dialog & {


### PR DESCRIPTION
- Update to the exact same z-index as the modal (intentionally, as the widget will appear in the DOM after modals and sho show visually above the modals without needing to be an extreme z-index value).
- Fixes #3604 & fixed while working on #10261
- Tested on Firefox 101, Chrome 111, Safari 16.1

## Before

<img width="1082" alt="Screenshot 2023-03-25 at 9 16 11 pm" src="https://user-images.githubusercontent.com/1396140/227714310-e5a5c2bc-c699-45ed-bac7-2e0e35366923.png">
<img width="1086" alt="Screenshot 2023-03-25 at 9 15 46 pm" src="https://user-images.githubusercontent.com/1396140/227714318-82721f94-d4a4-41ac-b8ee-0036a713c47a.png">

> Note: I have toggled the datetime picker to show manually to make the problem more visible (dropdown AND datetimepicker shown at the same time.


## After

<img width="981" alt="Screenshot 2023-03-25 at 9 12 20 pm" src="https://user-images.githubusercontent.com/1396140/227714360-f9df70b0-5e76-4202-aade-f4addcdfefcf.png">
<img width="1094" alt="Screenshot 2023-03-25 at 9 14 22 pm" src="https://user-images.githubusercontent.com/1396140/227714356-f89387f6-4050-460d-a8ca-5090904696eb.png">
<img width="971" alt="Screenshot 2023-03-25 at 9 22 12 pm" src="https://user-images.githubusercontent.com/1396140/227714519-cd6f1510-5c50-4eec-8e71-6277c2d01979.png">
