### PR TITLE
Documentation: Add info on `searchpromotions` stored queries

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -78,6 +78,7 @@ Changelog
  * Docs: Switch the Getting started tutorial’s snippets example to be more understandable (Damilola Oladele)
  * Docs: Update the deployment documentation page and remove outdated information (Jake Howard)
  * Docs: Add more items to performance page regarding pre-fetching images and frontend caching (Jake Howard)
+ * Docs: Add docs for managing stored queries in `searchpromotions` (Scott Foster)
  * Maintenance: Removed support for Python 3.7 (Dan Braghis)
  * Maintenance: Switch to ruff for flake8 / isort code checking (Oliver Parker)
  * Maintenance: Deprecate `insert_editor_css` in favour of `insert_global_admin_css` (Ester Beltrami)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -721,6 +721,7 @@
 * Sahil Jangra
 * Henry Harutyunyan
 * Alex Morega
+* Scott Foster
 
 ## Translators
 

--- a/docs/reference/management_commands.md
+++ b/docs/reference/management_commands.md
@@ -124,8 +124,6 @@ If this is omitted or provided with any number above 0 it will produce the same 
 
 An alias for the `update_index` command that can be used when another installed package (such as [Haystack](https://haystacksearch.org/)) provides a command named `update_index`. In this case, the other package's entry in `INSTALLED_APPS` should appear above `wagtail.search` so that its `update_index` command takes precedence over Wagtail's.
 
-(search_garbage_collect)=
-
 ## rebuild_references_index
 
 ```sh
@@ -156,7 +154,9 @@ Displays a summary of the contents of the references index. This shows the numbe
 ./manage.py search_garbage_collect
 ```
 
-Wagtail keeps a log of search queries that are popular on your website. On high traffic websites, this log may get big and you may want to clean out old search queries. This command cleans out all search query logs that are more than one week old (or a number of days configurable through the [`WAGTAILSEARCH_HITS_MAX_AGE`](wagtailsearch_hits_max_age) setting).
+```{versionchanged} 5.0
+This management command has been renamed to [`searchpromotions_garbage_collect`](searchpromotions_garbage_collect). See the [upgrade consideration](wagtailsearch_query_migration) for more details.
+```
 
 (wagtail_update_image_renditions)=
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -68,7 +68,7 @@ Define a search backend. For a full explanation, see [](wagtailsearch_backends).
 WAGTAILSEARCH_HITS_MAX_AGE = 14
 ```
 
-Set the number of days (default 7) that search query logs are kept for; these are used to identify popular search terms for [promoted search results](editors_picks). Queries older than this will be removed by the [](search_garbage_collect) command.
+Set the number of days (default 7) that search query logs are kept for; these are used to identify popular search terms for [promoted search results](editors_picks). Queries older than this will be removed by the [](searchpromotions_garbage_collect) command.
 
 ## Internationalisation
 

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -272,10 +272,12 @@ It is recommended that the `rebuild_references_index` management command is run 
 
 The undocumented `Page.get_static_site_paths` method (which returns a generator of URL paths for use by static site generator packages) has been removed. Packages relying on this functionality should provide their own fallback implementation.
 
+(wagtailsearch_query_migration)=
+
 ### `wagtailsearch.Query` has moved to `wagtail.contrib.search_promotions`
 
 The `wagtailsearch.Query` model has been moved from the `search` application to the contrib application `wagtail.contrib.search_promotions`.
-All imports will need to be updated and migrations will need to be run via a custom command, some imports will still work with a warning until a future version.
+All imports will need to be updated and migrations will need to be run via a management command, some imports will still work with a warning until a future version.
 
 #### Migration command
 
@@ -284,6 +286,10 @@ If you have daily hits records in the `wagtailsearch.Query` you can run the mana
 ```sh
 ./manage.py copy_daily_hits_from_wagtailsearch
 ```
+
+#### Managing stored search queries
+
+The `search_garbage_collect` command used to remove old stored search queries and daily hits has been moved to [`searchpromotions_garbage_collect`](searchpromotions_garbage_collect).
 
 #### Import updates
 

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -134,6 +134,7 @@ This feature was developed by Aman Pandey as part of the Google Summer of Code p
  * Revise main Getting started tutorial for clarity (Kevin Chung (kev-odin))
  * Update the [deployment documentation](deployment_guide) page and remove outdated information (Jake Howard)
  * Add more items to performance page regarding pre-fetching images and frontend caching (Jake Howard)
+ * Add docs for managing stored queries in `searchpromotions` (Scott Foster)
 
 ### Maintenance
 

--- a/docs/topics/search/searching.md
+++ b/docs/topics/search/searching.md
@@ -378,7 +378,7 @@ Here's an example Django view that could be used to add a "search" page to your 
 from django.shortcuts import render
 
 from wagtail.models import Page
-from wagtail.search.models import Query
+from wagtail.contrib.search_promotions.models import Query
 
 
 def search(request):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

**This PR adds some additional information about managing stored search queries that were moved to the `contrib.searchpromotions` app in 5.0.** I didn't find much info on the docs when I ran into issues with migrating, so the intent here is to help clear up any potential confusion about the migration and general usage.

## Changes

- Add brief explanation and usage example for the `Query` and `QueryDailyHits` models to the search promotions page
- Add note regarding the new cleanup command and link to the updated page in 5.0 release notes
- Redirect to `searchpromotions` where this functionality is referenced

## Checks

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour? **N/A**
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2] **N/A**
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
