### PR TITLE
Fix StreamBlock documentation indentation

### DIFF
--- a/docs/reference/streamfield/blocks.md
+++ b/docs/reference/streamfield/blocks.md
@@ -522,48 +522,44 @@ All block definitions accept the following optional keyword arguments:
 
            class Meta:
                icon='cogs'
-```
 
-(streamfield_top_level_streamblock)=
+    Since ``StreamField`` accepts an instance of ``StreamBlock`` as a parameter, in place of a list of block types, this makes it possible to re-use a common set of block types without repeating definitions:
 
-```{eval-rst}
-Since ``StreamField`` accepts an instance of ``StreamBlock`` as a parameter, in place of a list of block types, this makes it possible to re-use a common set of block types without repeating definitions:
+    .. code-block:: python
 
-.. code-block:: python
+        class HomePage(Page):
+            carousel = StreamField(
+                CarouselBlock(max_num=10, block_counts={'video': {'max_num': 2}}),
+                use_json_field=True
+            )
 
-    class HomePage(Page):
-        carousel = StreamField(
-            CarouselBlock(max_num=10, block_counts={'video': {'max_num': 2}}),
-            use_json_field=True
-        )
+    ``StreamBlock`` accepts the following additional options as either keyword arguments or ``Meta`` properties:
 
-``StreamBlock`` accepts the following additional options as either keyword arguments or ``Meta`` properties:
+    :param required: If true (the default), at least one sub-block must be supplied. This is ignored when using the ``StreamBlock`` as the top-level block of a StreamField; in this case the StreamField's ``blank`` property is respected instead.
+    :param min_num: Minimum number of sub-blocks that the stream must have.
+    :param max_num: Maximum number of sub-blocks that the stream may have.
+    :param block_counts: Specifies the minimum and maximum number of each block type, as a dictionary mapping block names to dicts with (optional) ``min_num`` and ``max_num`` fields.
+    :param collapsed: When true, all sub-blocks are initially collapsed.
+    :param form_classname: An HTML ``class`` attribute to set on the root element of this block as displayed in the editing interface.
 
-:param required: If true (the default), at least one sub-block must be supplied. This is ignored when using the ``StreamBlock`` as the top-level block of a StreamField; in this case the StreamField's ``blank`` property is respected instead.
-:param min_num: Minimum number of sub-blocks that the stream must have.
-:param max_num: Maximum number of sub-blocks that the stream may have.
-:param block_counts: Specifies the minimum and maximum number of each block type, as a dictionary mapping block names to dicts with (optional) ``min_num`` and ``max_num`` fields.
-:param collapsed: When true, all sub-blocks are initially collapsed.
-:param form_classname: An HTML ``class`` attribute to set on the root element of this block as displayed in the editing interface.
+    .. code-block:: python
+        :emphasize-lines: 6
 
-.. code-block:: python
-    :emphasize-lines: 6
+        body = StreamField([
+            # ...
+            ('event_promotions', blocks.StreamBlock([
+                ('hashtag', blocks.CharBlock()),
+                ('post_date', blocks.DateBlock()),
+            ], form_classname='event-promotions')),
+        ], use_json_field=True)
 
-    body = StreamField([
-        # ...
-        ('event_promotions', blocks.StreamBlock([
-            ('hashtag', blocks.CharBlock()),
-            ('post_date', blocks.DateBlock()),
-        ], form_classname='event-promotions')),
-    ], use_json_field=True)
+    .. code-block:: python
+        :emphasize-lines: 6
 
-.. code-block:: python
-    :emphasize-lines: 6
+        class EventPromotionsBlock(blocks.StreamBlock):
+            hashtag = blocks.CharBlock()
+            post_date = blocks.DateBlock()
 
-    class EventPromotionsBlock(blocks.StreamBlock):
-        hashtag = blocks.CharBlock()
-        post_date = blocks.DateBlock()
-
-        class Meta:
-            form_classname = 'event-promotions'
+            class Meta:
+                form_classname = 'event-promotions'
 ```

--- a/docs/releases/2.13.rst
+++ b/docs/releases/2.13.rst
@@ -110,7 +110,7 @@ Wagtail 2.13 will be the last Wagtail release to support IE11. Users accessing t
 Updated handling of non-required StreamFields
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The rules for determining whether a StreamField is required (i.e. at least one block must be provided) have been simplified and made consistent with other field types. Non-required fields are now indicated by ``blank=True`` on the ``StreamField`` definition; the default is ``blank=False`` (the field is required). In previous versions, to make a field non-required, it was necessary to define :ref:`a top-level StreamBlock<streamfield_top_level_streamblock>` with ``required=False`` (which applied the validation rule) as well as setting ``blank=True`` (which removed the asterisk from the form field). You should review your use of StreamField to check that ``blank=True`` is used on the fields you wish to make optional.
+The rules for determining whether a StreamField is required (i.e. at least one block must be provided) have been simplified and made consistent with other field types. Non-required fields are now indicated by ``blank=True`` on the ``StreamField`` definition; the default is ``blank=False`` (the field is required). In previous versions, to make a field non-required, it was necessary to define :ref:`a top-level StreamBlock<wagtail.blocks.StreamBlock>` with ``required=False`` (which applied the validation rule) as well as setting ``blank=True`` (which removed the asterisk from the form field). You should review your use of StreamField to check that ``blank=True`` is used on the fields you wish to make optional.
 
 
 New client-side implementation for custom StreamField blocks


### PR DESCRIPTION
Spotted while troubleshooting indexing issues. The parameters section of the StreamBlock docs and its `streamfield_top_level_streamblock` preamble aren’t semantically associated with the StreamBlock class.

This fixes it by moving all content to the same RST eval section, and re-indenting the content.