### PR TITLE
Add support for query time boosting to Elasticsearch 6+

### DIFF
--- a/wagtail/search/backends/elasticsearch6.py
+++ b/wagtail/search/backends/elasticsearch6.py
@@ -1,4 +1,5 @@
 from wagtail.search.index import get_indexed_models
+from wagtail.search.query import Fuzzy, MatchAll, Not, Phrase, PlainText
 
 from .elasticsearch5 import (
     Elasticsearch5Index,
@@ -15,7 +16,9 @@ class Elasticsearch6Mapping(Elasticsearch5Mapping):
     edgengrams_field_name = "_edgengrams"
 
     def get_boost_field_name(self, boost):
-        return f"{self.all_field_name}_boost_{boost}"
+        # replace . with _ to avoid issues with . in field names
+        boost = str(float(boost)).replace(".", "_")
+        return f"{self.all_field_name}_boost$$${boost}"
 
     def get_document_id(self, obj):
         return str(obj.pk)
@@ -47,6 +50,7 @@ class Elasticsearch6Mapping(Elasticsearch5Mapping):
                                 field_mapping["copy_to"],
                                 self.get_boost_field_name(field_mapping["boost"]),
                             ]
+                            del field_mapping["boost"]
 
                     del field_mapping["include_in_all"]
 
@@ -69,33 +73,97 @@ class Elasticsearch6Index(Elasticsearch5Index):
 class Elasticsearch6SearchQueryCompiler(Elasticsearch5SearchQueryCompiler):
     mapping_class = Elasticsearch6Mapping
 
-    def get_boosted_fields(self, fields):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        remapped_fields = self.remapped_fields or [self.mapping.all_field_name]
+        self.remapped_fields = remapped_fields + self.get_boosted_field_names()
+
+    def get_boosted_field_names(self):
         models = get_indexed_models()
         unique_boosts = set()
         for model in models:
             for field in model.get_searchable_search_fields():
                 if field.boost:
-                    unique_boosts.add(field.boost)
-        for boost in unique_boosts:
-            fields.append(f"{self.mapping.get_boost_field_name(boost)}^{boost}")
-        return fields
+                    unique_boosts.add(float(field.boost))
+        return [self.mapping.get_boost_field_name(_boost) for _boost in unique_boosts]
+
+    def add_boosts_to_fields(self, fields, boost=1):
+        boosted_fields = []
+        if not isinstance(fields, list):
+            fields = [fields]
+        for field in fields:
+            split = field.split("$$$")
+            if len(split) == 2:
+                _boost = float(split[1].replace("_", "."))
+                boosted_fields.append(f"{field}^{_boost * boost}")
+            else:
+                boosted_fields.append(field)
+        return boosted_fields
 
     def _compile_fuzzy_query(self, query, fields):
-        super()._compile_fuzzy_query(query, fields)
-
         return {
             "multi_match": {
                 "query": query.query_string,
-                "fields": self.get_boosted_fields(fields),
+                "fields": self.add_boosts_to_fields(fields),
                 "fuzziness": "AUTO",
             }
         }
 
-    def _compile_plaintext_query(self, query, fields, boost=1):
-        return super()._compile_plaintext_query(query, self.get_boosted_fields(fields))
+    def _compile_plaintext_query(self, query, fields, boost=1.0):
+        return super()._compile_plaintext_query(
+            query, self.add_boosts_to_fields(fields), boost
+        )
 
     def _compile_phrase_query(self, query, fields):
-        return super()._compile_phrase_query(query, self.get_boosted_fields(fields))
+        return super()._compile_phrase_query(query, self.add_boosts_to_fields(fields))
+
+    def get_inner_query(self):
+        if self.remapped_fields:
+            fields = self.remapped_fields
+        else:
+            fields = [self.mapping.all_field_name]
+
+        if len(fields) == 0:
+            # No fields. Return a query that'll match nothing
+            return {"bool": {"mustNot": {"match_all": {}}}}
+
+        # Handle MatchAll and PlainText separately as they were supported
+        # before "search query classes" was implemented and we'd like to
+        # keep the query the same as before
+        if isinstance(self.query, MatchAll):
+            return {"match_all": {}}
+
+        elif isinstance(self.query, PlainText):
+            return self._compile_plaintext_query(self.query, fields)
+
+        elif isinstance(self.query, Phrase):
+            return self._compile_phrase_query(self.query, fields)
+
+        elif isinstance(self.query, Fuzzy):
+            return self._compile_fuzzy_query(self.query, fields)
+
+        elif isinstance(self.query, Not):
+            return {
+                "bool": {
+                    "mustNot": [
+                        self._compile_query(self.query.subquery, field)
+                        for field in fields
+                    ]
+                }
+            }
+
+        else:
+            if len(fields) == 1:
+                return self._compile_query(self.query, fields[0])
+            else:
+                # Compile a query for each field then combine with disjunction
+                # max (or operator which takes the max score out of each of the
+                # field queries)
+                field_queries = []
+                for field in fields:
+                    field_queries.append(self._compile_query(self.query, field))
+
+                return {"dis_max": {"queries": field_queries}}
 
 
 class Elasticsearch6SearchResults(Elasticsearch5SearchResults):

--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -3,10 +3,8 @@ from copy import deepcopy
 from elasticsearch import NotFoundError
 from elasticsearch.helpers import bulk
 
-from wagtail.search.backends.elasticsearch5 import (
-    ElasticsearchAutocompleteQueryCompilerImpl,
-)
 from wagtail.search.backends.elasticsearch6 import (
+    Elasticsearch6AutocompleteQueryCompiler,
     Elasticsearch6Index,
     Elasticsearch6Mapping,
     Elasticsearch6SearchBackend,
@@ -85,7 +83,7 @@ class Elasticsearch7SearchResults(Elasticsearch6SearchResults):
 
 
 class Elasticsearch7AutocompleteQueryCompiler(
-    ElasticsearchAutocompleteQueryCompilerImpl, Elasticsearch6SearchQueryCompiler
+    Elasticsearch6AutocompleteQueryCompiler, Elasticsearch6SearchQueryCompiler
 ):
     pass
 

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -43,8 +43,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -64,13 +64,10 @@ class TestElasticsearch6SearchQuery(TestCase):
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
-                    "multi_match": {
-                        "fields": [
-                            "_edgengrams",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
-                        ],
-                        "query": "Hello",
+                    "match": {
+                        "_edgengrams": {
+                            "query": "Hello",
+                        }
                     },
                 },
             }
