### PR TITLE
Include wagtail-factories as part of wagtail.test.utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,8 @@ testing_extras = [
     "djhtml==1.5.2",
     # for validating string formats in .po translation files
     "polib>=1.1,<2.0",
-    # For streamfield migration toolkit
-    "wagtail-factories @ git+https://github.com/gasman/wagtail-factories.git@remove-wagtail-upper-bound#egg=wagtail-factories",
+    # For wagtail.test.utils.wagtail_factories (used for streamfield migration toolkit)
+    "factory-boy>=3.2",
 ]
 
 # Documentation dependencies

--- a/wagtail/test/streamfield_migrations/factories.py
+++ b/wagtail/test/streamfield_migrations/factories.py
@@ -1,6 +1,7 @@
 import factory
-import wagtail_factories
 from factory.django import DjangoModelFactory
+
+from wagtail.test.utils import wagtail_factories
 
 from . import models
 

--- a/wagtail/test/utils/wagtail_factories/__init__.py
+++ b/wagtail/test/utils/wagtail_factories/__init__.py
@@ -1,0 +1,4 @@
+from .blocks import *  # noqa
+from .factories import *  # noqa
+
+__version__ = "4.0.0"

--- a/wagtail/test/utils/wagtail_factories/__init__.py
+++ b/wagtail/test/utils/wagtail_factories/__init__.py
@@ -1,4 +1,2 @@
 from .blocks import *  # noqa
 from .factories import *  # noqa
-
-__version__ = "4.0.0"

--- a/wagtail/test/utils/wagtail_factories/blocks.py
+++ b/wagtail/test/utils/wagtail_factories/blocks.py
@@ -3,14 +3,9 @@ from collections import defaultdict
 import factory
 from factory.declarations import ParameteredAttribute
 
-from wagtail import VERSION as wagtail_version
+from wagtail import blocks
 from wagtail.documents.blocks import DocumentChooserBlock
 from wagtail.images.blocks import ImageChooserBlock
-
-if wagtail_version >= (3, 0):
-    from wagtail import blocks
-else:
-    from wagtail.core import blocks
 
 from .builder import (
     ListBlockStepBuilder,
@@ -138,11 +133,8 @@ class ListBlockFactory(factory.SubFactory):
             for _, params in sorted(result.items())
         ]
 
-        if wagtail_version >= (2, 16):
-            list_block_def = blocks.list_block.ListBlock(subfactory._meta.model())
-            return blocks.list_block.ListValue(list_block_def, values)
-        else:
-            return values
+        list_block_def = blocks.list_block.ListBlock(subfactory._meta.model())
+        return blocks.list_block.ListValue(list_block_def, values)
 
 
 class StructBlockFactory(factory.Factory):

