### PR TITLE
Follow up: remove `field_as_li.html` template

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -95,6 +95,7 @@ Changelog
  * Maintenance: Update uuid to v9 and Jest to v29, with `jest-environment-jsdom` and new snapshot format (LB (Ben) Johnston)
  * Maintenance: Update test cases producing undesirable console output due to missing mocks, uncaught errors, warnings (LB (Ben) Johnston)
  * Maintenance: Remove unused snippets _header_with_history.html template (Thibaud Colas)
+ * Maintenance: Remove `"wagtailadmin/shared/field_as_li.html"` template include (Storm Heg)
 
 
 5.0.2 (21.06.2023)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -151,6 +151,7 @@ This feature was developed by Aman Pandey as part of the Google Summer of Code p
  * Remove unused snippets _header_with_history.html template (Thibaud Colas)
  * Migrate dialog instantiation to a new `w-dialog` Stimulus controller, including in the Userbar (Loveth Omokaro, LB (Ben) Johnston)
  * Support dialog template cloning using a new `w-teleport` Stimulus controller (Loveth Omokaro, LB (Ben) Johnston)
+ * Remove `"wagtailadmin/shared/field_as_li.html"` template include (Storm Heg)
 
 ## Upgrade considerations
 
@@ -298,6 +299,24 @@ The undocumented shared include `wagtailadmin/shared/last_updated.html` is no lo
 
 <!-- ... -->
 {% human_readable_date my_model.timestamp %}
