### PR TITLE
Adding the value as a call argument to Block.get_template

### DIFF
--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -17,8 +17,8 @@ from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
 
 from wagtail.admin.staticfiles import versioned_static
-from wagtail.telepath import JSContext
 from wagtail.coreutils import accept_kwarg
+from wagtail.telepath import JSContext
 from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 __all__ = [

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -226,9 +226,9 @@ class Block(metaclass=BaseBlock):
         use a template (with the passed context, supplemented by the result of get_context) if a
         'template' property is specified on the block, and fall back on render_basic otherwise.
         """
-        args = {'context': context}
-        if accepts_kwarg(self.get_template, 'value'):
-            args['value'] = value
+        args = {"context": context}
+        if accepts_kwarg(self.get_template, "value"):
+            args["value"] = value
         else:
             warnings.warn(
                 "get_template should accept a 'value' argument as first argument, legacy call will be removed in Wagtail 6.0!.",

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -214,6 +214,9 @@ class Block(metaclass=BaseBlock):
         """
         Return the template to use for rendering the block if specified on meta class.
         This extraction was added to make dynamic templates possible if you override this method
+
+        value contains the current value of the block, allowing overriden methods to
+        select the proper template based on the actual block value.
         """
         return getattr(self.meta, "template", None)
 

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -17,7 +17,7 @@ from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
 
 from wagtail.admin.staticfiles import versioned_static
-from wagtail.coreutils import accept_kwarg
+from wagtail.coreutils import accepts_kwarg
 from wagtail.telepath import JSContext
 from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
@@ -227,7 +227,7 @@ class Block(metaclass=BaseBlock):
         'template' property is specified on the block, and fall back on render_basic otherwise.
         """
         args = {'context': context}
-        if accept_kwarg(self.get_template, 'value'):
+        if accepts_kwarg(self.get_template, 'value'):
             args['value'] = value
         else:
             warnings.warn(

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -2,6 +2,7 @@ import collections
 import itertools
 import json
 import re
+import warnings
 from functools import lru_cache
 from importlib import import_module
 
@@ -17,6 +18,8 @@ from django.utils.text import capfirst
 
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.telepath import JSContext
+from wagtail.coreutils import accept_kwarg
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 __all__ = [
     "BaseBlock",
@@ -220,7 +223,16 @@ class Block(metaclass=BaseBlock):
         use a template (with the passed context, supplemented by the result of get_context) if a
         'template' property is specified on the block, and fall back on render_basic otherwise.
         """
-        template = self.get_template(value=value, context=context)
+        args = {'context': context}
+        if accept_kwarg(self.get_template, 'value'):
+            args['value'] = value
+        else:
+            warnings.warn(
+                "get_template should accept a 'value' argument as first argument, legacy call will be removed in Wagtail 6.0!.",
+                RemovedInWagtail60Warning,
+            )
+
+        template = self.get_template(**args)
         if not template:
             return self.render_basic(value, context=context)
 

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -207,7 +207,7 @@ class Block(metaclass=BaseBlock):
         )
         return context
 
-    def get_template(self, context=None):
+    def get_template(self, value=None, context=None):
         """
         Return the template to use for rendering the block if specified on meta class.
         This extraction was added to make dynamic templates possible if you override this method
@@ -220,7 +220,7 @@ class Block(metaclass=BaseBlock):
         use a template (with the passed context, supplemented by the result of get_context) if a
         'template' property is specified on the block, and fall back on render_basic otherwise.
         """
-        template = self.get_template(context=context)
+        template = self.get_template(value=value, context=context)
         if not template:
             return self.render_basic(value, context=context)
 

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -5201,7 +5201,8 @@ class BlockChoosingTemplateBasedOnValue(blocks.Block):
         if value == "HEADING":
             return "tests/blocks/heading_block.html"
 
-        return None # using render_basic
+        return None  # using render_basic
+
 
 class TestOverriddenGetTemplateBlockTag(TestCase):
     def test_template_is_overridden_by_get_template(self):
@@ -5213,7 +5214,7 @@ class TestOverriddenGetTemplateBlockTag(TestCase):
         self.assertEqual(template, block.my_new_template)
 
     def test_block_render_passes_the_value_argument_to_get_template(self):
-        """ verifies Block.render() passes the value to get_template """
+        """verifies Block.render() passes the value to get_template"""
         block = BlockChoosingTemplateBasedOnValue()
 
         html = block.render("Hello World")
@@ -5221,7 +5222,6 @@ class TestOverriddenGetTemplateBlockTag(TestCase):
 
         html = block.render("HEADING")
         self.assertEqual(html, "<h1>HEADING</h1>")
-
 
 
 class TestValidationErrorAsJsonData(TestCase):

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -5188,9 +5188,20 @@ class BlockUsingGetTemplateMethod(blocks.Block):
 
     my_new_template = "my_super_awesome_dynamic_template.html"
 
-    def get_template(self):
+    def get_template(self, value=None, context=None):
         return self.my_new_template
 
+
+class BlockChoosingTemplateBasedOnValue(blocks.Block):
+
+    last_value = None
+
+    def get_template(self, value=None, context=None):
+        self.last_value = value
+        if value == "HEADING":
+            return "tests/blocks/heading_block.html"
+
+        return None # using render_basic
 
 class TestOverriddenGetTemplateBlockTag(TestCase):
     def test_template_is_overridden_by_get_template(self):
@@ -5200,6 +5211,17 @@ class TestOverriddenGetTemplateBlockTag(TestCase):
         )
         template = block.get_template()
         self.assertEqual(template, block.my_new_template)
+
+    def test_block_render_passes_the_value_argument_to_get_template(self):
+        """ verifies Block.render() passes the value to get_template """
+        block = BlockChoosingTemplateBasedOnValue()
+
+        html = block.render("Hello World")
+        self.assertEqual(html, "Hello World")
+
+        html = block.render("HEADING")
+        self.assertEqual(html, "<h1>HEADING</h1>")
+
 
 
 class TestValidationErrorAsJsonData(TestCase):


### PR DESCRIPTION
At the moment, the `Block.get_template` call only accept  the context as argument. When called in a dynamic context, there is no easy/clean way to access the current value of the block… 

When called from the render call, the value is received by render but not passed along to the get_template function.

Adding this patch allows the Block to decide the template used based on the actual block value (or the value of one of its fields).

Change is trivial (adding a parameter to get_template). I added it before the context argument to keep the API consistent, but this introduces a potential compatibility change for sites that would already override/call get_template with an argument.

Let me know your thoughts