### PR TITLE
added __eq__ for comparison of the  source of RichText objects and also added compare test case

### DIFF
--- a/wagtail/rich_text/__init__.py
+++ b/wagtail/rich_text/__init__.py
@@ -102,7 +102,7 @@ class RichText:
     def __eq__(self, other):
         if isinstance(other, RichText):
             return self.source == other.source
-        return False    
+        return False
 
 
 class EntityHandler:

--- a/wagtail/rich_text/__init__.py
+++ b/wagtail/rich_text/__init__.py
@@ -99,6 +99,11 @@ class RichText:
     def __bool__(self):
         return bool(self.source)
 
+    def __eq__(self, other):
+        if isinstance(other, RichText):
+            return self.source == other.source
+        return False    
+
 
 class EntityHandler:
     """

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -131,6 +131,11 @@ class TestRichTextValue(TestCase):
         value = RichText("<p>wagtail</p>")
         self.assertTrue(value)
 
+    def test_compare_value(self):
+        value1 = RichText("<p>wagtail</p>")
+        value2 = RichText("<p>wagtail</p>")
+        self.assertEquals(value1, value2)    
+
 
 class TestFeatureRegistry(TestCase):
     def test_register_rich_text_features_hook(self):

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -134,6 +134,9 @@ class TestRichTextValue(TestCase):
     def test_compare_value(self):
         value1 = RichText("<p>wagtail</p>")
         value2 = RichText("<p>wagtail</p>")
+        value3 = RichText("<p>django</p>")
+        self.assertNotEqual(value1, value3)
+        self.assertNotEqual(value1, 12345)
         self.assertEqual(value1, value2)
 
 

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -134,7 +134,7 @@ class TestRichTextValue(TestCase):
     def test_compare_value(self):
         value1 = RichText("<p>wagtail</p>")
         value2 = RichText("<p>wagtail</p>")
-        self.assertEquals(value1, value2)    
+        self.assertEqual(value1, value2)
 
 
 class TestFeatureRegistry(TestCase):


### PR DESCRIPTION

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10523
Added compare functionality for the RichText objects

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behavior?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
