### PR TITLE
Added regex operation to strip out spaces from phone numbers #10558

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Changelog
  * Add a predictable default ordering of the "Object/Other permissions" in the Group Editing view, allow this ordering to be customised (Daniel Kirkham)
  * Add `AbstractImage.get_renditions()` for efficient generation of multiple renditions (Andy Babic)
  * Optimise queries in collection permission policies using cache on the user object (Sage Abdullah)
+ * Phone numbers entered via a link chooser will now have any spaces stripped out, ensuring a valid href="tel:..." attribute (Sahil Jangra)
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -718,6 +718,7 @@
 * valnuro
 * Vitaly Babiy
 * Sébastien Corbin
+* Sahil Jangra
 
 ## Translators
 

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -37,6 +37,7 @@ Thank you to Damilola for his work, and to Google for sponsoring this project.
  * Implement a new design for chooser buttons with better accessibility (Thibaud Colas)
  * Add [`AbstractImage.get_renditions()`](image_renditions_multiple) for efficient generation of multiple renditions (Andy Babic)
  * Optimise queries in collection permission policies using cache on the user object (Sage Abdullah)
+ * Phone numbers entered via a link chooser will now have any spaces stripped out, ensuring a valid `href="tel:..."` attribute (Sahil Jangra)
 
 ### Bug fixes
 

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -992,6 +992,18 @@ class TestChooserPhoneLink(WagtailTestUtils, TestCase):
         # link text has changed, so tell the caller to use it
         self.assertIs(result["prefer_this_title_as_link_text"], True)
 
+    def test_phone_number_has_spaces(self):
+        response = self.post(
+            {
+                "phone-link-chooser-phone_number": "+1 234 567 890",
+                "phone-link-chooser-link_text": "call",
+            }
+        )
+        result = json.loads(response.content.decode())["result"]
+        self.assertEqual(result["url"], "tel:+1234567890")
+        self.assertEqual(result["title"], "call")
+        self.assertIs(result["prefer_this_title_as_link_text"], True)
+
 
 class TestCanChoosePage(WagtailTestUtils, TestCase):
     fixtures = ["test.json"]

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -739,4 +739,5 @@ class PhoneLinkView(BaseLinkFormView):
     link_url_field_name = "phone_number"
 
     def get_url_from_field_value(self, value):
+        value = re.sub(r"\s", "", value)
         return "tel:" + value


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10558 
I have added a regex operation 
``` 
        value = re.sub(r"\s", "", value)
```
which strips out the spaces from the given input and then returns the new value. I believe this should be enough to fix the given issue.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
