### PR TITLE
Dispatch resize event to resize Handsontable on initialisation

### DIFF
--- a/client/src/entrypoints/contrib/table_block/table.js
+++ b/client/src/entrypoints/contrib/table_block/table.js
@@ -174,7 +174,7 @@ function initTable(id, tableOptions) {
     // Render the table. Calling render also removes 'null' literals from empty cells.
     hot.render();
     resizeHeight(getHeight());
-    resizeWidth(getWidth());
+    window.dispatchEvent(new Event('resize'));
   });
 }
 window.initTable = initTable;


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10335 by modifying the width resize to rely on the event handlers by dispatching a `resize` event, much like how it worked pre-#10223.

File under: mysterious ways of how Handsontable works

Dark mode styles will be fixed separately.




_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
