### PR TITLE
Always show StreamField and InlinePanel block controls

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -59,6 +59,7 @@ Changelog
  * Fix: Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
  * Fix: Fix server-side caching of the icons sprite (Thibaud Colas)
  * Fix: Avoid showing scrollbars in the block picker unless necessary (Babitha Kumari)
+ * Fix: Always show Add buttons, guide lines, Move up/down, Duplicate, Delete; in StreamField and Inline Panel (Thibaud Colas)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp, Thibaud Colas)
  * Docs: Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)
@@ -106,6 +107,7 @@ Changelog
  * Fix: Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
  * Fix: Fix server-side caching of the icons sprite (Thibaud Colas)
  * Fix: Avoid showing scrollbars in the block picker unless necessary (Babitha Kumari)
+ * Fix: Always show Add buttons, guide lines, Move up/down, Duplicate, Delete; in StreamField and Inline Panel (Thibaud Colas)
 
 
 4.2.1 (13.03.2023)
@@ -288,6 +290,7 @@ Changelog
  * Fix: Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
  * Fix: Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
  * Fix: Fix server-side caching of the icons sprite (Thibaud Colas)
+ * Fix: Always show Add buttons, guide lines, Move up/down, Duplicate, Delete; in StreamField and Inline Panel (Thibaud Colas)
 
 
 4.1.3 (13.03.2023)

--- a/client/scss/components/_panel.scss
+++ b/client/scss/components/_panel.scss
@@ -56,8 +56,7 @@ $header-gap: theme('spacing.1');
 
 .w-panel__anchor,
 .w-panel__toggle,
