### PR TITLE
correct the way of getting the storage of an image(#9904)

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -165,7 +165,7 @@ class ImageFileMixin:
                 else:
                     # Some external storage backends don't allow reopening
                     # the file. Get a fresh file instance. #1397
-                    storage = self._meta.get_field("file").storage
+                    storage = self.file.storage
                     image_file = storage.open(self.file.name, "rb")
 
                 close_file = True


### PR DESCRIPTION
Fixes #9904 


-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?