### PR TITLE
Update type hints in admin/ui/components.py

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ Changelog
  * Maintenance: Remove color tokens which are duplicates / unused (Thibaud Colas)
  * Maintenance: Add tests to help with maintenance of theme color tokens (Thibaud Colas)
  * Maintenance: Split out a base listing view from generic index view (Matt Westcott)
+ * Maintenance: Update type hints in admin/ui/components.py so that `parent_context` is mutable (Andreas Nüßlein)
 
 
 5.0.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -56,6 +56,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
  * Remove color tokens which are duplicates / unused (Thibaud Colas)
  * Add tests to help with maintenance of theme color tokens (Thibaud Colas)
  * Split out a base listing view from generic index view (Matt Westcott)
+ * Update type hints in admin/ui/components.py so that `parent_context` is mutable (Andreas Nüßlein)
 
 
 ## Upgrade considerations

--- a/wagtail/admin/ui/components.py
+++ b/wagtail/admin/ui/components.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping
+from typing import Any, MutableMapping
 
 from django.forms import MediaDefiningClass
 from django.template import Context
@@ -6,10 +6,12 @@ from django.template.loader import get_template
 
 
 class Component(metaclass=MediaDefiningClass):
-    def get_context_data(self, parent_context: Mapping[str, Any]) -> Mapping[str, Any]:
+    def get_context_data(
+        self, parent_context: MutableMapping[str, Any]
+    ) -> MutableMapping[str, Any]:
         return {}
 
-    def render_html(self, parent_context: Mapping[str, Any] = None) -> str:
+    def render_html(self, parent_context: MutableMapping[str, Any] = None) -> str:
         if parent_context is None:
             parent_context = Context()
         context_data = self.get_context_data(parent_context)


### PR DESCRIPTION
the contexts are mutable, therefore a MutableMapping makes more sense than a Mapping type


PyCharm is complaining that I can't just do `ctx.update` or `ctx['foo'] = "bar"` on a `Mapping[str,Any]`-type. I think rightfully so. If I understand the typings correctly, we want a MutableMapping here.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.  

-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
  I feel that, to have tests for this, we'd need mypy first, which is not in the project yet, right?


[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
