### PR TITLE
Use a theme-agnostic color token for read-only panels support in dark mode

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -61,6 +61,7 @@ Changelog
  * Fix: Prevent 'choose' permission from being ignored when looking up 'choose', 'edit' and 'delete' permissions in combination (Sage Abdullah)
  * Fix: Take user's permissions into account for image / document counts on the admin dashboard (Sage Abdullah)
  * Fix: Avoid N+1 queries in users index view (Tidiane Dia)
+ * Fix: Use a theme-agnostic color token for read-only panels support in dark mode (Thibaud Colas)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)

--- a/client/scss/components/forms/_field-textoutput.scss
+++ b/client/scss/components/forms/_field-textoutput.scss
@@ -8,7 +8,7 @@
 .w-field__textoutput {
   @include input-base();
   @apply w-body-text-large;
-  background-color: theme('colors.grey.50');
+  background-color: theme('colors.surface-field-inactive');
   width: 100%;
   padding: theme('spacing.[1.5]') theme('spacing.5');
   min-height: $text-input-height;

--- a/client/scss/components/forms/_field-textoutput.scss
+++ b/client/scss/components/forms/_field-textoutput.scss
@@ -15,4 +15,9 @@
   position: relative;
   overflow: hidden;
   overflow-wrap: break-word;
+
+  &,
+  &:hover {
+    border-color: theme('colors.border-field-inactive');
+  }
 }

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -118,6 +118,7 @@ This feature was developed by Aman Pandey as part of the Google Summer of Code p
  * Prevent 'choose' permission from being ignored when looking up 'choose', 'edit' and 'delete' permissions in combination (Sage Abdullah)
  * Take user's permissions into account for image / document counts on the admin dashboard (Sage Abdullah)
  * Avoid N+1 queries in users index view (Tidiane Dia)
+ * Use a theme-agnostic color token for read-only panels support in dark mode (Thibaud Colas)
 
 ### Documentation
 


### PR DESCRIPTION
Fixes the last issue tracked on #10418, with `read_only=True` FieldPanel. `surface-field-inactive` is currently used for `disabled` fields.

I’ve additionally customised the border for consistency with disabled fields.