### PR TITLE
Fix falsy values not showing up in tables UI framework

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,13 @@ Changelog
  * Maintenance: Update pre-commit hooks to be in sync with latest changes to Eslint & Prettier for client-side changes (Storm Heg)
 
 
+5.1.1 (xx.xx.xxxx) - IN DEVELOPMENT
+~~~~~~~~~~~~~~~~
+
+ * Introduce `wagtail.admin.ui.tables.BooleanColumn` to display boolean values as icons (Sage Abdullah)
+ * Fix: Show not-`None` falsy values instead of blank in generic table cell template (Sage Abdullah)
+
+
 5.1 (01.08.2023)
 ~~~~~~~~~~~~~~~~
 

--- a/docs/reference/contrib/modeladmin/migrating_to_snippets.md
+++ b/docs/reference/contrib/modeladmin/migrating_to_snippets.md
@@ -53,6 +53,24 @@ There are a few attributes of `ModelAdmin` that need to be renamed/adjusted for 
 | `form_fields_exclude`  | {attr}`~wagtail.admin.viewsets.model.ModelViewSet.exclude_form_fields`           | Same value, but different attribute name to better align with `ModelViewSet`. |
 | - | {attr}`~SnippetViewSet.template_prefix` | New attribute. Set to the name of a template directory to override the `"wagtailsnippets/snippets/"` default. If set to `"modeladmin/"`, the template directory structure will be equal to what ModelAdmin uses. Make sure any custom templates are placed in the correct directory according to this prefix. See [](wagtailsnippets_templates) for more details. |
 
+### Boolean properties in `list_display`
+
+In ModelAdmin, boolean fields in `list_display` are rendered as tick/cross icons. To achieve the same behavior in SnippetViewSet, you need to use a `wagtail.admin.ui.tables.BooleanColumn` instance in `SnippetViewSet.list_display`:
+
+```python
+from wagtail.admin.ui.tables import BooleanColumn
+
+
+class MySnippetViewSet(SnippetViewSet):
+    list_display = ("title", BooleanColumn("is_active"))
+```
+
+The `BooleanColumn` class works with both model fields and custom properties that return booleans.
+
+```{versionadded} 5.1.1
+The `BooleanColumn` class was added.
+```
+
 ## Convert `ModelAdminGroup` class to `SnippetViewSetGroup`
 
 The {class}`~SnippetViewSetGroup` class is the snippets-equivalent to the `ModelAdminGroup` class. To migrate a `ModelAdminGroup` class to a `SnippetViewSetGroup` class, follow these instructions.

--- a/docs/reference/contrib/modeladmin/migrating_to_snippets.md
+++ b/docs/reference/contrib/modeladmin/migrating_to_snippets.md
@@ -53,6 +53,28 @@ There are a few attributes of `ModelAdmin` that need to be renamed/adjusted for 
 | `form_fields_exclude`  | {attr}`~wagtail.admin.viewsets.model.ModelViewSet.exclude_form_fields`           | Same value, but different attribute name to better align with `ModelViewSet`. |
 | - | {attr}`~SnippetViewSet.template_prefix` | New attribute. Set to the name of a template directory to override the `"wagtailsnippets/snippets/"` default. If set to `"modeladmin/"`, the template directory structure will be equal to what ModelAdmin uses. Make sure any custom templates are placed in the correct directory according to this prefix. See [](wagtailsnippets_templates) for more details. |
 
+## Convert `ModelAdminGroup` class to `SnippetViewSetGroup`
+
+The {class}`~SnippetViewSetGroup` class is the snippets-equivalent to the `ModelAdminGroup` class. To migrate a `ModelAdminGroup` class to a `SnippetViewSetGroup` class, follow these instructions.
+
+Change any imports of `ModelAdminGroup` to `SnippetViewSetGroup`:
+
+```diff
+- from wagtail.contrib.modeladmin.options import ModelAdminGroup
++ from wagtail.snippets.views.snippets import SnippetViewSetGroup
+```
+
+Change any references to `ModelAdminGroup` to `SnippetViewSetGroup`:
+
+```diff
+- class MyModelAdminGroup(ModelAdminGroup):
++ class MySnippetViewSetGroup(SnippetViewSetGroup):
+      ...
+
+- modeladmin_register(MyModelAdminGroup)
++ register_snippet(MySnippetViewSetGroup)
+```
+
 ## Unsupported features and customizations
 
 Some features and customizations in `ModelAdmin` are not directly supported via `SnippetViewSet`, but may be achievable via other means that are more in line with Wagtail's architecture.

