### PR TITLE
Fix autocompletion on sqlite FTS backend

### DIFF
--- a/wagtail/search/backends/database/sqlite/query.py
+++ b/wagtail/search/backends/database/sqlite/query.py
@@ -71,16 +71,12 @@ class Lexeme(LexemeCombinable, Value):
         super().__init__(value, output_field=output_field)
 
     def as_sql(self, compiler, connection):
-        param = "%s" % self.value.replace("'", "''").replace("\\", "\\\\")
+        param = self.value.replace("'", "''").replace("\\", "\\\\")
 
-        template = '"%s"'
-
-        label = ""
         if self.prefix:
-            label += "*"
-
-        if label:
-            param = "{}{}".format(param, label)
+            template = '"%s"*'
+        else:
+            template = '"%s"'
 
         return template, [param]
 

--- a/wagtail/search/tests/test_sqlite_backend.py
+++ b/wagtail/search/tests/test_sqlite_backend.py
@@ -8,7 +8,6 @@ from django.test.utils import override_settings
 
 from wagtail.search.backends.database.sqlite.utils import fts5_available
 from wagtail.search.tests.test_backends import BackendTests
-from wagtail.test.search import models
 
 
 @unittest.skipUnless(
@@ -44,23 +43,7 @@ class TestSQLiteSearchBackend(BackendTests, TestCase):
     def test_annotate_score_with_slice(self):
         return super().test_annotate_score_with_slice()
 
-    def test_autocomplete_raises_not_implemented_error(self):
-        with self.assertRaises(NotImplementedError):
-            self.backend.autocomplete("Py", models.Book)
-
-    @skip("The SQLite backend doesn't support autocomplete.")
-    def test_autocomplete(self):
-        return super().test_autocomplete()
-
-    @skip("The SQLite backend doesn't support autocomplete.")
-    def test_autocomplete_not_affected_by_stemming(self):
-        return super().test_autocomplete_not_affected_by_stemming()
-
-    @skip("The SQLite backend doesn't support autocomplete.")
-    def test_autocomplete_uses_autocompletefield(self):
-        return super().test_autocomplete_uses_autocompletefield()
-
-    @skip("The SQLite backend doesn't support autocomplete.")
+    @skip("The SQLite backend doesn't support searching on specified fields.")
     def test_autocomplete_with_fields_arg(self):
         return super().test_autocomplete_with_fields_arg()
 


### PR DESCRIPTION
* Fix incorrect signatures for `SQLiteAutocompleteQueryCompiler`
* Syntax for an autocomplete search should have the `*` outside of quotes - `"foo"*` rather than `"foo*"`
* Query compiler was hardcoded to search on the 'title' and 'body' fields of the FTS table, rather than 'autocomplete'

Full support for searching on specified fields is still lacking - the 'title' and 'body' fields are special cased, and other column names will return a SQL error.
