### PR TITLE
Experiment: add convenience wrapper for BeautifulSoup to test utilities

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Changelog
  * Maintenance: Remove unused WorkflowStatus view, urlpattern, and workflow-status.js (Storm Heg)
  * Maintenance: Add support for options/attrs in Telepath widgets so that attrs render on the created DOM (Storm Heg)
  * Maintenance: Update pre-commit hooks to be in sync with latest changes to Eslint & Prettier for client-side changes (Storm Heg)
+ * Maintenance: Add `WagtailTestUtils.get_soup()` method to get a `BeautifulSoup` object from an `HttpResponse` object (Storm Heg)
 
 
 5.1.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -34,6 +34,7 @@ depth: 1
  * Remove unused WorkflowStatus view, urlpattern, and workflow-status.js (Storm Heg)
  * Add support for options/attrs in Telepath widgets so that attrs render on the created DOM (Storm Heg)
  * Update pre-commit hooks to be in sync with latest changes to Eslint & Prettier for client-side changes (Storm Heg)
+ * Add `WagtailTestUtils.get_soup()` method to get a `BeautifulSoup` object from an `HttpResponse` object (Storm Heg)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/tests/test_privacy.py
+++ b/wagtail/admin/tests/test_privacy.py
@@ -364,11 +364,16 @@ class TestPrivacyIndicators(WagtailTestUtils, TestCase):
         # Check the response
         self.assertEqual(response.status_code, 200)
 
-        # Check the privacy indicator is private
-        self.assertContains(response, '<div class="" data-privacy-sidebar-private>')
-        self.assertContains(
-            response, '<div class="w-hidden" data-privacy-sidebar-public>'
-        )
+        soup = self.get_soup(response)
+
+        # Check the private privacy indicator is visible
+        private_indicator = soup.select_one("[data-privacy-sidebar-private]")
+        # There should not be any classes applied
+        self.assertEqual(private_indicator["class"], [])
+
+        # Privacy indicator should be hidden
+        public_indicator = soup.select_one("[data-privacy-sidebar-public].w-hidden")
+        self.assertIsNotNone(public_indicator)
 
     def test_explorer_private_child(self):
         """

--- a/wagtail/test/utils/wagtail_tests.py
+++ b/wagtail/test/utils/wagtail_tests.py
@@ -1,12 +1,18 @@
 import warnings
 from contextlib import contextmanager
 
+from bs4 import BeautifulSoup
 from django import VERSION as DJANGO_VERSION
 from django.contrib.auth import get_user_model
+from django.http import HttpRequest
 from django.test.testcases import assert_and_parse_html
 
 
 class WagtailTestUtils:
+    @staticmethod
+    def get_soup(request: HttpRequest, parser="html.parser") -> BeautifulSoup:
+        return BeautifulSoup(request.content, parser)
+
     @staticmethod
     def create_test_user():
         """


### PR DESCRIPTION
@laymonage and I discussed that it would be nice if there was an easy way to use BeautifulSoup to check the html of Django's test client response. We'd be keen to avoid situations where hard-to-understand regexes are used to check the response for the presence of a certain html tag or attribute.

This PR wraps and replaces Django's test client with one that provides convenience functions to utilise BeautifulSoup directly on the response.

This approach is described by one of my co-workers (@maerteijn 🙌 ) in his blog post: [Beautiful asserts with your Django Test Client](https://vicktor.nl/academy/beautiful-asserts-with-your-django-test-client/)


As a usage example, I converted a random test case to use the BeautifulSoup convenience functions.


---


I'd love to hear thoughts on this approach. Is this something that would benefit Wagtail?