### PR TITLE
Update number of tests in developer documentation

### DIFF
--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -81,7 +81,7 @@ python runtests.py
 
 ### Running only some of the tests
 
-At the time of writing, Wagtail has well over 2500 tests, which takes a while to
+At the time of writing, Wagtail has well over 5000 tests, which takes a while to
 run. You can run tests for only one part of Wagtail by passing in the path as
 an argument to `runtests.py` or `tox`:
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

With Wagtail 5.0 around the corner, I thought it was worth noting there are now well over 5000 tests included in the codebase - 5732 in my fork - up from the previously documented "over 2500" tests.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] ~~For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] ~~For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]~~
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

Check [contributing/developing.html](http://localhost:8080/contributing/developing.html#running-only-some-of-the-tests) in a dev environment:
<img width="550" alt="image" src="https://user-images.githubusercontent.com/1977376/232465508-a0ec55c2-2f66-45f0-ad48-bad9458983bb.png">

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
