### PR TITLE
fix Pinned Draftail toolbar highlight ,issue #10305

### DIFF
--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -8,7 +8,8 @@ $draftail-editor-chrome: theme('colors.primary.DEFAULT');
 $draftail-editor-chrome-text: $color-white;
 // This needs to remain a Sass value due to a limitation in Draftail.
 // $draftail-editor-chrome-active: $color-white;
-$draftail-editor-chrome-active: #fff;
+
+$draftail-editor-chrome-active: #808080;
 $draftail-editor-chrome-accent: transparent;
 
 $draftail-base-spacing: 0.375rem;


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10305 .
make Pinned Draftail toolbar  display formatting type for selected text,
for example , if  Select some text and give it italic formatting.
Notice that the Italic Icon for example in Pinned Draftail toolbar , not highlighted ,
and also when change from  floating Draftail toolbar to Pinned Draftail toolbar ,
the highlight don ,t appear ,
this issue because Pinned Draftail toolbar take a light background , and now ,
the issue solved and the highlight appear on Pinned Draftail toolbar Icons , as you can see on the attached record , the Italic Icon for example highlighted mean it , s appear when it ,s active , cause it ,s now be darker .
this my first PR on wagtail , and it ,s about styling so I don ,t know , what I must write a test or not cause it ,s only about styling , and I only change little code on this issue  ,so please if you have feedback  on my code ,
please let me know ,Thanks

https://user-images.githubusercontent.com/90080237/232264094-bf349d6f-decf-4e12-9220-f8802a23db3c.mp4








_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
