### PR TITLE
Add new Sustainability considerations page

### DIFF
--- a/docs/advanced_topics/index.md
+++ b/docs/advanced_topics/index.md
@@ -19,6 +19,7 @@ testing
 api/index
 amp
 accessibility_considerations
+sustainability_considerations
 boundblocks_and_values
 multi_site_multi_instance_multi_tenancy
 formbuilder_routablepage_redirect

--- a/docs/advanced_topics/sustainability_considerations.md
+++ b/docs/advanced_topics/sustainability_considerations.md
@@ -1,0 +1,35 @@
+# Sustainability considerations
+
+Here are guidelines and resources we recommend for projects with sustainability goals relating to climate action, such as the UN’s [Sustainable Development Goal 13: Climate action](https://sdgs.un.org/goals/goal13), and [SBTi’s Corporate Net-Zero Standard](https://sciencebasedtargets.org/net-zero).
+
+## Standards
+
+To account for the emissions of websites and track their reduction, we recommend following:
+
+- ITU [L.1420](https://www.itu.int/rec/T-REC-L.1420) and [L.1430](https://www.itu.int/rec/T-REC-L.1430)
+- GHG Protocol [Product Life Cycle Accounting and Reporting Standard](https://ghgprotocol.org/product-standard) (Scope 3), and its additional [ICT Sector Guidance](https://ghgprotocol.org/guidance-built-ghg-protocol).
+
+Those are the same standards used to assess the [sustainability of Wagtail](https://wagtail.org/sustainability/).
+
+## Guidelines
+
+Here are guidelines we would recommend applying to Wagtail websites:
+
+- [Sustainable Web Design Strategies](https://sustainablewebdesign.org/strategies/)
+- [GR491](https://gr491.isit-europe.org/en/)
+- [Green Design Principles by Microsoft (PDF)](https://wxcteam.microsoft.com/download/Microsoft-Green-Design-Principles.pdf)
+- [Green Software Foundation Patterns](https://patterns.greensoftware.foundation/catalog/web/)
+
+The [Sustainable Web Design W3C Community Group](https://www.w3.org/community/sustyweb/) is also working on _Web Environmental Sustainability Guidelines_, which will be highly relevant once published.
+
+## Quantifying emissions
+
+To quantify the emissions of a Wagtail website, we recommend three different approaches:
+
+- The [Sustainable Web Design](https://sustainablewebdesign.org/calculating-digital-emissions/) model, which uses page weight as a metric of energy efficiency, and page views as a metric of site utilisation. This model has clear [known limitations](https://www.fershad.com/writing/is-data-the-best-proxy-for-website-carbon-emissions/), but is nonetheless ideal to provide high-level figures for a wide range of websites or pages.
+- Infrastructure-based calculators such as [Cloud Carbon Footprint](https://www.cloudcarbonfootprint.org/), a measurement and analysis tools.
+- Measurement orchestration tools such as [Green Metrics](https://github.com/green-coding-berlin/green-metrics-tool), [GreenFrame](https://greenframe.io/), [Scaphandre](https://github.com/hubblo-org/scaphandre).
+
+---
+
+We will build upon those considerations as part of two [Google Summer of Code internships focusing on sustainability](https://wagtail.org/blog/going-green-with-google-summer-of-code/), in partnership with the [Green Web Foundation and Green Coding Berlin](https://github.com/wagtail/wagtail/discussions/8843).

--- a/docs/advanced_topics/sustainability_considerations.md
+++ b/docs/advanced_topics/sustainability_considerations.md
@@ -32,4 +32,4 @@ To quantify the emissions of a Wagtail website, we recommend three different app
 
 ---
 
-We will build upon those considerations as part of two [Google Summer of Code internships focusing on sustainability](https://wagtail.org/blog/going-green-with-google-summer-of-code/), in partnership with the [Green Web Foundation and Green Coding Berlin](https://github.com/wagtail/wagtail/discussions/8843).
+We are working upon those considerations as part of Wagtail's development process. An example of this is the two [Google Summer of Code internships focusing on sustainability](https://wagtail.org/blog/going-green-with-google-summer-of-code/), in partnership with the [Green Web Foundation and Green Coding Berlin](https://github.com/wagtail/wagtail/discussions/8843).


### PR DESCRIPTION
[Documentation PR preview](https://wagtail--10527.org.readthedocs.build/en/10527/advanced_topics/sustainability_considerations.html)

First version of a new documentation page. This falls quite short of what I was hoping to do initially (#10419), but I’d rather have _some_ version of this out sooner rather than later. This will be further fleshed out as part of our Google Summer of Code internships.

---

As-is, the primary purpose of the page is to share high-level standards and guidelines relevant for more or less all websites, based on how we [quantify emissions of Wagtail itself](https://wagtail.org/sustainability/). In the future I hope we will get to write recommendations/considerations more specific to Wagtail.