### PR TITLE
Implement minimap UI refinements (#10055)

### DIFF
--- a/client/scss/components/_footer.scss
+++ b/client/scss/components/_footer.scss
@@ -4,6 +4,8 @@
   $border-curvature: 3px;
   @include transition(bottom 0.5s ease 1s);
   @include row();
+  margin-inline-start: $mobile-nice-padding;
+  margin-inline-end: $mobile-nice-padding;
   z-index: 20;
 
   ul {

--- a/client/scss/components/_form-side.scss
+++ b/client/scss/components/_form-side.scss
@@ -18,9 +18,7 @@
   @apply w-absolute
       w-right-0
       w-top-full
-      w-w-full
       w-h-[calc(100vh-100%)]
-      md:w-w-1/3
       w-transform
       w-translate-x-full
       rtl:-w-translate-x-full
@@ -39,6 +37,11 @@
       lg:w-max-w-[31.25rem]
       xl:w-max-w-[46.875rem];
   z-index: calc(theme('zIndex.header') - 10);
+  width: var(--side-panel-width, 100%);
+
+  @include media-breakpoint-up(md) {
+    width: var(--side-panel-width, theme('width.[1/3]'));
+  }
 
   &--open {
     @apply w-translate-x-0 rtl:w-translate-x-0;
@@ -61,13 +64,13 @@
   }
 
   &__resize-grip-container {
-    @apply w-absolute w-place-items-center w-hidden md:w-flex w-z-10 w-left-[-21.5px];
-
-    height: calc(100% - theme('spacing.8'));
+    @apply w-absolute w-place-items-center w-hidden md:w-flex w-z-10 w-left-0;
+    top: 50%;
+    transform: translateY(-50%);
   }
 
   &__resize-grip {
-    @apply w-text-primary hover:w-text-primary-200 w-border w-border-transparent w-rounded w-bg-white w-p-3 w-hidden w-touch-pinch-zoom w-cursor-ew-resize;
+    @apply w-text-primary hover:w-text-primary-200 w-border w-border-transparent w-rounded w-bg-white w-p-2.5 w-hidden w-touch-pinch-zoom w-cursor-ew-resize;
 
     .form-side--open & {
       @apply w-flex;

--- a/client/scss/components/_form-side.scss
+++ b/client/scss/components/_form-side.scss
@@ -83,9 +83,16 @@
         @include focus-outline;
       }
     }
+  }
 
-    .icon {
-      @apply w-w-4 w-h-4;
+  &__resize-grip-icon {
+    width: 0.3125rem;
+    height: 1.375rem;
+    border-inline-start: 1px solid theme('colors.grey.150');
+    border-inline-end: 1px solid theme('colors.grey.150');
+
+    @media (forced-colors: active) {
+      background-color: ButtonText;
     }
   }
 

--- a/client/scss/components/_form-side.scss
+++ b/client/scss/components/_form-side.scss
@@ -63,6 +63,10 @@
     }
   }
 
