### PR TITLE
Fix missing link to UsageView from EditView for snippets

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)
+ * Fix: Fix missing link to `UsageView` from `EditView` for snippets (Christer Jensen)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)
@@ -27,6 +28,7 @@ Changelog
  * Fix: Pass the correct `for_update` value for `get_form_class` in `SnippetViewSet` edit views (Sage Abdullah)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)
+ * Fix: Fix missing link to `UsageView` from `EditView` for snippets (Christer Jensen)
  * Docs: Update documentation for `log_action` parameter on `RevisionMixin.save_revision` (Christer Jensen)
 
 

--- a/docs/releases/5.0.1.md
+++ b/docs/releases/5.0.1.md
@@ -20,6 +20,7 @@ depth: 1
  * Pass the correct `for_update` value for `get_form_class` in `SnippetViewSet` edit views (Sage Abdullah)
  * Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Remove comment button on InlinePanel fields (Sage Abdullah)
+ * Fix missing link to `UsageView` from `EditView` for snippets (Christer Jensen)
 
 ### Documentation
 

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -25,6 +25,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
  * Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Remove comment button on InlinePanel fields (Sage Abdullah)
+ * Fix missing link to `UsageView` from `EditView` for snippets (Christer Jensen)
 
 ### Documentation
 

--- a/wagtail/snippets/side_panels.py
+++ b/wagtail/snippets/side_panels.py
@@ -15,6 +15,7 @@ class SnippetStatusSidePanel(BaseStatusSidePanel):
         inherit = [
             "view",
             "history_url",
+            "usage_url",
             "workflow_history_url",
             "revisions_compare_url_name",
             "revision_enabled",

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -1210,6 +1210,12 @@ class TestSnippetEditView(BaseTestSnippetEditView):
         # History link should be present, one in the header and one in the status side panel
         self.assertContains(response, history_url, count=2)
 
+        usage_url = reverse(
+            "wagtailsnippets_tests_advert:usage", args=[quote(self.test_snippet.pk)]
+        )
+        # Usage link should be present in the status side panel
+        self.assertContains(response, usage_url)
+
         # Live status and last updated info should be shown, with a link to the history page
         self.assertContains(response, "3\xa0weeks ago")
         self.assertTagInHTML(

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -299,6 +299,7 @@ class EditView(generic.CreateEditViewOptionalFeaturesMixin, generic.EditView):
     history_url_name = None
     preview_url_name = None
     revisions_compare_url_name = None
+    usage_url_name = None
     permission_required = "change"
     template_name = "wagtailsnippets/snippets/edit.html"
     error_message = gettext_lazy("The snippet could not be saved due to errors.")
@@ -311,6 +312,9 @@ class EditView(generic.CreateEditViewOptionalFeaturesMixin, generic.EditView):
 
     def get_history_url(self):
         return reverse(self.history_url_name, args=[quote(self.object.pk)])
+
+    def get_usage_url(self):
+        return reverse(self.usage_url_name, args=[quote(self.object.pk)])
 
     def _get_action_menu(self):
         return SnippetActionMenu(
@@ -348,6 +352,7 @@ class EditView(generic.CreateEditViewOptionalFeaturesMixin, generic.EditView):
                 "action_menu": action_menu,
                 "side_panels": side_panels,
                 "history_url": self.get_history_url(),
+                "usage_url": self.get_usage_url(),
                 "revisions_compare_url_name": self.revisions_compare_url_name,
                 "media": media,
             }
@@ -909,6 +914,7 @@ class SnippetViewSet(ModelViewSet):
             preview_url_name=self.get_url_name("preview_on_edit"),
             lock_url_name=self.get_url_name("lock"),
             unlock_url_name=self.get_url_name("unlock"),
+            usage_url_name=self.get_url_name("usage"),
             revisions_compare_url_name=self.get_url_name("revisions_compare"),
             revisions_unschedule_url_name=self.get_url_name("revisions_unschedule"),
             workflow_history_url_name=self.get_url_name("workflow_history"),
@@ -979,6 +985,7 @@ class SnippetViewSet(ModelViewSet):
             preview_url_name=self.get_url_name("preview_on_edit"),
             lock_url_name=self.get_url_name("lock"),
             unlock_url_name=self.get_url_name("unlock"),
+            usage_url_name=self.get_url_name("usage"),
             revisions_compare_url_name=self.get_url_name("revisions_compare"),
             revisions_unschedule_url_name=self.get_url_name("revisions_unschedule"),
             revisions_revert_url_name=self.get_url_name("revisions_revert"),


### PR DESCRIPTION
After the 5.0 release there have been a regression with the removal of `usage_url()` from snippet models.
`wagtail.snippets.views.snippets.EditView` were not provided an alternative so rendered all `usage_url` in
templates with `None`.

This pull requests add a new instance variable `usage_url_name` to EditView. This is used to later populate
`usage_url` in the sidebar template. Similar to existing `history_url_name`.

-   [x] Do the tests still pass?
-   [X] Does the code comply with the style guide?
    -   [X] Run `make lint` from the Wagtail root.
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

1. Go to the edit page for any snippet.
2. Click _Status_ in the top right
3. Click link after _Usage_, for example "Used 2 times"
4. The link should no longer take you to a 404 page.