### PR TITLE
Bump What's new help menu item to 5.2

### DIFF
--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -1001,7 +1001,7 @@ def register_reports_menu():
 
 @hooks.register("register_help_menu_item")
 def register_whats_new_in_wagtail_version_menu_item():
-    version = "5.0"
+    version = "5.2"
     return DismissibleMenuItem(
         _("What's new in Wagtail %(version)s") % {"version": version},
         wagtail_feature_release_whats_new_link(),


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Missed this in #10694, I've updated the wiki to make sure we update this in the future. The `stable/5.1.x` branch was already updated when I made the RC.

It would be nice to just use the package's version automatically, but none of the functions in https://github.com/wagtail/wagtail/blob/main/wagtail/utils/version.py can consistently return a version number in `X.Y` format, so let's do that separately.

Will merge as soon as CI passes.
