### PR TITLE
Remove comment button on `InlinePanel` fields

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
  * Return filters from `parse_query_string` as a `QueryDict` to support multiple values (Aman Pandey)
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
+ * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)
@@ -25,6 +26,7 @@ Changelog
  * Fix: Fix error when deleting a single snippet through the bulk actions interface (Sage Abdullah)
  * Fix: Pass the correct `for_update` value for `get_form_class` in `SnippetViewSet` edit views (Sage Abdullah)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
+ * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)
  * Docs: Update documentation for `log_action` parameter on `RevisionMixin.save_revision` (Christer Jensen)
 
 

--- a/client/src/entrypoints/admin/comments.js
+++ b/client/src/entrypoints/admin/comments.js
@@ -155,7 +155,9 @@ window.comments = (() => {
 
     register() {
       if (!this.contentpath) {
-        // The widget has no valid contentpath, skip subscriptions
+        // The widget has no valid contentpath,
+        // remove the button and skip subscriptions
+        this.commentAdditionNode.remove();
         return undefined;
       }
       const initialState = commentApp.store.getState();

--- a/docs/releases/5.0.1.md
+++ b/docs/releases/5.0.1.md
@@ -19,6 +19,7 @@ depth: 1
  * Fix error when deleting a single snippet through the bulk actions interface (Sage Abdullah)
  * Pass the correct `for_update` value for `get_form_class` in `SnippetViewSet` edit views (Sage Abdullah)
  * Move comment notifications toggle to the comments side panel (Sage Abdullah)
+ * Remove comment button on InlinePanel fields (Sage Abdullah)
 
 ### Documentation
 

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -24,6 +24,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
 
  * Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Move comment notifications toggle to the comments side panel (Sage Abdullah)
+ * Remove comment button on InlinePanel fields (Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/comments.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/comments.html
@@ -2,7 +2,7 @@
 
 {# Comment Notifications Toggle  #}
 {% if form.show_comments_toggle %}
-    <div class="w-relative w-flex w-justify-end w-mt-1 w-bg-surface-page" data-comment-notifications hidden>
+    <div class="w-relative w-flex w-justify-end w-mt-1 w-ml-8" data-comment-notifications hidden>
         <label class="switch w-p-0 w-m-0 w-font-normal w-flex w-justify-between w-text-14 w-space-x-2">
             {% trans "Comment notifications" %}
             {{ form.comment_notifications }}


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10453 and a regression in #10437 that causes the side panel close button to overlap with the comment notifications toggle.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 113, Firefox 113, Safari 16.4 on macOS Ventura 13.3.1 (a)
    -   [ ] **Please list which assistive technologies [^3] you tested**:


[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
