### PR TITLE
ReferenceIndex model registration

### DIFF
--- a/docs/advanced_topics/reference_index.md
+++ b/docs/advanced_topics/reference_index.md
@@ -6,12 +6,47 @@ Wagtail maintains a reference index, which records references between objects wh
 
 ## Configuration
 
-The reference index does not require any configuration. It will by default index every model, unless configured to prevent this. Some of the models within Wagtail (such as revisions) are not indexed, so that object counts remain accurate.
+By default, the index will store references between objects managed within the Wagtail admin, specifically:
+- all Page types
+- Images
+- Documents
+- models registered as Snippets
+- models registered with ModelAdmin
+
+```{note}
+When introduced in Wagtail 4.1, the Reference Index recorded references in all application models by default. Wagtail 5.0 reduced the scope of the default models to those specifically linked with Wagtail.
+```
+
+Apps with models that are indexed need to listed in `INSTALLED_APPS` before the `wagtail` app.
+
+The reference index does not require any further configuration. However there are circumstances where it may be necessary to add or remove models from the index.
+
+(registering_a_model_for_indexing)=
+
+### Registering a Model for Indexing
+
+A model can be registered for reference indexing by adding code to the model's `app.py`:
+
+```python
+from django.apps import AppConfig
+
+
+class SprocketAppConfig(AppConfig):
+    ...
+    def ready(self):
+        from wagtail.models.reference_index import ReferenceIndex
+
+        from .models import SprocketController
+
+        ReferenceIndex.register_model(SprocketController)
+```
+
+### Preventing Indexing of models and fields
 
 The `wagtail_reference_index_ignore` attribute can be used to prevent indexing with a particular model or model field.
 
--   set the `wagtail_reference_index_ignore` attribute to `True` within any model class where you want to prevent indexing of all fields in the model; or
--   set the `wagtail_reference_index_ignore` attribute to `True` within any model field, to prevent that field or the related model field from being indexed:
+- set the `wagtail_reference_index_ignore` attribute to `True` within any model class where you want to prevent indexing of all fields in the model; or
+- set the `wagtail_reference_index_ignore` attribute to `True` within any model field, to prevent that field or the related model field from being indexed:
 
 ```python
 class CentralPage(Page):
@@ -27,4 +62,6 @@ class CentralPage(Page):
 
 ## Maintenance
 
-The index can be rebuilt with the `rebuild_references_index` management command. This will repopulate the references table and ensure that reference counts are displayed accurately. This should be done if models are manipulated outside of Wagtail.
+The index can be rebuilt with the `rebuild_references_index` management command. This will repopulate the references table and ensure that reference counts are displayed accurately. This should be done if models are manipulated outside of Wagtail, or after an upgrade.
+
+A summary of the index can be shown with the `show_references_index` management command. This shows the number of objects indexed against each model type, and can be useful to identify which models are being indexed without rebuilding the index itself.

--- a/docs/advanced_topics/reference_index.md
+++ b/docs/advanced_topics/reference_index.md
@@ -13,7 +13,7 @@ By default, the index will store references between objects managed within the W
 - models registered as Snippets
 - models registered with ModelAdmin
 
-```{note}
+```{versionchanged} 5.0
 When introduced in Wagtail 4.1, the Reference Index recorded references in all application models by default. Wagtail 5.0 reduced the scope of the default models to those specifically linked with Wagtail.
 ```
 

--- a/docs/advanced_topics/reference_index.md
+++ b/docs/advanced_topics/reference_index.md
@@ -25,7 +25,7 @@ The reference index does not require any further configuration. However there ar
 
 ### Registering a Model for Indexing
 
