### PR TITLE
Don't select the root page as the default destination for MoveBulkAction

### DIFF
--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_move.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_move.py
@@ -319,3 +319,34 @@ class TestBulkMove(WagtailTestUtils, TestCase):
             Page.objects.get(id=self.test_page_b_1.id).get_parent().id,
             self.section_b.id,
         )
+
+    def test_bulk_move_with_restricted_parent_page_types(self):
+        board_meetings = Page.objects.get(
+            url_path="/home/events/businessy-events/board-meetings/"
+        )
+        url = (
+            reverse(
+                "wagtail_bulk_action",
+                args=(
+                    "wagtailcore",
+                    "page",
+                    "move",
+                ),
+            )
+            + f"?id={board_meetings.id}"
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        html = response.content.decode()
+
+        self.assertInHTML("<p>Are you sure you want to move these pages?</p>", html)
+
+        self.assertInHTML(
+            '<li><a href="{edit_page_url}" target="_blank" rel="noreferrer">Board meetings</a></li>'.format(
+                edit_page_url=reverse(
+                    "wagtailadmin_pages:edit", args=[board_meetings.id]
+                ),
+            ),
+            html,
+        )

--- a/wagtail/admin/views/pages/bulk_actions/move.py
+++ b/wagtail/admin/views/pages/bulk_actions/move.py
@@ -43,7 +43,7 @@ class MoveBulkAction(PageBulkAction):
 
     def get_form_kwargs(self):
         ctx = super().get_form_kwargs()
-        ctx["destination"] = self.destination or Page.get_first_root_node()
+        ctx["destination"] = self.destination
         ctx["target_parent_models"] = self.target_parent_models
         ctx["pages_to_move"] = self.pages_to_move
         return ctx


### PR DESCRIPTION
As noted in https://github.com/wagtail/wagtail/issues/10473#issuecomment-1606830703, I think selecting the root page as the default destination when bulk-moving pages does not make sense to me.

The added test covers the fixed crash (#10473), which has already been fixed by #10362. I still added it, I hope that's ok(?).

If accepted, is it possible to backport this change to 4.1 (LTS)?
I know, @gasman already commented on a related PR/issue https://github.com/wagtail/wagtail/pull/10362#issuecomment-1520360164, but I think #10473 is a bit different, since it does not require any code-change (as in #10348, to invalidate the current location of a page), it affects all wagtail installations which already use `parent_page_types`.
For example, you can just install the latest bakerydemo (which currently has wagtail < 5.1) and try to bulk move one of the bread pages (-> crash).

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