@@ -104,8 +101,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                         "operator": "and",
@@ -132,8 +129,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -169,8 +166,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -221,8 +218,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -255,8 +252,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -279,8 +276,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "title",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -303,8 +300,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "title",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                         "operator": "and",
@@ -329,8 +326,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                         "fields": [
                             "title",
                             "content",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -357,8 +354,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                         "fields": [
                             "title",
                             "content",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                         "operator": "and",
@@ -385,8 +382,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -412,8 +409,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -439,8 +436,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -466,8 +463,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -493,8 +490,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -525,8 +522,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -555,8 +552,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -585,8 +582,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -615,8 +612,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -653,8 +650,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -713,8 +710,8 @@ class TestElasticsearch6SearchQuery(TestCase):
             "multi_match": {
                 "fields": [
                     "_all_text",
-                    "_all_text_boost_2^2",
-                    "_all_text_boost_10^10",
+                    "_all_text_boost$$$2_0^2.0",
+                    "_all_text_boost$$$10_0^10.0",
                 ],
                 "query": "Hello world",
                 "type": "phrase",
@@ -736,8 +733,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                 "fields": [
                     "title",
                     "content",
-                    "_all_text_boost_2^2",
-                    "_all_text_boost_10^10",
+                    "_all_text_boost$$$2_0^2.0",
+                    "_all_text_boost$$$10_0^10.0",
                 ],
                 "query": "Hello world",
                 "type": "phrase",
@@ -756,8 +753,8 @@ class TestElasticsearch6SearchQuery(TestCase):
             "multi_match": {
                 "fields": [
                     "title",
-                    "_all_text_boost_2^2",
-                    "_all_text_boost_10^10",
+                    "_all_text_boost$$$2_0^2.0",
+                    "_all_text_boost$$$10_0^10.0",
                 ],
                 "query": "Hello world",
                 "type": "phrase",
@@ -777,8 +774,8 @@ class TestElasticsearch6SearchQuery(TestCase):
             "multi_match": {
                 "fields": [
                     "_all_text",
-                    "_all_text_boost_2^2",
-                    "_all_text_boost_10^10",
+                    "_all_text_boost$$$2_0^2.0",
+                    "_all_text_boost$$$10_0^10.0",
                 ],
                 "query": "Hello world",
                 "fuzziness": "AUTO",
@@ -799,8 +796,8 @@ class TestElasticsearch6SearchQuery(TestCase):
             "multi_match": {
                 "fields": [
                     "title",
-                    "_all_text_boost_2^2",
-                    "_all_text_boost_10^10",
+                    "_all_text_boost$$$2_0^2.0",
+                    "_all_text_boost$$$10_0^10.0",
                 ],
                 "query": "Hello world",
                 "fuzziness": "AUTO",
@@ -808,7 +805,7 @@ class TestElasticsearch6SearchQuery(TestCase):
         }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
-    def test_fuzzy_query_multiple_fields_disallowed(self):
+    def test_fuzzy_query_multiple_fields(self):
         # Create a query
         query_compiler = self.query_compiler_class(
             models.Book.objects.all(),
@@ -816,9 +813,19 @@ class TestElasticsearch6SearchQuery(TestCase):
             fields=["title", "body"],
         )
 
-        # Check it
-        with self.assertRaises(NotImplementedError):
-            query_compiler.get_inner_query()
+        expected_result = {
+            "multi_match": {
+                "fields": [
+                    "title",
+                    "body",
+                    "_all_text_boost$$$2_0^2.0",
+                    "_all_text_boost$$$10_0^10.0",
+                ],
+                "query": "Hello world",
+                "fuzziness": "AUTO",
+            },
+        }
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
     def test_year_filter(self):
         # Create a query
@@ -837,8 +844,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -1054,7 +1061,7 @@ class TestElasticsearch6Mapping(TestCase):
                     "pk": {"type": "keyword", "store": True},
                     "content_type": {"type": "keyword"},
                     "_all_text": {"type": "text"},
-                    "_all_text_boost_2.0": {"type": "text"},
+                    "_all_text_boost$$$2_0": {"type": "text"},
                     "_edgengrams": {
                         "analyzer": "edgengram_analyzer",
                         "search_analyzer": "standard",
@@ -1062,8 +1069,7 @@ class TestElasticsearch6Mapping(TestCase):
                     },
                     "title": {
                         "type": "text",
-                        "boost": 2.0,
-                        "copy_to": ["_all_text", "_all_text_boost_2.0"],
+                        "copy_to": ["_all_text", "_all_text_boost$$$2_0"],
                     },
                     "title_edgengrams": {
                         "type": "text",
@@ -1181,8 +1187,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
                         "properties": {
                             "name": {
                                 "type": "text",
-                                "boost": 0.5,
-                                "copy_to": ["_all_text", "_all_text_boost_0.5"],
+                                "copy_to": ["_all_text", "_all_text_boost$$$0_5"],
                             },
                             "novel_id_filter": {"type": "integer"},
                         },
@@ -1193,8 +1198,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
                         "properties": {
                             "name": {
                                 "type": "text",
-                                "boost": 0.25,
-                                "copy_to": ["_all_text", "_all_text_boost_0.25"],
+                                "copy_to": ["_all_text", "_all_text_boost$$$0_25"],
                             }
                         },
                     },
@@ -1202,9 +1206,9 @@ class TestElasticsearch6MappingInheritance(TestCase):
                     "pk": {"type": "keyword", "store": True},
                     "content_type": {"type": "keyword"},
                     "_all_text": {"type": "text"},
-                    "_all_text_boost_0.25": {"type": "text"},
-                    "_all_text_boost_0.5": {"type": "text"},
-                    "_all_text_boost_2.0": {"type": "text"},
+                    "_all_text_boost$$$0_25": {"type": "text"},
+                    "_all_text_boost$$$0_5": {"type": "text"},
+                    "_all_text_boost$$$2_0": {"type": "text"},
                     "_edgengrams": {
                         "analyzer": "edgengram_analyzer",
                         "search_analyzer": "standard",
@@ -1212,8 +1216,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
                     },
                     "title": {
                         "type": "text",
-                        "boost": 2.0,
-                        "copy_to": ["_all_text", "_all_text_boost_2.0"],
+                        "copy_to": ["_all_text", "_all_text_boost$$$2_0"],
                     },
                     "title_edgengrams": {
                         "type": "text",

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -40,11 +40,14 @@ class TestElasticsearch6SearchQuery(TestCase):
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -61,11 +64,14 @@ class TestElasticsearch6SearchQuery(TestCase):
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
-                    "match": {
-                        "_edgengrams": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_edgengrams",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -95,12 +101,15 @@ class TestElasticsearch6SearchQuery(TestCase):
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                            "operator": "and",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                        "operator": "and",
+                    },
                 },
             }
         }
@@ -120,11 +129,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"term": {"title_filter": "Test"}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -154,11 +166,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -203,11 +218,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -234,11 +252,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -254,7 +275,16 @@ class TestElasticsearch6SearchQuery(TestCase):
         expected_result = {
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
-                "must": {"match": {"title": {"query": "Hello"}}},
+                "must": {
+                    "multi_match": {
+                        "fields": [
+                            "title",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
+                },
             }
         }
         self.assertDictEqual(query.get_query(), expected_result)
@@ -269,7 +299,17 @@ class TestElasticsearch6SearchQuery(TestCase):
         expected_result = {
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
-                "must": {"match": {"title": {"query": "Hello", "operator": "and"}}},
+                "must": {
+                    "multi_match": {
+                        "fields": [
+                            "title",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                        "operator": "and",
+                    },
+                },
             }
         }
         self.assertDictEqual(query.get_query(), expected_result)
@@ -285,7 +325,15 @@ class TestElasticsearch6SearchQuery(TestCase):
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
-                    "multi_match": {"fields": ["title", "content"], "query": "Hello"}
+                    "multi_match": {
+                        "fields": [
+                            "title",
+                            "content",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -306,10 +354,15 @@ class TestElasticsearch6SearchQuery(TestCase):
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
                     "multi_match": {
-                        "fields": ["title", "content"],
+                        "fields": [
+                            "title",
+                            "content",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
                         "query": "Hello",
                         "operator": "and",
-                    }
+                    },
                 },
             }
         }
@@ -329,11 +382,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"term": {"title_filter": "Test"}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -353,11 +409,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"bool": {"mustNot": {"exists": {"field": "title_filter"}}}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -377,11 +436,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"bool": {"mustNot": {"exists": {"field": "title_filter"}}}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -401,11 +463,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"exists": {"field": "title_filter"}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -425,11 +490,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"prefix": {"title_filter": "Test"}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -454,11 +522,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"gt": "2014-04-29"}}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -481,11 +552,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"lt": "2014-04-29"}}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -508,11 +582,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"gte": "2014-04-29"}}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -535,11 +612,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"lte": "2014-04-29"}}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -570,11 +650,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -627,9 +710,15 @@ class TestElasticsearch6SearchQuery(TestCase):
 
         # Check it
         expected_result = {
-            "match_phrase": {
-                "_all_text": "Hello world",
-            }
+            "multi_match": {
+                "fields": [
+                    "_all_text",
+                    "_all_text_boost_2^2",
+                    "_all_text_boost_10^10",
+                ],
+                "query": "Hello world",
+                "type": "phrase",
+            },
         }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
