### PR TITLE
Fix link in custom HTML attributes in Panels documentation

### DIFF
--- a/docs/reference/pages/panels.md
+++ b/docs/reference/pages/panels.md
@@ -351,7 +351,7 @@ Without a top-level panel definition, a `FieldPanel` will be constructed for eac
 
 ### Additional HTML attributes
 
-Use the `attrs` parameter to add custom attributes to the HTML element of the panel. This allows you to specify additional attributes, such as `data-*` attributes. The `attrs` parameter accepts a dictionary where the keys are the attribute names and these will be rendered in the same way as Django's widget `attrs`[https://docs.djangoproject.com/en/stable/ref/forms/widgets/#django.forms.Widget.attrs] where `True` and `False will be treated as HTML5 boolean attributes.
+Use the `attrs` parameter to add custom attributes to the HTML element of the panel. This allows you to specify additional attributes, such as `data-*` attributes. The `attrs` parameter accepts a dictionary where the keys are the attribute names and these will be rendered in the same way as Django's widget {attr}`~django.forms.Widget.attrs` where `True` and `False` will be treated as HTML5 boolean attributes.
 
 For example, you can use the `attrs` parameter to integrate your Stimulus controller to the panel:
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

## Before

<img width="830" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/4a5f6beb-a2ca-4205-82e5-a90544474833">

## After

<img width="830" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/fefb4bea-4ce3-457d-84c4-726062c0376b">
