### PR TITLE
Split out a base listing view from generic IndexView

### DIFF
--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -2,11 +2,18 @@ from django.contrib.admin.utils import quote, unquote
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
+from django.utils.translation import gettext as _
 from django.views import View
 from django.views.generic.base import ContextMixin, TemplateResponseMixin
+from django.views.generic.list import BaseListView
 
 from wagtail.admin import messages
+from wagtail.admin.filters import WagtailFilterSet
+from wagtail.admin.forms.search import SearchForm
+from wagtail.admin.ui.tables import Table
 from wagtail.admin.utils import get_valid_next_url_from_request
+from wagtail.search.backends import get_search_backend
+from wagtail.search.index import class_is_indexed
 
 
 class WagtailAdminTemplateMixin(TemplateResponseMixin, ContextMixin):
@@ -113,3 +120,199 @@ class BaseOperationView(BaseObjectMixin, View):
         self.perform_operation()
         self.add_success_message()
         return redirect(self.get_success_url())
+
+
+class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
+    model = None
+    index_url_name = None
+    template_name = "wagtailadmin/generic/index.html"
+    page_kwarg = "p"
+    is_searchable = None
+    search_kwarg = "q"
+    search_fields = None
+    default_ordering = None
+    list_filter = None
+    filters = None
+    filterset_class = None
+    search_backend_name = "default"
+    use_autocomplete = False
+    table_class = Table
+    context_object_name = None
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.filterset_class = self.get_filterset_class()
+        self.setup_search()
+
+    def setup_search(self):
+        self.is_searchable = self.get_is_searchable()
+        self.search_url = self.get_search_url()
+        self.search_form = self.get_search_form()
+        self.is_searching = False
+        self.search_query = None
+
+        if self.search_form and self.search_form.is_valid():
+            self.search_query = self.search_form.cleaned_data[self.search_kwarg]
+            self.is_searching = True
+
+    def get_index_url(self):
+        if self.index_url_name:
+            return reverse(self.index_url_name)
+
+    def get_search_url(self):
+        if not self.is_searchable:
+            return None
+        return self.index_url_name
+
+    def get_is_searchable(self):
+        if self.model is None:
+            return False
+        if self.is_searchable is None:
+            return class_is_indexed(self.model) or self.search_fields
+        return self.is_searchable
+
+    def get_search_form(self):
+        if self.model is None:
+            return None
+
+        if self.is_searchable and self.search_kwarg in self.request.GET:
+            return SearchForm(
+                self.request.GET,
+                placeholder=_("Search %(model_name)s")
+                % {"model_name": self.model._meta.verbose_name_plural},
+            )
+
+        return SearchForm(
+            placeholder=_("Search %(model_name)s")
+            % {"model_name": self.model._meta.verbose_name_plural}
+        )
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+
+        self.filters, queryset = self.filter_queryset(queryset)
+
+        ordering = self.get_ordering()
+        if ordering:
+            if not isinstance(ordering, (list, tuple)):
+                ordering = (ordering,)
+            queryset = queryset.order_by(*ordering)
+
+        # Preserve the model-level ordering if specified, but fall back on
+        # PK if not (to ensure pagination is consistent)
+        if not queryset.ordered:
+            queryset = queryset.order_by("pk")
+
+        return queryset
+
+    def paginate_queryset(self, queryset, page_size):
+        paginator = self.get_paginator(
+            queryset,
+            page_size,
+            orphans=self.get_paginate_orphans(),
+            allow_empty_first_page=self.get_allow_empty(),
+        )
+
+        page_number = self.request.GET.get(self.page_kwarg)
+        page = paginator.get_page(page_number)
+        return (paginator, page, page.object_list, page.has_other_pages())
+
+    def get_filterset_class(self):
+        if self.filterset_class:
+            return self.filterset_class
+
+        if not self.list_filter or not self.model:
+            return None
+
+        class Meta:
+            model = self.model
+            fields = self.list_filter
+
+        return type(
+            f"{self.model.__name__}FilterSet",
+            (WagtailFilterSet,),
+            {"Meta": Meta},
+        )
+
+    def filter_queryset(self, queryset):
+        # construct filter instance (self.filters) if not created already
+        if self.filterset_class and self.filters is None:
+            self.filters = self.filterset_class(
+                self.request.GET, queryset=queryset, request=self.request
+            )
+            queryset = self.filters.qs
+        elif self.filters:
+            # if filter object was created on a previous filter_queryset call, re-use it
+            queryset = self.filters.filter_queryset(queryset)
+
+        return self.filters, queryset
+
+    def search_queryset(self, queryset):
+        if not self.search_query:
+            return queryset
+
+        if class_is_indexed(queryset.model) and self.search_backend_name:
+            search_backend = get_search_backend(self.search_backend_name)
+            if self.use_autocomplete:
+                return search_backend.autocomplete(
+                    self.search_query, queryset, fields=self.search_fields
+                )
+            return search_backend.search(
+                self.search_query, queryset, fields=self.search_fields
+            )
+
+        filters = {
+            field + "__icontains": self.search_query
+            for field in self.search_fields or []
+        }
+        return queryset.filter(**filters)
+
+    def get_valid_orderings(self):
+        orderings = []
+        for col in self.columns:
+            if col.sort_key:
+                orderings.append(col.sort_key)
+                orderings.append("-%s" % col.sort_key)
+        return orderings
+
+    def get_ordering(self):
+        ordering = self.request.GET.get("ordering", self.default_ordering)
+        if ordering not in self.get_valid_orderings():
+            ordering = self.default_ordering
+        return ordering
+
+    def get_table(self, object_list, **kwargs):
+        return self.table_class(
+            self.columns,
+            object_list,
+            ordering=self.get_ordering(),
+            **kwargs,
+        )
+
+    def get_context_data(self, *args, object_list=None, **kwargs):
+        queryset = object_list if object_list is not None else self.object_list
+        queryset = self.search_queryset(queryset)
+
+        context = super().get_context_data(*args, object_list=queryset, **kwargs)
+
+        index_url = self.get_index_url()
+        table = self.get_table(context["object_list"], base_url=index_url)
+        context["media"] = table.media
+
+        if self.filters:
+            context["filters"] = self.filters
+            context["is_filtering"] = any(
+                self.request.GET.get(f) for f in self.filters.filters
+            )
+            context["media"] += self.filters.form.media
+
+        context["table"] = table
+        context["index_url"] = index_url
+        context["is_paginated"] = bool(self.paginate_by)
+        context["is_searchable"] = self.is_searchable
+        context["search_url"] = self.get_search_url()
+        context["search_form"] = self.search_form
+        context["is_searching"] = self.is_searching
+        context["query_string"] = self.search_query
+        context["model_opts"] = self.model and self.model._meta
+        return context

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -10,7 +10,7 @@ from django.views.generic.list import BaseListView
 from wagtail.admin import messages
 from wagtail.admin.filters import WagtailFilterSet
 from wagtail.admin.forms.search import SearchForm
