### PR TITLE
Fix flaky date test in wagtail.snippets.tests.test_viewset.TestListExport

### DIFF
--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -681,7 +681,6 @@ class TestListExport(BaseSnippetViewSetTests):
     @classmethod
     def setUpTestData(cls):
         cls.model.objects.create(text="Pot Noodle", country_code="UK")
-        cls.some_date = now().date()
 
         cls.first_published_at = "2023-07-01T13:12:11.100"
         if settings.USE_TZ:
@@ -695,6 +694,7 @@ class TestListExport(BaseSnippetViewSetTests):
         # Refresh so the first_published_at becomes a datetime object
         obj.refresh_from_db()
         cls.first_published_at = obj.first_published_at
+        cls.some_date = obj.some_date
 
     def test_get_not_export_shows_export_buttons(self):
         response = self.client.get(self.get_url("list"))


### PR DESCRIPTION


<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes a flaky test added in #10626.

The `some_date` field uses `auto_now`, which can yield a different result compared to `timezone.now().date()` depending on the timezone setting.

It's a minor fix to the test so I think I'll merge this as soon as CI passes.




_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
