### PR TITLE
Fix v5.0 comment UI regressions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -88,6 +88,8 @@ Changelog
  * Fix: Prevent long preview mode names from making the select element overflow the side panel (Sage Abdullah)
  * Fix: Autosize text area field will now correctly resize when switching between comments toggle states (Suyash Srivastava)
  * Fix: When i18n is not enabled, avoid making a Locale query on every page view (Dan Braghis)
+ * Fix: Fix initialisation of commenting widgets within StreamField (Thibaud Colas)
+ * Fix: Fix various regressions in the commenting UI (Thibaud Colas)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp, Thibaud Colas)
  * Docs: Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)

--- a/client/scss/components/_form-side.scss
+++ b/client/scss/components/_form-side.scss
@@ -19,6 +19,7 @@
       w-right-0
       w-top-full
       w-h-[calc(100vh-100%)]
+      w-invisible
       w-transform
       w-translate-x-full
       rtl:-w-translate-x-full
@@ -44,7 +45,7 @@
   }
 
   &--open {
-    @apply w-translate-x-0 rtl:w-translate-x-0;
+    @apply w-translate-x-0 rtl:w-translate-x-0 w-visible;
   }
 
   &--initial {

--- a/client/scss/components/forms/_field-comment-control.scss
+++ b/client/scss/components/forms/_field-comment-control.scss
@@ -1,3 +1,8 @@
+// Comments
+$icon-size: theme('spacing.4');
+$button-padding: theme('spacing.2');
+$button-space: theme('spacing.1');
+
 .w-field__comment-button {
   $root: &;
 
@@ -6,24 +11,21 @@
   color: theme('colors.text-button-outline-default');
   background: none;
   border: 0;
-  padding: 0;
-  inset-inline-end: 0;
+  padding: theme('spacing.4') $button-padding;
+  inset-inline-end: calc(-1 * ($icon-size + $button-padding * 2));
   top: 50%;
   transform: translateY(-50%);
-  margin-inline-start: theme('spacing.[2.5]');
-  visibility: hidden;
   opacity: 0;
 
   .icon {
-    width: $comment-button-size;
-    height: $comment-button-size;
+    width: $icon-size;
+    height: $icon-size;
     color: inherit;
   }
 
   // For devices without hover support, always show when comments are enabled.
   @media (hover: none) {
     .tab-content--comments-enabled & {
-      visibility: visible;
       opacity: 1;
     }
   }
@@ -35,7 +37,6 @@
     &:hover,
     &:focus,
     &.w-field__comment-button--focused {
-      visibility: visible;
       opacity: 1;
     }
   }
@@ -45,7 +46,7 @@
   .w-field--checkbox_select_multiple &,
   .w-field--admin_tag_widget & {
     transform: translateY(0);
-    top: 0.3125rem;
+    top: 0;
   }
 
   .w-field--date_field &,
@@ -53,7 +54,7 @@
   .w-field--time_field & {
     position: relative;
     transform: translateY(0);
-    top: 0.3125rem;
+    top: 0;
   }
 }
 