-from wagtail.admin.ui.tables import Table
+from wagtail.admin.ui.tables import Column, Table
 from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
@@ -138,6 +138,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
     use_autocomplete = False
     table_class = Table
     context_object_name = None
+    columns = [Column("__str__", label=_("Title"))]
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -72,6 +72,10 @@ class IndexView(LocaleMixin, PermissionCheckedMixin, BaseListingView):
     any_permission_required = ["add", "change", "delete"]
     list_display = ["__str__", UpdatedAtColumn()]
 
+    # if not overridden at the class level, get_columns() will auto-generate the column list
+    # based on list_display
+    columns = None
+
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
         self.columns = self.get_columns()
@@ -186,9 +190,7 @@ class IndexView(LocaleMixin, PermissionCheckedMixin, BaseListingView):
         )
 
     def get_columns(self):
-        try:
-            return self.columns
-        except AttributeError:
+        if self.columns is None:
             columns = []
             for i, field in enumerate(self.list_display):
                 if isinstance(field, Column):
@@ -199,7 +201,9 @@ class IndexView(LocaleMixin, PermissionCheckedMixin, BaseListingView):
                     column = self._get_custom_column(field)
                 columns.append(column)
 
-            return columns
+            self.columns = columns
+
+        return self.columns
 
     def get_edit_url(self, instance):
         if self.permission_policy and not instance.annotated_permissions["change"]:

--- a/wagtail/admin/views/generic/usage.py
+++ b/wagtail/admin/views/generic/usage.py
@@ -6,8 +6,11 @@ from django.utils.translation import gettext_lazy
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.ui import tables
 from wagtail.admin.utils import get_latest_str
