### PR TITLE
Deprecate `UserPagePermissionsProxy`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Explicitly specify `MenuItem.name` for all admin menu and submenu items (Justin Koestinger)
  * Add Embed URL provider support YouTube Shorts (valnuro)
  * Add initial implementation of `PagePermissionPolicy` (Sage Abdullah)
+ * Refactor `UserPagePermissionsProxy` and `PagePermissionTester` to use `PagePermissionPolicy` (Sage Abdullah)
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)
@@ -40,6 +41,7 @@ Changelog
  * Maintenance: Add tests to help with maintenance of theme color tokens (Thibaud Colas)
  * Maintenance: Split out a base listing view from generic index view (Matt Westcott)
  * Maintenance: Update type hints in admin/ui/components.py so that `parent_context` is mutable (Andreas Nüßlein)
+ * Maintenance: Deprecate `UserPagePermissionsProxy` (Sage Abdullah)
 
 
 5.0.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -779,7 +779,6 @@ The `get_url`, `is_shown`, `get_context_data` and `render_html` methods all acce
 -   `page` - for `view` = `'edit'` or `'revisions_revert'`, the page being edited
 -   `parent_page` - for `view` = `'create'`, the parent page of the page being created
 -   `request` - the current request object
--   `user_page_permissions` - a `UserPagePermissionsProxy` object for the current user, to test permissions against
 
 ```python
 from wagtail import hooks

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -779,6 +779,7 @@ The `get_url`, `is_shown`, `get_context_data` and `render_html` methods all acce
 -   `page` - for `view` = `'edit'` or `'revisions_revert'`, the page being edited
 -   `parent_page` - for `view` = `'create'`, the parent page of the page being created
 -   `request` - the current request object
+-   `user_page_permissions` - a `UserPagePermissionsProxy` object for the current user, to test permissions against
 
 ```python
 from wagtail import hooks

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -779,7 +779,11 @@ The `get_url`, `is_shown`, `get_context_data` and `render_html` methods all acce
 -   `page` - for `view` = `'edit'` or `'revisions_revert'`, the page being edited
 -   `parent_page` - for `view` = `'create'`, the parent page of the page being created
 -   `request` - the current request object
--   `user_page_permissions` - a `UserPagePermissionsProxy` object for the current user, to test permissions against
+-   `user_page_permissions` - a `UserPagePermissionsProxy` object for the current user, to test permissions against (deprecated)
+
+    ```{versionchanged} 5.0
+    The `user_page_permissions` context variable is deprecated. If you use `user_page_permissions.for_page(page)`, replace it with `page.permissions_for_user(user)` instead. To make queries based on the user's permissions, use `wagtail.permission_policies.pages.PagePermissionPolicy`.
+    ```
 
 ```python
 from wagtail import hooks

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -68,3 +68,44 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
 ### `insert_editor_css` hook is deprecated
 
 The `insert_editor_css` hook has been deprecated. The `insert_global_admin_css` hook has the same functionality, and all uses of `insert_editor_css` should be changed to `insert_global_admin_css`.
+
+### `UserPagePermissionsProxy` is deprecated
+
+The undocumented `wagtail.models.UserPagePermissionsProxy` class is deprecated.
+
+If you use the `.for_page(page)` method of the class to get a `PagePermissionTester` instance, you can replace it with `page.permissions_for_user(user)`.
+
+If you use the other methods, they can be replaced via the `wagtail.permission_policies.pages.PagePermissionPolicy` class. The following is a list of the `PagePermissionPolicy` equivalent of each method:
+
+```python
+from wagtail.models import UserPagePermissionsProxy
+from wagtail.permission_policies.pages import PagePermissionPolicy
+
+# proxy = UserPagePermissionsProxy(user)
+permission_policy = PagePermissionPolicy()
+
+# proxy.revisions_for_moderation()
+permission_policy.revisions_for_moderation(user)
+
+# proxy.explorable_pages()
+permission_policy.explorable_instances(user)
+
+# proxy.editable_pages()
+permission_policy.instances_user_has_permission_for(user, "edit")
+
+# proxy.can_edit_pages()
+permission_policy.instances_user_has_permission_for(user, "edit").exists()
+
+# proxy.publishable_pages()
+permission_policy.instances_user_has_permission_for(user, "publish")
+
+# proxy.can_publish_pages()
+permission_policy.instances_user_has_permission_for(user, "publish").exists()
+
+# proxy.can_remove_locks()
+permission_policy.user_has_any_permission(user, "unlock")
+```
+
+The `UserPagePermissionsProxy` object that was previously available in page's `ActionMenuItem` context as `user_page_permissions` has been removed. In cases where the page object is available (e.g. the page edit view), the `PagePermissionTester` object stored as the `user_page_permissions_tester` context variable is still available.
+
+If you use `UserPagePermissionsProxy` in your code, e.g. the `user_page_permissions` context variable in an `ActionMenuItem` subclass as part of your `register_page_action_menu_item` hooks, make sure to replace it either with the `PagePermissionTester` or the `PagePermissionPolicy` equivalent.

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -110,6 +110,8 @@ The `UserPagePermissionsProxy` object that was previously available in page's `A
 
 If you use `UserPagePermissionsProxy` in your code, e.g. the `user_page_permissions` context variable in an `ActionMenuItem` subclass as part of your `register_page_action_menu_item` hooks, make sure to replace it either with the `PagePermissionTester` or the `PagePermissionPolicy` equivalent.
 
-### `get_pages_with_direct_explore_permission` and `get_explorable_root_page` are deprecated
+### `get_pages_with_direct_explore_permission`, `get_explorable_root_page`, and `users_with_page_permission` are deprecated
 
 The undocumented `get_pages_with_direct_explore_permission` and `get_explorable_root_page` functions in `wagtail.admin.navigation` are deprecated. They can be replaced with `PagePermissionPolicy().instances_with_direct_explore_permission(user)` and `PagePermissionPolicy().explorable_root_instance(user)`, respectively.
+
+The undocumented `users_with_page_permission` function in `wagtail.admin.auth` is also deprecated. It can be replaced with `PagePermissionPolicy().users_with_permission_for_instance(action, page, include_superusers)`.

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -106,9 +106,11 @@ permission_policy.instances_user_has_permission_for(user, "publish").exists()
 permission_policy.user_has_permission(user, "unlock")
 ```
 
-The `UserPagePermissionsProxy` object that was previously available in page's `ActionMenuItem` context as `user_page_permissions` has been removed. In cases where the page object is available (e.g. the page edit view), the `PagePermissionTester` object stored as the `user_page_permissions_tester` context variable is still available.
+The `UserPagePermissionsProxy` object that is available in page's `ActionMenuItem` context as `user_page_permissions` (which might be used as part of a `register_page_action_menu_item` hook) has been deprecated. In cases where the page object is available (e.g. the page edit view), the `PagePermissionTester` object stored as the `user_page_permissions_tester` context variable can still be used.
 
-If you use `UserPagePermissionsProxy` in your code, e.g. the `user_page_permissions` context variable in an `ActionMenuItem` subclass as part of your `register_page_action_menu_item` hooks, make sure to replace it either with the `PagePermissionTester` or the `PagePermissionPolicy` equivalent.
+The `UserPagePermissionsProxy` object that is available in the template context as `user_page_permissions` as a side-effect of the `page_permissions` template tag has also been deprecated.
+
+If you use the `user_page_permissions` context variable or use the `UserPagePermissionsProxy` class directly, make sure to replace it either with the `PagePermissionTester` or the `PagePermissionPolicy` equivalent.
 
 ### `get_pages_with_direct_explore_permission`, `get_explorable_root_page`, and `users_with_page_permission` are deprecated
 

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -109,3 +109,7 @@ permission_policy.user_has_any_permission(user, "unlock")
 The `UserPagePermissionsProxy` object that was previously available in page's `ActionMenuItem` context as `user_page_permissions` has been removed. In cases where the page object is available (e.g. the page edit view), the `PagePermissionTester` object stored as the `user_page_permissions_tester` context variable is still available.
 
 If you use `UserPagePermissionsProxy` in your code, e.g. the `user_page_permissions` context variable in an `ActionMenuItem` subclass as part of your `register_page_action_menu_item` hooks, make sure to replace it either with the `PagePermissionTester` or the `PagePermissionPolicy` equivalent.
+
+### `get_pages_with_direct_explore_permission` and `get_explorable_root_page` are deprecated
+
+The undocumented `get_pages_with_direct_explore_permission` and `get_explorable_root_page` functions in `wagtail.admin.navigation` are deprecated. They can be replaced with `PagePermissionPolicy().instances_with_direct_explore_permission(user)` and `PagePermissionPolicy().explorable_root_instance(user)`, respectively.

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -22,6 +22,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
  * Explicitly specify `MenuItem.name` for all admin menu and submenu items (Justin Koestinger)
  * Add Embed URL provider support YouTube Shorts (e.g. [https://www.youtube.com/shorts/nX84KctJtG0](https://www.youtube.com/shorts/nX84KctJtG0)) (valnuro)
  * Add initial implementation of `PagePermissionPolicy` (Sage Abdullah)
+ * Refactor `UserPagePermissionsProxy` and `PagePermissionTester` to use `PagePermissionPolicy` (Sage Abdullah)
 
 ### Bug fixes
 
@@ -61,6 +62,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
  * Add tests to help with maintenance of theme color tokens (Thibaud Colas)
  * Split out a base listing view from generic index view (Matt Westcott)
  * Update type hints in admin/ui/components.py so that `parent_context` is mutable (Andreas Nüßlein)
+ * Deprecate `UserPagePermissionsProxy` (Sage Abdullah)
 
 
 ## Upgrade considerations

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -103,7 +103,7 @@ permission_policy.instances_user_has_permission_for(user, "publish")
 permission_policy.instances_user_has_permission_for(user, "publish").exists()
 
 # proxy.can_remove_locks()
-permission_policy.user_has_any_permission(user, "unlock")
+permission_policy.user_has_permission(user, "unlock")
 ```
 
 The `UserPagePermissionsProxy` object that was previously available in page's `ActionMenuItem` context as `user_page_permissions` has been removed. In cases where the page object is available (e.g. the page edit view), the `PagePermissionTester` object stored as the `user_page_permissions_tester` context variable is still available.

--- a/wagtail/actions/copy_page.py
+++ b/wagtail/actions/copy_page.py
@@ -73,8 +73,6 @@ class CopyPageAction:
         return self._uuid_mapping[old_uuid]
 
     def check(self, skip_permission_checks=False):
-        from wagtail.models import UserPagePermissionsProxy
-
         # Essential data model checks
         if self.page._state.adding:
             raise CopyPageIntegrityError("Page.copy() called on an unsaved page")
@@ -102,9 +100,7 @@ class CopyPageAction:
                 )
 
             if self.keep_live:
-                destination_perms = UserPagePermissionsProxy(self.user).for_page(
-                    self.to
-                )
+                destination_perms = self.to.permissions_for_user(self.user)
 
                 if not destination_perms.can_publish_subpage():
                     raise CopyPagePermissionError(

--- a/wagtail/actions/unpublish_page.py
+++ b/wagtail/actions/unpublish_page.py
@@ -57,9 +57,7 @@ class UnpublishPageAction(UnpublishAction):
         super().execute(skip_permission_checks)
 
         if self.include_descendants:
-            from wagtail.models import UserPagePermissionsProxy
 
-            user_perms = UserPagePermissionsProxy(self.user)
             for live_descendant_page in (
                 self.object.get_descendants()
                 .live()
@@ -68,5 +66,5 @@ class UnpublishPageAction(UnpublishAction):
                 .iterator()
             ):
                 action = UnpublishPageAction(live_descendant_page)
-                if user_perms.for_page(live_descendant_page).can_unpublish():
+                if live_descendant_page.permissions_for_user(self.user).can_unpublish():
                     action.execute(skip_permission_checks=True)

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -8,7 +8,6 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.admin.ui.components import Component
-from wagtail.models import UserPagePermissionsProxy
 
 
 class ActionMenuItem(Component):
@@ -41,7 +40,6 @@ class ActionMenuItem(Component):
             'view' = 'create', 'edit' or 'revisions_revert'
             'page' (if view = 'edit' or 'revisions_revert') = the page being edited
             'parent_page' (if view = 'create') = the parent page of the page being created
-            'user_page_permissions' = a UserPagePermissionsProxy for the current user, to test permissions against
             'lock' = a Lock object if the page is locked, otherwise None
             'locked_for_user' = True if the lock prevents the current user from editing the page
             may also contain:
@@ -270,8 +268,6 @@ class PageActionMenu:
         self.context = kwargs
         self.context["request"] = request
         page = self.context.get("page")
-        user_page_permissions = UserPagePermissionsProxy(self.request.user)
-        self.context["user_page_permissions"] = user_page_permissions
         if page:
             self.context["user_page_permissions_tester"] = page.permissions_for_user(
                 self.request.user

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.admin.ui.components import Component
+from wagtail.models import UserPagePermissionsProxy
 
 
 class ActionMenuItem(Component):
@@ -40,6 +41,7 @@ class ActionMenuItem(Component):
             'view' = 'create', 'edit' or 'revisions_revert'
             'page' (if view = 'edit' or 'revisions_revert') = the page being edited
             'parent_page' (if view = 'create') = the parent page of the page being created
+            'user_page_permissions' = a UserPagePermissionsProxy for the current user, to test permissions against
             'lock' = a Lock object if the page is locked, otherwise None
             'locked_for_user' = True if the lock prevents the current user from editing the page
             may also contain:
@@ -268,6 +270,8 @@ class PageActionMenu:
         self.context = kwargs
         self.context["request"] = request
         page = self.context.get("page")
+        user_page_permissions = UserPagePermissionsProxy(self.request.user)
+        self.context["user_page_permissions"] = user_page_permissions
         if page:
             self.context["user_page_permissions_tester"] = page.permissions_for_user(
                 self.request.user

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -29,7 +29,7 @@ class ActionMenuItem(Component):
     def get_user_page_permissions_tester(self, context):
         if "user_page_permissions_tester" in context:
             return context["user_page_permissions_tester"]
-        return context["user_page_permissions"].for_page(context["page"])
+        return context["page"].permissions_for_user(context["request"].user)
 
     def is_shown(self, context):
         """
@@ -79,8 +79,8 @@ class PublishMenuItem(ActionMenuItem):
     def is_shown(self, context):
         if context["view"] == "create":
             return (
-                context["user_page_permissions"]
-                .for_page(context["parent_page"])
+                context["parent_page"]
+                .permissions_for_user(context["request"].user)
                 .can_publish_subpage()
             )
         else:  # view == 'edit' or 'revisions_revert'
@@ -273,9 +273,9 @@ class PageActionMenu:
         user_page_permissions = UserPagePermissionsProxy(self.request.user)
         self.context["user_page_permissions"] = user_page_permissions
         if page:
-            self.context[
-                "user_page_permissions_tester"
-            ] = user_page_permissions.for_page(page)
+            self.context["user_page_permissions_tester"] = page.permissions_for_user(
+                self.request.user
+            )
 
         self.menu_items = []
 

--- a/wagtail/admin/api/filters.py
+++ b/wagtail/admin/api/filters.py
@@ -2,7 +2,7 @@ from rest_framework.filters import BaseFilterBackend
 
 from wagtail import hooks
 from wagtail.api.v2.utils import BadRequestError, parse_boolean
-from wagtail.models import UserPagePermissionsProxy
+from wagtail.permission_policies.pages import PagePermissionPolicy
 
 
 class HasChildrenFilter(BaseFilterBackend):
@@ -38,7 +38,8 @@ class ForExplorerFilter(BaseFilterBackend):
             for hook in hooks.get_hooks("construct_explorer_page_queryset"):
                 queryset = hook(parent_page, queryset, request)
 
-            user_perms = UserPagePermissionsProxy(request.user)
-            queryset = user_perms.explorable_pages() & queryset
+            queryset = (
+                PagePermissionPolicy().explorable_instances(request.user) & queryset
+            )
 
         return queryset

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -1,4 +1,5 @@
 import types
+import warnings
 from functools import wraps
 
 import l18n
@@ -13,9 +14,17 @@ from django.utils.translation import override
 from wagtail.admin import messages
 from wagtail.log_actions import LogContext
 from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 def users_with_page_permission(page, permission_type, include_superusers=True):
+    warnings.warn(
+        "users_with_page_permission() is deprecated. "
+        "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+        "users_with_permission_for_instance() instead.",
+        category=RemovedInWagtail60Warning,
+        stacklevel=2,
+    )
     return PagePermissionPolicy().users_with_permission_for_instance(
         permission_type, page, include_superusers
     )

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -122,23 +122,9 @@ def user_has_any_page_permission(user):
     Check if a user has any permission to add, edit, or otherwise manage any
     page.
     """
-    # Can't do nothin' if you're not active.
-    if not user.is_active:
-        return False
-
-    # Superusers can do anything.
-    if user.is_superuser:
-        return True
-
-    # At least one of the users groups has a GroupPagePermission.
-    # The user can probably do something.
-    if bool(PagePermissionPolicy().get_cached_permissions_for_user(user)):
-        return True
-
-    # Specific permissions for a page type do not mean anything.
-
-    # No luck! This user can not do anything with pages.
-    return False
+    return PagePermissionPolicy().user_has_any_permission(
+        user, {"add", "edit", "publish", "bulk_delete", "lock", "unlock"}
+    )
 
 
 def reject_request(request):

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -15,6 +15,7 @@ from django.utils.translation import override
 from wagtail.admin import messages
 from wagtail.log_actions import LogContext
 from wagtail.models import GroupPagePermission
+from wagtail.permission_policies.pages import PagePermissionPolicy
 
 
 def users_with_page_permission(page, permission_type, include_superusers=True):
@@ -137,7 +138,7 @@ def user_has_any_page_permission(user):
 
     # At least one of the users groups has a GroupPagePermission.
     # The user can probably do something.
-    if GroupPagePermission.objects.filter(group__in=user.groups.all()).exists():
+    if bool(PagePermissionPolicy().get_cached_permissions_for_user(user)):
         return True
 
     # Specific permissions for a page type do not mean anything.

--- a/wagtail/admin/forms/account.py
+++ b/wagtail/admin/forms/account.py
@@ -24,15 +24,9 @@ class NotificationPreferencesForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         permission_policy = PagePermissionPolicy()
-        publishable_pages = permission_policy.instances_user_has_permission_for(
-            self.instance.user, "publish"
-        )
-        editable_pages = permission_policy.instances_user_has_permission_for(
-            self.instance.user, "edit"
-        )
-        if not publishable_pages.exists():
+        if not permission_policy.user_has_permission(self.instance.user, "publish"):
             del self.fields["submitted_notifications"]
-        if not editable_pages.exists():
+        if not permission_policy.user_has_permission(self.instance.user, "edit"):
             del self.fields["approved_notifications"]
             del self.fields["rejected_notifications"]
             del self.fields["updated_comments_notifications"]

--- a/wagtail/admin/forms/account.py
+++ b/wagtail/admin/forms/account.py
@@ -13,7 +13,7 @@ from wagtail.admin.localization import (
     get_available_admin_time_zones,
 )
 from wagtail.admin.widgets import SwitchInput
-from wagtail.models import UserPagePermissionsProxy
+from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.users.models import UserProfile
 
 User = get_user_model()
@@ -22,10 +22,17 @@ User = get_user_model()
 class NotificationPreferencesForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        user_perms = UserPagePermissionsProxy(self.instance.user)
-        if not user_perms.can_publish_pages():
+
+        permission_policy = PagePermissionPolicy()
+        publishable_pages = permission_policy.instances_user_has_permission_for(
+            self.instance.user, "publish"
+        )
+        editable_pages = permission_policy.instances_user_has_permission_for(
+            self.instance.user, "edit"
+        )
+        if not publishable_pages.exists():
             del self.fields["submitted_notifications"]
-        if not user_perms.can_edit_pages():
+        if not editable_pages.exists():
             del self.fields["approved_notifications"]
             del self.fields["rejected_notifications"]
             del self.fields["updated_comments_notifications"]

--- a/wagtail/admin/mail.py
+++ b/wagtail/admin/mail.py
@@ -7,9 +7,9 @@ from django.core.mail.message import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.utils.translation import override
 
-from wagtail.admin.auth import users_with_page_permission
 from wagtail.coreutils import camelcase_to_underscore
 from wagtail.models import GroupApprovalTask, Page, TaskState, WorkflowState
+from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.users.models import UserProfile
 
 logger = logging.getLogger("wagtail.admin")
@@ -75,8 +75,8 @@ def send_moderation_notification(revision, notification, excluded_user=None):
         include_superusers = getattr(
             settings, "WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS", True
         )
-        recipient_users = users_with_page_permission(
-            revision.content_object, "publish", include_superusers
+        recipient_users = PagePermissionPolicy().users_with_permission_for_instance(
+            "publish", revision.content_object, include_superusers
         )
     elif notification in ["rejected", "approved"]:
         # Get submitter

--- a/wagtail/admin/navigation.py
+++ b/wagtail/admin/navigation.py
@@ -1,9 +1,19 @@
+import warnings
+
 from django.conf import settings
 
 from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 def get_pages_with_direct_explore_permission(user):
+    warnings.warn(
+        "get_pages_with_direct_explore_permission() is deprecated. "
+        "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+        "instances_with_direct_explore_permission() instead.",
+        category=RemovedInWagtail60Warning,
+        stacklevel=2,
+    )
     return PagePermissionPolicy().instances_with_direct_explore_permission(user)
 
 

--- a/wagtail/admin/navigation.py
+++ b/wagtail/admin/navigation.py
@@ -18,6 +18,13 @@ def get_pages_with_direct_explore_permission(user):
 
 
 def get_explorable_root_page(user):
+    warnings.warn(
+        "get_explorable_root_page() is deprecated. "
+        "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+        "explorable_root_instance() instead.",
+        category=RemovedInWagtail60Warning,
+        stacklevel=2,
+    )
     return PagePermissionPolicy().explorable_root_instance(user)
 
 

--- a/wagtail/admin/navigation.py
+++ b/wagtail/admin/navigation.py
@@ -1,30 +1,14 @@
 from django.conf import settings
 
-from wagtail.models import Page
+from wagtail.permission_policies.pages import PagePermissionPolicy
 
 
 def get_pages_with_direct_explore_permission(user):
-    # Get all pages that the user has direct add/edit/publish/lock permission on
-    if user.is_superuser:
-        # superuser has implicit permission on the root node
-        return Page.objects.filter(depth=1)
-    else:
-        return Page.objects.filter(
-            group_permissions__group__in=user.groups.all(),
-            group_permissions__permission_type__in=["add", "edit", "publish", "lock"],
-        )
+    return PagePermissionPolicy().instances_with_direct_explore_permission(user)
 
 
 def get_explorable_root_page(user):
-    # Get the highest common explorable ancestor for the given user. If the user
-    # has no permissions over any pages, this method will return None.
-    pages = get_pages_with_direct_explore_permission(user)
-    try:
-        root_page = pages.first_common_ancestor(include_self=True, strict=True)
-    except Page.DoesNotExist:
-        root_page = None
-
-    return root_page
+    return PagePermissionPolicy().explorable_root_instance(user)
 
 
 def get_site_for_user(user):

--- a/wagtail/admin/navigation.py
+++ b/wagtail/admin/navigation.py
@@ -12,7 +12,7 @@ def get_explorable_root_page(user):
 
 
 def get_site_for_user(user):
-    root_page = get_explorable_root_page(user)
+    root_page = PagePermissionPolicy().explorable_root_instance(user)
     if root_page:
         root_site = root_page.get_site()
     else:

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -48,13 +48,7 @@ from wagtail.coreutils import (
     get_locales_display_names,
 )
 from wagtail.coreutils import cautious_slugify as _cautious_slugify
-from wagtail.models import (
-    CollectionViewRestriction,
-    Locale,
-    Page,
-    PageViewRestriction,
-    UserPagePermissionsProxy,
-)
+from wagtail.models import CollectionViewRestriction, Locale, Page, PageViewRestriction
 from wagtail.telepath import JSContext
 from wagtail.users.utils import get_gravatar_url
 from wagtail.utils.deprecation import RemovedInWagtail60Warning
@@ -143,17 +137,6 @@ def widgettype(bound_field):
             return ""
 
 
-def _get_user_page_permissions(context):
-    # Create a UserPagePermissionsProxy object to represent the user's global permissions, and
-    # cache it in the context for the duration of the page request, if one does not exist already
-    if "user_page_permissions" not in context:
-        context["user_page_permissions"] = UserPagePermissionsProxy(
-            context["request"].user
-        )
-
-    return context["user_page_permissions"]
-
-
 @register.simple_tag(takes_context=True)
 def page_permissions(context, page):
     """
@@ -161,7 +144,7 @@ def page_permissions(context, page):
     Sets the variable 'page_perms' to a PagePermissionTester object that can be queried to find out
     what actions the current logged-in user can perform on the given page.
     """
-    return _get_user_page_permissions(context).for_page(page)
+    return page.permissions_for_user(context["request"].user)
 
 
 @register.simple_tag

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -29,7 +29,6 @@ from wagtail import hooks
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.localization import get_js_translation_strings
 from wagtail.admin.menu import admin_menu
-from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.search import admin_search_areas
 from wagtail.admin.staticfiles import versioned_static as versioned_static_func
 from wagtail.admin.ui import sidebar
@@ -49,6 +48,7 @@ from wagtail.coreutils import (
 )
 from wagtail.coreutils import cautious_slugify as _cautious_slugify
 from wagtail.models import CollectionViewRestriction, Locale, Page, PageViewRestriction
+from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.telepath import JSContext
 from wagtail.users.utils import get_gravatar_url
 from wagtail.utils.deprecation import RemovedInWagtail60Warning
@@ -76,7 +76,7 @@ def breadcrumbs(
 
     # find the closest common ancestor of the pages that this user has direct explore permission
     # (i.e. add/edit/publish/lock) over; this will be the root of the breadcrumb
-    cca = get_explorable_root_page(user)
+    cca = PagePermissionPolicy().explorable_root_instance(user)
     if not cca:
         return {"pages": Page.objects.none()}
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -47,7 +47,13 @@ from wagtail.coreutils import (
     get_locales_display_names,
 )
 from wagtail.coreutils import cautious_slugify as _cautious_slugify
-from wagtail.models import CollectionViewRestriction, Locale, Page, PageViewRestriction
+from wagtail.models import (
+    CollectionViewRestriction,
+    Locale,
+    Page,
+    PageViewRestriction,
+    UserPagePermissionsProxy,
+)
 from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.telepath import JSContext
 from wagtail.users.utils import get_gravatar_url
@@ -137,6 +143,18 @@ def widgettype(bound_field):
             return ""
 
 
+def _get_user_page_permissions(context):
+    # RemovedInWagtail60Warning: Remove this function
+
+    # Create a UserPagePermissionsProxy object to represent the user's global permissions, and
+    # cache it in the context for the duration of the page request, if one does not exist already
+    if "user_page_permissions" not in context:
+        context["user_page_permissions"] = UserPagePermissionsProxy(
+            context["request"].user
+        )
+    return context["user_page_permissions"]
+
+
 @register.simple_tag(takes_context=True)
 def page_permissions(context, page):
     """
@@ -144,6 +162,9 @@ def page_permissions(context, page):
     Sets the variable 'page_perms' to a PagePermissionTester object that can be queried to find out
     what actions the current logged-in user can perform on the given page.
     """
+    # RemovedInWagtail60Warning: Keep the UserPagePermissionsProxy object in the context
+    # for backwards compatibility during the deprecation period, even though we don't use it
+    _get_user_page_permissions(context)
     return page.permissions_for_user(context["request"].user)
 
 

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1871,12 +1871,25 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             response, reverse("wagtailadmin_pages:edit", args=(self.child_page.id,))
         )
 
-    def test_page_edit_num_queries(self):
+    def test_page_edit_num_queries_as_superuser(self):
         # Warm up cache so that result is the same when running this test in isolation
         # as when running it within the full test suite
         self.client.get(reverse("wagtailadmin_pages:edit", args=(self.event_page.id,)))
 
         with self.assertNumQueries(35):
+            self.client.get(
+                reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
+            )
+
+    def test_page_edit_num_queries_as_editor(self):
+        editor = self.create_user("editor", password="password")
+        editor.groups.add(Group.objects.get(name="Editors"))
+        self.login(username="editor")
+
+        # Warm up the cache as above.
+        self.client.get(reverse("wagtailadmin_pages:edit", args=(self.event_page.id,)))
+
+        with self.assertNumQueries(44):
             self.client.get(
                 reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
             )

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1876,7 +1876,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         # as when running it within the full test suite
         self.client.get(reverse("wagtailadmin_pages:edit", args=(self.event_page.id,)))
 
-        with self.assertNumQueries(41):
+        with self.assertNumQueries(39):
             self.client.get(
                 reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
             )

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1876,7 +1876,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         # as when running it within the full test suite
         self.client.get(reverse("wagtailadmin_pages:edit", args=(self.event_page.id,)))
 
-        with self.assertNumQueries(39):
+        with self.assertNumQueries(35):
             self.client.get(
                 reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
             )

--- a/wagtail/admin/tests/test_navigation.py
+++ b/wagtail/admin/tests/test_navigation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
@@ -50,24 +48,56 @@ class TestExplorablePages(WagtailTestUtils, TestCase):
     def test_admins_see_all_pages(self):
         User = get_user_model()
         user = User.objects.get(email="superman@example.com")
-        self.assertEqual(get_explorable_root_page(user).id, 1)
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "get_explorable_root_page() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            "explorable_root_instance() instead.",
+        ):
+            # Replace with PagePermissionPolicy().explorable_root_instance(user)
+            self.assertEqual(get_explorable_root_page(user).id, 1)
 
     def test_nav_root_for_nonadmin_is_closest_common_ancestor(self):
         User = get_user_model()
         user = User.objects.get(email="jane@example.com")
-        self.assertEqual(get_explorable_root_page(user).id, 2)
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "get_explorable_root_page() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            "explorable_root_instance() instead.",
+        ):
+            # Replace with PagePermissionPolicy().explorable_root_instance(user)
+            self.assertEqual(get_explorable_root_page(user).id, 2)
 
     def test_nonadmin_sees_leaf_page_at_root_level(self):
         User = get_user_model()
         user = User.objects.get(email="bob@example.com")
-        self.assertEqual(get_explorable_root_page(user).id, 6)
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "get_explorable_root_page() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            "explorable_root_instance() instead.",
+        ):
+            # Replace with PagePermissionPolicy().explorable_root_instance(user)
+            self.assertEqual(get_explorable_root_page(user).id, 6)
 
     def test_nonadmin_sees_pages_below_closest_common_ancestor(self):
         User = get_user_model()
         user = User.objects.get(email="josh@example.com")
         # Josh has permissions for /example-home/content/page-1 and /example-home/other-content,
         # of which the closest common ancestor is /example-home.
-        self.assertEqual(get_explorable_root_page(user).id, 4)
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "get_explorable_root_page() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            "explorable_root_instance() instead.",
+        ):
+            # Replace with PagePermissionPolicy().explorable_root_instance(user)
+            self.assertEqual(get_explorable_root_page(user).id, 4)
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
@@ -86,7 +116,15 @@ class TestExplorablePages(WagtailTestUtils, TestCase):
         # permission on)
         User = get_user_model()
         user = User.objects.get(email="sam@example.com")
