### PR TITLE
Move `SnippetViewSet` menu registration attributes and methods to base `ViewSet` class

### DIFF
--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -15,6 +15,42 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. automethod:: on_register
    .. automethod:: get_urlpatterns
    .. automethod:: get_url_name
+   .. autoattribute:: icon
+   .. autoattribute:: menu_icon
+
+      Defaults to :attr:`icon`.
+
+   .. autoattribute:: menu_label
+   .. autoattribute:: menu_name
+   .. autoattribute:: menu_order
+   .. autoattribute:: menu_url
+
+      Defaults to the first URL returned by :meth:`get_urlpatterns`.
+
+   .. autoattribute:: menu_item_class
+   .. autoattribute:: menu_hook
+   .. autoattribute:: add_to_admin_menu
+   .. autoattribute:: add_to_settings_menu
+   .. automethod:: get_menu_item
+```
+
+## ViewSetGroup
+
+```{eval-rst}
+.. autoclass:: wagtail.admin.viewsets.base.ViewSetGroup
+
+   .. attribute:: items
+      :value: ()
+
+      A list or tuple of :class:`~wagtail.admin.viewsets.base.ViewSet` classes or instances to be grouped together.
+
+   .. autoattribute:: menu_icon
+   .. autoattribute:: menu_label
+   .. autoattribute:: menu_name
+   .. autoattribute:: menu_order
+   .. autoattribute:: menu_item_class
+   .. autoattribute:: add_to_admin_menu
+   .. automethod:: get_menu_item
 ```
 
 ## ModelViewSet
@@ -38,11 +74,26 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
 
    .. automethod:: get_form_class
 
-   .. autoattribute:: icon
+   .. autoattribute:: menu_label
+
+      Defaults to the title-cased version of the model's
+      :attr:`~django.db.models.Options.verbose_name_plural`.
+
    .. autoattribute:: index_view_class
    .. autoattribute:: add_view_class
    .. autoattribute:: edit_view_class
    .. autoattribute:: delete_view_class
+```
+
+## ModelViewSetGroup
+
+```{eval-rst}
+.. autoclass:: wagtail.admin.viewsets.model.ModelViewSetGroup
+
+   .. autoattribute:: menu_label
+
+      If unset, defaults to the title-cased version of the model's
+      :attr:`~django.db.models.Options.app_label` from the first viewset.
 ```
 
 ## ChooserViewSet
@@ -87,12 +138,6 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
 .. autoclass:: wagtail.snippets.views.snippets.SnippetViewSet
 
    .. autoattribute:: model
-   .. autoattribute:: icon
-   .. autoattribute:: add_to_admin_menu
-   .. autoattribute:: add_to_settings_menu
-   .. autoattribute:: menu_label
-   .. autoattribute:: menu_name
-   .. autoattribute:: menu_order
    .. autoattribute:: list_display
    .. autoattribute:: list_export
    .. autoattribute:: list_filter
@@ -134,11 +179,6 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: edit_template_name
    .. autoattribute:: delete_template_name
    .. autoattribute:: history_template_name
-   .. automethod:: get_menu_label
-   .. automethod:: get_menu_name
-   .. automethod:: get_menu_icon
-   .. automethod:: get_menu_order
-   .. automethod:: get_menu_item
    .. automethod:: get_queryset
    .. automethod:: get_edit_handler
    .. automethod:: get_form_class
@@ -160,15 +200,4 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
 ```{eval-rst}
 .. autoclass:: wagtail.snippets.views.snippets.SnippetViewSetGroup
 
-   .. autoattribute:: items
-   .. autoattribute:: add_to_admin_menu
-   .. autoattribute:: menu_label
-   .. autoattribute:: menu_name
-   .. autoattribute:: menu_icon
-   .. autoattribute:: menu_order
-   .. automethod:: get_menu_label
-   .. automethod:: get_menu_name
-   .. automethod:: get_menu_icon
-   .. automethod:: get_menu_order
-   .. automethod:: get_menu_item
 ```

--- a/wagtail/admin/menu.py
+++ b/wagtail/admin/menu.py
@@ -204,7 +204,7 @@ class WagtailMenuRegisterable:
         with the Wagtail admin.
 
         The ``order`` parameter allows the method to be called from the outside
