### PR TITLE
Order group editor object permissions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Add oEmbed provider patterns for YouTube Shorts Shorts and YouTube Live URLs (valnuro, Fabien Le Frapper)
  * Add initial implementation of `PagePermissionPolicy` (Sage Abdullah)
  * Refactor `UserPagePermissionsProxy` and `PagePermissionTester` to use `PagePermissionPolicy` (Sage Abdullah)
+ * Add a predictable default ordering of the "Object/Other permissions" in the Group Editing view, allow this ordering to be customised (Daniel Kirkham)
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)

--- a/docs/extending/customising_group_views.md
+++ b/docs/extending/customising_group_views.md
@@ -106,3 +106,29 @@ INSTALLED_APPS = [
     ...,
 ]
 ```
+
+(customising_group_views_permissions_order)=
+
+## Customising the group editor permissions ordering
+
+The order that object types appear in the group editor's "Object permissions" and "Other permissions" sections can be configured by registering that order in one or more `AppConfig` definitions. The order value is typically an integer between 0 and 999, although this is not enforced.
+
+```python
+from django.apps import AppConfig
+
+
+class MyProjectAdminAppConfig(AppConfig):
+    name = "myproject_admin"
+    verbose_name = "My Project Admin"
+
+    def ready(self):
+        from wagtail.users.permission_order import register
+
+        register("gadgets.SprocketType", order=150)
+        register("gadgets.ChainType", order=151)
+        register("site_settings.Settings", order=160)
+```
+
+A model class can also be passed to `register()`.
+
+Any object types that are not explicitly given an order will be sorted in alphabetical order by `app_label` and `model`, and listed after all of the object types _with_ a configured order.

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -23,6 +23,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
  * Add oEmbed provider patterns for YouTube Shorts (e.g. [https://www.youtube.com/shorts/nX84KctJtG0](https://www.youtube.com/shorts/nX84KctJtG0)) and YouTube Live URLs (valnuro, Fabien Le Frapper)
  * Add initial implementation of `PagePermissionPolicy` (Sage Abdullah)
  * Refactor `UserPagePermissionsProxy` and `PagePermissionTester` to use `PagePermissionPolicy` (Sage Abdullah)
+ * Add a predictable default ordering of the "Object/Other permissions" in the Group Editing view, allow this [ordering to be customised](customising_group_views_permissions_order) (Daniel Kirkham)
 
 ### Bug fixes
 
@@ -120,3 +121,10 @@ If you use the `user_page_permissions` context variable or use the `UserPagePerm
 The undocumented `get_pages_with_direct_explore_permission` and `get_explorable_root_page` functions in `wagtail.admin.navigation` are deprecated. They can be replaced with `PagePermissionPolicy().instances_with_direct_explore_permission(user)` and `PagePermissionPolicy().explorable_root_instance(user)`, respectively.
 
 The undocumented `users_with_page_permission` function in `wagtail.admin.auth` is also deprecated. It can be replaced with `PagePermissionPolicy().users_with_permission_for_instance(action, page, include_superusers)`.
+
+### The default ordering of Group Editing Permissions models has changed
+
+The ordering for "Object permissions" and "Other permissions" now follows a predictable order equivalent do Django's default `Model` ordering.
+This will be different to the previous ordering which never intentionally implemented.
+
+This default ordering is now `["content_type__app_label", "content_type__model", "codename"]`, which can now be customised [](customising_group_views_permissions_order).

--- a/wagtail/users/permission_order.py
+++ b/wagtail/users/permission_order.py
@@ -1,0 +1,17 @@
+from django.contrib.contenttypes.models import ContentType
+
+from wagtail.coreutils import resolve_model_string
+
+CONTENT_TYPE_ORDER = {}
+
+
+def register(model, **kwargs):
+    """
+    Registers order against the model content_type, used to
+    control the order the models and its permissions appear
+    in the groups object permission editor
+    """
+    order = kwargs.pop("order", None)
+    if order is not None:
+        content_type = ContentType.objects.get_for_model(resolve_model_string(model))
+        CONTENT_TYPE_ORDER[content_type.id] = order

--- a/wagtail/users/templatetags/wagtailusers_tags.py
+++ b/wagtail/users/templatetags/wagtailusers_tags.py
@@ -4,6 +4,7 @@ import re
 from django import template
 
 from wagtail import hooks
+from wagtail.users.permission_order import CONTENT_TYPE_ORDER
 
 register = template.Library()
 
