### PR TITLE
Add clearer "expanded" state indicator for side panel toggles. Fix #9174

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changelog
  * Fix: Prevent crash when comparing page revisions that include `MultipleChooserPanel` (Matt Westcott)
  * Fix: Ensure that title and slug continue syncing after entering non-URL-safe characters (LB (Ben) Johnston)
  * Fix: Ensure that title and slug are synced on keypress, not just on blur (LB (Ben) Johnston)
+ * Fix: Add a more visible active state for side panel toggle buttons (Thibaud Colas)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)
@@ -47,6 +48,7 @@ Changelog
  * Fix: Prevent crash when comparing page revisions that include `MultipleChooserPanel` (Matt Westcott)
  * Fix: Ensure that title and slug continue syncing after entering non-URL-safe characters (LB (Ben) Johnston)
  * Fix: Ensure that title and slug are synced on keypress, not just on blur (LB (Ben) Johnston)
+ * Fix: Add a more visible active state for side panel toggle buttons (Thibaud Colas)
 
 
 5.0.1 (25.05.2023)

--- a/client/src/entrypoints/admin/comments.js
+++ b/client/src/entrypoints/admin/comments.js
@@ -319,8 +319,7 @@ window.comments = (() => {
     const commentCounter = document.createElement('div');
     commentCounter.className =
       '-w-mr-3 w-py-0.5 w-px-[0.325rem] w-translate-y-[-8px] rtl:w-translate-x-[4px] w-translate-x-[-4px] w-text-[0.5625rem] w-font-bold w-bg-surface-button-default w-text-text-button w-border w-border-surface-page w-rounded-[1rem]';
-    commentToggle.className =
-      'w-h-slim-header w-bg-transparent w-box-border w-py-3 w-px-3 w-flex w-justify-center w-items-center w-outline-offset-inside w-text-text-meta w-transition hover:w-transform hover:w-scale-110 hover:w-text-text-label focus:w-text-text-label expanded:w-text-text-label';
+
     commentToggle.appendChild(commentCounter);
 
     const updateCommentCount = () => {

--- a/client/src/tokens/objectStyles.js
+++ b/client/src/tokens/objectStyles.js
@@ -10,7 +10,8 @@ const borderRadius = {
 const borderWidth = {
   DEFAULT: '0.0625rem', // 1px
   0: '0',
-  5: '0.3125rem',
+  2: '0.125rem', // 2px
+  5: '0.3125rem', // 5px
 };
 
 // If adding new values, use T-shirt sizing naming.

--- a/docs/releases/5.0.2.md
+++ b/docs/releases/5.0.2.md
@@ -17,3 +17,4 @@ depth: 1
  * Prevent crash when comparing page revisions that include `MultipleChooserPanel` (Matt Westcott)
  * Ensure that title and slug continue syncing after entering non-URL-safe characters (LB (Ben) Johnston)
  * Ensure that title and slug are synced on keypress, not just on blur (LB (Ben) Johnston)
+ * Add a more visible active state for side panel toggle buttons (Thibaud Colas)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -35,6 +35,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
  * Prevent crash when comparing page revisions that include `MultipleChooserPanel` (Matt Westcott)
  * Ensure that title and slug continue syncing after entering non-URL-safe characters (LB (Ben) Johnston)
  * Ensure that title and slug are synced on keypress, not just on blur (LB (Ben) Johnston)
+ * Add a more visible active state for side panel toggle buttons (Thibaud Colas)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
@@ -14,23 +14,21 @@
     {% page_header_buttons parent_page page_perms=page_perms %}
 {% endblock %}
 {% block actions %}
-    {% with nav_icon_classes='w-w-4 w-h-4' nav_icon_button_classes='w-h-slim-header w-bg-transparent w-box-border w-py-3 w-px-3 w-flex w-justify-center w-items-center w-outline-offset-inside w-text-text-meta w-transition hover:w-transform hover:w-scale-110 hover:w-text-text-label focus:w-text-text-label' %}
-        {% if not parent_page.is_root %}
-            {% include "wagtailadmin/shared/side_panel_toggles.html" %}
-            {# Page history #}
-            {% if parent_page.get_latest_revision %}
-                <a href="{% url 'wagtailadmin_pages:history' parent_page.id %}"
-                    class="{{ nav_icon_button_classes }}"
-                    data-tippy-content="{% trans 'History' %}"
-                    data-tippy-offset="[0, 0]"
-                    data-tippy-placement="bottom"
-                    aria-label="{% trans 'History' %}"
-                >
-                    {% icon name="history" classname=nav_icon_classes %}
-                </a>
-            {% endif %}
-
-            {% include "wagtailadmin/shared/page_status_tag_new.html" with page=parent_page %}
+    {% if not parent_page.is_root %}
+        {% include "wagtailadmin/shared/side_panel_toggles.html" %}
+        {# Page history #}
+        {% if parent_page.get_latest_revision %}
+            <a href="{% url 'wagtailadmin_pages:history' parent_page.id %}"
+                class="{{ nav_icon_button_classes }}"
+                data-tippy-content="{% trans 'History' %}"
+                data-tippy-offset="[0, 0]"
+                data-tippy-placement="bottom"
+                aria-label="{% trans 'History' %}"
+            >
+                {% icon name="history" classname=nav_icon_classes %}
+            </a>
         {% endif %}
-    {% endwith %}
+
+        {% include "wagtailadmin/shared/page_status_tag_new.html" with page=parent_page %}
+    {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/page_create_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/page_create_header.html
@@ -11,7 +11,5 @@
 {% endblock %}
 
 {% block actions %}
-    {% with nav_icon_classes='w-w-4 w-h-4' nav_icon_button_classes='w-h-slim-header w-bg-transparent w-box-border w-py-3 w-px-3 w-flex w-justify-center w-items-center w-outline-offset-inside w-text-text-meta w-transition hover:w-transform hover:w-scale-110 hover:w-text-text-label focus:w-text-text-label' %}
-        {% include "wagtailadmin/shared/side_panel_toggles.html" %}
-    {% endwith %}
+    {% include "wagtailadmin/shared/side_panel_toggles.html" %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
@@ -15,23 +15,20 @@
 {% endblock %}
 
 {% block actions %}
-    {% with nav_icon_classes='w-w-4 w-h-4' nav_icon_button_classes='w-h-slim-header w-bg-transparent w-box-border w-py-3 w-px-3 w-flex w-justify-center w-items-center w-outline-offset-inside w-text-text-meta w-transition hover:w-transform hover:w-scale-110 hover:w-text-text-label focus:w-text-text-label' %}
-        {% include "wagtailadmin/shared/side_panel_toggles.html" %}
+    {% include "wagtailadmin/shared/side_panel_toggles.html" %}
 
-        {# Page history #}
-        {% if page.get_latest_revision %}
-            <a href="{% url 'wagtailadmin_pages:history' page.id %}"
-                class="{{ nav_icon_button_classes }}"
-                data-tippy-content="{% trans 'History' %}"
-                data-tippy-offset="[0, 0]"
-                data-tippy-placement="bottom"
-                aria-label="{% trans 'History' %}"
-            >
-                {% icon name="history" classname=nav_icon_classes %}
-            </a>
-        {% endif %}
+    {# Page history #}
+    {% if page.get_latest_revision %}
+        <a href="{% url 'wagtailadmin_pages:history' page.id %}"
+            class="{{ nav_icon_button_classes }}"
+            data-tippy-content="{% trans 'History' %}"
+            data-tippy-offset="[0, 0]"
+            data-tippy-placement="bottom"
+            aria-label="{% trans 'History' %}"
+        >
+            {% icon name="history" classname=nav_icon_classes %}
+        </a>
+    {% endif %}
 
-        {% include "wagtailadmin/shared/page_status_tag_new.html" with page=page_for_status %}
-
-    {% endwith %}
+    {% include "wagtailadmin/shared/page_status_tag_new.html" with page=page_for_status %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -1,6 +1,6 @@
 {% load wagtailadmin_tags i18n %}
 {% fragment as nav_icon_classes %}w-w-4 w-h-4{% endfragment %}
-{% fragment as nav_icon_button_classes %}w-h-slim-header w-bg-transparent w-box-border w-py-3 w-px-3 w-flex w-justify-center w-items-center w-outline-offset-inside w-text-text-meta w-transition hover:w-transform hover:w-scale-110 hover:w-text-text-label focus:w-text-text-label expanded:w-text-text-label{% endfragment %}
+{% fragment as nav_icon_button_classes %}w-w-slim-header w-h-slim-header w-bg-transparent w-box-border w-py-3 w-px-3 w-flex w-justify-center w-items-center w-outline-offset-inside w-text-text-meta w-transition hover:w-transform hover:w-scale-110 hover:w-text-text-label focus:w-text-text-label expanded:w-text-text-label{% endfragment %}
 {# Z index 99 to ensure header is always above  #}
 <header class="w-slim-header w-flex w-flex-col sm:w-flex-row w-items-center w-justify-between w-bg-surface-header w-border-b w-border-border-furniture w-px-0 w-py-0 w-mb-0 w-relative w-top-0 w-z-header sm:w-sticky w-min-h-slim-header">
 

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -1,4 +1,6 @@
 {% load wagtailadmin_tags i18n %}
+{% fragment as nav_icon_classes %}w-w-4 w-h-4{% endfragment %}
+{% fragment as nav_icon_button_classes %}w-h-slim-header w-bg-transparent w-box-border w-py-3 w-px-3 w-flex w-justify-center w-items-center w-outline-offset-inside w-text-text-meta w-transition hover:w-transform hover:w-scale-110 hover:w-text-text-label focus:w-text-text-label expanded:w-text-text-label{% endfragment %}
 {# Z index 99 to ensure header is always above  #}
 <header class="w-slim-header w-flex w-flex-col sm:w-flex-row w-items-center w-justify-between w-bg-surface-header w-border-b w-border-border-furniture w-px-0 w-py-0 w-mb-0 w-relative w-top-0 w-z-header sm:w-sticky w-min-h-slim-header">
 

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -1,6 +1,6 @@
 {% load wagtailadmin_tags i18n %}
-{% fragment as nav_icon_classes %}w-w-4 w-h-4{% endfragment %}
-{% fragment as nav_icon_button_classes %}w-w-slim-header w-h-slim-header w-bg-transparent w-box-border w-py-3 w-px-3 w-flex w-justify-center w-items-center w-outline-offset-inside w-text-text-meta w-transition hover:w-transform hover:w-scale-110 hover:w-text-text-label focus:w-text-text-label expanded:w-text-text-label{% endfragment %}
+{% fragment as nav_icon_classes %}w-w-4 w-h-4 group-hover:w-transform group-hover:w-scale-110{% endfragment %}
+{% fragment as nav_icon_button_classes %}w-w-slim-header w-h-slim-header w-bg-transparent w-border-transparent w-box-border w-py-3 w-px-3 w-flex w-justify-center w-items-center w-outline-offset-inside w-text-text-meta w-transition w-group hover:w-text-text-label focus:w-text-text-label expanded:w-text-text-label expanded:w-border-y-2 expanded:w-border-b-current{% endfragment %}
 {# Z index 99 to ensure header is always above  #}
 <header class="w-slim-header w-flex w-flex-col sm:w-flex-row w-items-center w-justify-between w-bg-surface-header w-border-b w-border-border-furniture w-px-0 w-py-0 w-mb-0 w-relative w-top-0 w-z-header sm:w-sticky w-min-h-slim-header">
 

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panel_toggles.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panel_toggles.html
@@ -2,7 +2,7 @@
 
 {% for panel in side_panels %}
     <button type="button"
-        class="{{ nav_icon_button_classes }} expanded:w-text-text-label"
+        class="{{ nav_icon_button_classes }}"
         aria-label="{{ panel.toggle_aria_label }}"
         data-tippy-content="{{ panel.title }}"
         data-tippy-offset="[0,0]"

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/headers/create_header.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/headers/create_header.html
@@ -22,7 +22,5 @@
 {% endblock %}
 
 {% block actions %}
-    {% with nav_icon_classes='w-w-4 w-h-4' nav_icon_button_classes='w-h-slim-header w-bg-transparent w-box-border w-py-3 w-px-3 w-flex w-justify-center w-items-center w-outline-offset-inside w-text-text-meta w-transition hover:w-transform hover:w-scale-110 hover:w-text-text-label focus:w-text-text-label' %}
-        {% include "wagtailadmin/shared/side_panel_toggles.html" %}
-    {% endwith %}
+    {% include "wagtailadmin/shared/side_panel_toggles.html" %}
 {% endblock %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/headers/edit_header.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/headers/edit_header.html
@@ -19,18 +19,16 @@
 {% endblock %}
 
 {% block actions %}
-    {% with nav_icon_classes='w-w-4 w-h-4' nav_icon_button_classes='w-h-slim-header w-bg-transparent w-box-border w-py-3 w-px-3 w-flex w-justify-center w-items-center w-outline-offset-inside w-text-text-meta w-transition hover:w-transform hover:w-scale-110 hover:w-text-text-label focus:w-text-text-label' %}
-        {% include "wagtailadmin/shared/side_panel_toggles.html" %}
+    {% include "wagtailadmin/shared/side_panel_toggles.html" %}
 
-        {# Object history #}
-        <a href="{{ view.get_history_url }}"
-            class="{{ nav_icon_button_classes }}"
-            data-tippy-content="{% trans 'History' %}"
-            data-tippy-offset="[0, 0]"
-            data-tippy-placement="bottom"
-            aria-label="{% trans 'History' %}"
-        >
-            {% icon name="history" classname=nav_icon_classes %}
-        </a>
-    {% endwith %}
+    {# Object history #}
+    <a href="{{ view.get_history_url }}"
+        class="{{ nav_icon_button_classes }}"
+        data-tippy-content="{% trans 'History' %}"
+        data-tippy-offset="[0, 0]"
+        data-tippy-placement="bottom"
+        aria-label="{% trans 'History' %}"
+    >
+        {% icon name="history" classname=nav_icon_classes %}
+    </a>
 {% endblock %}


### PR DESCRIPTION
Fixes #9174, with a few additional changes:

- Refactors those button and icon classes so we avoid duplicating them everywhere they’re used. Django Templates allows referencing variables defined in a parent template.
- Make sure the buttons are the same width as height to match the designs (40x50 -> 50x50)
- Add the new "expanded" state indicator, making sure its toggling doesn’t disrupt the buttons’ layout.

Those make the actual bug fix harder to review (sorry!), but at least from now on we only have one definition of those class names.

Screenshots for reference, light theme and forced colors dark theme:

![9174-10546](https://github.com/wagtail/wagtail/assets/877585/2c9019b1-b363-4999-ab7e-4009f3584f48)

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 113, Firefox 113, Safari 16.3 on macOS 13.2
    -   [x] **Please list which assistive technologies [^3] you tested**: WHCM, font resizing
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

**Please describe additional details for testing this change**.

Due to the refactoring this will require a quick check on all views reusing the slim header (snippets create/edit, pages create/edit, page listings). Aside from this, check the appearance of the expanded state on any one view. 

~Note for focus/hover – I chose to _not_ have the border when expanded, as the tooltip would get in the way.~