### PR TITLE
Convert the CONTRIBUTORS file to Markdown

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,4 @@
-Core team
-=========
+## Core team
 
 * Andy Chosak (consumerfinance.gov)
 * Coen van der Kamp (Four Digits)
@@ -22,8 +21,7 @@ Core team
 * Tom Dyson (Torchbox)
 * Vince Salvino (CodeRed)
 
-Core team alumni
-================
+## Core team alumni
 
 * Andy Babic
 * Bertrand Bordage
@@ -42,8 +40,7 @@ Core team alumni
 * Tim Heap
 * Will Barton
 
-Contributors
-============
+## Contributors
 
 * David Cranwell
 * Helen Chapman
@@ -722,8 +719,7 @@ Contributors
 * Vitaly Babiy
 * Sébastien Corbin
 
-Translators
-===========
+## Translators
 
 * Afrikaans: Jaco du Plessis, Jared Osborn
 * Arabic: Bashar Al-Abdulhadi, Abdulaziz Alfuhigi, Roger Allen, Khaled Arnaout, Amr Awad, Mohammed Abdul Gadir, Mohamed HossamElDin, Ahmad Kiswani, Waseem Kntar, Mahmoud Marayef, Mohamed Mayla, Ahmed Miske Sidi Med, Younes Oumakhou, Ultraify Media

--- a/docs/contributing/committing.md
+++ b/docs/contributing/committing.md
@@ -91,7 +91,7 @@ Backwards compatibility notes should also be included. See previous release note
 The release notes for each version are found in `docs/releases/x.x.x.md`.
 
 If the contributor is a new person, and this is their first contribution to Wagtail,
-they should be added to the `CONTRIBUTORS.rst` list.
+they should be added to the `CONTRIBUTORS.md` list.
 Contributors are added in chronological order,
 with new contributors added to the bottom of the list.
 Use their preferred name.


### PR DESCRIPTION
The "Committing code" docs page uses `CONTRIBUTORS.md` (https://docs.wagtail.org/en/stable/contributing/committing.html#update-changelog-txt-and-release-notes)