### PR TITLE
Icon font to SVG migration part 2 #6107 #10277

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -288,7 +288,7 @@ Changelog
  * Maintenance: Upgraded Transifex configuration to v3 (Loic Teixeira)
  * Maintenance: Replace repeated HTML `avatar` component with a template tag include `{% avatar ... %}` throughout the admin interface (Aman Pandey)
  * Maintenance: Remove unused `icon-help` and `help-inverse` code (Thibaud Colas)
- * Maintenance: Migrate privacy switch, FileFields, history buttons, error messages, Datetimepicker, ordering icons, thumbnails, and user creation form controls to SVG icons (Thibaud Colas)
+ * Maintenance: Migrate privacy switch, FileFields, history buttons, error messages, Datetimepicker, ordering icons, thumbnails, ModelAdmin, page listings, workflows, and user creation form controls to SVG icons (Thibaud Colas)
  * Maintenance: Switch form submission listings to use the same ordering icons as other listings (Thibaud Colas)
 
 

--- a/client/scss/components/_icons.scss
+++ b/client/scss/components/_icons.scss
@@ -137,12 +137,15 @@ use[href='#icon-spinner'] {
 // stylelint-disable-next-line no-duplicate-selectors
 .icon {
   &.initial {
-    @include svg-icon(1em);
-    vertical-align: initial;
+    @include svg-icon(1em, $position: initial);
   }
 
   &.default {
     @include svg-icon(1.5em);
+  }
+
+  &.middle {
+    @include svg-icon(1.5em, $position: middle);
   }
 
   &--flipped {

--- a/client/scss/components/_icons.scss
+++ b/client/scss/components/_icons.scss
@@ -35,6 +35,8 @@
 // Icon factory methods
 // =============================================================================
 
+// RemovedInWagtail60Warning
+// Font icons unused in Wagtail core, kept for backwards compatibility with third-party customisations.
 @each $icon, $content in $icons {
   .icon-#{$icon}:before {
     content: string.quote(#{$content});

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -286,18 +286,22 @@ ul.listing {
   .children a {
     color: $color-teal;
     display: block;
+    text-align: center;
 
-    &:before {
-      font-size: 3rem;
+    .icon {
+      width: 3rem;
+      height: 3rem;
     }
   }
 
   .no-children a {
     color: $color-grey-3;
     display: block;
+    text-align: center;
 
-    &:before {
-      font-size: 1.5rem;
+    .icon {
+      width: 1.5rem;
+      height: 1.5rem;
     }
 
     &:hover,
@@ -310,8 +314,9 @@ ul.listing {
     }
   }
 
-  &.small .children a:before {
-    font-size: 30px;
+  &.small .children a .icon {
+    width: 30px;
+    height: 30px;
   }
 
   th.ord {
@@ -340,14 +345,9 @@ ul.listing {
   .handle {
     cursor: move;
     width: 20px;
+    color: $color-grey-3;
 
-    &:before {
-      font-size: 20px;
-      color: $color-grey-3;
-      width: 1em;
-    }
-
-    &:hover:before {
+    &:hover {
       color: $color-text-base;
     }
   }
@@ -625,7 +625,7 @@ table.listing {
     tr:hover .children {
       background-color: $color-teal;
 
-      a:before {
+      .icon {
         color: $color-white;
       }
     }

--- a/client/scss/settings/_variables.icons.scss
+++ b/client/scss/settings/_variables.icons.scss
@@ -1,4 +1,7 @@
 @use 'sass:map';
+
+// RemovedInWagtail60Warning
+// Font icons unused in Wagtail core, kept for backwards compatibility with third-party customisations.
 $icons: (
   'arrow-down-big': '\e030',
   'arrow-down': '\e01a',

--- a/docs/extending/adding_reports.md
+++ b/docs/extending/adding_reports.md
@@ -167,7 +167,7 @@ from .views import UnpublishedChangesReportView
 
 @hooks.register('register_reports_menu_item')
 def register_unpublished_changes_report_menu_item():
-    return AdminOnlyMenuItem("Pages with unpublished changes", reverse('unpublished_changes_report'), classnames='icon icon-' + UnpublishedChangesReportView.header_icon, order=700)
+    return AdminOnlyMenuItem("Pages with unpublished changes", reverse('unpublished_changes_report'), icon_name=UnpublishedChangesReportView.header_icon, order=700)
 
 @hooks.register('register_admin_urls')
 def register_unpublished_changes_report_url():
@@ -230,7 +230,7 @@ from .views import UnpublishedChangesReportView
 
 @hooks.register('register_reports_menu_item')
 def register_unpublished_changes_report_menu_item():
-    return AdminOnlyMenuItem("Pages with unpublished changes", reverse('unpublished_changes_report'), classnames='icon icon-' + UnpublishedChangesReportView.header_icon, order=700)
+    return AdminOnlyMenuItem("Pages with unpublished changes", reverse('unpublished_changes_report'), icon_name=UnpublishedChangesReportView.header_icon, order=700)
 
 @hooks.register('register_admin_urls')
 def register_unpublished_changes_report_url():

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -842,7 +842,7 @@ from wagtail import hooks
 class UserbarPuppyLinkItem:
     def render(self, request):
         return '<li><a href="http://cuteoverload.com/tag/puppehs/" ' \
-            + 'target="_parent" role="menuitem" class="action icon icon-wagtail">Puppies!</a></li>'
+            + 'target="_parent" role="menuitem" class="action">Puppies!</a></li>'
 
 @hooks.register('construct_wagtail_userbar')
 def add_puppy_link_item(request, items):

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -131,7 +131,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Migrate `window.initSlugAutoPopulate` behaviour to a Stimulus Controller `w-sync` (Loveth Omokaro)
  * Rename `status` classes to `w-status` to align with preferred CSS class naming conventions (Mansi Gundre)
  * Remove unused `icon-help` and `help-inverse` code (Thibaud Colas)
- * Migrate privacy switch, FileFields, history buttons, error messages, Datetimepicker, ordering icons, thumbnails, and user creation form controls to SVG icons (Thibaud Colas)
+ * Migrate privacy switch, FileFields, history buttons, error messages, Datetimepicker, ordering icons, thumbnails, ModelAdmin, page listings, workflows, and user creation form controls to SVG icons (Thibaud Colas)
  * Switch form submission listings to use the same ordering icons as other listings (Thibaud Colas)
  * Include wagtail-factories in `wagtail.test.utils` to avoid cross-dependency issues (Matt Westcott)
 

--- a/wagtail/admin/templates/wagtailadmin/chooser/tables/page_navigate_to_children_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/tables/page_navigate_to_children_cell.html
@@ -1,6 +1,6 @@
 {% load i18n wagtailadmin_tags %}
 <td class="{% if value.can_descend %}children{% endif %} {% if column.classname %}{{ column.classname }}{% endif %}">
     {% if value.can_descend %}
-        <a href="{% url 'wagtailadmin_choose_page_child' value.id %}{% querystring p=None %}" class="icon text-replace icon-arrow-right navigate-pages" title="{% blocktrans trimmed with title=value.get_admin_display_title %}Explore subpages of '{{ title }}'{% endblocktrans %}">{% trans 'Explore' %}</a>
+        <a href="{% url 'wagtailadmin_choose_page_child' value.id %}{% querystring p=None %}" class="navigate-pages" title="{% blocktrans trimmed with title=value.get_admin_display_title %}Explore subpages of '{{ title }}'{% endblocktrans %}" arial-label="{% trans 'Explore' %}">{% icon name="arrow-right" classname="default" %}</a>
     {% endif %}
 </td>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
@@ -26,9 +26,12 @@
                     {% if show_ordering_column %}
                         <td class="ord">
                             {% if orderable and ordering == "ord" %}
-                                <div class="handle icon icon-grip text-replace" tabindex="0" aria-live="polite" data-order-handle>
-                                    {% trans 'Drag' %}
-                                    <span data-order-label>Item {{ forloop.counter }} of {{ pages|length }}</span>
+                                <div class="handle" tabindex="0" aria-live="polite" data-order-handle>
+                                    {% icon name="grip" classname="default" %}
+                                    <span class="w-sr-only">
+                                        {% trans 'Drag' %}
+                                        <span data-order-label>Item {{ forloop.counter }} of {{ pages|length }}</span>
+                                    </span>
                                 </div>
                             {% endif %}
                         </td>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_navigation_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_navigation_explore.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% comment %}
 Navigation controls for the page listing in 'explore' mode
@@ -8,16 +8,14 @@ Navigation controls for the page listing in 'explore' mode
     {% if page.is_navigable %}
         <a
             href="{% url 'wagtailadmin_explore' page.id %}"
-            class="icon icon-arrow-right text-replace"
             title="{% blocktrans trimmed with title=page.get_admin_display_title %}Explore child pages of '{{ title }}'{% endblocktrans %}"
             aria-label="{% blocktrans trimmed with title=page.get_admin_display_title %}Explore child pages of '{{ title }}'{% endblocktrans %}"
-        ></a>
+        >{% icon name="arrow-right" classname="default" %}</a>
     {% elif page_perms.can_add_subpage %}
         <a
             href="{% url 'wagtailadmin_pages:add_subpage' page.id %}"
-            class="icon icon-plus-inverse text-replace"
             title="{% blocktrans trimmed with title=page.get_admin_display_title %}Add a child page to '{{ title }}'{% endblocktrans %}"
             aria-label="{% blocktrans trimmed with title=page.get_admin_display_title %}Add a child page to '{{ title }}'{% endblocktrans %}"
-        ></a>
+        >{% icon name="plus-inverse" classname="default" %}</a>
     {% endif %}
 </td>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -5,7 +5,7 @@
 <div class="title-wrapper">
     {% if page.is_site_root %}
         {% if perms.wagtailcore.add_site or perms.wagtailcore.change_site or perms.wagtailcore.delete_site %}
-            <a href="{% url 'wagtailsites:index' %}" class="icon icon-site" title="{% trans 'Sites menu' %}"></a>
+            <a href="{% url 'wagtailsites:index' %}" title="{% trans 'Sites menu' %}">{% icon name="site" classname="initial w-align-text-top" %}</a>
         {% endif %}
     {% endif %}
 

--- a/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_pages_formset.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_pages_formset.html
@@ -48,7 +48,7 @@
 </script>
 
 <p class="add">
-    <button class="button bicolor icon icon-plus" id="id_{{ formset.prefix }}-ADD" value="Add" type="button">{% trans "Assign to another page" %}</button>
+    <button class="button bicolor button--icon" id="id_{{ formset.prefix }}-ADD" value="Add" type="button">{% icon name="plus" wrapped=1 %}{% trans "Assign to another page" %}</button>
 </p>
 
 

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -10,7 +10,7 @@
                 {% icon name="view" %}{% trans "Show disabled workflows" %}
             {% endif %}
         </a>
-        <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>
+        <a href="{% url view.add_url_name %}" class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}{{ view.add_item_label }}</a>
     {% endfragment %}
     {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon extra_actions=workflow_actions %}
 

--- a/wagtail/admin/templates/wagtailadmin/workflows/select_task_type.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/select_task_type.html
@@ -16,7 +16,7 @@
                     <li>
                         <div class="row row-flush">
                             <div class="col6">
-                                <a href="{% url 'wagtailadmin_workflows:add_task' app_label model_name %}" class="icon icon-plus-inverse icon-larger">{{ verbose_name }}</a>
+                                <a href="{% url 'wagtailadmin_workflows:add_task' app_label model_name %}">{% icon name="plus-inverse" classname="middle w-mr-1" %}{{ verbose_name }}</a>
                             </div>
                             <div class="col6">
                                 {{ description }}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/select_task_type.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/select_task_type.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 <p>{% trans "Choose which type of task you'd like to create." %}</p>
 
@@ -8,7 +8,7 @@
             <li>
                 <div class="row row-flush">
                     <div class="col6">
-                        <a href="{% url 'wagtailadmin_workflows:task_chooser_create' %}?create_model={{ app_label|urlencode }}.{{ model_name|urlencode }}" class="icon icon-plus-inverse icon-larger task-type-choice">{{ verbose_name }}</a>
+                        <a href="{% url 'wagtailadmin_workflows:task_chooser_create' %}?create_model={{ app_label|urlencode }}.{{ model_name|urlencode }}" class="task-type-choice">{% icon name="plus-inverse" classname="middle w-mr-1" %}{{ verbose_name }}</a>
                     </div>
                     <div class="col6">
                         {{ description }}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -10,7 +10,7 @@
                 {% icon name="view" %}{% trans "Show disabled tasks" %}
             {% endif %}
         </a>
-        <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>
+        <a href="{% url view.add_url_name %}" class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}{{ view.add_item_label }}</a>
     {% endfragment %}
     {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon extra_actions=workflow_actions %}
 

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -74,13 +74,10 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
 
         # Administrator (or user with add_site permission) should see the
-        # sites link with the icon-site icon
+        # sites link with its icon
         self.assertContains(
             response,
-            (
-                """<a href="/admin/sites/" class="icon icon-site" """
-                """title="Sites menu"></a>"""
-            ),
+            '<a href="/admin/sites/" title="Sites menu"><svg',
         )
 
     def test_ordering(self):

--- a/wagtail/contrib/modeladmin/helpers/button.py
+++ b/wagtail/contrib/modeladmin/helpers/button.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext as _
 class ButtonHelper:
 
     default_button_classnames = ["button"]
-    add_button_classnames = ["bicolor", "icon", "icon-plus"]
+    add_button_classnames = ["bicolor", "button--icon"]
     inspect_button_classnames = ["button-secondary"]
     edit_button_classnames = ["button-secondary"]
     delete_button_classnames = ["no"]
@@ -40,6 +40,7 @@ class ButtonHelper:
         return {
             "url": self.url_helper.create_url,
             "label": _("Add %(object)s") % {"object": self.verbose_name},
+            "icon": "plus",
             "classname": cn,
             "title": _("Add a new %(object)s") % {"object": self.verbose_name},
         }

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/button.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/button.html
@@ -1,1 +1,2 @@
-<a{% if button.url %} href="{{ button.url }}"{% endif %} class="{{ button.classname }}" title="{{ button.title }}"{% if button.target %} target="{{ button.target }}"{% endif %}{% if button.rel %} rel="{{ button.rel }}"{% endif %}>{{ button.label }}</a>
+{% load wagtailadmin_tags %}
+<a{% if button.url %} href="{{ button.url }}"{% endif %} class="{{ button.classname }}" title="{{ button.title }}"{% if button.target %} target="{{ button.target }}"{% endif %}{% if button.rel %} rel="{{ button.rel }}"{% endif %}>{% if button.icon %}{% icon name=button.icon wrapped=1 %}{% endif %}{{ button.label }}</a>


### PR DESCRIPTION
Follow-up to #10277 to complete all icon font changes for #6107.

This preserves a lot of the icon font setup, for backwards compatibility with sites that use icons in their own custom UI. Technically we _don’t_ support implementers reusing the icon font class names directly, but we do have a few code examples that make some use of the classes, so I thought we’d prefer to cautiously keep the icon font longer than strictly needed.

I’ve not updated the styles / alignment of most icons – will revisit this after #10303 with Ben as needed.

TODO:

- [x] Complete icon font -> SVG switch in listings
- [x] Complete icon font -> SVG switch in ModelAdmin
- [x] Deprecation notice (just a code comment)
- [x] Remove `icon-wagtail` icon font example from `hooks.md`
- [x] Remove 2x `icon-` examples from `adding_reports.md`

Regex I used to check for remaining icon font usage:

```
^(?!.*<(svg|use)).*[^#.](icon-angle-double-left|icon-angle-double-right|icon-arrow-down|icon-arrow-down-big|icon-arrow-left|icon-arrow-right|icon-arrow-right-full|icon-arrow-up|icon-arrow-up-big|icon-arrows-up-down|icon-bars|icon-bin|icon-bold|icon-breadcrumb-expand|icon-calendar|icon-calendar-alt|icon-calendar-check|icon-chain-broken|icon-check|icon-chevron-down|icon-circle-check|icon-circle-plus|icon-circle-xmark|icon-clipboard-list|icon-code|icon-cog|icon-cogs|icon-collapse-down|icon-collapse-up|icon-comment|icon-comment-add|icon-comment-add-reversed|icon-copy|icon-cross|icon-crosshairs|icon-cut|icon-date|icon-desktop|icon-doc-empty|icon-doc-empty-inverse|icon-doc-full|icon-doc-full-inverse|icon-dots-horizontal|icon-dots-vertical|icon-download|icon-download-alt|icon-draft|icon-duplicate|icon-edit|icon-ellipsis-v|icon-error|icon-expand-right|icon-folder|icon-folder-inverse|icon-folder-open-1|icon-folder-open-inverse|icon-form|icon-globe|icon-grip|icon-group|icon-h1|icon-h2|icon-h3|icon-h4|icon-h5|icon-h6|icon-help|icon-history|icon-home|icon-horizontalrule|icon-image|icon-info-circle|icon-italic|icon-key|icon-link|icon-link-external|icon-list-ol|icon-list-ul|icon-lock|icon-lock-open|icon-login|icon-logout|icon-mail|icon-media|icon-minus|icon-mobile-alt|icon-no-view|icon-openquote|icon-order|icon-order-down|icon-order-up|icon-password|icon-pick|icon-pilcrow|icon-placeholder|icon-plus|icon-plus-inverse|icon-radio-empty|icon-radio-full|icon-redirect|icon-repeat|icon-reset|icon-resubmit|icon-rotate|icon-search|icon-site|icon-snippet|icon-spinner|icon-strikethrough|icon-subscript|icon-success|icon-suitcase|icon-superscript|icon-table|icon-tablet-alt|icon-tag|icon-tasks|icon-thumbtack|icon-thumbtack-crossed|icon-tick|icon-tick-inverse|icon-time|icon-title|icon-undo|icon-uni52|icon-upload|icon-user|icon-utensils|icon-view|icon-wagtail-icon|icon-wagtail-inverse|icon-warning)(?!-after)
```