### PR TITLE
Docs - fix typo in Django forms reference

### DIFF
--- a/docs/extending/forms.md
+++ b/docs/extending/forms.md
@@ -1,6 +1,6 @@
 # Using forms in admin views
 
-[Django's forms framework](django:topics/forms) can be used within Wagtail admin views just like in any other Django app. However, Wagtail also provides various admin-specific form widgets, such as date/time pickers and choosers for pages, documents, images, and snippets. By constructing forms using `wagtail.admin.forms.models.WagtailAdminModelForm` as the base class instead of `django.forms.models.ModelForm`, the most appropriate widget will be selected for each model field. For example, given the model and form definition:
+[Django's forms framework](django:topics/forms/index) can be used within Wagtail admin views just like in any other Django app. However, Wagtail also provides various admin-specific form widgets, such as date/time pickers and choosers for pages, documents, images, and snippets. By constructing forms using `wagtail.admin.forms.models.WagtailAdminModelForm` as the base class instead of `django.forms.models.ModelForm`, the most appropriate widget will be selected for each model field. For example, given the model and form definition:
 
 ```python
 from django.db import models


### PR DESCRIPTION
- Small fix, noticed this when building the docs locally (getting an error as the Django ref was incorrect)
- Another note for #9778 - would be great if we could see these things when they come through the CI