### PR TITLE
Fix side panel stuck in resize state when pointer is released outside the grip

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -105,6 +105,7 @@ Changelog
  * Fix: Fix various regressions in the commenting UI (Thibaud Colas)
  * Fix: Prevent TableBlock from becoming uneditable after save (Sage Abdullah)
  * Fix: Correctly show the "new item" badge within menu sections previously dismissed (Sage Abdullah)
+ * Fix: Fix side panel stuck in resize state when pointer is released outside the grip (Sage Abdullah)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp, Thibaud Colas)
  * Docs: Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)
@@ -340,6 +341,12 @@ Changelog
  * Maintenance: Remove unused `icon-help` and `help-inverse` code (Thibaud Colas)
  * Maintenance: Migrate privacy switch, FileFields, history buttons, error messages, Datetimepicker, ordering icons, thumbnails, ModelAdmin, page listings, workflows, and user creation form controls to SVG icons (Thibaud Colas)
  * Maintenance: Switch form submission listings to use the same ordering icons as other listings (Thibaud Colas)
+
+
+4.1.5 (xx.xx.xxxx) - IN DEVELOPMENT
+~~~~~~~~~~~~~~~~
+
+ * Fix: Fix side panel stuck in resize state when pointer is released outside the grip (Sage Abdullah)
 
 
 4.1.4 (03.04.2023)

--- a/client/scss/components/_preview-panel.scss
+++ b/client/scss/components/_preview-panel.scss
@@ -37,6 +37,12 @@
       // Transform with the top-right physical corner as the origin since the layout is reversed.
       transform-origin: top right;
     }
+
+    // Prevent the iframe from capturing pointer events when resizing the panel, which
+    // would consume the pointerup event and leaving the panel stuck in a resizing state.
+    .side-panel-resizing & {
+      pointer-events: none;
+    }
   }
 
   &__sizes {

--- a/client/src/includes/sidePanel.js
+++ b/client/src/includes/sidePanel.js
@@ -182,6 +182,13 @@ export default function initSidePanel() {
     setSidePanelWidth(startWidth + delta * direction);
   };
 
+  const onPointerUp = (e) => {
+    resizeGrip.releasePointerCapture(e.pointerId);
+    resizeGrip.removeEventListener('pointermove', onPointerMove);
+    document.removeEventListener('pointerup', onPointerUp);
+    document.body.classList.remove('side-panel-resizing');
+  };
+
   resizeGrip.addEventListener('pointerdown', (e) => {
     // Ignore right-click, because it opens the context menu and doesn't trigger
     // pointerup when the click is released.
@@ -196,12 +203,11 @@ export default function initSidePanel() {
     document.body.classList.add('side-panel-resizing');
     resizeGrip.setPointerCapture(e.pointerId);
     resizeGrip.addEventListener('pointermove', onPointerMove);
-  });
 
-  resizeGrip.addEventListener('pointerup', (e) => {
-    resizeGrip.removeEventListener('pointermove', onPointerMove);
-    resizeGrip.releasePointerCapture(e.pointerId);
-    document.body.classList.remove('side-panel-resizing');
+    // The pointerup event might not be dispatched on the resizeGrip itself
+    // (e.g. when the pointer is above/below the grip, or beyond the side panel's
+    // minimum/maximum width), so listen for it on the document instead.
+    document.addEventListener('pointerup', onPointerUp);
   });
 
   // Handle resizing with keyboard using a hidden range input.

--- a/docs/releases/4.1.5.md
+++ b/docs/releases/4.1.5.md
@@ -1,0 +1,17 @@
+# Wagtail 4.1.5 release notes
+
+_Unreleased_
+
+```{contents}
+---
+local:
+depth: 1
+---
+```
+
+## What's new
+
+### Bug fixes
+
+ * Fix side panel stuck in resize state when pointer is released outside the grip (Sage Abdullah)
+

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -156,6 +156,7 @@ These features were developed by Sage Abdullah.
  * Fix various regressions in the commenting UI (Thibaud Colas)
  * Prevent TableBlock from becoming uneditable after save (Sage Abdullah)
  * Correctly show the "new item" badge within menu sections previously dismissed (Sage Abdullah)
+ * Fix side panel stuck in resize state when pointer is released outside the grip (Sage Abdullah)
 
 ### Documentation
 


### PR DESCRIPTION


<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes an issue where the side panel would be stuck in the resizing state if the pointer is released on top of the iframe or the minimap. 

To test, open the preview panel mode and drag the resize grip. When releasing the mouse button, make sure the pointer is above the iframe or the minimap. You'll notice that the cursor is still showing the resize cursor, and if you then hover to the resize grip then move the pointer to the left/right, the side panel will be resized, even when you're not holding down the mouse button.

A similar issue could sometimes also be triggered if:
- you release the pointer above or below the grip, or
- you hover to the main menu (while still dragging), and then release the button somewhere between the minimap or the iframe (not sure where exactly would trigger it)

This PR fixes all of the above cases.





_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 112, Firefox 112, Safari 16.4
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?


[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
