### PR TITLE
Allow manually specifying credentials for CloudFront frontend cache backend

### DIFF
--- a/docs/reference/contrib/frontendcache.md
+++ b/docs/reference/contrib/frontendcache.md
@@ -109,7 +109,7 @@ WAGTAILFRONTENDCACHE = {
 Previous versions allowed passing a dict for `DISTRIBUTION_ID` to allow specifying different distribution IDs for different hostnames. This is now deprecated; instead, multiple distribution IDs should be defined as [multiple backends](frontendcache_multiple_backends), with a `HOSTNAMES` parameter to define the hostnames associated with each one.
 ```
 
-Configuration of credentials can done in multiple ways. You won't need to store them in your Django settings file. You can read more about this here: [Boto 3 Docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html). The user will need a policy similar to:
+`boto3` will attempt to discover credentials itself. You can read more about this here: [Boto 3 Docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html). The user will need a policy similar to:
 
 ```json
 {
@@ -122,6 +122,20 @@ Configuration of credentials can done in multiple ways. You won't need to store 
             "Resource": "arn:aws:cloudfront::<account id>:distribution/<distribution id>"
         }
     ]
+}
+```
+
+To specify credentials manually, pass them as additional parameters:
+
+```python
+WAGTAILFRONTENDCACHE = {
+    'cloudfront': {
+        'BACKEND': 'wagtail.contrib.frontend_cache.backends.CloudfrontBackend',
+        'DISTRIBUTION_ID': 'your-distribution-id',
+        'AWS_ACCESS_KEY_ID': os.environ['FRONTEND_CACHE_AWS_ACCESS_KEY_ID'],
+        'AWS_SECRET_ACCESS_KEY': os.environ['FRONTEND_CACHE_AWS_SECRET_ACCESS_KEY'],
+        'AWS_SESSION_TOKEN': os.environ['FRONTEND_CACHE_AWS_SESSION_TOKEN']
+    },
 }
 ```
 

--- a/wagtail/contrib/frontend_cache/backends/cloudfront.py
+++ b/wagtail/contrib/frontend_cache/backends/cloudfront.py
@@ -22,7 +22,13 @@ class CloudfrontBackend(BaseBackend):
 
         super().__init__(params)
 
-        self.client = boto3.client("cloudfront")
+        self.client = boto3.client(
+            "cloudfront",
+            aws_access_key_id=params.get("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=params.get("AWS_SECRET_ACCESS_KEY"),
+            aws_session_token=params.get("AWS_SESSION_TOKEN"),
+        )
+
         try:
             self.cloudfront_distribution_id = params.pop("DISTRIBUTION_ID")
         except KeyError:


### PR DESCRIPTION
Currently, the CloudFront backend assumes `boto3` will find credentials. Instead, it's often useful to be able to manually specify credentials, especially when a specific set are needed for frontend invalidation.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