-        (e.g. a ``WagtailMenuRegisterableGroup``) to create a sub menu item with
+        (e.g. a ``ViewSetGroup``) to create a sub menu item with
         the correct order.
         """
         return self.menu_item_class(

--- a/wagtail/admin/tests/viewsets/test_base_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_base_viewset.py
@@ -1,0 +1,41 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from wagtail.test.utils.wagtail_tests import WagtailTestUtils
+
+
+class TestBaseViewSet(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.user = self.login()
+
+    def test_menu_items(self):
+        response = self.client.get(reverse("wagtailadmin_home"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Miscellaneous")
+        self.assertContains(response, "The Calendar")
+        self.assertContains(response, "The Greetings")
+
+    def test_calendar_index_view(self):
+        url = reverse("calendar:index")
+        response = self.client.get(url)
+        now = timezone.now()
+        self.assertEqual(url, "/admin/calendar/")
+        self.assertContains(response, f"{now.year} calendar")
+
+    def test_calendar_month_view(self):
+        url = reverse("calendar:month")
+        response = self.client.get(url)
+        now = timezone.now()
+        self.assertEqual(url, "/admin/calendar/month/")
+        self.assertContains(response, f"{now.year}/{now.month} calendar")
+
+    def test_greetings_view(self):
+        self.user.first_name = "Gordon"
+        self.user.last_name = "Freeman"
+        self.user.save()
+        url = reverse("greetings:index")
+        response = self.client.get(url)
+        self.assertEqual(url, "/admin/greetingz/")
+        self.assertContains(response, "Greetings")
+        self.assertContains(response, "Welcome to this greetings page, Gordon Freeman!")

--- a/wagtail/admin/viewsets/__init__.py
+++ b/wagtail/admin/viewsets/__init__.py
@@ -1,6 +1,7 @@
 from django.urls import include, path
 
 from wagtail import hooks
+from wagtail.admin.viewsets.base import ViewSetGroup
 
 
 class ViewSetRegistry:
@@ -10,13 +11,17 @@ class ViewSetRegistry:
     def populate(self):
         for fn in hooks.get_hooks("register_admin_viewset"):
             viewset = fn()
-            if isinstance(viewset, (list, tuple)):
-                for vs in viewset:
-                    self.register(vs)
-            else:
-                self.register(viewset)
+            self.register(viewset)
 
     def register(self, viewset):
+        # Allow registering a ViewSetGroup, which will register all of its
+        # registerables.
+        if isinstance(viewset, ViewSetGroup):
+            for vs in viewset.registerables:
+                self.register(vs)
+            viewset.on_register()
+            return
+
         self.viewsets.append(viewset)
         viewset.on_register()
         return viewset

--- a/wagtail/admin/viewsets/base.py
+++ b/wagtail/admin/viewsets/base.py
@@ -1,8 +1,11 @@
 from django.core.exceptions import ImproperlyConfigured
+from django.urls import reverse
 from django.utils.functional import cached_property
 
+from wagtail.admin.menu import WagtailMenuRegisterable
 
-class ViewSet:
+
+class ViewSet(WagtailMenuRegisterable):
     """
     Defines a viewset to be registered with the Wagtail admin.
 
@@ -57,7 +60,7 @@ class ViewSet:
         """
         Called when the viewset is registered; subclasses can override this to perform additional setup.
         """
-        pass
+        self.register_menu_item()
 
     def get_urlpatterns(self):
         """
@@ -70,3 +73,7 @@ class ViewSet:
         Returns the namespaced URL name for the given view.
         """
         return self.url_namespace + ":" + view_name
+
+    @cached_property
+    def menu_url(self):
+        return reverse(self.get_url_name(self.get_urlpatterns()[0].name))

--- a/wagtail/admin/viewsets/base.py
+++ b/wagtail/admin/viewsets/base.py
@@ -18,6 +18,9 @@ class ViewSet(WagtailMenuRegisterable):
     #: A name for this viewset, used as the default URL prefix and namespace.
     name = None
 
+    #: The icon to use across the views.
+    icon = ""
+
     def __init__(self, name=None, **kwargs):
         if name:
             self.__dict__["name"] = name
