### PR TITLE
Typo in PagePermissionHelper on user_can_unpublish_obj

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,6 +38,7 @@ Changelog
  * Fix: Remove unnecessary usage of `innerHTML` when modifying DOM content (LB (Ben) Johnston)
  * Fix: Avoid `ValueError` when extending `PagesAPIViewSet` and setting `meta_fields` to an empty list (Henry Harutyunyan, Alex Morega)
  * Fix: Improve accessibility for header search, remove autofocus on page load, advise screen readers that content has changed when results update (LB (Ben) Johnston)
+ * Fix: Fix incorrect override of `PagePermissionHelper.user_can_unpublish_obj()` in ModelAdmin (Sébastien Corbin)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -69,6 +69,7 @@ Thank you to Damilola for his work, and to Google for sponsoring this project.
  * Remove unnecessary usage of `innerHTML` when modifying DOM content (LB (Ben) Johnston)
  * Avoid `ValueError` when extending `PagesAPIViewSet` and setting `meta_fields` to an empty list (Henry Harutyunyan, Alex Morega)
  * Improve accessibility for header search, remove autofocus on page load, advise screen readers that content has changed when results update (LB (Ben) Johnston)
+ * Fix incorrect override of `PagePermissionHelper.user_can_unpublish_obj()` in ModelAdmin (Sébastien Corbin)
 
 ### Documentation
 

--- a/wagtail/contrib/modeladmin/helpers/permission.py
+++ b/wagtail/contrib/modeladmin/helpers/permission.py
@@ -177,7 +177,7 @@ class PagePermissionHelper(PermissionHelper):
         perms = obj.permissions_for_user(user)
         return perms.can_delete()
 
-    def user_can_publish_obj(self, user, obj):
+    def user_can_unpublish_obj(self, user, obj):
         perms = obj.permissions_for_user(user)
         return obj.live and perms.can_unpublish()
 

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -82,6 +82,29 @@ class TestIndexView(WagtailTestUtils, TestCase):
         root_page = Page.objects.get(depth=1)
         self.assertNotIn(root_page, response.context["paginator"].object_list)
 
+    def test_page_buttons_are_shown(self):
+        response = self.get()
+        self.assertContains(
+            response,
+            '<a href="/admin/tests/eventpage/inspect/12/" class="button button-secondary button-small" title="Inspect this event page">Inspect</a>',
+        )
+        self.assertContains(
+            response,
+            '<a href="/admin/pages/12/edit/?next=/admin/tests/eventpage/" class="button button-secondary button-small" title="Edit this event page">Edit</a>',
+        )
+        self.assertContains(
+            response,
+            '<a href="/admin/pages/12/copy/?next=/admin/tests/eventpage/" class="button button-small" title="Copy this event page">Copy</a>',
+        )
+        self.assertContains(
+            response,
+            '<a href="/admin/pages/12/unpublish/?next=/admin/tests/eventpage/" class="button button-small" title="Unpublish this event page">Unpublish</a>',
+        )
+        self.assertContains(
+            response,
+            '<a href="/admin/pages/12/delete/?next=/admin/tests/eventpage/" class="button no button-small" title="Delete this event page">Delete</a>',
+        )
+
 
 class TestExcludeFromExplorer(WagtailTestUtils, TestCase):
     fixtures = ["modeladmintest_test.json"]


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes a wrong `PermissionHelper` override that should be a `user_can_unpublish_obj()` method

Bug can be reproduced using a custom ModelAdmin on a model child of Page 



_Please check the following:_

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
