### PR TITLE
Fix `search_promotions` `0004_copy_queries` migration for long-lived Wagtail instances

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -73,6 +73,7 @@ Changelog
  * Fix: Ensure collapsible StreamBlocks expand as necessary to show validation errors (Storm Heg)
  * Fix: Ensure userbar dialog can sit above other website content (LB (Ben) Johnston)
  * Fix: Fix preview panel loading issues (Sage Abdullah)
+ * Fix: Fix `search_promotions` `0004_copy_queries` migration for long-lived Wagtail instances (Sage Abdullah)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -122,6 +122,7 @@ This feature was developed by Aman Pandey as part of the Google Summer of Code p
  * Ensure collapsible StreamBlocks expand as necessary to show validation errors (Storm Heg)
  * Ensure userbar dialog can sit above other website content (LB (Ben) Johnston)
  * Fix preview panel loading issues (Sage Abdullah)
+ * Fix `search_promotions` `0004_copy_queries` migration for long-lived Wagtail instances (Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/contrib/search_promotions/migrations/0004_copy_queries.py
+++ b/wagtail/contrib/search_promotions/migrations/0004_copy_queries.py
@@ -9,13 +9,22 @@ class Migration(migrations.Migration):
         ("wagtailsearchpromotions", "0003_query_querydailyhits"),
     ]
 
+    # Columns should be explicitly specified in case the order of columns
+    # between each table pair is different, which may be the case for Wagtail
+    # instances that were created when we still used django-south.
     operations = [
         migrations.RunSQL(
-            "INSERT INTO wagtailsearchpromotions_query SELECT * FROM wagtailsearch_query",
+            """
+            INSERT INTO wagtailsearchpromotions_query (id, query_string)
+            SELECT id, query_string FROM wagtailsearch_query
+            """,
             "",
         ),
         migrations.RunSQL(
-            "INSERT INTO wagtailsearchpromotions_querydailyhits SELECT * FROM wagtailsearch_querydailyhits",
+            """
+            INSERT INTO wagtailsearchpromotions_querydailyhits (id, date, hits, query_id)
+            SELECT id, date, hits, query_id FROM wagtailsearch_querydailyhits
+            """,
             "",
         ),
     ]


### PR DESCRIPTION
This migration would fail on Wagtail instances that have been around since v0.5 (when we still used django-south), because the column order of the wagtailsearch_querydailyhits table is different from the newly-created wagtailsearchpromotions_querydailyhits.

If you hit this issue, you deserve a 🌟

See https://github.com/torchbox/wagtail-torchbox/pull/503#issuecomment-1648172080 for more details

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.

**Please describe additional details for testing this change**.

If you really want to... you'll need to spin up a Wagtail instance with Wagtail v0.5 and upgrade it all the way up to 5.0 😂 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
