### PR TITLE
Migrate Elasticsearch backend to new autocomplete API and fully deprecate partial_match

### DIFF
--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -213,6 +213,14 @@ The following features deprecated in Wagtail 4.0 have been fully removed. See [W
 
 Django 4.0 reached end of life on 1st April 2023 and is no longer supported by Wagtail. Django 3.2 (LTS) is still supported until April 2024.
 
+### Elasticsearch backend no longer performs partial matching on `search`
+
+The `search` method on pages, images and documents, and on the backend object returned by `wagtail.search.backends.get_search_backend()`, no longer performs partial word matching when the Elasticsearch backend is in use. Previously, a search query such as `Page.objects.search("cat")` would return results containing the word "caterpillar", while `Page.objects.search("cat", partial_match=False)` would only return results for the exact word "cat". The `search` method now always performs exact word matches, and the `partial_match` argument has no effect. This change makes the Elasticsearch backend consistent with the database-backed full-text search backends.
+
+To revert to the previous partial word matching behaviour, use the `autocomplete` method instead - for example, `Page.objects.autocomplete("cat")`. It may also be necessary to add an [](wagtailsearch_index_autocompletefield) entry for the relevant fields on the model's `search_fields` definition, as the old `SearchField("some_field", partial_match=True)` format is no longer supported.
+
+The `partial_match` argument on `search` and `SearchField` is now deprecated, and should be removed from your code; it will be dropped entirely in Wagtail 6.
+
 ### `Page.get_static_site_paths` method removed
 
 The undocumented `Page.get_static_site_paths` method (which returns a generator of URL paths for use by static site generator packages) has been removed. Packages relying on this functionality should provide their own fallback implementation.

--- a/docs/topics/search/indexing.md
+++ b/docs/topics/search/indexing.md
@@ -91,7 +91,6 @@ These are used for performing full-text searches on your models, usually for tex
 
 #### Options
 
--   **partial_match** (`boolean`) - Setting this to true allows results to be matched on parts of words. For example, this is set on the title field by default, so a page titled `Hello World!` will be found if the user only types `Hel` into the search box.
 -   **boost** (`int/float`) - This allows you to set fields as being more important than others. Setting this to a high number on a field will cause pages with matches in that field to be ranked higher. By default, this is set to 2 on the Page title field and 1 on all other fields.
 
     ```{note}
@@ -107,17 +106,21 @@ These are used for performing full-text searches on your models, usually for tex
 
 -   **es_extra** (`dict`) - This field is to allow the developer to set or override any setting on the field in the Elasticsearch mapping. Use this if you want to make use of any Elasticsearch features that are not yet supported in Wagtail.
 
-(wagtailsearch_index_filterfield)=
+```{versionchanged} 5.0
+The `partial_match` option has been deprecated. To index a field for partial matching, use `AutocompleteField` instead.
+```
 
 ### `index.AutocompleteField`
 
 These are used for autocomplete queries that match partial words. For example, a page titled `Hello World!` will be found if the user only types `Hel` into the search box.
 
-This takes the exact same options as `index.SearchField` (with the exception of `partial_match`, which has no effect).
+This takes the same options as `index.SearchField`.
 
 ```{note}
 `index.AutocompleteField` should only be used on fields that are displayed in the search results. This allows users to see any words that were partial-matched.
 ```
+
+(wagtailsearch_index_filterfield)=
 
 ### `index.FilterField`
 
@@ -236,7 +239,8 @@ class Book(index.Indexed, models.Model):
     published_date = models.DateTimeField()
 
     search_fields = [
-        index.SearchField('title', partial_match=True, boost=10),
+        index.SearchField('title', boost=10),
+        index.AutocompleteField('title', boost=10),
         index.SearchField('get_genre_display'),
 
         index.FilterField('genre'),

--- a/docs/topics/search/indexing.md
+++ b/docs/topics/search/indexing.md
@@ -110,6 +110,8 @@ These are used for performing full-text searches on your models, usually for tex
 The `partial_match` option has been deprecated. To index a field for partial matching, use `AutocompleteField` instead.
 ```
 
+(wagtailsearch_index_autocompletefield)=
+
 ### `index.AutocompleteField`
 
 These are used for autocomplete queries that match partial words. For example, a page titled `Hello World!` will be found if the user only types `Hel` into the search box.

--- a/docs/topics/search/searching.md
+++ b/docs/topics/search/searching.md
@@ -30,8 +30,11 @@ All other methods of `PageQuerySet` can be used with `search()`. For example:
 The `search()` method will convert your `QuerySet` into an instance of one of Wagtail's `SearchResults` classes (depending on backend). This means that you must perform filtering before calling `search()`.
 ```
 
-Before the `autocomplete()` method was introduced, the search method also did partial matching. This behaviour is deprecated and you should either switch to the new `autocomplete()` method or pass `partial_match=False` into the search method to opt-in to the new behaviour.
-The partial matching in `search()` will be completely removed in a future release.
+The standard behaviour of the `search` method is to only return matches for complete words; for example, a search for "hel" will not return results containing the word "hello". The exception to this is the fallback database search backend, used when the database does not have full-text search extensions available, and no alternative backend has been specified. This performs basic substring matching, and will return results containing the search term ignoring all word boundaries.
+
+```{versionchanged} 5.0
+The Elasticsearch backend now defaults to matching on complete words. Previously, this backend performed partial matching by default, and it was necessary to pass the keyword argument `partial_match=False` to disable this. To perform searches with partial matching behaviour, you should instead use the `autocomplete` method (see below) in conjunction with `AutocompleteField`. Any occurrences of `partial_match=False` in your code can now be removed.
+```
 
 ### Autocomplete searches
 

--- a/docs/topics/snippets.md
+++ b/docs/topics/snippets.md
@@ -266,7 +266,8 @@ class Advert(index.Indexed, models.Model):
     ]
 
     search_fields = [
-        index.SearchField('text', partial_match=True),
+        index.SearchField('text'),
+        index.AutocompleteField('text'),
     ]
 ```
 

--- a/wagtail/admin/forms/choosers.py
+++ b/wagtail/admin/forms/choosers.py
@@ -76,24 +76,7 @@ class SearchFilterMixin(forms.Form):
         search_query = self.cleaned_data.get("q")
         if search_query:
             search_backend = get_search_backend()
-
-            # The search should work as an autocomplete by preference, but only if
-            # there are AutocompleteFields set up for this model in the search index;
-            # if not, fall back on a standard search so that we get results at all
-            if objects.model.get_autocomplete_search_fields():
-                try:
-                    objects = search_backend.autocomplete(search_query, objects)
-                except NotImplementedError:
-                    # Older search backends do not implement .autocomplete() but do support
-                    # partial_match on .search(). Newer ones will ignore partial_match.
-                    objects = search_backend.search(
-                        search_query, objects, partial_match=True
-                    )
-            else:
-                objects = search_backend.search(
-                    search_query, objects, partial_match=True
-                )
-
+            objects = search_backend.autocomplete(search_query, objects)
             self.is_searching = True
             self.search_query = search_query
         return objects

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -330,8 +330,6 @@ class TestChooserSearch(WagtailTestUtils, TransactionTestCase):
         self.assertContains(response, "foobarbaz")
 
     def test_partial_match(self):
-        # FIXME: SQLite and MySQL FTS backends don't support autocomplete searches
-        # https://github.com/wagtail/wagtail/issues/9903
         response = self.get({"q": "fooba"})
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/chooser/_search_results.html")

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -451,12 +451,7 @@ class SearchView(View):
             pages = pages.exclude(depth=1)  # never include root
             pages = pages.type(*desired_classes)
             pages = pages.specific()
-            try:
-                pages = pages.autocomplete(search_form.cleaned_data["q"])
-            except NotImplementedError:
-                # Older search backends do not implement .autocomplete() but do support
-                # partial_match on .search(). Newer ones will ignore partial_match.
-                pages = pages.search(search_form.cleaned_data["q"], partial_match=True)
+            pages = pages.autocomplete(search_form.cleaned_data["q"])
 
         else:
             pages = pages.none()

--- a/wagtail/contrib/modeladmin/helpers/search.py
+++ b/wagtail/contrib/modeladmin/helpers/search.py
@@ -66,7 +66,6 @@ class WagtailBackendSearchHandler(BaseSearchHandler):
         search_term,
         preserve_order=False,
         operator=None,
-        partial_match=True,
         backend=None,
         **kwargs,
     ):
