### PR TITLE
Fix collection field alignment in drop zone (multi-upload)

### DIFF
--- a/client/scss/components/forms/_drop-zone.scss
+++ b/client/scss/components/forms/_drop-zone.scss
@@ -14,4 +14,9 @@
   &.hovered {
     border-color: $color-teal;
   }
+
+  // override global field padding as fields are centre aligned in upload box
+  .w-field__input {
+    padding-inline-end: 0;
+  }
 }


### PR DESCRIPTION
- Fixes #10280
- Note: May need to backport to previous releases, would likely be broken in 4.1 & 4.2

**Before**

<img width="1144" alt="Screenshot 2023-03-29 at 5 59 09 pm" src="https://user-images.githubusercontent.com/1396140/228470637-e643b976-a204-464c-b7f5-7e7a1f269098.png">

**After**

<img width="1835" alt="Screenshot 2023-03-29 at 6 14 47 pm" src="https://user-images.githubusercontent.com/1396140/228470668-3a3f2618-8c8c-48f0-9aef-36631f1d6f23.png">
