### PR TITLE
Add the ability to use autocomplete search on generic IndexView and use it for snippets

### DIFF
--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -86,6 +86,7 @@ class IndexView(
     search_backend_name = "default"
     is_searchable = None
     search_kwarg = "q"
+    use_autocomplete = False
     filters = None
     filterset_class = None
     table_class = Table
@@ -261,6 +262,10 @@ class IndexView(
 
         if class_is_indexed(queryset.model) and self.search_backend_name:
             search_backend = get_search_backend(self.search_backend_name)
+            if self.use_autocomplete:
+                return search_backend.autocomplete(
+                    self.search_query, queryset, fields=self.search_fields
+                )
             return search_backend.search(
                 self.search_query, queryset, fields=self.search_fields
             )

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -504,8 +504,8 @@ class TestSnippetListViewWithSearchableSnippet(WagtailTestUtils, TransactionTest
         self.assertNotIn(self.snippet_b, items)
         self.assertIn(self.snippet_c, items)
 
-    def test_search_world(self):
-        response = self.get({"q": "World"})
+    def test_search_world_autocomplete(self):
+        response = self.get({"q": "wor"})
 
         # Just snippets with "World" should be in items
         items = list(response.context["page_obj"].object_list)

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -159,6 +159,9 @@ class IndexView(generic.IndexViewOptionalFeaturesMixin, generic.IndexView):
     any_permission_required = ["add", "change", "delete"]
     page_kwarg = "p"
     table_class = InlineActionsTable
+    # Search on the index view shows results immediately via AJAX,
+    # so it makes sense to use autocomplete rather than exact word matches
+    use_autocomplete = True
 
     def get_base_queryset(self):
         # Allow the queryset to be a callable that takes a request


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Per https://github.com/wagtail/wagtail/issues/9903#issuecomment-1513207422

Other views that extend the generic `IndexView` (e.g. users, groups, redirects) currently implement their own search with the Django ORM's `icontains` lookup, and as far as I'm aware, within Wagtail this new `use_autocomplete` option (name suggestions welcome) will only be used for Snippets (so far). However, this allows users who have a custom view based on the generic view for an `Indexed` model to make use of autocomplete.

This also ensures the snippets listing view and the chooser produces the same results for the same search query. Though I just realised that I haven't passed the search fields and search backend configuration from `SnippetViewSet` (#10290) all the way down to `SnippetChooserViewSet`, but one could argue that it should be the `SnippetChooserViewSet`'s responsibility. Either way, I think that's out of scope for now, as that requires a bit more refactoring.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

Using the database search backend, the modified test should fail before this change. With bakerydemo, searching for "oli" on the Person index view should show "Olivia Ava" in the results.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