--- a/docs/releases/5.1.1.md
+++ b/docs/releases/5.1.1.md
@@ -1,0 +1,29 @@
+# Wagtail 5.1.1 release notes - IN DEVELOPMENT
+
+_Unreleased_
+
+```{contents}
+---
+local:
+depth: 1
+---
+```
+
+## What's new
+
+
+### Other features
+
+ * Introduce `wagtail.admin.ui.tables.BooleanColumn` to display boolean values as icons (Sage Abdullah)
+
+### Bug fixes
+
+ * Show not-`None` falsy values instead of blank in generic table cell template (Sage Abdullah)
+
+### Documentation
+
+ * ...
+
+### Maintenance
+
+ * ...

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -290,7 +290,9 @@ The `insert_editor_css` hook has been deprecated. The `insert_global_admin_css` 
 
 ### `wagtail.contrib.modeladmin` is deprecated
 
-As part of the [RFC 85: Snippets parity with ModelAdmin](https://github.com/wagtail/rfcs/pull/85) implementation, the `wagtail.contrib.modeladmin` app is deprecated. To manage non-page models in Wagtail, use [`wagtail.snippets`](snippets) instead. If you still rely on ModelAdmin, use the separate [wagtail-modeladmin](https://github.com/wagtail-nest/wagtail-modeladmin) package. The `wagtail.contrib.modeladmin` module will be removed in a future release.
+As part of the [RFC 85: Snippets parity with ModelAdmin](https://github.com/wagtail/rfcs/pull/85) implementation, the `wagtail.contrib.modeladmin` app is deprecated. To manage non-page models in Wagtail, use [`wagtail.snippets`](snippets) instead. See [](../reference/contrib/modeladmin/migrating_to_snippets) for more details.
+
+If you still rely on ModelAdmin, use the separate [wagtail-modeladmin](https://github.com/wagtail-nest/wagtail-modeladmin) package. The `wagtail.contrib.modeladmin` module will be removed in a future release.
 
 ### `UserPagePermissionsProxy` is deprecated
 

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -6,6 +6,7 @@ Release notes
 
    upgrading
    5.2
+   5.1.1
    5.1
    5.0.2
    5.0.1

--- a/wagtail/admin/templates/wagtailadmin/tables/boolean_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/boolean_cell.html
@@ -1,0 +1,10 @@
+{% load wagtailadmin_tags %}
+<td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
+    {% if value is None %}
+        {% icon title=value|stringformat:'s' name="help" classname="default" %}
+    {% elif value %}
+        {% icon title=value|stringformat:'s' name="success" classname="default w-text-positive-100" %}
+    {% else %}
+        {% icon title=value|stringformat:'s' name="error" classname="default w-text-critical-100" %}
+    {% endif %}
+</td>

--- a/wagtail/admin/templates/wagtailadmin/tables/cell.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/cell.html
@@ -1,3 +1,3 @@
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
-    {% if value %}{{ value }}{% endif %}
+    {% if value is not None %}{{ value }}{% endif %}
 </td>

--- a/wagtail/admin/ui/tables/__init__.py
+++ b/wagtail/admin/ui/tables/__init__.py
@@ -243,6 +243,12 @@ class StatusTagColumn(Column):
         return context
 
 
+class BooleanColumn(Column):
+    """Represents a True/False/None value as a tick/cross/question icon"""
+
+    cell_template_name = "wagtailadmin/tables/boolean_cell.html"
+
+
 class LiveStatusTagColumn(StatusTagColumn):
     """Represents a live/draft status tag"""
 

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -666,6 +666,7 @@ class TestListViewWithCustomColumns(BaseSnippetViewSetTests):
         self.assertContains(response, "Country code")
         self.assertContains(response, "Custom FOO column")
         self.assertContains(response, "Updated")
+        self.assertContains(response, "Modulo two")
 
         self.assertContains(response, "Foo UK")
 
@@ -677,8 +678,13 @@ class TestListViewWithCustomColumns(BaseSnippetViewSetTests):
 
         html = response.content.decode()
 
-        # The bulk actions column plus 4 columns defined in FullFeaturedSnippetViewSet
-        self.assertTagInHTML("<th>", html, count=5, allow_extra_attrs=True)
+        # The bulk actions column plus 5 columns defined in FullFeaturedSnippetViewSet
+        self.assertTagInHTML("<th>", html, count=6, allow_extra_attrs=True)
+
+    def test_falsy_value(self):
+        # https://github.com/wagtail/wagtail/issues/10765
+        response = self.get()
+        self.assertContains(response, "<td>0</td>", html=True, count=1)
 
 
 class TestListExport(BaseSnippetViewSetTests):

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -667,6 +667,7 @@ class TestListViewWithCustomColumns(BaseSnippetViewSetTests):
         self.assertContains(response, "Custom FOO column")
         self.assertContains(response, "Updated")
         self.assertContains(response, "Modulo two")
+        self.assertContains(response, "Tristate")
 
         self.assertContains(response, "Foo UK")
 
@@ -678,13 +679,56 @@ class TestListViewWithCustomColumns(BaseSnippetViewSetTests):
 
         html = response.content.decode()
 
-        # The bulk actions column plus 5 columns defined in FullFeaturedSnippetViewSet
-        self.assertTagInHTML("<th>", html, count=6, allow_extra_attrs=True)
+        # The bulk actions column plus 6 columns defined in FullFeaturedSnippetViewSet
+        self.assertTagInHTML("<th>", html, count=7, allow_extra_attrs=True)
 
     def test_falsy_value(self):
         # https://github.com/wagtail/wagtail/issues/10765
         response = self.get()
         self.assertContains(response, "<td>0</td>", html=True, count=1)
+
+    def test_boolean_column(self):
+        self.model.objects.create(text="Another one")
+        response = self.get()
+        self.assertContains(
+            response,
+            """
+            <td>
+                <svg class="icon icon-success default w-text-positive-100" aria-hidden="true">
+                    <use href="#icon-success"></use>
+                </svg>
+                <span class="visuallyhidden">True</span>
+            </td>
+            """,
+            html=True,
+            count=1,
+        )
+        self.assertContains(
+            response,
+            """
+            <td>
+                <svg class="icon icon-error default w-text-critical-100" aria-hidden="true">
+                    <use href="#icon-error"></use>
+                </svg>
+                <span class="visuallyhidden">False</span>
+            </td>
+            """,
+            html=True,
+            count=1,
+        )
+        self.assertContains(
+            response,
+            """
+            <td>
+                <svg class="icon icon-help default" aria-hidden="true">
+                    <use href="#icon-help"></use>
+                </svg>
+                <span class="visuallyhidden">None</span>
+            </td>
+            """,
+            html=True,
+            count=1,
+        )
 
 
 class TestListExport(BaseSnippetViewSetTests):

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -1132,6 +1132,9 @@ class FullFeaturedSnippet(
     def modulo_two(self):
         return self.pk % 2
 
+    def tristate(self):
+        return (None, True, False)[self.pk % 3]
+
     def get_preview_template(self, request, mode_name):
         return "tests/previewable_model.html"
 

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -1129,6 +1129,9 @@ class FullFeaturedSnippet(
     def __str__(self):
         return self.text
 
+    def modulo_two(self):
+        return self.pk % 2
+
     def get_preview_template(self, request, mode_name):
         return "tests/previewable_model.html"
 

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -257,7 +257,13 @@ class FullFeaturedSnippetViewSet(SnippetViewSet):
     list_per_page = 5
     chooser_per_page = 15
     filterset_class = FullFeaturedSnippetFilterSet
-    list_display = ["text", "country_code", "get_foo_country_code", UpdatedAtColumn()]
+    list_display = [
+        "text",
+        "country_code",
+        "get_foo_country_code",
+        UpdatedAtColumn(),
+        "modulo_two",
+    ]
     list_export = [
         "text",
         "country_code",

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -17,7 +17,7 @@ from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElement
 from wagtail.admin.search import SearchArea
 from wagtail.admin.site_summary import SummaryItem
 from wagtail.admin.ui.components import Component
-from wagtail.admin.ui.tables import UpdatedAtColumn
+from wagtail.admin.ui.tables import BooleanColumn, UpdatedAtColumn
 from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail.admin.widgets import Button
 from wagtail.snippets.models import register_snippet
@@ -263,6 +263,7 @@ class FullFeaturedSnippetViewSet(SnippetViewSet):
         "get_foo_country_code",
         UpdatedAtColumn(),
         "modulo_two",
+        BooleanColumn("tristate"),
     ]
     list_export = [
         "text",


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10765.

The first commit fixes the falsy values issue. This should be OK to cherry-pick to 5.1.1. To test, you can add an integer field to a snippet model with the default value of 0, then add that to `list_display`. For quick testing, you can use a property/method instead so that you don't have to make and run migrations.

The second one adds a new `BooleanColumn` that allows you to show boolean values as tick/cross/question icon, similar to ModelAdmin and Django's admin:

<details><summary>Old screenshot</summary>
<p>



<img width="1252" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/1bc62b2a-f265-46a3-875d-f89606970a1c">

</p>
</details> 

![image](https://github.com/wagtail/wagtail/assets/6379424/745b8f15-cbab-4359-ba3f-66abbef9d960)

<img width="1203" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/3b5414b4-70d5-43c9-94a5-6ad03c0a99d2">

Not sure if this should be in a patch release as it can be considered a new feature. I think we did something similar for the slug panel, but that was because of a breaking change, whereas this is not really breaking as ModelAdmin is still available.

To test, you can add a boolean field or property/method and include it in `list_display`.

I've also added some missing docs for the ModelAdmin migration, which should be cherry-picked so we can update the docs as part of the 5.1.1 release.



_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
