### PR TITLE
Add annotate_with_permissions to permission policy classes

### DIFF
--- a/wagtail/permission_policies/base.py
+++ b/wagtail/permission_policies/base.py
@@ -238,12 +238,19 @@ class BaseDjangoAuthPermissionPolicy(BasePermissionPolicy):
     def _content_type(self):
         return ContentType.objects.get_for_model(self.auth_model)
 
+    def _get_permission_codename(self, action):
+        """
+        Get the permission codename as used by the django.contrib.auth Permission
+        model for the given action on this model
+        """
+        return f"{action}_{self.model_name}"
+
     def _get_permission_name(self, action):
         """
         Get the full app-label-qualified permission name (as required by
         user.has_perm(...) ) for the given action on this model
         """
-        return "%s.%s_%s" % (self.app_label, action, self.model_name)
+        return f"{self.app_label}.{self._get_permission_codename(action)}"
 
     def _get_users_with_any_permission_codenames_filter(self, permission_codenames):
         """

--- a/wagtail/permission_policies/base.py
+++ b/wagtail/permission_policies/base.py
@@ -128,6 +128,24 @@ class BasePermissionPolicy:
     def users_with_permission_for_instance(self, action, instance):
         return self.users_with_any_permission_for_instance([action], instance)
 
+    def annotate_with_permissions(self, queryset, user, actions):
+        """
+        Annotate each instance in the given queryset with a annotated_permissions
+        dictionary that maps each action in the given list of actions to a
+        boolean value indicating whether the given user has permission to
+        perform that action.
+
+        Subclasses may override this method to provide a more efficient
+        implementation, e.g. by performing a single database query to
+        determine the permissions for all instances in the queryset.
+        """
+        for instance in queryset:
+            instance.annotated_permissions = {
+                action: self.user_has_permission_for_instance(user, action, instance)
+                for action in actions
+            }
+        return queryset
+
 
 class BlanketPermissionPolicy(BasePermissionPolicy):
     """

--- a/wagtail/permission_policies/base.py
+++ b/wagtail/permission_policies/base.py
@@ -128,6 +128,14 @@ class BasePermissionPolicy:
     def users_with_permission_for_instance(self, action, instance):
         return self.users_with_any_permission_for_instance([action], instance)
 
+    def _update_instance_annotated_permissions(self, instance, update_dict):
+        """
+        Update the instance.annotated_permissions dictionary with the given update_dict.
+        """
+        annotation = getattr(instance, "annotated_permissions", {})
+        annotation.update(update_dict)
+        instance.annotated_permissions = annotation
+
     def annotate_with_permissions(self, queryset, user, actions):
         """
         Annotate each instance in the given queryset with a annotated_permissions
@@ -140,10 +148,15 @@ class BasePermissionPolicy:
         determine the permissions for all instances in the queryset.
         """
         for instance in queryset:
-            instance.annotated_permissions = {
-                action: self.user_has_permission_for_instance(user, action, instance)
-                for action in actions
-            }
+            self._update_instance_annotated_permissions(
+                instance,
+                {
+                    action: self.user_has_permission_for_instance(
+                        user, action, instance
+                    )
+                    for action in actions
+                },
+            )
         return queryset
 
 

