### PR TITLE
fix empty blocks created in migration operations

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@ Changelog
  * Fix: Use constant-time comparison for image serve URL signatures (Jake Howard)
  * Fix: Ensure taggit field type-ahead options show correctly in the dark mode theme (Sage Abdullah)
  * Fix: Fix the lock description message missing the model_name variable when locked only by system (Sébastien Corbin)
+ * Fix: Fix empty blocks created in migration operations (Sandil Ranasinghe)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -59,6 +59,7 @@ Thank you to Damilola for his work, and to Google for sponsoring this project.
  * Use constant-time comparison for image serve URL signatures (Jake Howard)
  * Ensure taggit field type-ahead options show correctly in the dark mode theme (Sage Abdullah)
  * Fix the lock description message missing the model_name variable when locked only by system (Sébastien Corbin)
+ * Fix empty blocks created in migration operations (Sandil Ranasinghe)
 
 ### Documentation
 

--- a/wagtail/blocks/migrations/operations.py
+++ b/wagtail/blocks/migrations/operations.py
@@ -164,8 +164,11 @@ class StreamChildrenToListBlockOperation(BaseBlockOperation):
                 mapped_block_value.append(child_block)
 
         self.map_temp_blocks_to_list_items()
-        new_list_block = {"type": self.list_block_name, "value": self.temp_blocks}
-        mapped_block_value.append(new_list_block)
+
+        if self.temp_blocks:
+            new_list_block = {"type": self.list_block_name, "value": self.temp_blocks}
+            mapped_block_value.append(new_list_block)
+
         return mapped_block_value
 
     def map_temp_blocks_to_list_items(self):
@@ -206,8 +209,10 @@ class StreamChildrenToStreamBlockOperation(BaseBlockOperation):
             else:
                 mapped_block_value.append(child_block)
 
-        new_stream_block = {"type": self.stream_block_name, "value": stream_value}
-        mapped_block_value.append(new_stream_block)
+        if stream_value:
+            new_stream_block = {"type": self.stream_block_name, "value": stream_value}
+            mapped_block_value.append(new_stream_block)
+
         return mapped_block_value
 
     @property

--- a/wagtail/tests/streamfield_migrations/test_simple_structures.py
+++ b/wagtail/tests/streamfield_migrations/test_simple_structures.py
@@ -107,6 +107,27 @@ class FieldChildBlockTest(TestCase):
             altered_raw_data[2]["value"][1]["value"], self.raw_data[2]["value"]
         )
 
+    def test_combine_to_listblock_no_existing_children(self):
+        """Combine all `simplestruct` blocks into a new ListBlock named `list1`
+        We have no `simplestruct` blocks in our existing data, so there should be no list1 blocks
+        created and the data should be intact.
+        """
+
+        altered_raw_data = apply_changes_to_raw_data(
+            raw_data=self.raw_data,
+            block_path_str="",
+            operation=StreamChildrenToListBlockOperation(
+                block_name="simplestruct", list_block_name="list1"
+            ),
+            streamfield=models.SampleModel.content,
+        )
+
+        self.assertEqual(len(altered_raw_data), 4)
+        self.assertEqual(altered_raw_data[0], self.raw_data[0])
+        self.assertEqual(altered_raw_data[1], self.raw_data[1])
+        self.assertEqual(altered_raw_data[2], self.raw_data[2])
+        self.assertEqual(altered_raw_data[3], self.raw_data[3])
+
     def test_combine_single_type_to_streamblock(self):
         """Combine all `char1` blocks as children of a new StreamBlock named `stream1`
 
@@ -165,6 +186,27 @@ class FieldChildBlockTest(TestCase):
         self.assertEqual(altered_raw_data[0]["value"][1], self.raw_data[1])
         self.assertEqual(altered_raw_data[0]["value"][2], self.raw_data[2])
         self.assertEqual(altered_raw_data[0]["value"][3], self.raw_data[3])
+
+    def test_combine_to_streamblock_no_existing_children(self):
+        """Combine all `simplestruct` blocks as children of a new StreamBlock named `stream1`
+        We have no `simplestruct` blocks in our existing data, so there should be no stream1 blocks
+        created and the data should be intact.
+        """
+
+        altered_raw_data = apply_changes_to_raw_data(
+            raw_data=self.raw_data,
+            block_path_str="",
+            operation=StreamChildrenToStreamBlockOperation(
+                block_names=["simplestruct"], stream_block_name="stream1"
+            ),
+            streamfield=models.SampleModel.content,
+        )
+
+        self.assertEqual(len(altered_raw_data), 4)
+        self.assertEqual(altered_raw_data[0], self.raw_data[0])
+        self.assertEqual(altered_raw_data[1], self.raw_data[1])
+        self.assertEqual(altered_raw_data[2], self.raw_data[2])
+        self.assertEqual(altered_raw_data[3], self.raw_data[3])
 
     def test_to_structblock(self):
         """Move each `char1` block inside a new StructBlock named `struct1`


### PR DESCRIPTION
Bug fix for streamfield migrations - fix empty blocks being created in some combining migration operations when some of the data doesn't have any of the block types which are to be combined into the new structural block.

- StreamChildrenToListBlockOperation
- StreamChildrenToStreamBlockOperation

Added a test for each corresponding operation