### PR TITLE
Docs - Align on client-side naming & fix Draftail typos

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -848,7 +848,7 @@ Changelog
  * Fix: Fix `updatemodulepaths` command for Python 3.7 (Matt Westcott)
  * Fix: Only show locale filter in choosers when i18n is enabled in settings (Matt Westcott)
  * Fix: Ensure that the live preview panel correctly clears the cache when a new page is created (Sage Abdullah)
- * Fix: Ensure that there is a larger hoverable area for add block (+) within the Drafttail editor (Steven Steinwand)
+ * Fix: Ensure that there is a larger hoverable area for add block (+) within the Draftail editor (Steven Steinwand)
  * Fix: Resolve multiple header styling issues for modal, alignment on small devices, outside click handling target on medium devices, close button target size and hover styles (Paarth Agarwal)
  * Fix: Fix issue where comments could not be added in StreamField that were already already saved (Jacob Topp-Mugglestone)
  * Fix: Remove outdated reference to Image.LoaderError (Matt Westcott)

--- a/docs/advanced_topics/customisation/admin_templates.md
+++ b/docs/advanced_topics/customisation/admin_templates.md
@@ -231,9 +231,9 @@ To add extra buttons to the password reset form, override the `submit_buttons` b
 {% endblock %}
 ```
 
-(extending_clientside_components)=
+(extending_client_side_react)=
 
-## Extending client-side components
+## Extending client-side React components
 
 Some of Wagtail’s admin interface is written as client-side JavaScript with [React](https://reactjs.org/).
 In order to customise or extend those components, you may need to use React too, as well as other related libraries.

--- a/docs/advanced_topics/icons.md
+++ b/docs/advanced_topics/icons.md
@@ -7,7 +7,7 @@ Wagtail comes with an SVG icon set. The icons are used throughout the admin inte
 Elements that use icons are:
 
 -   [Register Admin Menu Item](register_admin_menu_item)
--   [Client-side components](extending_clientside_components)
+-   [Client-side React components](extending_client_side_react)
 -   [Rich text editor toolbar buttons](extending_the_draftail_editor)
 -   [ModelAdmin menu](modeladmin_menu_icon)
 -   [Snippets](wagtailsnippets_icon)

--- a/docs/extending/extending_draftail.md
+++ b/docs/extending/extending_draftail.md
@@ -142,7 +142,7 @@ Here are the main requirements to create a new entity feature:
 -   Like for inline styles and blocks, set up the to/from DB conversion.
 -   The conversion usually is more involved, since entities contain data that needs to be serialised to HTML.
 
-To write the React components, Wagtail exposes its own React, Draft.js, and Draftail dependencies as global variables. Read more about this in [extending clientside components](extending_clientside_components).
+To write the React components, Wagtail exposes its own React, Draft.js, and Draftail dependencies as global variables. Read more about this in [extending client-side React components](extending_client_side_react).
 To go further, please look at the [Draftail documentation](https://www.draftail.org/docs/formatting-options) as well as the [Draft.js exporter documentation](https://github.com/springload/draftjs_exporter).
 
 Here is a detailed example to showcase how those tools are used in the context of Wagtail.
@@ -281,7 +281,7 @@ class StockSource extends React.Component {
 ```
 
 This source component uses data and callbacks provided by [Draftail](https://www.draftail.org/docs/api).
-It also uses dependencies from global variables – see [Extending clientside components](extending_clientside_components).
+It also uses dependencies from global variables – see [Extending client-side React components](extending_client_side_react).
 
 We then create the decorator component:
 

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -262,7 +262,7 @@ There are also many improvements to the documentation both under the hood and in
  * Fix `updatemodulepaths` command for Python 3.7 (Matt Westcott)
  * Only show locale filter in choosers when i18n is enabled in settings (Matt Westcott)
  * Ensure that the live preview panel correctly clears the cache when a new page is created (Sage Abdullah)
- * Ensure that there is a larger hoverable area for add block (+) within the Drafttail editor (Steven Steinwand)
+ * Ensure that there is a larger hoverable area for add block (+) within the Draftail editor (Steven Steinwand)
  * Resolve multiple header styling issues for modal, alignment on small devices, outside click handling target on medium devices, close button target size and hover styles (Paarth Agarwal)
  * Fix issue where comments could not be added in StreamField that were already already saved (Jacob Topp-Mugglestone)
  * Remove outdated reference to Image.LoaderError (Matt Westcott)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -461,12 +461,12 @@ Stimulus [targets](https://stimulus.hotwired.dev/reference/targets) and [actions
 
 The undocumented `window.addMessage` function is no longer available and will throw an error if called, if similar functionality is required use DOM Event dispatching instead as follows.
 
-```js
+```javascript
 // old
 window.addMessage('success', 'Content has updated');
 ```
 
-```js
+```javascript
 // new
 document.dispatchEvent(
     new CustomEvent('w-messages:add', {


### PR DESCRIPTION
- Prep for #10197 with some additional typos found while reviewing our JavaScript related docs
- Ensure we refer to React explicitly, not just 'components'
- Fix a few cases where Draftail was spelt incorrectly
- Align with `client-side` not `clientside` as this is used most commonly
- Fix `javascript` code snippet, does not impact syntax highlighting but all others have `javascript` and not `js`