--- a/wagtail/permission_policies/collections.py
+++ b/wagtail/permission_policies/collections.py
@@ -223,9 +223,10 @@ class CollectionPermissionPolicy(
         # Skip queryset annotation if we already know whether the user has permission
         if known_access is not None:
             for instance in queryset:
-                instance.annotated_permissions = {
-                    action: known_access for action in actions
-                }
+                self._update_instance_annotated_permissions(
+                    instance,
+                    {action: known_access for action in actions},
+                )
             return queryset
 
         queryset = queryset.annotate(
@@ -236,9 +237,10 @@ class CollectionPermissionPolicy(
         )
 
         for instance in queryset:
-            instance.annotated_permissions = {
-                action: getattr(instance, f"_w_can_{action}") for action in actions
-            }
+            self._update_instance_annotated_permissions(
+                instance,
+                {action: getattr(instance, f"_w_can_{action}") for action in actions},
+            )
         return queryset
 
 
@@ -460,12 +462,15 @@ class CollectionOwnershipPermissionPolicy(
                 )
 
         for instance in queryset:
-            instance.annotated_permissions = {
-                action: getattr(
-                    instance, f"_w_can_{action_aliases.get(action, action)}"
-                )
-                for action in actions
-            }
+            self._update_instance_annotated_permissions(
+                instance,
+                {
+                    action: getattr(
+                        instance, f"_w_can_{action_aliases.get(action, action)}"
+                    )
+                    for action in actions
+                },
+            )
         return queryset
 
 

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -161,6 +161,7 @@ class IndexView(generic.IndexViewOptionalFeaturesMixin, generic.IndexView):
     any_permission_required = ["add", "change", "delete"]
     page_kwarg = "p"
     table_class = InlineActionsTable
+    annotate_permissions = ["change", "delete"]
     # Search on the index view shows results immediately via AJAX,
     # so it makes sense to use autocomplete rather than exact word matches
     use_autocomplete = True

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -9,11 +9,7 @@ from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 from wagtail.snippets.bulk_actions.delete import DeleteBulkAction
 from wagtail.snippets.models import get_snippet_models
-from wagtail.snippets.permissions import (
-    get_permission_name,
-    user_can_edit_snippet_type,
-    user_can_edit_snippets,
-)
+from wagtail.snippets.permissions import user_can_edit_snippets
 from wagtail.snippets.views import snippets as snippet_views
 from wagtail.snippets.widgets import SnippetListingButton
 
@@ -65,7 +61,7 @@ def register_permissions():
 def register_snippet_listing_buttons(snippet, user, next_url=None):
     model = type(snippet)
 
-    if user_can_edit_snippet_type(user, model):
+    if snippet.annotated_permissions["change"]:
         yield SnippetListingButton(
             _("Edit"),
             reverse(
@@ -76,7 +72,7 @@ def register_snippet_listing_buttons(snippet, user, next_url=None):
             priority=10,
         )
 
-    if user.has_perm(get_permission_name("delete", model)):
+    if snippet.annotated_permissions["delete"]:
         yield SnippetListingButton(
             _("Delete"),
             reverse(

--- a/wagtail/tests/test_collection_permission_policies.py
+++ b/wagtail/tests/test_collection_permission_policies.py
@@ -557,6 +557,80 @@ class TestCollectionPermissionPolicy(PermissionPolicyTestCase):
             [],
         )
 
+    def test_annotate_with_permissions_with_known_access(self):
+        actions = ("change", "delete", "frobnicate")
+        # For these cases, the permissions are known without adding DB annotations
+        cases = (
+            (self.superuser, {action: True for action in actions}),
+            (self.inactive_superuser, {action: False for action in actions}),
+            (self.inactive_doc_changer, {action: False for action in actions}),
+            (self.anonymous_user, {action: False for action in actions}),
+        )
+        for user, expected_permissions in cases:
+            with self.assertNumQueries(1), self.subTest(user=user):
+                queryset = Document.objects.all().order_by("id")
+                queryset = self.policy.annotate_with_permissions(
+                    queryset, user, actions
+                )
+                for instance in queryset:
+                    self.assertEqual(
+                        instance.annotated_permissions,
+                        expected_permissions,
+                    )
+
+    def test_annotate_with_permissions_with_database_annotations(self):
+        actions = ("change", "delete", "frobnicate")
+        document_ids = (
+            # root document owned by report_changer
+            self.changer_doc.pk,
+            # reports document owned by report_changer
+            self.changer_report.pk,
+            # reports document owned by report_adder
+            self.adder_report.pk,
+            # reports document owned by useless_user
+            self.useless_report.pk,
+            # reports document with no owner
+            self.anonymous_report.pk,
+        )
+
+        with self.assertNumQueries(1), self.subTest(user=self.doc_changer):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.doc_changer, actions
+            )
+            expected = {"change": True, "delete": True, "frobnicate": False}
+            for instance in queryset:
+                self.assertEqual(instance.annotated_permissions, expected)
+
+        with self.assertNumQueries(1), self.subTest(user=self.report_changer):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.report_changer, actions
+            )
+            for instance in queryset:
+                expected = {"change": True, "delete": True, "frobnicate": False}
+                if instance.pk == self.changer_doc.pk:
+                    expected = {"change": False, "delete": False, "frobnicate": False}
+                self.assertEqual(instance.annotated_permissions, expected)
+
+        with self.assertNumQueries(1), self.subTest(user=self.report_adder):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.report_adder, actions
+            )
+            expected = {"change": False, "delete": False, "frobnicate": False}
+            for instance in queryset:
+                self.assertEqual(instance.annotated_permissions, expected)
+
+        with self.assertNumQueries(1), self.subTest(user=self.useless_user):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.useless_user, actions
+            )
+            expected = {"change": False, "delete": False, "frobnicate": False}
+            for instance in queryset:
+                self.assertEqual(instance.annotated_permissions, expected)
+
 
 class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
     def setUp(self):
