### PR TITLE
Optimise queries in collection permission policies using cache on the user object

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ Changelog
  * Refactor `UserPagePermissionsProxy` and `PagePermissionTester` to use `PagePermissionPolicy` (Sage Abdullah, Tidiane Dia)
  * Add a predictable default ordering of the "Object/Other permissions" in the Group Editing view, allow this ordering to be customised (Daniel Kirkham)
  * Add `AbstractImage.get_renditions()` for efficient generation of multiple renditions (Andy Babic)
+ * Optimise queries in collection permission policies using cache on the user object (Sage Abdullah)
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -35,6 +35,7 @@ Thank you to Damilola for his work, and to Google for sponsoring this project.
  * Add a predictable default ordering of the "Object/Other permissions" in the Group Editing view, allow this [ordering to be customised](customising_group_views_permissions_order) (Daniel Kirkham)
  * Implement a new design for chooser buttons with better accessibility (Thibaud Colas)
  * Add [`AbstractImage.get_renditions()`](image_renditions_multiple) for efficient generation of multiple renditions (Andy Babic)
+ * Optimise queries in collection permission policies using cache on the user object (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1889,7 +1889,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         # Warm up the cache as above.
         self.client.get(reverse("wagtailadmin_pages:edit", args=(self.event_page.id,)))
 
-        with self.assertNumQueries(44):
+        with self.assertNumQueries(39):
             self.client.get(
                 reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
             )


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Follows the approach in #10470. This PR makes it so that queries that utilise `GroupCollectionPermission` objects for a particular user makes use of a cache that's stored on the user object during the request-response cycle.

While working on this, I noticed that there is a concerning issue in the collection permission policies' `foo_has_any_permission_bar()` methods: the "any" logic is flawed due to the use of `elif`s. For example, if you use e.g. `user_has_any_permission_for_instance()` with `{"change", "choose"}` as the actions, the code will only ever check for `"change"` without considering whether you have the `"choose"` permissions, which is contrary to how the method should behave. I've fixed this locally but I decide to make a separate PR, will open another one soon.

## Performance improvement ⚡ 

Anecdotal performance increase with my current setup of bakerydemo, compare these numbers to the ones in #10521.

<details><summary>Details</summary>
<p>

**Note**: priming the "cache" in this case has nothing to do with this PR, it's just how other mechanisms in Wagtail utilises caching. Please compare the numbers using the `main` branch.

### Loading the dashboard, before and after cache is primed

![image](https://github.com/wagtail/wagtail/assets/6379424/8540056d-90d3-49a1-b786-de7418e54aa7)
![image](https://github.com/wagtail/wagtail/assets/6379424/553b8c76-7bee-4c96-8863-20b0be7a036a)


### Loading the page editor as an editor, before and after cache is primed

![image](https://github.com/wagtail/wagtail/assets/6379424/501146c7-becc-427e-91eb-8aead9e0a55a)
![image](https://github.com/wagtail/wagtail/assets/6379424/9b460402-100d-4bff-b830-67a76ab413f6)


</p>
</details> 


_Please check the following:_

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?