### PR TITLE
Don't redundantly try and find a site

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,6 +42,7 @@ Changelog
  * Maintenance: Split out a base listing view from generic index view (Matt Westcott)
  * Maintenance: Update type hints in admin/ui/components.py so that `parent_context` is mutable (Andreas Nüßlein)
  * Maintenance: Deprecate `UserPagePermissionsProxy` (Sage Abdullah)
+ * Maintenance: Optimise the Settings context processor to avoid redundantly finding a Site to improve cache ratios (Jake Howard)
 
 
 5.0.2 (21.06.2023)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -63,6 +63,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
  * Split out a base listing view from generic index view (Matt Westcott)
  * Update type hints in admin/ui/components.py so that `parent_context` is mutable (Andreas Nüßlein)
  * Deprecate `UserPagePermissionsProxy` (Sage Abdullah)
+ * Optimise the Settings context processor to avoid redundantly finding a Site to improve cache ratios (Jake Howard)
 
 
 ## Upgrade considerations

--- a/wagtail/contrib/settings/context_processors.py
+++ b/wagtail/contrib/settings/context_processors.py
@@ -1,5 +1,3 @@
-from django.utils.functional import SimpleLazyObject
-
 from wagtail.contrib.settings.models import BaseGenericSetting, BaseSiteSetting
 from wagtail.models import Site
 
@@ -74,12 +72,4 @@ class SettingModuleProxy(dict):
 
 
 def settings(request):
-    # Delay query until settings values are needed
-    def _inner(request):
-        site = Site.find_for_request(request)
-        if site is None:
-            return SettingProxy(request_or_site=None)
-
-        return SettingProxy(request_or_site=request)
-
-    return {"settings": SimpleLazyObject(lambda: _inner(request))}
+    return {"settings": SettingProxy(request_or_site=request)}


### PR DESCRIPTION
_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

We don't actually use the site. In all cases, it's sensible to fall back to passing the request instead, as this should improve cache ratios

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