--- a/wagtail/test/utils/wagtail_factories/blocks.py
+++ b/wagtail/test/utils/wagtail_factories/blocks.py
@@ -1,0 +1,250 @@
+from collections import defaultdict
+
+import factory
+from factory.declarations import ParameteredAttribute
+
+from wagtail import VERSION as wagtail_version
+from wagtail.documents.blocks import DocumentChooserBlock
+from wagtail.images.blocks import ImageChooserBlock
+
+if wagtail_version >= (3, 0):
+    from wagtail import blocks
+else:
+    from wagtail.core import blocks
+
+from .builder import (
+    ListBlockStepBuilder,
+    StreamBlockStepBuilder,
+    StructBlockStepBuilder,
+)
+from .factories import DocumentFactory, ImageFactory, PageFactory
+from .options import BlockFactoryOptions, StreamBlockFactoryOptions
+
+__all__ = [
+    "CharBlockFactory",
+    "IntegerBlockFactory",
+    "StreamBlockFactory",
+    "StreamFieldFactory",
+    "ListBlockFactory",
+    "StructBlockFactory",
+    "PageChooserBlockFactory",
+    "ImageChooserBlockFactory",
+    "DocumentChooserBlockFactory",
+]
+
+
+class StreamBlockFactory(factory.Factory):
+    _options_class = StreamBlockFactoryOptions
+    _builder_class = StreamBlockStepBuilder
+
+    @classmethod
+    def _generate(cls, strategy, params):
+        if cls._meta.abstract and not hasattr(cls, "__generate_abstract__"):
+            raise factory.errors.FactoryError(
+                "Cannot generate instances of abstract factory %(f)s; "
+                "Ensure %(f)s.Meta.model is set and %(f)s.Meta.abstract "
+                "is either not set or False." % {"f": cls.__name__}
+            )
+        step = cls._builder_class(cls._meta, params, strategy)
+        return step.build()
+
+    @classmethod
+    def _construct_stream(cls, block_class, *args, **kwargs):
+        def get_index(key):
+            return int(key.split(".")[0])
+
+        stream_length = max(map(get_index, kwargs.keys())) + 1 if kwargs else 0
+        stream_data = [None] * stream_length
+        for indexed_block_name, value in kwargs.items():
+            i, name = indexed_block_name.split(".")
+            stream_data[int(i)] = (name, value)
+
+        block_def = cls._meta.get_block_definition()
+        if block_def is None:
+            # We got an old style definition, so aren't aware of a StreamBlock class for the
+            # StreamField's child blocks. As nesting of StreamBlocks isn't supported for this
+            # kind of declaration, returning the stream data without up-casting it to a
+            # StreamValue is ok here. StreamField handles conversion to a StreamValue, but not
+            # recursively.
+            return stream_data
+        return blocks.StreamValue(block_def, stream_data)
+
+    @classmethod
+    def _build(cls, block_class, *args, **kwargs):
+        return cls._construct_stream(block_class, *args, **kwargs)
+
+    @classmethod
+    def _create(cls, block_class, *args, **kwargs):
+        return cls._construct_stream(block_class, *args, **kwargs)
+
+    class Meta:
+        abstract = True
+
+
+class StreamFieldFactory(ParameteredAttribute):
+    """
+    Syntax:
+        <streamfield>__<index>__<block_name>__<key>='foo',
+
+    Syntax to generate blocks with default factory values:
+        <streamfield>__<index>=<block_name>
+
+    """
+
+    def __init__(self, block_types, **kwargs):
+        super().__init__(**kwargs)
+        if isinstance(block_types, dict):
+            # Old style definition, dict mapping block name -> block factory
+            self.stream_block_factory = type(
+                "_GeneratedStreamBlockFactory",
+                (StreamBlockFactory,),
+                {**block_types, "__generate_abstract__": True},
+            )
+        elif isinstance(block_types, type) and issubclass(
+            block_types, StreamBlockFactory
+        ):
+            block_types._meta.block_def = block_types._meta.model()
+            self.stream_block_factory = block_types
+        else:
+            raise TypeError(
+                "StreamFieldFactory argument must be a StreamBlockFactory subclass or dict "
+                "mapping block names to factories"
+            )
+
+    def evaluate(self, instance, step, extra):
+        return self.stream_block_factory(**extra)
+
+
+class ListBlockFactory(factory.SubFactory):
+    _builder_class = ListBlockStepBuilder
+
+    def __call__(self, **kwargs):
+        return self.evaluate(None, None, kwargs)
+
+    def evaluate(self, instance, step, extra):
+        result = defaultdict(dict)
+        for key, value in extra.items():
+            if key.isdigit():
+                result[int(key)]["value"] = value
+            else:
+                prefix, label = key.split("__", maxsplit=1)
+                if prefix and prefix.isdigit():
+                    result[int(prefix)][label] = value
+
+        subfactory = self.get_factory()
+        force_sequence = step.sequence if self.FORCE_SEQUENCE else None
+        values = [
+            step.recurse(subfactory, params, force_sequence=force_sequence)
+            for _, params in sorted(result.items())
+        ]
+
+        if wagtail_version >= (2, 16):
+            list_block_def = blocks.list_block.ListBlock(subfactory._meta.model())
+            return blocks.list_block.ListValue(list_block_def, values)
+        else:
+            return values
+
+
+class StructBlockFactory(factory.Factory):
+    _options_class = BlockFactoryOptions
+    _builder_class = StructBlockStepBuilder
+
+    class Meta:
+        abstract = True
+        model = blocks.StructBlock
+
+    @classmethod
+    def _construct_struct_value(cls, block_class, params):
+        return blocks.StructValue(
+            block_class(),
+            [(name, value) for name, value in params.items()],
+        )
+
+    @classmethod
+    def _build(cls, block_class, *args, **kwargs):
+        return cls._construct_struct_value(block_class, kwargs)
+
+    @classmethod
+    def _create(cls, block_class, *args, **kwargs):
+        return cls._construct_struct_value(block_class, kwargs)
+
+
+class BlockFactory(factory.Factory):
+    _options_class = BlockFactoryOptions
+    _builder_class = factory.builder.StepBuilder
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def _construct_block(cls, block_class, *args, **kwargs):
+        if kwargs.get("value"):
+            return block_class().clean(kwargs["value"])
+        return block_class().get_default()
+
+    @classmethod
+    def _build(cls, block_class, *args, **kwargs):
+        return cls._construct_block(block_class, *args, **kwargs)
+
+    @classmethod
+    def _create(cls, block_class, *args, **kwargs):
+        return cls._construct_block(block_class, *args, **kwargs)
+
+
+class CharBlockFactory(BlockFactory):
+    class Meta:
+        model = blocks.CharBlock
+
+
+class IntegerBlockFactory(BlockFactory):
+    class Meta:
+        model = blocks.IntegerBlock
+
+
+class ChooserBlockFactory(BlockFactory):
+    pass
+
+
+class PageChooserBlockFactory(ChooserBlockFactory):
+    page = factory.SubFactory(PageFactory)
+
+    class Meta:
+        model = blocks.PageChooserBlock
+
+    @classmethod
+    def _build(cls, model_class, page):
+        return page
+
+    @classmethod
+    def _create(cls, model_class, page):
+        return page
+
+
+class ImageChooserBlockFactory(ChooserBlockFactory):
+    image = factory.SubFactory(ImageFactory)
+
+    class Meta:
+        model = ImageChooserBlock
+
+    @classmethod
+    def _build(cls, model_class, image):
+        return image
+
+    @classmethod
+    def _create(cls, model_class, image):
+        return image
+
+
+class DocumentChooserBlockFactory(ChooserBlockFactory):
+    document = factory.SubFactory(DocumentFactory)
+
+    class Meta:
+        model = DocumentChooserBlock
+
+    @classmethod
+    def _build(cls, model_class, document):
+        return document
+
+    @classmethod
+    def _create(cls, model_class, document):
+        return document

