### PR TITLE
Implement new Draftail customisation APIs. Fix #5580

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Changelog
  * Optimise queries in collection permission policies using cache on the user object (Sage Abdullah)
  * Phone numbers entered via a link chooser will now have any spaces stripped out, ensuring a valid href="tel:..." attribute (Sahil Jangra)
  * Auto-select the `StreamField` block when only one block type is declared (Sébastien Corbin)
+ * Add support for more advanced Draftail customisation APIs (Thibaud Colas)
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)

--- a/client/src/components/Draftail/__snapshots__/index.test.js.snap
+++ b/client/src/components/Draftail/__snapshots__/index.test.js.snap
@@ -15,8 +15,19 @@ Object {
   "bottomToolbar": [Function],
   "commandToolbar": [Function],
   "commands": true,
-  "controls": Array [],
-  "decorators": Array [],
+  "controls": Array [
+    Object {
+      "meta": [Function],
+      "type": "sentences",
+    },
+  ],
+  "decorators": Array [
+    Object {
+      "component": [Function],
+      "strategy": [Function],
+      "type": "punctuation",
+    },
+  ],
   "editorState": null,
   "enableHorizontalRule": Object {
     "description": "Horizontal line",
@@ -43,7 +54,12 @@ Object {
   "onFocus": null,
   "onSave": [Function],
   "placeholder": "Write something or type ‘/’ to insert a block",
-  "plugins": Array [],
+  "plugins": Array [
+    Object {
+      "handlePastedText": [Function],
+      "type": "anchorify",
+    },
+  ],
   "rawContentState": null,
   "readOnly": false,
   "showRedoControl": false,

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -90,11 +90,21 @@ const onSetToolbar = (choice, callback) => {
 /**
  * Registry for client-side code of Draftail plugins.
  */
-const PLUGINS = {};
+const PLUGINS = {
+  entityTypes: {},
+  plugins: {},
+  controls: {},
+  decorators: {},
+};
 
-const registerPlugin = (plugin) => {
-  PLUGINS[plugin.type] = plugin;
-  return PLUGINS;
+/**
+ * Client-side editor-specific equivalent to register_editor_plugin.
+ * `optionName` defaults to entityTypes for backwards-compatibility with
+ * previous function signature only allowing registering entities.
+ */
+const registerPlugin = (type, optionName = 'entityTypes') => {
+  PLUGINS[optionName][type.type] = type;
+  return PLUGINS[optionName];
 };
 
 /**
@@ -157,15 +167,28 @@ const initEditor = (selector, originalOptions, currentScript) => {
     const blockTypes = newOptions.blockTypes || [];
     const inlineStyles = newOptions.inlineStyles || [];
     let controls = newOptions.controls || [];
+    let decorators = newOptions.decorators || [];
+    let plugins = newOptions.plugins || [];
     const commands = newOptions.commands || true;
     let entityTypes = newOptions.entityTypes || [];
 
-    entityTypes = entityTypes.map(wrapWagtailIcon).map((type) => {
-      const plugin = PLUGINS[type.type];
-
+    entityTypes = entityTypes
+      .map(wrapWagtailIcon)
       // Override the properties defined in the JS plugin: Python should be the source of truth.
-      return { ...plugin, ...type };
-    });
+      .map((type) => ({ ...PLUGINS.entityTypes[type.type], ...type }));
+
+    controls = controls.map((type) => ({
+      ...PLUGINS.controls[type.type],
+      ...type,
+    }));
+    decorators = decorators.map((type) => ({
+      ...PLUGINS.decorators[type.type],
+      ...type,
+    }));
+    plugins = plugins.map((type) => ({
+      ...PLUGINS.plugins[type.type],
+      ...type,
+    }));
 
     // Only initialise the character count / max length on fields explicitly requiring it.
     if (field.hasAttribute('maxlength')) {
@@ -228,6 +251,8 @@ const initEditor = (selector, originalOptions, currentScript) => {
       inlineStyles: inlineStyles.map(wrapWagtailIcon),
       entityTypes,
       controls,
+      decorators,
+      plugins,
       commands,
       enableHorizontalRule,
     };

--- a/client/src/components/Draftail/index.test.js
+++ b/client/src/components/Draftail/index.test.js
@@ -41,14 +41,45 @@ describe('Draftail', () => {
       document.body.innerHTML = '<input id="test" value="null" />';
       const field = document.querySelector('#test');
 
-      draftail.registerPlugin({
-        type: 'IMAGE',
-        source: () => {},
-        block: () => {},
-      });
+      draftail.registerPlugin(
+        {
+          type: 'IMAGE',
+          source: () => {},
+          block: () => null,
+        },
+        'entityTypes',
+      );
+
+      draftail.registerPlugin(
+        {
+          type: 'sentences',
+          meta: () => null,
+        },
+        'controls',
+      );
+
+      draftail.registerPlugin(
+        {
+          type: 'punctuation',
+          strategy: () => {},
+          component: () => null,
+        },
+        'decorators',
+      );
+
+      draftail.registerPlugin(
+        {
+          type: 'anchorify',
+          handlePastedText: () => 'not-handled',
+        },
+        'plugins',
+      );
 
       draftail.initEditor('#test', {
         entityTypes: [{ type: 'IMAGE' }],
+        controls: [{ type: 'sentences' }],
+        decorators: [{ type: 'punctuation' }],
+        plugins: [{ type: 'anchorify' }],
         enableHorizontalRule: true,
       });
 
@@ -153,14 +184,30 @@ describe('Draftail', () => {
 
   describe('#registerPlugin', () => {
     it('works', () => {
+      const plugin = { type: 'TEST' };
+      expect(draftail.registerPlugin(plugin, 'entityTypes')).toMatchObject({
+        TEST: plugin,
+      });
+      expect(draftail.registerPlugin(plugin, 'controls')).toMatchObject({
+        TEST: plugin,
+      });
+      expect(draftail.registerPlugin(plugin, 'decorators')).toMatchObject({
+        TEST: plugin,
+      });
+      expect(draftail.registerPlugin(plugin, 'plugins')).toMatchObject({
+        TEST: plugin,
+      });
+    });
+
+    it('supports legacy entityTypes registration', () => {
       const plugin = {
-        type: 'TEST',
+        type: 'TEST_ENTITY',
         source: null,
         decorator: null,
       };
 
       expect(draftail.registerPlugin(plugin)).toMatchObject({
-        TEST: plugin,
+        TEST_ENTITY: plugin,
       });
     });
   });

--- a/client/src/entrypoints/admin/draftail.js
+++ b/client/src/entrypoints/admin/draftail.js
@@ -17,7 +17,7 @@ window.Draftail = Draftail;
 window.draftail = draftail;
 
 // Plugins for the built-in entities.
-const plugins = [
+const entityTypes = [
   {
     type: 'DOCUMENT',
     source: draftail.DocumentModalWorkflowSource,
@@ -41,4 +41,4 @@ const plugins = [
   },
 ];
 
-plugins.forEach(draftail.registerPlugin);
+entityTypes.forEach((type) => draftail.registerPlugin(type, 'entityTypes'));

--- a/client/src/entrypoints/admin/draftail.test.js
+++ b/client/src/entrypoints/admin/draftail.test.js
@@ -1,21 +1,49 @@
 require('./draftail');
 
 describe('draftail', () => {
-  it('exposes module as global', () => {
-    expect(window.draftail).toBeDefined();
+  it('exposes a stable API', () => {
+    expect(window.draftail).toMatchInlineSnapshot(`
+      Object {
+        "DocumentModalWorkflowSource": [Function],
+        "DraftUtils": Object {
+          "addHorizontalRuleRemovingSelection": [Function],
+          "addLineBreak": [Function],
+          "applyMarkdownStyle": [Function],
+          "getCommandPalettePrompt": [Function],
+          "getEntitySelection": [Function],
+          "getEntityTypeStrategy": [Function],
+          "getSelectedBlock": [Function],
+          "getSelectionEntity": [Function],
+          "handleDeleteAtomic": [Function],
+          "handleHardNewline": [Function],
+          "handleNewLine": [Function],
+          "insertNewUnstyledBlock": [Function],
+          "removeBlock": [Function],
+          "removeBlockEntity": [Function],
+          "removeCommandPalettePrompt": [Function],
+          "resetBlockWithType": [Function],
+          "updateBlockEntity": [Function],
+        },
+        "EmbedModalWorkflowSource": [Function],
+        "ImageModalWorkflowSource": [Function],
+        "LinkModalWorkflowSource": [Function],
+        "ModalWorkflowSource": [Function],
+        "Tooltip": [Function],
+        "TooltipEntity": [Function],
+        "initEditor": [Function],
+        "registerPlugin": [Function],
+        "splitState": [Function],
+      }
+    `);
   });
 
   it('exposes package as global', () => {
     expect(window.Draftail).toBeDefined();
   });
 
-  it('has defaults registered', () => {
-    expect(Object.keys(window.draftail.registerPlugin({}))).toEqual([
-      'DOCUMENT',
-      'LINK',
-      'IMAGE',
-      'EMBED',
-      'undefined',
-    ]);
+  it('has default entities registered', () => {
+    expect(
+      Object.keys(window.draftail.registerPlugin({}, 'entityTypes')),
+    ).toEqual(['DOCUMENT', 'LINK', 'IMAGE', 'EMBED', 'undefined']);
   });
 });

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -40,6 +40,7 @@ Thank you to Damilola for his work, and to Google for sponsoring this project.
  * Optimise queries in collection permission policies using cache on the user object (Sage Abdullah)
  * Phone numbers entered via a link chooser will now have any spaces stripped out, ensuring a valid `href="tel:..."` attribute (Sahil Jangra)
  * Auto-select the `StreamField` block when only one block type is declared (Sébastien Corbin)
+ * Add support for more [advanced Draftail customisation APIs](extending_the_draftail_editor_advanced) (Thibaud Colas)
 
 ### Bug fixes
 

--- a/wagtail/admin/rich_text/editors/draftail/features.py
+++ b/wagtail/admin/rich_text/editors/draftail/features.py
@@ -74,3 +74,21 @@ class InlineStyleFeature(ListFeature):
     """A feature which is listed in the inlineStyles list of the options"""
 
     option_name = "inlineStyles"
+
+
+class DecoratorFeature(ListFeature):
+    """A feature which is listed in the decorators list of the options"""
+
+    option_name = "decorators"
+
+
+class ControlFeature(ListFeature):
+    """A feature which is listed in the controls list of the options"""
+
+    option_name = "controls"
+
+
+class PluginFeature(ListFeature):
+    """A feature which is listed in the plugins list of the options"""
+
+    option_name = "plugins"


### PR DESCRIPTION
Fixes #5580 by implementing customisation APIs for Draftail `controls`, `decorators`, and `plugins`, based on the [draft shared last year](https://github.com/wagtail/wagtail/issues/5580#issuecomment-1185435563). I chose to ignore support for other customisation options I had listed in that issue – they’re not nearly as useful, and I’ve yet to see anyone requesting them.

Here is a demo of the customisations as per what I added in our documentation, along with the existing "stock" entity type:

![draftail-customisations](https://github.com/wagtail/wagtail/assets/877585/4754d94f-424e-40a4-8d5f-44eb097c1f79)

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~ There are no tests that I can see for other customisation options so I didn’t add any
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 114, Firefox 113, Safari 16.3 macOS 13.2
    -   [x] **Please list which assistive technologies [^3] you tested**: WHCM, Safari VoiceOver
-   [x] For new features: Has the documentation been updated accordingly?

For testing, this is available on a bakerydemo branch – it didn’t feel appropriate for this to be part of the vanilla bakerydemo: https://github.com/thibaudcolas/bakerydemo/tree/draftail-documented-customisations. I’d recommend reproducing the changes in that branch and checking the examples do work. Alternatively, I could also add those customisations to our test suite, but I don’t think we tend to do this for things that are only there for visual testing.
