### PR TITLE
Fix TableBlock initialisation

### DIFF
--- a/client/src/entrypoints/contrib/table_block/table.js
+++ b/client/src/entrypoints/contrib/table_block/table.js
@@ -30,7 +30,7 @@ function initTable(id, tableOptions) {
     });
     return htCoreHeight + tableParent.find('[data-field]').first().height();
   };
-  const resizeTargets = ['.handsontable', '.wtHider', '.wtHolder'];
+  const resizeTargets = [`#${containerId}`, '.wtHider', '.wtHolder'];
   const resizeHeight = function (height) {
     const currTable = $('#' + id);
     $.each(resizeTargets, function () {

--- a/client/src/entrypoints/contrib/table_block/table.js
+++ b/client/src/entrypoints/contrib/table_block/table.js
@@ -66,7 +66,7 @@ function initTable(id, tableOptions) {
     }
   }
 
-  if (hasOwn(!tableOptions, 'width') || hasOwn(!tableOptions, 'height')) {
+  if (!hasOwn(tableOptions, 'width') || !hasOwn(tableOptions, 'height')) {
     // Size to parent field width if width is not given in tableOptions
     $(window).on('resize', () => {
       hot.updateSettings({


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10427.

This took me longer than I'd like, but this should hopefully fix it for real this time. There are different causes that trigger this issue:

- The fixes in #10223 contained a few issues:
  - The `'[data-field] > .handsontable'` resize target selector shouldn't have been changed to `.handsontable`, as that would select **all** elements with the `.handsontable` (pretty much all elements created by the library).
    - I assume the original intention (before the PR) was to only select the outermost element with the class (thus the direct child of Wagtail's `[data-field]` element). This was broken in later Wagtail releases with the page editor redesign, as the outermost `.handsontable` element is no longer the direct child of `[data-field]`.
    - Instead of selecting all `.handsontable` elements , we should only select the outermost `.handsontable` element. Upon looking at the DOM, I think this is the same element that has the `foo-handsontable-container` ID, the same ID we store in the `containerId` variable.
  - `resizeWidth()` shouldn't be called with `getWidth()`. Looking through the file, `resizeWidth()` is only called with `'100%'`, within the resize event handler.
    - This is why the fix in #10367 worked, at least in 4.2.
- The changes in #9634 (merged in 4.2) included a flawed logic check during the refactoring. Instead of `hasOwn(!tableOptions, ...)`, it should be `!hasOwn(tableOptions, ...)`.
  - This results in the event handler never getting added in 4.2 and later. Thus, the `resizeWidth()` function is never called (with the incorrect selector still in place) after #10367, hence the issue was fixed.
  - The fix in #10367 didn't work in 4.1 because the logic check was still correct, which means that the incorrect selector was being used with `resizeWidth()`.

I don't know if there's a way to write unit tests for this. It would be nice to at least test the regression fix if we have a way to check that the resize event listener is added.

## Instructions for merging

- Merge both commits for `main` and `stable/5.0.x` (and 4.2 if backporting).
  - The first commit fixes the logic error, which in turn re-introduces the non-editable bug on 4.2 and later.
  - The second commit fixes the non-editable bug for all releases.
- Merge only the last commit for 4.1, as the regression fixed by the first one didn't exist yet.

Tested on Chrome, Firefox, and Safari, Wagtail 4.1 and main. Please also test on 4.2 if backporting.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
