### PR TITLE
Clean up unit tests that passed a function/data to Promise.resolve

### DIFF
--- a/client/src/controllers/DropdownController.test.js
+++ b/client/src/controllers/DropdownController.test.js
@@ -16,7 +16,7 @@ describe('DropdownController', () => {
     application = Application.start();
     application.register('w-dropdown', DropdownController);
 
-    await Promise.resolve(requestAnimationFrame);
+    await Promise.resolve();
 
     // set all animation durations to 0 so that tests can ignore animation delays
     // Tippy relies on transitionend which is not yet supported in JSDom

--- a/client/src/controllers/SwapController.test.js
+++ b/client/src/controllers/SwapController.test.js
@@ -599,7 +599,7 @@ describe('SwapController', () => {
       expect(beginEventHandler).not.toHaveBeenCalled();
 
       jest.runAllTimers(); // search is debounced
-      await Promise.resolve(requestAnimationFrame);
+      await Promise.resolve();
 
       // should fire a begin event before the request is made
       expect(beginEventHandler).toHaveBeenCalledTimes(1);
@@ -985,7 +985,7 @@ describe('SwapController', () => {
       expect(beginEventHandler).not.toHaveBeenCalled();
 
       jest.runAllTimers(); // search is debounced
-      await Promise.resolve(requestAnimationFrame);
+      await Promise.resolve();
 
       // should fire a begin event before the request is made
       expect(beginEventHandler).toHaveBeenCalledTimes(1);

--- a/client/src/controllers/TooltipController.test.js
+++ b/client/src/controllers/TooltipController.test.js
@@ -30,7 +30,7 @@ describe('TooltipController', () => {
     application = Application.start();
     application.register('w-tooltip', TooltipController);
 
-    await Promise.resolve(requestAnimationFrame);
+    await Promise.resolve();
 
     // set all animation durations to 0 so that tests can ignore animation delays
     // Tippy relies on transitionend which is not yet supported in JSDom
@@ -56,7 +56,7 @@ describe('TooltipController', () => {
 
     tooltipTrigger.dispatchEvent(new Event('mouseenter'));
 
-    await Promise.resolve(requestAnimationFrame);
+    await Promise.resolve();
 
     expect(document.querySelectorAll('[role="tooltip"]')).toHaveLength(1);
     const tooltip = document.querySelector('[role="tooltip"]');
@@ -74,7 +74,7 @@ describe('TooltipController', () => {
 
     tooltipTrigger.dispatchEvent(new Event('mouseenter'));
 
-    await Promise.resolve(requestAnimationFrame);
+    await Promise.resolve();
 
     const tooltip = document.querySelector('[role="tooltip"]');
 
@@ -96,7 +96,7 @@ describe('TooltipController', () => {
 
     tooltipTrigger.removeAttribute('data-controller');
 
-    await Promise.resolve(requestAnimationFrame);
+    await Promise.resolve();
 
     expect(controller.tippy.destroy).toHaveBeenCalled();
   });
@@ -129,7 +129,7 @@ describe('TooltipController', () => {
     // change the content value
     tooltipTrigger.setAttribute('data-w-tooltip-content-value', 'NEW content!');
 
-    await Promise.resolve(requestAnimationFrame);
+    await Promise.resolve();
 
     expect(tooltip.textContent).toEqual('NEW content!');
   });

--- a/client/src/controllers/UpgradeController.test.js
+++ b/client/src/controllers/UpgradeController.test.js
@@ -52,7 +52,7 @@ describe('UpgradeController', () => {
     application.register('w-upgrade', UpgradeController);
 
     // trigger next browser render cycle
-    await Promise.resolve(true);
+    await Promise.resolve();
 
     expect(global.fetch).toHaveBeenCalledWith(
       'https://releases.wagtail.org/mock.txt',
@@ -102,7 +102,7 @@ describe('UpgradeController', () => {
     application.register('w-upgrade', UpgradeController);
 
     // trigger next browser render cycle
-    await Promise.resolve(true);
+    await Promise.resolve();
 
     expect(
       document.getElementById('panel').classList.contains('w-hidden'),

--- a/client/src/includes/initStimulus.test.js
+++ b/client/src/includes/initStimulus.test.js
@@ -131,14 +131,14 @@ describe('initStimulus', () => {
 
     document.querySelector('section').after(section);
 
-    await Promise.resolve({});
+    await Promise.resolve();
 
     // after controller connected - should have an output element
     expect(document.querySelector('#example-a > output').innerHTML).toEqual(
       '2 / 10 words',
     );
 
-    await Promise.resolve({});
+    await Promise.resolve();
 
     // should respond to changes on the input
     const input = document.querySelector('#example-a > input');
@@ -152,7 +152,7 @@ describe('initStimulus', () => {
     // removal of the input should also remove the output (disconnect method)
     input.remove();
 
-    await Promise.resolve({});
+    await Promise.resolve();
 
     // should call the disconnect method (removal of the injected HTML)
     expect(document.querySelector('#example-a > output')).toEqual(null);
@@ -174,14 +174,14 @@ describe('initStimulus', () => {
 
     document.querySelector('section').after(section);
 
-    await Promise.resolve({});
+    await Promise.resolve();
 
     // after controller connected - should have an output element
     expect(document.querySelector('#example-b > output').innerHTML).toEqual(
       '2 / 5 words',
     );
 
-    await Promise.resolve({});
+    await Promise.resolve();
 
     // should respond to changes on the input
     const input = document.querySelector('#example-b > input');
@@ -195,7 +195,7 @@ describe('initStimulus', () => {
     // removal of the input should also remove the output (disconnect method)
     input.remove();
 
-    await Promise.resolve({});
+    await Promise.resolve();
 
     // should call the disconnect method (removal of the injected HTML)
     expect(document.querySelector('#example-b > output')).toEqual(null);


### PR DESCRIPTION
- Passing anything to Promise.resolve just means that will be the return value of the promise (.then)
- This does not actually run the function (e.g. in the case of requestAnimationFrame)
- Avoiding unit tests that could cause confusion in the future