@@ -644,10 +733,15 @@ class TestElasticsearch6SearchQuery(TestCase):
         # Check it
         expected_result = {
             "multi_match": {
-                "fields": ["title", "content"],
+                "fields": [
+                    "title",
+                    "content",
+                    "_all_text_boost_2^2",
+                    "_all_text_boost_10^10",
+                ],
                 "query": "Hello world",
                 "type": "phrase",
-            }
+            },
         }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
@@ -658,7 +752,17 @@ class TestElasticsearch6SearchQuery(TestCase):
         )
 
         # Check it
-        expected_result = {"match_phrase": {"title": "Hello world"}}
+        expected_result = {
+            "multi_match": {
+                "fields": [
+                    "title",
+                    "_all_text_boost_2^2",
+                    "_all_text_boost_10^10",
+                ],
+                "query": "Hello world",
+                "type": "phrase",
+            },
+        }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
     def test_fuzzy_query(self):
@@ -670,7 +774,15 @@ class TestElasticsearch6SearchQuery(TestCase):
 
         # Check it
         expected_result = {
-            "match": {"_all_text": {"query": "Hello world", "fuzziness": "AUTO"}}
+            "multi_match": {
+                "fields": [
+                    "_all_text",
+                    "_all_text_boost_2^2",
+                    "_all_text_boost_10^10",
+                ],
+                "query": "Hello world",
+                "fuzziness": "AUTO",
+            },
         }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
@@ -684,7 +796,15 @@ class TestElasticsearch6SearchQuery(TestCase):
 
         # Check it
         expected_result = {
-            "match": {"title": {"query": "Hello world", "fuzziness": "AUTO"}}
+            "multi_match": {
+                "fields": [
+                    "title",
+                    "_all_text_boost_2^2",
+                    "_all_text_boost_10^10",
+                ],
+                "query": "Hello world",
+                "fuzziness": "AUTO",
+            },
         }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
@@ -714,11 +834,14 @@ class TestElasticsearch6SearchQuery(TestCase):
                     {"term": {"publication_date_filter": 1900}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -931,6 +1054,7 @@ class TestElasticsearch6Mapping(TestCase):
                     "pk": {"type": "keyword", "store": True},
                     "content_type": {"type": "keyword"},
                     "_all_text": {"type": "text"},
+                    "_all_text_boost_2.0": {"type": "text"},
                     "_edgengrams": {
                         "analyzer": "edgengram_analyzer",
                         "search_analyzer": "standard",
@@ -939,7 +1063,7 @@ class TestElasticsearch6Mapping(TestCase):
                     "title": {
                         "type": "text",
                         "boost": 2.0,
-                        "copy_to": "_all_text",
+                        "copy_to": ["_all_text", "_all_text_boost_2.0"],
                     },
                     "title_edgengrams": {
                         "type": "text",
@@ -1058,7 +1182,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
                             "name": {
                                 "type": "text",
                                 "boost": 0.5,
-                                "copy_to": "_all_text",
+                                "copy_to": ["_all_text", "_all_text_boost_0.5"],
                             },
                             "novel_id_filter": {"type": "integer"},
                         },
@@ -1070,7 +1194,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
                             "name": {
                                 "type": "text",
                                 "boost": 0.25,
-                                "copy_to": "_all_text",
+                                "copy_to": ["_all_text", "_all_text_boost_0.25"],
                             }
                         },
                     },
@@ -1078,6 +1202,9 @@ class TestElasticsearch6MappingInheritance(TestCase):
                     "pk": {"type": "keyword", "store": True},
                     "content_type": {"type": "keyword"},
                     "_all_text": {"type": "text"},
