### PR TITLE
Fix two tests incorrectly testing StringIO stdout for no output

### DIFF
--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -923,7 +923,7 @@ class BackendTests(WagtailTestUtils):
         management.call_command(
             "update_index", verbosity=0, backend_name=self.backend_name, stdout=stdout
         )
-        self.assertFalse(stdout.read())
+        self.assertFalse(stdout.getvalue())
 
 
 @override_settings(

--- a/wagtail/tests/test_reference_index.py
+++ b/wagtail/tests/test_reference_index.py
@@ -238,7 +238,7 @@ class TestCreateOrUpdateForObject(TestCase):
             verbosity=0,
             stdout=stdout,
         )
-        self.assertFalse(stdout.read())
+        self.assertFalse(stdout.getvalue())
 
 
 class TestDescribeOnDelete(TestCase):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

No bug report issued.


While developing tests for another PR, I noticed at least two instances where StringIO had been used to capture the output of a management command, and then test there was no output:


```
        management.call_command(
            "rebuild_references_index",
            verbosity=0,
            stdout=stdout,
        )
        self.assertFalse(stdout.read())
```

It is necessary to either insert `stdout.seek(0)` before the read or use `stdout.getvalue()` to get the command output text. Both methods have been used across the suite of tests.

I believe I've found all the examples like this.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] ~~For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]~~
    -   [ ] **~~Please list the exact browser and operating system versions you tested~~**:
    -   [ ] **~~Please list which assistive technologies [^3] you tested~~**:
-   [ ] ~~For new features: Has the documentation been updated accordingly?~~

**Please describe additional details for testing this change**.
No further tests required.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
