### PR TITLE
Prevent lowercase conversions of IndexView column headers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)
  * Fix: Fix missing link to `UsageView` from `EditView` for snippets (Christer Jensen)
+ * Fix: Prevent lowercase conversions of IndexView column headers (Virag Jain)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)
@@ -29,6 +30,7 @@ Changelog
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)
  * Fix: Fix missing link to `UsageView` from `EditView` for snippets (Christer Jensen)
+ * Fix: Prevent lowercase conversions of IndexView column headers (Virag Jain)
  * Docs: Update documentation for `log_action` parameter on `RevisionMixin.save_revision` (Christer Jensen)
 
 
@@ -178,8 +180,9 @@ Changelog
 
  * Fix: Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
  * Fix: Ensure that copying page correctly picks up the latest revision (Matt Westcott)
- * Docs: Update documentation for `log_action` parameter on `RevisionMixin.save_revision` (Christer Jensen)
  * Fix: Adjust collection field alignment in multi-upload forms (LB (Ben) Johnston)
+ * Fix: Prevent lowercase conversions of IndexView column headers (Virag Jain)
+ * Docs: Update documentation for `log_action` parameter on `RevisionMixin.save_revision` (Christer Jensen)
 
 
 4.2.3 (02.05.2023)
@@ -383,6 +386,7 @@ Changelog
  * Fix: Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
  * Fix: Ensure that copying page correctly picks up the latest revision (Matt Westcott)
  * Fix: Adjust collection field alignment in multi-upload forms (LB (Ben) Johnston)
+ * Fix: Prevent lowercase conversions of IndexView column headers (Virag Jain)
  * Docs: Update documentation for `log_action` parameter on `RevisionMixin.save_revision` (Christer Jensen)
 
 4.1.5 (02.05.2023)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -710,6 +710,7 @@ Contributors
 * fidoriel
 * Ramon Wenger
 * Christer Jensen
+* Virag Jain
 
 Translators
 ===========

--- a/docs/releases/4.1.6.md
+++ b/docs/releases/4.1.6.md
@@ -16,6 +16,7 @@ depth: 1
  * Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
  * Ensure that copying page correctly picks up the latest revision (Matt Westcott)
  * Adjust collection field alignment in multi-upload forms (LB (Ben) Johnston)
+ * Prevent lowercase conversions of IndexView column headers (Virag Jain)
 
 ### Documentation
 

--- a/docs/releases/4.2.4.md
+++ b/docs/releases/4.2.4.md
@@ -16,6 +16,7 @@ depth: 1
  * Rectify previous fix for TableBlock becoming uneditable after save (Sage Abdullah)
  * Ensure that copying page correctly picks up the latest revision (Matt Westcott)
  * Adjust collection field alignment in multi-upload forms (LB (Ben) Johnston)
+ * Prevent lowercase conversions of IndexView column headers (Virag Jain)
 
 ### Documentation
 

--- a/docs/releases/5.0.1.md
+++ b/docs/releases/5.0.1.md
@@ -21,6 +21,7 @@ depth: 1
  * Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Remove comment button on InlinePanel fields (Sage Abdullah)
  * Fix missing link to `UsageView` from `EditView` for snippets (Christer Jensen)
+ * Prevent lowercase conversions of IndexView column headers (Virag Jain)
 
 ### Documentation
 

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -26,6 +26,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
  * Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Remove comment button on InlinePanel fields (Sage Abdullah)
  * Fix missing link to `UsageView` from `EditView` for snippets (Christer Jensen)
+ * Prevent lowercase conversions of IndexView column headers (Virag Jain)
 
 ### Documentation
 

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -10,6 +10,7 @@ from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
+from django.utils.text import capfirst
 from django.views.generic import TemplateView
 from django.views.generic.detail import BaseDetailView
 from django.views.generic.edit import BaseCreateView
@@ -299,7 +300,7 @@ class IndexView(
 
         return column_class(
             field_name,
-            label=label.title(),
+            label=capfirst(label),
             sort_key=sort_key,
             **kwargs,
         )

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -652,8 +652,8 @@ class TestListViewWithCustomColumns(BaseSnippetViewSetTests):
     def test_custom_columns(self):
         response = self.get()
         self.assertContains(response, "Text")
-        self.assertContains(response, "Country Code")
-        self.assertContains(response, "Custom Foo Column")
+        self.assertContains(response, "Country code")
+        self.assertContains(response, "Custom FOO column")
         self.assertContains(response, "Updated")
 
         self.assertContains(response, "Foo UK")

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -1135,7 +1135,7 @@ class FullFeaturedSnippet(
         return f"Foo {self.country_code}"
 
     get_foo_country_code.admin_order_field = "country_code"
-    get_foo_country_code.short_description = "Custom foo column"
+    get_foo_country_code.short_description = "custom FOO column"
 
     class Meta(TranslatableMixin.Meta):
         verbose_name = "full-featured snippet"


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10434  

Tried fixing the issue by importing the django's `capfirst` function and properly implementing it.


_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.


