### PR TITLE
Ensure 5.1 release notes cover the removed `search-success` event

### DIFF
--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -419,7 +419,7 @@ There are probably three places in your code, which have to be changed:
 2. Display: To display the timestamp in the user's timezone and format with a `LogFormatter`, we've created utils to parse (`wagtail.utils.timestamps.parse_datetime_localized()`) and render (`wagtail.utils.timestamps.render_timestamp()`) those timestamps. Look at the existing formatters [here](https://github.com/wagtail/wagtail/blob/main/wagtail/wagtail_hooks.py).
 3. Migration: You can use the code of the above migration ([source](https://github.com/wagtail/wagtail/blob/main/wagtail/migrations/0088_fix_log_entry_json_timestamps.py)) as a guideline to migrate your existing timestamps in the database.
 
-### Header searching now relies on data attributes
+### Header searching now relies on data attributes & event name change
 
 Previously the header search relied on inline scripts and a `window.headerSearch` global to activate the behaviour. This has now changed to a data attributes approach and the window global usage will be removed in a future major release.
 
@@ -493,4 +493,32 @@ Alternatively, if you have customisations that manually declare or override `win
     <input type="text" name="q" id="id_q" data-w-swap-target="input" />
 </form>
 <div id="some-results"></div>
+```
+
+Additionally, when the async search results are swapped into the DOM, the undocumented custom event `'search-success'` no longer gets dispatched. A new event `w-swap:success` will be dispatched, however this is slightly more generic and may trigger in other async DOM replacement usage.
+
+A roughly equivalent event listener can be implemented as follows.
+
+#### Success event before
+
+```javascript
+if (window.headerSearch) {
+    const searchInput = document.querySelector(window.headerSearch.termInput);
+    if (searchInput) {
+        searchInput.addEventListener('search-success', () => {
+            console.log('new search results!');
+        });
+    }
+}
+```
+
+#### Success event after
+
+```javascript
+if (document.querySelector('header .search-form')) {
+    document.addEventListener('w-swap:success', (event) => {
+        // if needed, do additional checks on target (e.g. #page-results) or event.detail.requestUrl
+        console.log('new search results!', event.target);
+    });
+}
 ```


### PR DESCRIPTION
- Relates to #9950 & PR #10645 / #9952
- The undocumented event `search-success` will no longer dispatch, this appears to have been in used by our code only but it's possible other packages leveraged this to add custom behaviour.

## Validation screenshot

<img width="1613" alt="Screenshot 2023-07-20 at 8 23 37 am" src="https://github.com/wagtail/wagtail/assets/1396140/d79ccef3-2931-433b-ab5e-3d078945628c">
