### PR TITLE
Fix title sync behaviour (use keyup) & refine performance

### DIFF
--- a/wagtail/admin/panels/page_utils.py
+++ b/wagtail/admin/panels/page_utils.py
@@ -25,7 +25,7 @@ def set_default_page_edit_handlers(cls):
                         "{title}*", title=gettext_lazy("Page title")
                     ),
                     "data-controller": "w-sync",
-                    "data-action": "focus->w-sync#check blur->w-sync#apply",
+                    "data-action": "focus->w-sync#check blur->w-sync#apply change->w-sync#apply keyup->w-sync#apply",
                     # ensure that if the page is live, the slug field does not receive updates from changes to the title field
                     "data-w-sync-target-value": "body:not(.page-is-live) [data-edit-form] #id_slug",
                 }


### PR DESCRIPTION
- Fixes #10517 
- That issue also requests an enhancement but I will do that as a new PR on top of this one under a feature for #161 (I have made a start to this stuff but it's not really ready to merge and I did not want to block 5.0.2)
- Previous to 5.0 the Slug field would be updated by changes to the title field as the user typed (keyup & keydown), this was assumed to be in place for an IE11 work around for copy but this ended up causing a regression where devs using the slug field and title field in the same tab (or same edit form) would not see the two fields keep in sync.
- **Question:** Not sure if we should update the 5.0 release notes to advise the addition of `keyup` if using the sync field manually. I do think it's a borderline edge case so maybe we can leave it.


## Commit 1 - Smallest change for 5.0.2 branch cherry pick

- This simply adds the keyup listener (intentionally not keydown also, as this would be quite slow in some browsers) to page_utils.
- This is kind of acceptable as there is already a settimeout use on sync field updates, so it should not block the UI.

## Commit 2 - Performance improvement to SyncController & added tests

- This build on commit 1 and adds a 50ms debounce, on the calling of the `apply` method, removing the default settimeout on the actual change to be made. This should not be a noticeable difference but gives the controller the ability to change this value with a data attribute and avoids the double timeout (the calling of the method and the applying of the change).
- Adds some unit tests for all this to the JS controller tests


## Testing

To test this, it's easier to put the slug and title field together in an existing Page on bakery demo, here is a change you can make in `bakerydemo/blog/models.py` to show the keyup behaviour.

```
class StandardPage(Page):
    # .. fields etc

    content_panels = Page.content_panels + Page.promote_panels + [
        FieldPanel("introduction"),
        FieldPanel("body"),
        FieldPanel("image"),
    ]

    promote_panels = []
````