### PR TITLE
Move semgrep to after other linting checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ develop: clean-pyc
 lint-server:
 	black --target-version py37 --check --diff .
 	ruff check .
-	semgrep --config .semgrep.yml --error .
 	curlylint --parse-only wagtail
 	git ls-files '*.html' | xargs djhtml --check
+	semgrep --config .semgrep.yml --error .
 
 lint-client:
 	npm run lint:css --silent


### PR DESCRIPTION
- Avoid failing all other checks if sempgrep is not compatible on an environment

On my VM I get the following error, this is normally not an issue as I know when changes for translations have been made. However, this also means all subsequent checks (e.g. curlylint) will not run, a simple work around is just to run the semgrep checks last.

```
root@3ed86aae1d34:/code/wagtail# make lint
black --target-version py37 --check --diff .
All done! ✨ 🍰 ✨
1153 files would be left unchanged.
ruff check .
semgrep --config .semgrep.yml --error .
Semgrep does not support Linux ARM64
make: *** [Makefile:23: lint-server] Error 2
```