### PR TITLE
Purge revisions of non-page models in `purge_revisions` command

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
  * Add support for `--template` option to `wagtail start` (Thibaud Colas)
  * Change to always cache renditions (Jake Howard)
  * Update link/document rich text tooltips for consistency with the inline toolbar (Albina Starykova)
+ * Purge revisions of non-page models in `purge_revisions` command (Sage Abdullah)
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)

--- a/docs/reference/management_commands.md
+++ b/docs/reference/management_commands.md
@@ -45,12 +45,18 @@ Options:
 ## purge_revisions
 
 ```sh
-manage.py purge_revisions [--days=<number of days>]
+manage.py purge_revisions [--days=<number of days>] [--pages] [--non-pages]
 ```
 
-This command deletes old page revisions which are not in moderation, live, approved to go live, or the latest
-revision for a page. If the `days` argument is supplied, only revisions older than the specified number of
+This command deletes old revisions which are not in moderation, live, approved to go live, or the latest
+revision. If the `days` argument is supplied, only revisions older than the specified number of
 days will be deleted.
+
+If the `pages` argument is supplied, only revisions of page models will be deleted. If the `non-pages` argument is supplied, only revisions of non-page models will be deleted. If both or neither arguments are supplied, revisions of all models will be deleted.
+
+```{versionadded} 5.1
+Support for deleting revisions of non-page models is added.
+```
 
 (purge_embeds)=
 

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -62,6 +62,7 @@ As part of tackling Wagtail’s technical debt and improving [CSP compatibility]
  * Add support for adding [HTML `attrs`](panels_attrs) on `FieldPanel`, `FieldRowPanel`, `MultiFieldPanel`, and others (Aman Pandey, Antoni Martyniuk, LB (Ben) Johnston)
  * Change to always cache renditions (Jake Howard)
  * Update link/document rich text tooltips for consistency with the inline toolbar (Albina Starykova)
+ * Purge revisions of non-page models in `purge_revisions` command (Sage Abdullah)
 
 ### Bug fixes
 
@@ -315,7 +316,7 @@ Note: The `data-w-tag-options-value` is a JSON object serialised into string. Dj
 ### Image Renditions are now cached by default
 
 Wagtail will try to use the cache called "renditions". If no such cache exists, it will fall back to using the default cache.
-You can [configure the "renditions" cache](custom_image_renditions_cache) to use a different cache backend or to provide 
+You can [configure the "renditions" cache](custom_image_renditions_cache) to use a different cache backend or to provide
 additional configuration parameters.
 
 ### Tooltips now rely on new data attributes

--- a/wagtail/management/commands/purge_revisions.py
+++ b/wagtail/management/commands/purge_revisions.py
@@ -1,15 +1,9 @@
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db.models import Q
 from django.utils import timezone
 
-from wagtail.models import Revision
-
-try:
-    from wagtail.models import WorkflowState
-
-    workflow_support = True
-except ImportError:
-    workflow_support = False
+from wagtail.models import Revision, WorkflowState
 
 
 class Command(BaseCommand):
@@ -46,7 +40,7 @@ def purge_revisions(days=None):
         approved_go_live_at__isnull=False
     )
 
-    if workflow_support:
+    if getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True):
         purgeable_revisions = purgeable_revisions.exclude(
             # and exclude revisions linked to an in progress or needs changes workflow state
             Q(task_states__workflow_state__status=WorkflowState.STATUS_IN_PROGRESS)

--- a/wagtail/management/commands/purge_revisions.py
+++ b/wagtail/management/commands/purge_revisions.py
@@ -13,7 +13,7 @@ except ImportError:
 
 
 class Command(BaseCommand):
-    help = "Delete page revisions which are not the latest revision for a page, published or scheduled to be published, or in moderation"
+    help = "Delete revisions which are not the latest revision, published or scheduled to be published, or in moderation"
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -39,7 +39,7 @@ class Command(BaseCommand):
 
 def purge_revisions(days=None):
     # exclude revisions which have been submitted for moderation in the old system
-    purgeable_revisions = Revision.page_revisions.exclude(
+    purgeable_revisions = Revision.objects.exclude(
         submitted_for_moderation=True
     ).exclude(
         # and exclude revisions with an approved_go_live_at date
@@ -61,7 +61,7 @@ def purge_revisions(days=None):
     deleted_revisions_count = 0
 
     for revision in purgeable_revisions.iterator():
-        # don't delete the latest revision for any page
+        # don't delete the latest revision
         if not revision.is_latest_revision():
             revision.delete()
             deleted_revisions_count += 1

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2656,8 +2656,14 @@ class Orderable(models.Model):
 
 
 class RevisionQuerySet(models.QuerySet):
+    def page_revisions_q(self):
+        return Q(base_content_type=get_default_page_content_type())
+
     def page_revisions(self):
-        return self.filter(base_content_type=get_default_page_content_type())
+        return self.filter(self.page_revisions_q())
+
+    def not_page_revisions(self):
+        return self.exclude(self.page_revisions_q())
 
     def submitted(self):
         return self.filter(submitted_for_moderation=True)
@@ -2671,12 +2677,7 @@ class RevisionQuerySet(models.QuerySet):
         )
 
 
-class RevisionsManager(models.Manager):
-    def get_queryset(self):
-        return RevisionQuerySet(self.model, using=self._db)
-
-    def for_instance(self, instance):
-        return self.get_queryset().for_instance(instance)
+RevisionsManager = models.Manager.from_queryset(RevisionQuerySet)
 
 
 class PageRevisionsManager(RevisionsManager):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

This ensures that the `purge_revisions` management command also purges revisions of non-page models, e.g. snippets that have the `RevisionMixin` enabled.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
