### PR TITLE
Fix translatable snippets listing language switcher position

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -15,6 +15,7 @@
     - `action_url` - if present, display an 'action' button. This is the URL to be used as the link URL for the button
     - `action_text` - text for the 'action' button
     - `action_icon` - icon for the 'action' button, default is 'plus'
+    - `base_actions` - base actions to appear before the main action
     - `extra_actions` - extra action buttons for the header. This is the HTML to be used for the extra buttons
     - `breadcrumb` - Custom breadcrumbs content as a variable, displayed in place of breadcrumb block before the header content
     - `header` - Replaces the header `h1` completely with custom variable content
@@ -58,6 +59,7 @@
             {% block right_column %}
                 {% if action_url %}
                     <div class="actionbutton">
+                        {{ base_actions }}
                         {% with action_icon|default:'plus' as action_icon_name %}
                             <a href="{{ action_url }}" class="button bicolor button--icon">{% icon name=action_icon_name wrapped=1 %}{{ action_text }}</a>
                         {% endwith %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/index.html
@@ -18,10 +18,10 @@
 
 {% block content %}
     {% fragment as breadcrumb %}{% include 'wagtailsnippets/snippets/headers/list_header.html' %}{% endfragment %}
-    {% fragment as extra_actions_locale %}{% if locale %}{% include 'wagtailadmin/shared/locale_selector.html' with class='c-dropdown--large' %}{% endif %}{% endfragment %}
+    {% fragment as base_action_locale %}{% if locale %}{% include 'wagtailadmin/shared/locale_selector.html' with class='c-dropdown--large' %}{% endif %}{% endfragment %}
     {% fragment as action_url_add_snippet %}{% if can_add_snippet %}{% url view.add_url_name %}{% if locale %}?locale={{ locale.language_code }}{% endif %}{% endif %}{% endfragment %}
     {% fragment as action_text_snippet %}{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}{% endfragment %}
-    {% include 'wagtailadmin/shared/header.html' with breadcrumb=breadcrumb title=model_opts.verbose_name_plural|capfirst icon=header_icon search_url=search_url  extra_actions=extra_actions_locale action_url=action_url_add_snippet action_icon="plus" action_text=action_text_snippet %}
+    {% include 'wagtailadmin/shared/header.html' with breadcrumb=breadcrumb title=model_opts.verbose_name_plural|capfirst icon=header_icon search_url=search_url base_actions=base_action_locale action_url=action_url_add_snippet action_icon="plus" action_text=action_text_snippet %}
 
     <div class="nice-padding{% if filters %} filterable{% endif %}">
         <div id="snippet-results" class="snippets">


### PR DESCRIPTION
- Adds a new `base_actions` template variable
- Fixes #10363

<img width="2010" alt="Screenshot 2023-04-21 at 4 22 06 pm" src="https://user-images.githubusercontent.com/1396140/233557902-2b2a7e12-4827-4e76-a7b4-5f34d3b789cc.png">

Note: I tried a few different approaches before adding a new template variable but this seemed to be the simplest.

We should try to make the way that the header actions are added a bit simpler but did not want to make this PR more complex. For example - when we add 'filtering' we do this multiple ways, sometimes in a sidebar, sometimes in a header (as called out on https://github.com/wagtail/wagtail/issues/10363#issuecomment-1515105873 ). We also have 'exports' showing at the right of the main action which means the 'add thing' is not always the right side thing.

Hopefully this change is ok for the 5.0 RC regression fix though and I might raise a new issue later to get some additional clean up actioned for header ... actions.