### PR TITLE
Fix CircleCI setup on wagtail/wagtail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           no_output_timeout: 30m
           command: |
             export PYTHONUNBUFFERED=1
-            DATABASE_NAME=wagtail.db pipenv run python -u runtests.py --parallel
+            pipenv run python -u runtests.py --parallel
 
   frontend:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,9 @@ jobs:
       - run: pipenv run doc8 docs
       - run:
           name: Run tests
-          no_output_timeout: 30m
           command: |
             export PYTHONUNBUFFERED=1
-            pipenv run python -u runtests.py --parallel
+            pipenv run python -u runtests.py --parallel=2
 
   frontend:
     docker:


### PR DESCRIPTION
In the past few PRs that modify the CircleCI setup (#10751, #10743, #10709), the CircleCI builds always succeeded on the PR, but always 💥 on Wagtail's own `main` branch.

For some reason CircleCI uses a higher tier runner on my PR builds: 
![image](https://github.com/wagtail/wagtail/assets/6379424/94d763f8-0e0e-4546-90d7-8ac0aa9e4664)

while Wagtail's builds use a lower tier:

![image](https://github.com/wagtail/wagtail/assets/6379424/69544d3f-4380-4dd1-ac42-b6d7e094c360)

I'm experimenting with this PR by creating it from a branch in wagtail/wagtail instead of my fork. If it fails, then my theory checks out. I'll try adding `--parallel=2` and see if it works after that.