### PR TITLE
Reinstate `field_as_li.html` template

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -103,7 +103,7 @@ Changelog
  * Maintenance: Remove unused snippets _header_with_history.html template (Thibaud Colas)
  * Maintenance: Migrate dialog instantiation to a new `w-dialog` Stimulus controller (Loveth Omokaro, LB (Ben) Johnston)
  * Maintenance: Support dialog template cloning using a new `w-teleport` Stimulus controller (Loveth Omokaro, LB (Ben) Johnston)
- * Maintenance: Remove `"wagtailadmin/shared/field_as_li.html"` template include (Storm Heg)
+ * Maintenance: Migrate away from using the `"wagtailadmin/shared/field_as_li.html"` template include (Storm Heg)
 
 
 5.0.2 (21.06.2023)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -158,7 +158,7 @@ This feature was developed by Aman Pandey as part of the Google Summer of Code p
  * Update uuid to v9 and Jest to v29, with `jest-environment-jsdom` and new snapshot format (LB (Ben) Johnston)
  * Update test cases producing undesirable console output due to missing mocks, uncaught errors, warnings (LB (Ben) Johnston)
  * Remove unused snippets _header_with_history.html template (Thibaud Colas)
- * Remove `"wagtailadmin/shared/field_as_li.html"` template include (Storm Heg)
+ * Migrate away from using the `"wagtailadmin/shared/field_as_li.html"` template include (Storm Heg)
 
 ## Upgrade considerations
 
@@ -308,9 +308,9 @@ The undocumented shared include `wagtailadmin/shared/last_updated.html` is no lo
 {% human_readable_date my_model.timestamp %}
 ```
 
-### Shared include `field_as_li.html` is no longer available
+### Shared include `field_as_li.html` will be removed
 
-The documented include `"wagtailadmin/shared/field_as_li.html"` has been removed, if being used it will need to be replaced with `"wagtailadmin/shared/field.html"` wrapped within `li` tags.
+The documented include `"wagtailadmin/shared/field_as_li.html"` will be removed in a future release, if being used it will need to be replaced with `"wagtailadmin/shared/field.html"` wrapped within `li` tags.
 
 #### Before
 

--- a/wagtail/admin/templates/wagtailadmin/shared/field_as_li.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/field_as_li.html
@@ -1,0 +1,2 @@
+{% comment %} RemovedInWagtail60 - this template is no longer used in Wagtail but kept around a little longer for compatibility with third-party packages. {% endcomment %}
+<li>{% include "wagtailadmin/shared/field.html" %}</li>


### PR DESCRIPTION
Other packages and projects may still rely on the existence of this template. We cannot simply remove it without a proper deprecation.

Ref: https://github.com/wagtail/wagtail/pull/10679#issuecomment-1637502335