### PR TITLE
Fix incorrect `GroupPagePermission` import in 5.1 release notes

### DIFF
--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -280,7 +280,7 @@ Update it to use a natural key for the `permission` field instead of the `permis
 If you have any code that creates `GroupPagePermission` objects, you will need to update it to use the `Permission` model instead of the `permission_type` string. For example, if you have code that looks like this:
 
 ```python
-from wagtail.core.models import GroupPagePermission
+from wagtail.models import GroupPagePermission
 
 permission = GroupPagePermission(group=group, page=page, permission_type="edit")
 permission.save()
@@ -290,7 +290,7 @@ Update it to use the `Permission` model instead:
 
 ```python
 from django.contrib.auth.models import Permission
-from wagtail.core.models import GroupPagePermission
+from wagtail.models import GroupPagePermission
 
 permission = GroupPagePermission(
     group=group,


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Don't know why I wrote `wagtail.core` here, it probably came from Copilot's suggestion 🤦 

It's a small doc fix, so I'll merge immediately.