### PR TITLE
5.0 release notes clean up

### DIFF
--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -93,7 +93,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Remove confusing `SettingsPanel` reference in the page editing `TabbedInterface` example as `SettingsPanel` no longer shows anything as of 4.1 (Kenny Wolf, Julian Bigler)
  * Add contributor guidelines for building [Stimulus Controllers](ui_guidelines_stimulus) (Thibaud Colas, Loveth Omokaro, LB (Ben) Johnston)
  * Fix typo in "Extending Draftail" documentation (Hans Kelson)
- * Docs: Clarify `ClusterableModel` requirements for using relations with `RevisionMixin`-enabled models (Sage Abdullah)
+ * Clarify `ClusterableModel` requirements for using relations with `RevisionMixin`-enabled models (Sage Abdullah)
 
 ### Maintenance
 
@@ -186,9 +186,9 @@ If there are custom styles in place for the `ModelAdmin`'s header content or mor
 | Heading & search (contains `h1`) | `.left.header-left`   | `.left`         |
 | Action buttons (`header_extra`)  | `.right.header-right` | `.right`        |
 
-### Slug field widget required for auto-formatting
+### Slug field auto-cleaning now relies on data attributes
 
-The slug field JavaScript behaviour was previously attached to any field with an ID of `id_slug`, this has now changed to be any field with the appropriate HTML data attributes.
+The slug field JavaScript behaviour was previously attached to any field with an ID of `id_slug`, this has now changed to be any field with the appropriate Stimulus data attributes.
 
 If using a custom edit handler or set of panels for page models, the correct widget will now need to be used for these data attributes to be included. This widget will use the `WAGTAIL_ALLOW_UNICODE_SLUGS` Django setting.
 
@@ -222,11 +222,11 @@ To allow unicode values, add the data attribute value;
     name="slug"
     data-controller="w-slug"
     data-action="blur->w-slug#slugify"
-    data-w-slug-allow-unicode="true"
+    data-w-slug-allow-unicode-value="true"
 />
 ```
 
-### Title field auto sync with the slug field on Pages is now implemented with Stimulus
+### Title field auto sync with the slug field on Pages now relies on data attributes
 
 The title field will sync its value with the slug field on Pages if the Page is not published and the slug has not been manually changed. This JavaScript behaviour previously attached to any field with an ID of `id_title`, this has now changed to be any field with the appropriate Stimulus data attributes.
 
@@ -253,13 +253,13 @@ To adjust what triggers the initial check (to see if the fields should be in syn
 
 Above we have adjusted these attributes to add a 'change' event listener to trigger the sync and also adjusted to look for a field with `some_other_slug` instead.
 
-### Progress button (`button-longrunning`) now implemented with Stimulus
+### Progress button (`button-longrunning`) now relies on data attributes
 
 The `button-longrunning` class usage has been updated to use the newly adopted Stimulus approach, the previous data attributes will be deprecated in a future release.
 
 If using the old approach, ensure any HTML templates are updated to the new approach before the next major release.
 
-#### Old syntax
+**Old syntax**
 
 ```html+django
 <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Creating…' %}">
@@ -268,7 +268,7 @@ If using the old approach, ensure any HTML templates are updated to the new appr
 </button>
 ```
 
-#### New syntax
+**New syntax**
 
 Minimum required attributes are `data-controller` and a `data-action`.
 


### PR DESCRIPTION
- Remove unnecessary `docs:` prefix on documentation item
- Fix w-slug attribute example (should end with -value)
- Remove heading levels for old/new syntax in progress button details
- Use a consistent approach to Stimulus adoption entries (focus on data attributes used, not Stimulus migration). After reviewing these three items as a whole, the titles were quite confusing and messy, I thought it would make sense to try to keep these worded roughly the same.
