### PR TITLE
Deprecate insert_editor_css in favour of insert_global_admin_css

### DIFF
--- a/docs/advanced_topics/customisation/streamfield_blocks.md
+++ b/docs/advanced_topics/customisation/streamfield_blocks.md
@@ -20,7 +20,7 @@ class PersonBlock(blocks.StructBlock):
         form_classname = 'person-block struct-block'
 ```
 
-You can then provide custom CSS for this block, targeted at the specified classname, by using the [](insert_editor_css) hook.
+You can then provide custom CSS for this block, targeted at the specified classname, by using the [](insert_global_admin_css) hook.
 
 ```{note}
 Wagtail's editor styling has some built in styling for the `struct-block` class and other related elements. If you specify a value for `form_classname`, it will overwrite the classes that are already applied to `StructBlock`, so you must remember to specify the `struct-block` as well.

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -454,6 +454,12 @@ def editor_css():
     )
 ```
 
+```{note}
+The `insert_editor_css` hook is deprecated and will be removed in a future release. We recommend using [](insert_global_admin_css) instead.
+```
+
+
+
 (insert_global_admin_css)=
 
 ### `insert_global_admin_css`

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -276,12 +276,19 @@ def test_page_is_public(context, page):
 @register.simple_tag
 def hook_output(hook_name):
     """
-    Example: {% hook_output 'insert_editor_css' %}
+    Example: {% hook_output 'insert_global_admin_css' %}
     Whenever we have a hook whose functions take no parameters and return a string, this tag can be used
     to output the concatenation of all of those return values onto the page.
     Note that the output is not escaped - it is the hook function's responsibility to escape unsafe content.
     """
     snippets = [fn() for fn in hooks.get_hooks(hook_name)]
+
+    if hook_name == "insert_editor_css" and snippets:
+        warn(
+            "The `insert_editor_css` hook is deprecated - use `insert_global_admin_css` instead.",
+            category=RemovedInWagtail60Warning,
+        )
+
     return mark_safe("".join(snippets))
 
 

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -34,7 +34,7 @@ from .forms import FavouriteColourForm
 
 
 # Register one hook using decorators...
-@hooks.register("insert_editor_css")
+@hooks.register("insert_global_admin_css")
 def editor_css():
     return """<link rel="stylesheet" href="/path/to/my/custom.css">"""
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10402 10402

Not sure how to test this 🤔




_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
