### PR TITLE
Don't update the reference index while deleting it

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -123,6 +123,7 @@ Changelog
  * Maintenance: Migrate away from using the `"wagtailadmin/shared/field_as_li.html"` template include (Storm Heg)
  * Maintenance: Deprecate `wagtail.contrib.modeladmin` (Sage Abdullah)
  * Maintenance: Upgrade documentation theme `sphinx_wagtail_theme` to v6.1.1 which includes multiple styling fixes and always visible code copy buttons (LB (Ben) Johnston)
+ * Maintenance: Don't update the reference index while deleting it (Andy Chosak)
 
 
 5.0.2 (21.06.2023)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -169,6 +169,7 @@ This feature was developed by Aman Pandey as part of the Google Summer of Code p
  * Remove unused snippets _header_with_history.html template (Thibaud Colas)
  * Migrate away from using the `"wagtailadmin/shared/field_as_li.html"` template include (Storm Heg)
  * Upgrade documentation theme `sphinx_wagtail_theme` to v6.1.1 which includes multiple styling fixes and always visible code copy buttons (LB (Ben) Johnston)
+ * Don't update the reference index while deleting it (Andy Chosak)
 
 ## Upgrade considerations
 

--- a/wagtail/management/commands/rebuild_references_index.py
+++ b/wagtail/management/commands/rebuild_references_index.py
@@ -3,6 +3,7 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from wagtail.models import ReferenceIndex
+from wagtail.signal_handlers import disable_reference_index_auto_update
 
 DEFAULT_CHUNK_SIZE = 1000
 
@@ -36,7 +37,8 @@ class Command(BaseCommand):
         self.write("Rebuilding reference index")
 
         with transaction.atomic():
-            ReferenceIndex.objects.all().delete()
+            with disable_reference_index_auto_update():
+                ReferenceIndex.objects.all().delete()
 
             for model in apps.get_models():
                 if not ReferenceIndex.is_indexed(model):


### PR DESCRIPTION
The `rebuild_reference_index` management command starts by deleting the entire ReferenceIndex table.

In Wagtail versions 4.1 and 4.2, all models are tracked in the reference index. Unfortunately this also includes the ReferenceIndex model itself. This is [changed in 5.0](https://docs.wagtail.org/en/stable/releases/5.0.html#referenceindex-no-longer-tracks-models-used-outside-of-wagtail
) to only track certain Wagtail-related models. 

This means that when rebuild_reference_index runs in versions 4.1 or 4.2, and deletes the ReferenceIndex table, it runs the code that checks whether ReferenceIndex instances have any references.

If the index contains a large number of references (as could happen if an upgrade to 4.1 built an index for a non-Wagtail model), this process becomes extremely slow. There's no need for the rebuild_reference_index command to update the index when deleting it, so this can be significantly optimized by disabling auto update here.

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?