### PR TITLE
Deprecate `wagtail.contrib.modeladmin`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -105,6 +105,7 @@ Changelog
  * Maintenance: Migrate dialog instantiation to a new `w-dialog` Stimulus controller (Loveth Omokaro, LB (Ben) Johnston)
  * Maintenance: Support dialog template cloning using a new `w-teleport` Stimulus controller (Loveth Omokaro, LB (Ben) Johnston)
  * Maintenance: Migrate away from using the `"wagtailadmin/shared/field_as_li.html"` template include (Storm Heg)
+ * Maintenance: Deprecate `wagtail.contrib.modeladmin` (Sage Abdullah)
 
 
 5.0.2 (21.06.2023)

--- a/docs/reference/contrib/modeladmin/index.md
+++ b/docs/reference/contrib/modeladmin/index.md
@@ -3,7 +3,7 @@
 The `modeladmin` module allows you to add any model in your project to the Wagtail admin. You can create customisable listing pages for a model, including plain Django models, and add navigation elements so that a model can be accessed directly from the Wagtail admin. Simply extend the `ModelAdmin` class, override a few attributes to suit your needs, register it with Wagtail using an easy one-line `modeladmin_register` method (you can copy and paste from the examples below), and you're good to go. Your model doesn’t need to extend `Page` or be registered as a `Snippet`, and it won’t interfere with any of the existing admin functionality that Wagtail provides.
 
 ```{note}
-The `modeladmin` module will be deprecated in a future release and published as a separate package. We recommend using [](snippets) instead.
+The `modeladmin` module is deprecated. To manage non-page models in Wagtail, use [`wagtail.snippets`](snippets) instead. If you still rely on ModelAdmin, use the separate [wagtail-modeladmin](https://github.com/wagtail-nest/wagtail-modeladmin) package. The `wagtail.contrib.modeladmin` module will be removed in a future release.
 ```
 
 (modeladmin_feature_summary)=

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -179,6 +179,10 @@ The Elasticsearch 5 and 6 search backends are deprecated and will be removed in 
 
 The `insert_editor_css` hook has been deprecated. The `insert_global_admin_css` hook has the same functionality, and all uses of `insert_editor_css` should be changed to `insert_global_admin_css`.
 
+### `wagtail.contrib.modeladmin` is deprecated
+
+As part of the [RFC 85: Snippets parity with ModelAdmin](https://github.com/wagtail/rfcs/pull/85) implementation, the `wagtail.contrib.modeladmin` app is deprecated. To manage non-page models in Wagtail, use [`wagtail.snippets`](snippets) instead. If you still rely on ModelAdmin, use the separate [wagtail-modeladmin](https://github.com/wagtail-nest/wagtail-modeladmin) package. The `wagtail.contrib.modeladmin` module will be removed in a future release.
+
 ### `UserPagePermissionsProxy` is deprecated
 
 The undocumented `wagtail.models.UserPagePermissionsProxy` class is deprecated.

--- a/wagtail/contrib/modeladmin/apps.py
+++ b/wagtail/contrib/modeladmin/apps.py
@@ -1,8 +1,19 @@
+from warnings import warn
+
 from django.apps import AppConfig
 from django.utils.translation import gettext_lazy as _
+
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class WagtailModelAdminAppConfig(AppConfig):
     name = "wagtail.contrib.modeladmin"
     label = "wagtailmodeladmin"
     verbose_name = _("Wagtail ModelAdmin")
+
+    def ready(self):
+        warn(
+            "wagtail.contrib.modeladmin is deprecated. "
+            "Use wagtail.snippets or the separate wagtail-modeladmin package instead.",
+            category=RemovedInWagtail60Warning,
+        )

--- a/wagtail/contrib/modeladmin/tests/test_deprecation.py
+++ b/wagtail/contrib/modeladmin/tests/test_deprecation.py
@@ -1,0 +1,13 @@
+from django.apps import apps
+from django.test import SimpleTestCase
+
+
+class TestDeprecationWarning(SimpleTestCase):
+    def test_deprecation_warning(self):
+        config = apps.get_app_config("wagtailmodeladmin")
+        with self.assertWarnsMessage(
+            DeprecationWarning,
+            "wagtail.contrib.modeladmin is deprecated. "
+            "Use wagtail.snippets or the separate wagtail-modeladmin package instead.",
+        ):
+            config.ready()


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Ref: wagtail/rfcs#85.

To be merged when the modeladmin package is published. Will write a migration guide from modeladmin to snippets in a separate PR (can be done later post-RC).





_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

Running bakerydemo with `python -Wd manage.py runserver` will show the deprecation warning.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