+                    "_all_text_boost_0.25": {"type": "text"},
+                    "_all_text_boost_0.5": {"type": "text"},
+                    "_all_text_boost_2.0": {"type": "text"},
                     "_edgengrams": {
                         "analyzer": "edgengram_analyzer",
                         "search_analyzer": "standard",
@@ -1086,7 +1213,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
                     "title": {
                         "type": "text",
                         "boost": 2.0,
-                        "copy_to": "_all_text",
+                        "copy_to": ["_all_text", "_all_text_boost_2.0"],
                     },
                     "title_edgengrams": {
                         "type": "text",

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -43,8 +43,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -101,8 +101,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                         "operator": "and",
@@ -129,8 +129,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -166,8 +166,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -218,8 +218,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -252,8 +252,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -276,8 +276,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "title",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -300,8 +300,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "title",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                         "operator": "and",
@@ -326,8 +326,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                         "fields": [
                             "title",
                             "content",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -354,8 +354,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                         "fields": [
                             "title",
                             "content",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                         "operator": "and",
@@ -382,8 +382,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -409,8 +409,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -436,8 +436,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -463,8 +463,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -490,8 +490,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -522,8 +522,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -552,8 +552,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -582,8 +582,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -612,8 +612,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -650,8 +650,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -710,8 +710,8 @@ class TestElasticsearch6SearchQuery(TestCase):
             "multi_match": {
                 "fields": [
                     "_all_text",
-                    "_all_text_boost$$$2_0^2.0",
-                    "_all_text_boost$$$10_0^10.0",
+                    "_all_text_boost_2_0^2.0",
+                    "_all_text_boost_10_0^10.0",
                 ],
                 "query": "Hello world",
                 "type": "phrase",
@@ -733,8 +733,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                 "fields": [
                     "title",
                     "content",
-                    "_all_text_boost$$$2_0^2.0",
-                    "_all_text_boost$$$10_0^10.0",
+                    "_all_text_boost_2_0^2.0",
+                    "_all_text_boost_10_0^10.0",
                 ],
                 "query": "Hello world",
                 "type": "phrase",
@@ -753,8 +753,8 @@ class TestElasticsearch6SearchQuery(TestCase):
             "multi_match": {
                 "fields": [
                     "title",
-                    "_all_text_boost$$$2_0^2.0",
-                    "_all_text_boost$$$10_0^10.0",
+                    "_all_text_boost_2_0^2.0",
+                    "_all_text_boost_10_0^10.0",
                 ],
                 "query": "Hello world",
                 "type": "phrase",
@@ -774,8 +774,8 @@ class TestElasticsearch6SearchQuery(TestCase):
             "multi_match": {
                 "fields": [
                     "_all_text",
-                    "_all_text_boost$$$2_0^2.0",
-                    "_all_text_boost$$$10_0^10.0",
+                    "_all_text_boost_2_0^2.0",
+                    "_all_text_boost_10_0^10.0",
                 ],
                 "query": "Hello world",
                 "fuzziness": "AUTO",
@@ -796,8 +796,8 @@ class TestElasticsearch6SearchQuery(TestCase):
             "multi_match": {
                 "fields": [
                     "title",
-                    "_all_text_boost$$$2_0^2.0",
-                    "_all_text_boost$$$10_0^10.0",
+                    "_all_text_boost_2_0^2.0",
+                    "_all_text_boost_10_0^10.0",
                 ],
                 "query": "Hello world",
                 "fuzziness": "AUTO",
@@ -818,8 +818,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                 "fields": [
                     "title",
                     "body",
-                    "_all_text_boost$$$2_0^2.0",
-                    "_all_text_boost$$$10_0^10.0",
+                    "_all_text_boost_2_0^2.0",
+                    "_all_text_boost_10_0^10.0",
                 ],
                 "query": "Hello world",
                 "fuzziness": "AUTO",
@@ -844,8 +844,8 @@ class TestElasticsearch6SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -1061,7 +1061,7 @@ class TestElasticsearch6Mapping(TestCase):
                     "pk": {"type": "keyword", "store": True},
                     "content_type": {"type": "keyword"},
                     "_all_text": {"type": "text"},
-                    "_all_text_boost$$$2_0": {"type": "text"},
+                    "_all_text_boost_2_0": {"type": "text"},
                     "_edgengrams": {
                         "analyzer": "edgengram_analyzer",
                         "search_analyzer": "standard",
@@ -1069,7 +1069,7 @@ class TestElasticsearch6Mapping(TestCase):
                     },
                     "title": {
                         "type": "text",
-                        "copy_to": ["_all_text", "_all_text_boost$$$2_0"],
+                        "copy_to": ["_all_text", "_all_text_boost_2_0"],
                     },
                     "title_edgengrams": {
                         "type": "text",
@@ -1187,7 +1187,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
                         "properties": {
                             "name": {
                                 "type": "text",
-                                "copy_to": ["_all_text", "_all_text_boost$$$0_5"],
+                                "copy_to": ["_all_text", "_all_text_boost_0_5"],
                             },
                             "novel_id_filter": {"type": "integer"},
                         },
@@ -1198,7 +1198,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
                         "properties": {
                             "name": {
                                 "type": "text",
-                                "copy_to": ["_all_text", "_all_text_boost$$$0_25"],
+                                "copy_to": ["_all_text", "_all_text_boost_0_25"],
                             }
                         },
                     },
@@ -1206,9 +1206,9 @@ class TestElasticsearch6MappingInheritance(TestCase):
                     "pk": {"type": "keyword", "store": True},
                     "content_type": {"type": "keyword"},
                     "_all_text": {"type": "text"},
-                    "_all_text_boost$$$0_25": {"type": "text"},
-                    "_all_text_boost$$$0_5": {"type": "text"},
-                    "_all_text_boost$$$2_0": {"type": "text"},
+                    "_all_text_boost_0_25": {"type": "text"},
+                    "_all_text_boost_0_5": {"type": "text"},
+                    "_all_text_boost_2_0": {"type": "text"},
                     "_edgengrams": {
                         "analyzer": "edgengram_analyzer",
                         "search_analyzer": "standard",
@@ -1216,7 +1216,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
                     },
                     "title": {
                         "type": "text",
-                        "copy_to": ["_all_text", "_all_text_boost$$$2_0"],
+                        "copy_to": ["_all_text", "_all_text_boost_2_0"],
                     },
                     "title_edgengrams": {
                         "type": "text",

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -41,7 +41,16 @@ class TestElasticsearch7SearchQuery(TestCase):
         expected_result = {
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
-                "must": {"match": {"_all_text": {"query": "Hello"}}},
+                "must": {
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
+                },
             }
         }
         self.assertDictEqual(query.get_query(), expected_result)
@@ -56,7 +65,16 @@ class TestElasticsearch7SearchQuery(TestCase):
         expected_result = {
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
-                "must": {"match": {"_edgengrams": {"query": "Hello"}}},
+                "must": {
+                    "multi_match": {
+                        "fields": [
+                            "_edgengrams",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
+                },
             }
         }
         self.assertDictEqual(query.get_query(), expected_result)
@@ -85,12 +103,15 @@ class TestElasticsearch7SearchQuery(TestCase):
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                            "operator": "and",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                        "operator": "and",
+                    },
                 },
             }
         }
@@ -110,11 +131,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"term": {"title_filter": "Test"}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -144,11 +168,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -193,11 +220,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -224,11 +254,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -244,7 +277,16 @@ class TestElasticsearch7SearchQuery(TestCase):
         expected_result = {
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
-                "must": {"match": {"title": {"query": "Hello"}}},
+                "must": {
+                    "multi_match": {
+                        "fields": [
+                            "title",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
+                },
             }
         }
         self.assertDictEqual(query.get_query(), expected_result)
@@ -259,7 +301,17 @@ class TestElasticsearch7SearchQuery(TestCase):
         expected_result = {
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
-                "must": {"match": {"title": {"query": "Hello", "operator": "and"}}},
+                "must": {
+                    "multi_match": {
+                        "fields": [
+                            "title",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                        "operator": "and",
+                    },
+                },
             }
         }
         self.assertDictEqual(query.get_query(), expected_result)
@@ -275,7 +327,15 @@ class TestElasticsearch7SearchQuery(TestCase):
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
-                    "multi_match": {"fields": ["title", "content"], "query": "Hello"}
+                    "multi_match": {
+                        "fields": [
+                            "title",
+                            "content",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    }
                 },
             }
         }
@@ -296,7 +356,12 @@ class TestElasticsearch7SearchQuery(TestCase):
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
                     "multi_match": {
-                        "fields": ["title", "content"],
+                        "fields": [
+                            "title",
+                            "content",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
                         "query": "Hello",
                         "operator": "and",
                     }
@@ -319,11 +384,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"term": {"title_filter": "Test"}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -343,11 +411,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"bool": {"mustNot": {"exists": {"field": "title_filter"}}}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -367,11 +438,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"bool": {"mustNot": {"exists": {"field": "title_filter"}}}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -391,11 +465,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"exists": {"field": "title_filter"}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -415,11 +492,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"prefix": {"title_filter": "Test"}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -444,11 +524,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"gt": "2014-04-29"}}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -471,11 +554,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"lt": "2014-04-29"}}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -498,11 +584,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"gte": "2014-04-29"}}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -525,11 +614,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"lte": "2014-04-29"}}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -560,11 +652,14 @@ class TestElasticsearch7SearchQuery(TestCase):
                     },
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
-                    }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
+                    },
                 },
             }
         }
