### PR TITLE
Add `TitleFieldPanel` to support shared usage of title field sync

### DIFF
--- a/docs/reference/pages/panels.md
+++ b/docs/reference/pages/panels.md
@@ -222,6 +222,19 @@ The `MultipleChooserPanel` definition on `BlogPage` would be:
             ]
 ```
 
+(title_field_panel)=
+
+### TitleFieldPanel
+
+```{eval-rst}
+.. module:: wagtail.admin.panels
+
+.. autoclass:: TitleFieldPanel
+
+    This is the panel to use for Page title fields or main titles on other models. It provides a default classname, placeholder and widget attributes to enable the automatic sync with the slug field in the form. Many of these defaults can be customised by passing additional arguments to the constructor. All the same `FieldPanel` arguments are supported including a custom widget. For more details, see :ref:`customising_panels`.
+
+```
+
 (customising_panels)=
 
 ## Panel customisation

--- a/wagtail/admin/panels/__init__.py
+++ b/wagtail/admin/panels/__init__.py
@@ -18,3 +18,4 @@ from .page_chooser_panel import *  # NOQA: F403
 from .page_utils import *  # NOQA: F403
 from .publishing_panel import *  # NOQA: F403
 from .signal_handlers import *  # NOQA: F403
+from .title_field_panel import *  # NOQA: F403

--- a/wagtail/admin/panels/page_utils.py
+++ b/wagtail/admin/panels/page_utils.py
@@ -1,6 +1,4 @@
-from django import forms
 from django.conf import settings
-from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy
 
 from wagtail.admin.forms.pages import WagtailAdminPageForm
@@ -12,25 +10,12 @@ from .comment_panel import CommentPanel
 from .field_panel import FieldPanel
 from .group import MultiFieldPanel, ObjectList, TabbedInterface
 from .publishing_panel import PublishingPanel
+from .title_field_panel import TitleFieldPanel
 
 
 def set_default_page_edit_handlers(cls):
     cls.content_panels = [
-        FieldPanel(
-            "title",
-            classname="title",
-            widget=forms.TextInput(
-                attrs={
-                    "placeholder": format_lazy(
-                        "{title}*", title=gettext_lazy("Page title")
-                    ),
-                    "data-controller": "w-sync",
-                    "data-action": "focus->w-sync#check blur->w-sync#apply change->w-sync#apply keyup->w-sync#apply",
-                    # ensure that if the page is live, the slug field does not receive updates from changes to the title field
-                    "data-w-sync-target-value": "body:not(.page-is-live) [data-edit-form] #id_slug",
-                }
-            ),
-        ),
+        TitleFieldPanel("title"),
     ]
 
     cls.promote_panels = [

--- a/wagtail/admin/panels/title_field_panel.py
+++ b/wagtail/admin/panels/title_field_panel.py
@@ -1,0 +1,129 @@
+from django.utils.text import format_lazy
+from django.utils.translation import gettext_lazy
+
+from wagtail.models import Page
+
+from .field_panel import FieldPanel
+
+
+class TitleFieldPanel(FieldPanel):
+    """
+    Prepares the default widget attributes that are used on Page title fields.
+    Can be used outside of pages to easily enable the slug field sync functionality.
+
+    :param apply_if_live: (optional) If ``True``, the built in slug sync behaviour will apply irrespective of the published state.
+        The default is ``False``, where the slug sync will only apply when the instance is not live (or does not have a live property).
+    :param classname: (optional) A CSS class name to add to the panel's HTML element. Default is ``"title"``.
+    :param placeholder: (optional) If a value is provided, it will be used as the field's placeholder, if ``False`` is provided no placeholder will be shown.
+        If ``True``, a placeholder value of ``"Title*"`` will be used or ``"Page Title*"`` if the model is a ``Page`` model.
+        The default is ``True``. If a widget is provided with a placeholder, the widget's value will be used instead.
+    :param targets: (optional) This allows you to override the default target of the field named `slug` on the form.
+        Accepts a list of field names, default is ``["slug"]``.
+        Note that the slugify/urlify behaviour relies on usage of the ``wagtail.admin.widgets.slug`` widget on the slug field.
+    """
+
+    def __init__(
+        self,
+        *args,
+        apply_if_live=False,
+        classname="title",
+        placeholder=True,
+        targets=["slug"],
+        **kwargs,
+    ):
+        kwargs["classname"] = classname
+        self.apply_if_live = apply_if_live
+        self.placeholder = placeholder
+        self.targets = targets
+        super().__init__(*args, **kwargs)
+
+    def clone_kwargs(self):
+        return {
+            **super().clone_kwargs(),
+            "apply_if_live": self.apply_if_live,
+            "placeholder": self.placeholder,
+            "targets": self.targets,
+        }
+
+    class BoundPanel(FieldPanel.BoundPanel):
+
+        apply_actions = [
+            "focus->w-sync#check",
+            "blur->w-sync#apply",
+            "change->w-sync#apply",
+            "keyup->w-sync#apply",
+        ]
+
+        def get_context_data(self, parent_context=None):
+            field = self.bound_field.field
+            if field and not self.read_only:
+                field.widget.attrs.update(**self.get_attrs())
+            return super().get_context_data(parent_context)
+
+        def get_attrs(self):
+            """
+            Generates a dict of widget attributes to be updated on the widget
+            before rendering.
+            """
+
+            panel = self.panel
+            widget = self.bound_field.field.widget
+
+            attrs = {}
+
+            controllers = [widget.attrs.get("data-controller", None), "w-sync"]
+            attrs["data-controller"] = " ".join(filter(None, controllers))
+
+            if self.get_should_apply():
+                actions = [widget.attrs.get("data-action", None)] + self.apply_actions
+                attrs["data-action"] = " ".join(filter(None, actions))
+
+            targets = [self.get_target_selector(target) for target in panel.targets]
+            attrs["data-w-sync-target-value"] = ", ".join(filter(None, targets))
+
+            placeholder = self.get_placeholder()
+            if placeholder and "placeholder" not in widget.attrs:
+                attrs["placeholder"] = placeholder
+
+            return attrs
+
+        def get_placeholder(self):
+            """
+            If placeholder is falsey, return None. Otherwise allow a valid placeholder
+            to be resolved.
+            """
+            placeholder = self.panel.placeholder
+
+            if not placeholder:
+                return None
+
+            if placeholder is True:
+                title = gettext_lazy("Title")
+
+                if issubclass(self.panel.model, Page):
+                    title = gettext_lazy("Page title")
+
+                return format_lazy("{title}*", title=title)
+
+            return placeholder
+
+        def get_should_apply(self):
+            """
+            Check that the title field should apply the sync with the target fields.
+            """
+            if self.panel.apply_if_live:
+                return True
+
+            instance = self.instance
+            if not instance:
+                return True
+
+            is_live = instance.pk and getattr(instance, "live", False)
+            return not is_live
+
+        def get_target_selector(self, target):
+            """
+            Prepare a selector for an individual target field.
+            """
+            field = self.form[target]
+            return f"#{field.id_for_label}"


### PR DESCRIPTION
- Avoid a widget approach used on default content_panels on Page, instead allow a shared `TitleFieldPanel` to be used
- This does not add any extra JavaScript but merely pulls out the default `page_utils` widget attrs approach to a shared class, adding documentation and tests.
- This approach also paves the way for some future solutions around a 'sync' or 'calculated' field panel type without going too deep in that direction - see #161 for future.
- Fixes #10517

## Testing (Page model)

* Update the `StandardPage` to not use the built in `Page.content_panels` but instead have a different structure.
* Load the admin interface and the title/slug sync should work as expected (updates the slug when the page is not live)

```py
# bakerydemo/base/models.py
class StandardPage(Page):
    # ... fields
    content_panels = [
        MultiFieldPanel([
            TitleFieldPanel("title"), # from wagtail.admin.panels import (... TitleFieldPanel)
            FieldPanel("introduction"), 
        ]),
        FieldPanel("body"),
        FieldPanel("image"),
    ]
