### PR TITLE
Always use expanded Sass output so CSS processing is identical in dev and prod builds

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -232,7 +232,17 @@ module.exports = function exports(env, argv) {
                 },
               },
             },
-            'sass-loader',
+            {
+              loader: 'sass-loader',
+              options: {
+                sassOptions: {
+                  // Manually set Sass output so it’s identical in production and development. See:
+                  // https://github.com/tailwindlabs/tailwindcss/issues/11027
+                  // https://github.com/webpack-contrib/sass-loader/issues/1129
+                  outputStyle: 'expanded',
+                },
+              },
+            },
           ],
         },
       ].concat(


### PR DESCRIPTION
Fixes a CSS build issue in our production builds, as seen in nightly releases, due to a bug in Tailwind revealed via style changes in #10304. On this line: https://github.com/wagtail/wagtail/blob/0447b259c7d65d4187b8eef8faeeddc87fee8e23/client/scss/components/_panel.scss#L31

Tailwind has trouble processing the `theme` function added with `$header-button-size`, when there are no spaces in the `calc` expression. Tailwind issue with more details: https://github.com/tailwindlabs/tailwindcss/issues/11027.

This is only an issue in production builds because it turns out our Sass setup in Webpack processes code differently in production and development (https://github.com/webpack-contrib/sass-loader/issues/1129). So the fix is to force Sass to always use the same output in both modes.

---

Here is the full diff of how our production and development styles differed before this change – as far as I can see the Tailwind bug is the only one that would cause real-world issues – others are just different cssnano optimisations:

```diff
 .w-body-text-large {
   font-size: 1.1875rem;
-}
-.w-body-text,
-.w-body-text-large {
   font-weight: 400;
   line-height: 1.5;
 }
 .w-body-text {
   font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
 }
[…]
  .w-panel__header {
-    margin-inline-start: calc((2 * 1.5rem + var(--header-gap)) * -1);
+    margin-inline-start: calc(
+      (2 * theme('spacing.6') + var(--header-gap)) * -1
+    );
  }
 […]
 .w-panel__heading {
   color: var(--w-color-text-label);
+  cursor: pointer;
 }
-.w-panel__heading,
 .w-panel__heading label {
   cursor: pointer;
 }
[…]
 .w-header {
-  color: var(--w-color-text-label);
   margin-bottom: 2rem;
 }
+.w-header,
 .w-header h1,
 .w-header h2 {
-  margin: 0;
+  color: var(--w-color-text-label);
 }
 .w-header h1,
 .w-header h2 {
-  color: var(--w-color-text-label);
+  margin: 0;
 }
 .w-header h1 {
+  color: var(--w-color-text-label);
   font-size: 1.875rem;
```

With this fix applied, the only difference between our production and development stylesheets is the presence of source maps.

For testing – I’ve only tested this by looking at the output of stylesheets before/after the changes. Commands:

```bash
./node_modules/.bin/webpack --config ./client/webpack.config.js --mode production
cp wagtail/admin/static/wagtailadmin/css/core.css core.prod.css
prettier --write core.prod.css
./node_modules/.bin/webpack --config ./client/webpack.config.js --mode development
cp wagtail/admin/static/wagtailadmin/css/core.css core.dev.css
prettier --write core.dev.css
git diff --no-index core.dev.css core.prod.css
```