### PR TITLE
Always cache renditions

### DIFF
--- a/docs/advanced_topics/images/renditions.md
+++ b/docs/advanced_topics/images/renditions.md
@@ -54,6 +54,14 @@ The return value is a dictionary of renditions keyed by the specification string
 }
 ```
 
+(caching_image_renditions)=
+
+## Caching image renditions
+
+Wagtail will cache image rendition lookups, which can improve the performance of pages which include many images.
+
+By default, Wagtail will try to use the cache called "renditions". If no such cache exists, it will fall back to using the default cache.
+
 (prefetching_image_renditions)=
 
 ## Prefetching image renditions

--- a/docs/advanced_topics/performance.md
+++ b/docs/advanced_topics/performance.md
@@ -24,25 +24,7 @@ CACHES = {
 }
 ```
 
-### Caching image renditions
-
-If you define a cache named 'renditions' (typically alongside your 'default' cache),
-Wagtail will cache image rendition lookups, which may improve the performance of pages
-which include many images.
-
-```python
-CACHES = {
-    'default': {...},
-    'renditions': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': '127.0.0.1:11211',
-        'TIMEOUT': 600,
-        'OPTIONS': {
-            'MAX_ENTRIES': 1000
-        }
-    }
-}
-```
+To use a different cache backend for [caching image renditions](caching_image_renditions), configure the "renditions" backend.
 
 ### Image URLs
 