-        self.assertEqual(get_explorable_root_page(user).id, 1)
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "get_explorable_root_page() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            "explorable_root_instance() instead.",
+        ):
+            # Replace with PagePermissionPolicy().explorable_root_instance(user)
+            self.assertEqual(get_explorable_root_page(user).id, 1)
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
@@ -101,4 +139,12 @@ class TestExplorablePages(WagtailTestUtils, TestCase):
     def test_nonadmin_with_no_page_perms_cannot_explore(self):
         User = get_user_model()
         user = User.objects.get(email="mary@example.com")
-        self.assertIsNone(get_explorable_root_page(user))
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "get_explorable_root_page() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            "explorable_root_instance() instead.",
+        ):
+            # Replace with PagePermissionPolicy().explorable_root_instance(user)
+            self.assertIsNone(get_explorable_root_page(user))

--- a/wagtail/admin/tests/test_navigation.py
+++ b/wagtail/admin/tests/test_navigation.py
@@ -8,6 +8,7 @@ from wagtail.admin.navigation import (
     get_pages_with_direct_explore_permission,
 )
 from wagtail.test.utils import WagtailTestUtils
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class TestExplorablePages(WagtailTestUtils, TestCase):
@@ -67,8 +68,16 @@ class TestExplorablePages(WagtailTestUtils, TestCase):
         # Josh has permissions for /example-home/content/page-1 and /example-home/other-content,
         # of which the closest common ancestor is /example-home.
         self.assertEqual(get_explorable_root_page(user).id, 4)