@@ -616,7 +711,13 @@ class TestElasticsearch7SearchQuery(TestCase):
         )
 
         # Check it
-        expected_result = {"match_phrase": {"_all_text": "Hello world"}}
+        expected_result = {
+            "multi_match": {
+                "fields": ["_all_text", "_all_text_boost_2^2", "_all_text_boost_10^10"],
+                "query": "Hello world",
+                "type": "phrase",
+            },
+        }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
     def test_phrase_query_multiple_fields(self):
@@ -631,7 +732,12 @@ class TestElasticsearch7SearchQuery(TestCase):
         expected_result = {
             "multi_match": {
                 "query": "Hello world",
-                "fields": ["title", "content"],
+                "fields": [
+                    "title",
+                    "content",
+                    "_all_text_boost_2^2",
+                    "_all_text_boost_10^10",
+                ],
                 "type": "phrase",
             }
         }
@@ -644,7 +750,13 @@ class TestElasticsearch7SearchQuery(TestCase):
         )
 
         # Check it
-        expected_result = {"match_phrase": {"title": "Hello world"}}
+        expected_result = {
+            "multi_match": {
+                "fields": ["title", "_all_text_boost_2^2", "_all_text_boost_10^10"],
+                "query": "Hello world",
+                "type": "phrase",
+            },
+        }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
     def test_fuzzy_query(self):
@@ -656,7 +768,11 @@ class TestElasticsearch7SearchQuery(TestCase):
 
         # Check it
         expected_result = {
-            "match": {"_all_text": {"query": "Hello world", "fuzziness": "AUTO"}}
+            "multi_match": {
+                "fields": ["_all_text", "_all_text_boost_2^2", "_all_text_boost_10^10"],
+                "query": "Hello world",
+                "fuzziness": "AUTO",
+            }
         }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
@@ -670,7 +786,11 @@ class TestElasticsearch7SearchQuery(TestCase):
 
         # Check it
         expected_result = {
-            "match": {"title": {"query": "Hello world", "fuzziness": "AUTO"}}
+            "multi_match": {
+                "fields": ["title", "_all_text_boost_2^2", "_all_text_boost_10^10"],
+                "query": "Hello world",
+                "fuzziness": "AUTO",
+            }
         }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
@@ -700,10 +820,13 @@ class TestElasticsearch7SearchQuery(TestCase):
                     {"range": {"publication_date_filter": {"lt": 1900}}},
                 ],
                 "must": {
-                    "match": {
-                        "_all_text": {
-                            "query": "Hello",
-                        }
+                    "multi_match": {
+                        "fields": [
+                            "_all_text",
+                            "_all_text_boost_2^2",
+                            "_all_text_boost_10^10",
+                        ],
+                        "query": "Hello",
                     }
                 },
             }
@@ -918,6 +1041,7 @@ class TestElasticsearch7Mapping(TestCase):
                 "pk": {"type": "keyword", "store": True},
                 "content_type": {"type": "keyword"},
                 "_all_text": {"type": "text"},