@@ -1039,6 +1113,86 @@ class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
             ),
             [],
         )
+
+    def test_annotate_with_permissions_with_known_access(self):
+        actions = ("change", "delete", "frobnicate")
+        # For these cases, the permissions are known without adding DB annotations
+        cases = (
+            (self.superuser, {action: True for action in actions}),
+            (self.inactive_superuser, {action: False for action in actions}),
+            (self.inactive_doc_changer, {action: False for action in actions}),
+            (self.anonymous_user, {action: False for action in actions}),
+        )
+        for user, expected_permissions in cases:
+            with self.assertNumQueries(1), self.subTest(user=user):
+                queryset = Document.objects.all().order_by("id")
+                queryset = self.policy.annotate_with_permissions(
+                    queryset, user, actions
+                )
+                for instance in queryset:
+                    self.assertEqual(
+                        instance.annotated_permissions,
+                        expected_permissions,
+                    )
+
+    def test_annotate_with_permissions_with_database_annotations(self):
+        actions = ("change", "delete", "frobnicate")
+        document_ids = (
+            # root document owned by report_changer
+            self.changer_doc.pk,
+            # reports document owned by report_changer
+            self.changer_report.pk,
+            # reports document owned by report_adder
+            self.adder_report.pk,
+            # reports document owned by useless_user
+            self.useless_report.pk,
+            # reports document with no owner
+            self.anonymous_report.pk,
+        )
+
+        with self.assertNumQueries(1), self.subTest(user=self.doc_changer):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.doc_changer, actions
+            )
+            expected = {"change": True, "delete": True, "frobnicate": False}
+            for instance in queryset:
+                self.assertEqual(instance.annotated_permissions, expected)
+
+        with self.assertNumQueries(1), self.subTest(user=self.report_changer):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.report_changer, actions
+            )
+            for instance in queryset:
+                expected = {"change": True, "delete": True, "frobnicate": False}
+                # even though changer_report is owned by report_changer, they can't
+                # change or delete it because it's in the root collection and they
+                # don't have add permission on the root collection
+                if instance.pk == self.changer_doc.pk:
+                    expected = {"change": False, "delete": False, "frobnicate": False}
+                self.assertEqual(instance.annotated_permissions, expected)
+
+        with self.assertNumQueries(1), self.subTest(user=self.report_adder):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.report_adder, actions
+            )
+            for instance in queryset:
+                expected = {"change": False, "delete": False, "frobnicate": False}
+                # adder_report is owned by report_adder, so they can change and delete
+                if instance.pk == self.adder_report.pk:
+                    expected = {"change": True, "delete": True, "frobnicate": False}
+                self.assertEqual(instance.annotated_permissions, expected)
+
+        with self.assertNumQueries(1), self.subTest(user=self.useless_user):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.useless_user, actions
+            )
+            expected = {"change": False, "delete": False, "frobnicate": False}
+            for instance in queryset:
+                self.assertEqual(instance.annotated_permissions, expected)
 
 
 class TestCollectionManagementPermission(

--- a/wagtail/tests/test_collection_permission_policies.py
+++ b/wagtail/tests/test_collection_permission_policies.py
@@ -572,6 +572,8 @@ class TestCollectionPermissionPolicy(PermissionPolicyTestCase):
                 queryset = self.policy.annotate_with_permissions(
                     queryset, user, actions
                 )
+                # no duplicates are returned
+                self.assertEqual(len(queryset), 5)
                 for instance in queryset:
                     self.assertEqual(
                         instance.annotated_permissions,
@@ -598,6 +600,8 @@ class TestCollectionPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.doc_changer, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             expected = {"change": True, "delete": True, "frobnicate": False}
             for instance in queryset:
                 self.assertEqual(instance.annotated_permissions, expected)
@@ -607,6 +611,8 @@ class TestCollectionPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_changer, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             for instance in queryset:
                 expected = {"change": True, "delete": True, "frobnicate": False}
                 if instance.pk == self.changer_doc.pk:
@@ -618,6 +624,8 @@ class TestCollectionPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_adder, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             expected = {"change": False, "delete": False, "frobnicate": False}
             for instance in queryset:
                 self.assertEqual(instance.annotated_permissions, expected)
@@ -627,6 +635,8 @@ class TestCollectionPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.useless_user, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             expected = {"change": False, "delete": False, "frobnicate": False}
             for instance in queryset:
                 self.assertEqual(instance.annotated_permissions, expected)
@@ -1129,6 +1139,8 @@ class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
                 queryset = self.policy.annotate_with_permissions(
                     queryset, user, actions
                 )
+                # no duplicates are returned
+                self.assertEqual(len(queryset), 5)
                 for instance in queryset:
                     self.assertEqual(
                         instance.annotated_permissions,
@@ -1155,6 +1167,8 @@ class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.doc_changer, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             expected = {"change": True, "delete": True, "frobnicate": False}
             for instance in queryset:
                 self.assertEqual(instance.annotated_permissions, expected)
@@ -1164,6 +1178,8 @@ class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_changer, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             for instance in queryset:
                 expected = {"change": True, "delete": True, "frobnicate": False}
                 # even though changer_report is owned by report_changer, they can't
@@ -1178,6 +1194,8 @@ class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_adder, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             for instance in queryset:
                 expected = {"change": False, "delete": False, "frobnicate": False}
                 # adder_report is owned by report_adder, so they can change and delete
@@ -1190,6 +1208,8 @@ class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.useless_user, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             expected = {"change": False, "delete": False, "frobnicate": False}
             for instance in queryset:
                 self.assertEqual(instance.annotated_permissions, expected)
@@ -1566,6 +1586,8 @@ class TestCollectionManagementPermission(
                 queryset = self.policy.annotate_with_permissions(
                     queryset, user, actions
                 )
+                # no duplicates are returned
+                self.assertEqual(len(queryset), 3)
                 for instance in queryset:
                     self.assertEqual(
                         instance.annotated_permissions,
@@ -1585,6 +1607,8 @@ class TestCollectionManagementPermission(
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_changer, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 3)
             expected = (
                 {"add": False, "change": False, "delete": False, "frobnicate": False},
                 {"add": False, "change": True, "delete": False, "frobnicate": False},
@@ -1599,6 +1623,8 @@ class TestCollectionManagementPermission(
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_adder, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 3)
             expected = (
                 {"add": False, "change": False, "delete": False, "frobnicate": False},
                 {"add": True, "change": False, "delete": False, "frobnicate": False},
@@ -1613,6 +1639,8 @@ class TestCollectionManagementPermission(
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_deleter, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 3)
             expected = (
                 {"add": False, "change": False, "delete": False, "frobnicate": False},
                 {"add": False, "change": False, "delete": True, "frobnicate": False},
@@ -1627,6 +1655,8 @@ class TestCollectionManagementPermission(
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.useless_user, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 3)
             expected = {action: False for action in actions}
             for instance in queryset:
                 self.assertEqual(instance.annotated_permissions, expected)


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10442.

Not sure how to handle non-conventional index views, such as ones that use a permission policy for a model but displays a list of objects that are not instances of that model. An example of this is the usage listing view which returns a list of `ReferenceGroups` objects. I currently worked around this by making the annotation optional (you have to specify the `annotate_permissions` list on the view).







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
