### PR TITLE
Fix/10285 correct serialization of download url property for document model with direct wagtaildocs serve method config

### DIFF
--- a/wagtail/api/v2/utils.py
+++ b/wagtail/api/v2/utils.py
@@ -27,6 +27,8 @@ def get_base_url(request=None):
 
 
 def get_full_url(request, path):
+    if path.startswith("http"):
+        return path
     base_url = get_base_url(request) or ""
     return base_url + path
 

--- a/wagtail/documents/tests/test_serializers.py
+++ b/wagtail/documents/tests/test_serializers.py
@@ -1,0 +1,65 @@
+from urllib.parse import urlparse
+
+from django.core.files.base import ContentFile
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+
+from wagtail.documents import models
+
+
+class TestCorrectDownloadUrlSerialization(TestCase):
+
+    """Test asserts that in case of both `redirect` and `direct`
+    WAGTAILDOCS_SERVE_METHOD settings `download_url` field
+    is correctly serialized by DocumentDownloadUrlField."""
+
+    def setUp(self):
+        self.document = models.Document(title="Test document", file_hash="123456")
+        self.document.file.save("example.doc", ContentFile("A boring example document"))
+
+    def tearDown(self):
+        # delete the FieldFile directly because the TestCase does not commit
+        # transactions to trigger transaction.on_commit() in the signal handler
+        self.document.file.delete()
+
+    def get_response(self, document_id, **params):
+        return self.client.get(
+            reverse("wagtailapi_v2:documents:detail", args=(document_id,)), params
+        )
+
+    def _assert_valid_url(self, url):
+        # NOTE: this assertion will not catch double protocol scheme insertion
+        parsed_url = urlparse(url)
+        if not all((parsed_url.scheme, parsed_url.netloc)):
+            return False
+        return True
+
+    @override_settings(
+        WAGTAILDOCS_SERVE_METHOD="redirect",
+        DEFAULT_FILE_STORAGE="wagtail.test.dummy_external_storage.DummyExternalStorage",
+        WAGTAILAPI_BASE_URL="http://example.com/",
+    )
+    def test_serializer_wagtaildocs_serve_redirect(self):
+        response = self.get_response(self.document.id)
+        data = response.json()
+        self.assertIn("meta", data)
+        meta = data["meta"]
+        self.assertIn("download_url", meta)
+        download_url = meta["download_url"]
+        self.assertTrue(download_url.startswith("http://example.com/"))
+
+    @override_settings(
+        WAGTAILDOCS_SERVE_METHOD="direct",
+        DEFAULT_FILE_STORAGE="wagtail.test.dummy_external_storage.DummyExternalStorage",
+        MEDIA_URL="http://remotestorage.com/media/",
+        WAGTAILAPI_BASE_URL="http://example.com/",
+    )
+    def test_serializer_wagtaildocs_serve_direct(self):
+        response = self.get_response(self.document.id)
+        data = response.json()
+        self.assertIn("meta", data)
+        meta = data["meta"]
+        self.assertIn("download_url", meta)
+        download_url = meta["download_url"]
+        self.assertTrue(download_url.startswith("http://remotestorage.com/media/"))


### PR DESCRIPTION
Fix [#10285](https://github.com/wagtail/wagtail/issues/10285)

Fixing the serialization of `download_url` property in Document model in case of `WAGTAILDOCS_SERVE_METHOD = "direct"` config turned on. Issue: [click here](https://github.com/wagtail/wagtail/issues/10285)





_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
