### PR TITLE
Use file-based SQLite database when running tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           no_output_timeout: 30m
           command: |
             export PYTHONUNBUFFERED=1
-            pipenv run python -u runtests.py --parallel
+            DATABASE_NAME=wagtail.db pipenv run python -u runtests.py --parallel
 
   frontend:
     docker:


### PR DESCRIPTION
Reverts the change discussed at https://github.com/wagtail/wagtail/pull/10709#discussion_r1281741904.

If this still fails, then I guess CircleCI doesn't like running tests in parallel.