### PR TITLE
Render large image renditions to disk

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -4,7 +4,7 @@ import os.path
 import time
 from collections import OrderedDict
 from contextlib import contextmanager
-from io import BytesIO
+from tempfile import SpooledTemporaryFile
 from typing import Union
 
 import willow
@@ -537,7 +537,10 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         start_time = time.time()
 
         try:
-            generated_image = filter.run(self, BytesIO())
+            generated_image = filter.run(
+                self,
+                SpooledTemporaryFile(max_size=settings.FILE_UPLOAD_MAX_MEMORY_SIZE),
+            )
 
             logger.debug(
                 "Generated '%s' rendition for image %d in %.1fms",


### PR DESCRIPTION
_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

This will make little difference to the render process, as Willow will still load most of the image into memory to operate on it, but saves them to disk once the generation is complete to help clean up memory faster.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
