### PR TITLE
Update rich text Link/Document Tooltip styles

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Changelog
  * Add support for adding HTML `attrs` on `FieldPanel`, `FieldRowPanel`, `MultiFieldPanel`, and others (Aman Pandey, Antoni Martyniuk, LB (Ben) Johnston)
  * Add support for `--template` option to `wagtail start` (Thibaud Colas)
  * Change to always cache renditions (Jake Howard)
+ * Update link/document rich text tooltips for consistency with the inline toolbar (Albina Starykova)
  * Fix: Prevent choosers from failing when initial value is an unrecognised ID, e.g. when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Fix: Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Fix: Remove comment button on InlinePanel fields (Sage Abdullah)

--- a/client/src/components/Draftail/Tooltip/Tooltip.scss
+++ b/client/src/components/Draftail/Tooltip/Tooltip.scss
@@ -11,14 +11,11 @@ $tooltip-z-index: $draftail-tooltip-z-index;
 $tooltip-color-no: theme('colors.critical.100');
 
 @mixin arrow--top {
-  margin-top: $tooltip-arrow-spacing;
+  margin-top: $tooltip-spacing;
   transform: translateX(calc(var(--w-direction-factor) * -50%));
 
   &::before {
-    bottom: 100%;
-    inset-inline-start: 50%;
-    transform: translateX(calc(var(--w-direction-factor) * -50%));
-    border-bottom-color: $tooltip-chrome;
+    content: none;
   }
 }
 

--- a/client/src/components/Draftail/decorators/TooltipEntity.js
+++ b/client/src/components/Draftail/decorators/TooltipEntity.js
@@ -116,12 +116,15 @@ class TooltipEntity extends Component {
                 </a>
               ) : null}
 
-              <button className="button Tooltip__button" onClick={this.onEdit}>
+              <button
+                className="button button-small Tooltip__button"
+                onClick={this.onEdit}
+              >
                 Edit
               </button>
 
               <button
-                className="button button-secondary no Tooltip__button"
+                className="button button-small button-secondary no Tooltip__button"
                 onClick={this.onRemove}
               >
                 Remove

--- a/client/src/components/Draftail/decorators/__snapshots__/TooltipEntity.test.js.snap
+++ b/client/src/components/Draftail/decorators/__snapshots__/TooltipEntity.test.js.snap
@@ -68,13 +68,13 @@ exports[`TooltipEntity #openTooltip 1`] = `
         www.example.com
       </a>
       <button
-        className="button Tooltip__button"
+        className="button button-small Tooltip__button"
         onClick={[Function]}
       >
         Edit
       </button>
       <button
-        className="button button-secondary no Tooltip__button"
+        className="button button-small button-secondary no Tooltip__button"
         onClick={[Function]}
       >
         Remove

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -57,6 +57,7 @@ As part of tackling Wagtail’s technical debt and improving [CSP compatibility]
  * Add the ability to export snippets listing via `SnippetViewSet.list_export` (Sage Abdullah)
  * Add support for adding [HTML `attrs`](panels_attrs) on `FieldPanel`, `FieldRowPanel`, `MultiFieldPanel`, and others (Aman Pandey, Antoni Martyniuk, LB (Ben) Johnston)
  * Change to always cache renditions (Jake Howard)
+ * Update link/document rich text tooltips for consistency with the inline toolbar (Albina Starykova)
 
 ### Bug fixes
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #9023 

Update rich text Link/Document Tooltip styles:
-  Has the same height and padding as the inline toolbar: uses button-small class on all buttons
-  No longer has a tooltip arrow
-  Has the same spacing between the tooltip and the link, as we’d have between the inline toolbar and text

The color palette for the 'no' button will be fixed in a separate PR.

| Before      | After |
| ----------- | ----------- |
| ![image](https://github.com/wagtail/wagtail/assets/51043550/e51bd29b-5be6-4e1d-8a29-1ec267c619b1)      | ![image](https://github.com/wagtail/wagtail/assets/51043550/7a9e3bba-799a-4946-a24f-ef242acb7033)       |
| ![image](https://github.com/wagtail/wagtail/assets/51043550/a6ad0de5-4d6d-45e3-9200-e29e571bbe80)   | ![image](https://github.com/wagtail/wagtail/assets/51043550/53f7d7af-3f49-4f5d-b35b-b80f00d2c409)        |







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**:
    Chrome 113, Firefox 113, Safari 16.3 macOS 13.2
    -   [ ] **Please list which assistive technologies [^3] you tested**:
    Color contrast check
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