--- a/wagtail/test/utils/wagtail_factories/builder.py
+++ b/wagtail/test/utils/wagtail_factories/builder.py
@@ -3,11 +3,7 @@ from itertools import zip_longest
 from factory import SubFactory
 from factory.builder import StepBuilder
 
-try:
-    from wagtail import blocks
-except ImportError:
-    # Wagtail<3.0
-    from wagtail.core import blocks
+from wagtail import blocks
 
 
 class StreamFieldFactoryException(Exception):

--- a/wagtail/test/utils/wagtail_factories/builder.py
+++ b/wagtail/test/utils/wagtail_factories/builder.py
@@ -1,0 +1,145 @@
+from itertools import zip_longest
+
+from factory import SubFactory
+from factory.builder import StepBuilder
+
+try:
+    from wagtail import blocks
+except ImportError:
+    # Wagtail<3.0
+    from wagtail.core import blocks
+
+
+class StreamFieldFactoryException(Exception):
+    pass
+
+
+class InvalidDeclaration(StreamFieldFactoryException):
+    pass
+
+
+class DuplicateDeclaration(StreamFieldFactoryException):
+    pass
+
+
+class UnknownChildBlockFactory(StreamFieldFactoryException):
+    pass
+
+
+class BaseBlockStepBuilder(StepBuilder):
+    def recurse(self, factory_meta, extras):
+        """Recurse into a sub-factory call."""
+        builder_class = factory_meta.factory._builder_class
+        return builder_class(factory_meta, extras, strategy=self.strategy)
+
+
+class StructBlockStepBuilder(BaseBlockStepBuilder):
+    pass
+
+
+class ListBlockStepBuilder(BaseBlockStepBuilder):
+    pass
+
+
+class StreamBlockStepBuilder(BaseBlockStepBuilder):
+    def __init__(self, factory_meta, extras, strategy):
+        indexed_block_names, extra_declarations = self.get_block_declarations(
+            factory_meta, extras
+        )
+        new_factory_class = self.create_factory_class(factory_meta, indexed_block_names)
+        super().__init__(new_factory_class._meta, extra_declarations, strategy)
+
+    def get_block_declarations(self, factory_meta, extras):
+        # Mapping of StreamValue index -> block name. We will use this to create a
+        # StreamBlockFactory subclass with one declaration for each pair, named
+        # <index>.<block_name>
+        indexed_block_names = {}
+
+        # Extra declarations passed at instantiation, renamed from <index>__<name>__... to
+        # <index>.<block_name>__..., to match the declarations on the StreamBlockFactory subclass
+        # we will generate. As DeclarationSet splits parameter names on "__" the
+        # <index>.<block_name> keys won't cause errors for unknown declarations (0__foo_block
+        # implies a declaration "0" with context "foo_block"). They will also have the important
+        # property of being uniquely hashable
+        extra_declarations = {}
+
+        for k, v in extras.items():
+            if k.isdigit():
+                # We got a declaration like `<index>="foo_block"' - <index> should get the
+                # default value for foo_block, so don't store this item in extra_declarations
+                if v not in factory_meta.base_declarations:
+                    raise UnknownChildBlockFactory(
+                        f"No factory defined for block '{v}'"
+                    )
+                key = int(k)
+                if key in indexed_block_names and indexed_block_names[key] != v:
+                    raise DuplicateDeclaration(
+                        f"Multiple declarations for index {key} at this level of nesting "
+                        f"(got {v}, already have {indexed_block_names[key]})"
+                    )
+                indexed_block_names[key] = v
+            else:
+                try:
+                    i, name, *params = k.split("__", maxsplit=2)
+                    key = int(i)
+                except (ValueError, TypeError):
+                    raise InvalidDeclaration(
+                        "StreamFieldFactory declarations must be of the form "
+                        "<index>=<block_name>, <index>__<block_name>=value or "
+                        f"<index>__<block_name>__<param>=value, got: {k}"
+                    )
+                if key in indexed_block_names and indexed_block_names[key] != name:
+                    raise DuplicateDeclaration(
+                        f"Multiple declarations for index {key} at this level of nesting "
+                        f"(got {name}, already have {indexed_block_names[key]})"
+                    )
+                indexed_block_names[key] = name
+                transformed_key = self.reconstruct_key(i, name, params)
+                extra_declarations[transformed_key] = v
+
+        self.validate_block_indexes_sequential(indexed_block_names, factory_meta)
+        return indexed_block_names, extra_declarations
+
+    def reconstruct_key(self, index, name, params):
+        return f"{index}.{'__'.join((name, *params))}"
+
+    def validate_block_indexes_sequential(self, indexed_block_names, factory_meta):
+        if not indexed_block_names:
+            # There were no declarations for this block, we will ultimately return an empty
+            # StreamValue
+            return
+        indexes = sorted(indexed_block_names.keys())
+        for declared, expected in zip_longest(indexes, range(max(indexes) + 1)):
+            if declared != expected:
+                raise InvalidDeclaration(
+                    f"Parameters for {factory_meta.factory} missing required index {expected}"
+                )
+
+    def create_factory_class(self, old_factory_meta, indexed_block_names):
+        # Create a new StreamBlockFactory subclass, with a declaration for each block the user
+        # requested at instantiation. This way we can rely on the factory_boy internals for
+        # object generation
+        new_class_dict = {"Meta": old_factory_meta.to_meta_class()}
+
+        block_def = old_factory_meta.get_block_definition()
+        for i, name in indexed_block_names.items():
+            declared_value = old_factory_meta.base_declarations[name]
+            if block_def is not None and isinstance(declared_value, SubFactory):
+                # Annotate the subfactory's factory with the correct block definition for that
+                # branch of the tree, so we can construct a StreamValue if there's no explicit
+                # block class defined (e.g. if a nested StreamBlock was declared inline like
+                # `inner_stream = StreamBlock(...))'
+                child_def = block_def.child_blocks[name]
+                if isinstance(child_def, blocks.ListBlock):
+                    # ListBlock is a special case as it is a concrete node in the stream block
+                    # tree, but ListBlockFactory is a SubFactory subclass, making it "abstract"
+                    # in the factory tree
+                    child_def = child_def.child_block
+                declared_value.get_factory()._meta.block_def = child_def
+            new_class_dict[f"{i}.{name}"] = declared_value
+
+        from .blocks import StreamBlockFactory
+
+        return type(
+            "_GeneratedStreamBlockFactory", (StreamBlockFactory,), new_class_dict
+        )

