### PR TITLE
Remove unused window.tagit_opts declarations

### DIFF
--- a/wagtail/documents/templates/wagtaildocs/documents/add.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/add.html
@@ -8,7 +8,6 @@
 
     {{ form.media.js }}
 
-    {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
     <script>
         $(function() {
             $('#id_file').on(

--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -79,14 +79,10 @@
     <!-- Main script -->
     <script src="{% versioned_static 'wagtaildocs/js/add-multiple.js' %}"></script>
 
-    {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
     <script>
         window.fileupload_opts = {
             max_title_length: {{ max_title_length|stringformat:"s"|default:"null" }}, //numeric format
             simple_upload_url: "{% url 'wagtaildocs:add' %}"
         }
-        window.tagit_opts = {
-            autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
-        };
     </script>
 {% endblock %}

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
@@ -113,11 +112,6 @@ class DocumentChooseViewMixin(ChooseViewMixin):
         context = super().get_context_data(**kwargs)
         context["collections"] = self.collections
         return context
-
-    def get_response_json_data(self):
-        json_data = super().get_response_json_data()
-        json_data["tag_autocomplete_url"] = reverse("wagtailadmin_tag_autocomplete")
-        return json_data
 
 
 class DocumentChooseView(

--- a/wagtail/images/templates/wagtailimages/images/add.html
+++ b/wagtail/images/templates/wagtailimages/images/add.html
@@ -8,7 +8,6 @@
 
     {{ form.media.js }}
 
-    {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
     <script>
         $(function() {
             $('#id_file').on(

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -94,7 +94,6 @@
     <!-- Main script -->
     <script src="{% versioned_static 'wagtailimages/js/add-multiple.js' %}"></script>
 
-    {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
     <script>
         window.fileupload_opts = {
             simple_upload_url: "{% url 'wagtailimages:add' %}",
@@ -106,8 +105,5 @@
                 accepted_file_types: "{{ error_accepted_file_types|escapejs }}"
             }
         }
-        window.tagit_opts = {
-            autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
-        };
     </script>
 {% endblock %}

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -133,11 +133,6 @@ class ImageChooseViewMixin(ChooseViewMixin):
         context["popular_tags"] = popular_tags_for_model(self.model)
         return context
 
-    def get_response_json_data(self):
-        json_data = super().get_response_json_data()
-        json_data["tag_autocomplete_url"] = reverse("wagtailadmin_tag_autocomplete")
-        return json_data
-
 
 class ImageChooseView(
     ImageChooseViewMixin, ImageCreationFormMixin, BaseImageChooseView


### PR DESCRIPTION
- Additional clean up from #10102
- See #10100
- The window global is no longer used, widgets come with the base tags URL by default now using Stimulus data attributes