--- a/client/scss/components/forms/_field-comment-control.scss
+++ b/client/scss/components/forms/_field-comment-control.scss
@@ -65,7 +65,7 @@ $button-space: theme('spacing.1');
   }
 
   &:not(:hover) {
-    .icon-comment-add {
+    .icon-comment-add-reversed {
       display: block;
     }
   }
@@ -73,7 +73,7 @@ $button-space: theme('spacing.1');
   &:hover {
     cursor: pointer;
 
-    .icon-comment-add-reversed {
+    .icon-comment-add {
       display: block;
     }
   }

--- a/client/scss/components/forms/_field.scss
+++ b/client/scss/components/forms/_field.scss
@@ -63,13 +63,6 @@
 .w-field__input {
   position: relative;
   margin-top: theme('spacing.[2.5]');
-  // This padding gives room for widgets such as comments beside of inputs
-  padding-inline-end: calc($comment-button-size + $comment-button-space);
-
-  .w-field__input {
-    // No need for extra padding for nested field inputs.
-    padding-inline-end: 0;
-  }
 }
 
 .w-field__icon {

--- a/client/scss/components/forms/_publishing.scss
+++ b/client/scss/components/forms/_publishing.scss
@@ -5,11 +5,6 @@
     margin-bottom: theme('spacing.2');
   }
 
-  .w-field__input {
-    // Remove unnecessary padding so that the fields fit within the dialog
-    padding-inline-end: 0;
-  }
-
   .w-field--date_time_field input {
     width: 100%;
   }

--- a/client/scss/layouts/_login.scss
+++ b/client/scss/layouts/_login.scss
@@ -82,10 +82,6 @@
     font-weight: theme('fontWeight.bold');
   }
 
-  .w-field__input {
-    padding: 0; // reset padding for field not used inside the admin interface
-  }
-
   .w-field__wrapper {
     margin-bottom: theme('spacing.6');
   }

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -60,10 +60,6 @@ $mobile-nav-indent: 50px;
 $sidebar-toggle-spacing: 12px;
 $sidebar-toggle-size: 35px;
 
-// Comments
-$comment-button-size: theme('spacing.5');
-$comment-button-space: theme('spacing.3');
-
 // transitions
 // Please keep in sync with SIDEBAR_TRANSITION_DURATION variable in `client/src/components/Sidebar/Sidebar.tsx`
 $menu-transition-duration: 150ms;

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.scss
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.scss
@@ -9,16 +9,11 @@
 .Draftail-CommentControl .Draftail-ToolbarButton {
   color: theme('colors.text-button-outline-default');
 
-  .icon {
-    width: theme('spacing.5');
-    height: theme('spacing.5');
-  }
-
-  &:not(:hover) .icon-comment-add-reversed {
+  &:not(:hover) .icon-comment-add {
     display: none;
   }
 
-  &:hover .icon-comment-add {
+  &:hover .icon-comment-add-reversed {
     display: none;
   }
 }

--- a/client/src/components/StreamField/blocks/FieldBlock.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.js
@@ -78,7 +78,6 @@ export class FieldBlock {
       addCommentButtonElement.classList.add(
         'w-field__comment-button',
         'w-field__comment-button--add',
-        'u-hidden',
       );
 
       ReactDOM.render(

--- a/client/src/components/StreamField/blocks/__snapshots__/FieldBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/FieldBlock.test.js.snap
@@ -51,7 +51,7 @@ exports[`telepath: wagtail.blocks.FieldBlock with comments enabled it renders co
           <div class=\\"w-field__help\\" id=\\"the-prefix-helptext\\" data-field-help=\\"\\"><p class=\\"help\\">drink <em>more</em> water</p></div>
           <div class=\\"w-field__input\\" data-field-input=\\"\\">
             <p name=\\"the-prefix\\" id=\\"the-prefix\\">The widget</p>
-          <button type=\\"button\\" aria-label=\\"Add Comment\\" data-comment-add=\\"\\" class=\\"w-field__comment-button w-field__comment-button--add u-hidden\\"><svg class=\\"icon icon-comment-add \\" aria-hidden=\\"true\\"><use href=\\"#icon-comment-add\\"></use></svg><svg class=\\"icon icon-comment-add-reversed \\" aria-hidden=\\"true\\"><use href=\\"#icon-comment-add-reversed\\"></use></svg></button></div>
+          <button type=\\"button\\" aria-label=\\"Add Comment\\" data-comment-add=\\"\\" class=\\"w-field__comment-button w-field__comment-button--add\\"><svg class=\\"icon icon-comment-add \\" aria-hidden=\\"true\\"><use href=\\"#icon-comment-add\\"></use></svg><svg class=\\"icon icon-comment-add-reversed \\" aria-hidden=\\"true\\"><use href=\\"#icon-comment-add-reversed\\"></use></svg></button></div>
         </div>
       </div>"
 `;

--- a/client/src/entrypoints/admin/comments.js
+++ b/client/src/entrypoints/admin/comments.js
@@ -144,17 +144,13 @@ window.comments = (() => {
   }
 
   class FieldLevelCommentWidget {
-    constructor({ fieldNode, commentAdditionNode, annotationTemplateNode }) {
+    constructor({ fieldNode, commentAdditionNode }) {
       this.fieldNode = fieldNode;
       this.contentpath = getContentPath(fieldNode);
       if (!commentAdditionNode) {
         throw new MissingElementError(commentAdditionNode);
       }
       this.commentAdditionNode = commentAdditionNode;
-      if (!annotationTemplateNode) {
-        throw new MissingElementError(annotationTemplateNode);
-      }
-      this.annotationTemplateNode = annotationTemplateNode;
     }
 
     register() {
@@ -221,7 +217,9 @@ window.comments = (() => {
     }
 
     getAnnotationForComment() {
-      const annotationNode = this.annotationTemplateNode.cloneNode(true);
+      const annotationNode = document
+        .querySelector('#comment-icon')
+        .cloneNode(true);
       annotationNode.id = '';
       annotationNode.setAttribute(
         'aria-label',
@@ -248,7 +246,6 @@ window.comments = (() => {
     const widget = new FieldLevelCommentWidget({
       fieldNode: buttonElement.closest('[data-contentpath]'),
       commentAdditionNode: buttonElement,
-      annotationTemplateNode: document.querySelector('#comment-icon'),
     });
     widget.register();
   }

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -143,6 +143,8 @@ We hope this new theme will bring accessibility improvements for users who perfe
  * Fix template configuration of snippets index results view (fidoriel, Sage Abdullah)
  * Prevent long preview mode names from making the select element overflow the side panel (Sage Abdullah)
  * When i18n is not enabled, avoid making a Locale query on every page view (Dan Braghis)
+ * Fix initialisation of commenting widgets within StreamField (Thibaud Colas)
+ * Fix various regressions in the commenting UI (Thibaud Colas)
 
 ### Documentation
 

--- a/wagtail/contrib/typed_table_block/static_src/typed_table_block/scss/typed_table_block.scss
+++ b/wagtail/contrib/typed_table_block/static_src/typed_table_block/scss/typed_table_block.scss
@@ -94,4 +94,14 @@
   .control-cell ul.add-column-menu {
     top: 0;
   }
+
+  .w-field--commentable {
+    // Add enough space for the comment button.
+    padding-inline-end: theme('spacing.8');
+  }
+
+  .w-field--draftail_rich_text_area {
+    // Add enough space for the block picker.
+    padding-inline-start: theme('spacing.9');
+  }
 }


### PR DESCRIPTION
Fixes a number of regressions with the commenting UI from #8345. The regressions are all unrelated to one-another aside from being about commenting, so might be easier to review commit-by-commit.

- The initialisation of the commenting widgets was failing within StreamField. There was likely a race condition in the previous implementation between Telepath initialising the fields and commenting initialisation.
- Changes to how comment buttons are positioned caused "add" buttons inside StreamField to overlap with the field. I’ve made further changes to how we do this so we fully get rid of the right padding of the fields, and instead use absolute positioning only.
- Comment buttons in StreamField were hidden permanently with `display: none` so couldn’t be revealed on hover
- The side panel’s "close" button was reachable when tabbing through the page, because we didn’t correctly hide the side panel when closed.

Additionally I swapped the comments’ "add" button’s default and hover icons, as per the design. This means the outline icon by default, and the filled icon on hover.

Recording of the result of all those changes:

![comment-regressions](https://user-images.githubusercontent.com/877585/233265366-515a0d40-e868-4545-960d-d9586bcfbd9d.gif)

There are still a few visual issues with comments in _dark mode_ specifically but those can wait.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 112, Firefox 111, Safari 16.3 on macOS 13.2
    -   [x] **Please list which assistive technologies [^3] you tested**: Keyboard, VoiceOver, WHCM
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

To test this,

- Go to a RecipePage in bakerydemo and try to add a comment on a Heading block in both the "Backstory" and "Body" fields
  - Note the "add" button appears as expected on hover/focus
  - Note the "add" button’s position is correct (top right next to the field)
  - Note the "add" button uses the outline icon, and filled icon on hover
- Tab through the slim header, minimap, and reach the page’s "Content" tab without having seen the side panels