+                "_all_text_boost_2.0": {"type": "text"},
                 "_edgengrams": {
                     "analyzer": "edgengram_analyzer",
                     "search_analyzer": "standard",
@@ -926,7 +1050,7 @@ class TestElasticsearch7Mapping(TestCase):
                 "title": {
                     "type": "text",
                     "boost": 2.0,
-                    "copy_to": "_all_text",
+                    "copy_to": ["_all_text", "_all_text_boost_2.0"],
                 },
                 "title_edgengrams": {
                     "type": "text",
@@ -1041,7 +1165,11 @@ class TestElasticsearch7MappingInheritance(TestCase):
                 "searchtests_novel__protagonist": {
                     "type": "nested",
                     "properties": {
-                        "name": {"type": "text", "boost": 0.5, "copy_to": "_all_text"},
+                        "name": {
+                            "type": "text",
+                            "boost": 0.5,
+                            "copy_to": ["_all_text", "_all_text_boost_0.5"],
+                        },
                         "novel_id_filter": {"type": "integer"},
                     },
                 },
@@ -1049,13 +1177,20 @@ class TestElasticsearch7MappingInheritance(TestCase):
                 "searchtests_novel__characters": {
                     "type": "nested",
                     "properties": {
-                        "name": {"type": "text", "boost": 0.25, "copy_to": "_all_text"}
+                        "name": {
+                            "type": "text",
+                            "boost": 0.25,
+                            "copy_to": ["_all_text", "_all_text_boost_0.25"],
+                        },
                     },
                 },
                 # Inherited
                 "pk": {"type": "keyword", "store": True},
                 "content_type": {"type": "keyword"},
                 "_all_text": {"type": "text"},
+                "_all_text_boost_0.25": {"type": "text"},
+                "_all_text_boost_0.5": {"type": "text"},
+                "_all_text_boost_2.0": {"type": "text"},
                 "_edgengrams": {
                     "analyzer": "edgengram_analyzer",
                     "search_analyzer": "standard",
@@ -1064,7 +1199,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
                 "title": {
                     "type": "text",
                     "boost": 2.0,
-                    "copy_to": "_all_text",
+                    "copy_to": ["_all_text", "_all_text_boost_2.0"],
                 },
                 "title_edgengrams": {
                     "type": "text",

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -45,8 +45,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -103,8 +103,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                         "operator": "and",
@@ -131,8 +131,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -168,8 +168,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -220,8 +220,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -254,8 +254,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -278,8 +278,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "title",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -302,8 +302,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "title",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                         "operator": "and",
@@ -328,8 +328,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                         "fields": [
                             "title",
                             "content",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     }
@@ -356,8 +356,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                         "fields": [
                             "title",
                             "content",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                         "operator": "and",
@@ -384,8 +384,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -411,8 +411,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -438,8 +438,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -465,8 +465,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -492,8 +492,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -524,8 +524,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -554,8 +554,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -584,8 +584,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -614,8 +614,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -652,8 +652,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -712,8 +712,8 @@ class TestElasticsearch7SearchQuery(TestCase):
             "multi_match": {
                 "fields": [
                     "_all_text",
-                    "_all_text_boost$$$2_0^2.0",
-                    "_all_text_boost$$$10_0^10.0",
+                    "_all_text_boost_2_0^2.0",
+                    "_all_text_boost_10_0^10.0",
                 ],
                 "query": "Hello world",
                 "type": "phrase",
@@ -736,8 +736,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                 "fields": [
                     "title",
                     "content",
-                    "_all_text_boost$$$2_0^2.0",
-                    "_all_text_boost$$$10_0^10.0",
+                    "_all_text_boost_2_0^2.0",
+                    "_all_text_boost_10_0^10.0",
                 ],
                 "type": "phrase",
             }
@@ -755,8 +755,8 @@ class TestElasticsearch7SearchQuery(TestCase):
             "multi_match": {
                 "fields": [
                     "title",
-                    "_all_text_boost$$$2_0^2.0",
-                    "_all_text_boost$$$10_0^10.0",
+                    "_all_text_boost_2_0^2.0",
+                    "_all_text_boost_10_0^10.0",
                 ],
                 "query": "Hello world",
                 "type": "phrase",
@@ -776,8 +776,8 @@ class TestElasticsearch7SearchQuery(TestCase):
             "multi_match": {
                 "fields": [
                     "_all_text",
-                    "_all_text_boost$$$2_0^2.0",
-                    "_all_text_boost$$$10_0^10.0",
+                    "_all_text_boost_2_0^2.0",
+                    "_all_text_boost_10_0^10.0",
                 ],
                 "query": "Hello world",
                 "fuzziness": "AUTO",
@@ -798,8 +798,8 @@ class TestElasticsearch7SearchQuery(TestCase):
             "multi_match": {
                 "fields": [
                     "title",
-                    "_all_text_boost$$$2_0^2.0",
-                    "_all_text_boost$$$10_0^10.0",
+                    "_all_text_boost_2_0^2.0",
+                    "_all_text_boost_10_0^10.0",
                 ],
                 "query": "Hello world",
                 "fuzziness": "AUTO",
@@ -820,8 +820,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                 "fields": [
                     "title",
                     "body",
-                    "_all_text_boost$$$2_0^2.0",
-                    "_all_text_boost$$$10_0^10.0",
+                    "_all_text_boost_2_0^2.0",
+                    "_all_text_boost_10_0^10.0",
                 ],
                 "query": "Hello world",
                 "fuzziness": "AUTO",
@@ -846,8 +846,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost$$$2_0^2.0",
-                            "_all_text_boost$$$10_0^10.0",
+                            "_all_text_boost_2_0^2.0",
+                            "_all_text_boost_10_0^10.0",
                         ],
                         "query": "Hello",
                     }
@@ -1064,7 +1064,7 @@ class TestElasticsearch7Mapping(TestCase):
                 "pk": {"type": "keyword", "store": True},
                 "content_type": {"type": "keyword"},
                 "_all_text": {"type": "text"},
-                "_all_text_boost$$$2_0": {"type": "text"},
+                "_all_text_boost_2_0": {"type": "text"},
                 "_edgengrams": {
                     "analyzer": "edgengram_analyzer",
                     "search_analyzer": "standard",
@@ -1072,7 +1072,7 @@ class TestElasticsearch7Mapping(TestCase):
                 },
                 "title": {
                     "type": "text",
-                    "copy_to": ["_all_text", "_all_text_boost$$$2_0"],
+                    "copy_to": ["_all_text", "_all_text_boost_2_0"],
                 },
                 "title_edgengrams": {
                     "type": "text",
@@ -1189,7 +1189,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
                     "properties": {
                         "name": {
                             "type": "text",
-                            "copy_to": ["_all_text", "_all_text_boost$$$0_5"],
+                            "copy_to": ["_all_text", "_all_text_boost_0_5"],
                         },
                         "novel_id_filter": {"type": "integer"},
                     },
@@ -1200,7 +1200,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
                     "properties": {
                         "name": {
                             "type": "text",
-                            "copy_to": ["_all_text", "_all_text_boost$$$0_25"],
+                            "copy_to": ["_all_text", "_all_text_boost_0_25"],
                         },
                     },
                 },
@@ -1208,9 +1208,9 @@ class TestElasticsearch7MappingInheritance(TestCase):
                 "pk": {"type": "keyword", "store": True},
                 "content_type": {"type": "keyword"},
                 "_all_text": {"type": "text"},
-                "_all_text_boost$$$0_25": {"type": "text"},
-                "_all_text_boost$$$0_5": {"type": "text"},
-                "_all_text_boost$$$2_0": {"type": "text"},
+                "_all_text_boost_0_25": {"type": "text"},
+                "_all_text_boost_0_5": {"type": "text"},
+                "_all_text_boost_2_0": {"type": "text"},
                 "_edgengrams": {
                     "analyzer": "edgengram_analyzer",
                     "search_analyzer": "standard",
@@ -1218,7 +1218,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
                 },
                 "title": {
                     "type": "text",
-                    "copy_to": ["_all_text", "_all_text_boost$$$2_0"],
+                    "copy_to": ["_all_text", "_all_text_boost_2_0"],
                 },
                 "title_edgengrams": {
                     "type": "text",

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -45,8 +45,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -66,13 +66,10 @@ class TestElasticsearch7SearchQuery(TestCase):
             "bool": {
                 "filter": {"match": {"content_type": "searchtests.Book"}},
                 "must": {
-                    "multi_match": {
-                        "fields": [
-                            "_edgengrams",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
-                        ],
-                        "query": "Hello",
+                    "match": {
+                        "_edgengrams": {
+                            "query": "Hello",
+                        }
                     },
                 },
             }
@@ -106,8 +103,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                         "operator": "and",
@@ -134,8 +131,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -171,8 +168,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -223,8 +220,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -257,8 +254,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -281,8 +278,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "title",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -305,8 +302,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "title",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                         "operator": "and",
@@ -331,8 +328,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                         "fields": [
                             "title",
                             "content",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     }
@@ -359,8 +356,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                         "fields": [
                             "title",
                             "content",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                         "operator": "and",
@@ -387,8 +384,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -414,8 +411,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -441,8 +438,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -468,8 +465,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -495,8 +492,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -527,8 +524,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -557,8 +554,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -587,8 +584,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -617,8 +614,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -655,8 +652,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     },
@@ -713,7 +710,11 @@ class TestElasticsearch7SearchQuery(TestCase):
         # Check it
         expected_result = {
             "multi_match": {
-                "fields": ["_all_text", "_all_text_boost_2^2", "_all_text_boost_10^10"],
+                "fields": [
+                    "_all_text",
+                    "_all_text_boost$$$2_0^2.0",
+                    "_all_text_boost$$$10_0^10.0",
+                ],
                 "query": "Hello world",
                 "type": "phrase",
             },
@@ -735,8 +736,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                 "fields": [
                     "title",
                     "content",
-                    "_all_text_boost_2^2",
-                    "_all_text_boost_10^10",
+                    "_all_text_boost$$$2_0^2.0",
+                    "_all_text_boost$$$10_0^10.0",
                 ],
                 "type": "phrase",
             }
@@ -752,7 +753,11 @@ class TestElasticsearch7SearchQuery(TestCase):
         # Check it
         expected_result = {
             "multi_match": {
-                "fields": ["title", "_all_text_boost_2^2", "_all_text_boost_10^10"],
+                "fields": [
+                    "title",
+                    "_all_text_boost$$$2_0^2.0",
+                    "_all_text_boost$$$10_0^10.0",
+                ],
                 "query": "Hello world",
                 "type": "phrase",
             },
@@ -769,7 +774,11 @@ class TestElasticsearch7SearchQuery(TestCase):
         # Check it
         expected_result = {
             "multi_match": {
-                "fields": ["_all_text", "_all_text_boost_2^2", "_all_text_boost_10^10"],
+                "fields": [
+                    "_all_text",
+                    "_all_text_boost$$$2_0^2.0",
+                    "_all_text_boost$$$10_0^10.0",
+                ],
                 "query": "Hello world",
                 "fuzziness": "AUTO",
             }
@@ -787,14 +796,18 @@ class TestElasticsearch7SearchQuery(TestCase):
         # Check it
         expected_result = {
             "multi_match": {
-                "fields": ["title", "_all_text_boost_2^2", "_all_text_boost_10^10"],
+                "fields": [
+                    "title",
+                    "_all_text_boost$$$2_0^2.0",
+                    "_all_text_boost$$$10_0^10.0",
+                ],
                 "query": "Hello world",
                 "fuzziness": "AUTO",
             }
         }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
-    def test_fuzzy_query_multiple_fields_disallowed(self):
+    def test_fuzzy_query_multiple_fields(self):
         # Create a query
         query_compiler = self.query_compiler_class(
             models.Book.objects.all(),
@@ -802,9 +815,19 @@ class TestElasticsearch7SearchQuery(TestCase):
             fields=["title", "body"],
         )
 
-        # Check it
-        with self.assertRaises(NotImplementedError):
-            query_compiler.get_inner_query()
+        expected_result = {
+            "multi_match": {
+                "fields": [
+                    "title",
+                    "body",
+                    "_all_text_boost$$$2_0^2.0",
+                    "_all_text_boost$$$10_0^10.0",
+                ],
+                "query": "Hello world",
+                "fuzziness": "AUTO",
+            }
+        }
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
     def test_year_filter(self):
         # Create a query
@@ -823,8 +846,8 @@ class TestElasticsearch7SearchQuery(TestCase):
                     "multi_match": {
                         "fields": [
                             "_all_text",
-                            "_all_text_boost_2^2",
-                            "_all_text_boost_10^10",
+                            "_all_text_boost$$$2_0^2.0",
+                            "_all_text_boost$$$10_0^10.0",
                         ],
                         "query": "Hello",
                     }
@@ -1041,7 +1064,7 @@ class TestElasticsearch7Mapping(TestCase):
                 "pk": {"type": "keyword", "store": True},
                 "content_type": {"type": "keyword"},
                 "_all_text": {"type": "text"},
-                "_all_text_boost_2.0": {"type": "text"},
+                "_all_text_boost$$$2_0": {"type": "text"},
                 "_edgengrams": {
                     "analyzer": "edgengram_analyzer",
                     "search_analyzer": "standard",
@@ -1049,8 +1072,7 @@ class TestElasticsearch7Mapping(TestCase):
                 },
                 "title": {
                     "type": "text",
-                    "boost": 2.0,
-                    "copy_to": ["_all_text", "_all_text_boost_2.0"],
+                    "copy_to": ["_all_text", "_all_text_boost$$$2_0"],
                 },
                 "title_edgengrams": {
                     "type": "text",
@@ -1167,8 +1189,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
                     "properties": {
                         "name": {
                             "type": "text",
-                            "boost": 0.5,
-                            "copy_to": ["_all_text", "_all_text_boost_0.5"],
+                            "copy_to": ["_all_text", "_all_text_boost$$$0_5"],
                         },
                         "novel_id_filter": {"type": "integer"},
                     },
@@ -1179,8 +1200,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
                     "properties": {
                         "name": {
                             "type": "text",
-                            "boost": 0.25,
-                            "copy_to": ["_all_text", "_all_text_boost_0.25"],
+                            "copy_to": ["_all_text", "_all_text_boost$$$0_25"],
                         },
                     },
                 },
@@ -1188,9 +1208,9 @@ class TestElasticsearch7MappingInheritance(TestCase):
                 "pk": {"type": "keyword", "store": True},
                 "content_type": {"type": "keyword"},
                 "_all_text": {"type": "text"},
-                "_all_text_boost_0.25": {"type": "text"},
-                "_all_text_boost_0.5": {"type": "text"},
-                "_all_text_boost_2.0": {"type": "text"},
+                "_all_text_boost$$$0_25": {"type": "text"},
+                "_all_text_boost$$$0_5": {"type": "text"},
+                "_all_text_boost$$$2_0": {"type": "text"},
                 "_edgengrams": {
                     "analyzer": "edgengram_analyzer",
                     "search_analyzer": "standard",
@@ -1198,8 +1218,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
                 },
                 "title": {
                     "type": "text",
-                    "boost": 2.0,
-                    "copy_to": ["_all_text", "_all_text_boost_2.0"],
+                    "copy_to": ["_all_text", "_all_text_boost$$$2_0"],
                 },
                 "title_edgengrams": {
                     "type": "text",


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #5422 

This PR adds support for query time boosting, when using elasticsearch 6+.

Index time boosting was deprecated on 5.0.0, and instead the boost for the respective fields [is applied at query time](https://www.elastic.co/guide/en/elasticsearch/reference/6.3/mapping-boost.html). Since wagtail uses an all encompassing field `_all_text`, the boosts are lost and therefore not applied. #5422 

The PR finds all distinct values of boost across all indexed models, creates separates fields for them, and funnels the data of the respective model fields into the new fields. These new fields are then also added to the fields being queried upon, with the appropriate boosts applied to them. ([following this comment](https://github.com/wagtail/wagtail/issues/5422#issuecomment-645435567))

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] ~For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]~
    -   [ ] ~**Please list the exact browser and operating system versions you tested**:~
    -   [ ] ~**Please list which assistive technologies [^3] you tested**:~
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.
If you have a project using es6+ where you would want to test the difference, check your current search results, then just point to this version of wagtail, run `update_index`, and see the difference.

If not, ensure that you have an elasticsearch v6+ instance running (locally or otherwise). The following steps takes you through how to setup [bakerydemo](https://github.com/wagtail/bakerydemo) to test the changes. If you want to skip it, I have made a branch in my fork (https://github.com/KIRA009/bakerydemo/tree/es6-boost-test) which does the same things described below. You can skip to the **After setup** section once done.

If not, setup a fresh installation of the bakerydemo app. Ensure that the local wagtail version is being used (the main branch).  Ensure that bakerydemo has elasticsearch 6+ installed (change elasticsearch version in `requirements/production.txt` to `6.8.2`, and wagtail version in `requirements/base.txt` appropriately)
Then, make following changes to `bakerydemo/settings/base.py`
```
WAGTAILSEARCH_BACKENDS = {
    "default": {
        "BACKEND": "wagtail.search.backends.elasticsearch6",
        "URLS": ["your-es6-conn-url"],
        "INDEX": "wagtail",
        "TIMEOUT": 5,
        "OPTIONS": {},
        "INDEX_SETTINGS": {
            "settings": {
                "index": {"number_of_shards": 1, "number_of_replicas": 0},
                "analysis": {
                    "analyzer": {
                        "default": {
                            "tokenizer": "whitespace",
                            "filter": [
                                "lowercase",
                                "porter_stem",
                                "english_stop_words",
                            ],
                        },
                    },
                    "filter": {
                        "english_stop_words": {
                            "type": "stop",
                            "stopwords": "_english_",
                        },
                    },
                },
            },
        },
    }
}
```

Go to `bakerydemo/breads/models.py` and add a new field `introduction_2` to `BreadPage`.  Make sure to add it to the `content_panels`. The `search_fields` should look something like this
```
search_fields = Page.search_fields + [
    index.SearchField("introduction", boost=5),
    index.SearchField("introduction_2", boost=2),
]
```
The boosts should be reasonably different.

Go to `bakerydemo/search/views.py`, change line 22 to 
```
search_results = Page.objects.live().search(search_query).annotate_score("score")
```

Finally, go to `bakerydemo/templates/search/search_results.html` and change line 23 to
```
<h3 class="listing-card__title">{{ result.specific }} {{ result.score }}</h3>
```

## After setup
Make sure to run `makemigrations` and `migrate` after this.

Now, go to any `BreadPage` (if you are using the provided fixtures, [here's one](http://localhost:8000/admin/pages/35/edit/)), edit the `introduction` field to `Lorem` and `introduction_2` field to `Lorem Lorem Lorem`. Visit any other `BreadPage`([here's another](http://localhost:8000/admin/pages/34/edit/)), and edit the `introduction` field to `Lorem Lorem Lorem` and `introduction_2` field to `Lorem`.

Now, run `update_index` and visit [http://localhost:8000/search/?q=Lorem](http://localhost:8000/search/?q=Lorem). You should see that despite the boosts, both pages have the same score, whereas ideally, the one which has `Lorem` more times in `introduction`, should have a higher score.

Checkout to this branch for wagtail, run `update_index` again, and visit [http://localhost:8000/search/?q=Lorem](http://localhost:8000/search/?q=Lorem) again. You should see the scores as expected

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
