### PR TITLE
Fix preview panel loading issues

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -72,6 +72,7 @@ Changelog
  * Fix: Use a theme-agnostic color token for read-only panels support in dark mode (Thibaud Colas)
  * Fix: Ensure collapsible StreamBlocks expand as necessary to show validation errors (Storm Heg)
  * Fix: Ensure userbar dialog can sit above other website content (LB (Ben) Johnston)
+ * Fix: Fix preview panel loading issues (Sage Abdullah)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)

--- a/client/src/entrypoints/admin/preview-panel.js
+++ b/client/src/entrypoints/admin/preview-panel.js
@@ -232,7 +232,9 @@ function initPreview() {
   }
 
   if (WAGTAIL_CONFIG.WAGTAIL_AUTO_UPDATE_PREVIEW) {
-    let oldPayload = new URLSearchParams(new FormData(form)).toString();
+    // Start with an empty payload so that when checkAndUpdatePreview is called
+    // for the first time when the panel is opened, it will always update the preview
+    let oldPayload = '';
     let updateInterval;
 
     const hasChanges = () => {

--- a/client/src/entrypoints/admin/preview-panel.js
+++ b/client/src/entrypoints/admin/preview-panel.js
@@ -177,6 +177,11 @@ function initPreview() {
           !data.is_available,
         );
 
+        if (!data.is_available) {
+          // Ensure the 'Preview not available' message is not scaled down
+          setPreviewWidth();
+        }
+
         if (data.is_valid) {
           reloadIframe();
         } else if (!cleared) {

--- a/client/src/entrypoints/admin/preview-panel.js
+++ b/client/src/entrypoints/admin/preview-panel.js
@@ -188,6 +188,10 @@ function initPreview() {
           clearPreviewData();
           cleared = true;
           reloadIframe();
+        } else {
+          // Finish the process when the data is invalid to prepare for the next update
+          // and avoid elements like the loading spinner to be shown indefinitely
+          finishUpdate();
         }
 
         return data.is_valid;

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -121,6 +121,7 @@ This feature was developed by Aman Pandey as part of the Google Summer of Code p
  * Use a theme-agnostic color token for read-only panels support in dark mode (Thibaud Colas)
  * Ensure collapsible StreamBlocks expand as necessary to show validation errors (Storm Heg)
  * Ensure userbar dialog can sit above other website content (LB (Ben) Johnston)
+ * Fix preview panel loading issues (Sage Abdullah)
 
 ### Documentation
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes a few old bugs and new regressions from #10502.

## Bug 1: preview iframe is not set to the right size when it's unavailable on initial load

When the preview is unavailable, we show the following message in the preview panel:

<details><summary>Screenshot</summary>
<p>

<img width="475" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/277a3437-5e56-45c9-806e-e450e3f1a67b">

</p>
</details> 

The "Preview not available" message in the centre is actually a webpage in an iframe, which is rendered by the preview view when no valid preview data is available. If the preview is unavailable, we have a special case handling in this function that sets the preview size between mobile/tablet/desktop:

https://github.com/wagtail/wagtail/blob/a6a91e1a014912c6f7f65cc367c099e9338c8906/client/src/entrypoints/admin/preview-panel.js#L24-L36

The handling is done by forcing the actual displayed size to be the default (mobile) size so that the message text doesn't get scaled to a small size.

This function doesn't get called on initial render of the panel, and since we saved the last selected size as of #9269, if you open the editor with an invalid initial preview and the last selected preview size is not mobile, the text will be scaled to that device size.

<details><summary>Bug screenshot</summary>
<p>

<img width="475" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/5e3588d2-6c01-40b0-bf6e-c0ef31bdb359">

</p>
</details>

To replicate this:
- Select the table or desktop preview panel size
- Go to the page create view, which should initially have invalid preview data (because title and slug are empty)
- Notice that the "Preview not available" message is scaled to be very small
- If you switch to any of the other preview sizes, it will be fixed

## Bug 2: loading spinner is shown indefinitely when editing a page with initially invalid data

If you try to edit a page that has an invalid data since the initial load and wait for about two seconds, the loading spinner will be shown indefinitely until you fix the error.

<details><summary>Screenshot</summary>
<p>


![preview-panel-loading-indefinite](https://github.com/wagtail/wagtail/assets/6379424/de6f0922-264e-42da-8c37-54a240a38a8c)

</p>
</details> 

To replicate this:
- Edit a page to have an expiry date that's one minute from the current time
  - Might be easier to set the user's timezone settings in `/admin/account/` first so that your input is submitted in your timezone
- Save a draft with these settings
- Wait until the minute passes
- Reload the page edit view
- Wait for two seconds, the preview panel will show the loading spinner indefinitely.

## Bug 3: preview iframe not loading on initial load of a snippets edit view

When editing a snippet with `PreviewableMixin` enabled, the preview iframe will not be loaded until you start editing.

<details><summary>Screen recording</summary>
<p>

https://github.com/wagtail/wagtail/assets/6379424/e8651d19-e750-40ae-a98a-97ba99076aa6

</p>
</details>

This isn't an issue with pages because the form data always changes after a few seconds from the initial render due to the initialisation of comments and StreamField blocks. I tried to eliminate the extra requests made during those initialisations in #10502, but that inadvertently caused this bug.

To replicate:
- Go to the edit view for a snippet that has `PreviewableMixin` enabled, e.g. the `Person` snippet in bakerydemo
- Open the preview panel
- Notice that the preview isn't shown until you start editing

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
