### PR TITLE
Formalise support for Django 4.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,17 +22,16 @@ concurrency:
 # Current configuration:
 # - django 3.2, python 3.7, postgres
 # - django 3.2, python 3.8, mysql
-# - django 4.0, python 3.9, sqlite
-# - django 4.1, python 3.10, mysql
-# - django 4.0, python 3.10, postgres, USE_EMAIL_USER_MODEL=yes
-# - django 4.1, python 3.11, postgres, DISABLE_TIMEZONE=yes
+# - django 4.1, python 3.9, sqlite
+# - django 4.2, python 3.10, mysql
+# - django 4.1, python 3.10, postgres, USE_EMAIL_USER_MODEL=yes
+# - django 4.2, python 3.11, postgres, DISABLE_TIMEZONE=yes
 # - django stable/4.2.x, python 3.10, postgres (allow failures)
-# - django stable/4.2.x, python 3.11, mysql (allow failures)
 # - django main, python 3.10, postgres (allow failures)
 # - elasticsearch 5, django 3.2, python 3.7, sqlite
 # - elasticsearch 6, django 3.2, python 3.7, postgres
-# - elasticsearch 7, django 4.0, python 3.8, postgres
-# - elasticsearch 7, django 4.1, python 3.9, sqlite, USE_EMAIL_USER_MODEL=yes
+# - elasticsearch 7, django 4.1, python 3.8, postgres
+# - elasticsearch 7, django 4.2, python 3.9, sqlite, USE_EMAIL_USER_MODEL=yes
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -44,7 +43,7 @@ jobs:
       matrix:
         include:
           - python: '3.9'
-            django: 'Django>=4.0,<4.1'
+            django: 'Django>=4.1,<4.2'
 
     steps:
       - uses: actions/checkout@v3
@@ -78,11 +77,12 @@ jobs:
             django: 'Django>=3.2,<3.3'
             experimental: false
           - python: '3.11'
-            django: 'Django>=4.1,<4.2'
+            django: 'Django>=4.2,<4.3'
+            postgres: 'postgres:12'
             notz: notz
             experimental: false
           - python: '3.10'
-            django: 'Django>=4.0,<4.1'
+            django: 'Django>=4.1,<4.2'
             experimental: false
             emailuser: emailuser
           - python: '3.10'
@@ -143,11 +143,8 @@ jobs:
             django: 'Django>=3.2,<3.3'
             experimental: false
           - python: '3.10'
-            django: 'Django>=4.1,<4.2'
+            django: 'Django>=4.2,<4.3'
             experimental: false
-          - python: '3.11'
-            django: 'git+https://github.com/django/django.git@stable/4.2.x#egg=Django'
-            experimental: true
 
     services:
       mysql:
@@ -237,7 +234,7 @@ jobs:
       matrix:
         include:
           - python: '3.9'
-            django: 'Django>=4.1,<4.2'
+            django: 'Django>=4.2,<4.3'
             emailuser: emailuser
     steps:
       - name: Configure sysctl limits
@@ -342,7 +339,7 @@ jobs:
       matrix:
         include:
           - python: '3.8'
-            django: 'Django>=4.0,<4.1'
+            django: 'Django>=4.1,<4.2'
             experimental: false
 
     services:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ _(If you are reading this on GitHub, the details here may not be indicative of t
 
 Wagtail supports:
 
--   Django 3.2.x, 4.0.x and 4.1.x
+-   Django 3.2.x, 4.1.x and 4.2.x
 -   Python 3.7, 3.8, 3.9, 3.10 and 3.11
 -   PostgreSQL, MySQL and SQLite (with JSON1) as database backends
 

--- a/docs/getting_started/integrating_into_django.md
+++ b/docs/getting_started/integrating_into_django.md
@@ -2,7 +2,7 @@
 
 Wagtail provides the `wagtail start` command and project template to get you started with a new Wagtail project as quickly as possible, but it's easy to integrate Wagtail into an existing Django project too.
 
-Wagtail is currently compatible with Django 3.2, 4.0, and 4.1. First, install the `wagtail` package from PyPI:
+Wagtail is currently compatible with Django 3.2, 4.1, and 4.2. First, install the `wagtail` package from PyPI:
 
 ```sh
 pip install wagtail

--- a/docs/releases/upgrading.md
+++ b/docs/releases/upgrading.md
@@ -59,6 +59,7 @@ The compatible versions of Django and Python for each Wagtail release are:
 
 | Wagtail release | Compatible Django versions | Compatible Python versions |
 | --------------- | -------------------------- | -------------------------- |
+| 5.0             | 3.2, 4.1, 4.2              | 3.7, 3.8, 3.9, 3.10, 3.11  |
 | 4.2             | 3.2, 4.0, 4.1              | 3.7, 3.8, 3.9, 3.10, 3.11  |
 | 4.1 LTS         | 3.2, 4.0, 4.1              | 3.7, 3.8, 3.9, 3.10, 3.11  |
 | 4.0             | 3.2, 4.0, 4.1              | 3.7, 3.8, 3.9, 3.10        |

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 
 
 install_requires = [
-    "Django>=3.2,<4.2",
+    "Django>=3.2,<4.3",
     "django-modelcluster>=6.0,<7.0",
     "django-permissionedforms>=0.1,<1.0",
     "django-taggit>=2.0,<4.0",
@@ -118,8 +118,8 @@ https://github.com/wagtail/wagtail/.",
         "Programming Language :: Python :: 3.11",
         "Framework :: Django",
         "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
+        "Framework :: Django :: 4.2",
         "Framework :: Wagtail",
         "Topic :: Internet :: WWW/HTTP :: Site Management",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{37,38,39,310,311}-dj{32,40,41,42stable,main}-{sqlite,postgres,mysql,mssql}-{elasticsearch7,elasticsearch6,elasticsearch5,noelasticsearch}-{customuser,emailuser}-{tz,notz},
+envlist = py{37,38,39,310,311}-dj{32,41,42,42stable,main}-{sqlite,postgres,mysql,mssql}-{elasticsearch7,elasticsearch6,elasticsearch5,noelasticsearch}-{customuser,emailuser}-{tz,notz},
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -24,8 +24,8 @@ deps =
     Embedly
 
     dj32: Django~=3.2.0
-    dj40: Django~=4.0.0
     dj41: Django~=4.1.0
+    dj42: Django~=4.2.0
     dj42stable: git+https://github.com/django/django.git@stable/4.2.x#egg=Django
     djmain: git+https://github.com/django/django.git@main#egg=Django
 

--- a/wagtail/project_template/requirements.txt
+++ b/wagtail/project_template/requirements.txt
@@ -1,2 +1,2 @@
-Django>=4.1,<4.2
+Django>=4.2,<4.3
 wagtail==5.0a0


### PR DESCRIPTION
Also drop support for Django 4.0, which is out of security support as of 1st April.