### PR TITLE
Add generic `ModelPermissionTester` based on `PagePermissionTester`

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/home/user_objects_in_workflow_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/user_objects_in_workflow_moderation.html
@@ -17,15 +17,11 @@
             <tbody>
                 {% for workflow_state in workflow_states %}
                     {% with obj=workflow_state.content_object %}
-                        {% is_page obj as is_page %}
-                        {% if is_page %}
-                            {% page_permissions obj as page_perms %}
-                        {% endif %}
                         <tr>
                             <td class="title" valign="top">
                                 <div class="title-wrapper">
                                     {% admin_edit_url obj as edit_url %}
-                                    {% if page_perms.can_edit or not is_page and edit_url %}
+                                    {% if edit_url %}
                                         <a href="{{ edit_url }}" title="{% trans 'Edit' %}">{% latest_str obj %}</a>
                                     {% else %}
                                         {% latest_str obj %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -17,15 +17,11 @@
             <tbody>
                 {% for state in states %}
                     {% with revision=state.task_state.revision obj=state.obj task_state=state.task_state actions=state.actions workflow_tasks=state.workflow_tasks %}
-                        {% is_page obj as is_page %}
-                        {% if is_page %}
-                            {% page_permissions obj as page_perms %}
-                        {% endif %}
                         <tr>
                             <td class="title" valign="top">
                                 <div class="title-wrapper">
                                     {% admin_edit_url obj as edit_url %}
-                                    {% if page_perms.can_edit or not is_page and edit_url %}
+                                    {% if edit_url %}
                                         <a href="{{ edit_url }}" title="{% trans 'Edit' %}">{% latest_str obj %}</a>
                                     {% else %}
                                         {% latest_str obj %}
@@ -48,7 +44,7 @@
                                                 {% for action_name, action_label, modal in actions %}
                                                     <button data-workflow-action-url="{% url state.workflow_action_url_name obj.pk|admin_urlquote action_name task_state.id %}" {% if modal %}data-launch-modal{% endif %}>{{ action_label }}</button>
                                                 {% endfor %}
-                                                {% if page_perms.can_edit or not is_page and edit_url %}
+                                                {% if edit_url %}
                                                     <a href="{{ edit_url }}">{% trans 'Edit' %}</a>
                                                 {% endif %}
                                                 {% if obj.is_previewable %}

--- a/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
@@ -4,15 +4,12 @@
     Choose when this {{ model_name }} should go live and/or expire
 {% endblocktrans%}
 
-{% if page %}
-    {% page_permissions instance as page_perms %}
-    {% trans 'Choose when this page should go live and/or expire' as schedule_publishing_dialog_subtitle %}
-    {% if page_perms.can_publish %}
-        {% trans 'This publishing schedule will only take effect after you select the "Publish" option' as message_heading %}
-    {% else %}
-        {% trans "Anyone with editing permissions can create schedules" as message_heading %}
-        {% trans "But only those with publishing permissions can make them effective." as message_description %}
-    {% endif %}
+{% permissions_tester instance as permissions %}
+{% if permissions.can_publish %}
+    {% trans 'This publishing schedule will only take effect after you select the "Publish" option' as message_heading %}
+{% else %}
+    {% trans "Anyone with editing permissions can create schedules" as message_heading %}
+    {% trans "But only those with publishing permissions can make them effective." as message_description %}
 {% endif %}
 
 {% dialog id='schedule-publishing-dialog' dialog_root_selector='[data-edit-form]' classname=classname icon_name='calendar-alt' title=_("Set publishing schedule") subtitle=schedule_publishing_dialog_subtitle|capfirst message_icon_name='info' message_status='info' message_heading=message_heading message_description=message_description %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -54,6 +54,7 @@ from wagtail.coreutils import cautious_slugify as _cautious_slugify
 from wagtail.models import (
     CollectionViewRestriction,
     Locale,
+    ModelPermissionTester,
     Page,
     PageViewRestriction,
 )
@@ -158,13 +159,26 @@ def widgettype(bound_field):
 
 
 @register.simple_tag(takes_context=True)
+def permissions_tester(context, object):
+    """
+    Usage: {% permissions_tester object as permissions %}
+    Sets the variable 'permissions' to a ModelPermissionTester/PagePermissionTester
+    object that can be queried to find out what actions the current logged-in user
+    can perform on the given object.
+    """
+    if isinstance(object, Page):
+        return object.permissions_for_user(context["request"].user)
+    return ModelPermissionTester(context["request"].user, object)
+
+
+@register.simple_tag(takes_context=True)
 def page_permissions(context, page):
     """
     Usage: {% page_permissions page as page_perms %}
     Sets the variable 'page_perms' to a PagePermissionTester object that can be queried to find out
     what actions the current logged-in user can perform on the given page.
     """
-    return page.permissions_for_user(context["request"].user)
+    return permissions_tester(context, page)
 
 
 @register.simple_tag

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -3290,22 +3290,14 @@ class PagePermissionTester(ModelPermissionTester):
             return False
 
     def can_unpublish(self):
-        if not self.user.is_active:
-            return False
-        if (not self.object.live) or self.page_is_root:
-            return False
-        if self.page_locked():
-            return False
-
-        return self.user.is_superuser or ("publish" in self.actions)
-
-    def can_publish(self):
-        if not self.user.is_active:
-            return False
         if self.page_is_root:
             return False
+        return super().can_unpublish()
 
-        return self.user.is_superuser or ("publish" in self.actions)
+    def can_publish(self):
+        if self.page_is_root:
+            return False
+        return super().can_publish()
 
     def can_set_view_restrictions(self):
         return self.can_publish()


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Our recent discoveries seem to suggest that we won't get rid of `PagePermissionTester`. If that's the case, it's likely that we want to use the same approach for non-page models.

This PR adds a generic `ModelPermissionTester` that works like `PagePermissionTester`, which does permission checks that also take into account the current circumstances of the object (e.g. workflows, lock state, etc.) and not just the `Permission`s.

Marking as draft since I'm still not convinced of the approach. A few thoughts:

- Page views do not use permission policies (at least not directly) to guard the view. Instead, it relies on `PagePermissionTester`, which now in turn relies on `PagePermissionPolicy`. `PagePermissionTester` is used for permission checks both at the beginning of a view (e.g. `raise PermissionDenied` at the start of `dispatch()` if the permissions do not satisfy) and for "action"-specific checks for the object, e.g. whether the user can lock, unschedule, etc. which may or may not map directly to a `Permission`.
- For snippets (and non-page models in general), the permission checks are done using `ModelPermissionPolicy` via `PermissionCheckedMixin`. This combo basically only checks whether the user has the specified permission codename for the model, without taking into account the object's circumstances.
- To allow for more-informed permission checks based on the object, I refactored `PermissionCheckedMixin` to have separate `user_has_permission()` method in 0f0ecb4938b825a552209676c40af5c5fae4aef9. Then, it is overridden in `CreateEditViewOptionalFeaturesMixin` to allow similar logic from `PagePermissionTester` to short-circuit/build upon the checks done by the permission policy: https://github.com/wagtail/wagtail/blob/61f0f4d362b49ccb87a51fc79c7d896bb1086577/wagtail/admin/views/generic/mixins.py#L269-L304
- If we were to add this generic `ModelPermissionTester`, where and how does it fit into `PermissionCheckedMixin` (or any other view class)? Also, note that `PermissionCheckedMixin` rely on strings that map directly to the `Permission`'s action part of the codename (e.g. `permission_required = "change"`, while `{Foo}PermissionTester` relies on the method names, e.g. `can_edit()`.
- As a follow-up, I feel like the bigger question is, where does the `{Foo}PermissionTester` fit in the grand scheme of things, now that we have permission policies for all Wagtail-managed models? Is `PermissionTester` really the name we want to call this kind of classes?
  - I'm thinking it should live somewhere close to the permission policy. Maybe as a child class within the permission policy, e.g. maybe you could do like
    ```py
    class PagePermissionPolicy(OwnershipPermissionPolicy):
        tester_class = PagePermissionTester

        def user_tester_for_instance(self, user, instance)
            tester = self.tester_class(user, instance)
            # or change the tester's constructor signature to accept a permission policy too
            tester.permission_policy = self
            return tester
    ```
- The `{Foo}PermissionTester` currently accept the user and the object instance in the `__init__`. I encountered a problem with the "create" view, where `self.object` is `None`, so the permission tester can't work properly.
  - For pages, what happens is usually a `PagePermissionTester` instance is created using the parent page, and then a method like `tester.can_add_subpage()` is used.
  - For snippets, the correct logic would be to fall back to just check based on the model and permissions, but this isn't possible as the tester doesn't have access to the model (if you pass `None` as the object).
  - The above idea of encapsulating the tester within the policy would allow the tester to access the model via `self.permission_policy.model` (or the policy can also supply it during instantiation). This can be used for fallback logic when the object is `None`.
  - That said, allowing `{Foo}PermissionTester` to work with `None` as the object seems like an anti-pattern. Perhaps the view should decide to use the plain policy when `self.object` is `None`, and use the tester when the `self.object` is available? But this means that the object needs to be fetched first... maybe just separate the logic/check based on what the view is (create vs. edit)?
- `Page` has a `permissions_for_user()` method that returns the `PagePermissionTester` object for the page and user, which is convenient. We can't do the same for non-page models (unless we patch the method to the model, which seems hacky). Using `ModelPermissionTester(user, object)` works though, and I'd say it isn't so bad.







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
