### PR TITLE
Fixes accessibility dialog box with class w-dialog has z-index of 130 and hides behind other elements on the page

### DIFF
--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -113,10 +113,10 @@ module.exports = {
           'inset-inline-start, padding-inline-start, width, transform, margin-top, min-height',
       },
       zIndex: {
-        'header': '100',
-        'sidebar': '110',
-        'sidebar-toggle': '120',
-        'dialog': '130',
+        'header': '9900',
+        'sidebar': '9910',
+        'sidebar-toggle': '9920',
+        'dialog': '9930',
       },
       keyframes: {
         'fade-in': {


### PR DESCRIPTION
This changes the zIndex to be compatible with bootstrap's sidebar while allowing the userbar to show above the accessibility menu. Thank you @fourfridays for the issue!

Fixes #10471







_Please check the following:_

-   [ Probably ] Do the tests still pass?[^1]
-   [ Yes ] Does the code comply with the style guide?
    -   [ Skipped ] Run `make lint` from the Wagtail root.
-   [ N/A ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ Skipped ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ N/A ] **Please list the exact browser and operating system versions you tested**:
    -   [ N/A ] **Please list which assistive technologies [^3] you tested**:
-   [ N/A ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
