### PR TITLE
Debounce and optimise live preview panel to prevent excessive requests

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
  * Fix: Ensure that title and slug continue syncing after entering non-URL-safe characters (LB (Ben) Johnston)
  * Fix: Ensure that title and slug are synced on keypress, not just on blur (LB (Ben) Johnston)
  * Fix: Add a more visible active state for side panel toggle buttons (Thibaud Colas)
+ * Fix: Debounce and optimise live preview panel to prevent excessive requests (Sage Abdullah)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)

--- a/client/src/entrypoints/admin/preview-panel.js
+++ b/client/src/entrypoints/admin/preview-panel.js
@@ -87,6 +87,7 @@ function initPreview() {
   let iframe = previewPanel.querySelector('[data-preview-iframe]');
   let spinnerTimeout;
   let hasPendingUpdate = false;
+  let cleared = false;
 
   const finishUpdate = () => {
     clearTimeout(spinnerTimeout);
@@ -173,8 +174,10 @@ function initPreview() {
 
         if (data.is_valid) {
           reloadIframe();
-        } else {
-          finishUpdate();
+        } else if (!cleared) {
+          clearPreviewData();
+          cleared = true;
+          reloadIframe();
         }
 
         return data.is_valid;
@@ -255,6 +258,12 @@ function initPreview() {
     previewSidePanel.addEventListener('hide', () => {
       clearInterval(updateInterval);
     });
+  } else {
+    // Even if the preview is not updated automatically, we still need to
+    // initialise the preview data when the panel is shown
+    previewSidePanel.addEventListener('show', () => {
+      setPreviewData();
+    });
   }
 
   //
@@ -277,11 +286,6 @@ function initPreview() {
   if (previewModeSelect) {
     previewModeSelect.addEventListener('change', handlePreviewModeChange);
   }
-
-  // Make sure current preview data in session exists and is up-to-date.
-  clearPreviewData()
-    .then(() => setPreviewData())
-    .then(() => reloadIframe());
 
   // Remember last selected device size
   let lastDevice = null;

--- a/client/src/entrypoints/admin/preview-panel.js
+++ b/client/src/entrypoints/admin/preview-panel.js
@@ -101,11 +101,16 @@ function initPreview() {
 
     // Create a new invisible iframe element
     const newIframe = document.createElement('iframe');
+    const url = new URL(previewUrl, window.location.href);
+    if (previewModeSelect) {
+      url.searchParams.set('mode', previewModeSelect.value);
+    }
+    url.searchParams.set('in_preview_panel', 'true');
     newIframe.style.width = 0;
     newIframe.style.height = 0;
     newIframe.style.opacity = 0;
     newIframe.style.position = 'absolute';
-    newIframe.src = iframe.src;
+    newIframe.src = url.toString();
 
     // Put it in the DOM so it loads the page
     iframe.insertAdjacentElement('afterend', newIframe);
@@ -272,10 +277,8 @@ function initPreview() {
 
   const handlePreviewModeChange = (event) => {
     const mode = event.target.value;
-    const url = new URL(iframe.src);
+    const url = new URL(previewUrl, window.location.href);
     url.searchParams.set('mode', mode);
-
-    iframe.src = url.toString();
     url.searchParams.delete('in_preview_panel');
     newTabButton.href = url.toString();
 

--- a/client/src/entrypoints/admin/preview-panel.js
+++ b/client/src/entrypoints/admin/preview-panel.js
@@ -1,4 +1,5 @@
 import { WAGTAIL_CONFIG } from '../../config/wagtailConfig';
+import { debounce } from '../../utils/debounce';
 import { gettext } from '../../utils/gettext';
 
 function initPreview() {
@@ -225,11 +226,17 @@ function initPreview() {
       return changed;
     };
 
+    // Call setPreviewData only if no changes have been made within the interval
+    const debouncedSetPreviewData = debounce(
+      setPreviewData,
+      WAGTAIL_CONFIG.WAGTAIL_AUTO_UPDATE_PREVIEW_INTERVAL,
+    );
+
     const checkAndUpdatePreview = () => {
       // Do not check for preview update if an update request is still pending
       // and don't send a new request if the form hasn't changed
       if (hasPendingUpdate || !hasChanges()) return;
-      setPreviewData();
+      debouncedSetPreviewData();
     };
 
     previewSidePanel.addEventListener('show', () => {
@@ -237,6 +244,8 @@ function initPreview() {
       checkAndUpdatePreview();
 
       // Only set the interval while the panel is shown
+      // This interval performs the checks for changes but not necessarily the
+      // update itself
       updateInterval = setInterval(
         checkAndUpdatePreview,
         WAGTAIL_CONFIG.WAGTAIL_AUTO_UPDATE_PREVIEW_INTERVAL,

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -38,6 +38,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
  * Ensure that title and slug continue syncing after entering non-URL-safe characters (LB (Ben) Johnston)
  * Ensure that title and slug are synced on keypress, not just on blur (LB (Ben) Johnston)
  * Add a more visible active state for side panel toggle buttons (Thibaud Colas)
+ * Debounce and optimise live preview panel to prevent excessive requests (Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/preview.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/preview.html
@@ -55,7 +55,7 @@
         </div>
 
         <div class="preview-panel__wrapper">
-            <iframe title="{% trans 'Preview' %}" class="preview-panel__iframe" data-preview-iframe src="{{ preview_url }}?in_preview_panel=true&mode={{ object.default_preview_mode|urlencode }}" aria-describedby="preview-panel-error-banner"></iframe>
+            <iframe loading="lazy" title="{% trans 'Preview' %}" class="preview-panel__iframe" data-preview-iframe aria-describedby="preview-panel-error-banner"></iframe>
         </div>
     </div>
 </div>

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -441,7 +441,7 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
     def test_show_preview_panel_on_create_with_single_mode(self):
         create_url = self.get_url_on_add("add", self.single)
         preview_url = self.get_url_on_add("preview_on_add", self.single)
-        iframe_url = preview_url + "?in_preview_panel=true&mode="
+        new_tab_url = preview_url + "?mode="
         response = self.client.get(create_url)
 
         self.assertEqual(response.status_code, 200)
@@ -454,8 +454,11 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
         # Should show the iframe
         self.assertContains(
             response,
-            f'<iframe title="Preview" class="preview-panel__iframe" data-preview-iframe src="{iframe_url}" aria-describedby="preview-panel-error-banner">',
+            '<iframe loading="lazy" title="Preview" class="preview-panel__iframe" data-preview-iframe aria-describedby="preview-panel-error-banner">',
         )
+
+        # Should show the new tab button with the default mode set
+        self.assertContains(response, f'href="{new_tab_url}" target="_blank"')
 
         # Should not show the preview mode selection
         self.assertNotContains(
@@ -466,7 +469,7 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
     def test_show_preview_panel_on_create_with_multiple_modes(self):
         create_url = self.get_url_on_add("add", self.multiple)
         preview_url = self.get_url_on_add("preview_on_add", self.multiple)
-        iframe_url = preview_url + "?in_preview_panel=true&mode=alt%231"
+        new_tab_url = preview_url + "?mode=alt%231"
         response = self.client.get(create_url)
 
         self.assertEqual(response.status_code, 200)
@@ -476,11 +479,14 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
         self.assertContains(response, 'data-side-panel="preview"')
         self.assertContains(response, 'data-action="%s"' % preview_url)
 
-        # Should show the iframe with the default mode set and correctly quoted
+        # Should show the iframe
         self.assertContains(
             response,
-            f'<iframe title="Preview" class="preview-panel__iframe" data-preview-iframe src="{iframe_url}" aria-describedby="preview-panel-error-banner">',
+            '<iframe loading="lazy" title="Preview" class="preview-panel__iframe" data-preview-iframe aria-describedby="preview-panel-error-banner">',
         )
+
+        # Should show the new tab button with the default mode set and correctly quoted
+        self.assertContains(response, f'href="{new_tab_url}" target="_blank"')
 
         # should show the preview mode selection
         self.assertContains(
@@ -497,7 +503,7 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
     def test_show_preview_panel_on_edit_with_single_mode(self):
         edit_url = self.get_url_on_edit("edit", self.single)
         preview_url = self.get_url_on_edit("preview_on_edit", self.single)
-        iframe_url = preview_url + "?in_preview_panel=true&mode="
+        new_tab_url = preview_url + "?mode="
         response = self.client.get(edit_url)
 
         self.assertEqual(response.status_code, 200)
@@ -510,8 +516,11 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
         # Should show the iframe
         self.assertContains(
             response,
-            f'<iframe title="Preview" class="preview-panel__iframe" data-preview-iframe src="{iframe_url}" aria-describedby="preview-panel-error-banner">',
+            '<iframe loading="lazy" title="Preview" class="preview-panel__iframe" data-preview-iframe aria-describedby="preview-panel-error-banner">',
         )
+
+        # Should show the new tab button with the default mode set
+        self.assertContains(response, f'href="{new_tab_url}" target="_blank"')
 
         # Should not show the preview mode selection
         self.assertNotContains(
@@ -522,7 +531,7 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
     def test_show_preview_panel_on_edit_with_multiple_modes(self):
         edit_url = self.get_url_on_edit("edit", self.multiple)
         preview_url = self.get_url_on_edit("preview_on_edit", self.multiple)
-        iframe_url = preview_url + "?in_preview_panel=true&mode=alt%231"
+        new_tab_url = preview_url + "?mode=alt%231"
         response = self.client.get(edit_url)
 
         self.assertEqual(response.status_code, 200)
@@ -532,11 +541,14 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
         self.assertContains(response, 'data-side-panel="preview"')
         self.assertContains(response, 'data-action="%s"' % preview_url)
 
-        # Should show the iframe with the default mode set and correctly quoted
+        # Should show the iframe
         self.assertContains(
             response,
-            f'<iframe title="Preview" class="preview-panel__iframe" data-preview-iframe src="{iframe_url}" aria-describedby="preview-panel-error-banner">',
+            '<iframe loading="lazy" title="Preview" class="preview-panel__iframe" data-preview-iframe aria-describedby="preview-panel-error-banner">',
         )
+
+        # Should show the new tab button with the default mode set and correctly quoted
+        self.assertContains(response, f'href="{new_tab_url}" target="_blank"')
 
         # should show the preview mode selection
         self.assertContains(

--- a/wagtail/snippets/tests/test_preview.py
+++ b/wagtail/snippets/tests/test_preview.py
@@ -291,7 +291,7 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
     def test_show_preview_panel_on_create_with_single_mode(self):
         create_url = self.get_url(self.single, "add")
         preview_url = self.get_url(self.single, "preview_on_add")
-        iframe_url = preview_url + "?in_preview_panel=true&mode="
+        new_tab_url = preview_url + "?mode="
         response = self.client.get(create_url)
 
         self.assertEqual(response.status_code, 200)
@@ -304,8 +304,11 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
         # Should show the iframe
         self.assertContains(
             response,
-            f'<iframe title="Preview" class="preview-panel__iframe" data-preview-iframe src="{iframe_url}" aria-describedby="preview-panel-error-banner">',
+            '<iframe loading="lazy" title="Preview" class="preview-panel__iframe" data-preview-iframe aria-describedby="preview-panel-error-banner">',
         )
+
+        # Should show the new tab button with the default mode set
+        self.assertContains(response, f'href="{new_tab_url}" target="_blank"')
 
         # Should not show the preview mode selection
         self.assertNotContains(
@@ -316,7 +319,7 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
     def test_show_preview_panel_on_create_with_multiple_modes(self):
         create_url = self.get_url(self.multiple, "add")
         preview_url = self.get_url(self.multiple, "preview_on_add")
-        iframe_url = preview_url + "?in_preview_panel=true&mode=alt%231"
+        new_tab_url = preview_url + "?mode=alt%231"
         response = self.client.get(create_url)
 
         self.assertEqual(response.status_code, 200)
@@ -326,11 +329,14 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
         self.assertContains(response, 'data-side-panel="preview"')
         self.assertContains(response, 'data-action="%s"' % preview_url)
 
-        # Should show the iframe with the default mode set and correctly quoted
+        # Should show the iframe
         self.assertContains(
             response,
-            f'<iframe title="Preview" class="preview-panel__iframe" data-preview-iframe src="{iframe_url}" aria-describedby="preview-panel-error-banner">',
+            '<iframe loading="lazy" title="Preview" class="preview-panel__iframe" data-preview-iframe aria-describedby="preview-panel-error-banner">',
         )
+
+        # Should show the new tab button with the default mode set and correctly quoted
+        self.assertContains(response, f'href="{new_tab_url}" target="_blank"')
 
         # should show the preview mode selection
         self.assertContains(
@@ -349,7 +355,7 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
         preview_url = self.get_url(
             self.single, "preview_on_edit", args=(self.multiple.pk,)
         )
-        iframe_url = preview_url + "?in_preview_panel=true&mode="
+        new_tab_url = preview_url + "?mode="
         response = self.client.get(edit_url)
 
         self.assertEqual(response.status_code, 200)
@@ -362,8 +368,11 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
         # Should show the iframe
         self.assertContains(
             response,
-            f'<iframe title="Preview" class="preview-panel__iframe" data-preview-iframe src="{iframe_url}" aria-describedby="preview-panel-error-banner">',
+            '<iframe loading="lazy" title="Preview" class="preview-panel__iframe" data-preview-iframe aria-describedby="preview-panel-error-banner">',
         )
+
+        # Should show the new tab button with the default mode set
+        self.assertContains(response, f'href="{new_tab_url}" target="_blank"')
 
         # Should not show the preview mode selection
         self.assertNotContains(
@@ -376,7 +385,7 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
         preview_url = self.get_url(
             self.multiple, "preview_on_edit", args=(self.multiple.pk,)
         )
-        iframe_url = preview_url + "?in_preview_panel=true&mode=alt%231"
+        new_tab_url = preview_url + "?mode=alt%231"
         response = self.client.get(edit_url)
 
         self.assertEqual(response.status_code, 200)
@@ -386,11 +395,14 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
         self.assertContains(response, 'data-side-panel="preview"')
         self.assertContains(response, 'data-action="%s"' % preview_url)
 
-        # Should show the iframe with the default mode set and correctly quoted
+        # Should show the iframe
         self.assertContains(
             response,
-            f'<iframe title="Preview" class="preview-panel__iframe" data-preview-iframe src="{iframe_url}" aria-describedby="preview-panel-error-banner">',
+            '<iframe loading="lazy" title="Preview" class="preview-panel__iframe" data-preview-iframe aria-describedby="preview-panel-error-banner">',
         )
+
+        # Should show the new tab button with the default mode set and correctly quoted
+        self.assertContains(response, f'href="{new_tab_url}" target="_blank"')
 
         # should show the preview mode selection
         self.assertContains(


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #9360, backported from some commits in #10356 with minor adjustments.

This PR:
- Adds debouncing to the updates so that an update is only performed if no changes have been made to the form within the specified interval. Previously, the interval is only used to specify the time it takes before a check should be performed, and an update request is immediately fired if a change is detected.
- Defer the first update/clearing of the preview data until the preview panel is opened. This means that the preview panel might take a few moment to display the preview on initial load, but I think it's worth the requests we prevent if the preview panel is never opened at all.
- Defer setting the `src` attribute on the preview iframe to prevent loading the iframe contents on initial page load. This has the same tradeoff as the above point.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
