### PR TITLE
Provide an `autocomplete` endpoint on the fallback search backend

### DIFF
--- a/wagtail/search/backends/database/fallback.py
+++ b/wagtail/search/backends/database/fallback.py
@@ -153,6 +153,13 @@ class DatabaseSearchQueryCompiler(BaseSearchQueryCompiler):
         )
 
 
+class DatabaseAutocompleteQueryCompiler(DatabaseSearchQueryCompiler):
+    # The fallback backend doesn't handle word boundaries, so standard searches are
+    # essentially equivalent to autocomplete queries anyhow. However, to provide a
+    # consistent API with other backends, we provide both endpoints.
+    pass
+
+
 class DatabaseSearchResults(BaseSearchResults):
     iterator_chunk_size = 2000
 
@@ -216,6 +223,7 @@ class DatabaseSearchResults(BaseSearchResults):
 
 class DatabaseSearchBackend(BaseSearchBackend):
     query_compiler_class = DatabaseSearchQueryCompiler
+    autocomplete_query_compiler_class = DatabaseSearchQueryCompiler
     results_class = DatabaseSearchResults
 
     def reset_index(self):

--- a/wagtail/search/tests/test_db_backend.py
+++ b/wagtail/search/tests/test_db_backend.py
@@ -16,26 +16,6 @@ from .test_backends import BackendTests
 class TestDBBackend(BackendTests, TestCase):
     backend_path = "wagtail.search.backends.database.fallback"
 
-    # Doesn't support autocomplete
-    @unittest.expectedFailure
-    def test_autocomplete(self):
-        super().test_autocomplete()
-
-    # Doesn't support autocomplete
-    @unittest.expectedFailure
-    def test_autocomplete_not_affected_by_stemming(self):
-        super().test_autocomplete_not_affected_by_stemming()
-
-    # Doesn't support autocomplete
-    @unittest.expectedFailure
-    def test_autocomplete_uses_autocompletefield(self):
-        super().test_autocomplete_uses_autocompletefield()
-
-    # Doesn't support autocomplete
-    @unittest.expectedFailure
-    def test_autocomplete_with_fields_arg(self):
-        super().test_autocomplete_with_fields_arg()
-
     # Doesn't support ranking
     @unittest.expectedFailure
     def test_ranking(self):


### PR DESCRIPTION
This is identical to the search method, since the standard search disregards word boundaries anyhow, but providing this endpoint means that we can document a common endpoint across all backends.