-from wagtail.admin.views.generic import BaseObjectMixin, IndexView
+from wagtail.admin.views.generic import BaseObjectMixin
+from wagtail.admin.views.generic.base import BaseListingView
 from wagtail.models import DraftStateMixin, ReferenceIndex
+
+from .permissions import PermissionCheckedMixin
 
 
 class TitleColumn(tables.TitleColumn):
@@ -15,10 +18,16 @@ class TitleColumn(tables.TitleColumn):
         return {"title": instance["edit_link_title"]}
 
 
-class UsageView(BaseObjectMixin, IndexView):
+class UsageView(PermissionCheckedMixin, BaseObjectMixin, BaseListingView):
     paginate_by = 20
     is_searchable = False
     page_title = gettext_lazy("Usage of")
+    permission_policy = None
+    edit_url_name = None
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.columns = self.get_columns()
 
     @cached_property
     def describe_on_delete(self):

--- a/wagtail/permission_policies/base.py
+++ b/wagtail/permission_policies/base.py
@@ -238,12 +238,19 @@ class BaseDjangoAuthPermissionPolicy(BasePermissionPolicy):
     def _content_type(self):
         return ContentType.objects.get_for_model(self.auth_model)
 
+    def _get_permission_codename(self, action):
+        """
+        Get the permission codename as used by the django.contrib.auth Permission
+        model for the given action on this model
+        """
+        return f"{action}_{self.model_name}"
+
     def _get_permission_name(self, action):
         """
         Get the full app-label-qualified permission name (as required by
         user.has_perm(...) ) for the given action on this model
         """
-        return "%s.%s_%s" % (self.app_label, action, self.model_name)
+        return f"{self.app_label}.{self._get_permission_codename(action)}"
 
     def _get_users_with_any_permission_codenames_filter(self, permission_codenames):
         """

--- a/wagtail/permission_policies/base.py
+++ b/wagtail/permission_policies/base.py
@@ -128,6 +128,24 @@ class BasePermissionPolicy:
     def users_with_permission_for_instance(self, action, instance):
         return self.users_with_any_permission_for_instance([action], instance)
 
+    def annotate_with_permissions(self, queryset, user, actions):
+        """
+        Annotate each instance in the given queryset with a annotated_permissions
+        dictionary that maps each action in the given list of actions to a
+        boolean value indicating whether the given user has permission to
+        perform that action.
+
+        Subclasses may override this method to provide a more efficient
+        implementation, e.g. by performing a single database query to
+        determine the permissions for all instances in the queryset.
+        """
+        for instance in queryset:
+            instance.annotated_permissions = {
+                action: self.user_has_permission_for_instance(user, action, instance)
+                for action in actions
+            }
+        return queryset
+
 
 class BlanketPermissionPolicy(BasePermissionPolicy):
     """

--- a/wagtail/permission_policies/base.py
+++ b/wagtail/permission_policies/base.py
@@ -128,6 +128,14 @@ class BasePermissionPolicy:
     def users_with_permission_for_instance(self, action, instance):
         return self.users_with_any_permission_for_instance([action], instance)
 
+    def _update_instance_annotated_permissions(self, instance, update_dict):
+        """
+        Update the instance.annotated_permissions dictionary with the given update_dict.
+        """
+        annotation = getattr(instance, "annotated_permissions", {})
+        annotation.update(update_dict)
+        instance.annotated_permissions = annotation
+
     def annotate_with_permissions(self, queryset, user, actions):
         """
         Annotate each instance in the given queryset with a annotated_permissions
@@ -140,10 +148,15 @@ class BasePermissionPolicy:
         determine the permissions for all instances in the queryset.
         """
         for instance in queryset:
-            instance.annotated_permissions = {
-                action: self.user_has_permission_for_instance(user, action, instance)
-                for action in actions
-            }
+            self._update_instance_annotated_permissions(
+                instance,
+                {
+                    action: self.user_has_permission_for_instance(
+                        user, action, instance
+                    )
+                    for action in actions
+                },
+            )
         return queryset
 
 

