### PR TITLE
Use custom dark theme colors for revision comparisons. Fix #10552

### DIFF
--- a/client/scss/layouts/_compare-revisions.scss
+++ b/client/scss/layouts/_compare-revisions.scss
@@ -1,9 +1,21 @@
-$color-addition-dark: #a6f3a6;
-$color-addition-light: #ebffeb;
-$color-deletion-dark: #f8cbcb;
-$color-deletion-light: #ffebeb;
+$color-addition-dark: var(--color-addition-dark);
+$color-addition-light: var(--color-addition-light);
+$color-deletion-dark: var(--color-deletion-dark);
+$color-deletion-light: var(--color-deletion-light);
 
 .comparison {
+  --color-addition-dark: #a6f3a6;
+  --color-addition-light: #ebffeb;
+  --color-deletion-dark: #f8cbcb;
+  --color-deletion-light: #ffebeb;
+
+  @include dark-theme() {
+    --color-addition-dark: #033a16;
+    --color-addition-light: #045720;
+    --color-deletion-dark: #67060c;
+    --color-deletion-light: #8e070f;
+  }
+
   &__child-object {
     border-top: 1px dashed theme('colors.border-furniture');
     padding: 1em;

--- a/client/scss/tools/_mixins.general.scss
+++ b/client/scss/tools/_mixins.general.scss
@@ -112,3 +112,18 @@
 @mixin show-focus-outline-inside {
   outline-offset: -1 * $focus-outline-width;
 }
+
+/**
+ * Apply styles for the dark theme only.
+ */
+@mixin dark-theme() {
+  .w-theme-dark & {
+    @content;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .w-theme-system & {
+      @content;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #10552, by introducing new revision comparison colors specifically for the dark theme. Replaces #10555.

Screenshot in the two themes (left: light as-is, right: proposed dark theme colors).

![comparing-revisions-dark-mode](https://github.com/wagtail/wagtail/assets/877585/c3317bc1-83ef-4e67-be7f-45c5c2ab901e)

Discussed with @benenright – those colors are more of a short-term workaround than anything, as both the light and proposed dark theme colors don’t have enough contrast against the page background, as well as us needing a way to show insertion/deletion with something else than color.

Full [contrast matrix](https://contrast-grid.eightshapes.com/?version=1.1.0&background-colors=%23a6f3a6%2Caddition-dark%20(light%20theme)%0D%0A%23ebffeb%2Caddition-light%20(light%20theme)%0D%0A%23f8cbcb%2Cdeletion-dark%20(light%20theme)%0D%0A%23ffebeb%2Cdeletion-light%20(light%20theme)%0D%0A%23033a16%2Caddition-dark%20(dark%20theme)%0D%0A%23045720%2Caddition-light%20(dark%20theme)%0D%0A%2367060c%2Cdeletion-dark%20(dark%20theme)%0D%0A%238e070f%2Cdeletion-light%20(dark%20theme)&foreground-colors=%23FFFFFF%2C%20White%20(light%20theme%20bg)%0D%0A%23262626%2C%20grey-600%20(light%20theme%20text%2C%20dark%20theme%20bg)%0D%0A%23F6F6F8%2C%20grey-50%20(dark%20theme%20text)&es-color-form__tile-size=compact&es-color-form__show-contrast=aaa&es-color-form__show-contrast=aa&es-color-form__show-contrast=aa18&es-color-form__show-contrast=dnp) – the first set of 4 needs a 3:1 against white (currently all DNP). And the last set of 4 needs a 3:1 against grey-600 (currently DNP).

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 114, Safari 16.3
    -   [x] **Please list which assistive technologies [^3] you tested**: None
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

I’d recommend going to the revision comparison view for a bakerydemo RecipePage, after having removed one ListBlock RichTextBlock, added one, and changed the text of one of the RichTextBlock.