### PR TITLE
Ensure StreamField panel validation errors are visible

### DIFF
--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -349,6 +349,11 @@ export class BaseSequenceChild extends EventEmitter {
 
   setError(error) {
     this.block.setError(error);
+
+    // If there is an error, the panel should be expanded always so the error is not obscured
+    if (error) {
+      toggleCollapsiblePanel(this.toggleElement, true);
+    }
   }
 
   focus(opts) {


### PR DESCRIPTION
...by rendering panels as expanded, regardless of the collapse setting specified by the Wagtail implementor.

Fixes #8990 partially (for StreamField panels only).

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?

_Developed and tested on Chrome v114 for macOS but should be browser independent._ 

**Open question:** does this need tests? If so, could you please point be to the right place to add a test.

**Testing instructions:**

This change is a relatively small fix and can be tested by making the following change to [blocks.py in bakerydemo](https://github.com/wagtail/bakerydemo/blob/811507f6d424cb588329d3293533f1f89c936872/bakerydemo/recipes/models.py#L64) to mark a StreamField as collapsed by default, creating the exact situation this PR addresses.

```diff
- RecipeStreamBlock()
+ RecipeStreamBlock(collapsed=True)
```

After making the change, the StreamBlock should be collapsed by default when visiting a recipe page in the bakerydemo Wagtail admin.

1. Go to a recipe page
2. Add new heading block to the page's body StreamField. Do not fill the required heading text!
3. Save the page, this should cause a validation error

**With this fix applied**
The heading block we just added should be expanded because it has an error. All other StreamBlocks in the body should be collapsed per the `collapsed=True` default set on the RecipeStreamBlock. See screenshot attached below.

<img width="664" alt="image" src="https://github.com/wagtail/wagtail/assets/13856515/0784f546-1e94-4e7b-9b36-750abf3ea81d">


**Original situation (without this fix)**
The heading block we just added appears collapsed and it is not clear where the validation error is on the page.