@@ -38,8 +39,13 @@ def format_permissions(permission_bound_field):
 
     """
     permissions = permission_bound_field.field._queryset
-    # get a distinct list of the content types that these permissions relate to
-    content_type_ids = set(permissions.values_list("content_type_id", flat=True))
+    # get a distinct and ordered list of the content types that these permissions relate to.
+    # relies on Permission model default ordering, dict.fromkeys() retaining that order
+    # from the queryset, and the stability of sorted().
+    content_type_ids = sorted(
+        dict.fromkeys(permissions.values_list("content_type_id", flat=True)),
+        key=lambda ct: CONTENT_TYPE_ORDER.get(ct, float("inf")),
+    )
 
     # iterate over permission_bound_field to build a lookup of individual renderable
     # checkbox objects

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -24,6 +24,7 @@ from wagtail.models import (
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.users.forms import UserCreationForm, UserEditForm
 from wagtail.users.models import UserProfile
+from wagtail.users.permission_order import register as register_permission_order
 from wagtail.users.views.groups import GroupViewSet
 from wagtail.users.views.users import get_user_creation_form, get_user_edit_form
 from wagtail.users.wagtail_hooks import get_group_viewset_cls
@@ -1946,6 +1947,71 @@ class TestGroupEditView(WagtailTestUtils, TestCase):
 
         # Should not show inputs for publish permissions on models without DraftStateMixin
         self.assertNotInHTML("Can publish advert", html)
+
+    def test_group_edit_loads_with_django_permissions_in_order(self):
+        # ensure objects are ordered as registered, followed by the default ordering
+
+        def object_position(object_perms):
+            # returns the list of objects in the object permsissions
+            # as provided by the format_permissions tag
+
+            def flatten(perm_set):
+                # iterates through perm_set dict, flattens the list if present
+                for v in perm_set.values():
+                    if isinstance(v, list):
+                        for e in v:
+                            yield e
+                    else:
+                        yield v
+
+            return [
+                (
+                    perm.content_type.app_label,
+                    perm.content_type.model,
+                )
+                for perm_set in object_perms
+                for perm in [next(v for v in flatten(perm_set) if "perm" in v)["perm"]]
+            ]
+
+        # Set order on two objects, should appear first and second
+        register_permission_order("snippetstests.fancysnippet", order=100)
+        register_permission_order("snippetstests.standardsnippet", order=110)
+
+        response = self.get()
+        object_positions = object_position(response.context["object_perms"])
+        self.assertEqual(
+            object_positions[0],
+            ("snippetstests", "fancysnippet"),
+            msg="Configured object permission order is incorrect",
+        )
+        self.assertEqual(
+            object_positions[1],
+            ("snippetstests", "standardsnippet"),
+            msg="Configured object permission order is incorrect",
+        )
+
+        # Swap order of the objects
+        register_permission_order("snippetstests.standardsnippet", order=90)
+        response = self.get()
+        object_positions = object_position(response.context["object_perms"])
+
+        self.assertEqual(
+            object_positions[0],
+            ("snippetstests", "standardsnippet"),
+            msg="Configured object permission order is incorrect",
+        )
+        self.assertEqual(
+            object_positions[1],
+            ("snippetstests", "fancysnippet"),
+            msg="Configured object permission order is incorrect",
+        )
+
+        # Test remainder of objects are sorted
+        self.assertEqual(
+            object_positions[2:],
+            sorted(object_positions[2:]),
+            msg="Default object permission order is incorrect",
+        )
 
 
 class TestGroupViewSet(TestCase):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10468

This PR implements a method to order the models or objects that appear in the "Object Permissions" and "Other Permissions" sections on the group editor.

As described in the referenced issue, the order that the objects appear is unmanaged, depending it would appear on the migration order and vagaries of retrieving the permissions from the database. The object type list is also formed via a `set()` which can therefore not guarantee an order. This PR allows an order to be defined via a registration process, so that the members of that set are sorted into that order before they are rendered.

The registration is decoupled from the registration of the permissions themselves. This is so that the ordering can be defined in an admin-related app, in one place in a project, rather than distributed around many individual apps.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] ~~For front-end changes: Did you test on all of Wagtail’s supported environments?~~[^2]
    -   [ ] **~~Please list the exact browser and operating system versions you tested~~**:
    -   [ ] **~~Please list which assistive technologies [^3] you tested~~**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

To test in a complete project, the registration can be added to an apps.py `AppConfig.ready()` method. Template code for this is in the documentation.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
