### PR TITLE
Patch chooser view/widget to support non-model data sources

### DIFF
--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -58,7 +58,10 @@ class BaseChooser(widgets.Input):
 
     @cached_property
     def model_class(self):
-        return resolve_model_string(self.model)
+        if isinstance(self.model, type):
+            return self.model
+        else:
+            return resolve_model_string(self.model)
 
     def value_from_datadict(self, data, files, name):
         # treat the empty string as None
@@ -129,6 +132,9 @@ class BaseChooser(widgets.Input):
         """
         return str(instance)
 
+    def get_object_id(self, instance):
+        return instance.pk
+
     def get_value_data_from_instance(self, instance):
         """
         Given a model instance, return a value that we can pass to both the server-side template
@@ -136,7 +142,7 @@ class BaseChooser(widgets.Input):
         for display. Typically this is a dict of id, title etc; it must be JSON-serialisable.
         """
         return {
-            "id": instance.pk,
+            "id": self.get_object_id(instance),
             "edit_url": AdminURLFinder().get_edit_url(instance),
             self.display_title_key: self.get_display_title(instance),
         }


### PR DESCRIPTION
A first pass at supporting non-model data sources (such as django-rest-framework API endpoints) in chooser widgets / views. [wagtail-generic-chooser](https://github.com/wagtail/wagtail-generic-chooser) handled this by abstracting away the data-handling (e.g. filtering, ordering and pagination of the result set) from the presentation, but this made the code overly complicated for the sake of a 'niche' use-case. And in any case, Django's QuerySet API is already a perfectly good abstraction away from databases - we don't really need another one :-)

My new approach is a new package [queryish](https://github.com/wagtail/queryish) that allows building Model / QuerySet-like classes that replicate enough of the QuerySet API to serve as the backend for basic filtered / paginated listing views. `wagtail.admin.viewsets.chooser` only needs fairly minor tweaks to be persuaded to accept these in place of models - specifically, avoiding calls to `resolve_model_string` on something that's neither a string nor a model class, and providing overrideable functions for getting ID and display title from our instances (which will often be raw dicts rather than real object instances).

With these changes, I was able to implement a simple DRF-backed chooser as follows:

```python
# views.py
from queryish.rest import APISource
from wagtail.admin.views.generic.chooser import ChooseResultsView, ChooseView, ChosenView, ChosenMultipleView
from wagtail.admin.viewsets.chooser import ChooserViewSet
from wagtail.admin.widgets.chooser import BaseChooser


class CountryAPISource(APISource):
    base_url = "http://localhost:8001/api/countries/"
    filter_fields = ["id", "name", "continent"]
    ordering_fields = ["id", "name", "continent"]


class CountryChooseView(ChooseView):
    def get_object_id(self, instance):
        return instance['id']

    def get_display_title(self, instance):
        return instance['name']


class CountryChooseResultsView(ChooseResultsView):
    def get_object_id(self, instance):
        return instance['id']

    def get_display_title(self, instance):
        return instance['name']


class CountryChosenView(ChosenView):
    def get_object_id(self, instance):
        return instance['id']

    def get_display_title(self, instance):
        return instance['name']


class CountryChosenMultipleView(ChosenMultipleView):
    def get_object_id(self, instance):
        return instance['id']

    def get_display_title(self, instance):
        return instance['name']


class BaseCountryChooserWidget(BaseChooser):
    # workaround for https://github.com/wagtail/wagtail/pull/9320 which causes chooser buttons to be invisible
    # for choosers that aren't within a ModelChoiceField
    classname = "w-field--model_choice_field"

    def get_object_id(self, instance):
        return instance['id']

    def get_display_title(self, instance):
        return instance['name']


class CountryChooserViewSet(ChooserViewSet):
    model = CountryAPISource
    choose_view_class = CountryChooseView
    choose_results_view_class = CountryChooseResultsView
    chosen_view_class = CountryChosenView
    chosen_multiple_view_class = CountryChosenMultipleView
    base_widget_class = BaseCountryChooserWidget

    choose_one_text = "Choose a country"
    choose_another_text = "Choose another country"

    # prevent viewset from registering the widget as the default one to use for ForeignKeys
    # to CountryAPISource (which can't exist)
    register_widget = False


country_chooser_viewset = CountryChooserViewSet("country_chooser")
CountryChooserWidget = country_chooser_viewset.widget_class


# wagtail_hooks.py
from wagtail import hooks
from .views import country_chooser_viewset


@hooks.register("register_admin_viewset")
def register_viewset():
    return country_chooser_viewset


# models.py
from .views import CountryChooserWidget
# within a page model:
    country = models.IntegerField(null=True, blank=True)
    content_panels = [
        # ...
        FieldPanel("country", widget=CountryChooserWidget),
    ]
```

Clearly it would be massively beneficial to be able to define `get_object_id` and `get_display_title` on the viewset and have those definitions propagate to the view / widget classes that need them. Since we want view / widget classes to continue being standalone and avoid containing any "am I part of a viewset?"-type logic, I think this would be best done by having the viewset dynamically build subclasses of `choose_view_class` and friends where appropriate. Doing this longhand for each class will be very boilerplate-y, so in an ideal world this would become a stock feature of the viewset mechanism - perhaps the relevant methods on the view / widget classes could be decorated with an "I am valid to be overridden in a dynamic-subclassing context" decorator that the viewset recognises.