### PR TITLE
Optimise use of specific on Task and TaskState

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/workflow_history/detail.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/workflow_history/detail.html
@@ -84,8 +84,8 @@
                                         {% else %}
                                             {% status task_state.get_status_display classname="w-status--primary" %}
                                         {% endif %}
-                                        {% if task_state.specific.get_comment %}
-                                            <p>{% trans 'with comment:' %} <b>"{{ task_state.specific.get_comment }}"</b></p>
+                                        {% if task_state.get_comment %}
+                                            <p>{% trans 'with comment:' %} <b>"{{ task_state.get_comment }}"</b></p>
                                         {% endif %}
                                     </td>
                                 {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -41,7 +41,7 @@
                                 </div>
                             </td>
                             <td>
-                                {{ task.specific.get_verbose_name }}
+                                {{ task.get_verbose_name }}
                             </td>
                             <td>
                                 {% for workflow in task.active_workflows|slice:":5" %}

--- a/wagtail/admin/views/generic/history.py
+++ b/wagtail/admin/views/generic/history.py
@@ -88,7 +88,7 @@ class WorkflowHistoryDetailView(
                     task_state.task: task_state
                     for task_state in TaskState.objects.filter(
                         workflow_state=self.workflow_state, revision=revision
-                    )
+                    ).specific()
                 },
             )
             for revision in self.revisions

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -401,7 +401,7 @@ class TaskIndex(IndexView):
         queryset = super().get_queryset()
         if not self.show_disabled():
             queryset = queryset.filter(active=True)
-        return queryset
+        return queryset.specific()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -4335,8 +4335,9 @@ class TaskState(SpecificMixin, models.Model):
         self.log_state_change_action(user, "approve")
         if update:
             self.workflow_state.update(user=user)
+        specific_self = self.specific
         task_approved.send(
-            sender=self.specific.__class__, instance=self.specific, user=user
+            sender=specific_self.__class__, instance=specific_self, user=user
         )
         return self
 
@@ -4354,8 +4355,9 @@ class TaskState(SpecificMixin, models.Model):
         self.log_state_change_action(user, "reject")
         if update:
             self.workflow_state.update(user=user)
+        specific_self = self.specific
         task_rejected.send(
-            sender=self.specific.__class__, instance=self.specific, user=user
+            sender=specific_self.__class__, instance=specific_self, user=user
         )
 
         return self
@@ -4389,8 +4391,9 @@ class TaskState(SpecificMixin, models.Model):
             self.workflow_state.update(user=user, next_task=self.task.specific)
         else:
             self.workflow_state.update(user=user)
+        specific_self = self.specific
         task_cancelled.send(
-            sender=self.specific.__class__, instance=self.specific, user=user
+            sender=specific_self.__class__, instance=specific_self, user=user
         )
         return self
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -74,7 +74,7 @@ from wagtail.fields import StreamField
 from wagtail.forms import TaskStateCommentForm
 from wagtail.locks import BasicLock, ScheduledForPublishLock, WorkflowLock
 from wagtail.log_actions import log
-from wagtail.query import PageQuerySet
+from wagtail.query import PageQuerySet, SpecificQuerySetMixin
 from wagtail.search import index
 from wagtail.signals import (
     page_published,
@@ -3449,9 +3449,12 @@ class WorkflowTask(Orderable):
         verbose_name_plural = _("workflow task orders")
 
 
-class TaskManager(models.Manager):
+class TaskQuerySet(SpecificQuerySetMixin, models.QuerySet):
     def active(self):
         return self.filter(active=True)
+
+
+TaskManager = models.Manager.from_queryset(TaskQuerySet)
 
 
 class Task(SpecificMixin, models.Model):
@@ -4204,7 +4207,7 @@ class WorkflowState(models.Model):
         ]
 
 
-class TaskStateManager(models.Manager):
+class BaseTaskStateManager(models.Manager):
     def reviewable_by(self, user):
         tasks = Task.objects.filter(active=True)
         states = TaskState.objects.none()
@@ -4212,25 +4215,29 @@ class TaskStateManager(models.Manager):
             states = states | task.specific.get_task_states_user_can_moderate(user=user)
         return states
 
+
+class TaskStateQueryset(SpecificQuerySetMixin, models.QuerySet):
     def for_instance(self, instance):
         """
         Filters to only TaskStates for the given instance
         """
