### PR TITLE
Fix autocompletion on MySQL FTS backend

### DIFF
--- a/wagtail/search/backends/database/mysql/query.py
+++ b/wagtail/search/backends/database/mysql/query.py
@@ -62,7 +62,7 @@ class Lexeme(LexemeCombinable, Value):
         template = "%s"
 
         if self.prefix:
-            param = "*{}".format(param)
+            param = "{}*".format(param)
         if self.invert:
             param = "(-{})".format(param)
         else:

--- a/wagtail/search/tests/test_mysql_backend.py
+++ b/wagtail/search/tests/test_mysql_backend.py
@@ -90,26 +90,6 @@ class TestMySQLSearchBackend(BackendTests, TransactionTestCase):
     def test_annotate_score_with_slice(self):
         return super().test_annotate_score_with_slice()
 
-    def test_autocomplete_raises_not_implemented_error(self):
-        with self.assertRaises(NotImplementedError):
-            self.backend.autocomplete("Py", models.Book)
-
-    @skip("The MySQL backend doesn't support autocomplete.")
-    def test_autocomplete(self):
-        return super().test_autocomplete()
-
-    @skip("The MySQL backend doesn't support autocomplete.")
-    def test_autocomplete_not_affected_by_stemming(self):
-        return super().test_autocomplete_not_affected_by_stemming()
-
-    @skip("The MySQL backend doesn't support autocomplete.")
-    def test_autocomplete_uses_autocompletefield(self):
-        return super().test_autocomplete_uses_autocompletefield()
-
-    @skip("The MySQL backend doesn't support autocomplete.")
-    def test_autocomplete_with_fields_arg(self):
-        return super().test_autocomplete_with_fields_arg()
-
     @skip("The MySQL backend doesn't guarantee correct ranking of results.")
     def test_ranking(self):
         return super().test_ranking()


### PR DESCRIPTION
Similar to #10341; the `*` operator should be appended to the term, not prepended. `title` and `body` are special-cased, and specifying other columns explicitly still does not work.
