### PR TITLE
Design fixes for v5.0 release candidate

### DIFF
--- a/client/scss/components/_form-side.scss
+++ b/client/scss/components/_form-side.scss
@@ -75,7 +75,7 @@
   }
 
   &__resize-grip {
-    @apply w-text-icon-secondary hover:w-text-icon-secondary-hover w-border w-border-transparent w-rounded w-bg-surface-page w-p-2.5 w-hidden w-touch-pinch-zoom w-cursor-ew-resize;
+    @apply w-text-icon-secondary hover:w-text-icon-secondary-hover w-border w-border-transparent w-rounded w-bg-surface-page w-py-2.5 w-pl-2.5 w-hidden w-touch-pinch-zoom w-cursor-ew-resize;
 
     .form-side--open & {
       @apply w-flex;

--- a/client/src/components/CommentApp/components/Comment/style.scss
+++ b/client/src/components/CommentApp/components/Comment/style.scss
@@ -10,7 +10,7 @@
   inset-inline-end: 0;
 
   &--focused {
-    inset-inline-end: 30px;
+    inset-inline-end: 25px;
   }
 
   &__text {

--- a/client/src/components/Minimap/Minimap.scss
+++ b/client/src/components/Minimap/Minimap.scss
@@ -3,6 +3,7 @@ $minimap-top-offset: var(--offset-top, calc(theme('spacing.slim-header') * 2));
 $minimap-width: 260px;
 $minimap-collapsed-width-mobile: 20px;
 $minimap-collapsed-width: 30px;
+$minimap-overflow: theme('spacing.2');
 $minimap-z-index: calc(theme('zIndex.header') - 20);
 
 @import './CollapseAll';
@@ -97,6 +98,7 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   min-height: 70px;
 
   :where(.w-minimap--expanded) & {
+    margin-inline-start: $minimap-overflow;
     border-inline-start: 1px solid theme('colors.border-furniture');
   }
 }
@@ -108,6 +110,10 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   overflow-x: hidden;
   list-style-type: none;
 
+  :where(.w-minimap--expanded) & {
+    padding-inline-start: $minimap-overflow;
+  }
+
   > li {
     display: flex;
   }
@@ -117,6 +123,7 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   flex-grow: 1;
 
   :where(.w-minimap--expanded) & {
+    margin-inline-start: $minimap-overflow;
     border-inline-start: 1px solid theme('colors.border-furniture');
   }
 }


### PR DESCRIPTION
Implements fixes for two unrelated issues I had introduced in the first RC:

- The minimap error badges should be able to overflow their container without getting cropped
- The page editor’s side panel resize grip shouldn’t overlap with comments (happened for focused comments only), or with the preview iframe (happened at the smallest panel size only).