@@ -73,6 +76,10 @@ class ViewSet(WagtailMenuRegisterable):
         Returns the namespaced URL name for the given view.
         """
         return self.url_namespace + ":" + view_name
+
+    @cached_property
+    def menu_icon(self):
+        return self.icon
 
     @cached_property
     def menu_url(self):

--- a/wagtail/admin/viewsets/base.py
+++ b/wagtail/admin/viewsets/base.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
 from django.utils.functional import cached_property
 
-from wagtail.admin.menu import WagtailMenuRegisterable
+from wagtail.admin.menu import WagtailMenuRegisterable, WagtailMenuRegisterableGroup
 
 
 class ViewSet(WagtailMenuRegisterable):
@@ -84,3 +84,13 @@ class ViewSet(WagtailMenuRegisterable):
     @cached_property
     def menu_url(self):
         return reverse(self.get_url_name(self.get_urlpatterns()[0].name))
+
+
+class ViewSetGroup(WagtailMenuRegisterableGroup):
+    """
+    A container for grouping together multiple ViewSet instances.
+    Creates a menu item with a submenu for accessing the main URL for each instances.
+    """
+
+    def on_register(self):
+        self.register_menu_item()

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -16,6 +16,9 @@ from .base import ViewSet, ViewSetGroup
 class ModelViewSet(ViewSet):
     """
     A viewset to allow listing, creating, editing and deleting model instances.
+
+    All attributes and methods from :class:`~wagtail.admin.viewsets.base.ViewSet`
+    are available.
     """
 
     #: The view class to use for the index view; must be a subclass of ``wagtail.admin.views.generic.IndexView``.
@@ -195,6 +198,14 @@ class ModelViewSet(ViewSet):
 
 
 class ModelViewSetGroup(ViewSetGroup):
+    """
+    A container for grouping together multiple
+    :class:`~wagtail.admin.viewsets.model.ModelViewSet` instances.
+
+    All attributes and methods from
+    :class:`~wagtail.admin.viewsets.base.ViewSetGroup` are available.
+    """
+
     def get_app_label_from_subitems(self):
         for instance in self.registerables:
             if app_label := getattr(instance, "app_label", ""):

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -10,7 +10,7 @@ from wagtail.admin.admin_url_finder import (
 from wagtail.admin.views import generic
 from wagtail.permissions import ModelPermissionPolicy
 
-from .base import ViewSet
+from .base import ViewSet, ViewSetGroup
 
 
 class ModelViewSet(ViewSet):
@@ -192,3 +192,15 @@ class ModelViewSet(ViewSet):
     def on_register(self):
         super().on_register()
         self.register_admin_url_finder()
+
+
+class ModelViewSetGroup(ViewSetGroup):
+    def get_app_label_from_subitems(self):
+        for instance in self.registerables:
+            if app_label := getattr(instance, "app_label", ""):
+                return app_label.title()
+        return ""
+
+    @cached_property
+    def menu_label(self):
+        return self.get_app_label_from_subitems()

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -30,6 +30,14 @@ class ModelViewSet(ViewSet):
     #: The view class to use for the delete view; must be a subclass of ``wagtail.admin.views.generic.DeleteView``.
     delete_view_class = generic.DeleteView
 
+    def __init__(self, name=None, **kwargs):
+        super().__init__(name=name, **kwargs)
+        if not self.model:
+            raise ImproperlyConfigured(
+                "ModelViewSet %r must define a `model` attribute or pass a `model` argument"
+                % self
+            )
+
     @property
     def permission_policy(self):
         return ModelPermissionPolicy(self.model)

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -18,8 +18,6 @@ class ModelViewSet(ViewSet):
     A viewset to allow listing, creating, editing and deleting model instances.
     """
 
-    icon = ""  #: The icon to use to represent the model within this viewset.
-
     #: The view class to use for the index view; must be a subclass of ``wagtail.admin.views.generic.IndexView``.
     index_view_class = generic.IndexView
 

--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -95,7 +95,7 @@ def _register_snippet_immediately(registerable, viewset=None):
         # register_snippet(CustomViewSetGroup) or
         # @register_snippet on class CustomViewSetGroup
         viewset_group = registerable()
