### PR TITLE
Fix template configuration of snippets index results view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -77,6 +77,7 @@ Changelog
  * Fix: Always show Add buttons, guide lines, Move up/down, Duplicate, Delete; in StreamField and Inline Panel (Thibaud Colas)
  * Fix: Make admin JS i18n endpoint accessible to non-authenticated users (Matt Westcott)
  * Fix: Fix incorrect API serialisation for document `download_url` when `WAGTAILDOCS_SERVE_METHOD` is `direct` (Swojak-A)
+ * Fix: Fix template configuration of snippets index results view (fidoriel, Sage Abdullah)
  * Autosize text area field will now correctly resize when switching between comments toggle states (Suyash Srivastava)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp, Thibaud Colas)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -707,6 +707,7 @@ Contributors
 * Hanoon
 * Steve Steinwand
 * Swojak-A
+* fidoriel
 
 Translators
 ===========

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -119,6 +119,7 @@ Those improvements were implemented by Albina Starykova as part of an [Outreachy
  * Make admin JS i18n endpoint accessible to non-authenticated users (Matt Westcott)
  * Autosize text area field will now correctly resize when switching between comments toggle states (Suyash Srivastava)
  * Fix incorrect API serialisation for document `download_url` when `WAGTAILDOCS_SERVE_METHOD` is `direct` (Swojak-A)
+ * Fix template configuration of snippets index results view (fidoriel, Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -684,6 +684,13 @@ class TestCustomTemplates(BaseSnippetViewSetTests):
                 [],
                 "tests/fullfeaturedsnippet_index.html",
             ),
+            "override index results template with namespaced template": (
+                # This is technically the same as the first case, but this ensures that
+                # the index results view can be overridden separately from the index view
+                "list_results",
+                [],
+                "wagtailsnippets/snippets/tests/fullfeaturedsnippet/index_results.html",
+            ),
             "override with get_history_template": (
                 "history",
                 [pk],
@@ -762,8 +769,8 @@ class TestDjangoORMSearchBackend(BaseSnippetViewSetTests):
             text="Python is a programming-bas, uh, language",
         )
 
-    def get(self, params={}):
-        return self.client.get(self.get_url("list"), params)
+    def get(self, params={}, url_name="list"):
+        return self.client.get(self.get_url(url_name), params)
 
     def test_simple(self):
         response = self.get()
@@ -796,20 +803,22 @@ class TestDjangoORMSearchBackend(BaseSnippetViewSetTests):
     def test_is_searchable(self):
         self.assertTrue(self.get().context["is_searchable"])
 
-    def test_search_one(self):
+    def test_search_index_view(self):
         response = self.get({"q": "Django"})
 
         # Only objects with "Django" should be in items
+        self.assertEqual(response.status_code, 200)
         self.assertCountEqual(
             list(response.context["page_obj"].object_list),
             [self.first, self.second],
         )
 
-    def test_search_the(self):
-        response = self.get({"q": "Python"})
+    def test_search_index_results_view(self):
+        response = self.get({"q": "Python"}, url_name="list_results")
 
         # Only objects with "Python" should be in items
+        self.assertEqual(response.status_code, 200)
         self.assertCountEqual(
-            list(response.context["page_obj"].object_list),
+            list(response.context["object_list"]),
             [self.second, self.third],
         )

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -152,14 +152,11 @@ class SnippetTitleColumn(TitleColumn):
 
 
 class IndexView(generic.IndexViewOptionalFeaturesMixin, generic.IndexView):
-    results_template_name = None
     view_name = "list"
     index_results_url_name = None
     delete_url_name = None
     any_permission_required = ["add", "change", "delete"]
     page_kwarg = "p"
-    # If true, returns just the 'results' include, for use in AJAX responses from search
-    results_only = False
     table_class = InlineActionsTable
 
     def get_base_queryset(self):
@@ -202,11 +199,6 @@ class IndexView(generic.IndexViewOptionalFeaturesMixin, generic.IndexView):
             ]
 
         return context
-
-    def get_template_names(self):
-        if self.results_only:
-            return self.results_template_name
-        return super().get_template_names()
 
 
 class CreateView(generic.CreateEditViewOptionalFeaturesMixin, generic.CreateView):
@@ -833,7 +825,6 @@ class SnippetViewSet(ModelViewSet):
             header_icon=self.icon,
             filterset_class=self.filterset_class,
             permission_policy=self.permission_policy,
-            results_only=True,
             index_url_name=self.get_url_name("list"),
             index_results_url_name=self.get_url_name("list_results"),
             add_url_name=self.get_url_name("add"),

--- a/wagtail/test/testapp/templates/wagtailsnippets/snippets/tests/fullfeaturedsnippet/index_results.html
+++ b/wagtail/test/testapp/templates/wagtailsnippets/snippets/tests/fullfeaturedsnippet/index_results.html
@@ -1,0 +1,4 @@
+{# Use include instead of extends as there are no blocks that we can override #}
+{% include "wagtailsnippets/snippets/index_results.html" %}
+
+<p>An added paragraph</p>


### PR DESCRIPTION
Fixes an error where an exception is thrown, because the results only flag is True on Ajax search requests, but the 
results template is none.



_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**
    -  I have tested firefox, with different screen sizes on manjaro. This PR does not modify any frontend code, so testing that is not needed.
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

Reproduce:
Create an indexed Snippet and register it. Add some entries to the model and perform a search. The template for the results is not found, render is performed on None. This PR sets the correct template to resolve this issue.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 220, in _get_response
    response = response.render()
               ^^^^^^^^^^^^^^^^^
  File "/code/wagtail/wagtail/admin/auth.py", line 204, in overridden_render
    return render()
           ^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/template/response.py", line 111, in render
    self.content = self.rendered_content
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/template/response.py", line 89, in rendered_content
    return template.render(context, self._request)
           ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'render'
```

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