-A model can be registered for reference indexing by adding code to the model's `app.py`:
+A model can be registered for reference indexing by adding code to `apps.py` in the app where the model is defined:
 
 ```python
 from django.apps import AppConfig

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -69,6 +69,7 @@ This has been made possible thanks to a multi-year refactoring effort to migrate
  * The select all checkbox in simple translation's submit translation page will now be in sync with other checkbox changes (Hanoon)
  * Allow admin templates for snippets to be overridden on a per-model or per-app basis (Sage Abdullah)
  * Allow overriding the base queryset to be used in snippet `IndexView` (Sage Abdullah)
+ * ReferenceIndex modified to only index Wagtail-related models, and allow other models to be explicitly registered (Daniel Kirkham)
 
 ### Bug fixes
 
@@ -427,3 +428,21 @@ The undocumented `get_admin_url_namespace()` and `get_admin_base_path()` methods
 ### Snippets `get_usage()` and `usage_url()` methods removed
 
 The undocumented `get_usage()` and `usage_url()` methods that were set on snippet models at runtime have been removed. Calls to the `get_usage()` method can be replaced with `wagtail.models.ReferenceIndex.get_grouped_references_to(object)`. The `usage_url()` method does not have a direct replacement, but the URL name can be retrieved via {meth}`SnippetModel.snippet_viewset.get_url_name("usage") <wagtail.admin.viewsets.base.ViewSet.get_url_name>`, which can be used to construct the URL with {func}`~django.urls.reverse`.
+
+### Changes to ReferenceIndex
+
+When introduced in Wagtail 4.1, the Reference Index recorded references in all application models by default. The default set of models being indexed has now been changed to only those used within the Wagtail admin, specifically:
+
+* all Page types
+* Images
+* Documents
+* models registered as Snippets
+* models registered with ModelAdmin
+
+This change will remove the impact of the indexing on non-Wagtail apps and models.
+
+If you have models that still require reference indexing, and which are not registered as Snippets or with ModelAdmin, you will need to explicitly register them within your app's `AppConfig.ready()` method. See [Reference Index](registering_a_model_for_indexing) for further details.
+
+The use of `wagtail_reference_index_ignore` to prevent indexing of models is unchanged, but in many cases it may no longer be necessary.
+
+It is recommended that the `rebuild_references_index` managagement command is run after the upgrade to remove any unnecessary records.

--- a/wagtail/apps.py
+++ b/wagtail/apps.py
@@ -1,4 +1,4 @@
-from django.apps import AppConfig
+from django.apps import AppConfig, apps
 from django.utils.translation import gettext_lazy as _
 
 
@@ -9,6 +9,19 @@ class WagtailAppConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
+        from wagtail.documents.models import AbstractDocument
+        from wagtail.images.models import AbstractImage
+        from wagtail.models import AbstractPage
+        from wagtail.models.reference_index import ReferenceIndex
+
+        for model in apps.get_models():
+            if (
+                issubclass(model, AbstractPage)
+                or issubclass(model, AbstractImage)
+                or issubclass(model, AbstractDocument)
+            ):
+                ReferenceIndex.register_model(model)
+
         from wagtail.signal_handlers import register_signal_handlers
 
         register_signal_handlers()

--- a/wagtail/apps.py
+++ b/wagtail/apps.py
@@ -9,17 +9,11 @@ class WagtailAppConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
-        from wagtail.documents.models import AbstractDocument
-        from wagtail.images.models import AbstractImage
         from wagtail.models import AbstractPage
         from wagtail.models.reference_index import ReferenceIndex
 
         for model in apps.get_models():
-            if (
-                issubclass(model, AbstractPage)
-                or issubclass(model, AbstractImage)
-                or issubclass(model, AbstractDocument)
-            ):
+            if issubclass(model, AbstractPage):
                 ReferenceIndex.register_model(model)
 
         from wagtail.signal_handlers import register_signal_handlers

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -12,7 +12,7 @@ from wagtail.admin.admin_url_finder import register_admin_url_finder
 from wagtail.admin.checks import check_panels_in_model
 from wagtail.admin.menu import Menu
 from wagtail.admin.panels import ObjectList, extract_panel_definitions_from_model_class
-from wagtail.models import Page, TranslatableMixin
+from wagtail.models import Page, ReferenceIndex, TranslatableMixin
 
 from .helpers import (
     AdminURLHelper,
@@ -82,7 +82,12 @@ class WagtailRegisterable:
 
         self.register_admin_url_finders()
 
+        self.register_indexing()
+
     def register_admin_url_finders(self):
+        pass
+
+    def register_indexing(self):
         pass
 
     def will_modify_explorer_page_queryset(self):
@@ -669,6 +674,9 @@ class ModelAdmin(WagtailRegisterable):
             )
             register_admin_url_finder(self.model, finder_class)
 
+    def register_indexing(self):
+        ReferenceIndex.register_model(self.model)
+
 
 class ModelAdminGroup(WagtailRegisterable):
     """
@@ -775,6 +783,10 @@ class ModelAdminGroup(WagtailRegisterable):
     def register_admin_url_finders(self):
         for instance in self.modeladmin_instances:
             instance.register_admin_url_finders()
+
+    def register_indexing(self):
+        for instance in self.modeladmin_instances:
+            instance.register_indexing()
 
 
 def modeladmin_register(modeladmin_class):

--- a/wagtail/documents/apps.py
+++ b/wagtail/documents/apps.py
@@ -12,3 +12,8 @@ class WagtailDocsAppConfig(AppConfig):
         from wagtail.documents.signal_handlers import register_signal_handlers
 
         register_signal_handlers()
+
+        from wagtail.documents import get_document_model
+        from wagtail.models.reference_index import ReferenceIndex
+
+        ReferenceIndex.register_model(get_document_model())

--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -35,3 +35,7 @@ class WagtailImagesAppConfig(AppConfig):
         register_comparison_class(
             ForeignKey, to=Image, comparison_class=ImageFieldComparison
         )
+
+        from wagtail.models.reference_index import ReferenceIndex
+
+        ReferenceIndex.register_model(get_image_model())

--- a/wagtail/management/commands/rebuild_references_index.py
+++ b/wagtail/management/commands/rebuild_references_index.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
             ReferenceIndex.objects.all().delete()
 
             for model in apps.get_models():
-                if not ReferenceIndex.model_is_indexable(model):
+                if not ReferenceIndex.is_indexed(model):
                     continue
 
                 self.write(str(model))

--- a/wagtail/management/commands/show_references_index.py
+++ b/wagtail/management/commands/show_references_index.py
@@ -1,0 +1,36 @@
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
+
+from wagtail.models import ReferenceIndex
+
+
+def model_name(model):
+    return f"{model.__module__}.{model.__name__}"
+
+
+class Command(BaseCommand):
+    def handle(self, **options):
+        self.stdout.write("Reference index entries:")
+        object_count = 0
+
+        for model in sorted(apps.get_models(), key=lambda m: model_name(m)):
+            if not ReferenceIndex.is_indexed(model):
+                continue
+
+            content_types = [
+                ContentType.objects.get_for_model(
+                    model_or_object, for_concrete_model=False
+                )
+                for model_or_object in ([model] + model._meta.get_parent_list())
+            ]
+            content_type = content_types[0]
+            base_content_type = content_types[-1]
+
+            count = ReferenceIndex.objects.filter(
+                content_type=content_type, base_content_type=base_content_type
+            ).count()
+            self.stdout.write(f"{count:>6}  {model_name(model)}")
+            object_count += count
+
+        self.stdout.write(f"Total entries: {object_count}")

--- a/wagtail/models/reference_index.py
+++ b/wagtail/models/reference_index.py
@@ -155,6 +155,10 @@ class ReferenceIndex(models.Model):
 
     wagtail_reference_index_ignore = True
 
+    # Store the models that are being tracked (via the post_save signal) and
+    # which are being indexed
+    _indexed_models = {}
+
     class Meta:
         unique_together = [
             (
@@ -203,7 +207,7 @@ class ReferenceIndex(models.Model):
 
         # Don't check any models that have a parental key, references from these will be collected from the parent
         if not allow_child_models and any(
-            [isinstance(field, ParentalKey) for field in model._meta.get_fields()]
+            isinstance(field, ParentalKey) for field in model._meta.get_fields()
         ):
             return False
 
@@ -234,6 +238,34 @@ class ReferenceIndex(models.Model):
                     return True
 
         return False
+
+    @classmethod
+    def register_model(cls, model):
+        """
+        Registers the model for indexing.
+
+        If there are child relationships (via a ParentalKey), those
+        saves and deletes on those models also need to be tracked
+        """
+        if cls.model_is_indexable(model):
+            cls._indexed_models[model] = True
+
+            for child_relation in get_all_child_relations(model):
+                if cls.model_is_indexable(
+                    child_relation.related_model,
+                    allow_child_models=True,
+                ):
+                    cls._indexed_models[
+                        child_relation.related_model
+                    ] = cls._indexed_models.get(child_relation.related_model, False)
+
+    @classmethod
+    def is_indexed(cls, model):
+        return cls._indexed_models.get(model, False)
+
+    @classmethod
+    def get_tracked_models(cls):
+        return cls._indexed_models.keys()
 
     @classmethod
     def _extract_references_from_object(cls, object):

--- a/wagtail/models/reference_index.py
+++ b/wagtail/models/reference_index.py
@@ -155,8 +155,10 @@ class ReferenceIndex(models.Model):
 
     wagtail_reference_index_ignore = True
 
-    # Store the models that are being tracked (via the post_save signal) and
-    # which are being indexed
+    # Store the models that are being tracked and indexed.
+    # If a model is present as a key, the model is tracked by receiving the corresponding
+    # model save and delete signals. If the value is True, then it is indexed.
+    # (False indicates the model has a ParentalKey relation with an indexed model.)
     _indexed_models = {}
 
     class Meta:
@@ -244,7 +246,7 @@ class ReferenceIndex(models.Model):
         """
         Registers the model for indexing.
 
-        If there are child relationships (via a ParentalKey), those
+        If there are child relationships (via a ParentalKey), the
         saves and deletes on those models also need to be tracked
         """
         if cls.model_is_indexable(model):

--- a/wagtail/signal_handlers.py
+++ b/wagtail/signal_handlers.py
@@ -86,7 +86,7 @@ def update_reference_index_on_save(instance, **kwargs):
             # parent is null, so there is no valid object to record references against
             return
 
-    if ReferenceIndex.model_is_indexable(type(instance)):
+    if ReferenceIndex.is_indexed(type(instance)):
         with transaction.atomic():
             ReferenceIndex.create_or_update_for_object(instance)
 
@@ -100,13 +100,15 @@ def remove_reference_index_on_delete(instance, **kwargs):
 
 
 def connect_reference_index_signal_handlers(**kwargs):
-    post_save.connect(update_reference_index_on_save)
-    post_delete.connect(remove_reference_index_on_delete)
+    for model in ReferenceIndex.get_tracked_models():
+        post_save.connect(update_reference_index_on_save, sender=model)
+        post_delete.connect(remove_reference_index_on_delete, sender=model)
 
 
 def disconnect_reference_index_signal_handlers(**kwargs):
-    post_save.disconnect(update_reference_index_on_save)
-    post_delete.disconnect(remove_reference_index_on_delete)
+    for model in ReferenceIndex.get_tracked_models():
+        post_save.disconnect(update_reference_index_on_save, sender=model)
+        post_delete.disconnect(remove_reference_index_on_delete, sender=model)
 
 
 def register_signal_handlers():

--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -10,7 +10,7 @@ from django.utils.module_loading import import_string
 
 from wagtail.admin.viewsets import viewsets
 from wagtail.hooks import search_for_hooks
-from wagtail.models import DraftStateMixin, LockableMixin, WorkflowMixin
+from wagtail.models import DraftStateMixin, LockableMixin, ReferenceIndex, WorkflowMixin
 
 SNIPPET_MODELS = []
 
@@ -101,6 +101,8 @@ def _register_snippet_immediately(model, viewset=None):
 
     SNIPPET_MODELS.append(model)
     SNIPPET_MODELS.sort(key=lambda x: x._meta.verbose_name)
+
+    ReferenceIndex.register_model(model)
 
 
 def register_deferred_snippets():

--- a/wagtail/test/testapp/apps.py
+++ b/wagtail/test/testapp/apps.py
@@ -7,3 +7,10 @@ class WagtailTestsAppConfig(AppConfig):
     name = "wagtail.test.testapp"
     label = "tests"
     verbose_name = _("Wagtail tests")
+
+    def ready(self):
+        from wagtail.models.reference_index import ReferenceIndex
+
+        from .models import PageChooserModel
+
+        ReferenceIndex.register_model(PageChooserModel)

--- a/wagtail/tests/test_reference_index.py
+++ b/wagtail/tests/test_reference_index.py
@@ -240,6 +240,15 @@ class TestCreateOrUpdateForObject(TestCase):
         )
         self.assertFalse(stdout.read())
 
+    def test_show_references_index(self):
+        stdout = StringIO()
+        management.call_command(
+            "show_references_index",
+            stdout=stdout,
+        )
+        self.assertIn(" 3  wagtail.images.models.Image", stdout.getvalue())
+        self.assertIn(" 4  wagtail.test.testapp.models.EventPage", stdout.getvalue())
+
 
 class TestDescribeOnDelete(TestCase):
     fixtures = ["test.json"]


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #9731, supercedes #9936

This PR proposes an alternative way to configure the models that are indexed by the [ReferenceIndex](https://docs.wagtail.org/en/latest/advanced_topics/reference_index.html) system. Instead of indexing all models including non-Wagtail-related models by default, this alternative requires models to be specifically registered.

In this implementation, models subclassed from Wagtail `AbstractPage`, `AbstractImage` and `AbstractDocument` models, including the default `Page`, `Image` and `Document` models, are by default indexed, as are models registered as Snippets and with ModelAdmin. The developer can exclude these models as desired, and register their own models via an app.ready() hook, as suggested in @gasman's [comment](https://github.com/wagtail/wagtail/issues/9731#issuecomment-1416244639).

This implementation is a draft. All the existing tests pass without change, however some further tests are probably warranted and the documentation will need to be updated. I am submitting this at this stage to get feedback on the overall approach which I describe below, and to get the reports from the full CI testing.

As this is likely to be considered a breaking change, @gasman expressed a desire to get this into the 5.0 release, I'd appreciate a fairly swift initial review so I can make appropriate changes including the tests and documentation. Feedback on suitable additional tests and possible deprecations would also be useful.

## Approach

Here are the key changes:
- `ReferenceIndex.model_is_indexable()` is no longer being called for every updated model instance. Instead, it is used to form `ReferenceIndex._indexed_models` which stores the models that need to be tracked via Django's `post_save` signal, and which are to be indexed. This list is formed using the new `ReferenceIndex.register_model()` method, which is for instance called in `wagtail.apps.WagtailAppConfig.ready()` for the default model types. Other apps can use the same technique to register their models as required. Note that `model_is_indexable()` still checks the `wagtail_reference_index_ignore` attribute to disable indexing where required.
- a new `ReferenceIndex.is_indexed()` method replaces `ReferenceIndex.model_is_indexable()` to provide a public interface to lookup the `_indexed_models` cached information.
- in `wagtail.signal_handlers` the `post_save` and `post_delete` signals are used as before, but only the necessary models are being tracked (using `sender=`), to remove the impact on non-Wagtail apps and models.
- Snippet and ModelAdmin model registration has been added.
- there is a new management command `show_references_index` which shows which models are indexed and how many index records are currently in the database.

## Existing Tests

As mentioned, the existing tests all pass without change, although it was necessary to register one model explicitly, `PageChooserModel`.

Below I've documented the models that are no longer being tracked within  `testapp` in case there are models anyone believes should be indexed by default:

```
wagtail.contrib.redirects.models.Redirect
wagtail.test.testapp.models.RelatedGenericRelation
wagtail.test.testapp.models.CustomFormPageSubmission
wagtail.test.testapp.models.EventPageChooserModel
wagtail.test.testapp.models.SnippetChooserModel
wagtail.test.testapp.models.SnippetChooserModelWithCustomPrimaryKey
wagtail.test.testapp.models.JSONStreamModel
wagtail.test.testapp.models.JSONMinMaxCountStreamModel
wagtail.test.testapp.models.JSONBlockCountsStreamModel
wagtail.test.testapp.models.ImportantPagesSiteSetting
wagtail.test.testapp.models.ImportantPagesGenericSetting
wagtail.test.testapp.models.SimpleTask
wagtail.test.search.models.Character
wagtail.test.i18n.models.TestNonParentalChildObject
wagtail.test.streamfield_migrations.models.SampleModel
wagtail.contrib.search_promotions.models.QueryDailyHits
wagtail.contrib.search_promotions.models.SearchPromotion
wagtail.contrib.forms.models.FormSubmission
wagtail.models.sites.Site
wagtail.models.collections.CollectionViewRestriction
wagtail.models.collections.GroupCollectionPermission
wagtail.models.GroupPagePermission
wagtail.models.PageViewRestriction
wagtail.models.WorkflowPage
wagtail.models.WorkflowContentType
wagtail.models.Task
wagtail.models.Workflow
wagtail.models.GroupApprovalTask
wagtail.models.WorkflowState
wagtail.models.TaskState
django.contrib.admin.models.LogEntry
django.contrib.auth.models.Permission
```

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] ~~For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]~~
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
