### PR TITLE
Add Youtube Shorts url to oembed all_providers

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -718,6 +718,7 @@ Contributors
 * NikilTn
 * Thiago C. S. Tioma
 * Kevin Chung (kev-odin)
+* valnuro
 
 Translators
 ===========

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -20,6 +20,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
  * Mark calls to `md5` as not being used for secure purposes, to avoid flagging on FIPS-mode systems (Sean Kelly)
  * Return filters from `parse_query_string` as a `QueryDict` to support multiple values (Aman Pandey)
  * Explicitly specify `MenuItem.name` for all admin menu and submenu items (Justin Koestinger)
+ * Add Embed URL provider support YouTube Shorts (e.g. [https://www.youtube.com/shorts/nX84KctJtG0](https://www.youtube.com/shorts/nX84KctJtG0)) (valnuro)
 
 ### Bug fixes
 

--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -681,6 +681,7 @@ youtube = {
         r"^https?://(?:[-\w]+\.)?youtube\.com/profile.+$",
         r"^https?://(?:[-\w]+\.)?youtube\.com/view_play_list.+$",
         r"^https?://(?:[-\w]+\.)?youtube\.com/playlist.+$",
+        r"^https?://(?:[-\w]+\.)?youtube\.com/shorts/.+$",
     ],
 }
 


### PR DESCRIPTION
Youtube allows to use oembed for shorts video now, but the code can't accept Youtube shorts url.
I added the required regex to fix it.
