### PR TITLE
Add RelatedObjectsColumn to the table UI framework

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,8 @@ Changelog
 ~~~~~~~~~~~~~~~~
 
  * Refine wording of page & collection privacy using password is a shared password and should not be used for secure content (Rohit Sharma, Jake Howard)
- * Add contributing development documentation on how to work with a fork of Wagtail (Nix Asteri, Dan Braghis)
+ * Add RelatedObjectsColumn to the table UI framework (Matt Westcott)
+ * Docs: Add contributing development documentation on how to work with a fork of Wagtail (Nix Asteri, Dan Braghis)
  * Maintenance: Remove duplicate 'path' in default_exclude_fields_in_copy (ramchandra-st)
 
 

--- a/wagtail/admin/templates/wagtailadmin/tables/related_objects_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/related_objects_cell.html
@@ -1,0 +1,9 @@
+<td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
+    {% if value %}
+        <ul>
+            {% for item in value %}
+                <li>{{ item }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+</td>

--- a/wagtail/admin/tests/ui/test_tables.py
+++ b/wagtail/admin/tests/ui/test_tables.py
@@ -2,7 +2,13 @@ from django.template import Context, Template
 from django.test import RequestFactory, TestCase
 from django.utils.html import format_html
 
-from wagtail.admin.ui.tables import BaseColumn, Column, Table, TitleColumn
+from wagtail.admin.ui.tables import (
+    BaseColumn,
+    Column,
+    RelatedObjectsColumn,
+    Table,
+    TitleColumn,
+)
 from wagtail.models import Page, Site
 
 
@@ -318,6 +324,47 @@ class TestTable(TestCase):
                 <tbody>
                     <tr><td>1 of 2</td><td>Paul</td><td>Simon</td></tr>
                     <tr><td>2 of 2</td><td>Art</td><td>Garfunkel</td></tr>
+                </tbody>
+            </table>
+        """,
+        )
+
+
+class TestRelatedObjectsColumn(TestCase):
+    def setUp(self):
+        self.rf = RequestFactory()
+
+    def render_component(self, obj):
+        request = self.rf.get("/")
+        template = Template("{% load wagtailadmin_tags %}{% component obj %}")
+        return template.render(Context({"request": request, "obj": obj}))
+
+    def test_table_render(self):
+        table = Table(
+            [
+                Column("title"),
+                RelatedObjectsColumn("sites_rooted_here"),
+            ],
+            Page.objects.all(),
+        )
+
+        html = self.render_component(table)
+        self.assertHTMLEqual(
+            html,
+            """
+            <table class="listing">
+                <thead>
+                    <tr><th>Title</th><th>Sites rooted here</th></tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Root</td>
+                        <td></td>
+                    </tr>
+                    <tr>
+                        <td>Welcome to your new Wagtail site!</td>
+                        <td><ul><li>localhost [default]</li></ul></td>
+                    </tr>
                 </tbody>
             </table>
         """,

--- a/wagtail/admin/ui/tables/__init__.py
+++ b/wagtail/admin/ui/tables/__init__.py
@@ -393,6 +393,15 @@ class DownloadColumn(Column):
         return context
 
 
+class RelatedObjectsColumn(Column):
+    """Outputs a list of objects related to the object through a one-to-many relationship"""
+
+    cell_template_name = "wagtailadmin/tables/related_objects_cell.html"
+
+    def get_value(self, instance):
+        return getattr(instance, self.accessor).all()
+
+
 class Table(Component):
     template_name = "wagtailadmin/tables/table.html"
     classname = "listing"


### PR DESCRIPTION
Extend the table UI framework with a new Column subclass RelatedObjectsColumn, which outputs a list of objects related to the object through a one-to-many relationship. No specific use-case for this within Wagtail yet - someone on the Slack was asking how to achieve this, and it occurred to me that this might be a useful thing for Wagtail to provide as standard...

Tested with the following (added to bakerydemo's base/wagtail_hooks.py):

```python
from wagtail.contrib.search_promotions.models import Query
from wagtail.admin.ui.tables import Column, RelatedObjectsColumn


class SearchPromotionViewSet(SnippetViewSet):
    model = Query
    menu_label = "Search Promotions"
    menu_icon = "search"
    menu_order = 400
    list_display = [
        Column("query_string"),
        RelatedObjectsColumn("editors_picks"),
    ]

register_snippet(SearchPromotionViewSet)
```

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
