### PR TITLE
Fix regressions from #10320

### DIFF
--- a/docs/advanced_topics/customisation/page_editing_interface.md
+++ b/docs/advanced_topics/customisation/page_editing_interface.md
@@ -109,13 +109,13 @@ register_image_format(Format('thumbnail', 'Thumbnail', 'richtext-image thumbnail
 
 To begin, import the `Format` class, `register_image_format` function, and optionally `unregister_image_format` function. To register a new `Format`, call the `register_image_format` with the `Format` object as the argument. The `Format` class takes the following constructor arguments:
 
-**`name`**
+**`name`**\
 The unique key used to identify the format. To unregister this format, call `unregister_image_format` with this string as the only argument.
 
-**`label`**
+**`label`**\
 The label used in the chooser form when inserting the image into the `RichTextField`.
 
-**`classnames`**
+**`classnames`**\
 The string to assign to the `class` attribute of the generated `<img>` tag.
 
 ```{note}

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -1785,7 +1785,7 @@ class TestPanelIcons(WagtailTestUtils, TestCase):
             # Django model field with default icon
             (FieldPanel("signup_link"), "link-external", "link-external", 1),
             # Django model field with no default icon
-            (FieldPanel("audience"), None, "arrow-down-big", 1),
+            (FieldPanel("audience"), None, "placeholder", 1),
             # Wagtail model field with default icon
             (FieldPanel("body"), "pilcrow", "pilcrow", 1),
             # Django ForeignKey with icon taken from the widget override
@@ -1812,7 +1812,7 @@ class TestPanelIcons(WagtailTestUtils, TestCase):
             # Django model field with default icon
             (FieldPanel("signup_link", icon="cog"), "cog", "link-external", 0),
             # Django model field with no default icon
-            (FieldPanel("audience", icon="check"), "check", "arrow-down-big", 0),
+            (FieldPanel("audience", icon="check"), "check", "placeholder", 0),
             # Wagtail model field with default icon
             (FieldPanel("body", icon="cut"), "cut", "pilcrow", 0),
             # Django ForeignKey with icon taken from the widget override


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes regressions from #10320.

Fixes the default `FieldPanel` icon test from failing, and a documentation typo due to the removal of trailing whitespaces when saving in my editor.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
