### PR TITLE
Elasticsearch 8 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ concurrency:
 # - elasticsearch 5, django 3.2, python 3.8, sqlite
 # - elasticsearch 6, django 3.2, python 3.8, postgres
 # - elasticsearch 7, django 4.1, python 3.8, postgres
-# - elasticsearch 7, django 4.2, python 3.9, sqlite, USE_EMAIL_USER_MODEL=yes
+# - elasticsearch 8, django 4.2, python 3.10, sqlite, USE_EMAIL_USER_MODEL=yes
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -231,12 +231,12 @@ jobs:
           name: coverage-data
           path: .coverage.*
 
-  test-sqlite-elasticsearch7:
+  test-sqlite-elasticsearch8:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - python: '3.9'
+          - python: '3.10'
             django: 'Django>=4.2,<4.3'
             emailuser: emailuser
     steps:
@@ -248,7 +248,7 @@ jobs:
           sudo sysctl -w vm.max_map_count=262144
       - uses: getong/elasticsearch-action@v1.2
         with:
-          elasticsearch version: 7.6.1
+          elasticsearch version: 8.8.0
           host port: 9200
           container port: 9200
           host node port: 9300
@@ -268,7 +268,7 @@ jobs:
           pip install certifi
       - name: Test
         run: |
-          coverage run --parallel-mode --source wagtail runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch7
+          coverage run --parallel-mode --source wagtail runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch8
         env:
           DATABASE_ENGINE: django.db.backends.sqlite3
           USE_EMAIL_USER_MODEL: ${{ matrix.emailuser }}
@@ -398,7 +398,7 @@ jobs:
       - test-postgres
       - test-mysql
       - test-sqlite-elasticsearch5
-      - test-sqlite-elasticsearch7
+      - test-sqlite-elasticsearch8
       - test-postgres-elasticsearch6
       - test-postgres-elasticsearch7
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,7 +264,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[testing]
           pip install "${{ matrix.django }}"
-          pip install "elasticsearch>=7,<8"
+          pip install "elasticsearch>=8,<9"
           pip install certifi
       - name: Test
         run: |

--- a/docs/advanced_topics/add_to_django_project.md
+++ b/docs/advanced_topics/add_to_django_project.md
@@ -328,7 +328,7 @@ WAGTAIL_SITE_NAME = 'My Project'
 # Replace the search backend
 #WAGTAILSEARCH_BACKENDS = {
 #  'default': {
-#    'BACKEND': 'wagtail.search.backends.elasticsearch5',
+#    'BACKEND': 'wagtail.search.backends.elasticsearch8',
 #    'INDEX': 'myapp'
 #  }
 #}

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -159,11 +159,10 @@ It is also possible to set `DATABASE_DRIVER`, which corresponds to the `driver` 
 
 ### Testing Elasticsearch
 
-You can test Wagtail against Elasticsearch by passing the `--elasticsearch`
-argument to `runtests.py`:
+You can test Wagtail against Elasticsearch by passing the argument `--elasticsearch5`, `--elasticsearch6`, `--elasticsearch7` or `--elasticsearch8` (corresponding to the version of Elasticsearch you want to test against):
 
 ```sh
-python runtests.py --elasticsearch
+python runtests.py --elasticsearch8
 ```
 
 Wagtail will attempt to connect to a local instance of Elasticsearch
@@ -173,7 +172,7 @@ If your Elasticsearch instance is located somewhere else, you can set the
 `ELASTICSEARCH_URL` environment variable to point to its location:
 
 ```sh
-ELASTICSEARCH_URL=http://my-elasticsearch-instance:9200 python runtests.py --elasticsearch
+ELASTICSEARCH_URL=https://my-elasticsearch-instance:9200 python runtests.py --elasticsearch8
 ```
 
 ### Unit tests for JavaScript

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -52,7 +52,7 @@ If you use the ``False`` setting, keep in mind that serving your pages both with
 ```python
 WAGTAILSEARCH_BACKENDS = {
     'default': {
-        'BACKEND': 'wagtail.search.backends.elasticsearch5',
+        'BACKEND': 'wagtail.search.backends.elasticsearch8',
         'INDEX': 'myapp'
     }
 }

--- a/docs/topics/search/backends.md
+++ b/docs/topics/search/backends.md
@@ -62,11 +62,12 @@ This backend is intended to be used for development and also should be good enou
 
 ### Elasticsearch Backend
 
-Elasticsearch versions 5, 6 and 7 are supported. Use the appropriate backend for your version:
+Elasticsearch versions 5, 6, 7 and 8 are supported. Use the appropriate backend for your version:
 
 -   `wagtail.search.backends.elasticsearch5` (Elasticsearch 5.x)
 -   `wagtail.search.backends.elasticsearch6` (Elasticsearch 6.x)
 -   `wagtail.search.backends.elasticsearch7` (Elasticsearch 7.x)
+-   `wagtail.search.backends.elasticsearch8` (Elasticsearch 8.x)
 
 Prerequisites are the [Elasticsearch](https://www.elastic.co/downloads/elasticsearch) service itself and, via pip, the [elasticsearch-py](https://elasticsearch-py.readthedocs.io/) package. The major version of the package must match the installed version of Elasticsearch:
 
@@ -82,6 +83,10 @@ pip install "elasticsearch>=6.4.0,<7.0.0"  # for Elasticsearch 6.x
 pip install "elasticsearch>=7.0.0,<8.0.0"  # for Elasticsearch 7.x
 ```
 
