### PR TITLE
Set `PYTHONUNBUFFERED=1` and increase `no_output_timeout` on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,12 @@ jobs:
       - run: git ls-files '*.html' | xargs pipenv run djhtml --check
       - run: pipenv run curlylint --parse-only wagtail
       - run: pipenv run doc8 docs
-      - run: pipenv run python -u runtests.py --parallel
+      - run:
+          name: Run tests
+          no_output_timeout: 30m
+          command: |
+            export PYTHONUNBUFFERED=1
+            pipenv run python -u runtests.py --parallel
 
   frontend:
     docker:


### PR DESCRIPTION
https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-