-.w-panel__controls .button.button--icon,
-.w-panel__controls-cue {
+.w-panel__controls .button.button--icon {
   @include show-focus-outline-inside();
   display: inline-grid;
   justify-content: center;
@@ -156,33 +155,6 @@ $header-gap: theme('spacing.1');
   @include media-breakpoint-up(sm) {
     margin: calc(-1 * theme('spacing.4'));
     margin-inline-start: 0;
-  }
-
-  // The cue is meant to be displayed on top of a real button.
-  > .w-panel__controls-cue {
-    position: absolute;
-    visibility: hidden;
-  }
-
-  @media (hover: hover) {
-    // Hiding with opacity only, so the elements can still be focused.
-    > * {
-      opacity: 0;
-    }
-
-    > .w-panel__controls-cue {
-      opacity: 1;
-      visibility: visible;
-    }
-
-    .w-panel__header:is(:hover, :focus-within) & > * {
-      opacity: 1;
-
-      // The cue should be fully hidden, not just transparent.
-      &.w-panel__controls-cue {
-        visibility: hidden;
-      }
-    }
   }
 }
 

--- a/client/scss/components/forms/_nested-panel.scss
+++ b/client/scss/components/forms/_nested-panel.scss
@@ -12,8 +12,6 @@ $panel-x-offset: calc($header-button-size-sm / 2 + $header-gap);
 
 // Styles for the top-level panel, and any panel within.
 .w-panel--nested {
-  @include guide-line-active();
-
   .w-panel__divider {
     @include guide-line-horizontal();
     // Slightly nicer text alignment.

--- a/client/scss/tools/_mixins.guide-line.scss
+++ b/client/scss/tools/_mixins.guide-line.scss
@@ -3,13 +3,15 @@
  * StreamField and InlinePanel.
  */
 
+$guide-line-default-color: theme('colors.grey.150');
+
 @mixin guide-line-vertical() {
   // 3px dash height, 3px space, 1px dash width.
   background-size: 1px 6px;
   background-repeat: repeat-y;
   background-image: linear-gradient(
     to bottom,
-    var(--guide-line-color, transparent) 50%,
+    var(--guide-line-color, $guide-line-default-color) 50%,
     rgba(255, 255, 255, 0) 0%
   );
 
@@ -26,7 +28,7 @@
   background-repeat: repeat-x;
   background-image: linear-gradient(
     to right,
-    var(--guide-line-color, transparent) 50%,
+    var(--guide-line-color, $guide-line-default-color) 50%,
     rgba(255, 255, 255, 0) 0%
   );
 
@@ -35,17 +37,6 @@
   @media (forced-colors: active) {
     border-top: 1px dashed var(--guide-line-color, CanvasText);
     background: none;
-  }
-}
-
-// Default guide line color for nested panels.
-@mixin guide-line-active() {
-  @media (hover: none) {
-    --guide-line-color: theme('colors.grey.150');
-  }
-
-  &:is(:hover, :focus-within) {
-    --guide-line-color: theme('colors.grey.150');
   }
 }
 

--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -178,13 +178,7 @@ export class BaseSequenceChild extends EventEmitter {
               </svg>
             </a>
             <div class="w-panel__divider"></div>
-            <div class="w-panel__controls" data-panel-controls>
-              <div class="w-panel__controls-cue">
-                <svg class="icon icon-dots-horizontal w-panel__icon" aria-hidden="true">
-                  <use href="#icon-dots-horizontal"></use>
-                </svg>
-              </div>
-            </div>
+            <div class="w-panel__controls" data-panel-controls></div>
           </div>
           <div id="${contentId}" class="w-panel__content">
             <div data-streamfield-block></div>

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -60,12 +60,9 @@ class InsertPosition extends BaseInsertionControl {
     super(placeholder, opts);
     this.onRequestInsert = opts && opts.onRequestInsert;
     const animate = opts && opts.animate;
-
+    const title = h(opts.strings.ADD);
     const button = $(`
-      <button type="button" title="${h(
-        opts.strings.ADD,
-      )}" data-streamfield-list-add
-          class="c-sf-add-button c-sf-add-button--visible">
+      <button type="button" title="${title}" data-streamfield-list-add class="c-sf-add-button">
         <svg class="icon icon-plus" aria-hidden="true"><use href="#icon-plus"></use></svg>
       </button>
     `);

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -77,7 +77,7 @@ class StreamBlockMenu extends BaseInsertionControl {
 
     const dom = $(`
       <div>
-        <button type="button" title="${comboBoxTriggerLabel}" class="c-sf-add-button c-sf-add-button--visible">
+        <button type="button" title="${comboBoxTriggerLabel}" class="c-sf-add-button">
           <svg class="icon icon-plus" aria-hidden="true"><use href="#icon-plus"></use></svg>
         </button>
       </div>
@@ -142,7 +142,6 @@ class StreamBlockMenu extends BaseInsertionControl {
     if (this.onRequestInsert) {
       this.onRequestInsert(this.index, { type: change.selectedItem.type });
     }
-    this.addButton.removeClass('c-sf-add-button--always-visible');
     this.close();
   }
 
@@ -155,10 +154,6 @@ class StreamBlockMenu extends BaseInsertionControl {
     } else {
       this.addButton.attr('disabled', 'true');
     }
-  }
-
-  reveal() {
-    this.addButton.addClass('c-sf-add-button--always-visible');
   }
 
   open() {
@@ -394,10 +389,6 @@ export class StreamBlock extends BaseSequenceBlock {
 
   setState(values) {
     super.setState(values);
-    if (values.length === 0) {
-      /* for an empty list, begin with the toggle revealed */
-      this.inserters[0].reveal();
-    }
   }
 
   setError(error) {

--- a/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
@@ -38,13 +38,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -106,13 +100,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -174,13 +162,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -256,13 +238,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered downward 1`]
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -324,13 +300,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered downward 1`]
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -406,13 +376,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered upward 1`] =
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -474,13 +438,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered upward 1`] =
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -556,13 +514,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be split 1`] = `
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -624,13 +576,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be split 1`] = `
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -692,13 +638,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be split 1`] = `
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -774,13 +714,7 @@ exports[`telepath: wagtail.blocks.ListBlock deleteBlock() deletes a block 1`] = 
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -842,13 +776,7 @@ exports[`telepath: wagtail.blocks.ListBlock deleteBlock() deletes a block 1`] = 
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -924,13 +852,7 @@ exports[`telepath: wagtail.blocks.ListBlock it renders correctly 1`] = `
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -992,13 +914,7 @@ exports[`telepath: wagtail.blocks.ListBlock it renders correctly 1`] = `
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -1074,13 +990,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError passes error messages to ch
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -1142,13 +1052,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError passes error messages to ch
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -1224,13 +1128,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError renders non-block errors 1`
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -1292,13 +1190,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError renders non-block errors 1`
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>

--- a/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
@@ -8,7 +8,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
         </div><div class=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-list-count=\\"\\" value=\\"3\\">
 
-        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
@@ -70,7 +70,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"22222222-2222-2222-2222-222222222222\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
@@ -132,7 +132,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"fake-uuid-v4-value\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-deleted\\" value=\\"\\">
@@ -194,7 +194,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button></div>
       </div>"
@@ -208,7 +208,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered downward 1`]
         </div><div class=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-list-count=\\"\\" value=\\"2\\">
 
-        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"22222222-2222-2222-2222-222222222222\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
@@ -270,7 +270,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered downward 1`]
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
@@ -332,7 +332,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered downward 1`]
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button></div>
       </div>"
