### PR TITLE
PublishMenuItem label is not overridable through hook

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Changelog
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)
  * Fix: Filter out comments on Page editing counts that do not correspond to a valid field / block path on the page such as when a field has been removed (Matt Westcott)
+ * Fix: Allow `PublishMenuItem` to more easily support overriding its label via `construct_page_action_menu` (Sébastien Corbin)
  * Docs: Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
  * Docs: Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)
  * Docs: Add documentation for building non-model-based choosers using the _queryish_ library (Matt Westcott)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -44,6 +44,7 @@ depth: 1
  * Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)
  * Filter out comments on Page editing counts that do not correspond to a valid field / block path on the page such as when a field has been removed (Matt Westcott)
+ * Allow `PublishMenuItem` to more easily support overriding its label via `construct_page_action_menu` (Sébastien Corbin)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/publish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/publish.html
@@ -10,5 +10,5 @@
 >
     {% if icon_name %}{% icon name=icon_name classname="button-longrunning__icon" %}{% endif %}
     {% icon name="spinner" %}
-    <em data-w-progress-target="label">{% if is_revision %}{% trans 'Publish this version' %}{% else %}{% trans 'Publish' %}{% endif %}</em>
+    <em data-w-progress-target="label">{% if is_revision %}{% trans 'Publish this version' %}{% else %}{{ label }}{% endif %}</em>
 </button>

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1891,6 +1891,21 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         self.assertContains(response, publish_button, html=True)
         self.assertNotContains(response, "<li>%s</li>" % publish_button, html=True)
 
+    def test_override_publish_action_menu_item_label(self):
+        def hook_func(menu_items, request, context):
+            for item in menu_items:
+                if item.name == "action-publish":
+                    item.label = "Foobar"
+                    break
+
+        with self.register_hook("construct_page_action_menu", hook_func):
+            response = self.client.get(
+                reverse("wagtailadmin_pages:edit", args=(self.single_event_page.id,))
+            )
+
+        # publish button should have another label
+        self.assertContains(response, "Foobar")
+
     def test_edit_alias_page(self):
         alias_page = self.event_page.create_alias(update_slug="new-event-page")
         response = self.client.get(


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10663 


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
