### PR TITLE
written tests to  proves the purge_revisions command won't crash when…

### DIFF
--- a/wagtail/tests/test_management_commands.py
+++ b/wagtail/tests/test_management_commands.py
@@ -620,12 +620,9 @@ class TestPurgeRevisionsCommandForPages(TestCase):
     base_options = {}
 
     def setUp(self):
-        self.object = self.get_object()
-
-    def get_object(self):
-        # Find root page
+        # Create a page and its revision
         self.root_page = Page.objects.get(id=2)
-        self.page = SimplePage(
+        self.page = Page(
             title="Hello world!",
             slug="hello-world",
             content="hello",
@@ -633,7 +630,15 @@ class TestPurgeRevisionsCommandForPages(TestCase):
         )
         self.root_page.add_child(instance=self.page)
         self.page.refresh_from_db()
-        return self.page
+
+        self.revision = Revision.objects.create(revision=1, page=self.page)
+        self.revision.user = self.user
+        self.revision.save()
+
+    def test_purge_revisions_protected_error(self):
+        # Run the purge_revisions command
+        with self.assertRaises(SystemExit):
+            self.call_command('purge_revisions', '--force')
 
     def assertRevisionNotExists(self, revision):
         self.assertFalse(Revision.objects.filter(id=revision.id).exists())


### PR DESCRIPTION
… a ProtectedError occurs

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #...







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
