### PR TITLE
Fix description when locked by system

### DIFF
--- a/wagtail/locks.py
+++ b/wagtail/locks.py
@@ -53,7 +53,10 @@ class BaseLock:
         """
         Returns a description of the lock to display to the given user.
         """
-        return capfirst(_("No one can make changes while the %(model_name)s is locked"))
+        return capfirst(
+            _("No one can make changes while the %(model_name)s is locked")
+            % {"model_name": self.model_name}
+        )
 
     def get_context_for_user(self, user, parent_context=None):
         """


### PR DESCRIPTION
Fix the lock description when lock is set only by system (i.e. `locked = True` in the model's code)

![Screenshot from 2023-06-23 10-43-28](https://github.com/wagtail/wagtail/assets/645207/3c7b184e-b3f3-44d8-b58d-dac72c057e98)


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
