### PR TITLE
Fix read_only panels for fields with translatable choice labels

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
 
  * Introduce `wagtail.admin.ui.tables.BooleanColumn` to display boolean values as icons (Sage Abdullah)
  * Fix: Show not-`None` falsy values instead of blank in generic table cell template (Sage Abdullah)
+ * Fix: Fix `read_only` panels for fields with translatable choice labels (Florent Lebreton)
 
 
 5.1 (01.08.2023)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -722,6 +722,7 @@
 * Henry Harutyunyan
 * Alex Morega
 * Scott Foster
+* Florent Lebreton
 
 ## Translators
 

--- a/docs/releases/5.1.1.md
+++ b/docs/releases/5.1.1.md
@@ -19,6 +19,7 @@ depth: 1
 ### Bug fixes
 
  * Show not-`None` falsy values instead of blank in generic table cell template (Sage Abdullah)
+ * Fix `read_only` panels for fields with translatable choice labels (Florent Lebreton)
 
 ### Documentation
 

--- a/wagtail/admin/panels/field_panel.py
+++ b/wagtail/admin/panels/field_panel.py
@@ -109,7 +109,7 @@ class FieldPanel(Panel):
         if not isinstance(choices, ModelChoiceIterator) and choices:
             labels = dict(choices)
             display_values = [
-                labels.get(v, v)  # Use raw value if no match found
+                str(labels.get(v, v))  # Use raw value if no match found
                 for v in (
                     # Account for single AND multiple choice fields
                     tuple(value)

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -81,8 +81,8 @@ from wagtail.snippets.models import register_snippet
 from .forms import FormClassAdditionalFieldPageForm, ValidatedPageForm
 
 EVENT_AUDIENCE_CHOICES = (
-    ("public", "Public"),
-    ("private", "Private"),
+    ("public", _("Public")),
+    ("private", _("Private")),
 )
 
 


### PR DESCRIPTION
Fixes #10772

-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [X] Run `make lint` from the Wagtail root.
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