+  &:has(.form-side__resize-grip:is(:hover, :focus-within)) {
+    @apply w-border-grey-150;
+  }
+
   &__resize-grip-container {
     @apply w-absolute w-place-items-center w-hidden md:w-flex w-z-10 w-left-0;
     top: 50%;
@@ -70,7 +74,7 @@
   }
 
   &__resize-grip {
-    @apply w-text-primary hover:w-text-primary-200 w-border w-border-transparent w-rounded w-bg-white w-p-2.5 w-hidden w-touch-pinch-zoom w-cursor-ew-resize;
+    @apply w-text-grey-150 hover:w-text-grey-200 w-border w-border-transparent w-rounded w-bg-white w-p-2.5 w-hidden w-touch-pinch-zoom w-cursor-ew-resize;
 
     .form-side--open & {
       @apply w-flex;
@@ -91,8 +95,8 @@
   &__resize-grip-icon {
     width: 0.3125rem;
     height: 1.375rem;
-    border-inline-start: 1px solid theme('colors.grey.150');
-    border-inline-end: 1px solid theme('colors.grey.150');
+    border-inline-start: 1px solid currentColor;
+    border-inline-end: 1px solid currentColor;
 
     @media (forced-colors: active) {
       background-color: ButtonText;

--- a/client/scss/components/forms/_form-width.scss
+++ b/client/scss/components/forms/_form-width.scss
@@ -3,9 +3,16 @@
 }
 
 @include media-breakpoint-up(md) {
-  .side-panel-open {
+  .side-panel-open,
+  .minimap-open {
     .tab-content {
       width: theme('width.[2/3]');
+    }
+  }
+
+  .side-panel-open.minimap-open {
+    .tab-content {
+      width: theme('width.[3/5]');
     }
   }
 }

--- a/client/src/components/Minimap/CollapseAll.scss
+++ b/client/src/components/Minimap/CollapseAll.scss
@@ -33,5 +33,9 @@
     inset-inline-end: 0;
     margin-top: theme('spacing.3');
     margin-inline-end: theme('spacing.3');
+
+    .side-panel-open & {
+      inset-inline-end: var(--side-panel-width, 0);
+    }
   }
 }

--- a/client/src/components/Minimap/Minimap.scss
+++ b/client/src/components/Minimap/Minimap.scss
@@ -31,6 +31,10 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
     );
   }
 
