### PR TITLE
Fix typo in 5.0 release doc

### DIFF
--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -70,7 +70,7 @@ Thank you to everyone who provided feedback on this new addition to the editor e
 
 Wagtail’s admin interface now supports dark mode. The new dark theme can be enabled in account preferences, as well as configuring permanent usage of the light theme, or following system preferences.
 
-We hope this new theme will bring accessibility improvements for users who perfer light text on dark backgrounds, and energy usage efficiency improvements for users of OLED monitors. This feature was developed by Thibaud Colas, with designs from Ben Enright.
+We hope this new theme will bring accessibility improvements for users who prefer light text on dark backgrounds, and energy usage efficiency improvements for users of OLED monitors. This feature was developed by Thibaud Colas, with designs from Ben Enright.
 
 ### Snippets parity with ModelAdmin
 


### PR DESCRIPTION
Fixes the typo "perfer" in release notes for version 5.0.

Looks like the readthedocs job is failing, I believe the following PR should resolve it: https://github.com/wagtail/wagtail/pull/10408. I'll rebase when it's merged.