### PR TITLE
Allow blocking redirect in Stimulus Action controller

### DIFF
--- a/client/src/controllers/ActionController.test.js
+++ b/client/src/controllers/ActionController.test.js
@@ -137,9 +137,39 @@ describe('ActionController', () => {
       select.dispatchEvent(
         new CustomEvent('change', { detail: { url: '/its/in/the/detail/' } }),
       );
+
       expect(window.location.assign).toHaveBeenCalledWith(
         '/check/out/the/param/',
       );
+    });
+
+    it('should allow redirection blocking via the event detail', () => {
+      const select = document.querySelector('select');
+
+      expect(window.location.href).toEqual('http://localhost/');
+      expect(window.location.assign).not.toHaveBeenCalled();
+
+      // setting to a non-null/undefined value should allow blocking
+      select.dispatchEvent(new CustomEvent('change', { detail: { url: '' } }));
+      select.dispatchEvent(
+        new CustomEvent('change', { detail: { url: false } }),
+      );
+
+      expect(window.location.assign).not.toHaveBeenCalled();
+    });
+
+    it('should allow redirection blocking via the Stimulus param approach', () => {
+      const select = document.querySelector('select');
+
+      expect(window.location.href).toEqual('http://localhost/');
+      expect(window.location.assign).not.toHaveBeenCalled();
+
+      // setting to a non-null/undefined value should allow blocking
+      select.dataset.wActionUrlParam = '';
+
+      select.dispatchEvent(new CustomEvent('change'));
+
+      expect(window.location.assign).not.toHaveBeenCalled();
     });
   });
 });

--- a/client/src/controllers/ActionController.ts
+++ b/client/src/controllers/ActionController.ts
@@ -87,7 +87,7 @@ export class ActionController extends Controller<
   redirect(
     event: CustomEvent<{ url?: string }> & { params?: { url?: string } },
   ) {
-    const url = event?.params?.url || event?.detail?.url || this.element.value;
+    const url = event?.params?.url ?? event?.detail?.url ?? this.element.value;
     if (!url) return;
     window.location.assign(url);
   }


### PR DESCRIPTION
- If values were false/empty string, it would fall back to the event value
- Instead, ensure that the custom event details OR the param can be used to override this and stop redirection
- Relates to #10035 & #10039
