### PR TITLE
Avoid `N+1` in users Index view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -60,6 +60,7 @@ Changelog
  * Fix: Improve visibility of scheduled publishing errors in status side panel (Sage Abdullah)
  * Fix: Prevent 'choose' permission from being ignored when looking up 'choose', 'edit' and 'delete' permissions in combination (Sage Abdullah)
  * Fix: Take user's permissions into account for image / document counts on the admin dashboard (Sage Abdullah)
+ * Fix: Avoid N+1 queries in users index view (Tidiane Dia)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -117,6 +117,7 @@ This feature was developed by Aman Pandey as part of the Google Summer of Code p
  * Improve visibility of scheduled publishing errors in status side panel (Sage Abdullah)
  * Prevent 'choose' permission from being ignored when looking up 'choose', 'edit' and 'delete' permissions in combination (Sage Abdullah)
  * Take user's permissions into account for image / document counts on the admin dashboard (Sage Abdullah)
+ * Avoid N+1 queries in users index view (Tidiane Dia)
 
 ### Documentation
 

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -246,6 +246,19 @@ class TestUserIndexView(WagtailTestUtils, TestCase):
         response = self.get({"ordering": "username"})
         self.assertEqual(response.context_data["ordering"], "username")
 
+    def test_num_queries(self):
+        # Warm up
+        self.get()
+
+        num_queries = 9
+        with self.assertNumQueries(num_queries):
+            self.get()
+
+        # Ensure we don't have any N+1 queries
+        self.create_user("test", "test@example.com", "gu@rd14n")
+        with self.assertNumQueries(num_queries):
+            self.get()
+
 
 class TestUserIndexResultsView(WagtailTestUtils, TestCase):
     def setUp(self):

--- a/wagtail/users/views/bulk_actions/user_bulk_action.py
+++ b/wagtail/users/views/bulk_actions/user_bulk_action.py
@@ -11,7 +11,7 @@ class UserBulkAction(BulkAction):
         listing_objects = self.model.objects.all().values_list("pk", flat=True)
         if "q" in self.request.GET:
             q = self.request.GET.get("q")
-            model_fields = [f.name for f in self.model._meta.get_fields()]
+            model_fields = {f.name for f in self.model._meta.get_fields()}
             conditions = get_users_filter_query(q, model_fields)
 
             listing_objects = listing_objects.filter(conditions)


### PR DESCRIPTION
I found an N+1 coming from the `wagtail_userprofile` field in the users' index view. 