### PR TITLE
Fix failing tests against Django main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,10 +94,9 @@ jobs:
             experimental: true
             postgres: 'postgres:12'
             install_extras: |
-              pip uninstall -y django-modelcluster django-taggit
+              pip uninstall -y django-modelcluster
               pip install \
-                git+https://github.com/wagtail/django-modelcluster.git@main#egg=django-modelcluster \
-                git+https://github.com/laymonage/django-taggit.git@django-5.0#egg=django-taggit
+                git+https://github.com/wagtail/django-modelcluster.git@main#egg=django-modelcluster
 
     services:
       postgres:

--- a/wagtail/admin/search.py
+++ b/wagtail/admin/search.py
@@ -1,7 +1,9 @@
+from functools import total_ordering
+
 from django.forms import Media, MediaDefiningClass
 from django.forms.utils import flatatt
 from django.template.loader import render_to_string
-from django.utils.functional import cached_property, total_ordering
+from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -42,7 +42,7 @@ from django.utils import timezone
 from django.utils import translation as translation
 from django.utils.cache import patch_cache_control
 from django.utils.encoding import force_str
-from django.utils.functional import cached_property
+from django.utils.functional import cached_property, Promise
 from django.utils.module_loading import import_string
 from django.utils.text import capfirst, slugify
 from django.utils.translation import gettext_lazy as _
@@ -2231,7 +2231,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         # make sure that page_description is actually a string rather than a model field
         if isinstance(description, str):
             return description
-        elif getattr(description, "_delegate_text", None):
+        elif isinstance(description, Promise):
             # description is a lazy object (e.g. the result of gettext_lazy())
             return str(description)
         else:


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes our tests from failing against Django's `main` as of https://github.com/django/django/pull/16958/commits/ee36e101e8f8c0acde4bb148b738ab7034e902a0.

Based on the description of that commit and [Python's docs](https://docs.python.org/3/library/functools.html#functools.total_ordering):

> **Note**
> While this decorator makes it easy to create well behaved totally ordered types, it does come at the cost of slower execution and more complex stack traces for the derived comparison methods. If performance benchmarking indicates this is a bottleneck for a given application, implementing all six rich comparison methods instead is likely to provide an easy speed boost.

and given that we only have two instances of `total_ordering` within the codebase, I think it's worth having a good first issue to replace `total_ordering` with our own comparison functions implementation. Will create one shortly. Edit: it's #10526.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.