--- a/wagtail/test/utils/wagtail_factories/factories.py
+++ b/wagtail/test/utils/wagtail_factories/factories.py
@@ -4,18 +4,11 @@ import factory
 from django.utils.text import slugify
 from factory import errors, utils
 from factory.declarations import ParameteredAttribute
-
-from wagtail.images import get_image_model
-
-try:
-    from wagtail.models import Collection, Page, Site
-except ImportError:
-    # Wagtail<3.0
-    from wagtail.core.models import Collection, Page, Site
-
 from factory.django import DjangoModelFactory
 
 from wagtail.documents import get_document_model
+from wagtail.images import get_image_model
+from wagtail.models import Collection, Page, Site
 
 __all__ = [
     "CollectionFactory",

--- a/wagtail/test/utils/wagtail_factories/factories.py
+++ b/wagtail/test/utils/wagtail_factories/factories.py
@@ -1,0 +1,156 @@
+import logging
+
+import factory
+from django.utils.text import slugify
+from factory import errors, utils
+from factory.declarations import ParameteredAttribute
+
+from wagtail.images import get_image_model
+
+try:
+    from wagtail.models import Collection, Page, Site
+except ImportError:
+    # Wagtail<3.0
+    from wagtail.core.models import Collection, Page, Site
+
+from factory.django import DjangoModelFactory
+
+from wagtail.documents import get_document_model
+
+__all__ = [
+    "CollectionFactory",
+    "ImageFactory",
+    "PageFactory",
+    "SiteFactory",
+    "DocumentFactory",
+]
+logger = logging.getLogger(__file__)
+
+
+class ParentNodeFactory(ParameteredAttribute):
+
+    EXTEND_CONTAINERS = True
+    FORCE_SEQUENCE = False
+    UNROLL_CONTEXT_BEFORE_EVALUATION = False
+
+    def generate(self, step, params):
+        if not params:
+            return None
+
+        subfactory = step.builder.factory_meta.factory
+        logger.debug(
+            "ParentNodeFactory: Instantiating %s.%s(%s), create=%r",
+            subfactory.__module__,
+            subfactory.__name__,
+            utils.log_pprint(kwargs=params),
+            step,
+        )
+        force_sequence = step.sequence if self.FORCE_SEQUENCE else None
+        return step.recurse(subfactory, params, force_sequence=force_sequence)
+
+
+class MP_NodeFactory(DjangoModelFactory):
+
+    parent = ParentNodeFactory()
+
+    @classmethod
+    def _build(cls, model_class, *args, **kwargs):
+        kwargs.pop("parent")
+        return model_class(**kwargs)
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        parent = kwargs.pop("parent")
+
+        if cls._meta.django_get_or_create:
+            instance = cls._get_or_create(model_class, *args, parent=parent, **kwargs)
+        else:
+            instance = cls._create_instance(model_class, parent, kwargs)
+            assert instance.pk
+        return instance
+
+    @classmethod
+    def _create_instance(cls, model_class, parent, kwargs):
+        instance = model_class(**kwargs)
+        if parent:
+            parent.add_child(instance=instance)
+        else:
+            model_class.add_root(instance=instance)
+        return instance
+
+    @classmethod
+    def _get_or_create(cls, model_class, *args, **kwargs):
+        """Create an instance of the model through objects.get_or_create."""
+        manager = cls._get_manager(model_class)
+        assert "defaults" not in cls._meta.django_get_or_create, (
+            "'defaults' is a reserved keyword for get_or_create "
+            "(in %s._meta.django_get_or_create=%r)"
+            % (cls, cls._meta.django_get_or_create)
+        )
+
+        lookup_fields = {}
+        for field in cls._meta.django_get_or_create:
+            if field not in kwargs:
+                raise errors.FactoryError(
+                    "django_get_or_create - "
+                    "Unable to find initialization value for '%s' in factory %s"
+                    % (field, cls.__name__)
+                )
+            lookup_fields[field] = kwargs[field]
+
+        parent = lookup_fields.pop("parent", None)
+        kwargs.pop("parent", None)
+
+        if parent:
+            try:
+                return manager.child_of(parent).get(**lookup_fields)
+            except model_class.DoesNotExist:
+                return cls._create_instance(model_class, parent, kwargs)
+        else:
+            return super()._get_or_create(model_class, *args, **kwargs)
+
+
+class CollectionFactory(MP_NodeFactory):
+    name = "Test collection"
+
+    class Meta:
+        model = Collection
+
+
+class PageFactory(MP_NodeFactory):
+    title = "Test page"
+    slug = factory.LazyAttribute(lambda obj: slugify(obj.title))
+
+    class Meta:
+        model = Page
+
+
+class CollectionMemberFactory(DjangoModelFactory):
+    collection = factory.SubFactory(CollectionFactory, parent=None)
+
+
+class ImageFactory(CollectionMemberFactory):
+    class Meta:
+        model = get_image_model()
+
+    title = "An image"
+    file = factory.django.ImageField()
+
+
+class SiteFactory(DjangoModelFactory):
+    hostname = "localhost"
+    port = factory.Sequence(lambda n: 81 + n)
+    site_name = "Test site"
+    root_page = factory.SubFactory(PageFactory, parent=None)
+    is_default_site = False
+
+    class Meta:
+        model = Site
+
+
+class DocumentFactory(CollectionMemberFactory):
+    class Meta:
+        model = get_document_model()
+
+    title = "A document"
+    file = factory.django.FileField()

--- a/wagtail/test/utils/wagtail_factories/options.py
+++ b/wagtail/test/utils/wagtail_factories/options.py
@@ -1,0 +1,60 @@
+from factory import declarations
+from factory.base import FactoryOptions, OptionDefault
+
+
+class BlockFactoryOptions(FactoryOptions):
+    def _build_default_options(self):
+        options = super()._build_default_options()
+        options.append(OptionDefault("block_def", None))
+        return options
+
+    def get_meta_dict(self):
+        return {
+            "model": self.model,
+            "block_def": self.block_def,
+            "abstract": self.abstract,
+            "strategy": self.strategy,
+            "inline_args": self.inline_args,
+            "exclude": self.exclude,
+            "rename": self.rename,
+        }
+
+    def to_meta_class(self):
+        """
+        Create a new Meta class from this instance's options, suitable for
+        inclusion on a factory subclass
+        """
+        return type("Meta", (), self.get_meta_dict())
+
+
+class StreamBlockFactoryOptions(BlockFactoryOptions):
+    def prepare_arguments(self, attributes):
+        # Like the base implementation, but ignore args as they are not relevant
+        # for instantiating StreamValues.
+
+        def get_block_name(key):
+            # Keys at this point will be like <index>.<block_name>
+            return key.split(".")[1]
+
+        kwargs = dict(attributes)
+        # 1. Extension points
+        kwargs = self.factory._adjust_kwargs(**kwargs)
+
+        # 2. Remove hidden objects
+        filtered_kwargs = {}
+        for k, v in kwargs.items():
+            block_name = get_block_name(k)
+            if (
+                block_name not in self.exclude
+                and block_name not in self.parameters
+                and v is not declarations.SKIP
+            ):
+                filtered_kwargs[k] = v
+
+        return (), filtered_kwargs
+
+    def get_block_definition(self):
+        if self.block_def is not None:
+            return self.block_def
+        elif self.model is not None:
+            return self.model()


### PR DESCRIPTION
As per https://github.com/wagtail/wagtail/pull/10296#issuecomment-1490161209 - include our own copy of wagtail-factories in `wagtail.test.utils` so that we don't have to deal with side effects of the circular dependency between wagtail and wagtail-factories.