### PR TITLE
Fix issue with MessagesController (base html) - error type

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -32,7 +32,7 @@
                 <template data-w-messages-target="template" data-type="success">
                     <li class="success">{% icon name="success" classname="messages-icon" %}<span></span></li>
                 </template>
-                <template data-w-messages-target="template" data-type="success">
+                <template data-w-messages-target="template" data-type="error">
                     <li class="error">{% icon name="warning" classname="messages-icon" %}<span></span></li>
                 </template>
                 <template data-w-messages-target="template" data-type="warning">


### PR DESCRIPTION
- The success type was used twice so there was no way to add an error message
- Relates to #10182
- Found while reviewing messages on #10277