### PR TITLE
Add inspect view to snippets

### DIFF
--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -96,6 +96,9 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: chooser_per_page
    .. autoattribute:: export_filename
    .. autoattribute:: ordering
+   .. autoattribute:: inspect_view_enabled
+   .. autoattribute:: inspect_view_fields
+   .. autoattribute:: inspect_view_fields_exclude
    .. autoattribute:: admin_url_namespace
    .. autoattribute:: base_url_path
    .. autoattribute:: chooser_admin_url_namespace
@@ -106,6 +109,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: delete_view_class
    .. autoattribute:: usage_view_class
    .. autoattribute:: history_view_class
+   .. autoattribute:: inspect_view_class
    .. autoattribute:: revisions_view_class
    .. autoattribute:: revisions_revert_view_class
    .. autoattribute:: revisions_compare_view_class
@@ -137,6 +141,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. automethod:: get_edit_template
    .. automethod:: get_delete_template
    .. automethod:: get_history_template
+   .. automethod:: get_inspect_template
    .. automethod:: get_admin_url_namespace
    .. automethod:: get_admin_base_path
    .. automethod:: get_chooser_admin_url_namespace

--- a/docs/topics/snippets/customising.md
+++ b/docs/topics/snippets/customising.md
@@ -53,6 +53,7 @@ class MemberViewSet(SnippetViewSet):
     icon = "user"
     list_display = ["name", "shirt_size", "get_shirt_size_display", UpdatedAtColumn()]
     list_per_page = 50
+    inspect_view_enabled = True
     admin_url_namespace = "member_views"
     base_url_path = "internal/member"
     filterset_class = MemberFilterSet
@@ -98,6 +99,18 @@ You can add the ability to export the listing view to a spreadsheet by setting t
 ```{versionadded} 5.1
 The ability to export the listing view was added.
 ```
