### PR TITLE
Fix mis-formatted treebeard link in docs/reference/pages/model_reference.md

### DIFF
--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -151,7 +151,7 @@ This document contains reference information for the model classes inside the `w
 In addition to the model fields provided, `Page` has many properties and methods that you may wish to reference, use, or override in creating your own models.
 
 ```{note}
-See also [django-treebeard](https://django-treebeard.readthedocs.io/en/latest/index.html)'s `node API [https://django-treebeard.readthedocs.io/en/latest/api.html](https://django-treebeard.readthedocs.io/en/latest/api.html). ``Page`` is a subclass of [materialized path tree](https://django-treebeard.readthedocs.io/en/latest/mp_tree.html) nodes.
+See also [django-treebeard](https://django-treebeard.readthedocs.io/en/latest/index.html)'s [node API](https://django-treebeard.readthedocs.io/en/latest/api.html). ``Page`` is a subclass of [materialized path tree](https://django-treebeard.readthedocs.io/en/latest/mp_tree.html) nodes.
 ```
 
 ```{eval-rst}


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes a mis-formatted link in docs/reference/pages/model_reference.md which wasn't migrated correctly from RST to MD.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] ~~For Python changes: Have you added tests to cover the new/fixed behaviour~~?
-   [ ] ~~For front-end changes: Did you test on all of Wagtail’s supported environments~~?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] ~~For new features: Has the documentation been updated accordingly~~?

**Please describe additional details for testing this change**.

Old:
<img width="695" alt="image" src="https://github.com/wagtail/wagtail/assets/1977376/9a383f1c-5dc0-4b03-b684-1abe276d9e89">

New:
<img width="695" alt="image" src="https://github.com/wagtail/wagtail/assets/1977376/31ebf480-b7ff-4cdc-ab62-ff5d991c61c4">

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