-        for page in get_pages_with_direct_explore_permission(user):
-            self.assertIn(page.id, [6, 8])
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "get_pages_with_direct_explore_permission() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            "instances_with_direct_explore_permission() instead.",
+        ):
+            # Replace with PagePermissionPolicy().instances_with_direct_explore_permission(user)
+            for page in get_pages_with_direct_explore_permission(user):
+                self.assertIn(page.id, [6, 8])
 
     def test_nonadmin_sees_only_explorable_pages(self):
         # Sam has permissions for /home and /example-home/content/page-1 , of which the closest
@@ -78,8 +87,16 @@ class TestExplorablePages(WagtailTestUtils, TestCase):
         User = get_user_model()
         user = User.objects.get(email="sam@example.com")
         self.assertEqual(get_explorable_root_page(user).id, 1)
-        for page in get_pages_with_direct_explore_permission(user):
-            self.assertIn(page.id, [2, 6])
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "get_pages_with_direct_explore_permission() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            "instances_with_direct_explore_permission() instead.",
+        ):
+            # Replace with PagePermissionPolicy().instances_with_direct_explore_permission(user)
+            for page in get_pages_with_direct_explore_permission(user):
+                self.assertIn(page.id, [2, 6])
 
     def test_nonadmin_with_no_page_perms_cannot_explore(self):
         User = get_user_model()

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.utils.http import urlencode
 
 from wagtail.admin.views.chooser import can_choose_page
