### PR TITLE
Add YouTube Live url to oembed provider 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,7 +8,7 @@ Changelog
  * Mark calls to `md5` as not being used for secure purposes, to avoid flagging on FIPS-mode systems (Sean Kelly)
  * Return filters from `parse_query_string` as a `QueryDict` to support multiple values (Aman Pandey)
  * Explicitly specify `MenuItem.name` for all admin menu and submenu items (Justin Koestinger)
- * Add Embed URL provider support YouTube Shorts (valnuro)
+ * Add oEmbed provider patterns for YouTube Shorts Shorts and YouTube Live URLs (valnuro, Fabien Le Frapper)
  * Add initial implementation of `PagePermissionPolicy` (Sage Abdullah)
  * Refactor `UserPagePermissionsProxy` and `PagePermissionTester` to use `PagePermissionPolicy` (Sage Abdullah)
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -20,7 +20,7 @@ FieldPanels can now be marked as read-only with the `read_only=True` keyword arg
  * Mark calls to `md5` as not being used for secure purposes, to avoid flagging on FIPS-mode systems (Sean Kelly)
  * Return filters from `parse_query_string` as a `QueryDict` to support multiple values (Aman Pandey)
  * Explicitly specify `MenuItem.name` for all admin menu and submenu items (Justin Koestinger)
- * Add Embed URL provider support YouTube Shorts (e.g. [https://www.youtube.com/shorts/nX84KctJtG0](https://www.youtube.com/shorts/nX84KctJtG0)) (valnuro)
+ * Add oEmbed provider patterns for YouTube Shorts (e.g. [https://www.youtube.com/shorts/nX84KctJtG0](https://www.youtube.com/shorts/nX84KctJtG0)) and YouTube Live URLs (valnuro, Fabien Le Frapper)
  * Add initial implementation of `PagePermissionPolicy` (Sage Abdullah)
  * Refactor `UserPagePermissionsProxy` and `PagePermissionTester` to use `PagePermissionPolicy` (Sage Abdullah)
 

--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -682,6 +682,7 @@ youtube = {
         r"^https?://(?:[-\w]+\.)?youtube\.com/view_play_list.+$",
         r"^https?://(?:[-\w]+\.)?youtube\.com/playlist.+$",
         r"^https?://(?:[-\w]+\.)?youtube\.com/shorts/.+$",
+        r"^https?://(?:[-\w]+\.)?youtube\.com/live/.+$",
     ],
 }
 


### PR DESCRIPTION
Very similar to : https://github.com/wagtail/wagtail/pull/10561 

It adds support for live YouTube video to the oembed provider.  
Example of a valid call to oembed url that does not work at the moment : https://www.youtube.com/oembed?url=https://youtube.com/live/A_wgJHSbQ50



_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
