### PR TITLE
fixes scrollbars in block-pickers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -57,6 +57,7 @@ Changelog
  * Fix: Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
  * Fix: Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
  * Fix: Fix server-side caching of the icons sprite (Thibaud Colas)
+ * Fix: Avoid showing scrollbars in the block picker unless necessary (Babitha Kumari)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp, Thibaud Colas)
  * Docs: Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)
@@ -102,6 +103,7 @@ Changelog
  * Fix: Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
  * Fix: Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
  * Fix: Fix server-side caching of the icons sprite (Thibaud Colas)
+ * Fix: Avoid showing scrollbars in the block picker unless necessary (Babitha Kumari)
 
 
 4.2.1 (13.03.2023)
@@ -281,6 +283,7 @@ Changelog
  * Fix: Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
  * Fix: Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
  * Fix: Fix server-side caching of the icons sprite (Thibaud Colas)
+ * Fix: Avoid showing scrollbars in the block picker unless necessary (Babitha Kumari)
 
 
 4.1.3 (13.03.2023)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -702,6 +702,7 @@ Contributors
 * Mng
 * George Sakkis
 * Mehul Aggarwal
+* Babitha Kumari
 
 Translators
 ===========

--- a/client/src/components/ComboBox/ComboBox.scss
+++ b/client/src/components/ComboBox/ComboBox.scss
@@ -33,7 +33,7 @@ $spacing-sm: theme('spacing.5');
 
 .w-combobox__menu {
   max-height: min(480px, 70vh);
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .w-combobox__optgroup {

--- a/docs/releases/4.1.4.md
+++ b/docs/releases/4.1.4.md
@@ -19,3 +19,4 @@ depth: 1
 * Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
 * Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
 * Fix server-side caching of the icons sprite (Thibaud Colas)
+* Avoid showing scrollbars in the block picker unless necessary (Babitha Kumari)

--- a/docs/releases/4.2.2.md
+++ b/docs/releases/4.2.2.md
@@ -19,3 +19,4 @@ depth: 1
 * Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
 * Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
 * Fix server-side caching of the icons sprite (Thibaud Colas)
+* Avoid showing scrollbars in the block picker unless necessary (Babitha Kumari)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -74,6 +74,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
  * Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
  * Fix server-side caching of the icons sprite (Thibaud Colas)
+ * Avoid showing scrollbars in the block picker unless necessary (Babitha Kumari)
 
 ### Documentation
 


### PR DESCRIPTION
 #10253 <!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10253 








_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -    Browsers : Firefox/111.0, Chromium/111.0
    -   Operating System : Manjaro Linux/22.0.5
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.
This change will display scrollbars only when content overflows 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
