### PR TITLE
Add page-specific icons (DRAFT)

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/chooser/browse.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/browse.html
@@ -5,7 +5,7 @@
     {% trans "Choose a page" as choose_str %}
 {% endif %}
 
-{% include "wagtailadmin/shared/header.html" with title=choose_str subtitle=page_type_names|join:", " search_url="wagtailadmin_choose_page_search" query_parameters="page_type="|add:page_type_string icon="doc-empty-inverse" %}
+{% include "wagtailadmin/shared/header.html" with title=choose_str subtitle=page_type_names|join:", " search_url="wagtailadmin_choose_page_search" query_parameters="page_type="|add:page_type_string icon=header_icon %}
 
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='internal' %}

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -234,6 +234,16 @@ class BrowseView(View):
         except (ValueError, LookupError):
             raise Http404
 
+        # Determine header icon
+        page_icon_set = set([
+            getattr(page_class, "admin_icon", "doc-empty-inverse")
+            for page_class in self.desired_classes
+        ])
+        if len(page_icon_set) == 1:
+            header_icon = page_icon_set.pop()
+        else:
+            header_icon = "doc-empty-inverse"
+
         # Find parent page
         if parent_page_id:
             self.parent_page = get_object_or_404(Page, id=parent_page_id)
@@ -382,6 +392,7 @@ class BrowseView(View):
                 "locale_options": locale_options,
                 "selected_locale": selected_locale,
                 "is_multiple_choice": self.is_multiple_choice,
+                "header_icon": header_icon,
             },
         )
 

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -235,10 +235,10 @@ class BrowseView(View):
             raise Http404
 
         # Determine header icon
-        page_icon_set = set([
+        page_icon_set = {
             getattr(page_class, "admin_icon", "doc-empty-inverse")
             for page_class in self.desired_classes
-        ])
+        }
         if len(page_icon_set) == 1:
             header_icon = page_icon_set.pop()
         else:

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -244,10 +244,10 @@ class AdminPageChooser(BaseChooser):
             cleaned_target_models = [Page]
 
         # Determine widget icons
-        page_icon_set = set([
+        page_icon_set = {
             getattr(page_class, "admin_icon", "doc-empty-inverse")
             for page_class in cleaned_target_models
-        ])
+        }
         if len(page_icon_set) == 1:
             self.icon = page_icon_set.pop()
         else:

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -216,7 +216,6 @@ class AdminPageChooser(BaseChooser):
     link_to_chosen_text = _("Edit this page")
     display_title_key = "display_title"
     chooser_modal_url_name = "wagtailadmin_choose_page"
-    icon = "doc-empty-inverse"
     classname = "page-chooser"
     js_constructor = "PageChooser"
 
@@ -243,6 +242,16 @@ class AdminPageChooser(BaseChooser):
                     )
         else:
             cleaned_target_models = [Page]
+
+        # Determine widget icons
+        page_icon_set = set([
+            getattr(page_class, "admin_icon", "doc-empty-inverse")
+            for page_class in cleaned_target_models
+        ])
+        if len(page_icon_set) == 1:
+            self.icon = page_icon_set.pop()
+        else:
+            self.icon = "doc-empty-inverse"
 
         if len(cleaned_target_models) == 1 and cleaned_target_models[0] is not Page:
             model_name = cleaned_target_models[0]._meta.verbose_name.title()
@@ -279,7 +288,9 @@ class AdminPageChooser(BaseChooser):
     def get_instance(self, value):
         instance = super().get_instance(value)
         if instance:
-            return instance.specific
+            specific = instance.specific
+            self.icon = getattr(specific, "admin_icon", self.icon)
+            return specific
 
     def get_display_title(self, instance):
         return instance.get_admin_display_title()


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Partially addresses #9652. See discussion there for details.

This draft PR adds page-specific icons, which will be shown in the page chooser widget and the page chooser browser.
The main omission functionally is when choosing a page, where the icons are not yet being passed to the front end, and therefore **not displayed or updated** in the widget before the containing page is saved.

As this is initially just for demonstration, there are no specific tests or documentation.

To use:

- set up a test project like bakery demo to use a development copy of Wagtail on this branch
- edit bakery demo, for instance like this:

```
# bakerydemo/locations/models.py
...
class LocationPage(Page):
    ...
    admin_icon = "crosshairs"
    ...

# bakerydemo/breads/models.py
...
class BreadPage(Page):
    ...
    random_page = models.ForeignKey(
        'wagtailcore.Page',
        verbose_name="Available from",
        null=True,
        blank=True,
        on_delete=models.PROTECT,
        related_name="+",
    )

    content_panels = Page.content_panels + [
        FieldPanel("introduction"),
        FieldPanel("image"),
        FieldPanel("body"),
        FieldPanel("origin"),
        FieldPanel("bread_type"),
        PageChooserPanel("random_page", ['locations.LocationPage']),  # new field
        MultiFieldPanel(
            [
                FieldPanel(
                    "ingredients",
                    widget=forms.CheckboxSelectMultiple,
                ),
            ],
            heading="Additional Metadata",
            classname="collapsed",
        ),
    ]
```

- makemigrations/migrate/runserver
- edit a bread page, and go to the "Available from" field
- save the page
- note the `crosshairs` icon now appears instead of the default `doc-empty-inverse` icon
- remove the page type constraint in the `PageChooserPanel`
- edit a bread page again, and select any type of page, and save
- if the page type is a LocationPage, the crosshairs will appear, otherwise the default `doc-empty-inverse` icon will appear
- other page types can have `admin_icon`s added, and those icons will appear if such pages are selected.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)