### PR TITLE
Fix tagit autocomplete text colour in dark mode

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changelog
  * Fix: Add a more visible active state for side panel toggle buttons (Thibaud Colas)
  * Fix: Debounce and optimise live preview panel to prevent excessive requests (Sage Abdullah)
  * Fix: Use constant-time comparison for image serve URL signatures (Jake Howard)
+ * Fix: Ensure taggit field type-ahead options show correctly in the dark mode theme (Sage Abdullah)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)

--- a/client/scss/overrides/_vendor.tagit.scss
+++ b/client/scss/overrides/_vendor.tagit.scss
@@ -58,6 +58,13 @@
 
 .ui-menu .ui-menu-item .ui-menu-item-wrapper {
   border: 1px solid transparent; // ensure border on hover (active) does not move content
+  color: theme('colors.text-context');
+
+  // use this instead of :hover as the UI's hover state is controlled via JS
+  // and there is a delay before the hover state is removed when the mouse leaves
+  &.ui-state-active {
+    color: theme('colors.text-label-menus-active');
+  }
 }
 
 .tagit-close {

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -55,6 +55,7 @@ Thank you to Damilola for his work, and to Google for sponsoring this project.
  * Navigation to translations via the locale dropdown is now accessible for screen reader and keyboard users (Thibaud Colas)
  * Make it possible for speech recognition users to reveal chooser buttons (Thibaud Colas)
  * Use constant-time comparison for image serve URL signatures (Jake Howard)
+ * Ensure taggit field type-ahead options show correctly in the dark mode theme (Sage Abdullah)
 
 ### Documentation
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes the issue mentioned in https://github.com/wagtail/wagtail/issues/10418#issuecomment-1607506072

## Screenshot

![tagit-darkmode-issue-fixed](https://github.com/wagtail/wagtail/assets/6379424/13f5c74a-8c3d-4350-af4f-1ea17dcf4756)

### Light mode (no change)

![tagit-darkmode-issue-fixed-light](https://github.com/wagtail/wagtail/assets/6379424/ca71cdae-f398-4397-ae38-aad2ff8ff661)






_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 114, Firefox 114, Safari 16.5.1

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
