### PR TITLE
Explicitly specify `MenuItem.name` for Snippets, Reports, and Settings menu items

### DIFF
--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -120,7 +120,13 @@ class SettingsMenuItem(SubmenuMenuItem):
 
 @hooks.register("register_admin_menu_item")
 def register_settings_menu():
-    return SettingsMenuItem(_("Settings"), settings_menu, icon_name="cogs", order=10000)
+    return SettingsMenuItem(
+        _("Settings"),
+        settings_menu,
+        name="settings",
+        icon_name="cogs",
+        order=10000,
+    )
 
 
 @hooks.register("register_permissions")
@@ -969,7 +975,13 @@ def register_aging_pages_report_menu_item():
 
 @hooks.register("register_admin_menu_item")
 def register_reports_menu():
-    return SubmenuMenuItem(_("Reports"), reports_menu, icon_name="site", order=9000)
+    return SubmenuMenuItem(
+        _("Reports"),
+        reports_menu,
+        name="reports",
+        icon_name="site",
+        order=9000,
+    )
 
 
 @hooks.register("register_help_menu_item")
@@ -1002,9 +1014,9 @@ def register_help_menu():
     return DismissibleSubmenuMenuItem(
         _("Help"),
         help_menu,
+        name="help",
         icon_name="help",
         order=11000,
-        name="help",
     )
 
 

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -39,7 +39,11 @@ class SnippetsMenuItem(MenuItem):
 @hooks.register("register_admin_menu_item")
 def register_snippets_menu_item():
     return SnippetsMenuItem(
-        _("Snippets"), reverse("wagtailsnippets:index"), icon_name="snippet", order=500
+        _("Snippets"),
+        reverse("wagtailsnippets:index"),
+        name="snippets",
+        icon_name="snippet",
+        order=500,
     )
 
 


### PR DESCRIPTION


<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #6111.

Is this worth backporting?

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
