### PR TITLE
Update pagination behaviour to reject out-of-range / invalid page numbers

### DIFF
--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -228,11 +228,7 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
-
-        # Check that we got page one
-        self.assertEqual(response.context["pages"].number, 1)
+        self.assertEqual(response.status_code, 404)
 
     def test_pagination_out_of_range(self):
         self.make_pages()
@@ -242,14 +238,7 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
-
-        # Check that we got the last page
-        self.assertEqual(
-            response.context["pages"].number,
-            response.context["pages"].paginator.num_pages,
-        )
+        self.assertEqual(response.status_code, 404)
 
     @override_settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True)
     def test_no_thousand_separators_in_bulk_action_checkbox(self):

--- a/wagtail/admin/tests/pages/test_page_search.py
+++ b/wagtail/admin/tests/pages/test_page_search.py
@@ -71,11 +71,13 @@ class TestPageSearch(WagtailTestUtils, TransactionTestCase):
         self.assertEqual(response.context["query_string"], "Hello")
 
     def test_pagination(self):
-        pages = ["0", "1", "-1", "9999", "Not a page"]
-        for page in pages:
-            response = self.get({"q": "Hello", "p": page})
-            self.assertEqual(response.status_code, 200)
-            self.assertTemplateUsed(response, "wagtailadmin/pages/search.html")
+        # page numbers in range should be accepted
+        response = self.get({"q": "Hello", "p": 1})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/search.html")
+        # page numbers out of range should return 404
+        response = self.get({"q": "Hello", "p": 9999})
+        self.assertEqual(response.status_code, 404)
 
     def test_root_can_appear_in_search_results(self):
         response = self.get({"q": "root"})

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -298,13 +298,13 @@ class TestChooserBrowseChild(WagtailTestUtils, TestCase):
         self.setup_pagination_test_data()
 
         response = self.get({"p": "foo"})
-        self.assertEqual(response.context["pagination_page"].number, 1)
+        self.assertEqual(response.status_code, 404)
 
     def test_pagination_out_of_range_page(self):
         self.setup_pagination_test_data()
 
         response = self.get({"p": 100})
-        self.assertEqual(response.context["pagination_page"].number, 5)
+        self.assertEqual(response.status_code, 404)
 
 
 class TestChooserSearch(WagtailTestUtils, TransactionTestCase):

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -1,7 +1,7 @@
 import re
 
 from django.conf import settings
-from django.core.paginator import Paginator
+from django.core.paginator import InvalidPage, Paginator
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
@@ -342,7 +342,10 @@ class BrowseView(View):
         # We apply pagination first so we don't need to walk the entire list
         # in the block below
         paginator = Paginator(pages, per_page=25)
-        pages = paginator.get_page(request.GET.get("p"))
+        try:
+            pages = paginator.page(request.GET.get("p", 1))
+        except InvalidPage:
+            raise Http404
 
         # Annotate each page with can_choose/can_decend flags
         for page in pages:

--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -8,7 +8,7 @@ from django.core.exceptions import (
     ObjectDoesNotExist,
     PermissionDenied,
 )
-from django.core.paginator import Paginator
+from django.core.paginator import InvalidPage, Paginator
 from django.forms.models import modelform_factory
 from django.http import Http404
 from django.template.loader import render_to_string