+```sh
+pip install "elasticsearch>=8.0.0,<9.0.0"  # for Elasticsearch 8.x
+```
+
 ```{warning}
 Version 6.3.1 of the Elasticsearch client library is incompatible with Wagtail. Use 6.4.0 or above.
 ```
@@ -91,8 +96,8 @@ The backend is configured in settings:
 ```python
 WAGTAILSEARCH_BACKENDS = {
     'default': {
-        'BACKEND': 'wagtail.search.backends.elasticsearch5',
-        'URLS': ['http://localhost:9200'],
+        'BACKEND': 'wagtail.search.backends.elasticsearch8',
+        'URLS': ['https://localhost:9200'],
         'INDEX': 'wagtail',
         'TIMEOUT': 5,
         'OPTIONS': {},
@@ -109,7 +114,7 @@ A username and password may be optionally supplied to the `URL` field to provide
 WAGTAILSEARCH_BACKENDS = {
     'default': {
         ...
-        'URLS': ['http://username:password@localhost:9200'],
+        'URLS': ['https://username:password@localhost:9200'],
         ...
     }
 }

--- a/runtests.py
+++ b/runtests.py
@@ -22,6 +22,7 @@ def make_parser():
     parser.add_argument("--elasticsearch5", action="store_true")
     parser.add_argument("--elasticsearch6", action="store_true")
     parser.add_argument("--elasticsearch7", action="store_true")
+    parser.add_argument("--elasticsearch8", action="store_true")
     parser.add_argument("--emailuser", action="store_true")
     parser.add_argument("--disabletimezone", action="store_true")
     parser.add_argument("--bench", action="store_true")
@@ -69,6 +70,9 @@ def runtests():
     elif args.elasticsearch7:
         os.environ.setdefault("ELASTICSEARCH_URL", "http://localhost:9200")
         os.environ.setdefault("ELASTICSEARCH_VERSION", "7")
+    elif args.elasticsearch8:
+        os.environ.setdefault("ELASTICSEARCH_URL", "http://localhost:9200")
+        os.environ.setdefault("ELASTICSEARCH_VERSION", "8")
 
     elif "ELASTICSEARCH_URL" in os.environ:
         # forcibly delete the ELASTICSEARCH_URL setting to skip those tests

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ testing_extras = [
     # Required for running the tests
     "python-dateutil>=2.7",
     "pytz>=2014.7",
-    "elasticsearch>=5.0,<6.0",
     "Jinja2>=3.0,<3.2",
     "boto3>=1.16,<1.17",
     "freezegun>=0.3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps =
     elasticsearch6: certifi
     elasticsearch7: elasticsearch>=7,<8
     elasticsearch7: certifi
-    elasticsearch8: elasticsearch>=7,<8
+    elasticsearch8: elasticsearch>=8,<9
     elasticsearch8: certifi
 
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{38,39,310,311}-dj{32,41,42,42stable,main}-{sqlite,postgres,mysql,mssql}-{elasticsearch7,elasticsearch6,elasticsearch5,noelasticsearch}-{customuser,emailuser}-{tz,notz},
+envlist = py{38,39,310,311}-dj{32,41,42,42stable,main}-{sqlite,postgres,mysql,mssql}-{elasticsearch8,elasticsearch7,elasticsearch6,elasticsearch5,noelasticsearch}-{customuser,emailuser}-{tz,notz},
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -10,6 +10,7 @@ commands =
     elasticsearch5: coverage run runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch5
     elasticsearch6: coverage run runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch6
     elasticsearch7: coverage run runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch7
+    elasticsearch8: coverage run runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch8
     noelasticsearch: coverage run runtests.py {posargs}
 
 basepython =
@@ -36,6 +37,8 @@ deps =
     elasticsearch6: certifi
     elasticsearch7: elasticsearch>=7,<8
     elasticsearch7: certifi
+    elasticsearch8: elasticsearch>=7,<8
+    elasticsearch8: certifi
 
 setenv =
     postgres: DATABASE_ENGINE=django.db.backends.postgresql

--- a/wagtail/search/backends/elasticsearch5.py
+++ b/wagtail/search/backends/elasticsearch5.py
@@ -1052,6 +1052,7 @@ class Elasticsearch5SearchBackend(BaseSearchBackend):
     basic_rebuilder_class = ElasticsearchIndexRebuilder
     atomic_rebuilder_class = ElasticsearchAtomicIndexRebuilder
     catch_indexing_errors = True
+    timeout_kwarg_name = "timeout"
 
     settings = {
         "settings": {
@@ -1146,7 +1147,9 @@ class Elasticsearch5SearchBackend(BaseSearchBackend):
             self.hosts = [self._get_host_config_from_url(url) for url in parsed_urls]
             options.update(self._get_options_from_host_urls(parsed_urls))
 
-        self.es = Elasticsearch(hosts=self.hosts, timeout=self.timeout, **options)
+        options[self.timeout_kwarg_name] = self.timeout
+
+        self.es = Elasticsearch(hosts=self.hosts, **options)
 
     def get_index_for_model(self, model):
         # Split models up into separate indices based on their root model.

--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -21,6 +21,18 @@ class Elasticsearch7Mapping(Elasticsearch6Mapping):
 
 
 class Elasticsearch7Index(Elasticsearch6Index):
+    def put(self):
+        self.es.indices.create(index=self.name, **self.backend.settings)
+
+    def delete(self):
+        try:
+            self.es.indices.delete(index=self.name)
+        except NotFoundError:
+            pass
+
+    def refresh(self):
+        self.es.indices.refresh(index=self.name)
+
     def add_model(self, model):
         # Get mapping
         mapping = self.mapping_class(model)
@@ -38,7 +50,9 @@ class Elasticsearch7Index(Elasticsearch6Index):
 
         # Add document to index
         self.es.index(
-            self.name, mapping.get_document(item), id=mapping.get_document_id(item)
+            index=self.name,
+            document=mapping.get_document(item),
+            id=mapping.get_document_id(item),
         )
 
     def add_items(self, model, items):
@@ -69,7 +83,7 @@ class Elasticsearch7Index(Elasticsearch6Index):
 
         # Delete document
         try:
-            self.es.delete(self.name, mapping.get_document_id(item))
+            self.es.delete(index=self.name, id=mapping.get_document_id(item))
         except NotFoundError:
             pass  # Document doesn't exist, ignore this exception
 
@@ -79,7 +93,10 @@ class Elasticsearch7SearchQueryCompiler(Elasticsearch6SearchQueryCompiler):
 
 
 class Elasticsearch7SearchResults(Elasticsearch6SearchResults):
-    pass
+    def _backend_do_search(self, body, **kwargs):
+        # As of Elasticsearch 7, the 'body' parameter is deprecated; instead, the top-level
+        # keys of the body dict are now kwargs in their own right
+        return self.backend.es.search(**body, **kwargs)
 
 
 class Elasticsearch7AutocompleteQueryCompiler(

--- a/wagtail/search/backends/elasticsearch8.py
+++ b/wagtail/search/backends/elasticsearch8.py
@@ -15,7 +15,12 @@ class Elasticsearch8Mapping(Elasticsearch7Mapping):
 
 
 class Elasticsearch8Index(Elasticsearch7Index):
-    pass
+    def add_model(self, model):
+        # Get mapping
+        mapping = self.mapping_class(model)
+
+        # Put mapping
+        self.es.indices.put_mapping(index=self.name, **mapping.get_mapping())
 
 
 class Elasticsearch8SearchQueryCompiler(Elasticsearch7SearchQueryCompiler):
@@ -36,6 +41,7 @@ class Elasticsearch8SearchBackend(Elasticsearch7SearchBackend):
     query_compiler_class = Elasticsearch8SearchQueryCompiler
     autocomplete_query_compiler_class = Elasticsearch8AutocompleteQueryCompiler
     results_class = Elasticsearch8SearchResults
+    timeout_kwarg_name = "request_timeout"
 
     def _get_host_config_from_url(self, url):
         """Given a parsed URL, return the host configuration to be added to self.hosts"""
@@ -46,8 +52,8 @@ class Elasticsearch8SearchBackend(Elasticsearch7SearchBackend):
         return {
             "host": url.hostname,
             "port": port,
-            "url_prefix": url.path,
-            "use_ssl": use_ssl,
+            "path_prefix": url.path,
+            "scheme": url.scheme,
         }
 
     def _get_options_from_host_urls(self, urls):

--- a/wagtail/search/backends/elasticsearch8.py
+++ b/wagtail/search/backends/elasticsearch8.py
@@ -1,0 +1,39 @@
+from wagtail.search.backends.elasticsearch7 import (
+    Elasticsearch7AutocompleteQueryCompiler,
+    Elasticsearch7Index,
+    Elasticsearch7Mapping,
+    Elasticsearch7SearchBackend,
+    Elasticsearch7SearchQueryCompiler,
+    Elasticsearch7SearchResults,
+)
+
+
+class Elasticsearch8Mapping(Elasticsearch7Mapping):
+    pass
+
+
+class Elasticsearch8Index(Elasticsearch7Index):
+    pass
+
+
+class Elasticsearch8SearchQueryCompiler(Elasticsearch7SearchQueryCompiler):
+    mapping_class = Elasticsearch8Mapping
+
+
+class Elasticsearch8SearchResults(Elasticsearch7SearchResults):
+    pass
+
+
+class Elasticsearch8AutocompleteQueryCompiler(Elasticsearch7AutocompleteQueryCompiler):
+    mapping_class = Elasticsearch8Mapping
+
+
+class Elasticsearch8SearchBackend(Elasticsearch7SearchBackend):
+    mapping_class = Elasticsearch8Mapping
+    index_class = Elasticsearch8Index
+    query_compiler_class = Elasticsearch8SearchQueryCompiler
+    autocomplete_query_compiler_class = Elasticsearch8AutocompleteQueryCompiler
+    results_class = Elasticsearch8SearchResults
+
+
+SearchBackend = Elasticsearch8SearchBackend

--- a/wagtail/search/backends/elasticsearch8.py
+++ b/wagtail/search/backends/elasticsearch8.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import ImproperlyConfigured
+
 from wagtail.search.backends.elasticsearch7 import (
     Elasticsearch7AutocompleteQueryCompiler,
     Elasticsearch7Index,
@@ -34,6 +36,37 @@ class Elasticsearch8SearchBackend(Elasticsearch7SearchBackend):
     query_compiler_class = Elasticsearch8SearchQueryCompiler
     autocomplete_query_compiler_class = Elasticsearch8AutocompleteQueryCompiler
     results_class = Elasticsearch8SearchResults
+
+    def _get_host_config_from_url(self, url):
+        """Given a parsed URL, return the host configuration to be added to self.hosts"""
+        use_ssl = url.scheme == "https"
+        port = url.port or (443 if use_ssl else 80)
+
+        # the verify_certs and http_auth options are no longer valid in Elasticsearch 8
+        return {
+            "host": url.hostname,
+            "port": port,
+            "url_prefix": url.path,
+            "use_ssl": use_ssl,
+        }
+
+    def _get_options_from_host_urls(self, urls):
+        """Given a list of parsed URLs, return a dict of additional options to be passed into the
+        Elasticsearch constructor; necessary for options that aren't valid as part of the 'hosts' config"""
+        opts = super()._get_options_from_host_urls(urls)
+
+        basic_auth = (urls[0].username, urls[0].password)
+        # Ensure that all urls have the same credentials
+        if any((url.username, url.password) != basic_auth for url in urls):
+            raise ImproperlyConfigured(
+                "Elasticsearch host configuration is invalid. "
+                "Elasticsearch 8 does not support multiple hosts with differing authentication credentials."
+            )
+
+        if basic_auth != (None, None):
+            opts["basic_auth"] = basic_auth
+
+        return opts
 
 
 SearchBackend = Elasticsearch8SearchBackend

--- a/wagtail/search/tests/elasticsearch_common_tests.py
+++ b/wagtail/search/tests/elasticsearch_common_tests.py
@@ -201,10 +201,35 @@ class ElasticsearchCommonSearchBackendTests(BackendTests):
         self.assertEqual(len(results), 54)
 
     def test_search_with_date_filter(self):
-        after_1900 = models.Book.objects.filter(publication_date__year__gt=1900)
+        results = self.backend.search(
+            MATCH_ALL, models.Book.objects.filter(publication_date__gt=date(2000, 6, 1))
+        )
+        self.assertEqual(len(results), 4)
 
-        results = self.backend.search(MATCH_ALL, after_1900)
-        self.assertEqual(len(after_1900), len(results))
+        results = self.backend.search(
+            MATCH_ALL, models.Book.objects.filter(publication_date__year__gte=2000)
+        )
+        self.assertEqual(len(results), 5)
+
+        results = self.backend.search(
+            MATCH_ALL, models.Book.objects.filter(publication_date__year__gt=2000)
+        )
+        self.assertEqual(len(results), 4)
+
+        results = self.backend.search(
+            MATCH_ALL, models.Book.objects.filter(publication_date__year__lte=1954)
+        )
+        self.assertEqual(len(results), 4)
+
+        results = self.backend.search(
+            MATCH_ALL, models.Book.objects.filter(publication_date__year__lt=1954)
+        )
+        self.assertEqual(len(results), 2)
+
+        results = self.backend.search(
+            MATCH_ALL, models.Book.objects.filter(publication_date__year=1954)
+        )
+        self.assertEqual(len(results), 2)
 
         # Filtering by date not supported, should throw a FilterError
         from wagtail.search.backends.base import FilterError

--- a/wagtail/search/tests/elasticsearch_common_tests.py
+++ b/wagtail/search/tests/elasticsearch_common_tests.py
@@ -200,37 +200,7 @@ class ElasticsearchCommonSearchBackendTests(BackendTests):
         results = self.backend.search(MATCH_ALL, models.Book)[110:]
         self.assertEqual(len(results), 54)
 
-    def test_search_with_date_filter(self):
-        results = self.backend.search(
-            MATCH_ALL, models.Book.objects.filter(publication_date__gt=date(2000, 6, 1))
-        )
-        self.assertEqual(len(results), 4)
-
-        results = self.backend.search(
-            MATCH_ALL, models.Book.objects.filter(publication_date__year__gte=2000)
-        )
-        self.assertEqual(len(results), 5)
-
-        results = self.backend.search(
-            MATCH_ALL, models.Book.objects.filter(publication_date__year__gt=2000)
-        )
-        self.assertEqual(len(results), 4)
-
-        results = self.backend.search(
-            MATCH_ALL, models.Book.objects.filter(publication_date__year__lte=1954)
-        )
-        self.assertEqual(len(results), 4)
-
-        results = self.backend.search(
-            MATCH_ALL, models.Book.objects.filter(publication_date__year__lt=1954)
-        )
-        self.assertEqual(len(results), 2)
-
-        results = self.backend.search(
-            MATCH_ALL, models.Book.objects.filter(publication_date__year=1954)
-        )
-        self.assertEqual(len(results), 2)
-
+    def test_cannot_filter_on_date_parts_other_than_year(self):
         # Filtering by date not supported, should throw a FilterError
         from wagtail.search.backends.base import FilterError
 

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -505,6 +505,37 @@ class BackendTests(WagtailTestUtils):
                 )
             )
 
+    def test_search_with_date_filter(self):
+        results = self.backend.search(
+            MATCH_ALL, models.Book.objects.filter(publication_date__gt=date(2000, 6, 1))
+        )
+        self.assertEqual(len(results), 4)
+
+        results = self.backend.search(
+            MATCH_ALL, models.Book.objects.filter(publication_date__year__gte=2000)
+        )
+        self.assertEqual(len(results), 5)
+
+        results = self.backend.search(
+            MATCH_ALL, models.Book.objects.filter(publication_date__year__gt=2000)
+        )
+        self.assertEqual(len(results), 4)
+
+        results = self.backend.search(
+            MATCH_ALL, models.Book.objects.filter(publication_date__year__lte=1954)
+        )
+        self.assertEqual(len(results), 4)
+
+        results = self.backend.search(
+            MATCH_ALL, models.Book.objects.filter(publication_date__year__lt=1954)
+        )
+        self.assertEqual(len(results), 2)
+
+        results = self.backend.search(
+            MATCH_ALL, models.Book.objects.filter(publication_date__year=1954)
+        )
+        self.assertEqual(len(results), 2)
+
     # ORDER BY RELEVANCE
 
     def test_order_by_relevance(self):

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -1,22 +1,31 @@
 import datetime
 import json
+import unittest
 from unittest import mock
 
 from django.db.models import Q
 from django.test import TestCase
-from elasticsearch.serializer import JSONSerializer
 
-from wagtail.search.backends.elasticsearch5 import Elasticsearch5SearchBackend
 from wagtail.search.query import MATCH_ALL, Fuzzy, Phrase
 from wagtail.test.search import models
 
 from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
 
+try:
+    from elasticsearch import VERSION as ELASTICSEARCH_VERSION
+    from elasticsearch.serializer import JSONSerializer
 
+    from wagtail.search.backends.elasticsearch5 import Elasticsearch5SearchBackend
+except ImportError:
+    ELASTICSEARCH_VERSION = (0, 0, 0)
+
+
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 5, "Elasticsearch 5 required")
 class TestElasticsearch5SearchBackend(ElasticsearchCommonSearchBackendTests, TestCase):
     backend_path = "wagtail.search.backends.elasticsearch5"
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 5, "Elasticsearch 5 required")
 class TestElasticsearch5SearchQuery(TestCase):
     def assertDictEqual(self, a, b):
         default = JSONSerializer().default
@@ -25,10 +34,13 @@ class TestElasticsearch5SearchQuery(TestCase):
             json.dumps(b, sort_keys=True, default=default),
         )
 
-    query_compiler_class = Elasticsearch5SearchBackend.query_compiler_class
-    autocomplete_query_compiler_class = (
-        Elasticsearch5SearchBackend.autocomplete_query_compiler_class
-    )
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.query_compiler_class = Elasticsearch5SearchBackend.query_compiler_class
+        cls.autocomplete_query_compiler_class = (
+            Elasticsearch5SearchBackend.autocomplete_query_compiler_class
+        )
 
     def test_simple(self):
         # Create a query
@@ -622,6 +634,7 @@ class TestElasticsearch5SearchQuery(TestCase):
         self.assertDictEqual(query_compiler.get_query(), expected_result)
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 5, "Elasticsearch 5 required")
 class TestElasticsearch5SearchResults(TestCase):
     fixtures = ["search"]
 
@@ -797,6 +810,7 @@ class TestElasticsearch5SearchResults(TestCase):
         self.assertEqual(results[2], models.Book.objects.get(id=1))
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 5, "Elasticsearch 5 required")
 class TestElasticsearch5Mapping(TestCase):
     fixtures = ["search"]
 
@@ -926,6 +940,7 @@ class TestElasticsearch5Mapping(TestCase):
         self.assertDictEqual(document, expected_result)
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 5, "Elasticsearch 5 required")
 class TestElasticsearch5MappingInheritance(TestCase):
     fixtures = ["search"]
 
@@ -1119,6 +1134,7 @@ class TestElasticsearch5MappingInheritance(TestCase):
         self.assertDictEqual(document, expected_result)
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 5, "Elasticsearch 5 required")
 @mock.patch("wagtail.search.backends.elasticsearch5.Elasticsearch")
 class TestBackendConfiguration(TestCase):
     def test_default_settings(self, Elasticsearch):

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -626,7 +626,7 @@ class TestElasticsearch5SearchQuery(TestCase):
             "bool": {
                 "filter": [
                     {"match": {"content_type": "searchtests.Book"}},
-                    {"range": {"publication_date_filter": {"gt": 1900}}},
+                    {"range": {"publication_date_filter": {"gte": "1901-01-01"}}},
                 ],
                 "must": {"match": {"_all": {"query": "Hello"}}},
             }

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -1,22 +1,31 @@
 import datetime
 import json
+import unittest
 from unittest import mock
 
 from django.db.models import Q
 from django.test import TestCase
-from elasticsearch.serializer import JSONSerializer
 
-from wagtail.search.backends.elasticsearch6 import Elasticsearch6SearchBackend
 from wagtail.search.query import MATCH_ALL, Fuzzy, Phrase
 from wagtail.test.search import models
 
 from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
 
+try:
+    from elasticsearch import VERSION as ELASTICSEARCH_VERSION
+    from elasticsearch.serializer import JSONSerializer
 
+    from wagtail.search.backends.elasticsearch6 import Elasticsearch6SearchBackend
+except ImportError:
+    ELASTICSEARCH_VERSION = (0, 0, 0)
+
+
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 6, "Elasticsearch 6 required")
 class TestElasticsearch6SearchBackend(ElasticsearchCommonSearchBackendTests, TestCase):
     backend_path = "wagtail.search.backends.elasticsearch6"
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 6, "Elasticsearch 6 required")
 class TestElasticsearch6SearchQuery(TestCase):
     def assertDictEqual(self, a, b):
         default = JSONSerializer().default
@@ -25,10 +34,13 @@ class TestElasticsearch6SearchQuery(TestCase):
             json.dumps(b, sort_keys=True, default=default),
         )
 
-    query_compiler_class = Elasticsearch6SearchBackend.query_compiler_class
-    autocomplete_query_compiler_class = (
-        Elasticsearch6SearchBackend.autocomplete_query_compiler_class
-    )
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.query_compiler_class = Elasticsearch6SearchBackend.query_compiler_class
+        cls.autocomplete_query_compiler_class = (
+            Elasticsearch6SearchBackend.autocomplete_query_compiler_class
+        )
 
     def test_simple(self):
         # Create a query
@@ -854,6 +866,7 @@ class TestElasticsearch6SearchQuery(TestCase):
         self.assertDictEqual(query_compiler.get_query(), expected_result)
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 6, "Elasticsearch 6 required")
 class TestElasticsearch6SearchResults(TestCase):
     fixtures = ["search"]
 
@@ -1029,6 +1042,7 @@ class TestElasticsearch6SearchResults(TestCase):
         self.assertEqual(results[2], models.Book.objects.get(id=1))
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 6, "Elasticsearch 6 required")
 class TestElasticsearch6Mapping(TestCase):
     fixtures = ["search"]
 
@@ -1144,6 +1158,7 @@ class TestElasticsearch6Mapping(TestCase):
         self.assertDictEqual(document, expected_result)
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 6, "Elasticsearch 6 required")
 class TestElasticsearch6MappingInheritance(TestCase):
     fixtures = ["search"]
 
@@ -1314,6 +1329,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
         self.assertDictEqual(document, expected_result)
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 6, "Elasticsearch 6 required")
 @mock.patch("wagtail.search.backends.elasticsearch5.Elasticsearch")
 class TestBackendConfiguration(TestCase):
     def test_default_settings(self, Elasticsearch):

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -849,7 +849,22 @@ class TestElasticsearch6SearchQuery(TestCase):
             "bool": {
                 "filter": [
                     {"match": {"content_type": "searchtests.Book"}},
-                    {"term": {"publication_date_filter": 1900}},
+                    {
+                        "bool": {
+                            "must": [
+                                {
+                                    "range": {
+                                        "publication_date_filter": {"gte": "1900-01-01"}
+                                    }
+                                },
+                                {
+                                    "range": {
+                                        "publication_date_filter": {"lt": "1901-01-01"}
+                                    }
+                                },
+                            ]
+                        }
+                    },
                 ],
                 "must": {
                     "multi_match": {

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -851,7 +851,7 @@ class TestElasticsearch7SearchQuery(TestCase):
             "bool": {
                 "filter": [
                     {"match": {"content_type": "searchtests.Book"}},
-                    {"range": {"publication_date_filter": {"lt": 1900}}},
+                    {"range": {"publication_date_filter": {"lt": "1900-01-01"}}},
                 ],
                 "must": {
                     "multi_match": {

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -1,22 +1,31 @@
 import datetime
 import json
+import unittest
 from unittest import mock
 
 from django.db.models import Q
 from django.test import TestCase
-from elasticsearch.serializer import JSONSerializer
 
-from wagtail.search.backends.elasticsearch7 import Elasticsearch7SearchBackend
 from wagtail.search.query import MATCH_ALL, Fuzzy, Phrase
 from wagtail.test.search import models
 
 from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
 
+try:
+    from elasticsearch import VERSION as ELASTICSEARCH_VERSION
+    from elasticsearch.serializer import JSONSerializer
 
+    from wagtail.search.backends.elasticsearch7 import Elasticsearch7SearchBackend
+except ImportError:
+    ELASTICSEARCH_VERSION = (0, 0, 0)
+
+
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 7, "Elasticsearch 7 required")
 class TestElasticsearch7SearchBackend(ElasticsearchCommonSearchBackendTests, TestCase):
     backend_path = "wagtail.search.backends.elasticsearch7"
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 7, "Elasticsearch 7 required")
 class TestElasticsearch7SearchQuery(TestCase):
     maxDiff = None
 
@@ -27,10 +36,13 @@ class TestElasticsearch7SearchQuery(TestCase):
             json.dumps(b, sort_keys=True, default=default),
         )
 
-    query_compiler_class = Elasticsearch7SearchBackend.query_compiler_class
-    autocomplete_query_compiler_class = (
-        Elasticsearch7SearchBackend.autocomplete_query_compiler_class
-    )
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.query_compiler_class = Elasticsearch7SearchBackend.query_compiler_class
+        cls.autocomplete_query_compiler_class = (
+            Elasticsearch7SearchBackend.autocomplete_query_compiler_class
+        )
 
     def test_simple(self):
         # Create a query
@@ -856,6 +868,7 @@ class TestElasticsearch7SearchQuery(TestCase):
         self.assertDictEqual(query_compiler.get_query(), expected_result)
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 7, "Elasticsearch 7 required")
 class TestElasticsearch7SearchResults(TestCase):
     fixtures = ["search"]
 
@@ -1031,6 +1044,7 @@ class TestElasticsearch7SearchResults(TestCase):
         self.assertEqual(results[2], models.Book.objects.get(id=1))
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 7, "Elasticsearch 7 required")
 class TestElasticsearch7Mapping(TestCase):
     fixtures = ["search"]
 
@@ -1146,6 +1160,7 @@ class TestElasticsearch7Mapping(TestCase):
         self.assertDictEqual(document, expected_result)
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 7, "Elasticsearch 7 required")
 class TestElasticsearch7MappingInheritance(TestCase):
     fixtures = ["search"]
     maxDiff = None
@@ -1315,6 +1330,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
         self.assertDictEqual(document, expected_result)
 
 
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 7, "Elasticsearch 7 required")
 @mock.patch("wagtail.search.backends.elasticsearch5.Elasticsearch")
 class TestBackendConfiguration(TestCase):
     def test_default_settings(self, Elasticsearch):

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -902,7 +902,7 @@ class TestElasticsearch7SearchResults(TestCase):
         list(results)  # Performs search
 
         search.assert_any_call(
-            body={"query": "QUERY"},
+            query="QUERY",
             _source=False,
             stored_fields="pk",
             index="wagtail__searchtests_book",
@@ -920,7 +920,7 @@ class TestElasticsearch7SearchResults(TestCase):
 
         search.assert_any_call(
             from_=10,
-            body={"query": "QUERY"},
+            query="QUERY",
             _source=False,
             stored_fields="pk",
             index="wagtail__searchtests_book",
@@ -936,7 +936,7 @@ class TestElasticsearch7SearchResults(TestCase):
 
         search.assert_any_call(
             from_=1,
-            body={"query": "QUERY"},
+            query="QUERY",
             _source=False,
             stored_fields="pk",
             index="wagtail__searchtests_book",
@@ -952,7 +952,7 @@ class TestElasticsearch7SearchResults(TestCase):
 
         search.assert_any_call(
             from_=10,
-            body={"query": "QUERY"},
+            query="QUERY",
             _source=False,
             stored_fields="pk",
             index="wagtail__searchtests_book",
@@ -969,7 +969,7 @@ class TestElasticsearch7SearchResults(TestCase):
 
         search.assert_any_call(
             from_=20,
-            body={"query": "QUERY"},
+            query="QUERY",
             _source=False,
             stored_fields="pk",
             index="wagtail__searchtests_book",

--- a/wagtail/search/tests/test_elasticsearch8_backend.py
+++ b/wagtail/search/tests/test_elasticsearch8_backend.py
@@ -1,0 +1,7 @@
+from django.test import TestCase
+
+from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
+
+
+class TestElasticsearch8SearchBackend(ElasticsearchCommonSearchBackendTests, TestCase):
+    backend_path = "wagtail.search.backends.elasticsearch8"

--- a/wagtail/search/tests/test_elasticsearch8_backend.py
+++ b/wagtail/search/tests/test_elasticsearch8_backend.py
@@ -1,7 +1,15 @@
+import unittest
+
 from django.test import TestCase
 
 from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
 
+try:
+    from elasticsearch import VERSION as ELASTICSEARCH_VERSION
+except ImportError:
+    ELASTICSEARCH_VERSION = (0, 0, 0)
 
+
+@unittest.skipIf(ELASTICSEARCH_VERSION[0] != 8, "Elasticsearch 8 required")
 class TestElasticsearch8SearchBackend(ElasticsearchCommonSearchBackendTests, TestCase):
     backend_path = "wagtail.search.backends.elasticsearch8"

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -205,8 +205,7 @@ if os.environ.get("DATABASE_ENGINE") == "django.db.backends.postgresql":
 
 if "ELASTICSEARCH_URL" in os.environ:
     if os.environ.get("ELASTICSEARCH_VERSION") == "8":
-        # for now, use the 7 backend for ES8
-        backend = "wagtail.search.backends.elasticsearch7"
+        backend = "wagtail.search.backends.elasticsearch8"
     elif os.environ.get("ELASTICSEARCH_VERSION") == "7":
         backend = "wagtail.search.backends.elasticsearch7"
     elif os.environ.get("ELASTICSEARCH_VERSION") == "6":

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -204,7 +204,10 @@ if os.environ.get("DATABASE_ENGINE") == "django.db.backends.postgresql":
     }
 
 if "ELASTICSEARCH_URL" in os.environ:
-    if os.environ.get("ELASTICSEARCH_VERSION") == "7":
+    if os.environ.get("ELASTICSEARCH_VERSION") == "8":
+        # for now, use the 7 backend for ES8
+        backend = "wagtail.search.backends.elasticsearch7"
+    elif os.environ.get("ELASTICSEARCH_VERSION") == "7":
         backend = "wagtail.search.backends.elasticsearch7"
     elif os.environ.get("ELASTICSEARCH_VERSION") == "6":
         backend = "wagtail.search.backends.elasticsearch6"


### PR DESCRIPTION
Support for Elasticsearch v8. Supersedes #10531

* Add a new `wagtail.search.backends.elasticsearch8` backend and CI test run configuration
* Update ES7 and ES8 backends to call elasticsearch-py methods with non-deprecated signatures as per https://github.com/elastic/elasticsearch-py/issues/1698 (keyword arguments for everything, and `body` JSON arguments split into individual keyword arguments for their top-level keys)
* Override construction of host config dicts to address moved / removed options
* Only run ES backend tests against the elasticsearch-py version they were intended for (previously we ran all tests regardless of version, which was a hack that relied on method signatures being mostly consistent across versions)
* Fix an issue where filters like `publication_date__year_gte=1950` were being translated to the equivalent of `publication_date >= 1950` rather than `publication_date >= '1950-01-01'`, which worked accidentally on older ES versions but doesn't any more.

Note: As per https://github.com/wagtail/wagtail/pull/10208#issuecomment-1492342970, we currently only run the full test suite against the fallback database search backend, as it tests features that aren't implemented across all backends (e.g. annotate_score and searching on individual columns). [A full test run](https://github.com/gasman/wagtail/actions/runs/5570385323) shows the ES8 backend failing on the same set of tests as ES5:

* wagtail.documents.tests.test_search.TestIssue613.test_issue_613_on_add (no such index)
* wagtail.documents.tests.test_search.TestIssue613.test_issue_613_on_edit (no such index)
* wagtail.images.tests.test_models.TestIssue613.test_issue_613_on_add (no such index)
* wagtail.images.tests.test_models.TestIssue613. test_issue_613_on_edit (no such index)
* wagtail.tests.test_page_queryset.TestPageQuerySetSearch.test_custom_order (no such column: location)
* wagtail.tests.test_page_queryset.TestPageQuerySetSearch.test_search (no such column: location)
* wagtail.tests.test_page_queryset.TestSpecificQuerySearch.test_specific_query_with_real_search_and_annotation (no such column: wagtailsearch_indexentry_fts)
* wagtail.snippets.tests.test_viewset.TestFilterSetClassSearch.test_filtered_searched_with_results (Couldn't find 'Fish and chips from the UK' in response)
* wagtail.tests.test_page_queryset.TestSpecificQuerySearch.test_specific_query_with_match_all_search_and_annotation

Some of these look like buggy tests rather than legitimate failures - in particular the snippet one is failing on everything but the fallback backend, which suggests to me it's probably running a regular `search` and expecting `autocomplete` behaviour. I plan to open a follow-up PR to deal with these (not essential for 5.1rc1).