+
+## Inspect view
+
+```{versionadded} 5.1
+The ability to enable inspect view was added.
+```
+
+The inspect view is disabled by default, as it's not often useful for most models. However, if you need a view that enables users to view more detailed information about an instance without the option to edit it, you can enable the inspect view by setting {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.inspect_view_enabled` on your `SnippetViewSet` class.
+
+When inspect view is enabled, an 'Inspect' button will automatically appear for each row on the listing view, which takes you to a view that shows a list of field values for that particular snippet.
+
+By default, all 'concrete' fields (where the field value is stored as a column in the database table for your model) will be shown. You can customise what values are displayed by specifying the {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.inspect_view_fields` or the {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.inspect_view_fields_exclude` attributes to your `SnippetViewSet` class.
 
 ## Templates
 

--- a/wagtail/admin/templates/wagtailadmin/generic/inspect.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/inspect.html
@@ -1,0 +1,34 @@
+{% extends "wagtailadmin/generic/base.html" %}
+{% load i18n wagtailadmin_tags %}
+
+{% block main_content %}
+    {% block fields_output %}
+        {% if fields %}
+            <dl>
+                {% for field in fields %}
+                    <dt>{{ field.label }}</dt>
+                    <dd>{{ field.value }}</dd>
+                {% endfor %}
+            </dl>
+        {% endif %}
+    {% endblock %}
+{% endblock %}
+
+{% block content %}
+    {{ block.super }}
+
+    {% block footer %}
+        {% if edit_url or delete_url %}
+            <footer class="footer">
+                <div class="footer__container">
+                    {% if edit_url %}
+                        <a href="{{ edit_url }}" class="button">{% trans 'Edit' %}</a>
+                    {% endif %}
+                    {% if delete_url %}
+                        <a href="{{ delete_url }}" class="button serious">{% trans 'Delete' %}</a>
+                    {% endif %}
+                </div>
+            </footer>
+        {% endif %}
+    {% endblock %}
+{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/generic/inspect.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/inspect.html
@@ -7,7 +7,13 @@
             <dl>
                 {% for field in fields %}
                     <dt>{{ field.label }}</dt>
-                    <dd>{{ field.value }}</dd>
+                    <dd>
+                        {% if field.component %}
+                            {% component field.component %}
+                        {% else %}
+                            {{ field.value }}
+                        {% endif %}
+                    </dd>
                 {% endfor %}
             </dl>
         {% endif %}

--- a/wagtail/admin/ui/fields.py
+++ b/wagtail/admin/ui/fields.py
@@ -1,0 +1,40 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.db import models
+
+from wagtail.admin.ui.components import Component
+from wagtail.utils.registry import ModelFieldRegistry
+
+display_class_registry = ModelFieldRegistry()
+
+
+def register_display_class(field_class, to=None, display_class=None, exact_class=False):
+    """
+    Define how model field values should be rendered in the admin.
+    The `display_class` should be a subclass of `wagtail.admin.ui.components.Component`
+    that takes a single argument in its constructor: the value of the field.
+
+    This is mainly useful for defining how fields are rendered in the inspect view,
+    but it can also be used in other places, e.g. listing views.
+    """
+
+    if display_class is None:
+        raise ImproperlyConfigured(
+            "register_display_class must be passed a 'display_class' keyword argument"
+        )
+
+    if to and field_class != models.ForeignKey:
+        raise ImproperlyConfigured(
+            "The 'to' argument on register_display_class is only valid for ForeignKey fields"
+        )
+
+    display_class_registry.register(
+        field_class, to=to, value=display_class, exact_class=exact_class
+    )
+
+
+class BaseFieldDisplay(Component):
+    def __init__(self, value):
+        self.value = value
+
+    def get_context_data(self, parent_context):
+        return {"value": self.value}

--- a/wagtail/admin/views/generic/__init__.py
+++ b/wagtail/admin/views/generic/__init__.py
@@ -18,6 +18,7 @@ from .models import (  # noqa: F401
     DeleteView,
     EditView,
     IndexView,
+    InspectView,
     RevisionsCompareView,
     RevisionsUnscheduleView,
     UnpublishView,

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -1,13 +1,18 @@
 from django import VERSION as DJANGO_VERSION
 from django.contrib.admin.utils import label_for_field, quote, unquote
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ImproperlyConfigured, PermissionDenied
+from django.core.exceptions import (
+    ImproperlyConfigured,
+    PermissionDenied,
+)
 from django.db import models, transaction
 from django.db.models.functions import Cast
 from django.forms import Form
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
+from django.template.defaultfilters import filesizeformat
 from django.urls import reverse
+from django.utils.html import format_html
 from django.utils.text import capfirst
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
@@ -712,6 +717,134 @@ class DeleteView(
             context["usage_url"] = self.usage_url
             context["usage_count"] = self.usage.count()
             context["is_protected"] = self.usage.is_protected
+        return context
+
+
+class InspectView(PermissionCheckedMixin, WagtailAdminTemplateMixin, TemplateView):
+    template_name = "wagtailadmin/generic/inspect.html"
+    page_title = gettext_lazy("Inspecting")
+    model = None
+    edit_url_name = None
+    delete_url_name = None
+    fields = []
+    fields_exclude = []
+    pk_url_kwarg = "pk"
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.pk = self.kwargs[self.pk_url_kwarg]
+        self.fields = self.get_fields()
+        self.object = self.get_object()
+
+    def get_object(self, queryset=None):
+        return get_object_or_404(self.model, pk=unquote(self.pk))
+
+    def get_page_subtitle(self):
+        return str(self.object)
+
+    def get_fields(self):
+        fields = self.fields or [
+            f.name
+            for f in self.model._meta.get_fields()
+            if f.concrete
+            and (not f.is_relation or (not f.auto_created and f.related_model))
+        ]
+
+        fields = [f for f in fields if f not in self.fields_exclude]
+        return fields
+
+    def get_field_label(self, field_name):
+        return capfirst(label_for_field(field_name, model=self.model))
+
+    def get_field_display_value(self, field_name):
+        # First we check for a 'get_fieldname_display' property/method on
+        # the model, and return the value of that, if present.
+        value_func = getattr(self.object, "get_%s_display" % field_name, None)
+        if value_func is not None:
+            if callable(value_func):
+                return value_func()
+            return value_func
+
+        # Now let's get the attribute value from the instance itself and see if
+        # we can render something useful. Raises AttributeError appropriately.
+        value = getattr(self.object, field_name)
+
+        if isinstance(value, models.Manager):
+            value = value.all()
+
+        if isinstance(value, models.QuerySet):
+            return ", ".join(str(obj) for obj in value) or "-"
+
+        # wagtail.images might not be installed
+        try:
+            from wagtail.images.models import AbstractImage
+
+            if isinstance(value, AbstractImage):
+                return self.get_image_field_display(value)
+        except RuntimeError:
+            pass
+
+        # wagtail.documents might not be installed
+        try:
+            from wagtail.documents.models import AbstractDocument
+
+            if isinstance(value, AbstractDocument):
+                # Render a link to the document
+                return self.get_document_field_display(value)
+        except RuntimeError:
+            pass
+
+        return value
+
+    def get_image_field_display(self, image):
+        from wagtail.images.shortcuts import get_rendition_or_not_found
+
+        return get_rendition_or_not_found(image, "max-400x400").img_tag()
+
+    def get_document_field_display(self, document):
+        return format_html(
+            '<a href="{}">{} <span class="meta">({}, {})</span></a>',
+            document.url,
+            document.title,
+            document.file_extension.upper(),
+            filesizeformat(document.file.size),
+        )
+
+    def get_context_for_field(self, field_name):
+        return {
+            "label": self.get_field_label(field_name),
+            "value": self.get_field_display_value(field_name),
+        }
+
+    def get_fields_context(self):
+        return [self.get_context_for_field(field_name) for field_name in self.fields]
+
+    def get_edit_url(self):
+        if not self.edit_url_name or (
+            self.permission_policy
+            and not self.permission_policy.user_has_permission(
+                self.request.user, "change"
+            )
+        ):
+            return None
+        return reverse(self.edit_url_name, args=(quote(self.pk),))
+
+    def get_delete_url(self):
+        if not self.delete_url_name or (
+            self.permission_policy
+            and not self.permission_policy.user_has_permission(
+                self.request.user, "delete"
+            )
+        ):
+            return None
+        return reverse(self.delete_url_name, args=(quote(self.pk),))
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["object"] = self.object
+        context["fields"] = self.get_fields_context()
+        context["edit_url"] = self.get_edit_url()
+        context["delete_url"] = self.get_delete_url()
         return context
 
 

--- a/wagtail/documents/apps.py
+++ b/wagtail/documents/apps.py
@@ -1,5 +1,8 @@
 from django.apps import AppConfig
+from django.db.models import ForeignKey
 from django.utils.translation import gettext_lazy as _
+
+from . import get_document_model
 
 
 class WagtailDocsAppConfig(AppConfig):
@@ -13,7 +16,14 @@ class WagtailDocsAppConfig(AppConfig):
 
         register_signal_handlers()
 
-        from wagtail.documents import get_document_model
+        Document = get_document_model()
+
+        from wagtail.admin.ui.fields import register_display_class
+
+        from .components import DocumentDisplay
+
+        register_display_class(ForeignKey, to=Document, display_class=DocumentDisplay)
+
         from wagtail.models.reference_index import ReferenceIndex
 
-        ReferenceIndex.register_model(get_document_model())
+        ReferenceIndex.register_model(Document)

--- a/wagtail/documents/components.py
+++ b/wagtail/documents/components.py
@@ -1,0 +1,5 @@
+from wagtail.admin.ui.fields import BaseFieldDisplay
+
+
+class DocumentDisplay(BaseFieldDisplay):
+    template_name = "wagtaildocs/components/document_display.html"

--- a/wagtail/documents/templates/wagtaildocs/components/document_display.html
+++ b/wagtail/documents/templates/wagtaildocs/components/document_display.html
@@ -1,0 +1,1 @@
+<a href="{{ value.url }}">{{ value.title }} <span class="meta">({{ value.file_extension|upper }}, {{ value.file.size|filesizeformat }})</span></a>

--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -36,6 +36,12 @@ class WagtailImagesAppConfig(AppConfig):
             ForeignKey, to=Image, comparison_class=ImageFieldComparison
         )
 
+        from wagtail.admin.ui.fields import register_display_class
+
+        from .components import ImageDisplay
+
+        register_display_class(ForeignKey, to=Image, display_class=ImageDisplay)
+
         from wagtail.models.reference_index import ReferenceIndex
 
-        ReferenceIndex.register_model(get_image_model())
+        ReferenceIndex.register_model(Image)

--- a/wagtail/images/components.py
+++ b/wagtail/images/components.py
@@ -1,0 +1,9 @@
+from wagtail.admin.ui.fields import BaseFieldDisplay
+from wagtail.images.shortcuts import get_rendition_or_not_found
+
+
+class ImageDisplay(BaseFieldDisplay):
+    rendition_spec = "max-400x400"
+
+    def render_html(self, parent_context):
+        return get_rendition_or_not_found(self.value, self.rendition_spec).img_tag()

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -701,7 +701,17 @@ class SnippetViewSet(ModelViewSet):
     #: Whether to enable the inspect view. Defaults to ``False``.
     inspect_view_enabled = False
 
-    #: The fields to display in the inspect view.
+    #: The model fields or attributes to display in the inspect view.
+    #:
+    #: If the field has a corresponding :meth:`~django.db.models.Model.get_FOO_display`
+    #: method on the model, the method's return value will be used instead.
+    #:
+    #: If you have ``wagtail.images`` installed, and the field's value is an instance of
+    #: ``wagtail.images.models.AbstractImage``, a thumbnail of that image will be rendered.
+    #:
+    #: If you have ``wagtail.documents`` installed, and the field's value is an instance of
+    #: ``wagtail.docs.models.AbstractDocument``, a link to that document will be rendered,
+    #: along with the document title, file extension and size.
     inspect_view_fields = []
 
     #: The fields to exclude from the inspect view.

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -10,7 +10,6 @@ from wagtail.admin.menu import MenuItem
 from wagtail.snippets.bulk_actions.delete import DeleteBulkAction
 from wagtail.snippets.models import get_snippet_models
 from wagtail.snippets.permissions import (
-    get_permission_name,
     user_can_edit_snippet_type,
     user_can_edit_snippets,
 )
@@ -64,27 +63,43 @@ def register_permissions():
 @hooks.register("register_snippet_listing_buttons")
 def register_snippet_listing_buttons(snippet, user, next_url=None):
     model = type(snippet)
+    viewset = model.snippet_viewset
+    permission_policy = viewset.permission_policy
 
     if user_can_edit_snippet_type(user, model):
         yield SnippetListingButton(
             _("Edit"),
             reverse(
-                model.snippet_viewset.get_url_name("edit"),
+                viewset.get_url_name("edit"),
                 args=[quote(snippet.pk)],
             ),
             attrs={"aria-label": _("Edit '%(title)s'") % {"title": str(snippet)}},
             priority=10,
         )
 
-    if user.has_perm(get_permission_name("delete", model)):
+    if viewset.inspect_view_enabled and permission_policy.user_has_any_permission(
+        user, viewset.inspect_view_class.any_permission_required
+    ):
+
+        yield SnippetListingButton(
+            _("Inspect"),
+            reverse(
+                viewset.get_url_name("inspect"),
+                args=[quote(snippet.pk)],
+            ),
+            attrs={"aria-label": _("Inspect '%(title)s'") % {"title": str(snippet)}},
+            priority=20,
+        )
+
+    if permission_policy.user_has_permission(user, "delete"):
         yield SnippetListingButton(
             _("Delete"),
             reverse(
-                model.snippet_viewset.get_url_name("delete"),
+                viewset.get_url_name("delete"),
                 args=[quote(snippet.pk)],
             ),
             attrs={"aria-label": _("Delete '%(title)s'") % {"title": str(snippet)}},
-            priority=20,
+            priority=30,
             classes=["no"],
         )
 

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -1117,6 +1117,8 @@ class FullFeaturedSnippet(
     )
     some_date = models.DateField(auto_now=True)
 
+    some_attribute = "some value"
+
     search_fields = [
         index.SearchField("text"),
         index.FilterField("text"),
@@ -1223,9 +1225,6 @@ class VariousOnDeleteModel(models.Model):
         use_json_field=True,
     )
     rich_text = RichTextField(blank=True)
-
-
-register_snippet(VariousOnDeleteModel)
 
 
 class StandardIndex(Page):

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -272,6 +272,7 @@ class FullFeaturedSnippetViewSet(SnippetViewSet):
     menu_name = "fullfeatured"
     # Ensure that the menu item is placed last
     menu_order = 999999
+    inspect_view_enabled = True
 
     # TODO: When specific search fields are supported in SQLite FTS (see #10217),
     # specify search_fields or get_search_fields here

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -28,6 +28,7 @@ from wagtail.test.testapp.models import (
     ModeratedModel,
     RevisableChildModel,
     RevisableModel,
+    VariousOnDeleteModel,
 )
 
 from .forms import FavouriteColourForm
@@ -342,7 +343,13 @@ class ModeratedModelViewSet(SnippetViewSet):
     }
 
 
+class VariousOnDeleteModelViewSet(SnippetViewSet):
+    model = VariousOnDeleteModel
+    inspect_view_enabled = True
+
+
 register_snippet(FullFeaturedSnippet, viewset=FullFeaturedSnippetViewSet)
 register_snippet(DraftStateModel, viewset=DraftStateModelViewSet)
 register_snippet(ModeratedModelViewSet)
 register_snippet(RevisableViewSetGroup)
+register_snippet(VariousOnDeleteModelViewSet)


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

This PR adds a generic `InspectView` that can be used for snippets via `SnippetViewSet`. The implementation is heavily based on ModelAdmin's `InspectView`.

Still a bit unsure of how image and documents should be handled though, as I don't really like how we need to import from `wagtail.images` and `wagtail.documents` within `wagtail.admin`.

I tried using the read-only `FieldPanel` but it doesn't handle image nor documents, so I decided not to use it.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

Add `inspect_view_enabled = True` to the `PersonViewSet` in bakerydemo.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
