### PR TITLE
Use `constant_time_compare` to verify image signatures

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changelog
  * Fix: Use `gettext_lazy` on generic model views so that language settings are correctly used (Matt Westcott)
  * Fix: Prevent JS error when reverting the spinner on a submit button after a validation error (LB (Ben) Johnston)
  * Fix: Prevent crash when comparing page revisions that include `MultipleChooserPanel` (Matt Westcott)
+ * Fix: Use constant-time comparison for image serve URL signatures (Jake Howard)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)

--- a/wagtail/images/utils.py
+++ b/wagtail/images/utils.py
@@ -3,6 +3,7 @@ import hashlib
 import hmac
 
 from django.conf import settings
+from django.utils.crypto import constant_time_compare
 from django.utils.encoding import force_str
 
 
@@ -94,7 +95,9 @@ def generate_signature(image_id, filter_spec, key=None):
 
 
 def verify_signature(signature, image_id, filter_spec, key=None):
-    return force_str(signature) == generate_signature(image_id, filter_spec, key=key)
+    return constant_time_compare(
+        signature, generate_signature(image_id, filter_spec, key=key)
+    )
 
 
 def find_image_duplicates(image, user, permission_policy):


### PR DESCRIPTION
Fixes #6127

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

Use a timing-safe comparison for image signatures. Image signatures are related to their filter spec, so crafting malicious signatures could allow users to create very large image renditions, which could cause lots of different issues.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