@@ -346,7 +346,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered upward 1`] =
         </div><div class=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-list-count=\\"\\" value=\\"2\\">
 
-        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"22222222-2222-2222-2222-222222222222\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
@@ -408,7 +408,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered upward 1`] =
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
@@ -470,7 +470,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered upward 1`] =
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button></div>
       </div>"
@@ -484,7 +484,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be split 1`] = `
         </div><div class=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-list-count=\\"\\" value=\\"3\\">
 
-        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
@@ -546,7 +546,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be split 1`] = `
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath-disabled=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-deleted\\" value=\\"\\">
@@ -608,7 +608,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be split 1`] = `
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"22222222-2222-2222-2222-222222222222\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
@@ -670,7 +670,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be split 1`] = `
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button></div>
       </div>"
@@ -684,7 +684,7 @@ exports[`telepath: wagtail.blocks.ListBlock deleteBlock() deletes a block 1`] = 
         </div><div class=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-list-count=\\"\\" value=\\"2\\">
 
-        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
@@ -746,7 +746,7 @@ exports[`telepath: wagtail.blocks.ListBlock deleteBlock() deletes a block 1`] = 
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"22222222-2222-2222-2222-222222222222\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"1\\">
@@ -808,7 +808,7 @@ exports[`telepath: wagtail.blocks.ListBlock deleteBlock() deletes a block 1`] = 
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button></div>
       </div>"
@@ -822,7 +822,7 @@ exports[`telepath: wagtail.blocks.ListBlock it renders correctly 1`] = `
         </div><div class=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-list-count=\\"\\" value=\\"2\\">
 
-        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
@@ -884,7 +884,7 @@ exports[`telepath: wagtail.blocks.ListBlock it renders correctly 1`] = `
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"22222222-2222-2222-2222-222222222222\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
@@ -946,7 +946,7 @@ exports[`telepath: wagtail.blocks.ListBlock it renders correctly 1`] = `
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button></div>
       </div>"
@@ -960,7 +960,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError passes error messages to ch
         </div><div class=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-list-count=\\"\\" value=\\"2\\">
 
-        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
@@ -1022,7 +1022,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError passes error messages to ch
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"22222222-2222-2222-2222-222222222222\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
@@ -1084,7 +1084,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError passes error messages to ch
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button></div>
       </div>"
