### PR TITLE
Elasticsearch 8 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,6 +279,53 @@ jobs:
           name: coverage-data
           path: .coverage.*
 
+  test-sqlite-elasticsearch8:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - python: '3.9'
+            django: 'Django>=4.2,<4.3'
+            emailuser: emailuser
+    steps:
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+      - uses: getong/elasticsearch-action@v1.2
+        with:
+          elasticsearch version: 8.8.1
+          host port: 9200
+          container port: 9200
+          host node port: 9300
+          node port: 9300
+          discovery type: 'single-node'
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[testing]
+          pip install "${{ matrix.django }}"
+          pip install "elasticsearch>=8,<9"
+          pip install certifi
+      - name: Test
+        run: |
+          coverage run --parallel-mode --source wagtail runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch8
+        env:
+          DATABASE_ENGINE: django.db.backends.sqlite3
+          USE_EMAIL_USER_MODEL: ${{ matrix.emailuser }}
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: .coverage.*
+
   # https://github.com/getong/elasticsearch-action doesn't work for Elasticsearch 6,
   # but https://github.com/elastic/elastic-github-actions does
   test-postgres-elasticsearch6:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -296,7 +296,7 @@ jobs:
           sudo sysctl -w vm.max_map_count=262144
       - uses: getong/elasticsearch-action@v1.2
         with:
-          elasticsearch version: 8.8.1
+          elasticsearch version: 8.8.0
           host port: 9200
           container port: 9200
           host node port: 9300

--- a/runtests.py
+++ b/runtests.py
@@ -22,6 +22,7 @@ def make_parser():
     parser.add_argument("--elasticsearch5", action="store_true")
     parser.add_argument("--elasticsearch6", action="store_true")
     parser.add_argument("--elasticsearch7", action="store_true")
+    parser.add_argument("--elasticsearch8", action="store_true")
     parser.add_argument("--emailuser", action="store_true")
     parser.add_argument("--disabletimezone", action="store_true")
     parser.add_argument("--bench", action="store_true")
@@ -69,6 +70,9 @@ def runtests():
     elif args.elasticsearch7:
         os.environ.setdefault("ELASTICSEARCH_URL", "http://localhost:9200")
         os.environ.setdefault("ELASTICSEARCH_VERSION", "7")
+    elif args.elasticsearch8:
+        os.environ.setdefault("ELASTICSEARCH_URL", "http://localhost:9200")
+        os.environ.setdefault("ELASTICSEARCH_VERSION", "8")
 
     elif "ELASTICSEARCH_URL" in os.environ:
         # forcibly delete the ELASTICSEARCH_URL setting to skip those tests

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{37,38,39,310,311}-dj{32,41,42,42stable,main}-{sqlite,postgres,mysql,mssql}-{elasticsearch7,elasticsearch6,elasticsearch5,noelasticsearch}-{customuser,emailuser}-{tz,notz},
+envlist = py{37,38,39,310,311}-dj{32,41,42,42stable,main}-{sqlite,postgres,mysql,mssql}-{elasticsearch8,elasticsearch7,elasticsearch6,elasticsearch5,noelasticsearch}-{customuser,emailuser}-{tz,notz},
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -10,6 +10,7 @@ commands =
     elasticsearch5: coverage run runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch5
     elasticsearch6: coverage run runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch6
     elasticsearch7: coverage run runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch7
+    elasticsearch8: coverage run runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch8
     noelasticsearch: coverage run runtests.py {posargs}
 
 basepython =
@@ -37,6 +38,8 @@ deps =
     elasticsearch6: certifi
     elasticsearch7: elasticsearch>=7,<8
     elasticsearch7: certifi
+    elasticsearch8: elasticsearch>=8,<9
+    elasticsearch8: certifi
 
 setenv =
     postgres: DATABASE_ENGINE=django.db.backends.postgresql

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -670,6 +670,19 @@ class TestIssue613(WagtailTestUtils, TestCase):
     def setUp(self):
         self.search_backend = self.get_elasticsearch_backend()
         self.login()
