### PR TITLE
Update Sphinx Wagtail Theme to v6.1.1

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -115,6 +115,7 @@ Changelog
  * Maintenance: Support dialog template cloning using a new `w-teleport` Stimulus controller (Loveth Omokaro, LB (Ben) Johnston)
  * Maintenance: Migrate away from using the `"wagtailadmin/shared/field_as_li.html"` template include (Storm Heg)
  * Maintenance: Deprecate `wagtail.contrib.modeladmin` (Sage Abdullah)
+ * Maintenance: Upgrade documentation theme `sphinx_wagtail_theme` to v6.1.1 which includes multiple styling fixes and always visible code copy buttons (LB (Ben) Johnston)
 
 
 5.0.2 (21.06.2023)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -163,6 +163,7 @@ This feature was developed by Aman Pandey as part of the Google Summer of Code p
  * Update test cases producing undesirable console output due to missing mocks, uncaught errors, warnings (LB (Ben) Johnston)
  * Remove unused snippets _header_with_history.html template (Thibaud Colas)
  * Migrate away from using the `"wagtailadmin/shared/field_as_li.html"` template include (Storm Heg)
+ * Upgrade documentation theme `sphinx_wagtail_theme` to v6.1.1 which includes multiple styling fixes and always visible code copy buttons (LB (Ben) Johnston)
 
 ## Upgrade considerations
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ documentation_extras = [
     "sphinxcontrib-spelling>=5.4.0,<6",
     "Sphinx>=1.5.2",
     "sphinx-autobuild>=0.6.0",
-    "sphinx-wagtail-theme==6.0.0",
+    "sphinx-wagtail-theme==6.1.1",
     "myst_parser==0.18.1",
     "sphinx_copybutton>=0.5,<1.0",
 ]


### PR DESCRIPTION
Ensure we get a range of fixes on the Sphinx Wagtail Theme such as mono space font family for names in code, ensure copy button is always visible, fix issue with version chooser on small devices.

## Links

- https://github.com/wagtail/sphinx-wagtail-theme/blob/main/CHANGELOG.md#611---2023-07-19
- https://github.com/wagtail/sphinx-wagtail-theme/blob/main/CHANGELOG.md#610---2023-07-19
- https://github.com/wagtail/sphinx-wagtail-theme/issues/257