### PR TITLE
Deprecate Elasticsearch 5 and 6 search backends

### DIFF
--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -171,6 +171,10 @@ Python 3.7 is no longer supported as of this release; please upgrade to Python 3
 
 Wagtail no longer supports Pillow versions below `9.1.0`.
 
+### Elasticsearch 5 and 6 backends are deprecated
+
+The Elasticsearch 5 and 6 search backends are deprecated and will be removed in a future release; please upgrade to Elasticsearch 7 or above.
+
 ### `insert_editor_css` hook is deprecated
 
 The `insert_editor_css` hook has been deprecated. The `insert_global_admin_css` hook has the same functionality, and all uses of `insert_editor_css` should be changed to `insert_global_admin_css`.

--- a/wagtail/search/backends/elasticsearch5.py
+++ b/wagtail/search/backends/elasticsearch5.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import warnings
 from collections import OrderedDict
 from urllib.parse import urlparse
 
@@ -25,6 +26,7 @@ from wagtail.search.index import (
     class_is_indexed,
 )
 from wagtail.search.query import And, Boost, Fuzzy, MatchAll, Not, Or, Phrase, PlainText
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 from wagtail.utils.utils import deep_update
 
 
@@ -1053,6 +1055,7 @@ class Elasticsearch5SearchBackend(BaseSearchBackend):
     atomic_rebuilder_class = ElasticsearchAtomicIndexRebuilder
     catch_indexing_errors = True
     timeout_kwarg_name = "timeout"
+    is_deprecated = True  # overriden on subclasses which are not deprecated
 
     settings = {
         "settings": {
@@ -1115,6 +1118,13 @@ class Elasticsearch5SearchBackend(BaseSearchBackend):
 
     def __init__(self, params):
         super().__init__(params)
+
+        if self.is_deprecated:
+            warnings.warn(
+                f"The {self.__module__} search backend is deprecated and will be removed in a future release. "
+                "Please upgrade to Elasticsearch 7 or above.",
+                RemovedInWagtail60Warning,
+            )
 
         # Get settings
         self.hosts = params.pop("HOSTS", None)

--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -111,6 +111,7 @@ class Elasticsearch7SearchBackend(Elasticsearch6SearchBackend):
     query_compiler_class = Elasticsearch7SearchQueryCompiler
     autocomplete_query_compiler_class = Elasticsearch7AutocompleteQueryCompiler
     results_class = Elasticsearch7SearchResults
+    is_deprecated = False
 
     settings = deepcopy(Elasticsearch6SearchBackend.settings)
     settings["settings"]["index"] = {"max_ngram_diff": 12}


### PR DESCRIPTION
Follow-up to #10686 - deprecate Elasticsearch 5 and 6 backends as these are now [out of support](https://endoflife.date/elasticsearch). (Version 7 will also be out of support by the time 5.1 is released, but forcing people to upgrade to a backend that's only just been added seems a bit harsh :-) )