### PR TITLE
Fix crash when deleting a single snippet using the bulk actions interface

### DIFF
--- a/wagtail/snippets/templates/wagtailsnippets/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/snippets/templates/wagtailsnippets/bulk_actions/confirm_bulk_delete.html
@@ -3,7 +3,7 @@
 
 {% block titletag %}
     {% if items|length == 1 %}
-        {% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Delete {{ snippet_type_name }}{% endblocktrans %} - {{ items|first }}
+        {% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Delete {{ snippet_type_name }}{% endblocktrans %} - {{ items.0.item }}
     {% else %}
         {{ items|length }} {{ model_opts.verbose_name_plural|capfirst }}
     {% endif %}
@@ -22,7 +22,7 @@
     {% if items %}
         {% if items|length == 1 %}
             <div class="usagecount">
-                <a href="{{ items.0.item.usage_url }}">{% blocktrans trimmed count usage_count=items.0.item.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                <a href="{{ items.0.usage_url }}">{% blocktrans trimmed count usage_count=items.0.usage_count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
             </div>
             <p>{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Are you sure you want to delete this {{ snippet_type_name }}?{% endblocktrans %}</p>
         {% else %}


### PR DESCRIPTION


<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10441.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
