### PR TITLE
Improve visibility of scheduled publishing errors in status side panel 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -51,6 +51,7 @@ Changelog
  * Fix: Add missing Time Zone conversions and date formatting throughout the admin (Stefan Hammer)
  * Fix: Ensure that audit logs and revisions are consistently use UTC and add migration for existing entries (Stefan Hammer)
  * Fix: Make sure "critical" buttons have enough color contrast in dark mode (Albina Starykova)
+ * Fix: Improve visibility of scheduled publishing errors in status side panel (Sage Abdullah)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)

--- a/client/scss/components/forms/_publishing.scss
+++ b/client/scss/components/forms/_publishing.scss
@@ -1,10 +1,5 @@
 // Styles for the fields in the scheduled publishing dialog
 .w-dialog.publishing {
-  .w-panel__wrapper {
-    margin-top: theme('spacing.2');
-    margin-bottom: theme('spacing.2');
-  }
-
   .w-field--date_time_field input {
     width: 100%;
   }

--- a/client/src/entrypoints/admin/comments.js
+++ b/client/src/entrypoints/admin/comments.js
@@ -312,15 +312,9 @@ window.comments = (() => {
     });
 
     // Keep number of comments up to date with comment app
-    const commentToggle = document.querySelector(
-      '[data-side-panel-toggle="comments"]',
+    const commentCounter = document.querySelector(
+      '[data-side-panel-toggle="comments"] [data-side-panel-toggle-counter]',
     );
-
-    const commentCounter = document.createElement('div');
-    commentCounter.className =
-      '-w-mr-3 w-py-0.5 w-px-[0.325rem] w-translate-y-[-8px] rtl:w-translate-x-[4px] w-translate-x-[-4px] w-text-[0.5625rem] w-font-bold w-bg-surface-button-default w-text-text-button w-border w-border-surface-page w-rounded-[1rem]';
-
-    commentToggle.appendChild(commentCounter);
 
     const updateCommentCount = () => {
       const commentCount = commentApp.selectors.selectCommentCount(
@@ -334,6 +328,7 @@ window.comments = (() => {
 
       if (commentCount > 0) {
         commentCounter.innerText = commentCount.toString();
+        commentCounter.hidden = false;
       } else {
         // Note: Hide the circle when its content is empty
         commentCounter.hidden = true;

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -97,6 +97,7 @@ As part of tackling Wagtail’s technical debt and improving [CSP compatibility]
  * Add missing Time Zone conversions and date formatting throughout the admin (Stefan Hammer)
  * Ensure that audit logs and revisions are consistently use UTC and add migration for existing entries (Stefan Hammer)
  * Make sure "critical" buttons have enough color contrast in dark mode (Albina Starykova)
+ * Improve visibility of scheduled publishing errors in status side panel (Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/panels/publishing_panel.py
+++ b/wagtail/admin/panels/publishing_panel.py
@@ -46,6 +46,7 @@ class PublishingPanel(MultiFieldPanel):
             context["request"] = self.request
             context["instance"] = self.instance
             context["classname"] = self.classname
+            context["model_opts"] = self.instance._meta
             if isinstance(self.instance, Page):
                 context["page"] = self.instance
             return context

--- a/wagtail/admin/panels/publishing_panel.py
+++ b/wagtail/admin/panels/publishing_panel.py
@@ -5,7 +5,7 @@ from wagtail.admin.widgets.datetime import AdminDateTimeInput
 from wagtail.models import Page
 
 from .field_panel import FieldPanel
-from .group import FieldRowPanel, MultiFieldPanel
+from .group import MultiFieldPanel
 
 
 # This allows users to include the publishing panel in their own per-model override
@@ -16,21 +16,17 @@ class PublishingPanel(MultiFieldPanel):
         js_overlay_parent_selector = "#schedule-publishing-dialog"
         updated_kwargs = {
             "children": [
-                FieldRowPanel(
-                    [
-                        FieldPanel(
-                            "go_live_at",
-                            widget=AdminDateTimeInput(
-                                js_overlay_parent_selector=js_overlay_parent_selector,
-                            ),
-                        ),
-                        FieldPanel(
-                            "expire_at",
-                            widget=AdminDateTimeInput(
-                                js_overlay_parent_selector=js_overlay_parent_selector,
-                            ),
-                        ),
-                    ],
+                FieldPanel(
+                    "go_live_at",
+                    widget=AdminDateTimeInput(
+                        js_overlay_parent_selector=js_overlay_parent_selector,
+                    ),
+                ),
+                FieldPanel(
+                    "expire_at",
+                    widget=AdminDateTimeInput(
+                        js_overlay_parent_selector=js_overlay_parent_selector,
+                    ),
                 ),
             ],
             "classname": "publishing",

--- a/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
@@ -6,7 +6,7 @@
 {% if page %}
     {% page_permissions instance as page_perms %}
     {% if page_perms.can_publish %}
-        {% trans "This publishing schedule will only take effect after you have published" as message_heading %}
+        {% trans 'This publishing schedule will only take effect after you select the "Publish" option' as message_heading %}
     {% else %}
         {% trans "Anyone with editing permissions can create schedules" as message_heading %}
         {% trans "But only those with publishing permissions can make them effective." as message_description %}

--- a/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
@@ -1,10 +1,13 @@
 {% load i18n wagtailadmin_tags %}
 
 {% trans 'Set publishing schedule' as schedule_publishing_dialog_title %}
-{% trans 'Choose when this page should go live and/or expire' as schedule_publishing_dialog_subtitle %}
+{% blocktrans trimmed with model_name=model_opts.verbose_name asvar schedule_publishing_dialog_subtitle %}
+    Choose when this {{ model_name }} should go live and/or expire
+{% endblocktrans%}
 
 {% if page %}
     {% page_permissions instance as page_perms %}
+    {% trans 'Choose when this page should go live and/or expire' as schedule_publishing_dialog_subtitle %}
     {% if page_perms.can_publish %}
         {% trans 'This publishing schedule will only take effect after you select the "Publish" option' as message_heading %}
     {% else %}
@@ -13,7 +16,7 @@
     {% endif %}
 {% endif %}
 
-{% dialog id='schedule-publishing-dialog' dialog_root_selector='[data-edit-form]' classname=classname icon_name='calendar-alt' title=schedule_publishing_dialog_title subtitle=schedule_publishing_dialog_subtitle message_icon_name='info' message_status='info' message_heading=message_heading message_description=message_description %}
+{% dialog id='schedule-publishing-dialog' dialog_root_selector='[data-edit-form]' classname=classname icon_name='calendar-alt' title=schedule_publishing_dialog_title subtitle=schedule_publishing_dialog_subtitle|capfirst message_icon_name='info' message_status='info' message_heading=message_heading message_description=message_description %}
     {% include 'wagtailadmin/panels/multi_field_panel.html' %}
 
     <button

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -1,6 +1,7 @@
 {% load wagtailadmin_tags i18n %}
 {% fragment as nav_icon_classes %}w-w-4 w-h-4 group-hover:w-transform group-hover:w-scale-110{% endfragment %}
-{% fragment as nav_icon_button_classes %}w-w-slim-header w-h-slim-header w-bg-transparent w-border-transparent w-box-border w-py-3 w-px-3 w-flex w-justify-center w-items-center w-outline-offset-inside w-text-text-meta w-transition w-group hover:w-text-text-label focus:w-text-text-label expanded:w-text-text-label expanded:w-border-y-2 expanded:w-border-b-current{% endfragment %}
+{% fragment as nav_icon_button_classes %}w-w-slim-header w-h-slim-header w-bg-transparent w-border-transparent w-box-border w-py-3 w-px-3 w-flex w-justify-center w-items-center w-outline-offset-inside w-text-text-meta w-transition w-group hover:w-text-text-label focus:w-text-text-label expanded:w-text-text-label expanded:w-border-y-2 expanded:w-border-b-current w-shrink-0{% endfragment %}
+{% fragment as nav_icon_counter_classes %}-w-mr-3 w-py-0.5 w-px-[0.325rem] w-translate-y-[-8px] rtl:w-translate-x-[4px] w-translate-x-[-4px] w-text-[0.5625rem] w-font-bold w-text-text-button w-border w-border-surface-page w-rounded-[1rem]{% endfragment %}
 {# Z index 99 to ensure header is always above  #}
 <header class="w-slim-header w-flex w-flex-col sm:w-flex-row w-items-center w-justify-between w-bg-surface-header w-border-b w-border-border-furniture w-px-0 w-py-0 w-mb-0 w-relative w-top-0 w-z-header sm:w-sticky w-min-h-slim-header">
 

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panel_toggle.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panel_toggle.html
@@ -1,0 +1,13 @@
+{% load wagtailadmin_tags %}
+
+<button type="button"
+    class="{{ nav_icon_button_classes }}"
+    aria-label="{{ toggle.aria_label }}"
+    data-tippy-content="{{ panel.title }}"
+    data-tippy-offset="[0,0]"
+    data-tippy-placement="bottom"
+    data-side-panel-toggle="{{ panel.name }}"
+    aria-expanded="false"
+>
+    {% icon name=toggle.icon_name classname=nav_icon_classes %}
+</button>

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panel_toggle.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panel_toggle.html
@@ -10,4 +10,9 @@
     aria-expanded="false"
 >
     {% icon name=toggle.icon_name classname=nav_icon_classes %}
+    {% if toggle.has_counter %}
+        <div data-side-panel-toggle-counter class="{{ nav_icon_counter_classes }} {{ toggle.counter_classname|default:'w-bg-surface-button-default'}}" {% if not count %}hidden{% endif %}>
+            {{ count }}
+        </div>
+    {% endif %}
 </button>

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panel_toggles.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panel_toggles.html
@@ -1,15 +1,5 @@
 {% load wagtailadmin_tags %}
 
 {% for panel in side_panels %}
-    <button type="button"
-        class="{{ nav_icon_button_classes }}"
-        aria-label="{{ panel.toggle_aria_label }}"
-        data-tippy-content="{{ panel.title }}"
-        data-tippy-offset="[0,0]"
-        data-tippy-placement="bottom"
-        data-side-panel-toggle="{{ panel.name }}"
-        aria-expanded="false"
-    >
-        {% icon name=panel.toggle_icon_name classname=nav_icon_classes %}
-    </button>
+    {% component panel.toggle %}
 {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/workflow.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/workflow.html
@@ -132,28 +132,34 @@
         {% endif %}
 
         {# Scheduled publishing #}
-        {% if has_draft_publishing_schedule %}
-            <div class="w-p-4 w-bg-info-50 w-rounded w-flex w-space-x-3">
-                {% if scheduled_go_live_at or scheduled_expire_at %}
+        {% if has_draft_publishing_schedule or schedule_has_errors %}
+            <div class="w-p-4 w-rounded w-flex w-space-x-3 {% if schedule_has_errors %}w-bg-critical-50{% else %}w-bg-info-50{% endif %}">
+                {% if schedule_has_errors %}
+                    {% icon name='warning' classname='w-w-4 w-h-4 w-text-critical-100' %}
+                {% elif scheduled_go_live_at or scheduled_expire_at %}
                     {% icon name='calendar-check' classname='w-w-4 w-h-4 w-text-info-100' %}
                 {% else %}
                     {% icon name='calendar' classname='w-w-4 w-h-4 w-text-info-100' %}
                 {% endif %}
                 <div class="w-flex w-flex-1 w-items-start w-justify-between">
                     <div class="w-flex w-flex-col w-flex-1 w-pr-5 w-space-y-1 w-help-text w-text-grey-400">
-                        {% if scheduled_go_live_at %}
-                            <div><span class="w-text-grey-600">{% trans 'Go-live:' %}</span> {{ scheduled_go_live_at }}</div>
-                        {% endif %}
-                        {% if scheduled_expire_at %}
-                            <div><span class="w-text-grey-600">{% trans 'Expiry:' %}</span> {{ scheduled_expire_at }}</div>
-                        {% endif %}
-                        {% if draft_go_live_at or draft_expire_at %}
-                            <div class="w-label-3 w-text-grey-600">{% trans 'Once published:' %}</div>
-                            {% if draft_go_live_at %}
-                                <div><span class="w-text-grey-600">{% trans 'Go-live:' %}</span> {{ draft_go_live_at }}</div>
+                        {% if schedule_has_errors %}
+                            <div class="w-label-3 w-text-primary">{% trans 'Invalid schedule' %}</div>
+                        {% else %}
+                            {% if scheduled_go_live_at %}
+                                <div><span class="w-text-grey-600">{% trans 'Go-live:' %}</span> {{ scheduled_go_live_at }}</div>
                             {% endif %}
-                            {% if draft_expire_at %}
-                                <div><span class="w-text-grey-600">{% trans 'Expiry:' %}</span> {{ draft_expire_at }}</div>
+                            {% if scheduled_expire_at %}
+                                <div><span class="w-text-grey-600">{% trans 'Expiry:' %}</span> {{ scheduled_expire_at }}</div>
+                            {% endif %}
+                            {% if draft_go_live_at or draft_expire_at %}
+                                <div class="w-label-3 w-text-primary">{% trans 'Once published:' %}</div>
+                                {% if draft_go_live_at %}
+                                    <div><span class="w-text-grey-600">{% trans 'Go-live:' %}</span> {{ draft_go_live_at }}</div>
+                                {% endif %}
+                                {% if draft_expire_at %}
+                                    <div><span class="w-text-grey-600">{% trans 'Expiry:' %}</span> {{ draft_expire_at }}</div>
+                                {% endif %}
                             {% endif %}
                         {% endif %}
                     </div>

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/workflow.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/workflow.html
@@ -39,7 +39,7 @@
                         {% if page %}
                             {% page_permissions object as page_perms %}
                         {% endif %}
-                        <div class="w-p-4 w-bg-info-50 w-rounded w-flex w-space-x-3">
+                        <div class="w-p-4 w-bg-info-50 w-rounded w-flex w-space-x-3 w-border w-border-transparent">
                             {% icon name='calendar-check' classname='w-w-4 w-h-4 w-text-info-100' %}
                             <div class="w-flex w-flex-1 w-items-start w-justify-between">
                                 <div class="w-flex w-flex-col w-flex-1 w-pr-5 w-space-y-1 w-help-text w-text-grey-400">
@@ -50,7 +50,7 @@
                                 </div>
                                 {% if show_schedule_publishing_toggle and not has_draft_publishing_schedule and not lock_context.locked %}
                                     {% trans 'Edit schedule' as edit_schedule_text %}
-                                    {% dialog_toggle classname='w-bg-transparent w-text-14 w-p-0 w-text-secondary hover:w-text-secondary-400 w-inline-flex w-justify-center w-transition' dialog_id="schedule-publishing-dialog" text=edit_schedule_text %}
+                                    {% dialog_toggle classname='w-bg-transparent w-text-14 w-p-0 w-text-secondary-600 hover:w-text-secondary-400 w-inline-flex w-justify-center w-transition' dialog_id="schedule-publishing-dialog" text=edit_schedule_text %}
                                 {% endif %}
                             </div>
                         </div>
@@ -133,7 +133,7 @@
 
         {# Scheduled publishing #}
         {% if has_draft_publishing_schedule or schedule_has_errors %}
-            <div class="w-p-4 w-rounded w-flex w-space-x-3 {% if schedule_has_errors %}w-bg-critical-50{% else %}w-bg-info-50{% endif %}">
+            <div class="w-p-4 w-rounded w-flex w-space-x-3 w-border w-border-transparent {% if schedule_has_errors %}w-bg-critical-50{% else %}w-bg-info-50{% endif %}">
                 {% if schedule_has_errors %}
                     {% icon name='warning' classname='w-w-4 w-h-4 w-text-critical-100' %}
                 {% elif scheduled_go_live_at or scheduled_expire_at %}
@@ -165,7 +165,7 @@
                     </div>
                     {% if show_schedule_publishing_toggle and not lock_context.locked %}
                         {% trans 'Edit schedule' as edit_schedule_text %}
-                        {% dialog_toggle classname='w-bg-transparent w-text-14 w-p-0 w-text-secondary hover:w-text-secondary-400 w-inline-flex w-justify-center w-transition' dialog_id="schedule-publishing-dialog" text=edit_schedule_text %}
+                        {% dialog_toggle classname='w-bg-transparent w-text-14 w-p-0 w-text-secondary-600 hover:w-text-secondary-400 w-inline-flex w-justify-center w-transition' dialog_id="schedule-publishing-dialog" text=edit_schedule_text %}
                     {% endif %}
                 </div>
             </div>

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -32,6 +32,11 @@ from wagtail.test.utils.timestamps import submittable_timestamp
 
 
 class TestPageCreation(WagtailTestUtils, TestCase):
+    STATUS_TOGGLE_BADGE_REGEX = (
+        r'data-side-panel-toggle="status"[^<]+<svg[^<]+<use[^<]+</use[^<]+</svg[^<]+'
+        r"<div data-side-panel-toggle-counter[^>]+w-bg-critical-200[^>]+>\s*%(num_errors)s\s*</div>"
+    )
+
     def setUp(self):
         # Find root page
         self.root_page = Page.objects.get(id=2)
@@ -526,6 +531,20 @@ class TestPageCreation(WagtailTestUtils, TestCase):
             "Go live date/time must be before expiry date/time",
         )
 
+        self.assertContains(
+            response,
+            '<div class="w-label-3 w-text-primary">Invalid schedule</div>',
+            html=True,
+        )
+
+        num_errors = 2
+
+        # Should show the correct number on the badge of the toggle button
+        self.assertRegex(
+            response.content.decode(),
+            self.STATUS_TOGGLE_BADGE_REGEX % {"num_errors": num_errors},
+        )
+
         # form should be marked as having unsaved changes for the purposes of the dirty-forms warning
         self.assertContains(response, "alwaysDirty: true")
 
@@ -551,6 +570,20 @@ class TestPageCreation(WagtailTestUtils, TestCase):
         # Check that a form error was raised
         self.assertFormError(
             response, "form", "expire_at", "Expiry date/time must be in the future"
+        )
+
+        self.assertContains(
+            response,
+            '<div class="w-label-3 w-text-primary">Invalid schedule</div>',
+            html=True,
+        )
+
+        num_errors = 1
+
+        # Should show the correct number on the badge of the toggle button
+        self.assertRegex(
+            response.content.decode(),
+            self.STATUS_TOGGLE_BADGE_REGEX % {"num_errors": num_errors},
         )
 
         # form should be marked as having unsaved changes for the purposes of the dirty-forms warning

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -447,7 +447,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
 
         self.assertContains(
             response,
-            "This publishing schedule will only take effect after you have published",
+            'This publishing schedule will only take effect after you select the "Publish" option',
         )
 
     def test_edit_post_scheduled_custom_timezone(self):
@@ -541,7 +541,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
 
         self.assertContains(
             response,
-            "This publishing schedule will only take effect after you have published",
+            'This publishing schedule will only take effect after you select the "Publish" option',
         )
 
     def test_schedule_panel_without_publish_permission(self):

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -10,10 +10,30 @@ from wagtail.models import DraftStateMixin, LockableMixin, Page, ReferenceIndex
 
 
 class BaseSidePanel(Component):
+    class SidePanelToggle(Component):
+        template_name = "wagtailadmin/shared/side_panel_toggle.html"
+        aria_label = ""
+        icon_name = ""
+
+        def __init__(self, panel):
+            self.panel = panel
+
+        def get_context_data(self, parent_context):
+            # Inherit classes from fragments defined in slim_header.html
+            inherit = {
+                "nav_icon_button_classes",
+                "nav_icon_classes",
+            }
+            context = {key: parent_context.get(key) for key in inherit}
+            context["toggle"] = self
+            context["panel"] = self.panel
+            return context
+
     def __init__(self, object, request):
         self.object = object
         self.request = request
         self.model = type(self.object)
+        self.toggle = self.SidePanelToggle(panel=self)
 
     def get_context_data(self, parent_context):
         context = {"panel": self, "object": self.object, "request": self.request}
@@ -23,12 +43,14 @@ class BaseSidePanel(Component):
 
 
 class BaseStatusSidePanel(BaseSidePanel):
+    class SidePanelToggle(BaseSidePanel.SidePanelToggle):
+        aria_label = gettext_lazy("Toggle status")
+        icon_name = "info-circle"
+
     name = "status"
     title = gettext_lazy("Status")
     template_name = "wagtailadmin/shared/side_panels/status.html"
     order = 100
-    toggle_aria_label = gettext_lazy("Toggle status")
-    toggle_icon_name = "info-circle"
 
     def __init__(
         self,
@@ -270,12 +292,14 @@ class PageStatusSidePanel(BaseStatusSidePanel):
 
 
 class CommentsSidePanel(BaseSidePanel):
+    class SidePanelToggle(BaseSidePanel.SidePanelToggle):
+        aria_label = gettext_lazy("Toggle comments")
+        icon_name = "comment"
+
     name = "comments"
     title = gettext_lazy("Comments")
     template_name = "wagtailadmin/shared/side_panels/comments.html"
     order = 300
-    toggle_aria_label = gettext_lazy("Toggle comments")
-    toggle_icon_name = "comment"
 
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)
@@ -284,12 +308,14 @@ class CommentsSidePanel(BaseSidePanel):
 
 
 class BasePreviewSidePanel(BaseSidePanel):
+    class SidePanelToggle(BaseSidePanel.SidePanelToggle):
+        aria_label = gettext_lazy("Toggle preview")
+        icon_name = "mobile-alt"
+
     name = "preview"
     title = gettext_lazy("Preview")
     template_name = "wagtailadmin/shared/side_panels/preview.html"
     order = 400
-    toggle_aria_label = gettext_lazy("Toggle preview")
-    toggle_icon_name = "mobile-alt"
 
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -14,6 +14,8 @@ class BaseSidePanel(Component):
         template_name = "wagtailadmin/shared/side_panel_toggle.html"
         aria_label = ""
         icon_name = ""
+        has_counter = True
+        counter_classname = ""
 
         def __init__(self, panel):
             self.panel = panel
@@ -23,10 +25,12 @@ class BaseSidePanel(Component):
             inherit = {
                 "nav_icon_button_classes",
                 "nav_icon_classes",
+                "nav_icon_counter_classes",
             }
             context = {key: parent_context.get(key) for key in inherit}
             context["toggle"] = self
             context["panel"] = self.panel
+            context["count"] = 0
             return context
 
     def __init__(self, object, request):
@@ -311,6 +315,7 @@ class BasePreviewSidePanel(BaseSidePanel):
     class SidePanelToggle(BaseSidePanel.SidePanelToggle):
         aria_label = gettext_lazy("Toggle preview")
         icon_name = "mobile-alt"
+        has_counter = False
 
     name = "preview"
     title = gettext_lazy("Preview")

--- a/wagtail/snippets/side_panels.py
+++ b/wagtail/snippets/side_panels.py
@@ -64,7 +64,7 @@ class SnippetSidePanels(BaseSidePanels):
         scheduled_object=None,
     ):
         self.side_panels = []
-        if object.pk or view.locale:
+        if object.pk or view.locale or show_schedule_publishing_toggle:
             self.side_panels += [
                 SnippetStatusSidePanel(
                     object,

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -822,10 +822,23 @@ class TestCreateDraftStateSnippet(WagtailTestUtils, TestCase):
             response,
             '<button\n    type="submit"\n    name="action-publish"\n    value="action-publish"\n    class="button action-save button-longrunning"\n    data-controller="w-progress"\n    data-action="w-progress#activate"\n',
         )
-        # The status side panel should not be shown
-        self.assertNotContains(
+        # The status side panel should be rendered so that the
+        # publishing schedule can be configured
+        self.assertContains(
             response,
-            '<div class="form-side__panel" data-side-panel="status">',
+            '<div class="form-side__panel" data-side-panel="status" hidden>',
+        )
+
+        # The status side panel should show "No publishing schedule set" info
+        self.assertContains(response, "No publishing schedule set")
+
+        # Should show the "Set schedule" button
+        html = response.content.decode()
+        self.assertTagInHTML(
+            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Set schedule</button>',
+            html,
+            count=1,
+            allow_extra_attrs=True,
         )
 
         # Should not show the Unpublish action menu item

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -841,6 +841,11 @@ class TestCreateDraftStateSnippet(WagtailTestUtils, TestCase):
             allow_extra_attrs=True,
         )
 
+        # Should show the correct subtitle in the dialog
+        self.assertContains(
+            response, "Choose when this draft state model should go live and/or expire"
+        )
+
         # Should not show the Unpublish action menu item
         unpublish_url = "/admin/snippets/tests/draftstatemodel/unpublish/"
         self.assertNotContains(response, unpublish_url)
@@ -1581,6 +1586,21 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
 
         # The status side panel should show "No publishing schedule set" info
         self.assertContains(response, "No publishing schedule set")
+
+        # Should show the "Set schedule" button
+        html = response.content.decode()
+        self.assertTagInHTML(
+            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Set schedule</button>',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+
+        # Should show the correct subtitle in the dialog
+        self.assertContains(
+            response,
+            "Choose when this draft state custom primary key model should go live and/or expire",
+        )
 
         # Should not show the Unpublish action menu item
         unpublish_url = reverse(


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #9767. I recommend hiding whitespace when reviewing.

<details><summary>Screenshots</summary>
<p>

<img width="559" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/e1797024-7eae-4162-b984-d4da1bccbae3">


<img width="610" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/2d176e25-f23f-4ad8-be04-a020714644a5">

</p>
</details> 

- The first two commits are refactoring the shared toggles and the comment toggle so that they can share the same markup for the counter badge.
- The two commits after that are fixing the issues mentioned in #9767.
  - If any of the scheduled publishing fields have an error, a red badge will show up on the status side panel toggle, and an "Invalid schedule" message is displayed in the status side panel in place of the draft schedule.
  - Possible error causes:
    - `expire_at` > `go_live_at`
    - `expire_at` < `now()`
    - Note that both of the above can happen at the same time. In that case, the message will just be concatenated due to this line: https://github.com/wagtail/wagtail/blob/6d4265cbfafdf6c0a556bb406aa0e9396fd2d1a4/wagtail/admin/templates/wagtailadmin/shared/field.html#L46-L48 I think we should do a better job at this, but we'll need a design opinion because I don't know which one looks better:

<details><summary>Screenshots</summary>
<p>

Current:
![image](https://github.com/wagtail/wagtail/assets/6379424/1b1d7cd6-6b0b-4d5a-8938-05a48ea15d5c)
Alternatives:
![image](https://github.com/wagtail/wagtail/assets/6379424/e49399cc-94a8-41c3-8a8e-4545d0129971)
![image](https://github.com/wagtail/wagtail/assets/6379424/5e0be3c9-4f91-4ade-aff7-2b60a313eb6f)
![image](https://github.com/wagtail/wagtail/assets/6379424/aaf80cbd-9b89-446e-bc14-309899ed26dd)
</p>
</details> 

- The rest of the PR is an assortment of bug fixes and improvements around scheduled publishing. See each commit message and review comments for more details.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.
- Edit a page/snippet and set an invalid schedule according to the validation rules described above.

I can go further regarding the many possible different states of the message box, but the above should be sufficient to test the UI. If you're interested, here are the states that I've tested:

1. Set an invalid schedule during the creation of a page/snippet
2. Set an invalid schedule on an existing page/snippet (regardless live/draft) that does not have any publishing schedule
3. Set an invalid schedule on an existing page/snippet that already has a draft publishing schedule (but not yet scheduled)
   - To trigger this, save the object with a valid schedule first.
4. Set an invalid schedule on an existing page/snippet that has an "active" expiry date
   - To trigger this, save the object with a valid expiry date (only) in the future, then hit "Publish".
5. Set an invalid schedule on an existing page/snippet that has an "active" expiry date and a draft publishing schedule (but not yet scheduled)
   - To trigger this, follow the trigger for number 4 but after hitting publish, set a valid schedule that is **after** the "active" expiry date. This results in an "active" expiry date and a "draft publishing" schedule.
6. Set an invalid schedule on an existing snippet that has an "active" scheduled publishing date and a draft publishing schedule.
   - To trigger this, set a "go live at" (with/without expiry date) on a snippet that has `DraftStateMixin`+`PublishingPanel` applied **but not `LockableMixin`**. Then, hit Publish so that the schedule becomes active. Because `LockableMixin` is not applied, the snippet can still be edited even after it's been scheduled. While at this state, set another **different** valid publishing schedule. This will result in a state where the snippet has an "active" schedule and a "draft" schedule. After this, try setting an invalid schedule.
   - This can be simulated using bakerydemo's `FooterText` snippet, as it has `DraftStateMixin`+`PublishingPanel` but not `LockableMixin`.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
