### PR TITLE
Fix slugify compare method to use urlify when checking if title/slug should sink on Page edit

### DIFF
--- a/client/src/controllers/SlugController.test.js
+++ b/client/src/controllers/SlugController.test.js
@@ -81,7 +81,7 @@ describe('compare behaviour', () => {
     const slugInput = document.querySelector('#id_slug');
 
     slugInput.dataset.action = [
-      'blur->w-slug#slugify',
+      'blur->w-slug#urlify',
       'custom:event->w-slug#compare',
     ].join(' ');
   });
@@ -109,6 +109,76 @@ describe('compare behaviour', () => {
     event.preventDefault = jest.fn();
 
     document.getElementById('id_slug').dispatchEvent(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('should prevent default using the slugify (default) behaviour as the compare function when urlify values is not equal', () => {
+    const slug = document.querySelector('#id_slug');
+
+    const title = 'Тестовий заголовок';
+
+    slug.setAttribute('value', title);
+
+    // apply the urlify method to the content to ensure the value before check is urlify
+    slug.dispatchEvent(new Event('blur'));
+
+    expect(slug.value).toEqual('testovij-zagolovok');
+
+    const event = new CustomEvent('custom:event', { detail: { value: title } });
+
+    event.preventDefault = jest.fn();
+
+    slug.dispatchEvent(event);
+
+    // slugify used for the compareAs value by default, so 'compare' fails
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('should not prevent default using the slugify (default) behaviour as the compare function when urlify value is equal', () => {
+    const slug = document.querySelector('#id_slug');
+
+    const title = 'the-french-dispatch-a-love-letter-to-journalists';
+
+    slug.setAttribute('value', title);
+
+    // apply the urlify method to the content to ensure the value before check is urlify
+    slug.dispatchEvent(new Event('blur'));
+
+    expect(slug.value).toEqual(
+      'the-french-dispatch-a-love-letter-to-journalists',
+    );
+
+    const event = new CustomEvent('custom:event', { detail: { value: title } });
+
+    event.preventDefault = jest.fn();
+
+    slug.dispatchEvent(event);
+
+    // slugify used for the compareAs value by default, so 'compare' passes with the initial urlify value on blur
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('should not prevent default using the urlify behaviour as the compare function when urlify value matches', () => {
+    const title = 'Тестовий заголовок';
+
+    const slug = document.querySelector('#id_slug');
+
+    slug.setAttribute('data-w-slug-compare-as-param', 'urlify');
+    slug.setAttribute('value', title);
+
+    // apply the urlify method to the content to ensure the value before check is urlify
+    slug.dispatchEvent(new Event('blur'));
+
+    expect(slug.value).toEqual('testovij-zagolovok');
+
+    const event = new CustomEvent('custom:event', {
+      detail: { compareAs: 'urlify', value: title },
+    });
+
+    event.preventDefault = jest.fn();
+
+    slug.dispatchEvent(event);
 
     expect(event.preventDefault).not.toHaveBeenCalled();
   });

--- a/client/src/controllers/SlugController.ts
+++ b/client/src/controllers/SlugController.ts
@@ -1,6 +1,8 @@
 import { Controller } from '@hotwired/stimulus';
 import { cleanForSlug } from '../utils/text';
 
+type SlugMethods = 'slugify' | 'urlify';
+
 /**
  * Adds ability to slugify the value of an input element.
  *
@@ -15,24 +17,30 @@ export class SlugController extends Controller<HTMLInputElement> {
   declare allowUnicodeValue: boolean;
 
   /**
-   * Allow for a comparison value to be provided, if does not compare to the
-   * current value (once transformed), then the event's default will
-   * be prevented.
+   * Allow for a comparison value to be provided so that a dispatched event can be
+   * prevented. This provides a way for other events to interact with this controller
+   * to block further updates if a value is not in sync.
+   * By default it will compare to the slugify method, this can be overridden by providing
+   * either a Stimulus param value on the element or the event's detail.
    */
   compare(
-    event: CustomEvent<{ value: string }> & { params?: { compareAs?: string } },
+    event: CustomEvent<{ compareAs?: SlugMethods; value: string }> & {
+      params?: { compareAs?: SlugMethods };
+    },
   ) {
     // do not attempt to compare if the current field is empty
     if (!this.element.value) {
       return true;
     }
 
-    const {
-      detail: { value = '' } = {},
-      params: { compareAs = 'slugify' } = {},
-    } = event;
+    const compareAs =
+      event.detail?.compareAs || event.params?.compareAs || 'slugify';
 
-    const compareValue = this[compareAs]({ detail: { value } }, true);
+    const compareValue = this[compareAs](
+      { detail: { value: event.detail?.value || '' } },
+      true,
+    );
+
     const currentValue = this.element.value;
 
     const valuesAreSame = compareValue.trim() === currentValue.trim();
@@ -50,7 +58,10 @@ export class SlugController extends Controller<HTMLInputElement> {
    * If a custom event with detail.value is provided, that value will be used
    * instead of the field's value.
    */
-  slugify(event: CustomEvent<{ value: string }>, ignoreUpdate = false) {
+  slugify(
+    event: CustomEvent<{ value: string }> | { detail: { value: string } },
+    ignoreUpdate = false,
+  ) {
     const unicodeSlugsEnabled = this.allowUnicodeValue;
     const { value = this.element.value } = event?.detail || {};
     const newValue = cleanForSlug(value.trim(), false, { unicodeSlugsEnabled });
@@ -68,7 +79,10 @@ export class SlugController extends Controller<HTMLInputElement> {
    * If a custom event with detail.value is provided, that value will be used
    * instead of the field's value.
    */
-  urlify(event: CustomEvent<{ value: string }>, ignoreUpdate = false) {
+  urlify(
+    event: CustomEvent<{ value: string }> | { detail: { value: string } },
+    ignoreUpdate = false,
+  ) {
     const unicodeSlugsEnabled = this.allowUnicodeValue;
     const { value = this.element.value } = event?.detail || {};
     const newValue = cleanForSlug(value.trim(), true, { unicodeSlugsEnabled });

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1579,7 +1579,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             reverse("wagtailadmin_pages:edit", args=(self.child_page.id,))
         )
 
-        input_field_for_draft_slug = '<input type="text" name="slug" value="revised-slug-in-draft-only" data-controller="w-slug" data-action="blur-&gt;w-slug#slugify w-sync:check-&gt;w-slug#compare w-sync:apply-&gt;w-slug#urlify:prevent" data-w-slug-allow-unicode-value maxlength="255" aria-describedby="panel-child-promote-child-for_search_engines-child-slug-helptext" required id="id_slug">'
+        input_field_for_draft_slug = '<input type="text" name="slug" value="revised-slug-in-draft-only" data-controller="w-slug" data-action="blur-&gt;w-slug#slugify w-sync:check-&gt;w-slug#compare w-sync:apply-&gt;w-slug#urlify:prevent" data-w-slug-compare-as-param="urlify" data-w-slug-allow-unicode-value maxlength="255" aria-describedby="panel-child-promote-child-for_search_engines-child-slug-helptext" required id="id_slug">'
         input_field_for_live_slug = '<input type="text" name="slug" value="hello-world" maxlength="255" aria-describedby="panel-child-promote-child-for_search_engines-child-slug-helptext" required id="id_slug" />'
 
         # Status Link should be the live page (not revision)

--- a/wagtail/admin/tests/test_widgets.py
+++ b/wagtail/admin/tests/test_widgets.py
@@ -660,7 +660,7 @@ class TestSlugInput(TestCase):
         html = widget.render("test", None, attrs={"id": "test-id"})
 
         self.assertInHTML(
-            '<input type="text" name="test" data-controller="w-slug" data-action="blur-&gt;w-slug#slugify w-sync:check-&gt;w-slug#compare w-sync:apply-&gt;w-slug#urlify:prevent" data-w-slug-allow-unicode-value id="test-id">',
+            '<input type="text" name="test" data-controller="w-slug" data-action="blur-&gt;w-slug#slugify w-sync:check-&gt;w-slug#compare w-sync:apply-&gt;w-slug#urlify:prevent" data-w-slug-allow-unicode-value data-w-slug-compare-as-param="urlify" id="test-id">',
             html,
         )
 

--- a/wagtail/admin/widgets/slug.py
+++ b/wagtail/admin/widgets/slug.py
@@ -10,6 +10,7 @@ class SlugInput(widgets.TextInput):
             "data-w-slug-allow-unicode-value": getattr(
                 settings, "WAGTAIL_ALLOW_UNICODE_SLUGS", True
             ),
+            "data-w-slug-compare-as-param": "urlify",
         }
         if attrs:
             default_attrs.update(attrs)


### PR DESCRIPTION
As this is a 5.0 regression, I have split this PR into two discrete commits, both could be patched onto 5.0 stable branch safely but I if we prefer the smallest change possible for patches we can do it.

For upgrade considerations - we should either add a specific note about SlugInput manual usage with data attributes needs this extra param OR maybe update the 5.0 notes accordingly. Not sure what is best.

## Commit A - small change to fix regression (also used for minimal patch to 5.0 branch)

- Intentionally small change with just one data attribute added to slug widget.
- Regression caused by migration of 'slugFollowsTitle' approach not consistently comparing to the urlify version of the util on when the user focuses on the title field, broke in #10189
- This was due to the two step adoption of the slug / title sync, the 'check' behaviour was not comparing correctly to the more complex slugify util
- Fixes #10532


## Commit B - enhance/refine testing on Slug controller

- Adding better unit test coverage for the exact scenario we want to use (making the compare check run on the non-default urlify)
- Add better TypeScript types and JSDoc to controller that make it clearer what's happening in this code
- Enhance the ability to override the slugify/urlify compare via the dispatched event, not used but will make customisations easier for this kind of thing


## Testing

- Tested in a bunch of scenarios, editing an unpublished page, creating a new page, manually modifying the slug to be back 'in sync' with the title.
- Follow steps on #10532 to reproduce the bug