@@ -79,6 +78,5 @@ class WagtailBackendSearchHandler(BaseSearchHandler):
             queryset,
             fields=self.search_fields or None,
             operator=operator,
-            partial_match=partial_match,
             order_by_relevance=not preserve_order,
         )

--- a/wagtail/contrib/modeladmin/tests/test_search_handlers.py
+++ b/wagtail/contrib/modeladmin/tests/test_search_handlers.py
@@ -20,7 +20,6 @@ class FakeSearchBackend:
         fields=None,
         operator=None,
         order_by_relevance=True,
-        partial_match=True,
     ):
         return {
             "query": query,
@@ -28,7 +27,6 @@ class FakeSearchBackend:
             "fields": fields,
             "operator": operator,
             "order_by_relevance": order_by_relevance,
-            "partial_match": partial_match,
         }
 
 
@@ -110,7 +108,6 @@ class TestSearchBackendHandler(TestCase):
                 "fields": None,
                 "operator": None,
                 "order_by_relevance": True,
-                "partial_match": True,
             },
         )
 
@@ -134,7 +131,6 @@ class TestSearchBackendHandler(TestCase):
                 "fields": search_fields,
                 "operator": None,
                 "order_by_relevance": True,
-                "partial_match": True,
             },
         )
 
@@ -157,7 +153,6 @@ class TestSearchBackendHandler(TestCase):
                 "fields": None,
                 "operator": None,
                 "order_by_relevance": False,
