### PR TITLE
Update checks.py

### DIFF
--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -189,7 +189,10 @@ def wagtail_admin_base_url_check(app_configs, **kwargs):
 def file_overwrite_check(app_configs, **kwargs):
     from django.conf import settings
 
-    file_storage = getattr(settings, "DEFAULT_FILE_STORAGE", None)
+    try:
+        file_storage = getattr(settings, "STORAGES")["default"]["BACKEND"]
+    except AttributeError:
+        file_storage = getattr(settings, "DEFAULT_FILE_STORAGE", None)
 
     errors = []
 

--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -190,13 +190,13 @@ def file_overwrite_check(app_configs, **kwargs):
     from django.conf import settings
     from django import VERSION as DJANGO_VERSION
 
-    if DJANGO_VERSION >= (4, 2):
+    if DJANGO_VERSION >= (5, 1):
+        file_storage = getattr(settings, "STORAGES")["default"]["BACKEND"]
+    elif DJANGO_VERSION >= (4, 2):
         try:
             file_storage = getattr(settings, "STORAGES")["default"]["BACKEND"]
         except AttributeError:
             file_storage = getattr(settings, "DEFAULT_FILE_STORAGE", None)
-    elif DJANGO_VERSION >= (5, 1):
-        file_storage = getattr(settings, "STORAGES")["default"]["BACKEND"]
     else:
         file_storage = getattr(settings, "DEFAULT_FILE_STORAGE", None)
 

--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -189,9 +189,14 @@ def wagtail_admin_base_url_check(app_configs, **kwargs):
 def file_overwrite_check(app_configs, **kwargs):
     from django.conf import settings
 
-    try:
+    if DJANGO_VERSION >= (4, 2):
+        try:
+            file_storage = getattr(settings, "STORAGES")["default"]["BACKEND"]
+        except AttributeError:
+            file_storage = getattr(settings, "DEFAULT_FILE_STORAGE", None)
+    elif DJANGO_VERSION >= (5, 1):
         file_storage = getattr(settings, "STORAGES")["default"]["BACKEND"]
-    except AttributeError:
+    else:
         file_storage = getattr(settings, "DEFAULT_FILE_STORAGE", None)
 
     errors = []

--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -188,6 +188,7 @@ def wagtail_admin_base_url_check(app_configs, **kwargs):
 @register("file_overwrite")
 def file_overwrite_check(app_configs, **kwargs):
     from django.conf import settings
+    from django import VERSION as DJANGO_VERSION
 
     if DJANGO_VERSION >= (4, 2):
         try:


### PR DESCRIPTION
Prevent "RemovedInDjango51Warning: The DEFAULT_FILE_STORAGE setting is deprecated. Use STORAGES instead."

Fixes #10461 