+```
+
+### Shared include `field_as_li.html` is no longer available
+
+The documented include `"wagtailadmin/shared/field_as_li.html"` has been removed, if being used it will need to be replaced with `"wagtailadmin/shared/field.html"` wrapped within `li` tags.
+
+#### Before
+
+```html+django
+{% include "wagtailadmin/shared/field_as_li.html" %}
+```
+
+#### After
+
+```html+django
+<li>
+    {% include "wagtailadmin/shared/field.html" %}
+</li>
 ```
 
 ### Tag (Tagit) field usage now relies on data attributes

--- a/wagtail/admin/templates/wagtailadmin/chooser/anchor_link.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/anchor_link.html
@@ -9,7 +9,9 @@
         {% csrf_token %}
         <ul class="fields">
             {% for field in form %}
-                {% include "wagtailadmin/shared/field_as_li.html" %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" %}
+                </li>
             {% endfor %}
             <li><input type="submit" value="{% trans 'Insert anchor' %}"  class="button" /></li>
         </ul>

--- a/wagtail/admin/templates/wagtailadmin/chooser/email_link.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/email_link.html
@@ -9,7 +9,9 @@
         {% csrf_token %}
         <ul class="fields">
             {% for field in form %}
-                {% include "wagtailadmin/shared/field_as_li.html" %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" %}
+                </li>
             {% endfor %}
             <li><input type="submit" value="{% trans 'Insert link' %}"  class="button" /></li>
         </ul>

--- a/wagtail/admin/templates/wagtailadmin/chooser/external_link.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/external_link.html
@@ -9,7 +9,9 @@
         {% csrf_token %}
         <ul class="fields">
             {% for field in form %}
-                {% include "wagtailadmin/shared/field_as_li.html" %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" %}
+                </li>
             {% endfor %}
             <li><input type="submit" value="{% trans 'Insert link' %}" class="button" /></li>
         </ul>

--- a/wagtail/admin/templates/wagtailadmin/chooser/phone_link.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/phone_link.html
@@ -9,7 +9,9 @@
         {% csrf_token %}
         <ul class="fields">
             {% for field in form %}
-                {% include "wagtailadmin/shared/field_as_li.html" %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" %}
+                </li>
             {% endfor %}
             <li><input type="submit" value="{% trans 'Insert link' %}"  class="button" /></li>
         </ul>

--- a/wagtail/admin/templates/wagtailadmin/generic/chooser/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/chooser/chooser.html
@@ -36,7 +36,9 @@
                         {% if filter_form.visible_fields %}
                             <ul class="fields">
                                 {% for field in filter_form.visible_fields %}
-                                    {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                                    <li>
+                                        {% include "wagtailadmin/shared/field.html" with field=field %}
+                                    </li>
                                 {% endfor %}
                             </ul>
                         {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/generic/chooser/creation_form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/chooser/creation_form.html
@@ -13,7 +13,9 @@
 
         <ul class="fields">
             {% for field in creation_form.visible_fields %}
-                {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" with field=field %}
+                </li>
             {% endfor %}
             <li>
                 {% if create_action_clicked_label %}

--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -19,7 +19,9 @@
         <ul class="fields">
             {% block visible_fields %}
                 {% for field in form.visible_fields %}
-                    {% include "wagtailadmin/shared/field_as_li.html" %}
+                    <li>
+                        {% include "wagtailadmin/shared/field.html" %}
+                    </li>
                 {% endfor %}
             {% endblock %}
 

--- a/wagtail/admin/templates/wagtailadmin/generic/multiple_upload/edit_form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/multiple_upload/edit_form.html
@@ -9,7 +9,9 @@
             {% if field.is_hidden %}
                 {{ field }}
             {% else %}
-                {% include "wagtailadmin/shared/field_as_li.html" %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" %}
+                </li>
             {% endif %}
         {% endfor %}
         <li>

--- a/wagtail/admin/templates/wagtailadmin/pages/copy.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/copy.html
@@ -11,20 +11,32 @@
             <input type="hidden" name="next" value="{{ next }}" />
 
             <ul class="fields">
-                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_title %}
-                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_slug %}
-                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_parent_page %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" with field=form.new_title %}
+                </li>
+                <li>
+                    {% include "wagtailadmin/shared/field.html" with field=form.new_slug %}
+                </li>
+                <li>
+                    {% include "wagtailadmin/shared/field.html" with field=form.new_parent_page %}
+                </li>
 
                 {% if form.copy_subpages %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.copy_subpages %}
+                    <li>
+                        {% include "wagtailadmin/shared/field.html" with field=form.copy_subpages %}
+                    </li>
                 {% endif %}
 
                 {% if form.publish_copies %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.publish_copies %}
+                    <li>
+                        {% include "wagtailadmin/shared/field.html" with field=form.publish_copies %}
+                    </li>
                 {% endif %}
 
                 {% if form.alias %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.alias %}
+                    <li>
+                        {% include "wagtailadmin/shared/field.html" with field=form.alias %}
+                    </li>
                 {% endif %}
             </ul>
 

--- a/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
@@ -10,7 +10,9 @@
             {% csrf_token %}
 
             <ul class="fields">
-                {% include "wagtailadmin/shared/field_as_li.html" with field=move_form.new_parent_page %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" with field=move_form.new_parent_page %}
+                </li>
             </ul>
 
             <input type="submit" value="{% trans 'Confirm' %}" class="button">

--- a/wagtail/admin/templates/wagtailadmin/shared/field_as_li.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/field_as_li.html
@@ -1,1 +1,0 @@
-<li>{% include "wagtailadmin/shared/field.html" %}</li>

--- a/wagtail/admin/templates/wagtailadmin/workflows/create_task.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/create_task.html
@@ -18,7 +18,9 @@
         <ul class="fields nice-padding">
             {% for field in form %}
                 {% if not field.is_hidden %}
-                    {% include "wagtailadmin/shared/field_as_li.html" %}
+                    <li>
+                        {% include "wagtailadmin/shared/field.html" %}
+                    </li>
                 {% else %}
                     {{ field }}
                 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/edit_task.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/edit_task.html
@@ -17,7 +17,9 @@
         <ul class="fields nice-padding">
             {% for field in form %}
                 {% if not field.is_hidden %}
-                    {% include "wagtailadmin/shared/field_as_li.html" %}
+                    <li>
+                        {% include "wagtailadmin/shared/field.html" %}
+                    </li>
                 {% else %}
                     {{ field }}
                 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/chooser.html
@@ -33,7 +33,9 @@
                 <form class="task-search" action="{% url 'wagtailadmin_workflows:task_chooser_results' %}" method="GET" novalidate>
                     <ul class="fields">
                         {% for field in search_form %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                            <li>
+                                {% include "wagtailadmin/shared/field.html" with field=field %}
+                            </li>
                         {% endfor %}
                     </ul>
                 </form>
@@ -48,7 +50,9 @@
         <form class="task-search" action="{% url 'wagtailadmin_workflows:task_chooser_results' %}" method="GET" novalidate>
             <ul class="fields">
                 {% for field in search_form %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                    <li>
+                        {% include "wagtailadmin/shared/field.html" with field=field %}
+                    </li>
                 {% endfor %}
             </ul>
         </form>

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/create_form.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/create_form.html
@@ -15,7 +15,9 @@
             {% if field.is_hidden %}
                 {{ field }}
             {% else %}
-                {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" with field=field %}
+                </li>
             {% endif %}
         {% endfor %}
         <li>

--- a/wagtail/contrib/forms/templates/wagtailforms/submissions_index.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/submissions_index.html
@@ -110,7 +110,9 @@
                     {% icon name="spinner" %}{% trans 'Apply filters' %}
                 </button>
                 {% for field in select_date_form %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                    <li>
+                        {% include "wagtailadmin/shared/field.html" with field=field %}
+                    </li>
                 {% endfor %}
             </form>
         </div>

--- a/wagtail/contrib/redirects/templates/wagtailredirects/add.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/add.html
@@ -12,7 +12,9 @@
 
         <ul class="fields">
             {% for field in form.visible_fields %}
-                {% include "wagtailadmin/shared/field_as_li.html" %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" %}
+                </li>
             {% endfor %}
 
             <li>

--- a/wagtail/contrib/redirects/templates/wagtailredirects/choose_import_file.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/choose_import_file.html
@@ -23,7 +23,9 @@
 
         <ul class="fields">
             {% for field in form.visible_fields %}
-                {% include "wagtailadmin/shared/field_as_li.html" %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" %}
+                </li>
             {% endfor %}
 
             <li>

--- a/wagtail/contrib/redirects/templates/wagtailredirects/confirm_import.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/confirm_import.html
@@ -16,7 +16,9 @@
 
         <ul class="fields">
             {% for field in form.visible_fields %}
-                {% include "wagtailadmin/shared/field_as_li.html" %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" %}
+                </li>
             {% endfor %}
 
             <li>

--- a/wagtail/contrib/redirects/templates/wagtailredirects/edit.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/edit.html
@@ -12,7 +12,9 @@
 
         <ul class="fields">
             {% for field in form.visible_fields %}
-                {% include "wagtailadmin/shared/field_as_li.html" %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" %}
+                </li>
             {% endfor %}
 
             <li>

--- a/wagtail/contrib/simple_translation/templates/simple_translation/admin/submit_translation.html
+++ b/wagtail/contrib/simple_translation/templates/simple_translation/admin/submit_translation.html
@@ -18,7 +18,9 @@
             <ul class="fields">
                 {% block visible_fields %}
                     {% for field in form.visible_fields %}
-                        {% include "wagtailadmin/shared/field_as_li.html" %}
+                        <li>
+                            {% include "wagtailadmin/shared/field.html" %}
+                        </li>
                     {% endfor %}
                 {% endblock %}
                 {% if form.show_submit %}

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -472,7 +472,9 @@
                         {% if field.name == 'file' %}
                             {% include "wagtailimages/images/_file_field.html" %}
                         {% else %}
-                            {% include "wagtailadmin/shared/field_as_li.html" %}
+                            <li>
+                                {% include "wagtailadmin/shared/field.html" %}
+                            </li>
                         {% endif %}
                     {% endfor %}
                     <li><button type="submit" class="button">{% trans 'Save' %}</button><a href="#" class="button no">{% trans "Delete image" %}</a></li>

--- a/wagtail/documents/templates/wagtaildocs/documents/add.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/add.html
@@ -57,7 +57,9 @@
                     {% if field.is_hidden %}
                         {{ field }}
                     {% else %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                        <li>
+                            {% include "wagtailadmin/shared/field.html" with field=field %}
+                        </li>
                     {% endif %}
                 {% endfor %}
                 <li>

--- a/wagtail/documents/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/edit.html
@@ -32,7 +32,9 @@
                         {% elif field.is_hidden %}
                             {{ field }}
                         {% else %}
-                            {% include "wagtailadmin/shared/field_as_li.html" %}
+                            <li>
+                                {% include "wagtailadmin/shared/field.html" %}
+                            </li>
                         {% endif %}
                     {% endfor %}
                     <li>

--- a/wagtail/embeds/templates/wagtailembeds/chooser/chooser.html
+++ b/wagtail/embeds/templates/wagtailembeds/chooser/chooser.html
@@ -9,7 +9,9 @@
             {% csrf_token %}
             <ul class="fields">
                 {% for field in form %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                    <li>
+                        {% include "wagtailadmin/shared/field.html" with field=field %}
+                    </li>
                 {% endfor %}
                 <li>
                     <button

--- a/wagtail/images/templates/wagtailimages/chooser/chooser.html
+++ b/wagtail/images/templates/wagtailimages/chooser/chooser.html
@@ -5,7 +5,9 @@
     <form data-chooser-modal-search action="{{ results_url }}" method="GET" autocomplete="off" novalidate>
         <ul class="fields">
             {% for field in filter_form %}
-                {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" with field=field %}
+                </li>
             {% endfor %}
             {% if popular_tags %}
                 <li class="taglist w-label-3">

--- a/wagtail/images/templates/wagtailimages/images/add.html
+++ b/wagtail/images/templates/wagtailimages/images/add.html
@@ -58,7 +58,9 @@
                     {% if field.is_hidden %}
                         {{ field }}
                     {% else %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                        <li>
+                            {% include "wagtailadmin/shared/field.html" with field=field %}
+                        </li>
                     {% endif %}
                 {% endfor %}
                 <li><input type="submit" value="{% trans 'Save' %}" class="button" /></li>

--- a/wagtail/search/templates/wagtailsearch/queries/chooser/chooser.html
+++ b/wagtail/search/templates/wagtailsearch/queries/chooser/chooser.html
@@ -6,7 +6,9 @@
     <form class="query-search full-width" action="{% url 'wagtailsearch_admin:queries_chooserresults' %}" method="GET" autocomplete="off" novalidate>
         <ul class="fields">
             {% for field in searchform %}
-                {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" with field=field %}
+                </li>
             {% endfor %}
             <li class="submit"><input type="submit" value="{% trans 'Search' %}" class="button" /></li>
         </ul>

--- a/wagtail/test/testapp/templates/tests/generic_view_templates/edit.html
+++ b/wagtail/test/testapp/templates/tests/generic_view_templates/edit.html
@@ -6,7 +6,9 @@
         <div class="tab-content">
             {% csrf_token %}
             <ul class="fields">
-                {% include "wagtailadmin/shared/field_as_li.html" with field=form.content %}
+                <li>
+                    {% include "wagtailadmin/shared/field.html" with field=form.content %}
+                </li>
                 <li>
                     <input type="submit" value="Save" class="button"/>
                 </li>

--- a/wagtail/users/templates/wagtailusers/groups/create.html
+++ b/wagtail/users/templates/wagtailusers/groups/create.html
@@ -20,7 +20,9 @@
 
             <ul class="fields">
                 {% block fields %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.name %}
+                    <li>
+                        {% include "wagtailadmin/shared/field.html" with field=form.name %}
+                    </li>
                     {% block extra_fields %}{% endblock extra_fields %}
                 {% endblock fields %}
                 <li>

--- a/wagtail/users/templates/wagtailusers/users/create.html
+++ b/wagtail/users/templates/wagtailusers/users/create.html
@@ -29,17 +29,29 @@
                     <ul class="fields">
                         {% block fields %}
                             {% if form.separate_username_field %}
-                                {% include "wagtailadmin/shared/field_as_li.html" with field=form.username_field %}
+                                <li>
+                                    {% include "wagtailadmin/shared/field.html" with field=form.username_field %}
+                                </li>
                             {% endif %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.email %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.first_name %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.last_name %}
+                            <li>
+                                {% include "wagtailadmin/shared/field.html" with field=form.email %}
+                            </li>
+                            <li>
+                                {% include "wagtailadmin/shared/field.html" with field=form.first_name %}
+                            </li>
+                            <li>
+                                {% include "wagtailadmin/shared/field.html" with field=form.last_name %}
+                            </li>
                             {% block extra_fields %}{% endblock extra_fields %}
                             {% if form.password1 %}
-                                {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
+                                <li>
+                                    {% include "wagtailadmin/shared/field.html" with field=form.password1 %}
+                                </li>
                             {% endif %}
                             {% if form.password2 %}
-                                {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
+                                <li>
+                                    {% include "wagtailadmin/shared/field.html" with field=form.password2 %}
+                                </li>
                             {% endif %}
                         {% endblock fields %}
 
@@ -59,8 +71,12 @@
                     aria-labelledby="tab-label-roles"
                 >
                     <ul class="fields">
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.groups %}
+                        <li>
+                            {% include "wagtailadmin/shared/field.html" with field=form.is_superuser %}
+                        </li>
+                        <li>
+                            {% include "wagtailadmin/shared/field.html" with field=form.groups %}
+                        </li>
                         <li><button class="button">{% trans "Add user" %}</button></li>
                     </ul>
                 </section>

--- a/wagtail/users/templates/wagtailusers/users/edit.html
+++ b/wagtail/users/templates/wagtailusers/users/edit.html
@@ -30,20 +30,34 @@
                     <ul class="fields">
                         {% block fields %}
                             {% if form.separate_username_field %}
-                                {% include "wagtailadmin/shared/field_as_li.html" with field=form.username_field %}
+                                <li>
+                                    {% include "wagtailadmin/shared/field.html" with field=form.username_field %}
+                                </li>
                             {% endif %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.email %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.first_name %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.last_name %}
+                            <li>
+                                {% include "wagtailadmin/shared/field.html" with field=form.email %}
+                            </li>
+                            <li>
+                                {% include "wagtailadmin/shared/field.html" with field=form.first_name %}
+                            </li>
+                            <li>
+                                {% include "wagtailadmin/shared/field.html" with field=form.last_name %}
+                            </li>
                             {% block extra_fields %}{% endblock extra_fields %}
                             {% if form.password1 %}
-                                {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
+                                <li>
+                                    {% include "wagtailadmin/shared/field.html" with field=form.password1 %}
+                                </li>
                             {% endif %}
                             {% if form.password2 %}
-                                {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
+                                <li>
+                                    {% include "wagtailadmin/shared/field.html" with field=form.password2 %}
+                                </li>
                             {% endif %}
                             {% if form.is_active %}
-                                {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_active %}
+                                <li>
+                                    {% include "wagtailadmin/shared/field.html" with field=form.is_active %}
+                                </li>
                             {% endif %}
 
                         {% endblock fields %}
@@ -64,10 +78,14 @@
                 >
                     <ul class="fields">
                         {% if form.is_superuser %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
+                            <li>
+                                {% include "wagtailadmin/shared/field.html" with field=form.is_superuser %}
+                            </li>
                         {% endif %}
 
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.groups %}
+                        <li>
+                            {% include "wagtailadmin/shared/field.html" with field=form.groups %}
+                        </li>
                         <li>
                             <input type="submit" value="{% trans 'Save' %}" class="button"/>
                             {% if can_delete %}


### PR DESCRIPTION
Ref: #9031

> Forms refactoring: replace field_as_li.html with field.html wrapped in li

Removed the `field_as_li.html` template and all references to it, replacing them with `field.html` wrapped in `<li>` tags.

The only trace left is a historical mention in the 1.0 release notes: [link](https://github.com/wagtail/wagtail/blob/9881ec12b8736706425506d55dd38a070b0055fc/docs/releases/1.0.rst?plain=1#L317)