--- a/wagtail/permission_policies/collections.py
+++ b/wagtail/permission_policies/collections.py
@@ -223,9 +223,10 @@ class CollectionPermissionPolicy(
         # Skip queryset annotation if we already know whether the user has permission
         if known_access is not None:
             for instance in queryset:
-                instance.annotated_permissions = {
-                    action: known_access for action in actions
-                }
+                self._update_instance_annotated_permissions(
+                    instance,
+                    {action: known_access for action in actions},
+                )
             return queryset
 
         queryset = queryset.annotate(
@@ -236,9 +237,10 @@ class CollectionPermissionPolicy(
         )
 
         for instance in queryset:
-            instance.annotated_permissions = {
-                action: getattr(instance, f"_w_can_{action}") for action in actions
-            }
+            self._update_instance_annotated_permissions(
+                instance,
+                {action: getattr(instance, f"_w_can_{action}") for action in actions},
+            )
         return queryset
 
 
@@ -460,12 +462,15 @@ class CollectionOwnershipPermissionPolicy(
                 )
 
         for instance in queryset:
-            instance.annotated_permissions = {
-                action: getattr(
-                    instance, f"_w_can_{action_aliases.get(action, action)}"
-                )
-                for action in actions
-            }
+            self._update_instance_annotated_permissions(
+                instance,
+                {
+                    action: getattr(
+                        instance, f"_w_can_{action_aliases.get(action, action)}"
+                    )
+                    for action in actions
+                },
+            )
         return queryset
 
 

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -9,11 +9,7 @@ from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 from wagtail.snippets.bulk_actions.delete import DeleteBulkAction
 from wagtail.snippets.models import get_snippet_models
-from wagtail.snippets.permissions import (
-    get_permission_name,
-    user_can_edit_snippet_type,
-    user_can_edit_snippets,
-)
+from wagtail.snippets.permissions import user_can_edit_snippets
 from wagtail.snippets.views import snippets as snippet_views
 from wagtail.snippets.widgets import SnippetListingButton
 
@@ -65,7 +61,7 @@ def register_permissions():
 def register_snippet_listing_buttons(snippet, user, next_url=None):
     model = type(snippet)
 
-    if user_can_edit_snippet_type(user, model):
+    if snippet.annotated_permissions["change"]:
         yield SnippetListingButton(
             _("Edit"),
             reverse(
@@ -76,7 +72,7 @@ def register_snippet_listing_buttons(snippet, user, next_url=None):
             priority=10,
         )
 
-    if user.has_perm(get_permission_name("delete", model)):
+    if snippet.annotated_permissions["delete"]:
         yield SnippetListingButton(
             _("Delete"),
             reverse(

--- a/wagtail/tests/test_collection_permission_policies.py
+++ b/wagtail/tests/test_collection_permission_policies.py
@@ -557,6 +557,80 @@ class TestCollectionPermissionPolicy(PermissionPolicyTestCase):
             [],
         )
 
+    def test_annotate_with_permissions_with_known_access(self):
+        actions = ("change", "delete", "frobnicate")
+        # For these cases, the permissions are known without adding DB annotations
+        cases = (
+            (self.superuser, {action: True for action in actions}),
+            (self.inactive_superuser, {action: False for action in actions}),
+            (self.inactive_doc_changer, {action: False for action in actions}),
+            (self.anonymous_user, {action: False for action in actions}),
+        )
+        for user, expected_permissions in cases:
+            with self.assertNumQueries(1), self.subTest(user=user):
+                queryset = Document.objects.all().order_by("id")
+                queryset = self.policy.annotate_with_permissions(
+                    queryset, user, actions
+                )
+                for instance in queryset:
+                    self.assertEqual(
+                        instance.annotated_permissions,
+                        expected_permissions,
+                    )
+
+    def test_annotate_with_permissions_with_database_annotations(self):
+        actions = ("change", "delete", "frobnicate")
+        document_ids = (
+            # root document owned by report_changer
+            self.changer_doc.pk,
+            # reports document owned by report_changer
+            self.changer_report.pk,
+            # reports document owned by report_adder
+            self.adder_report.pk,
+            # reports document owned by useless_user
+            self.useless_report.pk,
+            # reports document with no owner
+            self.anonymous_report.pk,
+        )
+
+        with self.assertNumQueries(1), self.subTest(user=self.doc_changer):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.doc_changer, actions
+            )
+            expected = {"change": True, "delete": True, "frobnicate": False}
+            for instance in queryset:
+                self.assertEqual(instance.annotated_permissions, expected)
+
+        with self.assertNumQueries(1), self.subTest(user=self.report_changer):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.report_changer, actions
+            )
+            for instance in queryset:
+                expected = {"change": True, "delete": True, "frobnicate": False}
+                if instance.pk == self.changer_doc.pk:
+                    expected = {"change": False, "delete": False, "frobnicate": False}
+                self.assertEqual(instance.annotated_permissions, expected)
+
+        with self.assertNumQueries(1), self.subTest(user=self.report_adder):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.report_adder, actions
+            )
+            expected = {"change": False, "delete": False, "frobnicate": False}
+            for instance in queryset:
+                self.assertEqual(instance.annotated_permissions, expected)
+
+        with self.assertNumQueries(1), self.subTest(user=self.useless_user):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.useless_user, actions
+            )
+            expected = {"change": False, "delete": False, "frobnicate": False}
+            for instance in queryset:
+                self.assertEqual(instance.annotated_permissions, expected)
+
 
 class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
     def setUp(self):
