### PR TITLE
Revise release note for model ordering #10469

### DIFF
--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -270,10 +270,10 @@ During the deprecation period, the `permission_type` field will still be availab
 
 ### The default ordering of Group Editing Permissions models has changed
 
-The ordering for "Object permissions" and "Other permissions" now follows a predictable order equivalent do Django's default `Model` ordering.
+The ordering for "Object permissions" and "Other permissions" now follows a predictable order equivalent to Django's default `Model` ordering.
 This will be different to the previous ordering which never intentionally implemented.
 
-This default ordering is now `["content_type__app_label", "content_type__model", "codename"]`, which can now be customised [](customising_group_views_permissions_order).
+The default ordering is now `["content_type__app_label", "content_type__model"]`, which can now be customised [](customising_group_views_permissions_order).
 
 ### Shared include `wagtailadmin/shared/last_updated.html` is no longer available
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

This PR revises the release notes for 5.1 added in #10469.

1. fixed a typo
2. removed "codename" from the documented default ordering since this final bit of ordering is lost when the permissions are organised into columns (add, change, delete, publish, lock, unlock, and finally custom).

_Please check the following:_

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