-from wagtail.models import Locale, Page, UserPagePermissionsProxy
+from wagtail.models import Locale, Page
 from wagtail.test.testapp.models import (
     EventIndex,
     EventPage,
@@ -998,35 +998,33 @@ class TestCanChoosePage(WagtailTestUtils, TestCase):
 
     def setUp(self):
         self.user = self.login()
-        self.permission_proxy = UserPagePermissionsProxy(self.user)
         self.desired_classes = (Page,)
 
     def test_can_choose_page(self):
         homepage = Page.objects.get(url_path="/home/")
-        result = can_choose_page(homepage, self.permission_proxy, self.desired_classes)
+        result = can_choose_page(homepage, self.user, self.desired_classes)
         self.assertTrue(result)
 
     def test_with_user_no_permission(self):
         homepage = Page.objects.get(url_path="/home/")
         # event editor does not have permissions on homepage
         event_editor = get_user_model().objects.get(email="eventeditor@example.com")
-        permission_proxy = UserPagePermissionsProxy(event_editor)
         result = can_choose_page(
-            homepage, permission_proxy, self.desired_classes, user_perm="copy_to"
+            homepage, event_editor, self.desired_classes, user_perm="copy_to"
         )
         self.assertFalse(result)
 
     def test_with_can_choose_root(self):
         root = Page.objects.get(url_path="/")
         result = can_choose_page(
-            root, self.permission_proxy, self.desired_classes, can_choose_root=True
+            root, self.user, self.desired_classes, can_choose_root=True
         )
         self.assertTrue(result)
 
     def test_with_can_not_choose_root(self):
         root = Page.objects.get(url_path="/")
         result = can_choose_page(
-            root, self.permission_proxy, self.desired_classes, can_choose_root=False
+            root, self.user, self.desired_classes, can_choose_root=False
         )
         self.assertFalse(result)
 
@@ -1034,7 +1032,7 @@ class TestCanChoosePage(WagtailTestUtils, TestCase):
         homepage = Page.objects.get(url_path="/home/")
         result = can_choose_page(
             homepage,
-            self.permission_proxy,
+            self.user,
             self.desired_classes,
             user_perm="move_to",
             target_pages=[homepage],
@@ -1046,7 +1044,7 @@ class TestCanChoosePage(WagtailTestUtils, TestCase):
         root = Page.objects.get(url_path="/")
         result = can_choose_page(
             root,
-            self.permission_proxy,
+            self.user,
             self.desired_classes,
             user_perm="move_to",
             target_pages=[homepage],
@@ -1060,7 +1058,7 @@ class TestCanChoosePage(WagtailTestUtils, TestCase):
         homepage = Page.objects.get(url_path="/home/")
         result = can_choose_page(
             homepage,
-            self.permission_proxy,
+            self.user,
             self.desired_classes,
             user_perm="move_to",
             target_pages=[board_meetings],
@@ -1072,7 +1070,7 @@ class TestCanChoosePage(WagtailTestUtils, TestCase):
         secret_plans = Page.objects.get(url_path="/home/secret-plans/")
         result = can_choose_page(
             homepage,
-            self.permission_proxy,
+            self.user,
             self.desired_classes,
             user_perm="bulk_move_to",
             target_pages=[homepage, secret_plans],
@@ -1085,7 +1083,7 @@ class TestCanChoosePage(WagtailTestUtils, TestCase):
         root = Page.objects.get(url_path="/")
         result = can_choose_page(
             root,
-            self.permission_proxy,
+            self.user,
             self.desired_classes,
             user_perm="bulk_move_to",
             target_pages=[homepage, secret_plans],
@@ -1102,7 +1100,7 @@ class TestCanChoosePage(WagtailTestUtils, TestCase):
         homepage = Page.objects.get(url_path="/home/")
         result = can_choose_page(
             homepage,
-            self.permission_proxy,
+            self.user,
             self.desired_classes,
             user_perm="bulk_move_to",
             target_pages=[board_meetings, steal_underpants],

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -6,13 +6,7 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy, ngettext
 
 from wagtail.admin.ui.components import Component
-from wagtail.models import (
-    DraftStateMixin,
-    LockableMixin,
-    Page,
-    ReferenceIndex,
-    UserPagePermissionsProxy,
-)
+from wagtail.models import DraftStateMixin, LockableMixin, Page, ReferenceIndex
 
 
 class BaseSidePanel(Component):
@@ -209,7 +203,6 @@ class PageStatusSidePanel(BaseStatusSidePanel):
 
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)
-        user_perms = UserPagePermissionsProxy(self.request.user)
         page = self.object
 
         if page.id:
@@ -255,7 +248,9 @@ class PageStatusSidePanel(BaseStatusSidePanel):
                         for translation in page.get_translations()
                         .only("id", "locale", "depth")
                         .select_related("locale")
-                        if user_perms.for_page(translation).can_edit()
+                        if translation.permissions_for_user(
+                            self.request.user
+                        ).can_edit()
                     ],
                     # The sum of translated pages plus 1 to account for the current page
                     "translations_total": page.get_translations().count() + 1,

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -29,7 +29,6 @@ from wagtail.admin.localization import (
     get_available_admin_time_zones,
 )
 from wagtail.log_actions import log
-from wagtail.models import UserPagePermissionsProxy
 from wagtail.users.models import UserProfile
 from wagtail.utils.loading import get_custom_form
 
@@ -162,13 +161,8 @@ class NotificationsSettingsPanel(BaseSettingsPanel):
     form_object = "profile"
 
     def is_active(self):
-        # Hide the panel if the user can't edit or publish pages
-        user_perms = UserPagePermissionsProxy(self.request.user)
-        if not user_perms.can_edit_pages() and not user_perms.can_publish_pages():
-            return False
-
         # Hide the panel if there are no notification preferences
-        return self.get_form().fields
+        return bool(self.get_form().fields)
 
 
 class LocaleSettingsPanel(BaseSettingsPanel):

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -23,7 +23,6 @@ from wagtail.models import (
     Page,
     Revision,
     TaskState,
-    UserPagePermissionsProxy,
     WorkflowState,
     get_default_page_content_type,
 )
@@ -101,9 +100,9 @@ class PagesForModerationPanel(Component):
     def get_context_data(self, parent_context):
         request = parent_context["request"]
         context = super().get_context_data(parent_context)
-        user_perms = UserPagePermissionsProxy(request.user)
         context["page_revisions_for_moderation"] = (
-            user_perms.revisions_for_moderation()
+            PagePermissionPolicy()
+            .revisions_for_moderation(request.user)
             .select_related("user")
             .order_by("-created_at")
         )

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -224,7 +224,7 @@ class LockedPagesPanel(Component):
                     locked=True,
                     locked_by=request.user,
                 ),
-                "can_remove_locks": PagePermissionPolicy().user_has_any_permission(
+                "can_remove_locks": PagePermissionPolicy().user_has_permission(
                     request.user, "unlock"
                 ),
                 "request": request,

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -27,6 +27,7 @@ from wagtail.models import (
     WorkflowState,
     get_default_page_content_type,
 )
+from wagtail.permission_policies.pages import PagePermissionPolicy
 
 User = get_user_model()
 
@@ -224,9 +225,9 @@ class LockedPagesPanel(Component):
                     locked=True,
                     locked_by=request.user,
                 ),
-                "can_remove_locks": UserPagePermissionsProxy(
-                    request.user
-                ).can_remove_locks(),
+                "can_remove_locks": PagePermissionPolicy().user_has_any_permission(
+                    request.user, "unlock"
+                ),
                 "request": request,
                 "csrf_token": parent_context["csrf_token"],
             }

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -16,7 +16,7 @@ from wagtail.admin.action_menu import PageActionMenu
 from wagtail.admin.ui.side_panels import PageSidePanels
 from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.admin.views.generic import HookResponseMixin
-from wagtail.models import Locale, Page, PageSubscription, UserPagePermissionsProxy
+from wagtail.models import Locale, Page, PageSubscription
 
 
 def add_subpage(request, parent_page_id):
@@ -381,7 +381,6 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
                 ]
 
             else:
-                user_perms = UserPagePermissionsProxy(self.request.user)
                 translations = [
                     {
                         "locale": translation.locale,
@@ -397,7 +396,9 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
                     for translation in self.parent_page.get_translations()
                     .only("id", "locale")
                     .select_related("locale")
-                    if user_perms.for_page(translation).can_add_subpage()
+                    if translation.permissions_for_user(
+                        self.request.user
+                    ).can_add_subpage()
                     and self.page_class
                     in translation.specific_class.creatable_subpage_models()
                     and self.page_class.can_create_at(translation)

--- a/wagtail/admin/views/pages/history.py
+++ b/wagtail/admin/views/pages/history.py
@@ -10,7 +10,7 @@ from wagtail.admin.filters import DateRangePickerWidget, WagtailFilterSet
 from wagtail.admin.views.generic import history
 from wagtail.admin.views.reports import ReportView
 from wagtail.log_actions import registry as log_action_registry
-from wagtail.models import Page, PageLogEntry, UserPagePermissionsProxy
+from wagtail.models import Page, PageLogEntry
 
 
 class PageHistoryReportFilterSet(WagtailFilterSet):
@@ -47,8 +47,7 @@ class PageWorkflowHistoryViewMixin:
     pk_url_kwarg = "page_id"
 
     def dispatch(self, request, *args, **kwargs):
-        user_perms = UserPagePermissionsProxy(request.user)
-        if not user_perms.for_page(self.object).can_edit():
+        if not self.object.permissions_for_user(request.user).can_edit():
             raise PermissionDenied
         return super().dispatch(request, *args, **kwargs)
 

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -10,7 +10,7 @@ from wagtail import hooks
 from wagtail.admin.auth import user_has_any_page_permission, user_passes_test
 from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.ui.side_panels import PageSidePanels
-from wagtail.models import Page, UserPagePermissionsProxy
+from wagtail.permission_policies.pages import Page, PagePermissionPolicy
 
 
 @user_passes_test(user_has_any_page_permission)
@@ -30,11 +30,9 @@ def index(request, parent_page_id=None):
 
     parent_page = parent_page.specific
 
-    user_perms = UserPagePermissionsProxy(request.user)
-    pages = (
-        parent_page.get_children().prefetch_related("content_type", "sites_rooted_here")
-        & user_perms.explorable_pages()
-    )
+    pages = parent_page.get_children().prefetch_related(
+        "content_type", "sites_rooted_here"
+    ) & PagePermissionPolicy().explorable_instances(request.user)
 
     # Get page ordering
     ordering = request.GET.get("ordering", "-latest_revision_created_at")

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -8,7 +8,6 @@ from django.urls import reverse
 
 from wagtail import hooks
 from wagtail.admin.auth import user_has_any_page_permission, user_passes_test
-from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.ui.side_panels import PageSidePanels
 from wagtail.permission_policies.pages import Page, PagePermissionPolicy
 
@@ -20,8 +19,10 @@ def index(request, parent_page_id=None):
     else:
         parent_page = Page.get_first_root_node()
 
+    permission_policy = PagePermissionPolicy()
+
     # This will always succeed because of the @user_passes_test above.
-    root_page = get_explorable_root_page(request.user)
+    root_page = permission_policy.explorable_root_instance(request.user)
 
     # If this page isn't a descendant of the user's explorable root page,
     # then redirect to that explorable root page instead.
@@ -32,7 +33,7 @@ def index(request, parent_page_id=None):
 
     pages = parent_page.get_children().prefetch_related(
         "content_type", "sites_rooted_here"
-    ) & PagePermissionPolicy().explorable_instances(request.user)
+    ) & permission_policy.explorable_instances(request.user)
 
     # Get page ordering
     ordering = request.GET.get("ordering", "-latest_revision_created_at")

--- a/wagtail/admin/views/pages/revisions.py
+++ b/wagtail/admin/views/pages/revisions.py
@@ -17,7 +17,7 @@ from wagtail.admin.views.generic.models import (
     RevisionsUnscheduleView,
 )
 from wagtail.admin.views.generic.preview import PreviewRevision
-from wagtail.models import Page, UserPagePermissionsProxy
+from wagtail.models import Page
 
 
 def revisions_index(request, page_id):
@@ -152,8 +152,7 @@ class RevisionsUnschedule(RevisionsUnscheduleView):
     def get_object(self, queryset=None):
         page = get_object_or_404(Page, id=self.pk).specific
 
-        user_perms = UserPagePermissionsProxy(self.request.user)
-        if not user_perms.for_page(page).can_unschedule():
+        if not page.permissions_for_user(self.request.user).can_unschedule():
             raise PermissionDenied
         return page
 

--- a/wagtail/admin/views/pages/unpublish.py
+++ b/wagtail/admin/views/pages/unpublish.py
@@ -8,7 +8,7 @@ from wagtail import hooks
 from wagtail.actions.unpublish_page import UnpublishPageAction
 from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.admin.views.generic.models import UnpublishView
-from wagtail.models import Page, UserPagePermissionsProxy
+from wagtail.models import Page
 
 
 class Unpublish(UnpublishView):
@@ -32,8 +32,7 @@ class Unpublish(UnpublishView):
         return self.object.get_admin_display_title()
 
     def dispatch(self, request, *args, **kwargs):
-        user_perms = UserPagePermissionsProxy(request.user)
-        if not user_perms.for_page(self.object).can_unpublish():
+        if not self.object.permissions_for_user(request.user).can_unpublish():
             raise PermissionDenied
         return super().dispatch(request, *args, **kwargs)
 

--- a/wagtail/admin/views/pages/usage.py
+++ b/wagtail/admin/views/pages/usage.py
@@ -5,7 +5,7 @@ from django.http import Http404
 from django.template.response import TemplateResponse
 
 from wagtail.admin.views import generic
-from wagtail.models import Page, UserPagePermissionsProxy
+from wagtail.models import Page
 
 
 def content_type_use(request, content_type_app_name, content_type_model_name):
@@ -45,7 +45,6 @@ class UsageView(generic.UsageView):
     header_icon = "doc-empty-inverse"
 
     def dispatch(self, request, *args, **kwargs):
-        user_perms = UserPagePermissionsProxy(request.user)
-        if not user_perms.for_page(self.object).can_edit():
+        if not self.object.permissions_for_user(request.user).can_edit():
             raise PermissionDenied
         return super().dispatch(request, *args, **kwargs)

--- a/wagtail/admin/views/reports/aging_pages.py
+++ b/wagtail/admin/views/reports/aging_pages.py
@@ -8,7 +8,8 @@ from django.utils.translation import gettext_lazy as _
 from wagtail.admin.filters import ContentTypeFilter, WagtailFilterSet
 from wagtail.admin.widgets import AdminDateInput
 from wagtail.coreutils import get_content_type_label
-from wagtail.models import Page, PageLogEntry, UserPagePermissionsProxy, get_page_models
+from wagtail.models import Page, PageLogEntry, get_page_models
+from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.users.utils import get_deleted_user_display_name
 
 from .base import PageReportView
@@ -98,8 +99,8 @@ class AgingPagesView(PageReportView):
             page=OuterRef("pk"), action__exact="wagtail.publish"
         )
         self.queryset = (
-            UserPagePermissionsProxy(self.request.user)
-            .publishable_pages()
+            PagePermissionPolicy()
+            .instances_user_has_permission_for(self.request.user, "publish")
             .exclude(last_published_at__isnull=True)
             .prefetch_workflow_states()
             .select_related("content_type")

--- a/wagtail/admin/views/reports/locked_pages.py
+++ b/wagtail/admin/views/reports/locked_pages.py
@@ -63,6 +63,6 @@ class LockedPagesView(PageReportView):
         return super().get_queryset()
 
     def dispatch(self, request, *args, **kwargs):
-        if not PagePermissionPolicy().user_has_any_permission(request.user, "unlock"):
+        if not PagePermissionPolicy().user_has_permission(request.user, "unlock"):
             raise PermissionDenied
         return super().dispatch(request, *args, **kwargs)

--- a/wagtail/admin/views/reports/workflows.py
+++ b/wagtail/admin/views/reports/workflows.py
@@ -18,11 +18,11 @@ from wagtail.coreutils import get_content_type_label
 from wagtail.models import (
     Task,
     TaskState,
-    UserPagePermissionsProxy,
     Workflow,
     WorkflowState,
     get_default_page_content_type,
 )
+from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.snippets.models import get_editable_models
 
 from .base import ReportView
@@ -36,7 +36,9 @@ def get_requested_by_queryset(request):
 
 
 def get_editable_page_ids_query(request):
-    pages = UserPagePermissionsProxy(request.user).editable_pages()
+    pages = PagePermissionPolicy().instances_user_has_permission_for(
+        request.user, "edit"
+    )
     # Need to cast the page ids to string because Postgres doesn't support
     # implicit type casts when querying on GenericRelations
     # https://code.djangoproject.com/ticket/16055

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -32,11 +32,11 @@ from wagtail.models import (
     Page,
     Task,
     TaskState,
-    UserPagePermissionsProxy,
     Workflow,
     WorkflowContentType,
     WorkflowState,
 )
+from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.permissions import task_permission_policy, workflow_permission_policy
 from wagtail.snippets.models import get_workflow_enabled_models
 from wagtail.workflows import get_task_types
@@ -307,9 +307,10 @@ class Disable(DeleteView):
 def usage(request, pk):
     workflow = get_object_or_404(Workflow, id=pk)
 
-    perms = UserPagePermissionsProxy(request.user)
-
-    pages = workflow.all_pages() & perms.editable_pages()
+    editable_pages = PagePermissionPolicy().instances_user_has_permission_for(
+        request.user, "edit"
+    )
+    pages = workflow.all_pages() & editable_pages
     paginator = Paginator(pages, per_page=10)
     pages = paginator.get_page(request.GET.get("p"))
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -908,7 +908,7 @@ def register_core_features(features):
 
 class LockedPagesMenuItem(MenuItem):
     def is_shown(self, request):
-        return PagePermissionPolicy().user_has_any_permission(request.user, "unlock")
+        return PagePermissionPolicy().user_has_permission(request.user, "unlock")
 
 
 class WorkflowReportMenuItem(MenuItem):

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -1168,10 +1168,10 @@ def add_pages_summary_item(request, items):
 
 class PageAdminURLFinder:
     def __init__(self, user):
-        self.page_perms = user and UserPagePermissionsProxy(user)
+        self.user = user
 
     def get_edit_url(self, instance):
-        if self.page_perms and not self.page_perms.for_page(instance).can_edit():
+        if self.user and not instance.permissions_for_user(self.user).can_edit():
             return None
         else:
             return reverse("wagtailadmin_pages:edit", args=(instance.pk,))

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -918,7 +918,7 @@ class WorkflowReportMenuItem(MenuItem):
 
 class SiteHistoryReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return UserPagePermissionsProxy(request.user).explorable_pages().exists()
+        return get_explorable_root_page(request.user) is not None
 
 
 class AgingPagesReportMenuItem(MenuItem):

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -53,7 +53,8 @@ from wagtail.admin.views.pages.bulk_actions import (
 )
 from wagtail.admin.viewsets import viewsets
 from wagtail.admin.widgets import Button, ButtonWithDropdownFromHook, PageListingButton
-from wagtail.models import Collection, Page, Task, UserPagePermissionsProxy, Workflow
+from wagtail.models import Collection, Page, Task, Workflow
+from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.permissions import (
     collection_permission_policy,
     task_permission_policy,
@@ -908,7 +909,7 @@ def register_core_features(features):
 
 class LockedPagesMenuItem(MenuItem):
     def is_shown(self, request):
-        return UserPagePermissionsProxy(request.user).can_remove_locks()
+        return PagePermissionPolicy().user_has_any_permission(request.user, "unlock")
 
 
 class WorkflowReportMenuItem(MenuItem):

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -23,7 +23,6 @@ from wagtail.admin.menu import (
     reports_menu,
     settings_menu,
 )
-from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.rich_text.converters.contentstate import link_entity
 from wagtail.admin.rich_text.converters.editor_html import (
     LinkTypeRule,
@@ -73,7 +72,7 @@ class ExplorerMenuItem(MenuItem):
 
     def get_context(self, request):
         context = super().get_context(request)
-        start_page = get_explorable_root_page(request.user)
+        start_page = PagePermissionPolicy().explorable_root_instance(request.user)
 
         if start_page:
             context["start_page_id"] = start_page.id
@@ -81,7 +80,7 @@ class ExplorerMenuItem(MenuItem):
         return context
 
     def render_component(self, request):
-        start_page = get_explorable_root_page(request.user)
+        start_page = PagePermissionPolicy().explorable_root_instance(request.user)
 
         if start_page:
             return PageExplorerMenuItemComponent(
@@ -919,7 +918,7 @@ class WorkflowReportMenuItem(MenuItem):
 
 class SiteHistoryReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return get_explorable_root_page(request.user) is not None
+        return PagePermissionPolicy().explorable_root_instance(request.user) is not None
 
 
 class AgingPagesReportMenuItem(MenuItem):

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -2,7 +2,8 @@ from django.contrib.contenttypes.models import ContentType
 
 from wagtail import hooks
 from wagtail.coreutils import safe_snake_case
-from wagtail.models import UserPagePermissionsProxy, get_page_models
+from wagtail.models import get_page_models
+from wagtail.permission_policies.pages import PagePermissionPolicy
 
 _FORM_CONTENT_TYPES = None
 
@@ -34,7 +35,9 @@ def get_forms_for_user(user):
     """
     Return a queryset of form pages that this user is allowed to access the submissions for
     """
-    editable_forms = UserPagePermissionsProxy(user).editable_pages()
+    editable_forms = PagePermissionPolicy().instances_user_has_permission_for(
+        user, "edit"
+    )
     editable_forms = editable_forms.filter(content_type__in=get_form_types())
 
     # Apply hooks

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -316,7 +316,7 @@ class TestImageIndexView(WagtailTestUtils, TestCase):
         self.get()
 
         # Initial number of queries.
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(12):
             self.get()
 
         # Add 5 images.
@@ -326,11 +326,11 @@ class TestImageIndexView(WagtailTestUtils, TestCase):
                 file=get_test_image_file(size=(1, 1)),
             )
 
-        with self.assertNumQueries(34):
+        with self.assertNumQueries(32):
             # The renditions needed don't exist yet. We have 20 = 5 * 4 additional queries.
             self.get()
 
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(12):
             # No extra additional queries since renditions exist and are saved in
             # the prefetched objects cache.
             self.get()

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -316,7 +316,7 @@ class TestImageIndexView(WagtailTestUtils, TestCase):
         self.get()
 
         # Initial number of queries.
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(14):
             self.get()
 
         # Add 5 images.
@@ -326,11 +326,11 @@ class TestImageIndexView(WagtailTestUtils, TestCase):
                 file=get_test_image_file(size=(1, 1)),
             )
 
-        with self.assertNumQueries(35):
-            # The renditions needed don't exist yet. We have 20 = 5 * 4 + 2 additional queries.
+        with self.assertNumQueries(34):
+            # The renditions needed don't exist yet. We have 20 = 5 * 4 additional queries.
             self.get()
 
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(14):
             # No extra additional queries since renditions exist and are saved in
             # the prefetched objects cache.
             self.get()

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2931,55 +2931,105 @@ class UserPagePermissionsProxy:
     def __init__(self, user):
         from wagtail.permission_policies.pages import PagePermissionPolicy
 
-        warnings.warn(
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
-            category=RemovedInWagtail60Warning,
-            stacklevel=2,
-        )
-
         self.user = user
         self.permission_policy = PagePermissionPolicy()
-        self.permissions = self.permission_policy.get_cached_permissions_for_user(user)
+
+    @cached_property
+    def permissions(self):
+        return self.permission_policy.get_cached_permissions_for_user(self.user)
 
     def revisions_for_moderation(self):
         """Return a queryset of page revisions awaiting moderation that this user has publish permission on"""
+        warnings.warn(
+            "UserPagePermissionsProxy.revisions_for_moderation() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy.revisions_for_moderation(user) instead.",
+            category=RemovedInWagtail60Warning,
+            stacklevel=2,
+        )
         return self.permission_policy.revisions_for_moderation(self.user)
 
     def for_page(self, page):
         """Return a PagePermissionTester object that can be used to query whether this user has
         permission to perform specific tasks on the given page"""
-        return PagePermissionTester(self.user, page)
+        warnings.warn(
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
+            category=RemovedInWagtail60Warning,
+            stacklevel=2,
+        )
+        return page.permissions_for_user(self.user)
 
     def explorable_pages(self):
         """Return a queryset of pages that the user has access to view in the
         explorer (e.g. add/edit/publish permission). Includes all pages with
         specific group permissions and also the ancestors of those pages (in
         order to enable navigation in the explorer)"""
+        warnings.warn(
+            "UserPagePermissionsProxy.explorable_pages() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            "explorable_instances(user) instead.",
+            category=RemovedInWagtail60Warning,
+            stacklevel=2,
+        )
         return self.permission_policy.explorable_instances(self.user)
 
     def editable_pages(self):
         """Return a queryset of the pages that this user has permission to edit"""
+        warnings.warn(
+            "UserPagePermissionsProxy.editable_pages() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            'instances_user_has_permission_for(user, "edit") instead.',
+            category=RemovedInWagtail60Warning,
+            stacklevel=2,
+        )
         return self.permission_policy.instances_user_has_permission_for(
             self.user, "edit"
         )
 
     def can_edit_pages(self):
         """Return True if the user has permission to edit any pages"""
+        warnings.warn(
+            "UserPagePermissionsProxy.can_edit_pages() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            'user_has_permission(user, "edit") instead.',
+            category=RemovedInWagtail60Warning,
+            stacklevel=2,
+        )
         return self.editable_pages().exists()
 
     def publishable_pages(self):
         """Return a queryset of the pages that this user has permission to publish"""
+        warnings.warn(
+            "UserPagePermissionsProxy.publishable_pages() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            'instances_user_has_permission_for(user, "publish") instead.',
+            category=RemovedInWagtail60Warning,
+            stacklevel=2,
+        )
         return self.permission_policy.instances_user_has_permission_for(
             self.user, "publish"
         )
 
     def can_publish_pages(self):
         """Return True if the user has permission to publish any pages"""
+        warnings.warn(
+            "UserPagePermissionsProxy.can_publish_pages() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            'user_has_permission(user, "publish") instead.',
+            category=RemovedInWagtail60Warning,
+            stacklevel=2,
+        )
         return self.publishable_pages().exists()
 
     def can_remove_locks(self):
         """Returns True if the user has permission to unlock pages they have not locked"""
+        warnings.warn(
+            "UserPagePermissionsProxy.can_remove_locks() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            'user_has_permission(user, "unlock") instead.',
+            category=RemovedInWagtail60Warning,
+            stacklevel=2,
+        )
         return self.permission_policy.user_has_permission(self.user, "unlock")
 
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2931,6 +2931,13 @@ class UserPagePermissionsProxy:
     def __init__(self, user):
         from wagtail.permission_policies.pages import PagePermissionPolicy
 
+        warnings.warn(
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            category=RemovedInWagtail60Warning,
+            stacklevel=2,
+        )
+
         self.user = user
         self.permission_policy = PagePermissionPolicy()
         self.permissions = self.permission_policy.get_cached_permissions_for_user(user)

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2980,7 +2980,7 @@ class UserPagePermissionsProxy:
 
     def can_remove_locks(self):
         """Returns True if the user has permission to unlock pages they have not locked"""
-        return self.permission_policy.user_has_any_permission(self.user, "unlock")
+        return self.permission_policy.user_has_permission(self.user, "unlock")
 
 
 class PagePermissionTester:

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -3214,7 +3214,7 @@ class PagePermissionTester:
             return False
 
         # Inspect permissions on the destination
-        destination_perms = PagePermissionTester(self.user, destination)
+        destination_perms = destination.permissions_for_user(self.user)
 
         # we always need at least add permission in the target
         if "add" not in destination_perms.permissions:
@@ -3248,7 +3248,7 @@ class PagePermissionTester:
             return True
 
         # Inspect permissions on the destination
-        destination_perms = PagePermissionTester(self.user, destination)
+        destination_perms = destination.permissions_for_user(self.user)
 
         if not destination.specific_class.creatable_subpage_models():
             return False
@@ -4438,9 +4438,11 @@ class PageLogEntryManager(BaseLogEntryManager):
         return super().log_action(instance, action, **kwargs)
 
     def viewable_by_user(self, user):
+        from wagtail.permission_policies.pages import PagePermissionPolicy
+
         q = Q(
-            page__in=UserPagePermissionsProxy(user)
-            .explorable_pages()
+            page__in=PagePermissionPolicy()
+            .explorable_instances(user)
             .values_list("pk", flat=True)
         )
 

--- a/wagtail/permission_policies/pages.py
+++ b/wagtail/permission_policies/pages.py
@@ -165,7 +165,7 @@ class PagePermissionPolicy(BasePermissionPolicy):
             ]
 
     def explorable_root_instance(self, user):
-        # This method is used all around the admin via get_explorable_root_page,
+        # This method is used all around the admin,
         # so cache the result on the user for the duration of the request
         if hasattr(user, self._explorable_root_instance_cache_name):
             return getattr(user, self._explorable_root_instance_cache_name)

--- a/wagtail/permission_policies/pages.py
+++ b/wagtail/permission_policies/pages.py
@@ -1,7 +1,8 @@
 from django.contrib.auth import get_user_model
-from django.db.models import Q
+from django.db.models import CharField, Q
+from django.db.models.functions import Cast
 
-from wagtail.models import GroupPagePermission, Page
+from wagtail.models import GroupPagePermission, Page, Revision
 from wagtail.permission_policies.base import BasePermissionPolicy
 
 
@@ -202,3 +203,31 @@ class PagePermissionPolicy(BasePermissionPolicy):
         fca_page = Page.objects.first_common_ancestor_of(page_permissions)
         explorable_pages = explorable_pages.filter(path__startswith=fca_page.path)
         return explorable_pages
+
+    def revisions_for_moderation(self, user):
+        # Deal with the trivial cases first...
+        if not user.is_active:
+            return Revision.objects.none()
+        if user.is_superuser:
+            return Revision.page_revisions.submitted()
+
+        # get the list of pages for which they have direct publish permission
+        # (i.e. they can publish any page within this subtree)
+        publishable_pages_paths = list(
+            {perm.page.path for perm in self.get_cached_permissions_for_user(user)}
+        )
+        if not publishable_pages_paths:
+            return Revision.objects.none()
+
+        # compile a filter expression to apply to the Revision.page_revisions.submitted() queryset:
+        # return only those pages whose paths start with one of the publishable_pages paths
+        only_my_sections = Q(path__startswith=publishable_pages_paths[0])
+        for page_path in publishable_pages_paths[1:]:
+            only_my_sections = only_my_sections | Q(path__startswith=page_path)
+
+        # return the filtered queryset
+        return Revision.page_revisions.submitted().filter(
+            object_id__in=Page.objects.filter(only_my_sections).values_list(
+                Cast("pk", output_field=CharField()), flat=True
+            )
+        )

--- a/wagtail/tests/test_page_permissions.py
+++ b/wagtail/tests/test_page_permissions.py
@@ -20,6 +20,7 @@ from wagtail.test.testapp.models import (
     EventPage,
     SingletonPageViaMaxCount,
 )
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class TestPagePermission(TestCase):
@@ -418,7 +419,14 @@ class TestPagePermission(TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        user_perms = UserPagePermissionsProxy(event_editor)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with PagePermissionPolicy().instances_user_has_permission_for()
+            user_perms = UserPagePermissionsProxy(event_editor)
+
         editable_pages = user_perms.editable_pages()
         can_edit_pages = user_perms.can_edit_pages()
         publishable_pages = user_perms.publishable_pages()
@@ -453,7 +461,14 @@ class TestPagePermission(TestCase):
         )
         about_us_page = Page.objects.get(url_path="/home/about-us/")
 
-        user_perms = UserPagePermissionsProxy(event_editor)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with PagePermissionPolicy().explorable_instances()
+            user_perms = UserPagePermissionsProxy(event_editor)
+
         explorable_pages = user_perms.explorable_pages()
 
         # Verify all pages below /home/events/ are explorable
@@ -489,7 +504,14 @@ class TestPagePermission(TestCase):
         corporate_editor = get_user_model().objects.get(
             email="corporateeditor@example.com"
         )
-        user_perms = UserPagePermissionsProxy(corporate_editor)
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with PagePermissionPolicy().explorable_instances()
+            user_perms = UserPagePermissionsProxy(corporate_editor)
 
         about_us_page = Page.objects.get(url_path="/home/about-us/")
         businessy_events = Page.objects.get(url_path="/home/events/businessy-events/")
@@ -514,7 +536,14 @@ class TestPagePermission(TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        user_perms = UserPagePermissionsProxy(event_moderator)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with PagePermissionPolicy().instances_user_has_permission_for()
+            user_perms = UserPagePermissionsProxy(event_moderator)
+
         editable_pages = user_perms.editable_pages()
         can_edit_pages = user_perms.can_edit_pages()
         publishable_pages = user_perms.publishable_pages()
@@ -547,7 +576,14 @@ class TestPagePermission(TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        user_perms = UserPagePermissionsProxy(user)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with PagePermissionPolicy().instances_user_has_permission_for()
+            user_perms = UserPagePermissionsProxy(user)
+
         editable_pages = user_perms.editable_pages()
         can_edit_pages = user_perms.can_edit_pages()
         publishable_pages = user_perms.publishable_pages()
@@ -582,7 +618,14 @@ class TestPagePermission(TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        user_perms = UserPagePermissionsProxy(user)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with PagePermissionPolicy().instances_user_has_permission_for()
+            user_perms = UserPagePermissionsProxy(user)
+
         editable_pages = user_perms.editable_pages()
         can_edit_pages = user_perms.can_edit_pages()
         publishable_pages = user_perms.publishable_pages()
@@ -615,7 +658,14 @@ class TestPagePermission(TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        user_perms = UserPagePermissionsProxy(user)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with PagePermissionPolicy().instances_user_has_permission_for()
+            user_perms = UserPagePermissionsProxy(user)
+
         editable_pages = user_perms.editable_pages()
         can_edit_pages = user_perms.can_edit_pages()
         publishable_pages = user_perms.publishable_pages()
@@ -644,8 +694,16 @@ class TestPagePermission(TestCase):
         christmas_page = EventPage.objects.get(url_path="/home/events/christmas/")
         locked_page = Page.objects.get(url_path="/home/my-locked-page/")
 
-        perms = UserPagePermissionsProxy(user).for_page(christmas_page)
-        locked_perms = UserPagePermissionsProxy(user).for_page(locked_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(user)
+            user_perms = UserPagePermissionsProxy(user)
+
+        perms = user_perms.for_page(christmas_page)
+        locked_perms = user_perms.for_page(locked_page)
 
         self.assertTrue(perms.can_lock())
         self.assertFalse(
@@ -657,7 +715,13 @@ class TestPagePermission(TestCase):
         user = get_user_model().objects.get(email="eventmoderator@example.com")
         christmas_page = EventPage.objects.get(url_path="/home/events/christmas/")
 
-        perms = UserPagePermissionsProxy(user).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(user)
+            perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertTrue(perms.can_lock())
         self.assertTrue(perms.can_unlock())
@@ -670,7 +734,13 @@ class TestPagePermission(TestCase):
             group__name="Event moderators", permission_type="unlock"
         ).delete()
 
-        perms = UserPagePermissionsProxy(user).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(user)
+            perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertTrue(perms.can_lock())
         self.assertFalse(perms.can_unlock())
@@ -689,7 +759,13 @@ class TestPagePermission(TestCase):
             group__name="Event moderators", permission_type="unlock"
         ).delete()
 
-        perms = UserPagePermissionsProxy(user).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(user)
+            perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         # Unlike in the previous test, the user can unlock this page as it was them who locked
         self.assertTrue(perms.can_lock())
@@ -699,7 +775,13 @@ class TestPagePermission(TestCase):
         user = get_user_model().objects.get(email="eventeditor@example.com")
         christmas_page = EventPage.objects.get(url_path="/home/events/christmas/")
 
-        perms = UserPagePermissionsProxy(user).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(user)
+            perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertFalse(perms.can_lock())
         self.assertFalse(perms.can_unlock())
@@ -708,7 +790,13 @@ class TestPagePermission(TestCase):
         user = get_user_model().objects.get(email="admin_only_user@example.com")
         christmas_page = EventPage.objects.get(url_path="/home/events/christmas/")
 
-        perms = UserPagePermissionsProxy(user).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(user)
+            perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertFalse(perms.can_lock())
         self.assertFalse(perms.can_unlock())
@@ -723,7 +811,13 @@ class TestPagePermission(TestCase):
             permission_type="lock",
         )
 
-        perms = UserPagePermissionsProxy(user).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(user)
+            perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertTrue(perms.can_lock())
 
@@ -734,7 +828,13 @@ class TestPagePermission(TestCase):
         user = get_user_model().objects.get(email="eventmoderator@example.com")
         christmas_page = EventPage.objects.get(url_path="/home/events/christmas/")
 
-        perms = UserPagePermissionsProxy(user).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(user)
+            perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertFalse(perms.page_locked())
 
@@ -748,14 +848,27 @@ class TestPagePermission(TestCase):
         christmas_page.locked_at = timezone.now()
         christmas_page.save()
 
-        perms = UserPagePermissionsProxy(user).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(user)
+            perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         # The user who locked the page shouldn't see the page as locked
         self.assertFalse(perms.page_locked())
 
         # Other users should see the page as locked
         other_user = get_user_model().objects.get(email="eventeditor@example.com")
-        other_perms = UserPagePermissionsProxy(other_user).for_page(christmas_page)
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(other_user)
+            other_perms = UserPagePermissionsProxy(other_user).for_page(christmas_page)
         self.assertTrue(other_perms.page_locked())
 
     @override_settings(WAGTAILADMIN_GLOBAL_EDIT_LOCK=True)
@@ -769,14 +882,28 @@ class TestPagePermission(TestCase):
         christmas_page.locked_at = timezone.now()
         christmas_page.save()
 
-        perms = UserPagePermissionsProxy(user).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(user)
+            perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         # The user who locked the page should now also see the page as locked
         self.assertTrue(perms.page_locked())
 
         # Other users should see the page as locked, like before
         other_user = get_user_model().objects.get(email="eventeditor@example.com")
-        other_perms = UserPagePermissionsProxy(other_user).for_page(christmas_page)
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(other_user)
+            other_perms = UserPagePermissionsProxy(other_user).for_page(christmas_page)
+
         self.assertTrue(other_perms.page_locked())
 
     def test_page_locked_in_workflow(self):
@@ -788,19 +915,41 @@ class TestPagePermission(TestCase):
         christmas_page.save_revision()
         workflow.start(christmas_page, editor)
 
-        moderator_perms = UserPagePermissionsProxy(moderator).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(moderator)
+            moderator_perms = UserPagePermissionsProxy(moderator).for_page(
+                christmas_page
+            )
 
         # the moderator is in the group assigned to moderate the task, so the page should
         # not be locked for them
         self.assertFalse(moderator_perms.page_locked())
 
-        superuser_perms = UserPagePermissionsProxy(superuser).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(superuser)
+            superuser_perms = UserPagePermissionsProxy(superuser).for_page(
+                christmas_page
+            )
 
         # superusers can moderate any GroupApprovalTask, so the page should not be locked
         # for them
         self.assertFalse(superuser_perms.page_locked())
 
-        editor_perms = UserPagePermissionsProxy(editor).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(editor)
+            editor_perms = UserPagePermissionsProxy(editor).for_page(christmas_page)
 
         # the editor is not in the group assigned to moderate the task, so the page should
         # be locked for them
@@ -814,14 +963,28 @@ class TestPagePermission(TestCase):
         christmas_page.save_revision()
         workflow.start(christmas_page, editor)
 
-        moderator_perms = UserPagePermissionsProxy(moderator).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(moderator)
+            moderator_perms = UserPagePermissionsProxy(moderator).for_page(
+                christmas_page
+            )
 
         # the moderator is in the group assigned to moderate the task, so they can lock the page, but can't unlock it
         # unless they're the locker
         self.assertTrue(moderator_perms.can_lock())
         self.assertFalse(moderator_perms.can_unlock())
 
-        editor_perms = UserPagePermissionsProxy(editor).for_page(christmas_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+        ):
+            # Replace with page.permissions_for_user(editor)
+            editor_perms = UserPagePermissionsProxy(editor).for_page(christmas_page)
 
         # the editor is not in the group assigned to moderate the task, so they can't lock or unlock the page
         self.assertFalse(editor_perms.can_lock())

--- a/wagtail/tests/test_page_permissions.py
+++ b/wagtail/tests/test_page_permissions.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import Group
 from django.test import Client, TestCase, override_settings
 from django.utils import timezone
 
+from wagtail.admin.auth import users_with_page_permission
 from wagtail.models import (
     GroupApprovalTask,
     GroupPagePermission,
@@ -688,6 +689,31 @@ class TestPagePermission(TestCase):
         )
 
         self.assertFalse(can_publish_pages)
+
+    def test_users_with_page_permission(self):
+        christmas_page = EventPage.objects.get(url_path="/home/events/christmas/")
+        event_moderator = get_user_model().objects.get(
+            email="eventmoderator@example.com"
+        )
+        superuser = get_user_model().objects.get(email="superuser@example.com")
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "users_with_page_permission() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            "users_with_permission_for_instance() instead.",
+        ):
+            users = users_with_page_permission(christmas_page, "publish", False)
+            self.assertCountEqual(users, {event_moderator})
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "users_with_page_permission() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            "users_with_permission_for_instance() instead.",
+        ):
+            users = users_with_page_permission(christmas_page, "publish", True)
+            self.assertCountEqual(users, {event_moderator, superuser})
 
     def test_lock_page_for_superuser(self):
         user = get_user_model().objects.get(email="superuser@example.com")

--- a/wagtail/tests/test_page_permissions.py
+++ b/wagtail/tests/test_page_permissions.py
@@ -420,18 +420,37 @@ class TestPagePermission(TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
+        user_perms = UserPagePermissionsProxy(event_editor)
+
+        # To be replaced with the suggestion in the warning's message
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.editable_pages() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            'instances_user_has_permission_for(user, "edit") instead.',
         ):
-            # Replace with PagePermissionPolicy().instances_user_has_permission_for()
-            user_perms = UserPagePermissionsProxy(event_editor)
-
-        editable_pages = user_perms.editable_pages()
-        can_edit_pages = user_perms.can_edit_pages()
-        publishable_pages = user_perms.publishable_pages()
-        can_publish_pages = user_perms.can_publish_pages()
+            editable_pages = user_perms.editable_pages()
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy.can_edit_pages() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            'user_has_permission(user, "edit") instead.',
+        ):
+            can_edit_pages = user_perms.can_edit_pages()
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy.publishable_pages() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            'instances_user_has_permission_for(user, "publish") instead.',
+        ):
+            publishable_pages = user_perms.publishable_pages()
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy.can_publish_pages() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            'user_has_permission(user, "publish") instead.',
+        ):
+            can_publish_pages = user_perms.can_publish_pages()
 
         self.assertFalse(editable_pages.filter(id=homepage.id).exists())
         self.assertTrue(editable_pages.filter(id=christmas_page.id).exists())
@@ -462,15 +481,15 @@ class TestPagePermission(TestCase):
         )
         about_us_page = Page.objects.get(url_path="/home/about-us/")
 
