### PR TITLE
Add support for --template argument to wagtail start. Fix #10423

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Add support for more advanced Draftail customisation APIs (Thibaud Colas)
  * Add the ability to export snippets listing via `SnippetViewSet.list_export` (Sage Abdullah)
  * Add support for adding HTML `attrs` on `FieldPanel`, `FieldRowPanel`, `MultiFieldPanel`, and others (Aman Pandey, Antoni Martyniuk, LB (Ben) Johnston)
+ * Add support for `--template` option to `wagtail start` (Thibaud Colas)
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)

--- a/docs/reference/project_template.md
+++ b/docs/reference/project_template.md
@@ -1,5 +1,7 @@
 # The project template
 
+By default, running the `wagtail start` command (e.g. `wagtail start mysite`) will create a new Django project with the following structure:
+
 ```text
 mysite/
     home/
@@ -40,6 +42,16 @@ mysite/
     manage.py
     requirements.txt
 ```
+
+To use a custom template instead, you can specify the `--template` option when running the `wagtail start` command. This option accepts a directory, file path, or URL of a custom project template (similar to {option}`django-admin startproject --template <django:startproject --template>`).
+
+For example, with a custom template hosted as a GitHub repository, you can use a URL like the following:
+
+```shell
+wagtail start myproject --template=https://github.com/githubuser/wagtail-awesome-template/archive/main.zip
+```
+
+The following is a reference for the default project template.
 
 ## The "home" app
 

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -26,6 +26,10 @@ As part of Google Season of Docs 2023, we worked with technical writer Damilola 
 
 Thank you to Damilola for his work, and to Google for sponsoring this project.
 
+### Custom template support for `wagtail start`
+
+The `wagtail start` command now supports an optional `--template` argument that allows you to specify a custom project template to use. This is useful if you want to use a custom template that includes additional features or customisations. For more details, see [the project template reference](/reference/project_template). This feature was developed by Thibaud Colas.
+
 ### Other features
 
  * Mark calls to `md5` as not being used for secure purposes, to avoid flagging on FIPS-mode systems (Sean Kelly)

--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -58,6 +58,9 @@ class Command:
 class CreateProject(Command):
     description = "Creates the directory structure for a new Wagtail project."
 
+    def __init__(self):
+        self.default_template_path = self.get_default_template_path()
+
     def add_arguments(self, parser):
         parser.add_argument("project_name", help="Name for your Wagtail project")
         parser.add_argument(
@@ -65,8 +68,20 @@ class CreateProject(Command):
             nargs="?",
             help="Destination directory inside which to create the project",
         )
+        parser.add_argument(
+            "--template",
+            help="The path or URL to load the template from.",
+            default=self.default_template_path,
+        )
 
-    def run(self, project_name=None, dest_dir=None):
+    def get_default_template_path(self):
+        import wagtail
+
+        wagtail_path = os.path.dirname(wagtail.__file__)
+        default_template_path = os.path.join(wagtail_path, "project_template")
+        return default_template_path
+
+    def run(self, project_name=None, dest_dir=None, **options):
         # Make sure given name is not already in use by another python package/module.
         try:
             __import__(project_name)
@@ -79,24 +94,20 @@ class CreateProject(Command):
                 "name. Please try another name." % project_name
             )
 
+        template_name = options["template"]
+        if template_name == self.default_template_path:
+            template_name = "the default Wagtail template"
+
         print(  # noqa: T201
-            "Creating a Wagtail project called %(project_name)s"
-            % {"project_name": project_name}
+            "Creating a Wagtail project called %(project_name)s using %(template_name)s"
+            % {"project_name": project_name, "template_name": template_name}
         )
-
-        # Create the project from the Wagtail template using startapp
-
-        # First find the path to Wagtail
-        import wagtail
-
-        wagtail_path = os.path.dirname(wagtail.__file__)
-        template_path = os.path.join(wagtail_path, "project_template")
 
         # Call django-admin startproject
         utility_args = [
             "django-admin",
             "startproject",
-            "--template=" + template_path,
+            "--template=" + options["template"],
             "--ext=html,rst",
             "--name=Dockerfile",
             project_name,


### PR DESCRIPTION
Fixes #10423. This is the "MVP" implementation which makes it possible to pass a `--template` to `startproject`, without any other niceties.

Potential improvements once we have a clearer idea of what to do with this:

- Documentation. Currently there are only a few mentions of the `wagtail` CLI, no single source of truth.
- Support for aliases / blessed template sources (https://github.com/wagtail/wagtail/issues/10423#issuecomment-1590782747). This would need building on top of `startproject`.
- Support for custom `extensions`, `name`, and other `startproject` options.
- Perhaps nicer CLI feedback or support for more `startproject` options
- Unit tests? I couldn’t see any for `start` nor `updatemodulepaths`

---

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~ No, there are no tests for this code currently.
-   ~~[ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]~~
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~ No, there are no docs for this CLI

To test this, make sure `start` still works with the default, and make sure it works with a `--template`:

```bash
wagtail start mysite
wagtail start mysite --template=https://github.com/thibaudcolas/wagtail-tutorial-template/archive/main.zip
# Potentially compare to:
./wagtail/test/manage.py startproject mysite --template=https://github.com/thibaudcolas/wagtail-tutorial-template/archive/main.zip
```