+    
+    def reset_index(self):
+        if self.search_backend.rebuilder_class:
+            index = self.search_backend.get_index_for_model(Image)
+            rebuilder = self.search_backend.rebuilder_class(index)
+            index = rebuilder.start()
+            index.add_model(Image)
+            rebuilder.finish()
+
+    def refresh_index(self):
+        index = self.search_backend.get_index_for_model(Image)
+        if index:
+            index.refresh()
 
     def add_image(self, **params):
         post_data = {
@@ -721,12 +734,12 @@ class TestIssue613(WagtailTestUtils, TestCase):
 
     def test_issue_613_on_add(self):
         # Reset the search index
-        self.search_backend.reset_index()
+        self.reset_index()
         self.search_backend.add_type(Image)
 
         # Add an image with some tags
         image = self.add_image(tags="hello")
-        self.search_backend.refresh_index()
+        self.refresh_index()
 
         # Search for it by tag
         results = self.search_backend.search("hello", Image)
@@ -737,12 +750,12 @@ class TestIssue613(WagtailTestUtils, TestCase):
 
     def test_issue_613_on_edit(self):
         # Reset the search index
-        self.search_backend.reset_index()
+        self.reset_index()
         self.search_backend.add_type(Image)
 
         # Add an image with some tags
         image = self.edit_image(tags="hello")
-        self.search_backend.refresh_index()
+        self.refresh_index()
 
         # Search for it by tag
         results = self.search_backend.search("hello", Image)

--- a/wagtail/search/backends/elasticsearch8.py
+++ b/wagtail/search/backends/elasticsearch8.py
@@ -1,0 +1,103 @@
+import copy
+from urllib.parse import urlparse
+from warnings import warn
+
+from elasticsearch import NotFoundError
+from wagtail.search.backends.elasticsearch7 import (
+    Elasticsearch7Index,
+    Elasticsearch7Mapping,
+    Elasticsearch7SearchBackend,
+    Elasticsearch7SearchQueryCompiler,
+    Elasticsearch7SearchResults,
+    ElasticsearchAutocompleteQueryCompilerImpl,
+)
+from wagtail.utils.utils import deep_update
+
+
+class Elasticsearch8Mapping(Elasticsearch7Mapping):
+    def get_field_mapping(self, field):
+        # Boost is no longer supported during index, rather use it while querying.
+        if hasattr(field, "boost"):
+            warn("Elasticsearch8 backend does not support boost on index.")
+            field.boost = None
+
+        return super().get_field_mapping(field)
+
+
+class Elasticsearch8Index(Elasticsearch7Index):
+    def put(self):
+        self.es.indices.create(index=self.name, settings=self.backend.settings)
+
+    def delete(self):
+        try:
+            self.es.indices.delete(index=self.name)
+        except NotFoundError:
+            pass
+
+    def exists(self):
+        return self.es.indices.exists(index=self.name)
+
+    def refresh(self):
+        self.es.indices.refresh(index=self.name)
+
+
+class Elasticsearch8SearchQueryCompiler(Elasticsearch7SearchQueryCompiler):
+    mapping_class = Elasticsearch8Mapping
+
+
+class Elasticsearch8SearchResults(Elasticsearch7SearchResults):
+    pass
+
+
+class Elasticsearch8AutocompleteQueryCompiler(
+    Elasticsearch7SearchQueryCompiler, ElasticsearchAutocompleteQueryCompilerImpl
+):
+    pass
+
+
+class Elasticsearch8SearchBackend(Elasticsearch7SearchBackend):
+    mapping_class = Elasticsearch8Mapping
+    index_class = Elasticsearch8Index
+    query_compiler_class = Elasticsearch8SearchQueryCompiler
+    autocomplete_query_compiler_class = Elasticsearch8AutocompleteQueryCompiler
+    results_class = Elasticsearch8SearchResults
+
+    settings = copy.deepcopy(Elasticsearch7SearchBackend.settings)
+    settings = settings["settings"]
+
+    def _get_settings(self, index_settings):
+
+        # Make the class settings attribute as instance settings attribute
+        settings = copy.deepcopy(self.settings)
+
+        # To also support the old notation of settings, we include this line
+        index_settings = index_settings.get("settings", index_settings)
+
+        return deep_update(settings, index_settings)
+
+    def _convert_urls_to_hosts(self, es_urls):
+        hosts = []
+
+        # if es_urls is not a list, convert it to a list
+        if isinstance(es_urls, str):
+            es_urls = [es_urls]
+
+        for url in es_urls:
+            parsed_url = urlparse(url)
+
+            use_ssl = parsed_url.scheme == "https"
+            port = parsed_url.port or (443 if use_ssl else 80)
+
+            hosts.append(
+                {
+                    "host": parsed_url.hostname,
+                    "port": port,
+                    "url_prefix": parsed_url.path,
+                    "use_ssl": use_ssl,
+                }
+            )
+
+        return hosts
+
+
+SearchBackend = Elasticsearch8SearchBackend

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import datetime
 import json
+import os
 from unittest import mock
+import unittest
 
 from django.db.models import Q
 from django.test import TestCase
@@ -623,6 +625,9 @@ class TestElasticsearch5SearchQuery(TestCase):
         self.assertDictEqual(query_compiler.get_query(), expected_result)
 
 
+@unittest.skipIf(
+    os.environ.get("ELASTICSEARCH_VERSION") == "8", "Elasticsearch 8 is not compatible with <7"
+)
 class TestElasticsearch5SearchResults(TestCase):
     fixtures = ["search"]
 

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import datetime
 import json
+import os
 from unittest import mock
+import unittest
 
 from django.db.models import Q
 from django.test import TestCase
@@ -725,6 +727,9 @@ class TestElasticsearch6SearchQuery(TestCase):
         self.assertDictEqual(query_compiler.get_query(), expected_result)
 
 
+@unittest.skipIf(
+    os.environ.get("ELASTICSEARCH_VERSION") == "8", "Elasticsearch 8 is not compatible with <7"
+)
 class TestElasticsearch6SearchResults(TestCase):
     fixtures = ["search"]
 

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import datetime
 import json
+import os
 from unittest import mock
+import unittest
 
 from django.db.models import Q
 from django.test import TestCase
@@ -711,6 +713,9 @@ class TestElasticsearch7SearchQuery(TestCase):
         self.assertDictEqual(query_compiler.get_query(), expected_result)
 
 
+@unittest.skipIf(
+    os.environ.get("ELASTICSEARCH_VERSION") == "8", "Elasticsearch 8 is not compatible with <7"
+)
 class TestElasticsearch7SearchResults(TestCase):
     fixtures = ["search"]
 

--- a/wagtail/search/tests/test_elasticsearch8_backend.py
+++ b/wagtail/search/tests/test_elasticsearch8_backend.py
@@ -1,0 +1,1252 @@
+# -*- coding: utf-8 -*-
+import datetime
+import json
+import os
+from unittest import mock
+import unittest
+
+from django.db.models import Q
+from django.test import TestCase
+from elasticsearch.serializer import JSONSerializer
+
+from wagtail.search.backends.elasticsearch8 import Elasticsearch8SearchBackend
+from wagtail.search.query import MATCH_ALL, Fuzzy, Phrase
+from wagtail.test.search import models
+
+from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
+
+
+class TestElasticsearch8SearchBackend(ElasticsearchCommonSearchBackendTests, TestCase):
+    backend_path = "wagtail.search.backends.elasticsearch8"
+
+
+class TestElasticsearch8SearchQuery(TestCase):
+    maxDiff = None
+
+    def assertDictEqual(self, a, b):
+        default = JSONSerializer().default
+        self.assertEqual(
+            json.dumps(a, sort_keys=True, default=default),
+            json.dumps(b, sort_keys=True, default=default),
+        )
+
+    query_compiler_class = Elasticsearch8SearchBackend.query_compiler_class
+    autocomplete_query_compiler_class = (
+        Elasticsearch8SearchBackend.autocomplete_query_compiler_class
+    )
+
+    def test_simple(self):
+        # Create a query
+        query = self.query_compiler_class(models.Book.objects.all(), "Hello")
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": {"match": {"content_type": "searchtests.Book"}},
+                "must": {"match": {"_all_text": {"query": "Hello"}}},
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_simple_autocomplete(self):
+        # Create a query
+        query = self.autocomplete_query_compiler_class(
+            models.Book.objects.all(), "Hello"
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": {"match": {"content_type": "searchtests.Book"}},
+                "must": {"match": {"_edgengrams": {"query": "Hello"}}},
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_none_query_string(self):
+        # Create a query
+        query = self.query_compiler_class(models.Book.objects.all(), MATCH_ALL)
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": {"match": {"content_type": "searchtests.Book"}},
+                "must": {"match_all": {}},
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_and_operator(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.all(), "Hello", operator="and"
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": {"match": {"content_type": "searchtests.Book"}},
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                            "operator": "and",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_filter(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.filter(title="Test"), "Hello"
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {"term": {"title_filter": "Test"}},
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_and_filter(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.filter(
+                title="Test", publication_date=datetime.date(2017, 10, 18)
+            ),
+            "Hello",
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {
+                        "bool": {
+                            "must": [
+                                {"term": {"publication_date_filter": "2017-10-18"}},
+                                {"term": {"title_filter": "Test"}},
+                            ]
+                        }
+                    },
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+
+        # Make sure field filters are sorted (as they can be in any order which may cause false positives)
+        query = query.get_query()
+        field_filters = query["bool"]["filter"][1]["bool"]["must"]
+        field_filters[:] = sorted(
+            field_filters, key=lambda f: list(f["term"].keys())[0]
+        )
+
+        self.assertDictEqual(query, expected_result)
+
+    def test_or_filter(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.filter(
+                Q(title="Test") | Q(publication_date=datetime.date(2017, 10, 18))
+            ),
+            "Hello",
+        )
+
+        # Make sure field filters are sorted (as they can be in any order which may cause false positives)
+        query = query.get_query()
+        field_filters = query["bool"]["filter"][1]["bool"]["should"]
+        field_filters[:] = sorted(
+            field_filters, key=lambda f: list(f["term"].keys())[0]
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {
+                        "bool": {
+                            "should": [
+                                {"term": {"publication_date_filter": "2017-10-18"}},
+                                {"term": {"title_filter": "Test"}},
+                            ]
+                        }
+                    },
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query, expected_result)
+
+    def test_negated_filter(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.exclude(publication_date=datetime.date(2017, 10, 18)),
+            "Hello",
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {
+                        "bool": {
+                            "mustNot": {
+                                "term": {"publication_date_filter": "2017-10-18"}
+                            }
+                        }
+                    },
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_fields(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.all(), "Hello", fields=["title"]
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": {"match": {"content_type": "searchtests.Book"}},
+                "must": {"match": {"title": {"query": "Hello"}}},
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_fields_with_and_operator(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.all(), "Hello", fields=["title"], operator="and"
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": {"match": {"content_type": "searchtests.Book"}},
+                "must": {"match": {"title": {"query": "Hello", "operator": "and"}}},
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_multiple_fields(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.all(), "Hello", fields=["title", "content"]
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": {"match": {"content_type": "searchtests.Book"}},
+                "must": {
+                    "multi_match": {"fields": ["title", "content"], "query": "Hello"}
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_multiple_fields_with_and_operator(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.all(),
+            "Hello",
+            fields=["title", "content"],
+            operator="and",
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": {"match": {"content_type": "searchtests.Book"}},
+                "must": {
+                    "multi_match": {
+                        "fields": ["title", "content"],
+                        "query": "Hello",
+                        "operator": "and",
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_exact_lookup(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.filter(title__exact="Test"), "Hello"
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {"term": {"title_filter": "Test"}},
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_none_lookup(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.filter(title=None), "Hello"
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {"bool": {"mustNot": {"exists": {"field": "title_filter"}}}},
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_isnull_true_lookup(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.filter(title__isnull=True), "Hello"
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {"bool": {"mustNot": {"exists": {"field": "title_filter"}}}},
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_isnull_false_lookup(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.filter(title__isnull=False), "Hello"
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {"exists": {"field": "title_filter"}},
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_startswith_lookup(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.filter(title__startswith="Test"), "Hello"
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {"prefix": {"title_filter": "Test"}},
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_gt_lookup(self):
+        # This also tests conversion of python dates to strings
+
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.filter(
+                publication_date__gt=datetime.datetime(2014, 4, 29)
+            ),
+            "Hello",
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {"range": {"publication_date_filter": {"gt": "2014-04-29"}}},
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_lt_lookup(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.filter(
+                publication_date__lt=datetime.datetime(2014, 4, 29)
+            ),
+            "Hello",
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {"range": {"publication_date_filter": {"lt": "2014-04-29"}}},
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_gte_lookup(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.filter(
+                publication_date__gte=datetime.datetime(2014, 4, 29)
+            ),
+            "Hello",
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {"range": {"publication_date_filter": {"gte": "2014-04-29"}}},
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_lte_lookup(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.filter(
+                publication_date__lte=datetime.datetime(2014, 4, 29)
+            ),
+            "Hello",
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {"range": {"publication_date_filter": {"lte": "2014-04-29"}}},
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_range_lookup(self):
+        start_date = datetime.datetime(2014, 4, 29)
+        end_date = datetime.datetime(2014, 8, 19)
+
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.filter(publication_date__range=(start_date, end_date)),
+            "Hello",
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {
+                        "range": {
+                            "publication_date_filter": {
+                                "gte": "2014-04-29",
+                                "lte": "2014-08-19",
+                            }
+                        }
+                    },
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query.get_query(), expected_result)
+
+    def test_custom_ordering(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.order_by("publication_date"),
+            "Hello",
+            order_by_relevance=False,
+        )
+
+        # Check it
+        expected_result = [{"publication_date_filter": "asc"}]
+        self.assertDictEqual(query.get_sort(), expected_result)
+
+    def test_custom_ordering_reversed(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.order_by("-publication_date"),
+            "Hello",
+            order_by_relevance=False,
+        )
+
+        # Check it
+        expected_result = [{"publication_date_filter": "desc"}]
+        self.assertDictEqual(query.get_sort(), expected_result)
+
+    def test_custom_ordering_multiple(self):
+        # Create a query
+        query = self.query_compiler_class(
+            models.Book.objects.order_by("publication_date", "number_of_pages"),
+            "Hello",
+            order_by_relevance=False,
+        )
+
+        # Check it
+        expected_result = [
+            {"publication_date_filter": "asc"},
+            {"number_of_pages_filter": "asc"},
+        ]
+        self.assertDictEqual(query.get_sort(), expected_result)
+
+    def test_phrase_query(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(), Phrase("Hello world")
+        )
+
+        # Check it
+        expected_result = {"match_phrase": {"_all_text": "Hello world"}}
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_phrase_query_multiple_fields(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Phrase("Hello world"),
+            fields=["title", "content"],
+        )
+
+        # Check it
+        expected_result = {
+            "multi_match": {
+                "query": "Hello world",
+                "fields": ["title", "content"],
+                "type": "phrase",
+            }
+        }
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_phrase_query_single_field(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(), Phrase("Hello world"), fields=["title"]
+        )
+
+        # Check it
+        expected_result = {"match_phrase": {"title": "Hello world"}}
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_fuzzy_query(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+        )
+
+        # Check it
+        expected_result = {
+            "match": {"_all_text": {"query": "Hello world", "fuzziness": "AUTO"}}
+        }
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_fuzzy_query_single_field(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            fields=["title"],
+        )
+
+        # Check it
+        expected_result = {
+            "match": {"title": {"query": "Hello world", "fuzziness": "AUTO"}}
+        }
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_fuzzy_query_multiple_fields_disallowed(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            fields=["title", "body"],
+        )
+
+        # Check it
+        with self.assertRaises(NotImplementedError):
+            query_compiler.get_inner_query()
+
+    def test_year_filter(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.filter(publication_date__year__lt=1900), "Hello"
+        )
+
+        # Check it
+        expected_result = {
+            "bool": {
+                "filter": [
+                    {"match": {"content_type": "searchtests.Book"}},
+                    {"range": {"publication_date_filter": {"lt": 1900}}},
+                ],
+                "must": {
+                    "match": {
+                        "_all_text": {
+                            "query": "Hello",
+                        }
+                    }
+                },
+            }
+        }
+        self.assertDictEqual(query_compiler.get_query(), expected_result)
+
+
+@unittest.skipIf(
+    os.environ.get("ELASTICSEARCH_VERSION") != "8", "Elasticsearch 8 is not compatible with <7"
+)
+class TestElasticsearch8SearchResults(TestCase):
+    fixtures = ["search"]
+
+    def assertDictEqual(self, a, b):
+        default = JSONSerializer().default
+        self.assertEqual(json.dumps(a, sort_keys=True, default=default), json.dumps)
+
+    def get_results(self):
+        backend = Elasticsearch8SearchBackend({})
+        query = mock.MagicMock()
+        query.queryset = models.Book.objects.all()
+        query.get_query.return_value = "QUERY"
+        query.get_sort.return_value = None
+        return backend.results_class(backend, query)
+
+    def construct_search_response(self, results):
+        return {
+            "_shards": {"failed": 0, "successful": 5, "total": 5},
+            "hits": {
+                "hits": [
+                    {
+                        "_id": "searchtests_book:" + str(result),
+                        "_index": "wagtail",
+                        "_score": 1,
+                        "_type": "searchtests_book",
+                        "fields": {
+                            "pk": [str(result)],
+                        },
+                    }
+                    for result in results
+                ],
+                "max_score": 1,
+                "total": len(results),
+            },
+            "timed_out": False,
+            "took": 2,
+        }
+
+    @mock.patch("elasticsearch.Elasticsearch.search")
+    def test_basic_search(self, search):
+        search.return_value = self.construct_search_response([])
+        results = self.get_results()
+
+        list(results)  # Performs search
+
+        search.assert_any_call(
+            body={"query": "QUERY"},
+            _source=False,
+            stored_fields="pk",
+            index="wagtail__searchtests_book",
+            scroll="2m",
+            size=100,
+        )
+
+    @mock.patch("elasticsearch.Elasticsearch.search")
+    def test_get_single_item(self, search):
+        # Need to return something to prevent index error
+        search.return_value = self.construct_search_response([1])
+        results = self.get_results()
+
+        results[10]  # Performs search
+
+        search.assert_any_call(
+            from_=10,
+            body={"query": "QUERY"},
+            _source=False,
+            stored_fields="pk",
+            index="wagtail__searchtests_book",
+            size=1,
+        )
+
+    @mock.patch("elasticsearch.Elasticsearch.search")
+    def test_slice_results(self, search):
+        search.return_value = self.construct_search_response([])
+        results = self.get_results()[1:4]
+
+        list(results)  # Performs search
+
+        search.assert_any_call(
+            from_=1,
+            body={"query": "QUERY"},
+            _source=False,
+            stored_fields="pk",
+            index="wagtail__searchtests_book",
+            size=3,
+        )
+
+    @mock.patch("elasticsearch.Elasticsearch.search")
+    def test_slice_results_multiple_times(self, search):
+        search.return_value = self.construct_search_response([])
+        results = self.get_results()[10:][:10]
+
+        list(results)  # Performs search
+
+        search.assert_any_call(
+            from_=10,
+            body={"query": "QUERY"},
+            _source=False,
+            stored_fields="pk",
+            index="wagtail__searchtests_book",
+            size=10,
+        )
+
+    @mock.patch("elasticsearch.Elasticsearch.search")
+    def test_slice_results_and_get_item(self, search):
+        # Need to return something to prevent index error
+        search.return_value = self.construct_search_response([1])
+        results = self.get_results()[10:]
+
+        results[10]  # Performs search
+
+        search.assert_any_call(
+            from_=20,
+            body={"query": "QUERY"},
+            _source=False,
+            stored_fields="pk",
+            index="wagtail__searchtests_book",
+            size=1,
+        )
+
+    @mock.patch("elasticsearch.Elasticsearch.search")
+    def test_result_returned(self, search):
+        search.return_value = self.construct_search_response([1])
+        results = self.get_results()
+
+        self.assertEqual(results[0], models.Book.objects.get(id=1))
+
+    @mock.patch("elasticsearch.Elasticsearch.search")
+    def test_len_1(self, search):
+        search.return_value = self.construct_search_response([1])
+        results = self.get_results()
+
+        self.assertEqual(len(results), 1)
+
+    @mock.patch("elasticsearch.Elasticsearch.search")
+    def test_len_2(self, search):
+        search.return_value = self.construct_search_response([1, 2])
+        results = self.get_results()
+
+        self.assertEqual(len(results), 2)
+
+    @mock.patch("elasticsearch.Elasticsearch.search")
+    def test_duplicate_results(self, search):  # Duplicates will not be removed
+        search.return_value = self.construct_search_response([1, 1])
+        results = list(
+            self.get_results()
+        )  # Must cast to list so we only create one query
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0], models.Book.objects.get(id=1))
+        self.assertEqual(results[1], models.Book.objects.get(id=1))
+
+    @mock.patch("elasticsearch.Elasticsearch.search")
+    def test_result_order(self, search):
+        search.return_value = self.construct_search_response([1, 2, 3])
+        results = list(
+            self.get_results()
+        )  # Must cast to list so we only create one query
+
+        self.assertEqual(results[0], models.Book.objects.get(id=1))
+        self.assertEqual(results[1], models.Book.objects.get(id=2))
+        self.assertEqual(results[2], models.Book.objects.get(id=3))
+
+    @mock.patch("elasticsearch.Elasticsearch.search")
+    def test_result_order_2(self, search):
+        search.return_value = self.construct_search_response([3, 2, 1])
+        results = list(
+            self.get_results()
+        )  # Must cast to list so we only create one query
+
+        self.assertEqual(results[0], models.Book.objects.get(id=3))
+        self.assertEqual(results[1], models.Book.objects.get(id=2))
+        self.assertEqual(results[2], models.Book.objects.get(id=1))
+
+
+class TestElasticsearch8Mapping(TestCase):
+    fixtures = ["search"]
+
+    maxDiff = None
+
+    def assertDictEqual(self, a, b):
+        default = JSONSerializer().default
+        self.assertEqual(
+            json.dumps(a, sort_keys=True, default=default),
+            json.dumps(b, sort_keys=True, default=default),
+        )
+
+    def setUp(self):
+        # Create ES mapping
+        self.es_mapping = Elasticsearch8SearchBackend.mapping_class(models.Book)
+
+        # Create ES document
+        self.obj = models.Book.objects.get(id=4)
+
+    def test_get_document_type(self):
+        self.assertEqual(self.es_mapping.get_document_type(), "doc")
+
+    def test_get_mapping(self):
+        # Build mapping
+        mapping = self.es_mapping.get_mapping()
+
+        # Check
+        expected_result = {
+            "properties": {
+                "pk": {"type": "keyword", "store": True},
+                "content_type": {"type": "keyword"},
+                "_all_text": {"type": "text"},
+                "_edgengrams": {
+                    "analyzer": "edgengram_analyzer",
+                    "search_analyzer": "standard",
+                    "type": "text",
+                },
+                "title": {
+                    "type": "text",
+                    "copy_to": "_all_text",
+                },
+                "title_edgengrams": {
+                    "type": "text",
+                    "analyzer": "edgengram_analyzer",
+                    "search_analyzer": "standard",
+                },
+                "title_filter": {"type": "keyword"},
+                "authors": {
+                    "type": "nested",
+                    "properties": {
+                        "name": {"type": "text", "copy_to": "_all_text"},
+                        "name_edgengrams": {
+                            "analyzer": "edgengram_analyzer",
+                            "search_analyzer": "standard",
+                            "type": "text",
+                        },
+                        "date_of_birth_filter": {"type": "date"},
+                    },
+                },
+                "authors_filter": {"type": "integer"},
+                "publication_date_filter": {"type": "date"},
+                "number_of_pages_filter": {"type": "integer"},
+                "tags": {
+                    "type": "nested",
+                    "properties": {
+                        "name": {"type": "text", "copy_to": "_all_text"},
+                        "slug_filter": {"type": "keyword"},
+                    },
+                },
+                "tags_filter": {"type": "integer"},
+            }
+        }
+
+        self.assertDictEqual(mapping, expected_result)
+
+    def test_get_document_id(self):
+        self.assertEqual(self.es_mapping.get_document_id(self.obj), str(self.obj.pk))
+
+    def test_get_document(self):
+        # Get document
+        document = self.es_mapping.get_document(self.obj)
+
+        # Sort edgengrams
+        if "_edgengrams" in document:
+            document["_edgengrams"].sort()
+
+        # Check
+        expected_result = {
+            "pk": "4",
+            "content_type": ["searchtests.Book"],
+            "_edgengrams": [
+                "J. R. R. Tolkien",
+                "The Fellowship of the Ring",
+            ],
+            "title": "The Fellowship of the Ring",
+            "title_edgengrams": "The Fellowship of the Ring",
+            "title_filter": "The Fellowship of the Ring",
+            "authors": [
+                {
+                    "name": "J. R. R. Tolkien",
+                    "name_edgengrams": "J. R. R. Tolkien",
+                    "date_of_birth_filter": datetime.date(1892, 1, 3),
+                }
+            ],
+            "authors_filter": [2],
+            "publication_date_filter": datetime.date(1954, 7, 29),
+            "number_of_pages_filter": 423,
+            "tags": [],
+            "tags_filter": [],
+        }
+
+        self.assertDictEqual(document, expected_result)
+
+
+class TestElasticsearch8MappingInheritance(TestCase):
+    fixtures = ["search"]
+    maxDiff = None
+
+    def assertDictEqual(self, a, b):
+        default = JSONSerializer().default
+        self.assertEqual(
+            json.dumps(a, sort_keys=True, default=default),
+            json.dumps(b, sort_keys=True, default=default),
+        )
+
+    def setUp(self):
+        # Create ES mapping
+        self.es_mapping = Elasticsearch8SearchBackend.mapping_class(models.Novel)
+
+        self.obj = models.Novel.objects.get(id=4)
+
+    def test_get_document_type(self):
+        self.assertEqual(self.es_mapping.get_document_type(), "doc")
+
+    def test_get_mapping(self):
+        # Build mapping
+        mapping = self.es_mapping.get_mapping()
+
+        # Check
+        expected_result = {
+            "properties": {
+                # New
+                "searchtests_novel__setting": {
+                    "type": "text",
+                    "copy_to": "_all_text",
+                },
+                "searchtests_novel__setting_edgengrams": {
+                    "type": "text",
+                    "analyzer": "edgengram_analyzer",
+                    "search_analyzer": "standard",
+                },
+                "searchtests_novel__protagonist": {
+                    "type": "nested",
+                    "properties": {
+                        "name": {"type": "text", "copy_to": "_all_text"},
+                        "novel_id_filter": {"type": "integer"},
+                    },
+                },
+                "searchtests_novel__protagonist_id_filter": {"type": "integer"},
+                "searchtests_novel__characters": {
+                    "type": "nested",
+                    "properties": {
+                        "name": {"type": "text", "copy_to": "_all_text"}
+                    },
+                },
+                # Inherited
+                "pk": {"type": "keyword", "store": True},
+                "content_type": {"type": "keyword"},
+                "_all_text": {"type": "text"},
+                "_edgengrams": {
+                    "analyzer": "edgengram_analyzer",
+                    "search_analyzer": "standard",
+                    "type": "text",
+                },
+                "title": {
+                    "type": "text",
+                    "copy_to": "_all_text",
+                },
+                "title_edgengrams": {
+                    "type": "text",
+                    "analyzer": "edgengram_analyzer",
+                    "search_analyzer": "standard",
+                },
+                "title_filter": {"type": "keyword"},
+                "authors": {
+                    "type": "nested",
+                    "properties": {
+                        "name": {"type": "text", "copy_to": "_all_text"},
+                        "name_edgengrams": {
+                            "analyzer": "edgengram_analyzer",
+                            "search_analyzer": "standard",
+                            "type": "text",
+                        },
+                        "date_of_birth_filter": {"type": "date"},
+                    },
+                },
+                "authors_filter": {"type": "integer"},
+                "publication_date_filter": {"type": "date"},
+                "number_of_pages_filter": {"type": "integer"},
+                "tags": {
+                    "type": "nested",
+                    "properties": {
+                        "name": {"type": "text", "copy_to": "_all_text"},
+                        "slug_filter": {"type": "keyword"},
+                    },
+                },
+                "tags_filter": {"type": "integer"},
+            }
+        }
+
+        self.assertDictEqual(mapping, expected_result)
+
+    def test_get_document_id(self):
+        # This must be tests_searchtest instead of 'tests_searchtest_tests_searchtestchild'
+        # as it uses the contents base content type name.
+        # This prevents the same object being accidentally indexed twice.
+        self.assertEqual(self.es_mapping.get_document_id(self.obj), str(self.obj.pk))
+
+    def test_get_document(self):
+        # Build document
+        document = self.es_mapping.get_document(self.obj)
+
+        # Sort edgengrams
+        if "_edgengrams" in document:
+            document["_edgengrams"].sort()
+
+        # Sort characters
+        if "searchtests_novel__characters" in document:
+            document["searchtests_novel__characters"].sort(key=lambda c: c["name"])
+
+        # Check
+        expected_result = {
+            # New
+            "searchtests_novel__setting": "Middle Earth",
+            "searchtests_novel__setting_edgengrams": "Middle Earth",
+            "searchtests_novel__protagonist": {
+                "name": "Frodo Baggins",
+                "novel_id_filter": 4,
+            },
+            "searchtests_novel__protagonist_id_filter": 8,
+            "searchtests_novel__characters": [
+                {"name": "Bilbo Baggins"},
+                {"name": "Frodo Baggins"},
+                {"name": "Gandalf"},
+            ],
+            # Changed
+            "content_type": ["searchtests.Novel", "searchtests.Book"],
+            "_edgengrams": [
+                "J. R. R. Tolkien",
+                "Middle Earth",
+                "The Fellowship of the Ring",
+            ],
+            # Inherited
+            "pk": "4",
+            "title": "The Fellowship of the Ring",
+            "title_edgengrams": "The Fellowship of the Ring",
+            "title_filter": "The Fellowship of the Ring",
+            "authors": [
+                {
+                    "name": "J. R. R. Tolkien",
+                    "name_edgengrams": "J. R. R. Tolkien",
+                    "date_of_birth_filter": datetime.date(1892, 1, 3),
+                }
+            ],
+            "authors_filter": [2],
+            "publication_date_filter": datetime.date(1954, 7, 29),
+            "number_of_pages_filter": 423,
+            "tags": [],
+            "tags_filter": [],
+        }
+
+        self.assertDictEqual(document, expected_result)
+
+
+@mock.patch("wagtail.search.backends.elasticsearch5.Elasticsearch")
+class TestBackendConfiguration(TestCase):
+    def test_default_settings(self, Elasticsearch):
+        Elasticsearch8SearchBackend(params={})
+
+        Elasticsearch.assert_called_with(
+            hosts=[
+                {
+                    "host": "localhost",
+                    "port": 9200,
+                    "url_prefix": "",
+                    "use_ssl": False,
+                }
+            ],
+            timeout=10,
+        )
+
+    def test_hosts(self, Elasticsearch):
+        Elasticsearch8SearchBackend(
+            params={
+                "HOSTS": [
+                    {
+                        "host": "127.0.0.1",
+                        "port": 9300,
+                        "use_ssl": True,
+                    }
+                ]
+            }
+        )
+
+        Elasticsearch.assert_called_with(
+            hosts=[
+                {
+                    "host": "127.0.0.1",
+                    "port": 9300,
+                    "use_ssl": True,
+                }
+            ],
+            timeout=10,
+        )
+
+    def test_urls(self, Elasticsearch):
+        # This test backwards compatibility with old URLS setting
+        Elasticsearch8SearchBackend(
+            params={
+                "URLS": [
+                    "http://localhost:12345",
+                    "https://127.0.0.1:54321",
+                    "http://username:password@elasticsearch.mysite.com",
+                    "https://elasticsearch.mysite.com/hello",
+                ],
+            }
+        )
+
+        Elasticsearch.assert_called_with(
+            hosts=[
+                {
+                    "host": "localhost",
+                    "port": 12345,
+                    "url_prefix": "",
+                    "use_ssl": False,
+                    "verify_certs": False,
+                    "http_auth": None,
+                },
+                {
+                    "host": "127.0.0.1",
+                    "port": 54321,
+                    "url_prefix": "",
+                    "use_ssl": True,
+                },
+                {
+                    "host": "elasticsearch.mysite.com",
+                    "port": 80,
+                    "url_prefix": "",
+                    "use_ssl": False,
+                },
+                {
+                    "host": "elasticsearch.mysite.com",
+                    "port": 443,
+                    "url_prefix": "/hello",
+                    "use_ssl": True,
+                },
+            ],
+            timeout=10,
+        )

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -204,7 +204,9 @@ if os.environ.get("DATABASE_ENGINE") == "django.db.backends.postgresql":
     }
 
 if "ELASTICSEARCH_URL" in os.environ:
-    if os.environ.get("ELASTICSEARCH_VERSION") == "7":
+    if os.environ.get("ELASTICSEARCH_VERSION") == "8":
+        backend = "wagtail.search.backends.elasticsearch8"
+    elif os.environ.get("ELASTICSEARCH_VERSION") == "7":
         backend = "wagtail.search.backends.elasticsearch7"
     elif os.environ.get("ELASTICSEARCH_VERSION") == "6":
         backend = "wagtail.search.backends.elasticsearch6"


### PR DESCRIPTION
# Fixes

Introduction of a new Elasticsearch backend that adds compatibility for the following changes/deprecations:

* Elasticsearch client initialisation; `verify_certs` and `http_auth` are deprecated for the hosts dictionary. 
* Elasticsearch API method calling; Positional arguments can’t be used with the new Elasticsearch API methods. The use of keyword argument is enforced.
* Index settings; The settings dictionary structure when calling the API method `create` is expected differently.
* Boosting; The boost parameter on field indices/mappings has been removed. Boost needs to be used while querying.

# To do

- [ ] All tests pass
- [x] The code complies with the style guide
- [x] Added tests to cover the new feature
- [ ] Documentation has been updated

# Nice to have?
- [ ] Improvement of boosted searching
- [ ] Additional features (release in Elasticsearch 8)

**Additional**

1. With the current state of the PR, the boosting feature is disabled **for Elasticsearch 8**. We only provide a warning to the user that boosting is not supported and ignore it in the search fields definition. I think that this needs to be implemented where we execute the query, `search()` for example. 
2. New features that have been added in Elasticsearch 8 have not been included in the PR (yet?). For now it is solely solves compatibility issues.

If you have an idea on how we should implement boosting or what kind of new features should included, please let me know. Help would be greatly appreciated!