@@ -1039,6 +1113,86 @@ class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
             ),
             [],
         )
+
+    def test_annotate_with_permissions_with_known_access(self):
+        actions = ("change", "delete", "frobnicate")
+        # For these cases, the permissions are known without adding DB annotations
+        cases = (
+            (self.superuser, {action: True for action in actions}),
+            (self.inactive_superuser, {action: False for action in actions}),
+            (self.inactive_doc_changer, {action: False for action in actions}),
+            (self.anonymous_user, {action: False for action in actions}),
+        )
+        for user, expected_permissions in cases:
+            with self.assertNumQueries(1), self.subTest(user=user):
+                queryset = Document.objects.all().order_by("id")
+                queryset = self.policy.annotate_with_permissions(
+                    queryset, user, actions
+                )
+                for instance in queryset:
+                    self.assertEqual(
+                        instance.annotated_permissions,
+                        expected_permissions,
+                    )
+
+    def test_annotate_with_permissions_with_database_annotations(self):
+        actions = ("change", "delete", "frobnicate")
+        document_ids = (
+            # root document owned by report_changer
+            self.changer_doc.pk,
+            # reports document owned by report_changer
+            self.changer_report.pk,
+            # reports document owned by report_adder
+            self.adder_report.pk,
+            # reports document owned by useless_user
+            self.useless_report.pk,
+            # reports document with no owner
+            self.anonymous_report.pk,
+        )
+
+        with self.assertNumQueries(1), self.subTest(user=self.doc_changer):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.doc_changer, actions
+            )
+            expected = {"change": True, "delete": True, "frobnicate": False}
+            for instance in queryset:
+                self.assertEqual(instance.annotated_permissions, expected)
+
+        with self.assertNumQueries(1), self.subTest(user=self.report_changer):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.report_changer, actions
+            )
+            for instance in queryset:
+                expected = {"change": True, "delete": True, "frobnicate": False}
+                # even though changer_report is owned by report_changer, they can't
+                # change or delete it because it's in the root collection and they
+                # don't have add permission on the root collection
+                if instance.pk == self.changer_doc.pk:
+                    expected = {"change": False, "delete": False, "frobnicate": False}
+                self.assertEqual(instance.annotated_permissions, expected)
+
+        with self.assertNumQueries(1), self.subTest(user=self.report_adder):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.report_adder, actions
+            )
+            for instance in queryset:
+                expected = {"change": False, "delete": False, "frobnicate": False}
+                # adder_report is owned by report_adder, so they can change and delete
+                if instance.pk == self.adder_report.pk:
+                    expected = {"change": True, "delete": True, "frobnicate": False}
+                self.assertEqual(instance.annotated_permissions, expected)
+
+        with self.assertNumQueries(1), self.subTest(user=self.useless_user):
+            queryset = Document.objects.filter(id__in=document_ids).order_by("id")
+            queryset = self.policy.annotate_with_permissions(
+                queryset, self.useless_user, actions
+            )
+            expected = {"change": False, "delete": False, "frobnicate": False}
+            for instance in queryset:
+                self.assertEqual(instance.annotated_permissions, expected)
 
 
 class TestCollectionManagementPermission(

--- a/wagtail/tests/test_collection_permission_policies.py
+++ b/wagtail/tests/test_collection_permission_policies.py
@@ -572,6 +572,8 @@ class TestCollectionPermissionPolicy(PermissionPolicyTestCase):
                 queryset = self.policy.annotate_with_permissions(
                     queryset, user, actions
                 )
+                # no duplicates are returned
+                self.assertEqual(len(queryset), 5)
                 for instance in queryset:
                     self.assertEqual(
                         instance.annotated_permissions,
@@ -598,6 +600,8 @@ class TestCollectionPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.doc_changer, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             expected = {"change": True, "delete": True, "frobnicate": False}
             for instance in queryset:
                 self.assertEqual(instance.annotated_permissions, expected)
@@ -607,6 +611,8 @@ class TestCollectionPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_changer, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             for instance in queryset:
                 expected = {"change": True, "delete": True, "frobnicate": False}
                 if instance.pk == self.changer_doc.pk:
@@ -618,6 +624,8 @@ class TestCollectionPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_adder, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             expected = {"change": False, "delete": False, "frobnicate": False}
             for instance in queryset:
                 self.assertEqual(instance.annotated_permissions, expected)
@@ -627,6 +635,8 @@ class TestCollectionPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.useless_user, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             expected = {"change": False, "delete": False, "frobnicate": False}
             for instance in queryset:
                 self.assertEqual(instance.annotated_permissions, expected)
@@ -1129,6 +1139,8 @@ class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
                 queryset = self.policy.annotate_with_permissions(
                     queryset, user, actions
                 )
+                # no duplicates are returned
+                self.assertEqual(len(queryset), 5)
                 for instance in queryset:
                     self.assertEqual(
                         instance.annotated_permissions,
@@ -1155,6 +1167,8 @@ class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.doc_changer, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             expected = {"change": True, "delete": True, "frobnicate": False}
             for instance in queryset:
                 self.assertEqual(instance.annotated_permissions, expected)
@@ -1164,6 +1178,8 @@ class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_changer, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             for instance in queryset:
                 expected = {"change": True, "delete": True, "frobnicate": False}
                 # even though changer_report is owned by report_changer, they can't
@@ -1178,6 +1194,8 @@ class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_adder, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             for instance in queryset:
                 expected = {"change": False, "delete": False, "frobnicate": False}
                 # adder_report is owned by report_adder, so they can change and delete
@@ -1190,6 +1208,8 @@ class TestCollectionOwnershipPermissionPolicy(PermissionPolicyTestCase):
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.useless_user, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 5)
             expected = {"change": False, "delete": False, "frobnicate": False}
             for instance in queryset:
                 self.assertEqual(instance.annotated_permissions, expected)
@@ -1566,6 +1586,8 @@ class TestCollectionManagementPermission(
                 queryset = self.policy.annotate_with_permissions(
                     queryset, user, actions
                 )
+                # no duplicates are returned
+                self.assertEqual(len(queryset), 3)
                 for instance in queryset:
                     self.assertEqual(
                         instance.annotated_permissions,
@@ -1585,6 +1607,8 @@ class TestCollectionManagementPermission(
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_changer, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 3)
             expected = (
                 {"add": False, "change": False, "delete": False, "frobnicate": False},
                 {"add": False, "change": True, "delete": False, "frobnicate": False},
@@ -1599,6 +1623,8 @@ class TestCollectionManagementPermission(
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_adder, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 3)
             expected = (
                 {"add": False, "change": False, "delete": False, "frobnicate": False},
                 {"add": True, "change": False, "delete": False, "frobnicate": False},
@@ -1613,6 +1639,8 @@ class TestCollectionManagementPermission(
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.report_deleter, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 3)
             expected = (
                 {"add": False, "change": False, "delete": False, "frobnicate": False},
                 {"add": False, "change": False, "delete": True, "frobnicate": False},
@@ -1627,6 +1655,8 @@ class TestCollectionManagementPermission(
             queryset = self.policy.annotate_with_permissions(
                 queryset, self.useless_user, actions
             )
+            # no duplicates are returned
+            self.assertEqual(len(queryset), 3)
             expected = {action: False for action in actions}
             for instance in queryset:
                 self.assertEqual(instance.annotated_permissions, expected)


### PR DESCRIPTION
An attempt to clean up the issue encountered in #10452 where IndexView is making assumptions about the nature of the items being listed (e.g. their permission checks) that don't apply to all listings.