@@ -1098,7 +1098,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError renders non-block errors 1`
         </div><div class=\\"\\"><p class=\\"help-block help-critical\\">At least three blocks are required</p>
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-list-count=\\"\\" value=\\"2\\">
 
-        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
@@ -1160,7 +1160,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError renders non-block errors 1`
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><div data-contentpath=\\"22222222-2222-2222-2222-222222222222\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
@@ -1222,7 +1222,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError renders non-block errors 1`
       </div>
           </div>
         </section>
-      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
       </button></div>
       </div>"

--- a/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
@@ -8,7 +8,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
         </div><div class=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-stream-count=\\"\\" value=\\"3\\">
         <div data-streamfield-stream-container=\\"\\"><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div><div data-contentpath=\\"1\\">
@@ -72,7 +72,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
           </div>
         </section>
       </div><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div><div data-contentpath=\\"2\\">
@@ -136,7 +136,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
           </div>
         </section>
       </div><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div><div data-contentpath=\\"fake-uuid-v4-value\\">
@@ -200,7 +200,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
           </div>
         </section>
       </div><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div></div>
@@ -215,7 +215,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered downward 1
         </div><div class=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-stream-count=\\"\\" value=\\"2\\">
         <div data-streamfield-stream-container=\\"\\"><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div><div data-contentpath=\\"2\\">
@@ -279,7 +279,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered downward 1
           </div>
         </section>
       </div><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div><div data-contentpath=\\"1\\">
@@ -343,7 +343,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered downward 1
           </div>
         </section>
       </div><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div></div>
@@ -358,7 +358,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered upward 1`]
         </div><div class=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-stream-count=\\"\\" value=\\"2\\">
         <div data-streamfield-stream-container=\\"\\"><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div><div data-contentpath=\\"2\\">
@@ -422,7 +422,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered upward 1`]
           </div>
         </section>
       </div><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div><div data-contentpath=\\"1\\">
@@ -486,7 +486,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered upward 1`]
           </div>
         </section>
       </div><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div></div>
@@ -501,7 +501,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders correctly 1`] = `
         </div><div class=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-stream-count=\\"\\" value=\\"2\\">
         <div data-streamfield-stream-container=\\"\\"><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div><div data-contentpath=\\"1\\">
@@ -565,7 +565,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders correctly 1`] = `
           </div>
         </section>
       </div><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div><div data-contentpath=\\"2\\">
@@ -629,7 +629,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders correctly 1`] = `
           </div>
         </section>
       </div><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div></div>
@@ -644,7 +644,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders menus on opening 1`] = 
         </div><div class=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-stream-count=\\"\\" value=\\"2\\">
         <div data-streamfield-stream-container=\\"\\"><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div><div data-contentpath=\\"1\\">
@@ -708,7 +708,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders menus on opening 1`] = 
           </div>
         </section>
       </div><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"true\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"true\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       <div data-tippy-root=\\"\\" id=\\"tippy-5\\" style=\\"z-index: 9999; visibility: visible; transition: none; position: absolute; left: 0px; top: 0px; margin: 0px;\\"><div class=\\"tippy-box\\" data-state=\\"hidden\\" tabindex=\\"-1\\" data-theme=\\"dropdown\\" data-animation=\\"fade\\" style=\\"max-width: 350px; transition-duration: 0ms;\\" role=\\"tooltip\\"><div class=\\"tippy-content\\" data-state=\\"hidden\\" style=\\"transition-duration: 0ms;\\"><div><div class=\\"w-combobox\\"><label id=\\"downshift-0-label\\" for=\\"downshift-0-input\\" class=\\"w-sr-only\\">Search options…</label><div class=\\"w-combobox__field\\"><input aria-activedescendant=\\"\\" aria-autocomplete=\\"list\\" aria-controls=\\"downshift-0-menu\\" aria-expanded=\\"false\\" aria-labelledby=\\"downshift-0-label\\" autocomplete=\\"off\\" id=\\"downshift-0-input\\" role=\\"combobox\\" type=\\"text\\" placeholder=\\"Search options…\\" value=\\"\\"></div><div id=\\"downshift-0-menu\\" role=\\"listbox\\" aria-labelledby=\\"downshift-0-label\\" class=\\"w-combobox__menu\\"><div class=\\"w-combobox__optgroup\\"><div role=\\"option\\" aria-selected=\\"false\\" id=\\"downshift-0-item-0\\" class=\\"w-combobox__option w-combobox__option--col1\\"><div class=\\"w-combobox__option-icon\\"><svg class=\\"icon icon-placeholder \\" aria-hidden=\\"true\\"><use href=\\"#icon-placeholder\\"></use></svg></div><div class=\\"w-combobox__option-text\\">Test Block A</div></div><div role=\\"option\\" aria-selected=\\"false\\" id=\\"downshift-0-item-1\\" class=\\"w-combobox__option w-combobox__option--col2\\"><div class=\\"w-combobox__option-icon\\"><svg class=\\"icon icon-pilcrow \\" aria-hidden=\\"true\\"><use href=\\"#icon-pilcrow\\"></use></svg></div><div class=\\"w-combobox__option-text\\">Test Block B</div></div></div></div></div></div></div></div></div></div><div data-contentpath=\\"2\\">