```

* Now, make the page live, confirm the slug does not sync.
* Then change the `TitleFieldPanel("title"),` to `TitleFieldPanel("title", apply_if_live=True),` and check that the slug now syncs, even if page is published.

## Testing (snippet model)

* The title field panel should work for other fields on non-page model, here is a quick way to test this.
* Once the model is updated, you should be able to [edit a Person snippet](http://localhost:8000/admin/snippets/base/person/edit/4/) and see that the placeholder for the 'first name' field is "title*" and the changing the first name field will automatically update the last name field.

```py
# bakerydemo/base/models.py
class Person(
    WorkflowMixin,
    DraftStateMixin,
    LockableMixin,
    RevisionMixin,
    PreviewableMixin,
    index.Indexed,
    ClusterableModel,
):
    # ... fields
    panels = [
        MultiFieldPanel(
            [
                FieldRowPanel(
                    [
                        TitleFieldPanel("first_name", targets=["last_name"]), # update this line only
                        FieldPanel("last_name"),
                    ]
                )
            ],
            "Name",
        ),
        FieldPanel("job_title"),
        FieldPanel("image"),
        PublishingPanel(),
    ]
```

* Now make an update to the TitleFieldPanel to avoid the sync target. `TitleFieldPanel("first_name", targets=[])`, it should still have the placehoder but no longer sync with the other field.