-        queryset = self.get_queryset()
         try:
             # Use RevisionMixin.get_base_content_type() if available
-            return queryset.filter(
+            return self.filter(
                 workflow_state__base_content_type=instance.get_base_content_type(),
                 workflow_state__object_id=str(instance.pk),
             )
         except AttributeError:
             # Fallback to ContentType for the model
-            return queryset.filter(
+            return self.filter(
                 workflow_state__content_type=ContentType.objects.get_for_model(
                     instance, for_concrete_model=False
                 ),
                 workflow_state__object_id=str(instance.pk),
             )
+
+
+TaskStateManager = BaseTaskStateManager.from_queryset(TaskStateQueryset)
 
 
 class TaskState(SpecificMixin, models.Model):

--- a/wagtail/models/specific.py
+++ b/wagtail/models/specific.py
@@ -1,0 +1,128 @@
+from django.db.models import DEFERRED
+from django.contrib.contenttypes.models import ContentType
+from django.utils.functional import cached_property
+
+
+class SpecificMixin:
+    """
+    Mixin for models that support multi-table inheritance and provide a
+    ``content_type`` field pointing to the specific model class, to provide
+    methods and properties for retrieving the specific instance of the model.
+    """
+
+    def get_specific(self, deferred=False, copy_attrs=None, copy_attrs_exclude=None):
+        """
+        Return this object in its most specific subclassed form.
+
+        By default, a database query is made to fetch all field values for the
+        specific object. If you only require access to custom methods or other
+        non-field attributes on the specific object, you can use
+        ``deferred=True`` to avoid this query. However, any attempts to access
+        specific field values from the returned object will trigger additional
+        database queries.
+
+        By default, references to all non-field attribute values are copied
+        from current object to the returned one. This includes:
+
+        * Values set by a queryset, for example: annotations, or values set as
+          a result of using ``select_related()`` or ``prefetch_related()``.
+        * Any ``cached_property`` values that have been evaluated.
+        * Attributes set elsewhere in Python code.
+
+        For fine-grained control over which non-field values are copied to the
+        returned object, you can use ``copy_attrs`` to specify a complete list
+        of attribute names to include. Alternatively, you can use
+        ``copy_attrs_exclude`` to specify a list of attribute names to exclude.
+
+        If called on an object that is already an instance of the most specific
+        class, the object will be returned as is, and no database queries or
+        other operations will be triggered.
+
+        If the object was originally created using a model that has since
+        been removed from the codebase, an instance of the base class will be
+        returned (without any custom field values or other functionality
+        present on the original class). Usually, deleting these objects is the
+        best course of action, but there is currently no safe way for Wagtail
+        to do that at migration time.
+        """
+        model_class = self.specific_class
+
+        if model_class is None:
+            # The codebase and database are out of sync (e.g. the model exists
+            # on a different git branch and migrations were not applied or
+            # reverted before switching branches). So, the best we can do is
+            # return the page in it's current form.
+            return self
+
+        if isinstance(self, model_class):
+            # self is already an instance of the most specific class.
+            return self
+
+        if deferred:
+            # Generate a tuple of values in the order expected by __init__(),
+            # with missing values substituted with DEFERRED ()
+            values = tuple(
+                getattr(self, f.attname, self.pk if f.primary_key else DEFERRED)
+                for f in model_class._meta.concrete_fields
+            )
+            # Create object from known attribute values
+            specific_obj = model_class(*values)
+            specific_obj._state.adding = self._state.adding
+        else:
+            # Fetch object from database
+            specific_obj = model_class._default_manager.get(id=self.id)
+
+        # Copy non-field attribute values
+        if copy_attrs is not None:
+            for attr in (attr for attr in copy_attrs if attr in self.__dict__):
+                setattr(specific_obj, attr, getattr(self, attr))
+        else:
+            exclude = copy_attrs_exclude or ()
+            for k, v in ((k, v) for k, v in self.__dict__.items() if k not in exclude):
+                # only set values that haven't already been set
+                specific_obj.__dict__.setdefault(k, v)
+
+        return specific_obj
+
+    @cached_property
+    def specific(self):
+        """
+        Returns this object in its most specific subclassed form with all field
+        values fetched from the database. The result is cached in memory.
+        """
+        return self.get_specific()
+
+    @cached_property
+    def specific_deferred(self):
+        """
+        Returns this object in its most specific subclassed form without any
+        additional field values being fetched from the database. The result
+        is cached in memory.
+        """
+        return self.get_specific(deferred=True)
+
+    @cached_property
+    def specific_class(self):
+        """
+        Return the class that this object would be if instantiated in its
+        most specific form.
+
+        If the model class can no longer be found in the codebase, and the
+        relevant ``ContentType`` has been removed by a database migration,
+        the return value will be ``None``.
+
+        If the model class can no longer be found in the codebase, but the
+        relevant ``ContentType`` is still present in the database (usually a
+        result of switching between git branches without running or reverting
+        database migrations beforehand), the return value will be ``None``.
+        """
+        return self.cached_content_type.model_class()
+
+    @property
+    def cached_content_type(self):
+        """
+        Return this object's ``content_type`` value from the ``ContentType``
+        model's cached manager, which will avoid a database query if the
+        content type is already in memory.
+        """
+        return ContentType.objects.get_for_id(self.content_type_id)

--- a/wagtail/query.py
+++ b/wagtail/query.py
@@ -139,11 +139,11 @@ class TreeQuerySet(MP_NodeQuerySet):
         return self.exclude(self.sibling_of_q(other, inclusive))
 
 
-class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
+class SpecificQuerySetMixin:
     def __init__(self, *args, **kwargs):
         """Set custom instance attributes"""
         super().__init__(*args, **kwargs)
-        # set by defer_streamfields()
+        # set by PageQuerySet.defer_streamfields()
         self._defer_streamfields = False
 
     def _clone(self):
@@ -152,6 +152,23 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
         clone._defer_streamfields = self._defer_streamfields
         return clone
 
+    def specific(self, defer=False):
+        """
+        This efficiently gets all the specific items for the queryset, using
+        the minimum number of queries.
+
+        When the "defer" keyword argument is set to True, only generic
+        field values will be loaded and all specific fields will be deferred.
+        """
+        clone = self._clone()
+        if defer:
+            clone._iterable_class = DeferredSpecificIterable
+        else:
+            clone._iterable_class = SpecificIterable
+        return clone
+
+
+class PageQuerySet(SearchableQuerySetMixin, SpecificQuerySetMixin, TreeQuerySet):
     def live_q(self):
         return Q(live=True)
 
@@ -393,21 +410,6 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
             return clone
         return clone.defer(*streamfield_names)
 
-    def specific(self, defer=False):
-        """
-        This efficiently gets all the specific pages for the queryset, using
-        the minimum number of queries.
-
-        When the "defer" keyword argument is set to True, only generic page
-        field values will be loaded and all specific fields will be deferred.
-        """
-        clone = self._clone()
-        if defer:
-            clone._iterable_class = DeferredSpecificIterable
-        else:
-            clone._iterable_class = SpecificIterable
-        return clone
-
     def in_site(self, site):
         """
         This filters the QuerySet to only contain pages within the specified site.
@@ -495,21 +497,19 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
 class SpecificIterable(BaseIterable):
     def __iter__(self):
         """
-        Identify and return all specific pages in a queryset, and return them
+        Identify and return all specific items in a queryset, and return them
         in the same order, with any annotations intact.
         """
-        from wagtail.models import Page
-
         qs = self.queryset
         annotation_aliases = qs.query.annotations.keys()
         values_qs = qs.values("pk", "content_type", *annotation_aliases)
 
-        # Gather pages in batches to reduce peak memory usage
+        # Gather items in batches to reduce peak memory usage
         for values in self._get_chunks(values_qs):
 
             annotations_by_pk = defaultdict(list)
             if annotation_aliases:
-                # Extract annotation results keyed by pk so we can reapply to fetched pages.
+                # Extract annotation results keyed by pk so we can reapply to fetched items.
                 for data in values:
                     annotations_by_pk[data["pk"]] = {
                         k: v for k, v in data.items() if k in annotation_aliases
@@ -525,55 +525,55 @@ class SpecificIterable(BaseIterable):
                 pk: ContentType.objects.get_for_id(pk) for _, pk in pks_and_types
             }
 
-            # Get the specific instances of all pages, one model class at a time.
-            pages_by_type = {}
+            # Get the specific instances of all items, one model class at a time.
+            items_by_type = {}
             missing_pks = []
 
             for content_type, pks in pks_by_type.items():
                 # look up model class for this content type, falling back on the original
                 # model (i.e. Page) if the more specific one is missing
                 model = content_types[content_type].model_class() or qs.model
-                pages = model.objects.filter(pk__in=pks)
+                items = model.objects.filter(pk__in=pks)
 
-                if qs._defer_streamfields:
-                    pages = pages.defer_streamfields()
+                if qs._defer_streamfields and hasattr(items, "defer_streamfields"):
+                    items = items.defer_streamfields()
 
-                pages_for_type = {page.pk: page for page in pages}
-                pages_by_type[content_type] = pages_for_type
-                missing_pks.extend(pk for pk in pks if pk not in pages_for_type)
+                items_for_type = {item.pk: item for item in items}
+                items_by_type[content_type] = items_for_type
+                missing_pks.extend(pk for pk in pks if pk not in items_for_type)
 
-            # Fetch generic pages to supplement missing items
+            # Fetch generic items to supplement missing items
             if missing_pks:
-                generic_pages = (
-                    Page.objects.filter(pk__in=missing_pks)
+                generic_items = (
+                    qs.model.objects.filter(pk__in=missing_pks)
                     .select_related("content_type")
                     .in_bulk()
                 )
                 warnings.warn(
-                    "Specific versions of the following pages could not be found. "
+                    "Specific versions of the following items could not be found. "
                     "This is most likely because a database migration has removed "
-                    "the relevant table or record since the page was created:\n{}".format(
+                    "the relevant table or record since the item was created:\n{}".format(
                         [
                             {"id": p.id, "title": p.title, "type": p.content_type}
-                            for p in generic_pages.values()
+                            for p in generic_items.values()
                         ]
                     ),
                     category=RuntimeWarning,
                 )
             else:
-                generic_pages = {}
+                generic_items = {}
 
-            # Yield all pages in the order they occurred in the original query.
+            # Yield all items in the order they occurred in the original query.
             for pk, content_type in pks_and_types:
                 try:
-                    page = pages_by_type[content_type][pk]
+                    item = items_by_type[content_type][pk]
                 except KeyError:
-                    page = generic_pages[pk]
+                    item = generic_items[pk]
                 if annotation_aliases:
                     # Reapply annotations before returning
-                    for annotation, value in annotations_by_pk.get(page.pk, {}).items():
-                        setattr(page, annotation, value)
-                yield page
+                    for annotation, value in annotations_by_pk.get(item.pk, {}).items():
+                        setattr(item, annotation, value)
+                yield item
 
     def _get_chunks(self, queryset) -> Iterable[Tuple[Dict[str, Any]]]:
         if not self.chunked_fetch:
@@ -582,7 +582,7 @@ class SpecificIterable(BaseIterable):
             yield tuple(queryset)
         else:
             # Iterate through the queryset, returning the rows in manageable
-            # chunks for self.__iter__() to fetch full pages for
+            # chunks for self.__iter__() to fetch full instances for
             current_chunk = []
             for r in queryset.iterator(self.chunk_size):
                 current_chunk.append(r)
@@ -601,9 +601,9 @@ class DeferredSpecificIterable(ModelIterable):
                 yield obj.specific_deferred
             else:
                 warnings.warn(
-                    "A specific version of the following page could not be returned "
-                    "because the specific page model is not present on the active "
-                    f"branch: <Page id='{obj.id}' title='{obj.title}' "
+                    "A specific version of the following object could not be returned "
+                    "because the specific model is not present on the active "
+                    f"branch: <{obj.__class__.__name__} id='{obj.id}' title='{obj.title}' "
                     f"type='{obj.content_type}'>",
                     category=RuntimeWarning,
                 )

--- a/wagtail/tests/test_page_queryset.py
+++ b/wagtail/tests/test_page_queryset.py
@@ -896,7 +896,7 @@ class TestSpecificQuery(WagtailTestUtils, TestCase):
         ):
             with self.assertWarnsRegex(
                 RuntimeWarning,
-                "Specific versions of the following pages could not be found",
+                "Specific versions of the following items could not be found",
             ):
                 pages = list(
                     Page.objects.get(url_path="/home/").get_children().specific()


### PR DESCRIPTION
Refactor `Page.specific` and associated methods, and `PageQuerySet.specific()`, into mixins that can be shared with Task and TaskState. This reduces code duplication and gives Task and TaskState querysets a `specific()` method that they didn't have previously. Use this to reduce query counts in workflow admin views.