### PR TITLE
Ensure that copying page correctly picks up the latest revision

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~~
 
  * Fix: Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
+ * Fix: Ensure that copying page correctly picks up the latest revision (Matt Westcott)
 
 
 5.0 (02.05.2023)
@@ -165,6 +166,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~~
 
  * Fix: Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
+ * Fix: Ensure that copying page correctly picks up the latest revision (Matt Westcott)
 
 
 4.2.3 (02.05.2023)
@@ -366,6 +368,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~~
 
  * Fix: Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
+ * Fix: Ensure that copying page correctly picks up the latest revision (Matt Westcott)
 
 
 4.1.5 (02.05.2023)

--- a/docs/releases/4.1.6.md
+++ b/docs/releases/4.1.6.md
@@ -14,3 +14,4 @@ depth: 1
 ### Bug fixes
 
  * Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
+ * Ensure that copying page correctly picks up the latest revision (Matt Westcott)

--- a/docs/releases/4.2.4.md
+++ b/docs/releases/4.2.4.md
@@ -14,3 +14,4 @@ depth: 1
 ### Bug fixes
 
  * Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
+ * Ensure that copying page correctly picks up the latest revision (Matt Westcott)

--- a/docs/releases/5.0.1.md
+++ b/docs/releases/5.0.1.md
@@ -14,3 +14,4 @@ depth: 1
 ### Bug fixes
 
  * Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
+ * Ensure that copying page correctly picks up the latest revision (Matt Westcott)


### PR DESCRIPTION
Fixes #10393

Ensure that `CopyPageAction` correctly sets the `latest_revision` field on the copied page before saving the additional revision - failing to do this means that the additional revision will be based on whatever is in the real database table instead.

_Please check the following:_

-   [ ] Do the tests still pass?
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
