### PR TITLE
Resolve CircleCI dependency issues by installing non-testing deps first

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,13 @@ jobs:
       - restore_cache:
           key: pipenv-v1-{{ checksum "setup.py" }}
       # Only install if .venv wasn’t cached.
+      # Install without testing dependencies, first to ensure that wagtail is already installed
+      # before pipenv tries to resolve the wagtail-factories dependency on wagtail; otherwise
+      # it will end up fetching the latest wagtail release package and try to resolve further
+      # dependencies based on that
       - run: |
           if [[ ! -e ".venv" ]]; then
+              pipenv install -e .
               pipenv install -e .[testing,docs]
           fi
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,13 @@ jobs:
       - restore_cache:
           key: pipenv-v1-{{ checksum "setup.py" }}
       # Only install if .venv wasn’t cached.
+      # Install without testing dependencies, first to ensure that wagtail is already installed
+      # before pipenv tries to resolve the wagtail-factories dependency on wagtail; otherwise
+      # it will end up fetching the latest wagtail release package and try to resolve further
+      # dependencies based on that
       - run: |
           if [[ ! -e ".venv" ]]; then
+              pipenv install --pre -e .
               pipenv install --pre -e .[testing,docs]
           fi
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,9 @@ jobs:
       - restore_cache:
           key: pipenv-v1-{{ checksum "setup.py" }}
       # Only install if .venv wasn’t cached.
-      # Install without testing dependencies, first to ensure that wagtail is already installed
-      # before pipenv tries to resolve the wagtail-factories dependency on wagtail; otherwise
-      # it will end up fetching the latest wagtail release package and try to resolve further
-      # dependencies based on that
       - run: |
           if [[ ! -e ".venv" ]]; then
-              pipenv install -e .
-              pipenv install -e .[testing,docs]
+              pipenv install --pre -e .[testing,docs]
           fi
       - save_cache:
           key: pipenv-v1-{{ checksum "setup.py" }}


### PR DESCRIPTION
Trying to fix CircleCI test failures introduced by #9842 - I think this is because pipenv is installing Wagtail with test dependencies into a fresh environment, encountering the wagtail-factories dependency (which depends on wagtail) and, since Wagtail isn't installed yet, trying to resolve that against the current Wagtail release package (which depends on the previous version of Willow).