### PR TITLE
Fix snippet search test to work on non-fallback database backends

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,7 @@ Changelog
 5.2 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~
 
- * ...
+ * Maintenance: Fix snippet search test to work on non-fallback database backends (Matt Westcott)
 
 
 5.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -26,7 +26,7 @@ depth: 1
 
 ### Maintenance
 
- * ...
+ * Fix snippet search test to work on non-fallback database backends (Matt Westcott)
 
 
 ## Upgrade considerations

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -1121,6 +1121,7 @@ class FullFeaturedSnippet(
 
     search_fields = [
         index.SearchField("text"),
+        index.AutocompleteField("text"),
         index.FilterField("text"),
         index.FilterField("country_code"),
     ]


### PR DESCRIPTION
As per https://github.com/wagtail/wagtail/pull/10208#issuecomment-1492342970, we currently only run the full test suite against the fallback search backend, which means we aren't routinely spotting tests with bugs that make them incompatible with other backends

One such test is `wagtail.snippets.tests.test_viewset.TestFilterSetClassSearch.test_filtered_searched_with_results` - this performs an autocomplete search on a field that does not have AutocompleteField defined on it. Add this missing field.