### PR TITLE
Add the ability to export snippets listing via `SnippetViewSet.list_export`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Changelog
  * Phone numbers entered via a link chooser will now have any spaces stripped out, ensuring a valid href="tel:..." attribute (Sahil Jangra)
  * Auto-select the `StreamField` block when only one block type is declared (Sébastien Corbin)
  * Add support for more advanced Draftail customisation APIs (Thibaud Colas)
+ * Add the ability to export snippets listing via `SnippetViewSet.list_export` (Sage Abdullah)
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -69,6 +69,8 @@
   }
 
   .right {
+    display: flex;
+    gap: theme('spacing[2.5]');
     text-align: end;
     float: right;
   }

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -94,6 +94,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: search_backend_name
    .. autoattribute:: list_per_page
    .. autoattribute:: chooser_per_page
+   .. autoattribute:: export_filename
    .. autoattribute:: ordering
    .. autoattribute:: admin_url_namespace
    .. autoattribute:: base_url_path

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -87,6 +87,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: menu_name
    .. autoattribute:: menu_order
    .. autoattribute:: list_display
+   .. autoattribute:: list_export
    .. autoattribute:: list_filter
    .. autoattribute:: filterset_class
    .. autoattribute:: search_fields

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -41,6 +41,7 @@ Thank you to Damilola for his work, and to Google for sponsoring this project.
  * Phone numbers entered via a link chooser will now have any spaces stripped out, ensuring a valid `href="tel:..."` attribute (Sahil Jangra)
  * Auto-select the `StreamField` block when only one block type is declared (Sébastien Corbin)
  * Add support for more [advanced Draftail customisation APIs](extending_the_draftail_editor_advanced) (Thibaud Colas)
+ * Add the ability to export snippets listing via `SnippetViewSet.list_export` (Sage Abdullah)
 
 ### Bug fixes
 

