### PR TITLE
Disable homepage release banner

### DIFF
--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -315,7 +315,8 @@ class HomeView(WagtailAdminTemplateMixin, TemplateView):
         request = self.request
         panels = [
             SiteSummaryPanel(request),
-            WhatsNewInWagtailVersionPanel(),
+            # Disabled until a release warrants the banner.
+            # WhatsNewInWagtailVersionPanel(),
             UpgradeNotificationPanel(),
             WorkflowObjectsToModeratePanel(),
             PagesForModerationPanel(),


### PR DESCRIPTION
The "Things in Wagtail 4 have changed" banner isn’t that suitable for the latest Wagtail 5.0 release, since the user-facing changes in there are rather incremental.

I’ve only commented out the relevant line in dashboard panels definitions so we get to bring this back easily in the future.