### PR TITLE
replace @total_ordering by implementing all comparison operators

### DIFF
--- a/wagtail/admin/search.py
+++ b/wagtail/admin/search.py
@@ -11,7 +11,6 @@ from wagtail import hooks
 from wagtail.admin.forms.search import SearchForm
 
 
-@total_ordering
 class SearchArea(metaclass=MediaDefiningClass):
     template = "wagtailadmin/shared/search_area.html"
 
@@ -33,8 +32,20 @@ class SearchArea(metaclass=MediaDefiningClass):
     def __lt__(self, other):
         return (self.order, self.label) < (other.order, other.label)
 
+    def __le__(self, other):
+        return (self.order, self.label) <= (other.order, other.label)
+
+    def __ge__(self, other):
+        return (self.order, self.label) >= (other.order, other.label)
+
+    def __gt__(self, other):
+        return (self.order, self.label) > (other.order, other.label)
+
     def __eq__(self, other):
         return (self.order, self.label) == (other.order, other.label)
+
+    def __ne__(self, other):
+        return (self.order, self.label) != (other.order, other.label)
 
     def is_shown(self, request):
         """

--- a/wagtail/admin/search.py
+++ b/wagtail/admin/search.py
@@ -1,5 +1,3 @@
-from functools import total_ordering
-
 from django.forms import Media, MediaDefiningClass
 from django.forms.utils import flatatt
 from django.template.loader import render_to_string

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -8,7 +8,6 @@ from django.utils.html import format_html
 from wagtail import hooks
 
 
-@total_ordering
 class Button:
     show = True
 
@@ -42,10 +41,36 @@ class Button:
             return NotImplemented
         return (self.priority, self.label) < (other.priority, other.label)
 
+    def __le__(self, other):
+        if not isinstance(other, Button):
+            return NotImplemented
+        return (self.priority, self.label) <= (other.priority, other.label)
+
+    def __ge__(self, other):
+        if not isinstance(other, Button):
+            return NotImplemented
+        return (self.priority, self.label) >= (other.priority, other.label)
+
+    def __gt__(self, other):
+        if not isinstance(other, Button):
+            return NotImplemented
+        return (self.priority, self.label) > (other.priority, other.label)
+
     def __eq__(self, other):
         if not isinstance(other, Button):
             return NotImplemented
         return (
+            self.label == other.label
+            and self.url == other.url
+            and self.classes == other.classes
+            and self.attrs == other.attrs
+            and self.priority == other.priority
+        )
+
+    def __ne__(self, other):
+        if not isinstance(other, Button):
+            return NotImplemented
+        return not (
             self.label == other.label
             and self.url == other.url
             and self.classes == other.classes

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -1,5 +1,3 @@
-from functools import total_ordering
-
 from django.forms.utils import flatatt
 from django.template.loader import render_to_string
 from django.utils.functional import cached_property


### PR DESCRIPTION
Fixes #10526

since using @total_ordering has performance tradeoffs, I've replaced @total_ordering decorator by implementing the remaining comparison operators  `__eq__()`, `__ne__()`, `__lt__()`, `__le__()`, `__gt__()`, and `__ge__()`


- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide?
    - [x]  Run make lint from the Wagtail root.

