### PR TITLE
Ensure field comment buttons always respect WAGTAILADMIN_COMMENTS_ENABLED. Fix #10406

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changelog
 
  * Fix: Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
  * Fix: Ensure that copying page correctly picks up the latest revision (Matt Westcott)
+ * Fix: Ensure comment buttons always respect `WAGTAILADMIN_COMMENTS_ENABLED` (Thibaud Colas)
  * Docs: Update documentation for `log_action` parameter on `RevisionMixin.save_revision` (Christer Jensen)
 
 

--- a/client/scss/components/forms/_field-comment-control.scss
+++ b/client/scss/components/forms/_field-comment-control.scss
@@ -15,12 +15,18 @@ $button-space: theme('spacing.1');
   inset-inline-end: calc(-1 * ($icon-size + $button-padding * 2));
   top: 50%;
   transform: translateY(-50%);
+  // Only show the buttons when commenting is enabled.
+  display: none;
   opacity: 0;
 
   .icon {
     width: $icon-size;
     height: $icon-size;
     color: inherit;
+  }
+
+  .tab-content--comments-enabled & {
+    display: block;
   }
 
   // For devices without hover support, always show when comments are enabled.
@@ -32,8 +38,8 @@ $button-space: theme('spacing.1');
 
   // Hide by default, reveal on hover of parent, for devices supporting hover interaction
   @media (hover: hover) {
-    .tab-content--comments-enabled .w-field__input:hover > &,
-    .tab-content--comments-enabled .w-field__input:focus-within > &,
+    .w-field__input:hover > &,
+    .w-field__input:focus-within > &,
     &:hover,
     &:focus,
     &.w-field__comment-button--focused {

--- a/docs/releases/5.0.1.md
+++ b/docs/releases/5.0.1.md
@@ -15,6 +15,7 @@ depth: 1
 
  * Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
  * Ensure that copying page correctly picks up the latest revision (Matt Westcott)
+ * Ensure comment buttons always respect `WAGTAILADMIN_COMMENTS_ENABLED` (Thibaud Colas)
 
 ### Documentation
 


### PR DESCRIPTION
Fixes #10406. Updates the comment button styles to make sure the buttons are always hidden when commenting is disabled with `WAGTAILADMIN_COMMENTS_ENABLED`.

The selectors had been refactored along the way and we were still showing the comment buttons on direct hover/focus. The new implementation completely separates the buttons’ reveal effect with `opacity` from their "enabled/disabled" logic so the code is simpler to follow and less error-prone.

---

Ideally we wouldn’t need this `.tab-content--comments-enabled` at all and would instead _not_ add the buttons onto the page when comments are enabled. I’ve added that to the list of refactorings on #9670.

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 112, Firefox 111 on macOS 13.2
    -   [x] **Please list which assistive technologies [^3] you tested**: WHCM
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

To test this, set `WAGTAILADMIN_COMMENTS_ENABLED = False` in Django settings.