### PR TITLE
Allow multiple permissions on wagtailadmin.admin content type

### DIFF
--- a/wagtail/users/templatetags/wagtailusers_tags.py
+++ b/wagtail/users/templatetags/wagtailusers_tags.py
@@ -75,12 +75,12 @@ def format_permissions(permission_bound_field):
         content_perms_dict = {}
         custom_perms = []
 
-        if content_perms[0].content_type.name == "admin":
-            perm = content_perms[0]
-            other_perms.append((perm, checkboxes_by_id[perm.id]))
-            continue
-
         for perm in content_perms:
+            # All 'wagtailadmin.admin' perms should be separate rows
+            if perm.content_type.name == "admin":
+                other_perms.append((perm, checkboxes_by_id[perm.id]))
+                continue
+
             content_perms_dict["object"] = perm.content_type.name
             checkbox = checkboxes_by_id[perm.id]
             # identify the main categories of permission, and assign to


### PR DESCRIPTION
This allows multiple custom permissions attached to the `wagtailadmin.admin` content type - in particular, fixes the Wagtail 2FA group permissions.

Fixes #8086

-   [ ] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

- Set up wagtail 2FA with the custom user permissions, as described in https://github.com/torchbox-forks/wagtail-2fa#making-2fa-optional
- Go to http://localhost:8000/admin/groups/ and edit a group
- You should see the 'Enable 2FA' option there, and it should let you toggle it and the regular 'Can access Wagtail admin' option.