### PR TITLE
Add initial implementation of `PagePermissionPolicy`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
  * Return filters from `parse_query_string` as a `QueryDict` to support multiple values (Aman Pandey)
  * Explicitly specify `MenuItem.name` for all admin menu and submenu items (Justin Koestinger)
  * Add Embed URL provider support YouTube Shorts (valnuro)
+ * Add initial implementation of `PagePermissionPolicy` (Sage Abdullah)
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -21,6 +21,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
  * Return filters from `parse_query_string` as a `QueryDict` to support multiple values (Aman Pandey)
  * Explicitly specify `MenuItem.name` for all admin menu and submenu items (Justin Koestinger)
  * Add Embed URL provider support YouTube Shorts (e.g. [https://www.youtube.com/shorts/nX84KctJtG0](https://www.youtube.com/shorts/nX84KctJtG0)) (valnuro)
+ * Add initial implementation of `PagePermissionPolicy` (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/permission_policies/base.py
+++ b/wagtail/permission_policies/base.py
@@ -26,7 +26,7 @@ class BasePermissionPolicy:
     fine-grained permission logic).
     """
 
-    perm_cache_name = ""
+    permission_cache_name = ""
 
     def __init__(self, model):
         self._model_or_name = model
@@ -61,12 +61,12 @@ class BasePermissionPolicy:
         This can be useful for the other methods to perform efficient queries
         against the set of permissions that the user has.
         """
-        if hasattr(user, self.perm_cache_name):
-            perms = getattr(user, self.perm_cache_name)
+        if hasattr(user, self.permission_cache_name):
+            perms = getattr(user, self.permission_cache_name)
         else:
             perms = self.get_all_permissions_for_user(user)
-            if self.perm_cache_name:
-                setattr(user, self.perm_cache_name, perms)
+            if self.permission_cache_name:
+                setattr(user, self.permission_cache_name, perms)
         return perms
 
     # Basic user permission tests. Most policies are expected to override these,

--- a/wagtail/permission_policies/pages.py
+++ b/wagtail/permission_policies/pages.py
@@ -1,0 +1,154 @@
+from django.contrib.auth import get_user_model
+from django.db.models import (
+    CharField,
+    Exists,
+    ExpressionWrapper,
+    F,
+    OuterRef,
+    PositiveIntegerField,
+    Q,
+    Value,
+)
+
+from wagtail.models import GroupPagePermission
+from wagtail.permission_policies.base import BasePermissionPolicy
+
+
+class PagePermissionPolicy(BasePermissionPolicy):
+    def _base_user_has_permission(self, user):
+        if not user.is_active:
+            return False
+        if user.is_superuser:
+            return True
+        return None
+
+    def user_has_permission(self, user, action):
+        base_permission = self._base_user_has_permission(user)
+        if base_permission is not None:
+            return base_permission
+        return GroupPagePermission.objects.filter(
+            group__user=user,
+            permission_type=action,
+        ).exists()
+
+    def user_has_any_permission(self, user, actions):
+        base_permission = self._base_user_has_permission(user)
+        if base_permission is not None:
+            return base_permission
+        return GroupPagePermission.objects.filter(
+            group__user=user,
+            permission_type__in=actions,
+        ).exists()
+
+    def users_with_any_permission(self, actions):
+        return (
+            get_user_model()
+            ._default_manager.filter(is_active=True)
+            .filter(
+                Q(is_superuser=True)
+                | Exists(
+                    GroupPagePermission.objects.filter(
+                        group__pk__in=OuterRef("groups"),
+                        permission_type__in=actions,
+                    )
+                )
+            )
+            .distinct()
+        )
+
+    def _base_user_permissions_for_instance_query(self, user, instance=None):
+        if instance:
+            # If we're filtering by an instance, we can use the instance's path and depth
+            instance_path = Value(instance.path, CharField())
+            instance_depth = Value(instance.depth, PositiveIntegerField())
+        else:
+            # Otherwise, we need to use the path and depth of the page being permission-checked
+            instance_path = ExpressionWrapper(
+                OuterRef("path"),
+                output_field=CharField(),
+            )
+            instance_depth = ExpressionWrapper(
+                OuterRef("depth"),
+                output_field=PositiveIntegerField(),
+            )
+
+        return GroupPagePermission.objects.annotate(
+            _instance_path=instance_path,
+            _instance_depth=instance_depth,
+        ).filter(
+            _instance_path__startswith=F("page__path"),
+            _instance_depth__gte=F("page__depth"),
+            group__user=user,
+        )
+
+    def user_has_permission_for_instance(self, user, action, instance):
+        base_permission = self._base_user_has_permission(user)
+        if base_permission is not None:
+            return base_permission
+        return (
+            self._base_user_permissions_for_instance_query(user, instance)
+            .filter(permission_type=action)
+            .exists()
+        )
+
+    def user_has_any_permission_for_instance(self, user, actions, instance):
+        base_permission = self._base_user_has_permission(user)
+        if base_permission is not None:
+            return base_permission
+        return (
+            self._base_user_permissions_for_instance_query(user, instance)
+            .filter(permission_type__in=actions)
+            .exists()
+        )
+
+    def _base_instances_user_has_permission_for_query(self, user, **kwargs):
+        return self.model._default_manager.filter(
+            Exists(
+                self._base_user_permissions_for_instance_query(user).filter(**kwargs)
+            )
+        ).distinct()
+
+    def instances_user_has_any_permission_for(self, user, actions):
+        base_permission = self._base_user_has_permission(user)
+        if base_permission is False:
+            return self.model._default_manager.none()
+        if base_permission is True:
+            return self.model._default_manager.all()
+        return self._base_instances_user_has_permission_for_query(
+            user, permission_type__in=actions
+        )
+
+    def instances_user_has_permission_for(self, user, action):
+        base_permission = self._base_user_has_permission(user)
+        if base_permission is False:
+            return self.model._default_manager.none()
+        if base_permission is True:
+            return self.model._default_manager.all()
+        return self._base_instances_user_has_permission_for_query(
+            user, permission_type=action
+        )
+
+    def _base_users_with_permission_for_instance_query(self, instance, **kwargs):
+        return (
+            get_user_model()
+            ._default_manager.filter(is_active=True)
+            .filter(
+                Q(is_superuser=True)
+                | Exists(
+                    self._base_user_permissions_for_instance_query(
+                        user=OuterRef("pk"), instance=instance
+                    ).filter(**kwargs)
+                )
+            )
+            .distinct()
+        )
+
+    def users_with_any_permission_for_instance(self, actions, instance):
+        return self._base_users_with_permission_for_instance_query(
+            instance, permission_type__in=actions
+        )
+
+    def users_with_permission_for_instance(self, action, instance):
+        return self._base_users_with_permission_for_instance_query(
+            instance, permission_type=action
+        )

--- a/wagtail/permission_policies/pages.py
+++ b/wagtail/permission_policies/pages.py
@@ -24,9 +24,9 @@ class PagePermissionPolicy(BasePermissionPolicy):
 
     def get_all_permissions_for_user(self, user):
         if not user.is_active or user.is_anonymous or user.is_superuser:
-            return set()
-        return set(
-            GroupPagePermission.objects.filter(group__user=user).select_related("page")
+            return GroupPagePermission.objects.none()
+        return GroupPagePermission.objects.filter(group__user=user).select_related(
+            "page"
         )
 
     def _base_user_has_permission(self, user):

--- a/wagtail/permission_policies/pages.py
+++ b/wagtail/permission_policies/pages.py
@@ -6,7 +6,7 @@ from wagtail.permission_policies.base import BasePermissionPolicy
 
 
 class PagePermissionPolicy(BasePermissionPolicy):
-    perm_cache_name = "_page_perm_cache"
+    permission_cache_name = "_page_permission_cache"
 
     def __init__(self, model=Page):
         super().__init__(model=model)

--- a/wagtail/permission_policies/pages.py
+++ b/wagtail/permission_policies/pages.py
@@ -32,12 +32,23 @@ class PagePermissionPolicy(BasePermissionPolicy):
         base_permission = self._base_user_has_permission(user)
         if base_permission is not None:
             return base_permission
+
+        # User with only "add" permission can still edit their own pages
+        actions = set(actions)
+        if "edit" in actions:
+            actions.add("add")
+
         permissions = {
             perm.permission_type for perm in self.get_cached_permissions_for_user(user)
         }
-        return bool(set(actions) & permissions)
+        return bool(actions & permissions)
 
     def users_with_any_permission(self, actions):
+        # User with only "add" permission can still edit their own pages
+        actions = set(actions)
+        if "edit" in actions:
+            actions.add("add")
+
         groups = GroupPagePermission.objects.filter(
             permission_type__in=actions
         ).values_list("group", flat=True)

--- a/wagtail/permission_policies/pages.py
+++ b/wagtail/permission_policies/pages.py
@@ -12,12 +12,15 @@ from django.db.models import (
     Value,
 )
 
-from wagtail.models import GroupPagePermission
+from wagtail.models import GroupPagePermission, Page
 from wagtail.permission_policies.base import BasePermissionPolicy
 
 
 class PagePermissionPolicy(BasePermissionPolicy):
     perm_cache_name = "_page_perm_cache"
+
+    def __init__(self, model=Page):
+        super().__init__(model=model)
 
     def get_all_permissions_for_user(self, user):
         if not user.is_active or user.is_anonymous or user.is_superuser:

--- a/wagtail/tests/test_page_permission_policies.py
+++ b/wagtail/tests/test_page_permission_policies.py
@@ -1,0 +1,427 @@
+from django.contrib.auth.models import AnonymousUser, Group
+from django.test import TestCase
+
+from wagtail.models import Page, GroupPagePermission
+from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.test.utils import WagtailTestUtils
+from wagtail.tests.test_permission_policies import PermissionPolicyTestUtils
+
+
+class PermissionPolicyTestCase(PermissionPolicyTestUtils, WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.root_page = Page.objects.get(id=2)
+
+        self.reports_page = self.root_page.add_child(
+            instance=Page(
+                title="Reports",
+                slug="reports",
+            )
+        )
+
+        root_editors_group = Group.objects.create(name="Root editors")
+        GroupPagePermission.objects.create(
+            group=root_editors_group,
+            page=self.root_page,
+            permission_type="edit",
+        )
+
+        report_editors_group = Group.objects.create(name="Report editors")
+        GroupPagePermission.objects.create(
+            group=report_editors_group,
+            page=self.reports_page,
+            permission_type="edit",
+        )
+
+        report_adders_group = Group.objects.create(name="Report adders")
+        GroupPagePermission.objects.create(
+            group=report_adders_group,
+            page=self.reports_page,
+            permission_type="add",
+        )
+
+        # Users
+        self.superuser = self.create_superuser(
+            "superuser", "superuser@example.com", "password"
+        )
+        self.inactive_superuser = self.create_superuser(
+            "inactivesuperuser", "inactivesuperuser@example.com", "password"
+        )
+        self.inactive_superuser.is_active = False
+        self.inactive_superuser.save()
+
+        # a user with edit permission through the root_editors_group
+        self.root_editor = self.create_user(
+            "rooteditor", "rooteditor@example.com", "password"
+        )
+        self.root_editor.groups.add(root_editors_group)
+
+        # a user that has edit permission, but is inactive
+        self.inactive_root_editor = self.create_user(
+            "inactiverooteditor", "inactiverooteditor@example.com", "password"
+        )
+        self.inactive_root_editor.groups.add(root_editors_group)
+        self.inactive_root_editor.is_active = False
+        self.inactive_root_editor.save()
+
+        # a user with edit permission on reports via the report_editors_group
+        self.report_editor = self.create_user(
+            "reporteditor", "reporteditor@example.com", "password"
+        )
+        self.report_editor.groups.add(report_editors_group)
+
+        # a user with add permission on reports via the report_adders_group
+        self.report_adder = self.create_user(
+            "reportadder", "reportadder@example.com", "password"
+        )
+        self.report_adder.groups.add(report_adders_group)
+
+        # a user with no permissions
+        self.useless_user = self.create_user(
+            "uselessuser", "uselessuser@example.com", "password"
+        )
+
+        self.anonymous_user = AnonymousUser()
+
+        # a page in the root owned by 'reporteditor'
+        self.editor_page = self.root_page.add_child(
+            instance=Page(
+                title="reporteditor's page",
+                slug="reporteditor-page",
+                owner=self.report_editor,
+            )
+        )
+
+        # a page in reports owned by 'reporteditor'
+        self.editor_report = self.reports_page.add_child(
+            instance=Page(
+                title="reporteditor's report",
+                slug="reporteditor-report",
+                owner=self.report_editor,
+            )
+        )
+
+        # a page in reports owned by 'reportadder'
+        self.adder_report = self.reports_page.add_child(
+            instance=Page(
+                title="reportadder's report",
+                slug="reportadder-report",
+                owner=self.report_adder,
+            )
+        )
+
+        # a page in reports owned by 'uselessuser'
+        self.useless_report = self.reports_page.add_child(
+            instance=Page(
+                title="uselessuser's report",
+                slug="uselessuser-report",
+                owner=self.useless_user,
+            )
+        )
+
+        # a page in reports with no owner
+        self.anonymous_report = self.reports_page.add_child(
+            instance=Page(
+                title="anonymous report",
+                slug="anonymous-report",
+            )
+        )
+
+
+class TestPagePermissionPolicy(PermissionPolicyTestCase):
+    def setUp(self):
+        super().setUp()
+        self.policy = PagePermissionPolicy(Page)
+
+    def test_user_has_permission(self):
+        self.assertUserPermissionMatrix(
+            [
+                (self.superuser, True, True, True, True),
+                (self.inactive_superuser, False, False, False, False),
+                (self.root_editor, False, True, False, False),
+                (self.inactive_root_editor, False, False, False, False),
+                (self.report_editor, False, True, False, False),
+                (self.report_adder, True, False, False, False),
+                (self.useless_user, False, False, False, False),
+                (self.anonymous_user, False, False, False, False),
+            ],
+            ["add", "edit", "delete", "frobnicate"],
+        )
+
+    def test_user_has_any_permission(self):
+        self.assertTrue(
+            self.policy.user_has_any_permission(self.superuser, ["add", "edit"])
+        )
+        self.assertFalse(
+            self.policy.user_has_any_permission(
+                self.inactive_superuser, ["add", "edit"]
+            )
+        )
+        self.assertTrue(
+            self.policy.user_has_any_permission(self.report_editor, ["add", "edit"])
+        )
+        self.assertTrue(
+            self.policy.user_has_any_permission(self.report_adder, ["add", "edit"])
+        )
+        self.assertFalse(
+            self.policy.user_has_any_permission(self.anonymous_user, ["add", "edit"])
+        )
+
+    def test_users_with_any_permission(self):
+        users_with_add_or_change_permission = self.policy.users_with_any_permission(
+            ["add", "edit"]
+        )
+
+        self.assertResultSetEqual(
+            users_with_add_or_change_permission,
+            [
+                self.superuser,
+                self.root_editor,
+                self.report_editor,
+                self.report_adder,
+            ],
+        )
+
+    def test_users_with_permission(self):
+        users_with_change_permission = self.policy.users_with_permission("edit")
+
+        self.assertResultSetEqual(
+            users_with_change_permission,
+            [
+                self.superuser,
+                self.root_editor,
+                self.report_editor,
+            ],
+        )
+
+        users_with_custom_permission = self.policy.users_with_permission("frobnicate")
+
+        self.assertResultSetEqual(
+            users_with_custom_permission,
+            [
+                self.superuser,
+            ],
+        )
+
+    def test_user_has_permission_for_instance(self):
+        # page in the root is only editable by users with permissions
+        # on the root page
+        self.assertUserInstancePermissionMatrix(
+            self.editor_page,
+            [
+                (self.superuser, True, True, True),
+                (self.inactive_superuser, False, False, False),
+                (self.root_editor, True, False, False),
+                (self.inactive_root_editor, False, False, False),
+                (self.report_editor, False, False, False),
+                (self.report_adder, False, False, False),
+                (self.useless_user, False, False, False),
+                (self.anonymous_user, False, False, False),
+            ],
+            ["edit", "delete", "frobnicate"],
+        )
+
+        # page in 'reports' is editable by users with permissions
+        # on 'reports' or the root page
+        self.assertUserInstancePermissionMatrix(
+            self.useless_report,
+            [
+                (self.superuser, True, True, True),
+                (self.inactive_superuser, False, False, False),
+                (self.root_editor, True, False, False),
+                (self.inactive_root_editor, False, False, False),
+                (self.report_editor, True, False, False),
+                (self.report_adder, False, False, False),
+                (self.useless_user, False, False, False),
+                (self.anonymous_user, False, False, False),
+            ],
+            ["edit", "delete", "frobnicate"],
+        )
+
+    def test_user_has_any_permission_for_instance(self):
+        self.assertTrue(
+            self.policy.user_has_any_permission_for_instance(
+                self.report_editor, ["edit", "delete"], self.useless_report
+            )
+        )
+
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.report_editor, ["edit", "delete"], self.editor_page
+            )
+        )
+
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.anonymous_user, ["edit", "delete"], self.editor_page
+            )
+        )
+
+    def test_instances_user_has_permission_for(self):
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.superuser,
+                "edit",
+            ),
+            Page.objects.all(),
+        )
+
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.inactive_superuser,
+                "edit",
+            ),
+            [],
+        )
+
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.root_editor,
+                "edit",
+            ),
+            [
+                self.root_page,
+                self.reports_page,
+                self.editor_page,
+                self.editor_report,
+                self.adder_report,
+                self.useless_report,
+                self.anonymous_report,
+            ],
+        )
+
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.report_editor,
+                "edit",
+            ),
+            [
+                self.reports_page,
+                self.editor_report,
+                self.useless_report,
+                self.adder_report,
+                self.anonymous_report,
+            ],
+        )
+
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.useless_user,
+                "edit",
+            ),
+            [],
+        )
+
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.anonymous_user,
+                "edit",
+            ),
+            [],
+        )
+
+    def test_instances_user_has_any_permission_for(self):
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.superuser, ["edit", "delete"]
+            ),
+            Page.objects.all(),
+        )
+
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.inactive_superuser, ["edit", "delete"]
+            ),
+            [],
+        )
+
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.root_editor, ["edit", "delete"]
+            ),
+            [
+                self.root_page,
+                self.reports_page,
+                self.editor_page,
+                self.editor_report,
+                self.adder_report,
+                self.useless_report,
+                self.anonymous_report,
+            ],
+        )
+
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.report_editor, ["edit", "delete"]
+            ),
+            [
+                self.reports_page,
+                self.editor_report,
+                self.adder_report,
+                self.useless_report,
+                self.anonymous_report,
+            ],
+        )
+
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.useless_user, ["edit", "delete"]
+            ),
+            [],
+        )
+
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.anonymous_user, ["edit", "delete"]
+            ),
+            [],
+        )
+
+    def test_users_with_permission_for_instance(self):
+        self.assertResultSetEqual(
+            self.policy.users_with_permission_for_instance("edit", self.editor_page),
+            [self.superuser, self.root_editor],
+        )
+        self.assertResultSetEqual(
+            self.policy.users_with_permission_for_instance("edit", self.adder_report),
+            [self.superuser, self.root_editor, self.report_editor],
+        )
+        self.assertResultSetEqual(
+            self.policy.users_with_permission_for_instance("edit", self.editor_report),
+            [self.superuser, self.root_editor, self.report_editor],
+        )
+        self.assertResultSetEqual(
+            self.policy.users_with_permission_for_instance("edit", self.useless_report),
+            [self.superuser, self.root_editor, self.report_editor],
+        )
+        self.assertResultSetEqual(
+            self.policy.users_with_permission_for_instance(
+                "edit", self.anonymous_report
+            ),
+            [self.superuser, self.root_editor, self.report_editor],
+        )
+
+    def test_users_with_any_permission_for_instance(self):
+        self.assertResultSetEqual(
+            self.policy.users_with_any_permission_for_instance(
+                ["edit", "delete"], self.editor_page
+            ),
+            [self.superuser, self.root_editor],
+        )
+        self.assertResultSetEqual(
+            self.policy.users_with_any_permission_for_instance(
+                ["edit", "delete"], self.adder_report
+            ),
+            [self.superuser, self.root_editor, self.report_editor],
+        )
+        self.assertResultSetEqual(
+            self.policy.users_with_any_permission_for_instance(
+                ["edit", "delete"], self.useless_report
+            ),
+            [self.superuser, self.root_editor, self.report_editor],
+        )
+        self.assertResultSetEqual(
+            self.policy.users_with_any_permission_for_instance(
+                ["delete", "frobnicate"], self.useless_report
+            ),
+            [self.superuser],
+        )