+  .side-panel-open & {
+    inset-inline-end: var(--side-panel-width, 0);
+  }
+
   &--expanded {
     transform: translateX(0);
     // Take up the whole height so overlap with the page looks better.
@@ -52,17 +56,13 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   background-color: theme('colors.white.DEFAULT');
   color: theme('colors.primary.DEFAULT');
   transform: rotate(180deg);
+  // Expand is available for keyboard users only.
+  opacity: 0;
+  pointer-events: none;
 
   @include media-breakpoint-up(sm) {
     margin-top: theme('spacing.9');
     padding: theme('spacing.[1.5]');
-
-    // On devices supporting hover, this is available for keyboard users only.
-    // Mouse users open the minimap by hovering.
-    @media (hover: hover) {
-      opacity: 0;
-      pointer-events: none;
-    }
 
     *:focus {
       opacity: 1;
@@ -90,7 +90,7 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   :where(.w-minimap--expanded) & {
     opacity: 1;
     pointer-events: auto;
-    margin-top: theme('spacing.[0.5]');
+    margin-top: theme('spacing.3');
     margin-inline-start: theme('spacing.3');
     padding: theme('spacing.3');
     transform: rotate(0deg);

--- a/client/src/components/Minimap/Minimap.scss
+++ b/client/src/components/Minimap/Minimap.scss
@@ -1,9 +1,8 @@
 // If unset, default to the "mobile" height of the slim header.
 $minimap-top-offset: var(--offset-top, calc(theme('spacing.slim-header') * 2));
-$minimap-width: 300px;
+$minimap-width: 260px;
 $minimap-collapsed-width-mobile: 20px;
 $minimap-collapsed-width: 30px;
-$minimap-overflow: theme('spacing.2');
 $minimap-z-index: calc(theme('zIndex.header') - 20);
 
 @import './CollapseAll';
@@ -24,10 +23,7 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
 
   @include media-breakpoint-up(sm) {
     transform: translateX(
-      calc(
-        var(--w-direction-factor) *
-          (100% - $minimap-collapsed-width - $minimap-overflow)
-      )
+      calc(var(--w-direction-factor) * (100% - $minimap-collapsed-width))
     );
   }
 
@@ -101,7 +97,6 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   min-height: 70px;
 
   :where(.w-minimap--expanded) & {
-    margin-inline-start: $minimap-overflow;
     border-inline-start: 1px solid theme('colors.grey.100');
   }
 }
@@ -109,7 +104,6 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
 .w-minimap__list {
   margin: 0;
   padding: 0;
-  padding-inline-start: $minimap-overflow;
   overflow-y: auto;
   overflow-x: hidden;
   list-style-type: none;
@@ -123,7 +117,6 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   flex-grow: 1;
 
   :where(.w-minimap--expanded) & {
-    margin-inline-start: $minimap-overflow;
     border-inline-start: 1px solid theme('colors.grey.100');
   }
 }

--- a/client/src/components/Minimap/Minimap.tsx
+++ b/client/src/components/Minimap/Minimap.tsx
@@ -8,6 +8,7 @@ import React, {
 
 import { debounce } from '../../utils/debounce';
 import { gettext } from '../../utils/gettext';
+import { toggleCollapsiblePanel } from '../../includes/panels';
 import Icon from '../Icon/Icon';
 
 import CollapseAll from './CollapseAll';
@@ -127,11 +128,13 @@ const Minimap: React.FunctionComponent<MinimapProps> = ({
   const listRef = useRef<HTMLOListElement>(null);
 
   const onClickToggle = () => toggleMinimap(!expanded);
-  const onClickLink = (e: React.MouseEvent) => {
+  const onClickLink = (link: MinimapMenuItem, e: React.MouseEvent) => {
     // Prevent navigating if the link is only partially shown.
     if (!expanded) {
       e.preventDefault();
     }
+
+    toggleCollapsiblePanel(link.toggle, true);
     toggleMinimap(true);
   };
 

--- a/client/src/components/Minimap/Minimap.tsx
+++ b/client/src/components/Minimap/Minimap.tsx
@@ -214,6 +214,7 @@ const Minimap: React.FunctionComponent<MinimapProps> = ({
       <div className={`w-minimap ${expanded ? 'w-minimap--expanded' : ''}`}>
         <div className="w-minimap__header">
           <button
+            id="w-minimap-toggle"
             type="button"
             aria-expanded={expanded}
             onClick={onClickToggle}

--- a/client/src/components/Minimap/Minimap.tsx
+++ b/client/src/components/Minimap/Minimap.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, {
+  useEffect,
+  useState,
+  useRef,
+  useMemo,
+  useCallback,
+} from 'react';
 
 import { debounce } from '../../utils/debounce';
 import { gettext } from '../../utils/gettext';
@@ -70,6 +76,16 @@ const updateScrollPosition = (list: HTMLOListElement) => {
   list.scrollTop = newScroll;
 };
 
+const getInitialMinimapExpanded = () => {
+  let saved = 'false';
+  try {
+    saved = localStorage.getItem('wagtail:minimap-expanded') || saved;
+  } catch {
+    // Use the default if localStorage isn’t available.
+  }
+  return saved === 'true';
+};
+
 /**
  * Minimap sidebar menu, with one internal link per section of the page.
  * The minimap has a lot of advanced behavior:
@@ -85,9 +101,23 @@ const Minimap: React.FunctionComponent<MinimapProps> = ({
   onUpdate,
   toggleAllPanels,
 }) => {
-  const [expanded, setExpanded] = useState<boolean>(false);
-  // Keep track of whether we should keep the minimap expanded (should auto-close on mouseout if not interacted with).
-  const [keepExpanded, setKeepExpanded] = useState<boolean>(false);
+  const initialExpanded = useMemo(() => getInitialMinimapExpanded(), []);
+  const [expanded, setExpanded] = useState<boolean>(initialExpanded);
+  const toggleMinimap = useCallback(
+    (newExpanded = !expanded) => {
+      setExpanded(newExpanded);
+      document.body.classList.toggle('minimap-open', newExpanded);
+      try {
+        localStorage.setItem(
+          'wagtail:minimap-expanded',
+          newExpanded ? 'true' : 'false',
+        );
+      } catch {
+        // Skip saving the preference if localStorage isn’t available.
+      }
+    },
+    [expanded, setExpanded],
+  );
   // Collapse all yes/no state.
   const [panelsExpanded, setPanelsExpanded] = useState<boolean>(true);
   const [intersections, setIntersections] = useState<LinkIntersections>({});
@@ -96,43 +126,18 @@ const Minimap: React.FunctionComponent<MinimapProps> = ({
   const updateLinks = useRef<CallableFunction | null>(null);
   const listRef = useRef<HTMLOListElement>(null);
 
-  // Keep track of all the different ways the minimap can be opened and closed.
-  const onMouseOver = () => {
-    if (window.matchMedia('(hover: hover)').matches) {
-      // Opening with hover should not keep the menu expanded.
-      setExpanded(true);
-    }
-  };
-  const onMouseOut = () => {
-    if (window.matchMedia('(hover: hover)').matches) {
-      if (!keepExpanded) {
-        setExpanded(false);
-        setKeepExpanded(false);
-      }
-    }
-  };
-  const onClickToggle = () => {
-    setExpanded(!expanded);
-    setKeepExpanded(!expanded);
-  };
+  const onClickToggle = () => toggleMinimap(!expanded);
   const onClickLink = (e: React.MouseEvent) => {
     // Prevent navigating if the link is only partially shown.
     if (!expanded) {
       e.preventDefault();
     }
-    setExpanded(true);
-    setKeepExpanded(true);
+    toggleMinimap(true);
   };
 
   useEffect(() => {
-    const onClickOutside = (e: MouseEvent) => {
-      if (container.contains(e.target as HTMLElement)) {
-        return;
-      }
-      setExpanded(false);
-      setKeepExpanded(false);
-    };
-    document.addEventListener('click', onClickOutside, true);
+    // Sync the body class with the initial expanded state.
+    toggleMinimap(initialExpanded);
   }, []);
 
   /**
@@ -203,13 +208,7 @@ const Minimap: React.FunctionComponent<MinimapProps> = ({
         floating
         insideMinimap={expanded}
       />
-      {/* Keyboard support is implemented with the toggle button. */}
-      {/* eslint-disable-next-line jsx-a11y/mouse-events-have-key-events */}
-      <div
-        className={`w-minimap ${expanded ? 'w-minimap--expanded' : ''}`}
-        onMouseOver={onMouseOver}
-        onMouseOut={onMouseOut}
-      >
+      <div className={`w-minimap ${expanded ? 'w-minimap--expanded' : ''}`}>
         <div className="w-minimap__header">
           <button
             type="button"

--- a/client/src/components/Minimap/MinimapItem.scss
+++ b/client/src/components/Minimap/MinimapItem.scss
@@ -91,3 +91,12 @@
     margin-inline-end: calc($badge-size - theme('spacing.px'));
   }
 }
+
+.w-minimap-item__icon,
+.w-minimap-item__label {
+  opacity: 0;
+
+  :where(.w-minimap--expanded) & {
+    opacity: 1;
+  }
+}

--- a/client/src/components/Minimap/MinimapItem.test.tsx
+++ b/client/src/components/Minimap/MinimapItem.test.tsx
@@ -7,7 +7,7 @@ const mockItem = {
   toggle: document.createElement('button'),
   panel: document.createElement('div'),
   href: '',
-  label: 'text with more than 26 characters',
+  label: 'text with more than 22 characters',
   icon: '',
   required: true,
   errorCount: 1,
@@ -49,7 +49,7 @@ describe('MinimapItem', () => {
 
   it('truncates long label texts', () => {
     const wrapper = shallow(<MinimapItem {...mockProps} />);
-    expect(wrapper.text()).toBe('1<Icon />text with more than 26 cha…*');
+    expect(wrapper.text()).toBe('1<Icon />text with more than 22…*');
   });
 
   it('does not truncate short label texts', () => {

--- a/client/src/components/Minimap/MinimapItem.tsx
+++ b/client/src/components/Minimap/MinimapItem.tsx
@@ -40,7 +40,7 @@ const MinimapItem: React.FunctionComponent<MinimapItemProps> = ({
     '%(num)s errors',
     errorCount,
   ).replace('%(num)s', `${errorCount}`);
-  const text = label.length > 26 ? `${label.substring(0, 26)}…` : label;
+  const text = label.length > 22 ? `${label.substring(0, 22)}…` : label;
   return (
     <a
       href={href}

--- a/client/src/components/Minimap/MinimapItem.tsx
+++ b/client/src/components/Minimap/MinimapItem.tsx
@@ -51,6 +51,8 @@ const MinimapItem: React.FunctionComponent<MinimapItemProps> = ({
       aria-current={intersects}
       // Prevent interacting with the links when they are only partially shown.
       tabIndex={expanded ? undefined : -1}
+      // Use the toggle button as description when collapsed.
+      aria-describedby={expanded ? undefined : 'w-minimap-toggle'}
     >
       {hasError ? (
         <div className="w-minimap-item__errors" aria-label={errorsLabel}>

--- a/client/src/components/Minimap/MinimapItem.tsx
+++ b/client/src/components/Minimap/MinimapItem.tsx
@@ -19,7 +19,7 @@ interface MinimapItemProps {
   item: MinimapMenuItem;
   intersects: boolean;
   expanded: boolean;
-  onClick: (e: React.MouseEvent) => void;
+  onClick: (item: MinimapMenuItem, e: React.MouseEvent) => void;
 }
 
 const requiredMark = <span className="w-required-mark">*</span>;
@@ -47,7 +47,7 @@ const MinimapItem: React.FunctionComponent<MinimapItemProps> = ({
       className={`w-minimap-item w-minimap-item--${level} ${
         intersects ? 'w-minimap-item--active' : ''
       } ${hasError ? 'w-minimap-item--error' : ''}`}
-      onClick={onClick}
+      onClick={onClick.bind(null, item)}
       aria-current={intersects}
       // Prevent interacting with the links when they are only partially shown.
       tabIndex={expanded ? undefined : -1}

--- a/client/src/includes/sidePanel.js
+++ b/client/src/includes/sidePanel.js
@@ -155,7 +155,10 @@ export default function initSidePanel() {
       newWidth,
     ).replace('%(num)s', newWidth);
 
-    sidePanelWrapper.style.width = `${newWidth}px`;
+    sidePanelWrapper.parentElement.style.setProperty(
+      '--side-panel-width',
+      `${newWidth}px`,
+    );
     const inputPercentage = ((newWidth - minWidth) / range) * 100;
     widthInput.value = getDirectedPercentage(inputPercentage);
     widthInput.setAttribute('aria-valuetext', valueText);

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels.html
@@ -17,7 +17,7 @@
             {% endcomment %}
             <input type="range" step="10" dir="ltr" class="form-side__width-input" name="wagtail-side-panel-width" data-form-side-width-input />
             <span class="w-sr-only">{% trans 'Side panel width' %}</span>
-            {% icon name="grip" %}
+            <div class="form-side__resize-grip-icon"></div>
         </label>
     </div>
 

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels.html
@@ -1,5 +1,9 @@
 {% load wagtailadmin_tags i18n %}
 
+{% if not in_explorer %}
+    {# Rendering for the minimap is done with React. #}
+    <aside aria-label="{% trans 'Minimap' %}" data-minimap-container></aside>
+{% endif %}
 <aside class="form-side form-side--initial" aria-label="{% trans 'Side panels' %}" data-form-side{% if in_explorer %} data-form-side-explorer{% endif %}>
     <button type="button" class="form-side__close-button" data-form-side-close-button aria-label="{% trans 'Toggle side panel' %}">
         {% icon name="expand-right" %}
@@ -28,7 +32,3 @@
         </div>
     {% endfor %}
 </aside>
-{% if not in_explorer %}
-    {# Rendering for the minimap is done with React. #}
-    <aside aria-label="{% trans 'Minimap' %}" data-minimap-container></aside>
-{% endif %}


### PR DESCRIPTION
Implements refinements from #10055 earmarked for Wagtail v5, specifically:

- Prevent overlapping with footer actions (#9642)
- Keep the minimap open between page reloads (#9704)
- Display the minimap next to side panels so it can always be used (#9799)
- Make the minimap open on click only, with correct ARIA description, for speech recognition users (#9666)
- Reveal the target section on click if collapsed

And a few additional design changes:

- New resize icon and hover effect
- Make the minimap smaller

Screenshot:

![minimap-10055](https://user-images.githubusercontent.com/877585/232640706-1211e9a0-f695-4f39-9e88-2ff4ef503f39.png)




_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 112, Firefox 111, Safari 16.3 on macOS 13.2
    -   [x] **Please list which assistive technologies [^3] you tested**: WHCM, VoiceOver, keyboard
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~
