### PR TITLE
Guard against TypeError in `0088_fix_log_entry_json_timestamps` migration

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -74,6 +74,7 @@ Changelog
  * Fix: Ensure userbar dialog can sit above other website content (LB (Ben) Johnston)
  * Fix: Fix preview panel loading issues (Sage Abdullah)
  * Fix: Fix `search_promotions` `0004_copy_queries` migration for long-lived Wagtail instances (Sage Abdullah)
+ * Fix: Guard against `TypeError` in `0088_fix_log_entry_json_timestamps` migration (Sage Abdullah)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -123,6 +123,7 @@ This feature was developed by Aman Pandey as part of the Google Summer of Code p
  * Ensure userbar dialog can sit above other website content (LB (Ben) Johnston)
  * Fix preview panel loading issues (Sage Abdullah)
  * Fix `search_promotions` `0004_copy_queries` migration for long-lived Wagtail instances (Sage Abdullah)
+ * Guard against `TypeError` in `0088_fix_log_entry_json_timestamps` migration (Sage Abdullah)
 
 ### Documentation
 


### PR DESCRIPTION
Old logs may have the data set to JSON `null` instead of an empty JSON object `{}`. I recommend hiding whitespace when reviewing the changes.

See https://github.com/wagtail/wagtail/pull/8021#issuecomment-1658082683 and https://github.com/wagtail/wagtail/pull/9590#discussion_r1279096075 for more details.

I think ideally we should also migrate such old logs to the empty JSON object so all logs are normalised to JSON objects (and Python dictionaries on the app-level), so it's safer to assume this to be the case in newer migrations (if any). I'll open a separate PR for it.

Running this on [torchbox/wagtail-torchbox](https://github.com/torchbox/wagtail-torchbox):

## Before
<img width="1011" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/9a037cbb-3dd4-4560-960e-1ddf038ccf5c">

## After
<img width="821" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/82e8896c-40bc-4a76-952e-fc3c39aa9b03">