--- a/docs/topics/snippets/customising.md
+++ b/docs/topics/snippets/customising.md
@@ -93,6 +93,12 @@ You can add the ability to filter the listing view by defining a {attr}`~wagtail
 
 If you would like to make further customisations to the filtering mechanism, you can also use a custom `wagtail.admin.filters.WagtailFilterSet` subclass by overriding the {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.filterset_class` attribute. The `list_filter` attribute is ignored if `filterset_class` is set. For more details, refer to [django-filter's documentation](https://django-filter.readthedocs.io/en/stable/guide/usage.html#the-filter).
 
+You can add the ability to export the listing view to a spreadsheet by setting the {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.list_export` attribute to specify the columns to be exported.
+
+```{versionadded} 5.1
+The ability to export the listing view was added.
+```
+
 ## Templates
 
 For all views that are used for a snippet model, Wagtail looks for templates in the following directories within your project or app, before resorting to the defaults:

--- a/docs/topics/snippets/customising.md
+++ b/docs/topics/snippets/customising.md
@@ -93,7 +93,7 @@ You can add the ability to filter the listing view by defining a {attr}`~wagtail
 
 If you would like to make further customisations to the filtering mechanism, you can also use a custom `wagtail.admin.filters.WagtailFilterSet` subclass by overriding the {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.filterset_class` attribute. The `list_filter` attribute is ignored if `filterset_class` is set. For more details, refer to [django-filter's documentation](https://django-filter.readthedocs.io/en/stable/guide/usage.html#the-filter).
 
-You can add the ability to export the listing view to a spreadsheet by setting the {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.list_export` attribute to specify the columns to be exported.
+You can add the ability to export the listing view to a spreadsheet by setting the {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.list_export` attribute to specify the columns to be exported. The {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.export_filename` attribute can be used to customise the file name of the exported spreadsheet.
 
 ```{versionadded} 5.1
 The ability to export the listing view was added.

--- a/wagtail/admin/templates/wagtailadmin/reports/base_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/base_report.html
@@ -8,13 +8,7 @@
         <div class="report__actions">
             {% block actions %}
                 {% if view.list_export %}
-                    <div class="dropdown dropdown-button match-width">
-                        <a href="{{ view.xlsx_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}</a>
-                        <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
-                        <ul>
-                            <li><a  class="button bicolor button--icon" href="{{ view.csv_export_url }}">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a></li>
-                        </ul>
-                    </div>
+                    {% include view.export_buttons_template_name %}
                 {% endif %}
             {% endblock %}
         </div>

--- a/wagtail/admin/templates/wagtailadmin/reports/workflow.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/workflow.html
@@ -2,7 +2,7 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block actions %}
-    <div class="addbutton">
+    <div>
         <a href="{% url 'wagtailadmin_reports:workflow_tasks' %}" class="button">{% trans "By Task" %}</a>
     </div>
     {{ block.super }}

--- a/wagtail/admin/templates/wagtailadmin/reports/workflow_tasks.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/workflow_tasks.html
@@ -2,7 +2,7 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block actions %}
-    <div class="addbutton">
+    <div>
         <a href="{% url 'wagtailadmin_reports:workflow' %}" class="button">{% trans 'By Workflow' %}</a>
     </div>
     {{ block.super }}

--- a/wagtail/admin/templates/wagtailadmin/shared/export_buttons.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/export_buttons.html
@@ -1,0 +1,16 @@
+{% load i18n wagtailadmin_tags %}
+{% comment "text/markdown" %}
+
+    Variables accepted by this template:
+
+    - `view` - a view instance (usually of `SpreadsheetExportMixin`) that has `xlsx_export_url` and `csv_export_url` properties.
+
+{% endcomment %}
+
+<div class="dropdown dropdown-button match-width col">
+    <a href="{{ view.xlsx_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}</a>
+    <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
+    <ul>
+        <li><a  class="button bicolor button--icon" href="{{ view.csv_export_url }}">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a></li>
+    </ul>
+</div>

--- a/wagtail/admin/views/mixins.py
+++ b/wagtail/admin/views/mixins.py
@@ -152,6 +152,8 @@ class SpreadsheetExportMixin:
     # A dictionary of column heading overrides in the format {field: heading}
     export_headings = {}
 
+    export_buttons_template_name = "wagtailadmin/shared/export_buttons.html"
+
     def get_filename(self):
         """Gets the base filename for the exported spreadsheet, without extensions"""
         return "spreadsheet-export"

--- a/wagtail/admin/views/mixins.py
+++ b/wagtail/admin/views/mixins.py
@@ -154,6 +154,15 @@ class SpreadsheetExportMixin:
 
     export_buttons_template_name = "wagtailadmin/shared/export_buttons.html"
 
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.is_export = request.GET.get("export") in self.FORMATS
+
+    def get_paginate_by(self, queryset):
+        if self.is_export:
+            return None
+        return super().get_paginate_by(queryset)
+
     def get_filename(self):
         """Gets the base filename for the exported spreadsheet, without extensions"""
         return "spreadsheet-export"

--- a/wagtail/admin/views/mixins.py
+++ b/wagtail/admin/views/mixins.py
@@ -154,6 +154,8 @@ class SpreadsheetExportMixin:
 
     export_buttons_template_name = "wagtailadmin/shared/export_buttons.html"
 
+    export_filename = "spreadsheet-export"
+
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
         self.is_export = request.GET.get("export") in self.FORMATS
@@ -165,7 +167,7 @@ class SpreadsheetExportMixin:
 
     def get_filename(self):
         """Gets the base filename for the exported spreadsheet, without extensions"""
-        return "spreadsheet-export"
+        return self.export_filename
 
     def to_row_dict(self, item):
         """Returns an OrderedDict (in the order given by list_export) of the exportable information for a model instance"""

--- a/wagtail/admin/views/reports/base.py
+++ b/wagtail/admin/views/reports/base.py
@@ -20,9 +20,7 @@ class ReportView(SpreadsheetExportMixin, IndexView):
 
     def get(self, request, *args, **kwargs):
         self.filters, self.object_list = self.get_filtered_queryset()
-        self.is_export = self.request.GET.get("export") in self.FORMATS
         if self.is_export:
-            self.paginate_by = None
             self.object_list = self.decorate_paginated_queryset(self.object_list)
             return self.as_spreadsheet(self.object_list, self.request.GET.get("export"))
         else:

--- a/wagtail/contrib/forms/templates/wagtailforms/submissions_index.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/submissions_index.html
@@ -82,19 +82,7 @@
 {% endblock %}
 {% block content %}
     {% fragment as form_actions %}
-        <div class="dropdown dropdown-button">
-            <a href="{{ view.xlsx_export_url }}" class="button bicolor button--icon">
-                {% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}
-            </a>
-            <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
-            <ul>
-                <li>
-                    <a class="button bicolor button--icon" href="{{ view.csv_export_url }}">
-                        {% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}
-                    </a>
-                </li>
-            </ul>
-        </div>
+        {% include view.export_buttons_template_name %}
     {% endfragment %}
 
     {% include "wagtailadmin/shared/header.html" with classname="w-header--no-border" title=page_title subtitle=form_page.title|capfirst icon="form" merged=1 extra_actions=form_actions %}

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -165,9 +165,7 @@ class SubmissionsListView(SpreadsheetExportMixin, ListView):
         if not get_forms_for_user(request.user).filter(pk=self.form_page.id).exists():
             raise PermissionDenied
 
-        self.is_export = self.request.GET.get("export") in self.FORMATS
         if self.is_export:
-            self.paginate_by = None
             data_fields = self.form_page.get_data_fields()
             # Set the export fields and the headings for spreadsheet export
             self.list_export = [field for field, label in data_fields]

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -28,19 +28,7 @@
                             {% include 'modeladmin/includes/button.html' with button=view.button_helper.add_button %}
                         {% endif %}
                         {% if view.list_export %}
-                            <div class="dropdown dropdown-button match-width col">
-                                <a href="?export=xlsx&{{ request.GET.urlencode }}" class="button bicolor button--icon">
-                                    {% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}
-                                </a>
-                                <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
-                                <ul>
-                                    <li>
-                                        <a class="button bicolor button--icon" href="?export=csv&{{ request.GET.urlencode }}">{% icon name="download" wrapped=1 %}
-                                            {% trans 'Download CSV' %}
-                                        </a>
-                                    </li>
-                                </ul>
-                            </div>
+                            {% include view.export_buttons_template_name %}
                         {% endif %}
                     </div>
                 {% endif %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/index.html
@@ -16,7 +16,12 @@
     {% fragment as base_action_locale %}{% if locale %}{% include 'wagtailadmin/shared/locale_selector.html' with theme="large" %}{% endif %}{% endfragment %}
     {% fragment as action_url_add_snippet %}{% if can_add_snippet %}{% url view.add_url_name %}{% if locale %}?locale={{ locale.language_code }}{% endif %}{% endif %}{% endfragment %}
     {% fragment as action_text_snippet %}{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}{% endfragment %}
-    {% include 'wagtailadmin/shared/header.html' with breadcrumb=breadcrumb title=model_opts.verbose_name_plural|capfirst icon=header_icon search_url=search_url base_actions=base_action_locale action_url=action_url_add_snippet action_icon="plus" action_text=action_text_snippet %}
+    {% fragment as extra_actions %}
+        {% if view.list_export %}
+            {% include view.export_buttons_template_name %}
+        {% endif %}
+    {% endfragment %}
+    {% include 'wagtailadmin/shared/header.html' with breadcrumb=breadcrumb title=model_opts.verbose_name_plural|capfirst icon=header_icon search_url=search_url base_actions=base_action_locale action_url=action_url_add_snippet action_icon="plus" action_text=action_text_snippet extra_actions=extra_actions %}
 
     <div class="nice-padding{% if filters %} filterable{% endif %}">
         <div id="listing-results" class="snippets">

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -707,6 +707,11 @@ class TestListExport(BaseSnippetViewSetTests):
         response = self.client.get(self.get_url("list"), {"export": "csv"})
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get("Content-Disposition"),
+            'attachment; filename="all-fullfeatured-snippets.csv"',
+        )
+
         data_lines = response.getvalue().decode().split("\n")
         self.assertEqual(
             data_lines[0],
@@ -725,6 +730,11 @@ class TestListExport(BaseSnippetViewSetTests):
         response = self.client.get(self.get_url("list"), {"export": "xlsx"})
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get("Content-Disposition"),
+            'attachment; filename="all-fullfeatured-snippets.xlsx"',
+        )
+
         workbook_data = response.getvalue()
         worksheet = load_workbook(filename=BytesIO(workbook_data)).active
         cell_array = [[cell.value for cell in row] for row in worksheet.rows]

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -672,6 +672,9 @@ class SnippetViewSet(ModelViewSet):
     #: A list or tuple, where each item is the name of a field, an attribute, or a single-argument callable on the model.
     list_export = []
 
+    #: The base file name for the exported listing, without extensions. If unset, the model's :attr:`~django.db.models.Options.db_table` will be used instead.
+    export_filename = None
+
     #: The number of items to display per page in the index view. Defaults to 20.
     list_per_page = 20
 
@@ -868,6 +871,7 @@ class SnippetViewSet(ModelViewSet):
             list_display=self.list_display,
             list_filter=self.list_filter,
             list_export=self.list_export,
+            export_filename=self.get_export_filename(),
             paginate_by=self.list_per_page,
             default_ordering=self.ordering,
             search_fields=self.search_fields,
@@ -891,6 +895,7 @@ class SnippetViewSet(ModelViewSet):
             list_display=self.list_display,
             list_filter=self.list_filter,
             list_export=self.list_export,
+            export_filename=self.get_export_filename(),
             paginate_by=self.list_per_page,
             default_ordering=self.ordering,
             search_fields=self.search_fields,
@@ -1237,6 +1242,9 @@ class SnippetViewSet(ModelViewSet):
         ``index_view.get_base_queryset()`` will be used instead.
         """
         return None
+
+    def get_export_filename(self):
+        return self.export_filename or self.model_opts.db_table
 
     def get_templates(self, action="index", fallback=""):
         """

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -669,6 +669,7 @@ class SnippetViewSet(ModelViewSet):
     #: If ``filterset_class`` is set, this attribute will be ignored.
     list_filter = None
 
+    #: A list or tuple, where each item is the name of a field, an attribute, or a single-argument callable on the model.
     list_export = []
 
     #: The number of items to display per page in the index view. Defaults to 20.

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -257,6 +257,13 @@ class FullFeaturedSnippetViewSet(SnippetViewSet):
     chooser_per_page = 15
     filterset_class = FullFeaturedSnippetFilterSet
     list_display = ["text", "country_code", "get_foo_country_code", UpdatedAtColumn()]
+    list_export = [
+        "text",
+        "country_code",
+        "get_foo_country_code",
+        "some_date",
+        "first_published_at",
+    ]
     index_template_name = "tests/fullfeaturedsnippet_index.html"
     ordering = ["text", "-_updated_at", "-pk"]
     add_to_admin_menu = True

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -264,6 +264,7 @@ class FullFeaturedSnippetViewSet(SnippetViewSet):
         "some_date",
         "first_published_at",
     ]
+    export_filename = "all-fullfeatured-snippets"
     index_template_name = "tests/fullfeaturedsnippet_index.html"
     ordering = ["text", "-_updated_at", "-pk"]
     add_to_admin_menu = True


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

This, along with #10621 bring the missing pieces from modeladmin to snippets. With both of these PRs, snippets will be mostly at parity with ModelAdmin.

<details><summary>Outdated screenshot</summary>
<p>

~~Marking as draft because even though I managed to extract the export button HTML to a shared template, there's an issue with the styles on snippets:~~

<img width="1051" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/fad31d45-b3c4-49b0-93ba-158dfd99824b">

</p>
</details> 

The last commit is not ideal, as it's just a workaround (see the collapsed details above) until #10148 is fixed. The existing views that have the export functionality get around the issue by either:
- Not having any other action (e.g. form submissions view, most of the report pages)
- Some inconsistent markup around the HTML/custom CSS so that they play well together (modeladmin, workflow/workflow task reports, redirects listing)

However, I don't think it's worth waiting for #10148 to be fixed as that issue might be made redundant by the Universal Listings work.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

Add `list_export` to `PersonViewSet` on bakerydemo, e.g.

```python
class PersonViewSet(SnippetViewSet):
    ...
    list_export = ("first_name", "last_name", "job_title")
```

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