-        for admin_viewset in viewset_group.viewsets:
+        for admin_viewset in viewset_group.registerables:
             register_snippet_viewset(admin_viewset)
         viewset_group.on_register()
         return

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -9,7 +9,7 @@ from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
 from django.template.defaultfilters import date
-from django.test import TestCase, TransactionTestCase
+from django.test import SimpleTestCase, TestCase, TransactionTestCase
 from django.urls import NoReverseMatch, resolve, reverse
 from django.utils.timezone import now
 from openpyxl import load_workbook
@@ -43,15 +43,18 @@ from wagtail.test.testapp.models import (
 from wagtail.test.utils import WagtailTestUtils
 
 
-class TestIncorrectRegistration(TestCase):
+class TestIncorrectRegistration(SimpleTestCase):
     def test_no_model_set_or_passed(self):
         # The base SnippetViewSet class has no `model` attribute set,
         # so using it directly should raise an error
-        with self.assertRaisesMessage(
-            ImproperlyConfigured,
-            "SnippetViewSet must be passed a model or define a model attribute.",
-        ):
+        with self.assertRaises(ImproperlyConfigured) as cm:
             register_snippet(SnippetViewSet)
+        message = str(cm.exception)
+        self.assertIn("ModelViewSet", message)
+        self.assertIn(
+            "must define a `model` attribute or pass a `model` argument",
+            message,
+        )
 
 
 class BaseSnippetViewSetTests(WagtailTestUtils, TestCase):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -1542,8 +1542,11 @@ class SnippetViewSet(ModelViewSet):
 
 class SnippetViewSetGroup(ModelViewSetGroup):
     """
-    A container for grouping together multiple SnippetViewSet instances. Creates
-    a menu item with a submenu for accessing the listing pages of those instances.
+    A container for grouping together multiple
+    :class:`~wagtail.snippets.views.snippets.SnippetViewSet` instances.
+
+    All attributes and methods from
+    :class:`~wagtail.admin.viewsets.model.ModelViewSetGroup` are available.
     """
 
     def __init__(self):

--- a/wagtail/test/testapp/templates/tests/misc/calendar.html
+++ b/wagtail/test/testapp/templates/tests/misc/calendar.html
@@ -1,0 +1,17 @@
+{% extends "wagtailadmin/generic/base.html" %}
+
+{% block extra_css %}
+    {{ block.super }}
+    <style>
+        table.month {
+            margin: 20px;
+        }
+        table.month td, table.month th {
+            padding: 5px;
+        }
+    </style>
+{% endblock %}
+
+{% block main_content %}
+    {{ calendar_html|safe }}
+{% endblock %}

--- a/wagtail/test/testapp/templates/tests/misc/greetings.html
+++ b/wagtail/test/testapp/templates/tests/misc/greetings.html
@@ -1,0 +1,6 @@
+{% extends "wagtailadmin/generic/base.html" %}
+{% block titletag %}Greetings{% endblock %}
+
+{% block main_content %}
+    Welcome to this greetings page, {{ user.get_full_name }}!
+{% endblock %}

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -30,6 +30,7 @@ from wagtail.test.testapp.models import (
     RevisableModel,
     VariousOnDeleteModel,
 )
+from wagtail.test.testapp.views import MiscellaneousViewSetGroup
 
 from .forms import FavouriteColourForm
 
@@ -240,6 +241,11 @@ class BrokenLinksSummaryItem(SummaryItem):
 @hooks.register("construct_homepage_summary_items")
 def add_broken_links_summary_item(request, items):
     items.append(BrokenLinksSummaryItem(request))
+
+
+@hooks.register("register_admin_viewset")
+def register_viewsets():
+    return MiscellaneousViewSetGroup()
 
 
 class FullFeaturedSnippetFilterSet(WagtailFilterSet):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Part of #10740.

This introduces the `WagtailMenuRegisterable` and `WagtailMenuRegisterableGroup` classes, which encapsulates menu item registration and can be used outside of `ViewSet`s.

If we don't want this to be in the base `ViewSet` class, we can also create another class e.g. `WagtailAdminViewSet`.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
    - Added tests for the base `ViewSet` class, will write more for the `ModelViewSet` in upcoming PRs when we make further changes to `ModelViewSet`.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
