### PR TITLE
Make `SnippetViewSet` extend `ModelViewSet` and stop patching methods on the model

### DIFF
--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -370,3 +370,7 @@ Note that a new template tag has been built for usage within the admin that may 
 ### Snippets `get_admin_url_namespace()` and `get_admin_base_path()` moved to `SnippetViewSet`
 
 The undocumented `get_admin_url_namespace()` and `get_admin_base_path()` methods that were set on snippet models at runtime have been moved to the {class}`~wagtail.snippets.views.snippets.SnippetViewSet` class. If you use these methods, you could access them via {meth}`SnippetModel.snippet_viewset.get_admin_url_namespace() <wagtail.snippets.views.snippets.SnippetViewSet.get_admin_url_namespace>` and {meth}`SnippetModel.snippet_viewset.get_admin_base_path() <wagtail.snippets.views.snippets.SnippetViewSet.get_admin_base_path>`, respectively.
+
+### Snippets `get_usage()` and `usage_url()` methods removed
+
+The undocumented `get_usage()` and `usage_url()` methods that were set on snippet models at runtime have been removed. Calls to the `get_usage()` method can be replaced with `wagtail.models.ReferenceIndex.get_grouped_references_to(object)`. The `usage_url()` method does not have a direct replacement, but the URL name can be retrieved via {meth}`SnippetModel.snippet_viewset.get_url_name("usage") <wagtail.admin.viewsets.base.ViewSet.get_url_name>`, which can be used to construct the URL with {func}`~django.urls.reverse`.

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -366,3 +366,7 @@ Note that a new template tag has been built for usage within the admin that may 
 {% status "live" url="/test-url/" title=trans_title hidden_label=trans_hidden_label classname="w-status--primary" attrs='target="_blank" rel="noreferrer"' %}
 {% status status_label classname="w-status--primary" %}
 ```
+
+### Snippets `get_admin_url_namespace()` and `get_admin_base_path()` moved to `SnippetViewSet`
+
+The undocumented `get_admin_url_namespace()` and `get_admin_base_path()` methods that were set on snippet models at runtime have been moved to the {class}`~wagtail.snippets.views.snippets.SnippetViewSet` class. If you use these methods, you could access them via {meth}`SnippetModel.snippet_viewset.get_admin_url_namespace() <wagtail.snippets.views.snippets.SnippetViewSet.get_admin_url_namespace>` and {meth}`SnippetModel.snippet_viewset.get_admin_base_path() <wagtail.snippets.views.snippets.SnippetViewSet.get_admin_base_path>`, respectively.

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -201,7 +201,7 @@ def admin_url_name(obj, action):
     """
     if isinstance(obj, Page):
         return f"wagtailadmin_pages:{action}"
-    return obj.get_admin_url_namespace() + f":{action}"
+    return obj.snippet_viewset.get_url_name(action)
 
 
 @register.simple_tag

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -1136,7 +1136,7 @@ class BaseSnippetWorkflowTests(BasePageWorkflowTests):
 
     def get_url(self, view, args=None):
         return reverse(
-            f"{self.object.get_admin_url_namespace()}:{view}",
+            self.model.snippet_viewset.get_url_name(view),
             args=(quote(self.object.pk),) if args is None else args,
         )
 

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -680,7 +680,7 @@ class DeleteView(
     def get_usage(self):
         if not self.usage_url:
             return None
-        return ReferenceIndex.get_references_to(self.object).group_by_source_object()
+        return ReferenceIndex.get_grouped_references_to(self.object)
 
     def get_success_url(self):
         next_url = get_valid_next_url_from_request(self.request)
@@ -874,7 +874,7 @@ class UnpublishView(HookResponseMixin, WagtailAdminTemplateMixin, TemplateView):
         return get_object_or_404(self.model, pk=unquote(self.pk))
 
     def get_usage(self):
-        return ReferenceIndex.get_references_to(self.object).group_by_source_object()
+        return ReferenceIndex.get_grouped_references_to(self.object)
 
     def get_objects_to_unpublish(self):
         # Hook to allow child classes to have more objects to unpublish (e.g. page descendants)

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -183,14 +183,17 @@ class WorkflowObjectsToModeratePanel(Component):
             actions = state.task.specific.get_actions(obj, request.user)
             workflow_tasks = state.workflow_state.all_tasks_with_status()
 
-            url_name_prefix = "wagtailadmin_pages"
-            if not isinstance(obj, Page):
-                url_name_prefix = obj.get_admin_url_namespace()
+            workflow_action_url_name = "wagtailadmin_pages:workflow_action"
+            workflow_preview_url_name = "wagtailadmin_pages:workflow_preview"
 
-            workflow_action_url_name = f"{url_name_prefix}:workflow_action"
-            workflow_preview_url_name = None
-            if getattr(obj, "is_previewable", False):
-                workflow_preview_url_name = f"{url_name_prefix}:workflow_preview"
+            # Snippets can also have workflows
+            if not isinstance(obj, Page):
+                viewset = obj.snippet_viewset
+                workflow_action_url_name = viewset.get_url_name("workflow_action")
+                workflow_preview_url_name = viewset.get_url_name("workflow_preview")
+
+            if not getattr(obj, "is_previewable", False):
+                workflow_preview_url_name = None
 
             context["states"].append(
                 {

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -103,6 +103,20 @@ class ModelViewSet(ViewSet):
             exclude=exclude,
         )
 
+    @property
+    def url_finder_class(self):
+        return type(
+            "_ModelAdminURLFinder",
+            (ModelAdminURLFinder,),
+            {
+                "permission_policy": self.permission_policy,
+                "edit_url_name": self.get_url_name("edit"),
+            },
+        )
+
+    def register_admin_url_finder(self):
+        register_admin_url_finder(self.model, self.url_finder_class)
+
     def get_urlpatterns(self):
         return super().get_urlpatterns() + [
             path("", self.index_view, name="index"),
@@ -113,12 +127,4 @@ class ModelViewSet(ViewSet):
 
     def on_register(self):
         super().on_register()
-        url_finder_class = type(
-            "_ModelAdminURLFinder",
-            (ModelAdminURLFinder,),
-            {
-                "permission_policy": self.permission_policy,
-                "edit_url_name": self.get_url_name("edit"),
-            },
-        )
-        register_admin_url_finder(self.model, url_finder_class)
+        self.register_admin_url_finder()

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -166,7 +166,7 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
         return reverse("wagtaildocs_serve", args=[self.id, self.filename])
 
     def get_usage(self):
-        return ReferenceIndex.get_references_to(self).group_by_source_object()
+        return ReferenceIndex.get_grouped_references_to(self)
 
     @property
     def usage_url(self):

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -311,7 +311,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         return full_path
 
     def get_usage(self):
-        return ReferenceIndex.get_references_to(self).group_by_source_object()
+        return ReferenceIndex.get_grouped_references_to(self)
 
     @property
     def usage_url(self):

--- a/wagtail/models/reference_index.py
+++ b/wagtail/models/reference_index.py
@@ -482,7 +482,7 @@ class ReferenceIndex(models.Model):
     @classmethod
     def get_references_to(cls, object):
         """
-        Returns all inboud references for the given object.
+        Returns all inbound references for the given object.
 
         Args:
             object (Model): The model instance to fetch ReferenceIndex records for
@@ -494,6 +494,20 @@ class ReferenceIndex(models.Model):
             to_content_type_id=cls._get_base_content_type(object),
             to_object_id=object.pk,
         )
+
+    @classmethod
+    def get_grouped_references_to(cls, object):
+        """
+        Returns all inbound references for the given object, grouped by the object
+        they are found on.
+
+        Args:
+            object (Model): The model instance to fetch ReferenceIndex records for
+
+        Returns:
+            A ReferenceGroups object
+        """
+        return cls.get_references_to(object).group_by_source_object()
 
     @property
     def _content_type(self):

--- a/wagtail/snippets/action_menu.py
+++ b/wagtail/snippets/action_menu.py
@@ -147,7 +147,7 @@ class WorkflowMenuItem(ActionMenuItem):
 
     def get_url(self, parent_context):
         instance = parent_context["instance"]
-        url_name = instance.get_admin_url_namespace() + ":collect_workflow_action_data"
+        url_name = instance.snippet_viewset.get_url_name("collect_workflow_action_data")
         return reverse(
             url_name,
             args=(

--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -10,7 +10,7 @@ from django.utils.module_loading import import_string
 
 from wagtail.admin.viewsets import viewsets
 from wagtail.hooks import search_for_hooks
-from wagtail.models import DraftStateMixin, LockableMixin, ReferenceIndex, WorkflowMixin
+from wagtail.models import DraftStateMixin, LockableMixin, WorkflowMixin
 
 SNIPPET_MODELS = []
 
@@ -90,11 +90,6 @@ def _register_snippet_immediately(model, viewset=None):
 
     from wagtail.snippets.views.snippets import SnippetViewSet
 
-    model.get_usage = lambda obj: ReferenceIndex.get_references_to(
-        obj
-    ).group_by_source_object()
-    model.usage_url = get_snippet_usage_url
-
     if viewset is None:
         viewset = SnippetViewSet
     elif isinstance(viewset, str):
@@ -106,10 +101,6 @@ def _register_snippet_immediately(model, viewset=None):
 
     SNIPPET_MODELS.append(model)
     SNIPPET_MODELS.sort(key=lambda x: x._meta.verbose_name)
-
-
-def get_snippet_usage_url(self):
-    return reverse(self.snippet_viewset.get_url_name("usage"), args=[quote(self.pk)])
 
 
 def register_deferred_snippets():

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -3570,7 +3570,12 @@ class TestSnippetDelete(WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailadmin/generic/confirm_delete.html")
         self.assertContains(response, "This advert is referenced 2 times")
         self.assertContains(
-            response, self.test_snippet.usage_url() + "?describe_on_delete=1"
+            response,
+            reverse(
+                "wagtailsnippets_tests_advert:usage",
+                args=[quote(self.test_snippet.pk)],
+            )
+            + "?describe_on_delete=1",
         )
 
     def test_before_delete_snippet_hook_get(self):
@@ -4966,7 +4971,12 @@ class TestSnippetViewWithCustomPrimaryKey(WagtailTestUtils, TestCase):
             "This standard snippet with custom primary key is referenced 0 times",
         )
         self.assertContains(
-            response, self.snippet_a.usage_url() + "?describe_on_delete=1"
+            response,
+            reverse(
+                "wagtailsnippets_snippetstests_standardsnippetwithcustomprimarykey:usage",
+                args=[quote(self.snippet_a.pk)],
+            )
+            + "?describe_on_delete=1",
         )
 
     def test_redirect_to_edit(self):

--- a/wagtail/snippets/tests/test_usage.py
+++ b/wagtail/snippets/tests/test_usage.py
@@ -27,7 +27,7 @@ class TestUsageCount(TestCase):
 
     def test_snippet_usage_count(self):
         advert = Advert.objects.get(pk=1)
-        self.assertEqual(advert.get_usage().count(), 2)
+        self.assertEqual(ReferenceIndex.get_grouped_references_to(advert).count(), 2)
 
 
 class TestUsedBy(TestCase):
@@ -41,11 +41,12 @@ class TestUsedBy(TestCase):
 
     def test_snippet_used_by(self):
         advert = Advert.objects.get(pk=1)
+        usage = ReferenceIndex.get_grouped_references_to(advert)
 
-        self.assertIsInstance(advert.get_usage()[0], tuple)
-        self.assertIsInstance(advert.get_usage()[0][0], Page)
-        self.assertIsInstance(advert.get_usage()[0][1], list)
-        self.assertIsInstance(advert.get_usage()[0][1][0], ReferenceIndex)
+        self.assertIsInstance(usage[0], tuple)
+        self.assertIsInstance(usage[0][0], Page)
+        self.assertIsInstance(usage[0][1], list)
+        self.assertIsInstance(usage[0][1][0], ReferenceIndex)
 
 
 class TestSnippetUsageView(WagtailTestUtils, TestCase):
@@ -194,7 +195,7 @@ class TestSnippetUsageView(WagtailTestUtils, TestCase):
         )
         Page.objects.get(pk=1).add_child(instance=gfk_page)
 
-        self.assertEqual(advert.get_usage().count(), 1)
+        self.assertEqual(ReferenceIndex.get_grouped_references_to(advert).count(), 1)
 
         response = self.client.get(
             reverse("wagtailsnippets_tests_advert:usage", args=["1"])

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -197,11 +197,6 @@ class TestAdminURLs(WagtailTestUtils, TestCase):
             viewset.get_admin_url_namespace(),
             "wagtailsnippets_tests_advert",
         )
-        # Accessed via the model
-        self.assertEqual(
-            snippet.get_admin_url_namespace(),
-            "wagtailsnippets_tests_advert",
-        )
         # Get specific URL name
         self.assertEqual(
             viewset.get_url_name("edit"),
@@ -227,8 +222,6 @@ class TestAdminURLs(WagtailTestUtils, TestCase):
 
         # Accessed via the viewset
         self.assertEqual(viewset.get_admin_base_path(), "snippets/tests/advert")
-        # Accessed via the model
-        self.assertEqual(snippet.get_admin_base_path(), "snippets/tests/advert")
         # Get specific URL
         self.assertEqual(reverse(viewset.get_url_name("edit"), args=[pk]), expected_url)
         # Ensure AdminURLFinder returns the correct URL
@@ -250,8 +243,6 @@ class TestAdminURLs(WagtailTestUtils, TestCase):
         viewset = snippet.snippet_viewset
         # Accessed via the viewset
         self.assertEqual(viewset.get_admin_url_namespace(), "some_namespace")
-        # Accessed via the model
-        self.assertEqual(snippet.get_admin_url_namespace(), "some_namespace")
         # Get specific URL name
         self.assertEqual(viewset.get_url_name("edit"), "some_namespace:edit")
         # Chooser namespace
@@ -273,8 +264,6 @@ class TestAdminURLs(WagtailTestUtils, TestCase):
         expected_choose_url = "/admin/choose/wisely/"
         # Accessed via the viewset
         self.assertEqual(viewset.get_admin_base_path(), "deep/within/the/admin")
-        # Accessed via the model
-        self.assertEqual(snippet.get_admin_base_path(), "deep/within/the/admin")
         # Get specific URL
         self.assertEqual(reverse(viewset.get_url_name("edit"), args=[pk]), expected_url)
         # Ensure AdminURLFinder returns the correct URL

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -10,7 +10,6 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
-from wagtail.admin.admin_url_finder import register_admin_url_finder
 from wagtail.admin.checks import check_panels_in_model
 from wagtail.admin.filters import DateRangePickerWidget, WagtailFilterSet
 from wagtail.admin.panels import get_edit_handler
@@ -31,7 +30,7 @@ from wagtail.admin.views.generic.preview import PreviewOnEdit as PreviewOnEditVi
 from wagtail.admin.views.generic.preview import PreviewRevision
 from wagtail.admin.views.reports.base import ReportView
 from wagtail.admin.viewsets import viewsets
-from wagtail.admin.viewsets.base import ViewSet
+from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.log_actions import registry as log_registry
 from wagtail.models import (
     DraftStateMixin,
@@ -582,7 +581,7 @@ class WorkflowHistoryDetailView(
     permission_required = "change"
 
 
-class SnippetViewSet(ViewSet):
+class SnippetViewSet(ModelViewSet):
     """
     A viewset that instantiates the admin views for snippets.
     """
@@ -1167,9 +1166,6 @@ class SnippetViewSet(ViewSet):
 
         return urlpatterns + legacy_redirects
 
-    def register_admin_url_finder(self):
-        register_admin_url_finder(self.model, self.url_finder_class)
-
     def register_model_check(self):
         def snippets_model_check(app_configs, **kwargs):
             return check_panels_in_model(self.model, "snippets")
@@ -1191,6 +1187,5 @@ class SnippetViewSet(ViewSet):
     def on_register(self):
         super().on_register()
         viewsets.register(self.chooser_viewset)
-        self.register_admin_url_finder()
         self.register_model_check()
         self.register_model_methods()

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -97,7 +97,7 @@ class ModelIndexView(generic.IndexView):
         return super().dispatch(request, *args, **kwargs)
 
     def get_list_url(self, type):
-        return reverse(type["model"].get_admin_url_namespace() + ":list")
+        return reverse(type["model"].snippet_viewset.get_url_name("list"))
 
     def get_queryset(self):
         return None
@@ -1172,20 +1172,7 @@ class SnippetViewSet(ModelViewSet):
 
         checks.register(snippets_model_check, "panels")
 
-    def register_model_methods(self):
-        @classmethod
-        def get_admin_url_namespace(cls):
-            return self.get_admin_url_namespace()
-
-        @classmethod
-        def get_admin_base_path(cls):
-            return self.get_admin_base_path()
-
-        self.model.get_admin_url_namespace = get_admin_url_namespace
-        self.model.get_admin_base_path = get_admin_base_path
-
     def on_register(self):
         super().on_register()
         viewsets.register(self.chooser_viewset)
         self.register_model_check()
-        self.register_model_methods()


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Follow up to https://github.com/wagtail/wagtail/pull/10235#discussion_r1145184334.

I also made it so that `SnippetViewSet` extends the `ModelViewSet` class. This ensures that we have a consistent approach for the `ViewSet` internals, and helps bring Snippets features to be generic in the future.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
    -   The corresponding tests are removed instead.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