@@ -772,7 +772,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders menus on opening 1`] = 
           </div>
         </section>
       </div><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div></div>
@@ -787,7 +787,7 @@ exports[`telepath: wagtail.blocks.StreamBlock setError renders error messages 1`
         </div><div class=\\"\\"><p class=\\"help-block help-critical\\">At least three blocks are required</p>
         <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-stream-count=\\"\\" value=\\"2\\">
         <div data-streamfield-stream-container=\\"\\"><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div><div data-contentpath=\\"1\\">
@@ -851,7 +851,7 @@ exports[`telepath: wagtail.blocks.StreamBlock setError renders error messages 1`
           </div>
         </section>
       </div><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div><div data-contentpath=\\"2\\">
@@ -915,7 +915,7 @@ exports[`telepath: wagtail.blocks.StreamBlock setError renders error messages 1`
           </div>
         </section>
       </div><div>
-        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" aria-expanded=\\"false\\">
+        <button type=\\"button\\" title=\\"Insert a block\\" class=\\"c-sf-add-button\\" aria-expanded=\\"false\\">
           <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
         </button>
       </div></div>

--- a/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
@@ -39,13 +39,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -109,13 +103,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -179,13 +167,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -264,13 +246,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered downward 1
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -334,13 +310,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered downward 1
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -419,13 +389,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered upward 1`]
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -489,13 +453,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered upward 1`]
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -574,13 +532,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders correctly 1`] = `
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -644,13 +596,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders correctly 1`] = `
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -729,13 +675,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders menus on opening 1`] = 
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -799,13 +739,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders menus on opening 1`] = 
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -884,13 +818,7 @@ exports[`telepath: wagtail.blocks.StreamBlock setError renders error messages 1`
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\" disabled=\\"disabled\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>
@@ -954,13 +882,7 @@ exports[`telepath: wagtail.blocks.StreamBlock setError renders error messages 1`
               </svg>
             </a>
             <div class=\\"w-panel__divider\\"></div>
-            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\">
-              <div class=\\"w-panel__controls-cue\\">
-                <svg class=\\"icon icon-dots-horizontal w-panel__icon\\" aria-hidden=\\"true\\">
-                  <use href=\\"#icon-dots-horizontal\\"></use>
-                </svg>
-              </div>
-            <button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
+            <div class=\\"w-panel__controls\\" data-panel-controls=\\"\\"><button type=\\"button\\" class=\\"button button--icon text-replace white\\" title=\\"Move up\\">
         <svg class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\">
           <use href=\\"#icon-arrow-up\\"></use>
         </svg>

--- a/client/src/components/StreamField/scss/components/c-sf-add-button.scss
+++ b/client/src/components/StreamField/scss/components/c-sf-add-button.scss
@@ -9,8 +9,6 @@
   background-color: $color-white;
   padding: 0;
   cursor: pointer;
-  opacity: 0;
-  pointer-events: none;
   border: 1px solid currentColor;
   border-radius: theme('borderRadius.full');
   margin-inline-start: -1px;
@@ -25,25 +23,6 @@
     transform: rotate(45deg);
   }
 
-  &--visible {
-    opacity: 1;
-    pointer-events: unset;
-
-    @media (hover: hover) {
-      opacity: 0;
-
-      .w-panel--nested:is(:hover, :focus-within) & {
-        opacity: 1;
-      }
-    }
-  }
-
-  &--always-visible {
-    @media (hover: hover) {
-      opacity: 1;
-    }
-  }
-
   &:hover,
   &:focus-visible {
     color: $color-white;
@@ -52,18 +31,9 @@
 
   &[disabled] {
     opacity: 0.2;
-    pointer-events: none;
 
     @media (forced-colors: active) {
       color: GrayText;
-    }
-
-    @media (hover: hover) {
-      opacity: 0;
-
-      .w-panel--nested:is(:hover, :focus-within) & {
-        opacity: 0.2;
-      }
     }
   }
 }

--- a/docs/releases/4.1.4.md
+++ b/docs/releases/4.1.4.md
@@ -19,3 +19,4 @@ depth: 1
 * Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
 * Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
 * Fix server-side caching of the icons sprite (Thibaud Colas)
+* Always show Add buttons, guide lines, Move up/down, Duplicate, Delete; in StreamField and Inline Panel (Thibaud Colas)

--- a/docs/releases/4.2.2.md
+++ b/docs/releases/4.2.2.md
@@ -20,3 +20,4 @@ depth: 1
 * Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
 * Fix server-side caching of the icons sprite (Thibaud Colas)
 * Avoid showing scrollbars in the block picker unless necessary (Babitha Kumari)
+* Always show Add buttons, guide lines, Move up/down, Duplicate, Delete; in StreamField and Inline Panel (Thibaud Colas)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -76,6 +76,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
  * Fix server-side caching of the icons sprite (Thibaud Colas)
  * Avoid showing scrollbars in the block picker unless necessary (Babitha Kumari)
+ * Always show Add buttons, guide lines, Move up/down, Duplicate, Delete; in StreamField and Inline Panel (Thibaud Colas)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/shared/panel.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/panel.html
@@ -45,9 +45,6 @@
             <div class="w-panel__divider"></div>
             {% if header_controls %}
                 <div class="w-panel__controls" data-panel-controls>
-                    <div class="w-panel__controls-cue">
-                        {% icon name="dots-horizontal" classname="w-panel__icon" %}
-                    </div>
                     {{ header_controls }}
                 </div>
             {% endif %}


### PR DESCRIPTION
Fixes some of the issues reported in #9666. This is part of #9755, but only contains changes that are:

1. Straightforward enough / clear-cut "UX bug fixes" so we can backport them to v4.1 and v4.2
2. Related to the availability of StreamField controls for users of voice recognition software

This doesn’t implement the [expected designs](https://www.figma.com/file/hDFd9f5e6BFGeMGNxgbLmO/Wagtail-CMS-(Copy)?node-id=10990-145320&t=x0eWvhZg7It6sKwX-4) for StreamField/InlinePanel controls in Wagtail 5 – just removes all the code related to show/hiding them.

Changes are:

- Always-visible "Add" buttons in StreamField
- Always-visible "guide lines" illustrating the nesting in StreamField and InlinePanel
- Always-visible "Move up", "Move down", "Duplicate", "Delete" buttons in StreamField and InlinePanel

---

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 111, Firefox 111, Safari 16.3 on macOS 13.2
    -   [x] **Please list which assistive technologies [^3] you tested**: Forced colors mode / WHCM only
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

To test this – the main aspect is checking the UI looks the same now as the "touch screen" version in the past. There are no other visual changes than which elements are visible.