+        user_perms = UserPagePermissionsProxy(event_editor)
+
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.explorable_pages() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            "explorable_instances(user) instead.",
         ):
-            # Replace with PagePermissionPolicy().explorable_instances()
-            user_perms = UserPagePermissionsProxy(event_editor)
-
-        explorable_pages = user_perms.explorable_pages()
+            explorable_pages = user_perms.explorable_pages()
 
         # Verify all pages below /home/events/ are explorable
         self.assertTrue(explorable_pages.filter(id=christmas_page.id).exists())
@@ -506,19 +525,19 @@ class TestPagePermission(TestCase):
             email="corporateeditor@example.com"
         )
 
-        with self.assertWarnsMessage(
-            RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
-        ):
-            # Replace with PagePermissionPolicy().explorable_instances()
-            user_perms = UserPagePermissionsProxy(corporate_editor)
+        user_perms = UserPagePermissionsProxy(corporate_editor)
 
         about_us_page = Page.objects.get(url_path="/home/about-us/")
         businessy_events = Page.objects.get(url_path="/home/events/businessy-events/")
         events_page = Page.objects.get(url_path="/home/events/")
 
-        explorable_pages = user_perms.explorable_pages()
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy.explorable_pages() is deprecated. "
+            "Use wagtail.permission_policies.pages.PagePermissionPolicy."
+            "explorable_instances(user) instead.",
+        ):
+            explorable_pages = user_perms.explorable_pages()
 
         self.assertTrue(explorable_pages.filter(id=about_us_page.id).exists())
         self.assertTrue(explorable_pages.filter(id=businessy_events.id).exists())
