### PR TITLE
Update documentation for save_revision

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -709,6 +709,7 @@ Contributors
 * Swojak-A
 * fidoriel
 * Ramon Wenger
+* Christer Jensen
 
 Translators
 ===========

--- a/docs/releases/4.1.6.md
+++ b/docs/releases/4.1.6.md
@@ -15,3 +15,7 @@ depth: 1
 
  * Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
  * Ensure that copying page correctly picks up the latest revision (Matt Westcott)
+
+### Documentation
+
+ * Update documentation for `log_action` parameter on `RevisionMixin.save_revision` (Christer Jensen)

--- a/docs/releases/4.2.4.md
+++ b/docs/releases/4.2.4.md
@@ -15,3 +15,7 @@ depth: 1
 
  * Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
  * Ensure that copying page correctly picks up the latest revision (Matt Westcott)
+
+### Documentation
+
+ * Update documentation for `log_action` parameter on `RevisionMixin.save_revision` (Christer Jensen)

--- a/docs/releases/5.0.1.md
+++ b/docs/releases/5.0.1.md
@@ -15,3 +15,7 @@ depth: 1
 
  * Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
  * Ensure that copying page correctly picks up the latest revision (Matt Westcott)
+
+### Documentation
+
+ * Update documentation for `log_action` parameter on `RevisionMixin.save_revision` (Christer Jensen)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -29,6 +29,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
  * Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)
+ * Update documentation for `log_action` parameter on `RevisionMixin.save_revision` (Christer Jensen)
 
 ### Maintenance
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -349,7 +349,7 @@ class RevisionMixin(models.Model):
         :param submitted_for_moderation: Indicates whether the object was submitted for moderation.
         :param approved_go_live_at: The date and time the revision is approved to go live.
         :param changed: Indicates whether there were any content changes.
-        :param log_action: Flag for logging the action. Pass ``False`` to skip logging. Can be passed an action string.
+        :param log_action: Flag for logging the action. Pass ``True`` to also create a log entry. Can be passed an action string.
             Defaults to ``"wagtail.edit"`` when no ``previous_revision`` param is passed, otherwise ``"wagtail.revert"``.
         :param previous_revision: Indicates a revision reversal. Should be set to the previous revision instance.
         :type previous_revision: Revision


### PR DESCRIPTION
Updated the documentation for method `save_revision()` on the `RevisionMixin` class.

Previous documentation seemed to incorrectly imply that the default value for `log_action` was `True` when it is in fact `False`. This can confuse readers not always looking closely at the method signature (e.g. me).

Personally I would have liked to change the signature's default value to `True` instead, but I assumed that is not something worth doing considering compatibility. So I updated the documentation.