--- a/wagtail/tests/test_page_permission_policies.py
+++ b/wagtail/tests/test_page_permission_policies.py
@@ -179,7 +179,7 @@ class TestPagePermissionPolicy(PermissionPolicyTestCase):
                 (self.root_editor, False, True, False, False),
                 (self.inactive_root_editor, False, False, False, False),
                 (self.report_editor, False, True, False, False),
-                (self.report_adder, True, False, False, False),
+                (self.report_adder, True, True, False, False),
                 (self.useless_user, False, False, False, False),
                 (self.anonymous_user, False, False, False, False),
             ],
@@ -204,6 +204,9 @@ class TestPagePermissionPolicy(PermissionPolicyTestCase):
         self.assertFalse(
             self.policy.user_has_any_permission(self.anonymous_user, ["add", "edit"])
         )
+        self.assertTrue(
+            self.policy.user_has_any_permission(self.report_adder, ["edit"])
+        )
 
     def test_users_with_any_permission(self):
         users_with_add_or_change_permission = self.policy.users_with_any_permission(
@@ -212,6 +215,32 @@ class TestPagePermissionPolicy(PermissionPolicyTestCase):
 
         self.assertResultSetEqual(
             users_with_add_or_change_permission,
+            [
+                self.superuser,
+                self.root_editor,
+                self.report_editor,
+                self.report_adder,
+            ],
+        )
+
+        users_with_add_or_frobnicate_permission = self.policy.users_with_any_permission(
+            ["add", "frobnicate"]
+        )
+
+        self.assertResultSetEqual(
+            users_with_add_or_frobnicate_permission,
+            [
+                self.superuser,
+                self.report_adder,
+            ],
+        )
+
+        users_with_edit_or_frobnicate_permission = (
+            self.policy.users_with_any_permission(["edit", "frobnicate"])
+        )
+
+        self.assertResultSetEqual(
+            users_with_edit_or_frobnicate_permission,
             [
                 self.superuser,
                 self.root_editor,
@@ -229,6 +258,7 @@ class TestPagePermissionPolicy(PermissionPolicyTestCase):
                 self.superuser,
                 self.root_editor,
                 self.report_editor,
+                self.report_adder,
             ],
         )
 

--- a/wagtail/tests/test_page_permission_policies.py
+++ b/wagtail/tests/test_page_permission_policies.py
@@ -130,7 +130,7 @@ class PermissionPolicyTestCase(PermissionPolicyTestUtils, WagtailTestUtils, Test
 class TestPagePermissionPolicy(PermissionPolicyTestCase):
     def setUp(self):
         super().setUp()
-        self.policy = PagePermissionPolicy(Page)
+        self.policy = PagePermissionPolicy()
 
     def test_user_has_permission(self):
         self.assertUserPermissionMatrix(

--- a/wagtail/tests/test_page_permission_policies.py
+++ b/wagtail/tests/test_page_permission_policies.py
@@ -383,7 +383,7 @@ class TestPagePermissionPolicy(PermissionPolicyTestCase):
         )
         self.assertResultSetEqual(
             self.policy.users_with_permission_for_instance("edit", self.adder_report),
-            [self.superuser, self.root_editor, self.report_editor],
+            [self.superuser, self.root_editor, self.report_editor, self.report_adder],
         )
         self.assertResultSetEqual(
             self.policy.users_with_permission_for_instance("edit", self.editor_report),
@@ -411,7 +411,7 @@ class TestPagePermissionPolicy(PermissionPolicyTestCase):
             self.policy.users_with_any_permission_for_instance(
                 ["edit", "delete"], self.adder_report
             ),
-            [self.superuser, self.root_editor, self.report_editor],
+            [self.superuser, self.root_editor, self.report_editor, self.report_adder],
         )
         self.assertResultSetEqual(
             self.policy.users_with_any_permission_for_instance(

--- a/wagtail/tests/test_page_permission_policies.py
+++ b/wagtail/tests/test_page_permission_policies.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import AnonymousUser, Group
 from django.test import TestCase
 
-from wagtail.models import Page, GroupPagePermission
+from wagtail.models import GroupPagePermission, Page
 from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.tests.test_permission_policies import PermissionPolicyTestUtils

--- a/wagtail/tests/test_permission_policies.py
+++ b/wagtail/tests/test_permission_policies.py
@@ -17,14 +17,15 @@ class PermissionPolicyTestUtils:
     def assertResultSetEqual(self, actual, expected):
         self.assertEqual(set(actual), set(expected))
 
-    def assertUserPermissionMatrix(self, test_cases):
+    def assertUserPermissionMatrix(self, test_cases, actions=()):
         """
         Given a list of (user, can_add, can_change, can_delete, can_frobnicate) tuples
         (where 'frobnicate' is an unrecognised action not defined on the model),
         confirm that all tuples correctly represent permissions for that user as
         returned by user_has_permission
         """
-        actions = ["add", "change", "delete", "frobnicate"]
+        if not actions:
+            actions = ["add", "change", "delete", "frobnicate"]
         for test_case in test_cases:
             user = test_case[0]
             expected_results = zip(actions, test_case[1:])
@@ -42,14 +43,15 @@ class PermissionPolicyTestUtils:
                         % (user, action),
                     )
 
-    def assertUserInstancePermissionMatrix(self, instance, test_cases):
+    def assertUserInstancePermissionMatrix(self, instance, test_cases, actions=()):
         """
         Given a list of (user, can_change, can_delete, can_frobnicate) tuples
         (where 'frobnicate' is an unrecognised action not defined on the model),
         confirm that all tuples correctly represent permissions for that user on
         the given instance, as returned by user_has_permission_for_instance
         """
-        actions = ["change", "delete", "frobnicate"]
+        if not actions:
+            actions = ["change", "delete", "frobnicate"]
         for test_case in test_cases:
             user = test_case[0]
             expected_results = zip(actions, test_case[1:])


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

This PR adds an initial version of `PagePermissionPolicy` that implements the methods in `BasePermissionPolicy` using ORM lookups with the `GroupPagePermission` model. This does not take into account any advanced logic that we currently have in `UserPagePermissionsProxy` and `PagePermissionTester` (e.g. ownership, preventing deletion based on published child pages, etc.).

~~I tried to make all the logic done on the database level so that each method only runs a single database query. Not sure if this is a good idea though, as it might be more efficient to fetch all the `GroupPagePermission` objects for the user in a single query, and infer the permissions in Python with additional queries as necessary. However, I don't know where to put the cached `GroupPagePermission` objects for the user in order to do this, as the `BasePermissionPolicy` class is pretty much stateless..~~

For the record, Django queries all `Permission` objects for a user and cache them on the user object when a permission check is done:

https://github.com/django/django/blob/main/django/contrib/auth/backends.py#L66-L109

**Edit**: I've updated the approach to cache the permission objects on the user object and compute the logic using them.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