@@ -537,18 +556,17 @@ class TestPagePermission(TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        with self.assertWarnsMessage(
-            RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
-        ):
-            # Replace with PagePermissionPolicy().instances_user_has_permission_for()
-            user_perms = UserPagePermissionsProxy(event_moderator)
+        user_perms = UserPagePermissionsProxy(event_moderator)
 
-        editable_pages = user_perms.editable_pages()
-        can_edit_pages = user_perms.can_edit_pages()
-        publishable_pages = user_perms.publishable_pages()
-        can_publish_pages = user_perms.can_publish_pages()
+        # To be replaced with the suggestion in the warning's message
+        with self.assertWarns(RemovedInWagtail60Warning):
+            editable_pages = user_perms.editable_pages()
+        with self.assertWarns(RemovedInWagtail60Warning):
+            can_edit_pages = user_perms.can_edit_pages()
+        with self.assertWarns(RemovedInWagtail60Warning):
+            publishable_pages = user_perms.publishable_pages()
+        with self.assertWarns(RemovedInWagtail60Warning):
+            can_publish_pages = user_perms.can_publish_pages()
 
         self.assertFalse(editable_pages.filter(id=homepage.id).exists())
         self.assertTrue(editable_pages.filter(id=christmas_page.id).exists())
@@ -577,18 +595,17 @@ class TestPagePermission(TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        with self.assertWarnsMessage(
-            RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
-        ):
-            # Replace with PagePermissionPolicy().instances_user_has_permission_for()
-            user_perms = UserPagePermissionsProxy(user)
+        user_perms = UserPagePermissionsProxy(user)
 
-        editable_pages = user_perms.editable_pages()
-        can_edit_pages = user_perms.can_edit_pages()
-        publishable_pages = user_perms.publishable_pages()
-        can_publish_pages = user_perms.can_publish_pages()
+        # To be replaced with the suggestion in the warning's message
+        with self.assertWarns(RemovedInWagtail60Warning):
+            editable_pages = user_perms.editable_pages()
+        with self.assertWarns(RemovedInWagtail60Warning):
+            can_edit_pages = user_perms.can_edit_pages()
+        with self.assertWarns(RemovedInWagtail60Warning):
+            publishable_pages = user_perms.publishable_pages()
+        with self.assertWarns(RemovedInWagtail60Warning):
+            can_publish_pages = user_perms.can_publish_pages()
 
         self.assertFalse(editable_pages.filter(id=homepage.id).exists())
         self.assertFalse(editable_pages.filter(id=christmas_page.id).exists())
@@ -619,18 +636,17 @@ class TestPagePermission(TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        with self.assertWarnsMessage(
-            RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
-        ):
-            # Replace with PagePermissionPolicy().instances_user_has_permission_for()
-            user_perms = UserPagePermissionsProxy(user)
+        user_perms = UserPagePermissionsProxy(user)
 
-        editable_pages = user_perms.editable_pages()
-        can_edit_pages = user_perms.can_edit_pages()
-        publishable_pages = user_perms.publishable_pages()
-        can_publish_pages = user_perms.can_publish_pages()
+        # To be replaced with the suggestion in the warning's message
+        with self.assertWarns(RemovedInWagtail60Warning):
+            editable_pages = user_perms.editable_pages()
+        with self.assertWarns(RemovedInWagtail60Warning):
+            can_edit_pages = user_perms.can_edit_pages()
+        with self.assertWarns(RemovedInWagtail60Warning):
+            publishable_pages = user_perms.publishable_pages()
+        with self.assertWarns(RemovedInWagtail60Warning):
+            can_publish_pages = user_perms.can_publish_pages()
 
         self.assertTrue(editable_pages.filter(id=homepage.id).exists())
         self.assertTrue(editable_pages.filter(id=christmas_page.id).exists())
@@ -659,18 +675,17 @@ class TestPagePermission(TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        with self.assertWarnsMessage(
-            RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
-        ):
-            # Replace with PagePermissionPolicy().instances_user_has_permission_for()
-            user_perms = UserPagePermissionsProxy(user)
+        user_perms = UserPagePermissionsProxy(user)
 
-        editable_pages = user_perms.editable_pages()
-        can_edit_pages = user_perms.can_edit_pages()
-        publishable_pages = user_perms.publishable_pages()
-        can_publish_pages = user_perms.can_publish_pages()
+        # To be replaced with the suggestion in the warning's message
+        with self.assertWarns(RemovedInWagtail60Warning):
+            editable_pages = user_perms.editable_pages()
+        with self.assertWarns(RemovedInWagtail60Warning):
+            can_edit_pages = user_perms.can_edit_pages()
+        with self.assertWarns(RemovedInWagtail60Warning):
+            publishable_pages = user_perms.publishable_pages()
+        with self.assertWarns(RemovedInWagtail60Warning):
+            can_publish_pages = user_perms.can_publish_pages()
 
         self.assertFalse(editable_pages.filter(id=homepage.id).exists())
         self.assertFalse(editable_pages.filter(id=christmas_page.id).exists())
@@ -720,16 +735,21 @@ class TestPagePermission(TestCase):
         christmas_page = EventPage.objects.get(url_path="/home/events/christmas/")
         locked_page = Page.objects.get(url_path="/home/my-locked-page/")
 
+        user_perms = UserPagePermissionsProxy(user)
+
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(user)
-            user_perms = UserPagePermissionsProxy(user)
+            perms = user_perms.for_page(christmas_page)
 
-        perms = user_perms.for_page(christmas_page)
-        locked_perms = user_perms.for_page(locked_page)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
+        ):
+            locked_perms = user_perms.for_page(locked_page)
 
         self.assertTrue(perms.can_lock())
         self.assertFalse(
@@ -743,10 +763,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(user)
             perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertTrue(perms.can_lock())
@@ -762,10 +781,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(user)
             perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertTrue(perms.can_lock())
@@ -787,10 +805,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(user)
             perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         # Unlike in the previous test, the user can unlock this page as it was them who locked
@@ -803,10 +820,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(user)
             perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertFalse(perms.can_lock())
@@ -818,10 +834,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(user)
             perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertFalse(perms.can_lock())
@@ -839,10 +854,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(user)
             perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertTrue(perms.can_lock())
@@ -856,10 +870,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(user)
             perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertFalse(perms.page_locked())
@@ -876,10 +889,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(user)
             perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         # The user who locked the page shouldn't see the page as locked
@@ -890,10 +902,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(other_user)
             other_perms = UserPagePermissionsProxy(other_user).for_page(christmas_page)
         self.assertTrue(other_perms.page_locked())
 
@@ -910,10 +921,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(user)
             perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         # The user who locked the page should now also see the page as locked
@@ -924,10 +934,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(other_user)
             other_perms = UserPagePermissionsProxy(other_user).for_page(christmas_page)
 
         self.assertTrue(other_perms.page_locked())
@@ -943,10 +952,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(moderator)
             moderator_perms = UserPagePermissionsProxy(moderator).for_page(
                 christmas_page
             )
@@ -957,10 +965,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(superuser)
             superuser_perms = UserPagePermissionsProxy(superuser).for_page(
                 christmas_page
             )
@@ -971,10 +978,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(editor)
             editor_perms = UserPagePermissionsProxy(editor).for_page(christmas_page)
 
         # the editor is not in the group assigned to moderate the task, so the page should
@@ -991,10 +997,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(moderator)
             moderator_perms = UserPagePermissionsProxy(moderator).for_page(
                 christmas_page
             )
@@ -1006,10 +1011,9 @@ class TestPagePermission(TestCase):
 
         with self.assertWarnsMessage(
             RemovedInWagtail60Warning,
-            "UserPagePermissionsProxy is deprecated. "
-            "Use wagtail.permission_policies.pages.PagePermissionPolicy instead.",
+            "UserPagePermissionsProxy.for_page() is deprecated. "
+            "Use page.permissions_for_user(user) instead.",
         ):
-            # Replace with page.permissions_for_user(editor)
             editor_perms = UserPagePermissionsProxy(editor).for_page(christmas_page)
 
         # the editor is not in the group assigned to moderate the task, so they can't lock or unlock the page


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Follow-up to #10521. This PR eliminates all use of `UserPagePermissionsProxy` in favour of `PagePermissionPolicy` and the existing `PagePermissionTester`. `PagePermissionTester` no longer needs `UserPagePermissionsProxy` to work. It can be instantiated either by `PagePermissionTester(user, page)` or via the existing convenience method `Page.permissions_for_user(user)`.





_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
