### PR TITLE
Refactor fixtures for `test_issue_10411`

### DIFF
--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from wagtail.api.v2 import signal_handlers
+from wagtail.api.v2.views import PagesAPIViewSet
 from wagtail.models import Locale, Page, Site
 from wagtail.models.view_restrictions import BaseViewRestriction
 from wagtail.test.demosite import models
@@ -28,6 +29,10 @@ def get_total_page_count():
         .public()
         .count()
     )
+
+
+class Test10411APIViewSet(PagesAPIViewSet):
+    meta_fields = []
 
 
 class TestPageListing(WagtailTestUtils, TestCase):
@@ -1028,7 +1033,7 @@ class TestPageListing(WagtailTestUtils, TestCase):
 
     def test_issue_10411(self):
         # Bug with removing meta fields from API
-        response = self.client.get(reverse("testapp_api_v2:test_issue_10411:listing"))
+        response = self.client.get(reverse("wagtailapi_v2:issue_10411:listing"))
         self.assertEqual(response.status_code, 200)
 
 

--- a/wagtail/test/testapp/urls.py
+++ b/wagtail/test/testapp/urls.py
@@ -1,10 +1,6 @@
 from django.urls import path
 
-from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.test.testapp import views
-
-api_router = WagtailAPIRouter("testapp_api_v2")
-api_router.register_endpoint("test_issue_10411", views.Test10411ApiViewSet)
 
 urlpatterns = [
     path("bob-only-zone", views.bob_only_zone, name="testapp_bob_only_zone"),
@@ -18,5 +14,4 @@ urlpatterns = [
         views.TestDeleteView.as_view(),
         name="testapp_generic_delete",
     ),
-    path("api/v2/", api_router.urls),
 ]

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -7,7 +7,6 @@ from django.utils.translation import gettext_lazy
 from wagtail.admin import messages
 from wagtail.admin.auth import user_passes_test
 from wagtail.admin.views.generic import DeleteView, EditView, IndexView
-from wagtail.api.v2.views import PagesAPIViewSet
 from wagtail.contrib.forms.views import SubmissionsListView
 
 from .models import ModelWithStringTypePrimaryKey
@@ -82,7 +81,3 @@ class TestDeleteView(DeleteView):
     delete_url_name = "testapp_generic_delete"
     success_message = gettext_lazy("User '%(object)s' updated.")
     page_title = gettext_lazy("test delete view")
-
-
-class Test10411ApiViewSet(PagesAPIViewSet):
-    meta_fields = []

--- a/wagtail/test/urls.py
+++ b/wagtail/test/urls.py
@@ -7,6 +7,7 @@ from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.admin.views import home
 from wagtail.api.v2.router import WagtailAPIRouter
+from wagtail.api.v2.tests.test_pages import Test10411APIViewSet
 from wagtail.api.v2.views import PagesAPIViewSet
 from wagtail.contrib.sitemaps import Sitemap
 from wagtail.contrib.sitemaps import views as sitemaps_views
@@ -22,6 +23,7 @@ api_router = WagtailAPIRouter("wagtailapi_v2")
 api_router.register_endpoint("pages", PagesAPIViewSet)
 api_router.register_endpoint("images", ImagesAPIViewSet)
 api_router.register_endpoint("documents", DocumentsAPIViewSet)
+api_router.register_endpoint("issue_10411", Test10411APIViewSet)
 
 
 urlpatterns = [


### PR DESCRIPTION
Addresses https://github.com/wagtail/wagtail/pull/10638#discussion_r1254136613.

Simply importing `wagtail.test.urls.api_router` into `wagtail/api/v2/tests/test_pages.py` and registering a new endpoint on it doesn't work, probably because it has already generated its URL patterns into `wagtail.test.urls.urlpatterns`.

I learned about the pattern of [overriding `ROOT_URLCONF` for testing](https://docs.djangoproject.com/en/4.2/topics/testing/tools/#urlconf-configuration), and that seemed to be a clean way of adding `Test10411APIViewSet` to the URL routing.

Here is a single diff with this patch and https://github.com/wagtail/wagtail/pull/10638 squashed together: https://github.com/wagtail/wagtail/compare/3da4b686eb...mgax:wagtail:refactor-test-for-10411.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   ~~For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]~~
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   ~~For new features: Has the documentation been updated accordingly?~~

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