-                "partial_match": True,
             },
         )
 

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -44,13 +44,13 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
     objects = DocumentQuerySet.as_manager()
 
     search_fields = CollectionMember.search_fields + [
-        index.SearchField("title", partial_match=True, boost=10),
+        index.SearchField("title", boost=10),
         index.AutocompleteField("title"),
         index.FilterField("title"),
         index.RelatedFields(
             "tags",
             [
-                index.SearchField("name", partial_match=True, boost=10),
+                index.SearchField("name", boost=10),
                 index.AutocompleteField("name"),
             ],
         ),

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -67,19 +67,7 @@ class BaseListingView(TemplateView):
                 query_string = self.form.cleaned_data["q"]
                 if query_string:
                     search_backend = get_search_backend()
-                    if documents.model.get_autocomplete_search_fields():
-                        try:
-                            documents = search_backend.autocomplete(
-                                query_string, documents
-                            )
-                        except NotImplementedError:
-                            documents = search_backend.search(
-                                query_string, documents, partial_match=True
-                            )
-                    else:
-                        documents = search_backend.search(
-                            query_string, documents, partial_match=True
-                        )
+                    documents = search_backend.autocomplete(query_string, documents)
         else:
             self.form = SearchForm(placeholder=_("Search documents"))
 

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -318,13 +318,13 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         return reverse("wagtailimages:image_usage", args=(self.id,))
 
     search_fields = CollectionMember.search_fields + [
-        index.SearchField("title", partial_match=True, boost=10),
+        index.SearchField("title", boost=10),
         index.AutocompleteField("title"),
         index.FilterField("title"),
         index.RelatedFields(
             "tags",
             [
-                index.SearchField("name", partial_match=True, boost=10),
+                index.SearchField("name", boost=10),
                 index.AutocompleteField("name"),
             ],
         ),

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -107,17 +107,7 @@ class BaseListingView(TemplateView):
                 query_string = self.form.cleaned_data["q"]
                 if query_string:
                     search_backend = get_search_backend()
-                    if images.model.get_autocomplete_search_fields():
-                        try:
-                            images = search_backend.autocomplete(query_string, images)
-                        except NotImplementedError:
-                            images = search_backend.search(
-                                query_string, images, partial_match=True
-                            )
-                    else:
-                        images = search_backend.search(
-                            query_string, images, partial_match=True
-                        )
+                    images = search_backend.autocomplete(query_string, images)
         else:
             self.form = SearchForm(placeholder=_("Search images"))
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -1158,7 +1158,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
     alias_of.wagtail_reference_index_ignore = True
 
     search_fields = [
-        index.SearchField("title", partial_match=True, boost=2),
+        index.SearchField("title", boost=2),
         index.AutocompleteField("title"),
         index.FilterField("title"),
         index.FilterField("id"),

--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -8,6 +8,7 @@ from django.db.models.sql.where import SubqueryConstraint, WhereNode
 
 from wagtail.search.index import class_is_indexed, get_indexed_models
 from wagtail.search.query import MATCH_ALL, PlainText
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class FilterError(Exception):
@@ -56,7 +57,18 @@ class BaseSearchQueryCompiler:
         self.query = query
         self.fields = fields
         self.order_by_relevance = order_by_relevance
-        self.partial_match = partial_match  # RemovedInWagtail60Warning
+        if partial_match:
+            warn(
+                "The partial_match=True argument on `search` is no longer supported. "
+                "Use the `autocomplete` method instead",
+                category=RemovedInWagtail60Warning,
+            )
+        elif partial_match is not None:
+            warn(
+                "The partial_match=False argument on `search` is no longer required "
+                "and should be removed",
+                category=RemovedInWagtail60Warning,
+            )
 
     def _get_filterable_field(self, field_attname):
         # Get field

--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -42,7 +42,7 @@ class BaseSearchQueryCompiler:
         fields=None,
         operator=None,
         order_by_relevance=True,
-        partial_match=True,
+        partial_match=None,  # RemovedInWagtail60Warning
     ):
         self.queryset = queryset
         if query is None:
@@ -56,7 +56,7 @@ class BaseSearchQueryCompiler:
         self.query = query
         self.fields = fields
         self.order_by_relevance = order_by_relevance
-        self.partial_match = partial_match
+        self.partial_match = partial_match  # RemovedInWagtail60Warning
 
     def _get_filterable_field(self, field_attname):
         # Get field
@@ -427,7 +427,7 @@ class BaseSearchBackend:
         fields=None,
         operator=None,
         order_by_relevance=True,
-        partial_match=True,
+        partial_match=None,  # RemovedInWagtail60Warning
     ):
         return self._search(
             self.query_compiler_class,
@@ -436,7 +436,7 @@ class BaseSearchBackend:
             fields=fields,
             operator=operator,
             order_by_relevance=order_by_relevance,
-            partial_match=partial_match,
+            partial_match=partial_match,  # RemovedInWagtail60Warning
         )
 
     def autocomplete(

--- a/wagtail/search/backends/elasticsearch6.py
+++ b/wagtail/search/backends/elasticsearch6.py
@@ -56,7 +56,7 @@ class Elasticsearch6SearchResults(Elasticsearch5SearchResults):
 
 
 class Elasticsearch6AutocompleteQueryCompiler(
-    Elasticsearch6SearchQueryCompiler, ElasticsearchAutocompleteQueryCompilerImpl
+    ElasticsearchAutocompleteQueryCompilerImpl, Elasticsearch6SearchQueryCompiler
 ):
     pass
 

--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -85,7 +85,7 @@ class Elasticsearch7SearchResults(Elasticsearch6SearchResults):
 
 
 class Elasticsearch7AutocompleteQueryCompiler(
-    Elasticsearch6SearchQueryCompiler, ElasticsearchAutocompleteQueryCompilerImpl
+    ElasticsearchAutocompleteQueryCompilerImpl, Elasticsearch6SearchQueryCompiler
 ):
     pass
 

--- a/wagtail/search/index.py
+++ b/wagtail/search/index.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from warnings import warn
 
 from django.apps import apps
 from django.core import checks
@@ -9,6 +10,7 @@ from django.db.models.fields.related import ForeignObjectRel, OneToOneRel, Relat
 from modelcluster.fields import ParentalManyToManyField
 
 from wagtail.search.backends import get_search_backends_with_name
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 logger = logging.getLogger("wagtail.search.index")
 
@@ -295,8 +297,13 @@ class BaseField:
 class SearchField(BaseField):
     def __init__(self, field_name, boost=None, partial_match=False, **kwargs):
         super().__init__(field_name, **kwargs)
+        if partial_match:
+            warn(
+                "The partial_match option on SearchField has no effect and will be removed. "
+                "Use AutocompleteField instead",
+                category=RemovedInWagtail60Warning,
+            )
         self.boost = boost
-        self.partial_match = partial_match
 
 
 class AutocompleteField(BaseField):

--- a/wagtail/search/queryset.py
+++ b/wagtail/search/queryset.py
@@ -8,7 +8,7 @@ class SearchableQuerySetMixin:
         fields=None,
         operator=None,
         order_by_relevance=True,
-        partial_match=True,
+        partial_match=None,  # RemovedInWagtail60Warning
         backend="default",
     ):
         """
@@ -21,7 +21,7 @@ class SearchableQuerySetMixin:
             fields=fields,
             operator=operator,
             order_by_relevance=order_by_relevance,
-            partial_match=partial_match,
+            partial_match=partial_match,  # RemovedInWagtail60Warning
         )
 
     def autocomplete(

--- a/wagtail/search/tests/elasticsearch_common_tests.py
+++ b/wagtail/search/tests/elasticsearch_common_tests.py
@@ -33,7 +33,7 @@ class ElasticsearchCommonSearchBackendTests(BackendTests):
             )
 
     def test_partial_search(self):
-        results = self.backend.search("Java", models.Book)
+        results = self.backend.autocomplete("Java", models.Book)
 
         self.assertUnsortedListEqual(
             [r.title for r in results],
@@ -57,7 +57,7 @@ class ElasticsearchCommonSearchBackendTests(BackendTests):
 
     def test_child_partial_search(self):
         # Note: Expands to "Westeros". Which is in a field on Novel.setting
-        results = self.backend.search("Wes", models.Book)
+        results = self.backend.autocomplete("Wes", models.Book)
 
         self.assertUnsortedListEqual(
             [r.title for r in results],
@@ -73,7 +73,7 @@ class ElasticsearchCommonSearchBackendTests(BackendTests):
         index.add_item(book)
         index.refresh()
 
-        results = self.backend.search("Hello", models.Book)
+        results = self.backend.autocomplete("Hello", models.Book)
 
         self.assertUnsortedListEqual([r.title for r in results], ["Ĥéllø"])
 
@@ -223,14 +223,3 @@ class ElasticsearchCommonSearchBackendTests(BackendTests):
     @unittest.expectedFailure
     def test_prefix_multiple_words(self):
         super().test_prefix_multiple_words()
-
-    # Elasticsearch always does prefix matching on `partial_match` fields,
-    # even when we don’t use `Prefix`.
-    @unittest.expectedFailure
-    def test_incomplete_plain_text(self):
-        super().test_incomplete_plain_text()
-
-    # Elasticsearch does not support 'fields' arguments on autocomplete queries
-    @unittest.expectedFailure
-    def test_autocomplete_with_fields_arg(self):
-        super().test_autocomplete_with_fields_arg()

--- a/wagtail/search/tests/elasticsearch_common_tests.py
+++ b/wagtail/search/tests/elasticsearch_common_tests.py
@@ -41,14 +41,14 @@ class ElasticsearchCommonSearchBackendTests(BackendTests):
         )
 
     def test_disabled_partial_search(self):
-        results = self.backend.search("Java", models.Book, partial_match=False)
+        results = self.backend.search("Java", models.Book)
 
         self.assertUnsortedListEqual([r.title for r in results], [])
 
     def test_disabled_partial_search_with_whole_term(self):
         # Making sure that there isn't a different reason why the above test
         # returned no results
-        results = self.backend.search("JavaScript", models.Book, partial_match=False)
+        results = self.backend.search("JavaScript", models.Book)
 
         self.assertUnsortedListEqual(
             [r.title for r in results],

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -249,6 +249,9 @@ class BackendTests(WagtailTestUtils):
     def test_autocomplete_uses_autocompletefield(self):
         # Autocomplete should only require an AutocompleteField, not a SearchField with
         # partial_match=True
+        # TODO: given that partial_match=True has no effect as of Wagtail 5, also test that
+        # AutocompleteField is actually being respected, and it's not just relying on the
+        # presence of a SearchField (with or without partial_match)
         results = self.backend.autocomplete("Georg", models.Author)
         self.assertUnsortedListEqual(
             [r.name for r in results],

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -570,7 +570,6 @@ class TestElasticsearch5SearchQuery(TestCase):
         query_compiler = self.query_compiler_class(
             models.Book.objects.all(),
             Fuzzy("Hello world"),
-            partial_match=False,
         )
 
         # Check it
@@ -585,7 +584,6 @@ class TestElasticsearch5SearchQuery(TestCase):
             models.Book.objects.all(),
             Fuzzy("Hello world"),
             fields=["title"],
-            partial_match=False,
         )
 
         # Check it
@@ -600,7 +598,6 @@ class TestElasticsearch5SearchQuery(TestCase):
             models.Book.objects.all(),
             Fuzzy("Hello world"),
             fields=["title", "body"],
-            partial_match=False,
         )
 
         # Check it

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -27,6 +27,9 @@ class TestElasticsearch5SearchQuery(TestCase):
         )
 
     query_compiler_class = Elasticsearch5SearchBackend.query_compiler_class
+    autocomplete_query_compiler_class = (
+        Elasticsearch5SearchBackend.autocomplete_query_compiler_class
+    )
 
     def test_simple(self):
         # Create a query
@@ -36,9 +39,22 @@ class TestElasticsearch5SearchQuery(TestCase):
         expected_result = {
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
+            }
+        }
+        self.assertDictEqual(query_compiler.get_query(), expected_result)
+
+    def test_simple_autocomplete(self):
+        # Create a query
+        query_compiler = self.autocomplete_query_compiler_class(
+            models.Book.objects.all(), "Hello"
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": {"match": {"content_type": "searchtests.Book"}},
+                "must": {"match": {"_partials": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)
@@ -67,10 +83,11 @@ class TestElasticsearch5SearchQuery(TestCase):
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all", "_partials"],
-                        "operator": "and",
+                    "match": {
+                        "_all": {
+                            "query": "Hello",
+                            "operator": "and",
+                        }
                     }
                 },
             }
@@ -90,9 +107,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                     {"match": {"content_type": "searchtests.Book"}},
                     {"term": {"title_filter": "Test"}},
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)
@@ -120,9 +135,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                         }
                     },
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
 
@@ -165,9 +178,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                         }
                     },
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query, expected_result)
@@ -192,9 +203,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                         }
                     },
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)
@@ -283,9 +292,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                     {"match": {"content_type": "searchtests.Book"}},
                     {"term": {"title_filter": "Test"}},
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)
@@ -303,9 +310,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                     {"match": {"content_type": "searchtests.Book"}},
                     {"bool": {"mustNot": {"exists": {"field": "title_filter"}}}},
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)
@@ -323,9 +328,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                     {"match": {"content_type": "searchtests.Book"}},
                     {"bool": {"mustNot": {"exists": {"field": "title_filter"}}}},
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)
@@ -343,9 +346,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                     {"match": {"content_type": "searchtests.Book"}},
                     {"exists": {"field": "title_filter"}},
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)
@@ -363,9 +364,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                     {"match": {"content_type": "searchtests.Book"}},
                     {"prefix": {"title_filter": "Test"}},
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)
@@ -388,9 +387,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                     {"match": {"content_type": "searchtests.Book"}},
                     {"range": {"publication_date_filter": {"gt": "2014-04-29"}}},
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)
@@ -411,9 +408,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                     {"match": {"content_type": "searchtests.Book"}},
                     {"range": {"publication_date_filter": {"lt": "2014-04-29"}}},
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)
@@ -434,9 +429,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                     {"match": {"content_type": "searchtests.Book"}},
                     {"range": {"publication_date_filter": {"gte": "2014-04-29"}}},
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)
@@ -457,9 +450,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                     {"match": {"content_type": "searchtests.Book"}},
                     {"range": {"publication_date_filter": {"lte": "2014-04-29"}}},
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)
@@ -488,9 +479,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                         }
                     },
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)
@@ -542,8 +531,24 @@ class TestElasticsearch5SearchQuery(TestCase):
 
         # Check it
         expected_result = {
+            "match_phrase": {
+                "_all": "Hello world",
+            }
+        }
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_phrase_query_multiple_fields(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Phrase("Hello world"),
+            fields=["title", "content"],
+        )
+
+        # Check it
+        expected_result = {
             "multi_match": {
-                "fields": ["_all", "_partials"],
+                "fields": ["title", "content"],
                 "query": "Hello world",
                 "type": "phrase",
             }
@@ -602,19 +607,6 @@ class TestElasticsearch5SearchQuery(TestCase):
         with self.assertRaises(NotImplementedError):
             query_compiler.get_inner_query()
 
-    def test_fuzzy_query_partial_match_disallowed(self):
-        # Create a query
-        query_compiler = self.query_compiler_class(
-            models.Book.objects.all(),
-            Fuzzy("Hello world"),
-            fields=["_all"],
-            partial_match=True,
-        )
-
-        # Check it
-        with self.assertRaises(NotImplementedError):
-            query_compiler.get_inner_query()
-
     def test_year_filter(self):
         # Create a query
         query_compiler = self.query_compiler_class(
@@ -628,9 +620,7 @@ class TestElasticsearch5SearchQuery(TestCase):
                     {"match": {"content_type": "searchtests.Book"}},
                     {"range": {"publication_date_filter": {"gt": 1900}}},
                 ],
-                "must": {
-                    "multi_match": {"query": "Hello", "fields": ["_all", "_partials"]}
-                },
+                "must": {"match": {"_all": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query_compiler.get_query(), expected_result)

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -851,8 +851,6 @@ class TestElasticsearch5Mapping(TestCase):
                         "type": "text",
                         "boost": 2.0,
                         "include_in_all": True,
-                        "analyzer": "edgengram_analyzer",
-                        "search_analyzer": "standard",
                     },
                     "title_edgengrams": {
                         "type": "text",
@@ -921,7 +919,6 @@ class TestElasticsearch5Mapping(TestCase):
             "_partials": [
                 "J. R. R. Tolkien",
                 "The Fellowship of the Ring",
-                "The Fellowship of the Ring",
             ],
             "title": "The Fellowship of the Ring",
             "title_edgengrams": "The Fellowship of the Ring",
@@ -976,6 +973,10 @@ class TestElasticsearch5MappingInheritance(TestCase):
                     "searchtests_novel__setting": {
                         "type": "text",
                         "include_in_all": True,
+                    },
+                    "searchtests_novel__setting_edgengrams": {
+                        "type": "text",
+                        "include_in_all": False,
                         "analyzer": "edgengram_analyzer",
                         "search_analyzer": "standard",
                     },
@@ -1020,8 +1021,6 @@ class TestElasticsearch5MappingInheritance(TestCase):
                         "type": "text",
                         "boost": 2.0,
                         "include_in_all": True,
-                        "analyzer": "edgengram_analyzer",
-                        "search_analyzer": "standard",
                     },
                     "title_edgengrams": {
                         "type": "text",
@@ -1094,6 +1093,7 @@ class TestElasticsearch5MappingInheritance(TestCase):
         expected_result = {
             # New
             "searchtests_novel__setting": "Middle Earth",
+            "searchtests_novel__setting_edgengrams": "Middle Earth",
             "searchtests_novel__protagonist": {
                 "name": "Frodo Baggins",
                 "novel_id_filter": 4,
@@ -1109,7 +1109,6 @@ class TestElasticsearch5MappingInheritance(TestCase):
             "_partials": [
                 "J. R. R. Tolkien",
                 "Middle Earth",
-                "The Fellowship of the Ring",
                 "The Fellowship of the Ring",
             ],
             # Inherited

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -27,6 +27,9 @@ class TestElasticsearch6SearchQuery(TestCase):
         )
 
     query_compiler_class = Elasticsearch6SearchBackend.query_compiler_class
+    autocomplete_query_compiler_class = (
+        Elasticsearch6SearchBackend.autocomplete_query_compiler_class
+    )
 
     def test_simple(self):
         # Create a query
@@ -37,9 +40,31 @@ class TestElasticsearch6SearchQuery(TestCase):
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_simple_autocomplete(self):
+        # Create a query
+        query = self.autocomplete_query_compiler_class(
+            models.Book.objects.all(), "Hello"
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": {"match": {"content_type": "searchtests.Book"}},
+                "must": {
+                    "match": {
+                        "_edgengrams": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -70,10 +95,11 @@ class TestElasticsearch6SearchQuery(TestCase):
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
-                        "operator": "and",
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                            "operator": "and",
+                        }
                     }
                 },
             }
@@ -94,9 +120,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"term": {"title_filter": "Test"}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -127,9 +154,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -175,9 +203,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -205,9 +234,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -299,9 +329,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"term": {"title_filter": "Test"}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -322,9 +353,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"bool": {"mustNot": {"exists": {"field": "title_filter"}}}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -345,9 +377,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"bool": {"mustNot": {"exists": {"field": "title_filter"}}}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -368,9 +401,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"exists": {"field": "title_filter"}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -391,9 +425,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"prefix": {"title_filter": "Test"}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -419,9 +454,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"gt": "2014-04-29"}}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -445,9 +481,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"lt": "2014-04-29"}}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -471,9 +508,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"gte": "2014-04-29"}}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -497,9 +535,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"lte": "2014-04-29"}}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -531,9 +570,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -587,8 +627,24 @@ class TestElasticsearch6SearchQuery(TestCase):
 
         # Check it
         expected_result = {
+            "match_phrase": {
+                "_all_text": "Hello world",
+            }
+        }
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_phrase_query_multiple_fields(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Phrase("Hello world"),
+            fields=["title", "content"],
+        )
+
+        # Check it
+        expected_result = {
             "multi_match": {
-                "fields": ["_all_text", "_edgengrams"],
+                "fields": ["title", "content"],
                 "query": "Hello world",
                 "type": "phrase",
             }
@@ -647,19 +703,6 @@ class TestElasticsearch6SearchQuery(TestCase):
         with self.assertRaises(NotImplementedError):
             query_compiler.get_inner_query()
 
-    def test_fuzzy_query_partial_match_disallowed(self):
-        # Create a query
-        query_compiler = self.query_compiler_class(
-            models.Book.objects.all(),
-            Fuzzy("Hello world"),
-            fields=["_all"],
-            partial_match=True,
-        )
-
-        # Check it
-        with self.assertRaises(NotImplementedError):
-            query_compiler.get_inner_query()
-
     def test_year_filter(self):
         # Create a query
         query_compiler = self.query_compiler_class(
@@ -674,9 +717,10 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"term": {"publication_date_filter": 1900}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -899,8 +899,6 @@ class TestElasticsearch6Mapping(TestCase):
                         "type": "text",
                         "boost": 2.0,
                         "copy_to": "_all_text",
-                        "analyzer": "edgengram_analyzer",
-                        "search_analyzer": "standard",
                     },
                     "title_edgengrams": {
                         "type": "text",
@@ -955,7 +953,6 @@ class TestElasticsearch6Mapping(TestCase):
             "_edgengrams": [
                 "J. R. R. Tolkien",
                 "The Fellowship of the Ring",
-                "The Fellowship of the Ring",
             ],
             "title": "The Fellowship of the Ring",
             "title_edgengrams": "The Fellowship of the Ring",
@@ -1008,6 +1005,9 @@ class TestElasticsearch6MappingInheritance(TestCase):
                     "searchtests_novel__setting": {
                         "type": "text",
                         "copy_to": "_all_text",
+                    },
+                    "searchtests_novel__setting_edgengrams": {
+                        "type": "text",
                         "analyzer": "edgengram_analyzer",
                         "search_analyzer": "standard",
                     },
@@ -1046,8 +1046,6 @@ class TestElasticsearch6MappingInheritance(TestCase):
                         "type": "text",
                         "boost": 2.0,
                         "copy_to": "_all_text",
-                        "analyzer": "edgengram_analyzer",
-                        "search_analyzer": "standard",
                     },
                     "title_edgengrams": {
                         "type": "text",
@@ -1106,6 +1104,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
         expected_result = {
             # New
             "searchtests_novel__setting": "Middle Earth",
+            "searchtests_novel__setting_edgengrams": "Middle Earth",
             "searchtests_novel__protagonist": {
                 "name": "Frodo Baggins",
                 "novel_id_filter": 4,
@@ -1121,7 +1120,6 @@ class TestElasticsearch6MappingInheritance(TestCase):
             "_edgengrams": [
                 "J. R. R. Tolkien",
                 "Middle Earth",
-                "The Fellowship of the Ring",
                 "The Fellowship of the Ring",
             ],
             # Inherited

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -666,7 +666,6 @@ class TestElasticsearch6SearchQuery(TestCase):
         query_compiler = self.query_compiler_class(
             models.Book.objects.all(),
             Fuzzy("Hello world"),
-            partial_match=False,
         )
 
         # Check it
@@ -681,7 +680,6 @@ class TestElasticsearch6SearchQuery(TestCase):
             models.Book.objects.all(),
             Fuzzy("Hello world"),
             fields=["title"],
-            partial_match=False,
         )
 
         # Check it
@@ -696,7 +694,6 @@ class TestElasticsearch6SearchQuery(TestCase):
             models.Book.objects.all(),
             Fuzzy("Hello world"),
             fields=["title", "body"],
-            partial_match=False,
         )
 
         # Check it

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -652,7 +652,6 @@ class TestElasticsearch7SearchQuery(TestCase):
         query_compiler = self.query_compiler_class(
             models.Book.objects.all(),
             Fuzzy("Hello world"),
-            partial_match=False,
         )
 
         # Check it
@@ -667,7 +666,6 @@ class TestElasticsearch7SearchQuery(TestCase):
             models.Book.objects.all(),
             Fuzzy("Hello world"),
             fields=["title"],
-            partial_match=False,
         )
 
         # Check it
@@ -682,7 +680,6 @@ class TestElasticsearch7SearchQuery(TestCase):
             models.Book.objects.all(),
             Fuzzy("Hello world"),
             fields=["title", "body"],
-            partial_match=False,
         )
 
         # Check it

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -19,6 +19,8 @@ class TestElasticsearch7SearchBackend(ElasticsearchCommonSearchBackendTests, Tes
 
 
 class TestElasticsearch7SearchQuery(TestCase):
+    maxDiff = None
+
     def assertDictEqual(self, a, b):
         default = JSONSerializer().default
         self.assertEqual(
@@ -27,6 +29,9 @@ class TestElasticsearch7SearchQuery(TestCase):
         )
 
     query_compiler_class = Elasticsearch7SearchBackend.query_compiler_class
+    autocomplete_query_compiler_class = (
+        Elasticsearch7SearchBackend.autocomplete_query_compiler_class
+    )
 
     def test_simple(self):
         # Create a query
@@ -36,12 +41,22 @@ class TestElasticsearch7SearchQuery(TestCase):
         expected_result = {
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
-                "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
-                    }
-                },
+                "must": {"match": {"_all_text": {"query": "Hello"}}},
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_simple_autocomplete(self):
+        # Create a query
+        query = self.autocomplete_query_compiler_class(
+            models.Book.objects.all(), "Hello"
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": {"match": {"content_type": "searchtests.Book"}},
+                "must": {"match": {"_edgengrams": {"query": "Hello"}}},
             }
         }
         self.assertDictEqual(query.get_query(), expected_result)
@@ -70,10 +85,11 @@ class TestElasticsearch7SearchQuery(TestCase):
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
-                        "operator": "and",
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                            "operator": "and",
+                        }
                     }
                 },
             }
@@ -94,9 +110,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"term": {"title_filter": "Test"}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -127,9 +144,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -175,9 +193,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -205,9 +224,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -299,9 +319,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"term": {"title_filter": "Test"}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -322,9 +343,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"bool": {"mustNot": {"exists": {"field": "title_filter"}}}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -345,9 +367,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"bool": {"mustNot": {"exists": {"field": "title_filter"}}}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -368,9 +391,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"exists": {"field": "title_filter"}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -391,9 +415,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"prefix": {"title_filter": "Test"}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -419,9 +444,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"gt": "2014-04-29"}}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -445,9 +471,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"lt": "2014-04-29"}}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -471,9 +498,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"gte": "2014-04-29"}}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -497,9 +525,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"lte": "2014-04-29"}}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -531,9 +560,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }
@@ -586,10 +616,22 @@ class TestElasticsearch7SearchQuery(TestCase):
         )
 
         # Check it
+        expected_result = {"match_phrase": {"_all_text": "Hello world"}}
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_phrase_query_multiple_fields(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Phrase("Hello world"),
+            fields=["title", "content"],
+        )
+
+        # Check it
         expected_result = {
             "multi_match": {
-                "fields": ["_all_text", "_edgengrams"],
                 "query": "Hello world",
+                "fields": ["title", "content"],
                 "type": "phrase",
             }
         }
@@ -647,19 +689,6 @@ class TestElasticsearch7SearchQuery(TestCase):
         with self.assertRaises(NotImplementedError):
             query_compiler.get_inner_query()
 
-    def test_fuzzy_query_partial_match_disallowed(self):
-        # Create a query
-        query_compiler = self.query_compiler_class(
-            models.Book.objects.all(),
-            Fuzzy("Hello world"),
-            fields=["_all"],
-            partial_match=True,
-        )
-
-        # Check it
-        with self.assertRaises(NotImplementedError):
-            query_compiler.get_inner_query()
-
     def test_year_filter(self):
         # Create a query
         query_compiler = self.query_compiler_class(
@@ -674,9 +703,10 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"lt": 1900}}},
                 ],
                 "must": {
-                    "multi_match": {
-                        "query": "Hello",
-                        "fields": ["_all_text", "_edgengrams"],
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
                     }
                 },
             }

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -862,6 +862,8 @@ class TestElasticsearch7SearchResults(TestCase):
 class TestElasticsearch7Mapping(TestCase):
     fixtures = ["search"]
 
+    maxDiff = None
+
     def assertDictEqual(self, a, b):
         default = JSONSerializer().default
         self.assertEqual(
@@ -898,8 +900,6 @@ class TestElasticsearch7Mapping(TestCase):
                     "type": "text",
                     "boost": 2.0,
                     "copy_to": "_all_text",
-                    "analyzer": "edgengram_analyzer",
-                    "search_analyzer": "standard",
                 },
                 "title_edgengrams": {
                     "type": "text",
@@ -953,7 +953,6 @@ class TestElasticsearch7Mapping(TestCase):
             "_edgengrams": [
                 "J. R. R. Tolkien",
                 "The Fellowship of the Ring",
-                "The Fellowship of the Ring",
             ],
             "title": "The Fellowship of the Ring",
             "title_edgengrams": "The Fellowship of the Ring",
@@ -977,6 +976,7 @@ class TestElasticsearch7Mapping(TestCase):
 
 class TestElasticsearch7MappingInheritance(TestCase):
     fixtures = ["search"]
+    maxDiff = None
 
     def assertDictEqual(self, a, b):
         default = JSONSerializer().default
@@ -1005,6 +1005,9 @@ class TestElasticsearch7MappingInheritance(TestCase):
                 "searchtests_novel__setting": {
                     "type": "text",
                     "copy_to": "_all_text",
+                },
+                "searchtests_novel__setting_edgengrams": {
+                    "type": "text",
                     "analyzer": "edgengram_analyzer",
                     "search_analyzer": "standard",
                 },
@@ -1035,8 +1038,6 @@ class TestElasticsearch7MappingInheritance(TestCase):
                     "type": "text",
                     "boost": 2.0,
                     "copy_to": "_all_text",
-                    "analyzer": "edgengram_analyzer",
-                    "search_analyzer": "standard",
                 },
                 "title_edgengrams": {
                     "type": "text",
@@ -1094,6 +1095,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
         expected_result = {
             # New
             "searchtests_novel__setting": "Middle Earth",
+            "searchtests_novel__setting_edgengrams": "Middle Earth",
             "searchtests_novel__protagonist": {
                 "name": "Frodo Baggins",
                 "novel_id_filter": 4,
@@ -1109,7 +1111,6 @@ class TestElasticsearch7MappingInheritance(TestCase):
             "_edgengrams": [
                 "J. R. R. Tolkien",
                 "Middle Earth",
-                "The Fellowship of the Ring",
                 "The Fellowship of the Ring",
             ],
             # Inherited

--- a/wagtail/search/tests/test_indexed_class.py
+++ b/wagtail/search/tests/test_indexed_class.py
@@ -51,7 +51,7 @@ class TestSearchFields(TestCase):
     def test_basic(self):
         cls = self.make_dummy_type(
             [
-                index.SearchField("test", boost=100, partial_match=False),
+                index.SearchField("test", boost=100),
                 index.FilterField("filter_test"),
             ]
         )
@@ -72,8 +72,8 @@ class TestSearchFields(TestCase):
         # as intended.
         cls = self.make_dummy_type(
             [
-                index.SearchField("test", boost=100, partial_match=False),
-                index.SearchField("test", partial_match=True),
+                index.SearchField("test", boost=100),
+                index.SearchField("test"),
             ]
         )
 
@@ -87,14 +87,11 @@ class TestSearchFields(TestCase):
         # Boost should be reset to the default if it's not specified by the override
         self.assertIsNone(field.boost)
 
-        # Check that the partial match was overridden
-        self.assertTrue(field.partial_match)
-
     def test_different_field_types_dont_override(self):
         # A search and filter field with the same name should be able to coexist
         cls = self.make_dummy_type(
             [
-                index.SearchField("test", boost=100, partial_match=False),
+                index.SearchField("test", boost=100),
                 index.FilterField("test"),
             ]
         )

--- a/wagtail/test/search/models.py
+++ b/wagtail/test/search/models.py
@@ -26,7 +26,7 @@ class Book(index.Indexed, models.Model):
     tags = TaggableManager()
 
     search_fields = [
-        index.SearchField("title", partial_match=True, boost=2.0),
+        index.SearchField("title", boost=2.0),
         index.AutocompleteField("title"),
         index.FilterField("title"),
         index.FilterField("authors"),
@@ -91,7 +91,8 @@ class Novel(Book):
     )
 
     search_fields = Book.search_fields + [
-        index.SearchField("setting", partial_match=True),
+        index.SearchField("setting"),
+        index.AutocompleteField("setting"),
         index.RelatedFields(
             "characters",
             [


### PR DESCRIPTION
Fixes #9903 and #9657

With all search backends now supporting the `autocomplete()` method, the final piece of the puzzle is to switch Elasticsearch's `search` method away from the legacy behaviour of performing partial matches by default and requiring a `partial_match=False` argument to override that. (This was previously the standard behaviour of all backends, but the database FTS backends broke from it and now Elasticsearch is the outlier.) This means that we now enforce the use of `autocomplete` for partial-match searches across all backends, and can deprecate the `partial_match` flag that only Elasticsearch honoured at this point.

Unfortunately this has required a lot of unpicking of the Elasticsearch test suite (since all the tests were written on the basis that it would be constructing a partial-match query), but at least those changes are somewhat mechanical...