@@ -232,7 +232,10 @@ class BaseChooseView(
         objects = self.filter_object_list(objects)
 
         paginator = Paginator(objects, per_page=self.per_page)
-        return paginator.get_page(request.GET.get("p"))
+        try:
+            return paginator.page(request.GET.get("p", 1))
+        except InvalidPage:
+            raise Http404
 
     def get(self, request):
         self.filter_form = self.get_filter_form()

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -240,18 +240,6 @@ class IndexView(
 
         return queryset
 
-    def paginate_queryset(self, queryset, page_size):
-        paginator = self.get_paginator(
-            queryset,
-            page_size,
-            orphans=self.get_paginate_orphans(),
-            allow_empty_first_page=self.get_allow_empty(),
-        )
-
-        page_number = self.request.GET.get(self.page_kwarg)
-        page = paginator.get_page(page_number)
-        return (paginator, page, page.object_list, page.has_other_pages())
-
     def filter_queryset(self, queryset):
         # construct filter instance (self.filters) if not created already
         if self.filterset_class and self.filters is None:

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -1,6 +1,7 @@
 from django.conf import settings
-from django.core.paginator import Paginator
+from django.core.paginator import InvalidPage, Paginator
 from django.db.models import Count
+from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -90,7 +91,10 @@ def index(request, parent_page_id=None):
     # Pagination
     if do_paginate:
         paginator = Paginator(pages, per_page=50)
-        pages = paginator.get_page(request.GET.get("p"))
+        try:
+            pages = paginator.page(request.GET.get("p", 1))
+        except InvalidPage:
+            raise Http404
 
     show_ordering_column = request.GET.get("ordering") == "ord"
 

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.core.paginator import Paginator
+from django.core.paginator import InvalidPage, Paginator
 from django.http import Http404
 from django.template.response import TemplateResponse
 from django.views.decorators.vary import vary_on_headers
@@ -113,7 +113,10 @@ def search(request):
         form = SearchForm()
 
     paginator = Paginator(pages, per_page=20)
-    pages = paginator.get_page(request.GET.get("p"))
+    try:
+        pages = paginator.page(request.GET.get("p", 1))
+    except InvalidPage:
+        raise Http404
 
     if request.headers.get("x-requested-with") == "XMLHttpRequest":
         return TemplateResponse(

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -174,11 +174,7 @@ class TestFormsIndex(WagtailTestUtils, TestCase):
         response = self.client.get(reverse("wagtailforms:index"), {"p": "Hello world!"})
 
         # Check response
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailforms/index.html")
-
-        # Check that it got page one
-        self.assertEqual(response.context["page_obj"].number, 1)
+        self.assertEqual(response.status_code, 404)
 
     def test_forms_index_pagination_out_of_range(self):
         # Create some more form pages to make pagination kick in
@@ -188,13 +184,7 @@ class TestFormsIndex(WagtailTestUtils, TestCase):
         response = self.client.get(reverse("wagtailforms:index"), {"p": 99999})
 
         # Check response
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailforms/index.html")
-
-        # Check that it got the last page
-        self.assertEqual(
-            response.context["page_obj"].number, response.context["paginator"].num_pages
-        )
+        self.assertEqual(response.status_code, 404)
 
     def test_cannot_see_forms_without_permission(self):
         # Login with as a user without permission to see forms
@@ -310,7 +300,7 @@ class TestFormsIndexWithLocalisationEnabled(WagtailTestUtils, TestCase):
         self.assertEqual(response.context["page_obj"].number, 2)
 
         response = self.client.get(self.forms_index_url, {"p": 3})
-        self.assertEqual(response.context["page_obj"].number, 2)
+        self.assertEqual(response.status_code, 404)
 
         # now check the French pages.
         response = self.client.get(
@@ -478,11 +468,7 @@ class TestFormsSubmissionsList(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailforms/submissions_index.html")
-
-        # Check that we got page one
-        self.assertEqual(response.context["page_obj"].number, 1)
+        self.assertEqual(response.status_code, 404)
 
     def test_list_submissions_pagination_out_of_range(self):
         self.make_list_submissions()
@@ -493,13 +479,7 @@ class TestFormsSubmissionsList(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailforms/submissions_index.html")
-
-        # Check that we got the last page
-        self.assertEqual(
-            response.context["page_obj"].number, response.context["paginator"].num_pages
-        )
+        self.assertEqual(response.status_code, 404)
 
     def test_list_submissions_default_order(self):
         response = self.client.get(
@@ -1187,11 +1167,7 @@ class TestCustomFormsSubmissionsList(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailforms/submissions_index.html")
-
-        # Check that we got page one
-        self.assertEqual(response.context["page_obj"].number, 1)
+        self.assertEqual(response.status_code, 404)
 
     def test_list_submissions_pagination_out_of_range(self):
         self.make_list_submissions()
@@ -1202,13 +1178,7 @@ class TestCustomFormsSubmissionsList(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailforms/submissions_index.html")
-
-        # Check that we got the last page
-        self.assertEqual(
-            response.context["page_obj"].number, response.context["paginator"].num_pages
-        )
+        self.assertEqual(response.status_code, 404)
 
 
 class TestDeleteFormSubmission(WagtailTestUtils, TestCase):

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -600,10 +600,12 @@ class TestRedirectsIndexView(WagtailTestUtils, TestCase):
         self.assertEqual(len(response.context["redirects"]), 2)
 
     def test_pagination(self):
-        pages = ["0", "1", "-1", "9999", "Not a page"]
-        for page in pages:
-            response = self.get({"p": page})
-            self.assertEqual(response.status_code, 200)
+        # page numbers in range should be accepted
+        response = self.get({"p": 1})
+        self.assertEqual(response.status_code, 200)
+        # page numbers out of range should return 404
+        response = self.get({"p": 9999})
+        self.assertEqual(response.status_code, 404)
 
     def test_listing_order(self):
         for i in range(0, 10):

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -1,9 +1,10 @@
 import os
 
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
-from django.core.paginator import Paginator
+from django.core.paginator import InvalidPage, Paginator
 from django.db import transaction
 from django.db.models import Q
+from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -62,7 +63,10 @@ def index(request):
 
     # Pagination
     paginator = Paginator(redirects, per_page=20)
-    redirects = paginator.get_page(request.GET.get("p"))
+    try:
+        redirects = paginator.page(request.GET.get("p", 1))
+    except InvalidPage:
+        raise Http404
 
     # Render template
     if request.headers.get("x-requested-with") == "XMLHttpRequest":

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -136,11 +136,7 @@ class TestSearchPromotionsIndexView(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailsearchpromotions/index.html")
-
-        # Check that we got page one
-        self.assertEqual(response.context["queries"].number, 1)
+        self.assertEqual(response.status_code, 404)
 
     def test_pagination_out_of_range(self):
         self.make_search_picks()
@@ -150,14 +146,7 @@ class TestSearchPromotionsIndexView(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailsearchpromotions/index.html")
-
-        # Check that we got the last page
-        self.assertEqual(
-            response.context["queries"].number,
-            response.context["queries"].paginator.num_pages,
-        )
+        self.assertEqual(response.status_code, 404)
 
     def test_results_are_ordered_alphabetically(self):
         self.make_search_picks()

--- a/wagtail/contrib/search_promotions/views.py
+++ b/wagtail/contrib/search_promotions/views.py
@@ -1,6 +1,7 @@
-from django.core.paginator import Paginator
+from django.core.paginator import InvalidPage, Paginator
 from django.db import transaction
 from django.db.models import Sum, functions
+from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -47,7 +48,10 @@ def index(request):
 
     # Paginate
     paginator = Paginator(queries, per_page=20)
-    queries = paginator.get_page(request.GET.get("p"))
+    try:
+        queries = paginator.page(request.GET.get("p", 1))
+    except InvalidPage:
+        raise Http404
 
     if request.headers.get("x-requested-with") == "XMLHttpRequest":
         return TemplateResponse(

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -1617,11 +1617,7 @@ class TestDocumentChooserView(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtaildocs/chooser/results.html")
-
-        # Check that we got page one
-        self.assertEqual(response.context["results"].number, 1)
+        self.assertEqual(response.status_code, 404)
 
     def test_pagination_out_of_range(self):
         self.make_docs()
@@ -1631,14 +1627,7 @@ class TestDocumentChooserView(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtaildocs/chooser/results.html")
-
-        # Check that we got the last page
-        self.assertEqual(
-            response.context["results"].number,
-            response.context["results"].paginator.num_pages,
-        )
+        self.assertEqual(response.status_code, 404)
 
     def test_construct_queryset_hook_browse(self):
         document = models.Document.objects.create(

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -77,10 +77,12 @@ class TestImageIndexView(WagtailTestUtils, TestCase):
         self.assertContains(response, "a cute puppy")
 
     def test_pagination(self):
-        pages = ["0", "1", "-1", "9999", "Not a page"]
-        for page in pages:
-            response = self.get({"p": page})
-            self.assertEqual(response.status_code, 200)
+        # page numbers in range should be accepted
+        response = self.get({"p": 1})
+        self.assertEqual(response.status_code, 200)
+        # page numbers out of range should return 404
+        response = self.get({"p": 9999})
+        self.assertEqual(response.status_code, 404)
 
     def test_per_page(self):
         response = self.get({"entries_per_page": 60})

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1590,10 +1590,12 @@ class TestImageChooserView(WagtailTestUtils, TestCase):
         self.assertEqual(response.context["search_query"], "Hello")
 
     def test_pagination(self):
-        pages = ["0", "1", "-1", "9999", "Not a page"]
-        for page in pages:
-            response = self.get({"p": page})
-            self.assertEqual(response.status_code, 200)
+        # page numbers in range should be accepted
+        response = self.get({"p": 1})
+        self.assertEqual(response.status_code, 200)
+        # page numbers out of range should return 404
+        response = self.get({"p": 9999})
+        self.assertEqual(response.status_code, 404)
 
     def test_filter_by_tag(self):
         for i in range(0, 10):

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -2,8 +2,8 @@ import os
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.core.paginator import Paginator
-from django.http import HttpResponse, JsonResponse
+from django.core.paginator import InvalidPage, Paginator
+from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -121,7 +121,10 @@ class BaseListingView(TemplateView):
 
         entries_per_page = self.get_num_entries_per_page()
         paginator = Paginator(images, per_page=entries_per_page)
-        images = paginator.get_page(self.request.GET.get("p"))
+        try:
+            images = paginator.page(self.request.GET.get("p", 1))
+        except InvalidPage:
+            raise Http404
 
         next_url = reverse("wagtailimages:index")
         request_query_string = self.request.META.get("QUERY_STRING")

--- a/wagtail/search/tests/test_queries.py
+++ b/wagtail/search/tests/test_queries.py
@@ -176,10 +176,12 @@ class TestQueryChooserView(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_pagination(self):
-        pages = ["0", "1", "-1", "9999", "Not a page"]
-        for page in pages:
-            response = self.get({"p": page})
-            self.assertEqual(response.status_code, 200)
+        # page numbers in range should be accepted
+        response = self.get({"p": 1})
+        self.assertEqual(response.status_code, 200)
+        # page numbers out of range should return 404
+        response = self.get({"p": 9999})
+        self.assertEqual(response.status_code, 404)
 
 
 class TestSeparateFiltersFromQuery(SimpleTestCase):

--- a/wagtail/search/views/queries.py
+++ b/wagtail/search/views/queries.py
@@ -1,4 +1,5 @@
-from django.core.paginator import Paginator
+from django.core.paginator import InvalidPage, Paginator
+from django.http import Http404
 from django.template.response import TemplateResponse
 
 from wagtail.admin.forms.search import SearchForm
@@ -23,7 +24,10 @@ def chooser(request, get_results=False):
         searchform = SearchForm()
 
     paginator = Paginator(queries, per_page=10)
-    queries = paginator.get_page(request.GET.get("p"))
+    try:
+        queries = paginator.page(request.GET.get("p", 1))
+    except InvalidPage:
+        raise Http404
 
     # Render
     if get_results:

--- a/wagtail/sites/tests.py
+++ b/wagtail/sites/tests.py
@@ -20,12 +20,6 @@ class TestSiteIndexView(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/generic/index.html")
 
-    def test_pagination(self):
-        pages = ["0", "1", "-1", "9999", "Not a page"]
-        for page in pages:
-            response = self.get({"p": page})
-            self.assertEqual(response.status_code, 200)
-
 
 class TestSiteCreateView(WagtailTestUtils, TestCase):
     def setUp(self):

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -4347,14 +4347,13 @@ class TestSnippetChoose(WagtailTestUtils, TestCase):
         self.assertEqual(response.context["results"][0].text, "advert 1")
 
     def test_simple_pagination(self):
-
-        pages = ["0", "1", "-1", "9999", "Not a page"]
-        for page in pages:
-            response = self.get({"p": page})
-            self.assertEqual(response.status_code, 200)
-            self.assertTemplateUsed(
-                response, "wagtailadmin/generic/chooser/chooser.html"
-            )
+        # page numbers in range should be accepted
+        response = self.get({"p": 1})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/generic/chooser/chooser.html")
+        # page numbers out of range should return 404
+        response = self.get({"p": 9999})
+        self.assertEqual(response.status_code, 404)
 
     def test_not_searchable(self):
         # filter_form should not have a search field

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -135,12 +135,13 @@ class TestSnippetListView(WagtailTestUtils, TestCase):
         self.assertEqual(response.context["page_obj"][0].text, "advert 10")
 
     def test_simple_pagination(self):
-
-        pages = ["0", "1", "-1", "9999", "Not a page"]
-        for page in pages:
-            response = self.get({"p": page})
-            self.assertEqual(response.status_code, 200)
-            self.assertTemplateUsed(response, "wagtailsnippets/snippets/index.html")
+        # page numbers in range should be accepted
+        response = self.get({"p": 1})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailsnippets/snippets/index.html")
+        # page numbers out of range should return 404
+        response = self.get({"p": 9999})
+        self.assertEqual(response.status_code, 404)
 
     def test_displays_add_button(self):
         self.assertContains(self.get(), "Add advert")

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -136,10 +136,12 @@ class TestGroupUsersView(WagtailTestUtils, TestCase):
         self.assertIn(self.test_user, results)
 
     def test_pagination(self):
-        pages = ["0", "1", "-1", "9999", "Not a page"]
-        for page in pages:
-            response = self.get({"p": page})
-            self.assertEqual(response.status_code, 200)
+        # page numbers in range should be accepted
+        response = self.get({"p": 1})
+        self.assertEqual(response.status_code, 200)
+        # page numbers out of range should return 404
+        response = self.get({"p": 9999})
+        self.assertEqual(response.status_code, 404)
 
 
 class TestGroupUsersResultsView(WagtailTestUtils, TestCase):
@@ -226,10 +228,12 @@ class TestUserIndexView(WagtailTestUtils, TestCase):
         self.assertIn(self.test_user, results)
 
     def test_pagination(self):
-        pages = ["0", "1", "-1", "9999", "Not a page"]
-        for page in pages:
-            response = self.get({"p": page})
-            self.assertEqual(response.status_code, 200)
+        # page numbers in range should be accepted
+        response = self.get({"p": 1})
+        self.assertEqual(response.status_code, 200)
+        # page numbers out of range should return 404
+        response = self.get({"p": 9999})
+        self.assertEqual(response.status_code, 404)
 
     def test_valid_ordering(self):
         # checking that only valid ordering used, in case of `IndexView` the valid


### PR DESCRIPTION
For many years, this bit of test code has been merrily copied around the Wagtail codebase:
```
    def test_pagination(self):
        pages = ['0', '1', '-1', '9999', 'Not a page']
        for page in pages:
            response = self.get({'p': page})
            self.assertEqual(response.status_code, 200)
```

There are several things wrong with this:

* It's testing something irrelevant - we don't really care how out-of-range and invalid page numbers behave. Most likely, this test was written just to bump up test coverage and reflect the existing behaviour, not _desired_ behaviour
* It entirely fails in its goal of testing pagination - a view can not implement pagination at all and still pass this test. Indeed, one of the places this test appears is for the sites index page, which is not and never has been paginated...
* On the other hand, a view implemented via `django.views.generic.list.BaseListView` _does_ fail this test, because [the stock `paginate_queryset` method](https://ccbv.co.uk/projects/Django/4.2/django.views.generic.list/BaseListView/#paginate_queryset) rejects invalid page numbers. This has led to developers wasting effort on customising the base Django behaviour to keep the test passing: see https://github.com/laymonage/wagtail/commit/9c8436d5d4f594af7be1717be4e4f6ec9a218882 and https://github.com/wagtail/wagtail/blob/815cb6e405c0671db829279ed418c4a0ed21bbbf/wagtail/contrib/forms/views.py#L26-L27

Since we aim to port more things to generic class-based views in the long term, it makes sense to ditch these workarounds and standardise on Django's favoured behaviour of rejecting invalid page numbers, so that future developers can port things to CBVs and not get derailed by trying to keep these broken tests passing.