### PR TITLE
Update ReadTheDocs settings to v2 to resolve urllib3 build issue

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,11 @@
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.11'
 python:
-  version: 3.7
-  pip_install: true
-requirements_file: null
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-myst_parser==0.18.1
-sphinx-wagtail-theme==6.0.0
-sphinx-copybutton>=0.5,<1.0


### PR DESCRIPTION
Spotted as part of #10407. There is an issue with Read The Docs’ builds due to an upstream dependency update (`urllib3` incompatible with Ubuntu 20?). See https://github.com/readthedocs/readthedocs.org/issues/10290.

This attempts to update our RTD configuration to their v2 schema, so we can specify `ubuntu-22.04` as the Docker image for our builds. Except for the Python version upgrade, all changes here are according to my understanding of the RTD configuration file [migrating from v1](https://docs.readthedocs.io/en/stable/config-file/v2.html#migrating-from-v1) guidance.

---

Build error (see [full job logs](https://readthedocs.org/projects/wagtail/builds/20418521/)):

```
python -m sphinx -T -E -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
Running Sphinx v5.3.0

[…]
Could not import extension sphinx.builders.linkcheck (exception: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017. See: https://github.com/urllib3/urllib3/issues/2168)
```

---

As part of this I chose to switching to installing the `docs` extra and removing the separate `requirements.txt`. I believe it would be possible to replicate the build steps as-is if we wanted though. Relevant RTD build logs _before_ this change:

```
python -m pip install --upgrade --no-cache-dir pillow==5.4.1 mock==1.0.1 alabaster>=0.7,<0.8,!=0.7.5 commonmark==0.9.1 recommonmark==0.5.0 sphinx<2 sphinx-rtd-theme<0.5 readthedocs-sphinx-ext<2.3 jinja2<3.1.0
python -m pip install --exists-action=w --no-cache-dir -r docs/requirements.txt
python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir /home/docs/checkouts/readthedocs.org/user_builds/wagtail/checkouts/10400
```

RTD build logs _after_ this change:

```
python -m pip install --upgrade --no-cache-dir pillow mock==1.0.1 alabaster>=0.7,<0.8,!=0.7.5 commonmark==0.9.1 recommonmark==0.5.0 sphinx<2 sphinx-rtd-theme<0.5 readthedocs-sphinx-ext<2.3 jinja2<3.1.0
python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir .[docs]
```