### PR TITLE
Remove whats-new-in-wagtail-5.0 from expected menu item labels

### DIFF
--- a/wagtail/admin/tests/test_menu.py
+++ b/wagtail/admin/tests/test_menu.py
@@ -399,7 +399,6 @@ class TestMenuRendering(WagtailTestUtils, TestCase):
             "editor-guide",
             "sites",
             "publishables",
-            "whats-new-in-wagtail-5.0",
             "locked-pages",
             "single-event-pages",
             "event-pages",


### PR DESCRIPTION
This prevents the test from failing if we bump the version number. Cleanup of #10501, missed this during review. Will merge after CI passes.

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->