--- a/docs/advanced_topics/performance.md
+++ b/docs/advanced_topics/performance.md
@@ -24,7 +24,21 @@ CACHES = {
 }
 ```
 
-To use a different cache backend for [caching image renditions](caching_image_renditions), configure the "renditions" backend.
+To use a different cache backend for [caching image renditions](caching_image_renditions), configure the "renditions" backend:
+
+```python
+CACHES = {
+    'default': {...},
+    'renditions': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+        'TIMEOUT': 600,
+        'OPTIONS': {
+            'MAX_ENTRIES': 1000
+        }
+    }
+}
+```
 
 ### Image URLs
 

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -451,7 +451,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         cache_key = Rendition.construct_cache_key(
             self, filter.get_cache_key(self), filter.spec
         )
-        Rendition.cache.set(cache_key, rendition)
+        Rendition.cache_backend.set(cache_key, rendition)
 
         return rendition
 
@@ -525,7 +525,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
             if not getattr(rendition, "_from_cache", False)
         }
         if cache_additions:
-            Rendition.cache.set_many(cache_additions)
+            Rendition.cache_backend.set_many(cache_additions)
 
         # Return a dict in the expected format
         return {filter.spec: rendition for filter, rendition in renditions.items()}
@@ -584,7 +584,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
                 Rendition.construct_cache_key(self, filter.get_cache_key(self), spec)
                 for spec, filter in filters_by_spec.items()
             ]
-            for rendition in Rendition.cache.get_many(cache_keys).values():
+            for rendition in Rendition.cache_backend.get_many(cache_keys).values():
                 filter = filters_by_spec[rendition.filter_spec]
                 found[filter] = rendition
 
@@ -1120,7 +1120,7 @@ class AbstractRendition(ImageFileMixin, models.Model):
         )
 
     @classproperty
-    def cache(self) -> BaseCache:
+    def cache_backend(cls) -> BaseCache:
         try:
             return caches["renditions"]
         except InvalidCacheBackendError:
@@ -1132,7 +1132,7 @@ class AbstractRendition(ImageFileMixin, models.Model):
         )
 
     def purge_from_cache(self):
-        self.cache.delete(self.get_cache_key())
+        self.cache_backend.delete(self.get_cache_key())
 
     class Meta:
         abstract = True

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -456,7 +456,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
             self._add_to_prefetched_renditions(rendition)
 
         cache_key = Rendition.construct_cache_key(
-            self.id, filter.get_cache_key(self), filter.spec
+            self, filter.get_cache_key(self), filter.spec
         )
         self.renditions_cache.set(cache_key, rendition)
 
@@ -525,7 +525,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         # Update the cache
         cache_additions = {
             Rendition.construct_cache_key(
-                self.id, filter.get_cache_key(self), filter.spec
+                self, filter.get_cache_key(self), filter.spec
             ): rendition
             for filter, rendition in renditions.items()
             # prevent writing of cached data back to the cache
@@ -588,7 +588,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
 
             # Query the cache first
             cache_keys = [
-                Rendition.construct_cache_key(self.id, filter.get_cache_key(self), spec)
+                Rendition.construct_cache_key(self, filter.get_cache_key(self), spec)
                 for spec, filter in filters_by_spec.items()
             ]
             for rendition in self.renditions_cache.get_many(cache_keys).values():
@@ -1121,15 +1121,15 @@ class AbstractRendition(ImageFileMixin, models.Model):
         return errors
 
     @staticmethod
-    def construct_cache_key(image_id, filter_cache_key, filter_spec):
-        return "image-{}-{}-{}".format(image_id, filter_cache_key, filter_spec)
+    def construct_cache_key(image, filter_cache_key, filter_spec):
+        return "image-{}-{}-{}".format(image.file_hash, filter_cache_key, filter_spec)
 
     def purge_from_cache(self):
         try:
             cache = caches["renditions"]
             cache.delete(
                 self.construct_cache_key(
-                    self.image_id, self.focal_point_key, self.filter_spec
+                    self.image, self.focal_point_key, self.filter_spec
                 )
             )
         except InvalidCacheBackendError:

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1115,7 +1115,7 @@ class AbstractRendition(ImageFileMixin, models.Model):
 
     @staticmethod
     def construct_cache_key(image, filter_cache_key, filter_spec):
-        return "wagtail-image-" + "-".join(
+        return "wagtail-rendition-" + "-".join(
             [str(image.id), image.file_hash, filter_cache_key, filter_spec]
         )
 

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1122,7 +1122,12 @@ class AbstractRendition(ImageFileMixin, models.Model):
 
     @staticmethod
     def construct_cache_key(image, filter_cache_key, filter_spec):
-        return "image-{}-{}-{}".format(image.file_hash, filter_cache_key, filter_spec)
+        return "wagtail-image-" + "-".join([
+            str(image.id),
+            image.file_hash,
+            filter_cache_key,
+            filter_spec
+        ])
 
     def purge_from_cache(self):
         try:

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -22,7 +22,7 @@ from django.db import models
 from django.db.models import Q
 from django.forms.utils import flatatt
 from django.urls import reverse
-from django.utils.functional import cached_property
+from django.utils.functional import cached_property, classproperty
 from django.utils.module_loading import import_string
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
@@ -427,13 +427,6 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         except AttributeError:
             pass
 
-    @property
-    def renditions_cache(self) -> BaseCache:
-        try:
-            return caches["renditions"]
-        except InvalidCacheBackendError:
-            return caches[DEFAULT_CACHE_ALIAS]
-
     def get_rendition(self, filter: Union["Filter", str]) -> "AbstractRendition":
         """
         Returns a ``Rendition`` instance with a ``file`` field value (an
@@ -458,7 +451,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         cache_key = Rendition.construct_cache_key(
             self, filter.get_cache_key(self), filter.spec
         )
-        self.renditions_cache.set(cache_key, rendition)
+        Rendition.cache.set(cache_key, rendition)
 
         return rendition
 
@@ -532,7 +525,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
             if not getattr(rendition, "_from_cache", False)
         }
         if cache_additions:
-            self.renditions_cache.set_many(cache_additions)
+            Rendition.cache.set_many(cache_additions)
 
         # Return a dict in the expected format
         return {filter.spec: rendition for filter, rendition in renditions.items()}
@@ -591,7 +584,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
                 Rendition.construct_cache_key(self, filter.get_cache_key(self), spec)
                 for spec, filter in filters_by_spec.items()
             ]
-            for rendition in self.renditions_cache.get_many(cache_keys).values():
+            for rendition in Rendition.cache.get_many(cache_keys).values():
                 filter = filters_by_spec[rendition.filter_spec]
                 found[filter] = rendition
 
@@ -1122,23 +1115,24 @@ class AbstractRendition(ImageFileMixin, models.Model):
 
     @staticmethod
     def construct_cache_key(image, filter_cache_key, filter_spec):
-        return "wagtail-image-" + "-".join([
-            str(image.id),
-            image.file_hash,
-            filter_cache_key,
-            filter_spec
-        ])
+        return "wagtail-image-" + "-".join(
+            [str(image.id), image.file_hash, filter_cache_key, filter_spec]
+        )
+
+    @classproperty
+    def cache(self) -> BaseCache:
+        try:
+            return caches["renditions"]
+        except InvalidCacheBackendError:
+            return caches[DEFAULT_CACHE_ALIAS]
+
+    def get_cache_key(self):
+        return self.construct_cache_key(
+            self.image, self.focal_point_key, self.filter_spec
+        )
 
     def purge_from_cache(self):
-        try:
-            cache = caches["renditions"]
-            cache.delete(
-                self.construct_cache_key(
-                    self.image, self.focal_point_key, self.filter_spec
-                )
-            )
-        except InvalidCacheBackendError:
-            pass
+        self.cache.delete(self.get_cache_key())
 
     class Meta:
         abstract = True

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -310,6 +310,9 @@ class TestImageIndexView(WagtailTestUtils, TestCase):
             allow_extra_attrs=True,
         )
 
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+    )
     def test_num_queries(self):
         # Warm up cache so that result is the same when running this test in isolation
         # as when running it within the full test suite.
@@ -1136,6 +1139,9 @@ class TestImageEditView(WagtailTestUtils, TestCase):
         self.assertNotEqual(old_rendition.file.name, new_rendition.file.name)
         self.assertNotEqual(self.get_content(new_rendition.file), old_rendition_data)
 
+        with self.assertRaises(type(old_rendition).DoesNotExist):
+            old_rendition.refresh_from_db()
+
     def test_reupload_different_name(self):
         """
         Checks that reuploading the image file with a different file name
@@ -1172,6 +1178,9 @@ class TestImageEditView(WagtailTestUtils, TestCase):
         new_rendition = self.image.get_rendition("fill-5x5")
         self.assertNotEqual(old_rendition.file.name, new_rendition.file.name)
         self.assertNotEqual(self.get_content(new_rendition.file), old_rendition_data)
+
+        with self.assertRaises(type(old_rendition).DoesNotExist):
+            old_rendition.refresh_from_db()
 
     @override_settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True)
     def test_no_thousand_separators_in_focal_point_editor(self):
@@ -1636,6 +1645,9 @@ class TestImageChooserView(WagtailTestUtils, TestCase):
         self.assertEqual(len(response.context["results"]), 1)
         self.assertEqual(response.context["results"][0], image)
 
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+    )
     def test_num_queries(self):
         # Initial number of queries.
         with self.assertNumQueries(8):

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -491,8 +491,8 @@ class TestRenditions(TestCase):
             },
         },
     )
-    def test_renditions_cache_backend(self):
-        cache = caches["renditions"]
+    def test_renditions_cache(self):
+        cache = Rendition.cache_backend
         rendition = self.image.get_rendition("width-500")
         rendition_cache_key = rendition.get_cache_key()
 
@@ -530,6 +530,29 @@ class TestRenditions(TestCase):
         self.image.renditions.all().delete()
         new_rendition = self.image.get_rendition("width-500")
         self.assertFalse(hasattr(new_rendition, "_mark"))
+
+    def test_prefers_rendition_cache_backend(self):
+        with override_settings(
+            CACHES={
+                "default": {
+                    "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+                },
+                "renditions": {
+                    "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+                },
+            }
+        ):
+            self.assertEqual(Rendition.cache_backend, caches["renditions"])
+
+    def test_uses_default_cache_when_no_renditions_cache(self):
+        with override_settings(
+            CACHES={
+                "default": {
+                    "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+                }
+            }
+        ):
+            self.assertEqual(Rendition.cache_backend, caches["default"])
 
     def test_focal_point(self):
         self.image.focal_point_x = 100

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -494,9 +494,7 @@ class TestRenditions(TestCase):
     def test_renditions_cache_backend(self):
         cache = caches["renditions"]
         rendition = self.image.get_rendition("width-500")
-        rendition_cache_key = "image-{}-{}-{}".format(
-            rendition.image.id, rendition.focal_point_key, rendition.filter_spec
-        )
+        rendition_cache_key = rendition.get_cache_key()
 
         # Check rendition is saved to cache
         self.assertEqual(cache.get(rendition_cache_key), rendition)

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -237,6 +237,9 @@ class TestImagePermissions(WagtailTestUtils, TestCase):
         self.assertFalse(self.image.is_editable_by_user(self.user))
 
 
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+)
 class TestRenditions(TestCase):
     SPECS = ("height-66", "width-100", "width-400")
 
@@ -593,6 +596,9 @@ class TestRenditions(TestCase):
         settings = bkp
 
 
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+)
 class TestPrefetchRenditions(TestCase):
     fixtures = ["test.json"]
 


### PR DESCRIPTION
_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

Caches are incredibly useful for improving the performance of a site. We already cache lots of things under the hood of Wagtail. 

This should provide a big performance boost to those who don't set the cache, with minimal extra overhead.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
