### PR TITLE
Add srcset_image and picture tags for responsive images

### DIFF
--- a/docs/advanced_topics/images/renditions.md
+++ b/docs/advanced_topics/images/renditions.md
@@ -38,13 +38,13 @@ See also: [](image_tag)
 
 ## Generating multiple renditions for an image
 
-You can generate multiple renditions of the same image from Python using the native `get_renditions()` method. It will accept any number of 'specification' strings, and will generate a set of matching renditions much more efficiently than generating each one individually. For example:
+You can generate multiple renditions of the same image from Python using the native `get_renditions()` method. It will accept any number of 'specification' strings or `Filter instances`, and will generate a set of matching renditions much more efficiently than generating each one individually. For example:
 
 ```python
 image.get_renditions('width-600', 'height-400', 'fill-300x186|jpegquality-60')
 ```
 
-The return value is a dictionary of renditions keyed by the specification strings that were provided to the method. The return value from the above example would look something like this:
+The return value is a dictionary of renditions keyed by the specifications that were provided to the method. The return value from the above example would look something like this:
 
 ```python
 {

--- a/docs/reference/jinja2.md
+++ b/docs/reference/jinja2.md
@@ -89,7 +89,7 @@ See [](image_tag) for more information
 
 Resize an image, and render an `<img>` tag including `srcset` with multiple sizes.
 Browsers will select the most appropriate image to load based on [responsive image rules](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
-The `sizes` attribute is mandatory unless you store the output of `srcset_image` for later use.
+The [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes) attribute is essential unless you store the output of `srcset_image` for later use.
 
 ```html+jinja
 {{ srcset_image(page.header_image, "fill-{512x100,1024x200}", sizes="100vw", class="header-image") }}
@@ -100,6 +100,30 @@ Or resize an image and retrieve the renditions for more bespoke use:
 ```html+jinja
 {% set bg=srcset_image(page.background_image, "max-{512x512,1024x1024}") %}
 <div class="wrapper" style="background-image: image-set(url({{ bg.renditions[0].url }}) 1x, url({{ bg.renditions[1].url }}) 2x);"></div>
+```
+
+### `picture()`
+
+Resize or convert an image, rendering a `<picture>` tag including multiple `source` formats with `srcset` for multiple sizes.
+Browsers will select the [first supported image format](https://web.dev/learn/design/picture-element/#image-formats), and pick a size based on [responsive image rules](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
+
+`picture` can render an image in multiple formats:
+
+```html+jinja
+{{ picture(page.header_image, "format-{avif,jpeg}") }}
+```
+
+Or render multiple formats and multiple sizes like `srcset_image` does. The [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes) attribute is essential when the picture tag renders images in multiple sizes:
+
+```html+jinja
+{{ picture(page.header_image, "format-{avif,jpeg}|fill-{512x100,1024x200}", sizes="100vw") }}
+```
+
+Or resize an image and retrieve the renditions for more bespoke use:
+
+```html+jinja
+{% set bg=picture(page.background_image, "format-{avif,jpeg}|max-{512x512,1024x1024}") %}
+<div class="wrapper" style="background-image: image-set(url({{ bg.formats['avif'][0].url }}) 1x type('image/avif'), url({{ bg.formats['avif'][1].url }}) 2x type('image/avif'), url({{ bg.formats['jpeg'][0].url }}) 1x type('image/jpeg'), url({{ bg.formats['jpeg'][1].url }}) 2x type('image/jpeg'));"></div>
 ```
 
 ### `|richtext`

--- a/docs/reference/jinja2.md
+++ b/docs/reference/jinja2.md
@@ -70,18 +70,37 @@ See [](slugurl_tag) for more information
 
 ### `image()`
 
-Resize an image, and print an `<img>` tag:
+Resize an image, and render an `<img>` tag:
 
 ```html+jinja
-{# Print an image tag #}
 {{ image(page.header_image, "fill-1024x200", class="header-image") }}
+```
 
-{# Resize an image #}
+Or resize an image and retrieve the resized image object (rendition) for more bespoke use:
+
+```html+jinja
 {% set background=image(page.background_image, "max-1024x1024") %}
-<div class="wrapper" style="background-image: url({{ background.url }});">
+<div class="wrapper" style="background-image: url({{ background.url }});"></div>
 ```
 
 See [](image_tag) for more information
+
+### `srcset_image()`
+
+Resize an image, and render an `<img>` tag including `srcset` with multiple sizes.
+Browsers will select the most appropriate image to load based on [responsive image rules](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
+The `sizes` attribute is mandatory unless you store the output of `srcset_image` for later use.
+
+```html+jinja
+{{ srcset_image(page.header_image, "fill-{512x100,1024x200}", sizes="100vw", class="header-image") }}
+```
+
+Or resize an image and retrieve the renditions for more bespoke use:
+
+```html+jinja
+{% set bg=srcset_image(page.background_image, "max-{512x512,1024x1024}") %}
+<div class="wrapper" style="background-image: image-set(url({{ bg.renditions[0].url }}) 1x, url({{ bg.renditions[1].url }}) 2x);"></div>
+```
 
 ### `|richtext`
 

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -29,6 +29,21 @@ In the above syntax example `[image]` is the Django object referring to the imag
 
 Note that a space separates `[image]` and `[resize-rule]`, but the resize rule must not contain spaces. The width is always specified before the height. Resized images will maintain their original aspect ratio unless the `fill` rule is used, which may result in some pixels being cropped.
 
+(responsive_images)=
+
+## Responsive images
+
+In addition to `image`, Wagtail also provides a `srcset_image` template tag which generates an `<img>` tag with a `srcset` attribute. This allows browsers to select the most appropriate image file to load based on [responsive image rules](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
+
+The syntax for `srcset_image` is the same as `image, with two exceptions:
+
+```html+django
+{% srcset_image [image] [resize-rule-with-brace-expansion] sizes="100vw" %}
+```
+
+- The resize rule should be provided with multiple sizes in a brace-expansion pattern, like `width-{200,400}`. This will generate the `srcset` attribute, with as many URLs as there are sizes defined in the resize rule.
+- The `sizes` attribute is mandatory. This tells the browser how large the image will be displayed on the page, so that it can select the most appropriate image to load.
+
 (available_resizing_methods)=
 
 ## Available resizing methods
@@ -177,7 +192,7 @@ You can also add default attributes to all images (a default class or data attri
 
 ### 2. Generating the image "as foo" to access individual properties
 
-Wagtail can assign the image data to another variable using Django's `as` syntax:
+Wagtail can assign the image data to another variable using Django's `as` syntax, to access the underlying image Rendition (`tmp_photo`):
 
 ```html+django
 {% image page.photo width-400 as tmp_photo %}
@@ -186,11 +201,36 @@ Wagtail can assign the image data to another variable using Django's `as` syntax
     height="{{ tmp_photo.height }}" alt="{{ tmp_photo.alt }}" class="my-custom-class" />
 ```
 
+This is also possible with the `srcset_image` tag, to retrieve multiple size renditions:
+
+```html+django
+{% srcset_image page.photo width-{200,400} as tmp_photo %}
+
+<img
+    src="{{ tmp_photo.renditions.0.url }}"
+    width="{{ tmp_photo.renditions.0.width }}"
+    height="{{ tmp_photo.renditions.0.height }}"
+    alt="{{ tmp_photo.renditions.0.alt }}"
+    srcset="{{ tmp_photo.renditions.0.url }} 200w, {{ tmp_photo.renditions.1.url }} 400w"
+    sizes="100vw"
+    class="my-custom-class"
+/>
+```
+
+And with the picture tag, to retrieve multiple formats:
+
+```html+django
+{% picture page.photo format-{avif,jpeg} as tmp_photo %}
+
+{{ tmp_photo.avif.0.url }}
+{{ tmp_photo.jpeg.0.url }}
+```
+
 ```{note}
 The image property used for the `src` attribute is `image.url`, not `image.src`.
 ```
 
-This syntax exposes the underlying image Rendition (`tmp_photo`) to the developer. A "Rendition" contains the information specific to the way you've requested to format the image using the resize-rule, dimensions, and source URL. The following properties are available:
+Renditions contain the information specific to the way you've requested to format the image using the resize-rule, dimensions, and source URL. The following properties are available:
 
 ### `url`
 

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -29,11 +29,25 @@ In the above syntax example `[image]` is the Django object referring to the imag
 
 Note that a space separates `[image]` and `[resize-rule]`, but the resize rule must not contain spaces. The width is always specified before the height. Resized images will maintain their original aspect ratio unless the `fill` rule is used, which may result in some pixels being cropped.
 
+(multiple_formats)=
+
+## Multiple formats
+
+To render an image in multiple formats, you can use the `picture` tag:
+
+```html+django
+{% picture page.photo width-400 format-{avif,jpeg} %}
+```
+
+Compared to `image`, this will render a `<picture>` element with one `<source>` element per format. The browser [picks the first format it supports](https://web.dev/learn/design/picture-element/#source), or defaults to a fallback `<img>` element.
+
+`picture` can also be used with responsive image resize rules.
+
 (responsive_images)=
 
 ## Responsive images
 
-In addition to `image`, Wagtail also provides a `srcset_image` template tag which generates an `<img>` tag with a `srcset` attribute. This allows browsers to select the most appropriate image file to load based on [responsive image rules](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
+Wagtail provides `picture` and `srcset_image` template tags which can generate an `<img>` tag with a `srcset` attribute. This allows browsers to select the most appropriate image file to load based on [responsive image rules](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
 
 The syntax for `srcset_image` is the same as `image, with two exceptions:
 
@@ -42,7 +56,15 @@ The syntax for `srcset_image` is the same as `image, with two exceptions:
 ```
 
 - The resize rule should be provided with multiple sizes in a brace-expansion pattern, like `width-{200,400}`. This will generate the `srcset` attribute, with as many URLs as there are sizes defined in the resize rule.
-- The `sizes` attribute is mandatory. This tells the browser how large the image will be displayed on the page, so that it can select the most appropriate image to load.
+- The [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes) attribute is essential. This tells the browser how large the image will be displayed on the page, so that it can select the most appropriate image to load.
+
+Here is an example with the `picture` tag:
+
+```html+django
+{% picture page.photo fill-{512x100,1024x200} format-{avif,jpeg} sizes="100vw" %}
+```
+
+This will generate a `<picture>` element with one `<source>` for AVIF and one fallback `<img>` with JPEG. Both the source and fallback image will have the `sizes` attribute, and a `srcset` with two URLs each.
 
 (available_resizing_methods)=
 

--- a/wagtail/images/image_operations.py
+++ b/wagtail/images/image_operations.py
@@ -409,13 +409,15 @@ class WebPQualityOperation(FilterOperation):
 
 
 class FormatOperation(FilterOperation):
+    supported_formats = ["jpeg", "png", "gif", "webp", "avif"]
+
     def construct(self, format, *options):
         self.format = format
         self.options = options
 
-        if self.format not in ["jpeg", "png", "gif", "webp", "avif"]:
+        if self.format not in self.supported_formats:
             raise ValueError(
-                "Format must be either 'jpeg', 'png', 'gif', 'webp' or 'avif'"
+                f"Format must be one of: {', '.join(self.supported_formats)}. Got: {self.format}"
             )
 
     def run(self, willow, image, env):

--- a/wagtail/images/jinja2tags.py
+++ b/wagtail/images/jinja2tags.py
@@ -1,19 +1,16 @@
-import re
-
 from django import template
 from jinja2.ext import Extension
 
-from .shortcuts import get_rendition_or_not_found
+from .models import Filter, ResponsiveImage
+from .shortcuts import get_rendition_or_not_found, get_renditions_or_not_found
 from .templatetags.wagtailimages_tags import image_url
-
-allowed_filter_pattern = re.compile(r"^[A-Za-z0-9_\-\.\|]+$")
 
 
 def image(image, filterspec, **attrs):
     if not image:
         return ""
 
-    if not allowed_filter_pattern.match(filterspec):
+    if not Filter.pipe_spec_pattern.match(filterspec):
         raise template.TemplateSyntaxError(
             "filter specs in 'image' tag may only contain A-Z, a-z, 0-9, dots, hyphens, pipes and underscores. "
             "(given filter: {})".format(filterspec)
@@ -27,6 +24,22 @@ def image(image, filterspec, **attrs):
         return rendition
 
 
+def srcset_image(image, filterspec, **attrs):
+    if not image:
+        return ""
+
+    if not Filter.pipe_expanding_spec_pattern.match(filterspec):
+        raise template.TemplateSyntaxError(
+            "filter specs in 'srcset_image' tag may only contain A-Z, a-z, 0-9, dots, hyphens, curly braces, commas, pipes and underscores. "
+            "(given filter: {})".format(filterspec)
+        )
+
+    specs = Filter.expand_spec(filterspec)
+    renditions = get_renditions_or_not_found(image, specs)
+
+    return ResponsiveImage(renditions, attrs)
+
+
 class WagtailImagesExtension(Extension):
     def __init__(self, environment):
         super().__init__(environment)
@@ -35,6 +48,7 @@ class WagtailImagesExtension(Extension):
             {
                 "image": image,
                 "image_url": image_url,
+                "srcset_image": srcset_image,
             }
         )
 

--- a/wagtail/images/jinja2tags.py
+++ b/wagtail/images/jinja2tags.py
@@ -1,7 +1,7 @@
 from django import template
 from jinja2.ext import Extension
 
-from .models import Filter, ResponsiveImage
+from .models import Filter, Picture, ResponsiveImage
 from .shortcuts import get_rendition_or_not_found, get_renditions_or_not_found
 from .templatetags.wagtailimages_tags import image_url
 
@@ -40,6 +40,22 @@ def srcset_image(image, filterspec, **attrs):
     return ResponsiveImage(renditions, attrs)
 
 
+def picture(image, filterspec, **attrs):
+    if not image:
+        return ""
+
+    if not Filter.pipe_expanding_spec_pattern.match(filterspec):
+        raise template.TemplateSyntaxError(
+            "filter specs in 'picture' tag may only contain A-Z, a-z, 0-9, dots, hyphens, curly braces, commas, pipes and underscores. "
+            "(given filter: {})".format(filterspec)
+        )
+
+    specs = Filter.expand_spec(filterspec)
+    renditions = get_renditions_or_not_found(image, specs)
+
+    return Picture(renditions, attrs)
+
+
 class WagtailImagesExtension(Extension):
     def __init__(self, environment):
         super().__init__(environment)
@@ -49,6 +65,7 @@ class WagtailImagesExtension(Extension):
                 "image": image,
                 "image_url": image_url,
                 "srcset_image": srcset_image,
+                "picture": picture,
             }
         )
 

--- a/wagtail/images/shortcuts.py
+++ b/wagtail/images/shortcuts.py
@@ -21,3 +21,22 @@ def get_rendition_or_not_found(image, specs):
         rendition = Rendition(image=image, width=0, height=0)
         rendition.file.name = "not-found"
         return rendition
+
+
+def get_renditions_or_not_found(image, specs):
+    """
+    Like get_rendition_or_not_found, but for multiple renditions.
+    Tries to get / create the renditions for the image or renders not-found images if the image does not exist.
+
+    :param image: AbstractImage
+    :param specs: iterable of str or Filter
+    """
+    try:
+        return image.get_renditions(*specs)
+    except SourceImageIOError:
+        Rendition = image.renditions.model
+        rendition = Rendition(image=image, width=0, height=0)
+        rendition.file.name = "not-found"
+        return {
+            spec if isinstance(spec, str) else spec.spec: rendition for spec in specs
+        }

--- a/wagtail/images/templatetags/wagtailimages_tags.py
+++ b/wagtail/images/templatetags/wagtailimages_tags.py
@@ -1,21 +1,24 @@
-import re
-
 from django import template
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import NoReverseMatch
 
-from wagtail.images.models import Filter
-from wagtail.images.shortcuts import get_rendition_or_not_found
+from wagtail.images.models import Filter, ResponsiveImage
+from wagtail.images.shortcuts import (
+    get_rendition_or_not_found,
+    get_renditions_or_not_found,
+)
 from wagtail.images.utils import to_svg_safe_spec
 from wagtail.images.views.serve import generate_image_url
 
 register = template.Library()
-allowed_filter_pattern = re.compile(r"^[A-Za-z0-9_\-\.]+$")
 
 
-@register.tag(name="image")
 def image(parser, token):
-    bits = token.split_contents()[1:]
+    """
+    Image tag parser implementation. Shared between all image tags supporting filter specs
+    as space-separated arguments.
+    """
+    tag_name, *bits = token.split_contents()
     image_expr = parser.compile_filter(bits[0])
     bits = bits[1:]
 
@@ -24,8 +27,9 @@ def image(parser, token):
     output_var_name = None
 
     as_context = False  # if True, the next bit to be read is the output variable name
-    is_valid = True
+    error_messages = []
 
+    multi_rendition = tag_name != "image"
     preserve_svg = False
 
     for bit in bits:
@@ -37,7 +41,7 @@ def image(parser, token):
                 output_var_name = bit
             else:
                 # more than one item exists after 'as' - reject as invalid
-                is_valid = False
+                error_messages.append("More than one variable name after 'as'")
         elif bit == "preserve-svg":
             preserve_svg = True
         else:
@@ -47,36 +51,41 @@ def image(parser, token):
                     value
                 )  # setup to resolve context variables as value
             except ValueError:
-                if allowed_filter_pattern.match(bit):
+                allowed_pattern = (
+                    Filter.expanding_spec_pattern
+                    if multi_rendition
+                    else Filter.spec_pattern
+                )
+                if allowed_pattern.match(bit):
                     filter_specs.append(bit)
                 else:
                     raise template.TemplateSyntaxError(
-                        "filter specs in 'image' tag may only contain A-Z, a-z, 0-9, dots, hyphens and underscores. "
+                        "filter specs in image tags may only contain A-Z, a-z, 0-9, dots, hyphens and underscores (and commas and curly braces for multi-image tags). "
                         "(given filter: {})".format(bit)
                     )
 
     if as_context and output_var_name is None:
         # context was introduced but no variable given ...
-        is_valid = False
+        error_messages.append("Missing a variable name after 'as'")
 
     if output_var_name and attrs:
         # attributes are not valid when using the 'as img' form of the tag
-        is_valid = False
+        error_messages.append("Do not use attributes with 'as' context assignments")
 
     if len(filter_specs) == 0:
         # there must always be at least one filter spec provided
-        is_valid = False
+        error_messages.append("Image tags must be used with at least one filter spec")
 
     if len(bits) == 0:
         # no resize rule provided eg. {% image page.image %}
-        raise template.TemplateSyntaxError(
-            "no resize rule provided. "
-            "'image' tag should be of the form {% image self.photo max-320x200 [ custom-attr=\"value\" ... ] %} "
-            "or {% image self.photo max-320x200 as img %}"
-        )
+        error_messages.append("No resize rule provided")
 
-    if is_valid:
-        return ImageNode(
+    if len(error_messages) == 0:
+        Node = {
+            "image": ImageNode,
+            "srcset_image": SrcsetImageNode,
+        }
+        return Node[tag_name](
             image_expr,
             filter_specs,
             attrs=attrs,
@@ -84,10 +93,16 @@ def image(parser, token):
             preserve_svg=preserve_svg,
         )
     else:
+        errors = "; ".join(error_messages)
         raise template.TemplateSyntaxError(
-            "'image' tag should be of the form {% image self.photo max-320x200 [ custom-attr=\"value\" ... ] %} "
-            "or {% image self.photo max-320x200 as img %}"
+            f"Invalid arguments provided to {tag_name}: {errors}. "
+            'Image tags should be of the form {% image self.photo max-320x200 [ custom-attr="value" ... ] %} '
+            "or {% image self.photo max-320x200 as img %}. "
         )
+
+
+register.tag("image", image)
+register.tag("srcset_image", image)
 
 
 class ImageNode(template.Node):
@@ -110,19 +125,29 @@ class ImageNode(template.Node):
             return Filter(to_svg_safe_spec(self.filter_specs))
         return Filter(spec="|".join(self.filter_specs))
 
-    def render(self, context):
+    def validate_image(self, context):
         try:
             image = self.image_expr.resolve(context)
         except template.VariableDoesNotExist:
-            return ""
+            return
 
         if not image:
             if self.output_var_name:
                 context[self.output_var_name] = None
-            return ""
+            return
 
         if not hasattr(image, "get_rendition"):
-            raise ValueError("image tag expected an Image object, got %r" % image)
+            raise ValueError(
+                "Image template tags expect an Image object, got %r" % image
+            )
+
+        return image
+
+    def render(self, context):
+        image = self.validate_image(context)
+
+        if not image:
+            return ""
 
         rendition = get_rendition_or_not_found(
             image,
@@ -139,6 +164,35 @@ class ImageNode(template.Node):
             for key in self.attrs:
                 resolved_attrs[key] = self.attrs[key].resolve(context)
             return rendition.img_tag(resolved_attrs)
+
+
+class SrcsetImageNode(ImageNode):
+    def get_filters(self, preserve_svg=False):
+        filter_specs = Filter.expand_spec(self.filter_specs)
+        if preserve_svg:
+            return [Filter(to_svg_safe_spec(f)) for f in filter_specs]
+        return [Filter(spec=f) for f in filter_specs]
+
+    def render(self, context):
+        image = self.validate_image(context)
+
+        if not image:
+            return ""
+
+        specs = self.get_filters(preserve_svg=self.preserve_svg and image.is_svg())
+        renditions = get_renditions_or_not_found(image, specs)
+
+        if self.output_var_name:
+            # Wrap the renditions in ResponsiveImage object, to support both
+            # rendering as-is and access to the data.
+            context[self.output_var_name] = ResponsiveImage(renditions)
+            return ""
+
+        resolved_attrs = {}
+        for key in self.attrs:
+            resolved_attrs[key] = self.attrs[key].resolve(context)
+
+        return ResponsiveImage(renditions, resolved_attrs).__html__()
 
 
 @register.simple_tag()

--- a/wagtail/images/tests/test_blocks.py
+++ b/wagtail/images/tests/test_blocks.py
@@ -1,14 +1,16 @@
-import os
 import unittest.mock
 
 from django.apps import apps
-from django.conf import settings
-from django.core import serializers
 from django.test import TestCase
 
 from wagtail.images.blocks import ImageChooserBlock
 
-from .utils import Image, get_test_image_file
+from .utils import (
+    Image,
+    get_test_bad_image,
+    get_test_image_file,
+    get_test_image_filename,
+)
 
 
 class TestImageChooserBlock(TestCase):
@@ -18,39 +20,15 @@ class TestImageChooserBlock(TestCase):
             file=get_test_image_file(),
         )
 
-        # Create an image with a missing file, by deserializing fom a python object
-        # (which bypasses FileField's attempt to read the file)
-        self.bad_image = list(
-            serializers.deserialize(
-                "python",
-                [
-                    {
-                        "fields": {
-                            "title": "missing image",
-                            "height": 100,
-                            "file": "original_images/missing-image.jpg",
-                            "width": 100,
-                        },
-                        "model": "wagtailimages.image",
-                    }
-                ],
-            )
-        )[0].object
+        self.bad_image = get_test_bad_image()
         self.bad_image.save()
-
-    def get_image_filename(self, image, filterspec):
-        """
-        Get the generated filename for a resized image
-        """
-        name, ext = os.path.splitext(os.path.basename(image.file.name))
-        return f"{settings.MEDIA_URL}images/{name}.{filterspec}{ext}"
 
     def test_render(self):
         block = ImageChooserBlock()
         html = block.render(self.image)
         expected_html = (
             '<img alt="Test image" src="{}" width="640" height="480">'.format(
-                self.get_image_filename(self.image, "original")
+                get_test_image_filename(self.image, "original")
             )
         )
 

--- a/wagtail/images/tests/test_jinja2.py
+++ b/wagtail/images/tests/test_jinja2.py
@@ -15,6 +15,8 @@ from .utils import (
 
 
 class JinjaImagesTestCase(TestCase):
+    maxDiff = None
+
     def setUp(self):
         self.engine = engines["jinja2"]
 
@@ -48,6 +50,10 @@ class TestImageJinja(JinjaImagesTestCase):
                 get_test_image_filename(self.image, "width-200")
             ),
         )
+
+    def test_no_image(self):
+        rendered = self.render('{{ image(myimage, "width-2") }}', {"myimage": None})
+        self.assertEqual(rendered, "")
 
     def test_image_attributes(self):
         self.assertHTMLEqual(
@@ -159,6 +165,12 @@ class TestSrcsetImageJinja(JinjaImagesTestCase):
         """
         self.assertHTMLEqual(rendered, expected)
 
+    def test_no_image(self):
+        rendered = self.render(
+            '{{ srcset_image(myimage, "width-2") }}', {"myimage": None}
+        )
+        self.assertEqual(rendered, "")
+
     def test_srcset_output_single_image(self):
         self.assertHTMLEqual(
             self.render(
@@ -185,21 +197,14 @@ class TestSrcsetImageJinja(JinjaImagesTestCase):
         self.assertHTMLEqual(rendered, expected)
 
     def test_srcset_image_assignment_render_as_is(self):
-        filename_200 = get_test_image_filename(self.image, "width-200")
-        filename_400 = get_test_image_filename(self.image, "width-400")
         rendered = self.render(
             '{% set bg=srcset_image(myimage, "width-{200,400}") %}{{ bg }}',
             {"myimage": self.image},
         )
-        expected = f"""
-            <img
-                src="{filename_200}"
-                srcset="{filename_200} 200w, {filename_400} 400w"
-                alt="Test image"
-                width="200"
-                height="150"
-            >
-        """
+        expected = self.render(
+            '{{ srcset_image(myimage, "width-{200,400}") }}',
+            {"myimage": self.image},
+        )
         self.assertHTMLEqual(rendered, expected)
 
     def test_missing_srcset_image(self):
@@ -270,5 +275,188 @@ class TestSrcsetImageJinja(JinjaImagesTestCase):
                 width="200"
                 height="150"
             >
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+
+class TestPictureJinja(JinjaImagesTestCase):
+    def test_picture_formats_multi_sizes(self):
+        filenames = [
+            get_test_image_filename(self.image, "width-200.format-jpeg"),
+            get_test_image_filename(self.image, "width-400.format-jpeg"),
+            get_test_image_filename(self.image, "width-200.format-webp"),
+            get_test_image_filename(self.image, "width-400.format-webp"),
+            get_test_image_filename(self.image, "width-200.format-gif"),
+            get_test_image_filename(self.image, "width-400.format-gif"),
+        ]
+
+        rendered = self.render(
+            '{{ picture(myimage, "width-{200,400}|format-{jpeg,webp,gif}", sizes="100vw") }}',
+            {"myimage": self.image},
+        )
+        expected = f"""
+            <picture>
+            <source srcset="{filenames[2]} 200w, {filenames[3]} 400w" sizes="100vw" type="image/webp">
+            <source srcset="{filenames[0]} 200w, {filenames[1]} 400w" sizes="100vw" type="image/jpeg">
+            <img
+                sizes="100vw"
+                src="{filenames[4]}"
+                srcset="{filenames[4]} 200w, {filenames[5]} 400w"
+                alt="Test image"
+                width="200"
+                height="150"
+            >
+            </picture>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_picture_formats_only(self):
+        filename_jpeg = get_test_image_filename(self.image, "format-jpeg")
+        filename_webp = get_test_image_filename(self.image, "format-webp")
+
+        rendered = self.render(
+            '{{ picture(myimage, "format-{jpeg,webp}") }}',
+            {"myimage": self.image},
+        )
+        expected = f"""
+            <picture>
+            <source srcset="{filename_webp}" type="image/webp">
+            <img
+                src="{filename_jpeg}"
+                alt="Test image"
+                width="640"
+                height="480"
+            >
+            </picture>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_picture_sizes_only(self):
+        rendered = self.render(
+            '{{ picture(myimage, "width-{200,400}", sizes="100vw") }}',
+            {"myimage": self.image},
+        )
+        expected = self.render(
+            '<picture>{{ srcset_image(myimage, "width-{200,400}", sizes="100vw") }}</picture>',
+            {"myimage": self.image},
+        )
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_picture_single_format(self):
+        rendered = self.render(
+            '{{ picture(myimage, "format-jpeg") }}',
+            {"myimage": self.image},
+        )
+        expected = self.render(
+            '<picture>{{ image(myimage, "format-jpeg") }}</picture>',
+            {"myimage": self.image},
+        )
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_no_image(self):
+        rendered = self.render('{{ picture(myimage, "width-2") }}', {"myimage": None})
+        self.assertEqual(rendered, "")
+
+    def test_picture_assignment(self):
+        template = (
+            '{% set bg=picture(myimage, "width-{200,400}|format-{jpeg,webp}") %}'
+            "width: {{ bg.formats['jpeg'][0].width }}, url: {{ bg.formats['jpeg'][0].url }} "
+            "width: {{ bg.formats['jpeg'][1].width }}, url: {{ bg.formats['jpeg'][1].url }} "
+            "width: {{ bg.formats['webp'][0].width }}, url: {{ bg.formats['webp'][0].url }} "
+            "width: {{ bg.formats['webp'][1].width }}, url: {{ bg.formats['webp'][1].url }} "
+        )
+        rendered = self.render(template, {"myimage": self.image})
+        expected = f"""
+            width: 200, url: {get_test_image_filename(self.image, "width-200.format-jpeg")}
+            width: 400, url: {get_test_image_filename(self.image, "width-400.format-jpeg")}
+            width: 200, url: {get_test_image_filename(self.image, "width-200.format-webp")}
+            width: 400, url: {get_test_image_filename(self.image, "width-400.format-webp")}
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_picture_assignment_render_as_is(self):
+        rendered = self.render(
+            '{% set bg=picture(myimage, "width-{200,400}|format-{jpeg,webp,gif}", sizes="100vw") %}{{ bg }}',
+            {"myimage": self.image},
+        )
+        expected = self.render(
+            '{{ picture(myimage, "width-{200,400}|format-{jpeg,webp,gif}", sizes="100vw") }}',
+            {"myimage": self.image},
+        )
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_missing_picture(self):
+        rendered = self.render(
+            '{{ picture(myimage, "format-{jpeg,webp}") }}',
+            {"myimage": self.bad_image},
+        )
+        expected = """
+            <picture>
+                <source srcset="/media/not-found" type="image/webp">
+                <img
+                    src="/media/not-found"
+                    alt="missing image"
+                    width="0"
+                    height="0"
+                >
+            </picture>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_invalid_character(self):
+        with self.assertRaisesRegex(
+            TemplateSyntaxError, "filter specs in 'picture' tag may only"
+        ):
+            self.render(
+                '{{ picture(myimage, "fill-{20×20,40×40}", sizes="100vw") }}',
+                {"myimage": self.image},
+            )
+
+    def test_custom_default_attrs(self):
+        with unittest.mock.patch.object(
+            apps.get_app_config("wagtailimages"),
+            "default_attrs",
+            new={"decoding": "async", "loading": "lazy"},
+        ):
+            rendered = self.render(
+                '{{ picture(myimage, "format-{jpeg,webp}") }}',
+                {"myimage": self.bad_image},
+            )
+            expected = """
+                <picture>
+                    <source srcset="/media/not-found" type="image/webp">
+                    <img
+                        src="/media/not-found"
+                        alt="missing image"
+                        width="0"
+                        height="0"
+                        decoding="async"
+                        loading="lazy"
+                    >
+                </picture>
+            """
+            self.assertHTMLEqual(rendered, expected)
+
+    def test_chaining_filterspecs(self):
+        filename_jpeg = get_test_image_filename(
+            self.image, "format-jpeg.jpegquality-40.webpquality-40"
+        )
+        filename_webp = get_test_image_filename(
+            self.image, "format-webp.jpegquality-40.webpquality-40"
+        )
+        rendered = self.render(
+            '{{ picture(myimage, "format-{jpeg,webp}|jpegquality-40|webpquality-40") }}',
+            {"myimage": self.image},
+        )
+        expected = f"""
+            <picture>
+            <source srcset="{filename_webp}" type="image/webp">
+            <img
+                src="{filename_jpeg}"
+                alt="Test image"
+                width="640"
+                height="480"
+            >
+            </picture>
         """
         self.assertHTMLEqual(rendered, expected)

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -7,13 +7,14 @@ from django.core.files.storage import DefaultStorage, Storage
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models import Prefetch
 from django.db.utils import IntegrityError
-from django.test import TestCase, TransactionTestCase
+from django.test import SimpleTestCase, TestCase, TransactionTestCase
 from django.urls import reverse
 from willow.image import Image as WillowImage
 
 from wagtail.images.models import (
     Filter,
     Rendition,
+    ResponsiveImage,
     SourceImageIOError,
     get_rendition_storage,
 )
@@ -26,7 +27,7 @@ from wagtail.test.testapp.models import (
 )
 from wagtail.test.utils import WagtailTestUtils, override_settings
 
-from .utils import Image, get_test_image_file
+from .utils import Image, get_test_image_file, get_test_image_filename
 
 
 class CustomStorage(Storage):
@@ -236,6 +237,147 @@ class TestImagePermissions(WagtailTestUtils, TestCase):
         self.assertFalse(self.image.is_editable_by_user(self.user))
 
 
+class TestFilters(SimpleTestCase):
+    def test_expand_spec_single(self):
+        self.assertEqual(Filter.expand_spec("width-100"), ["width-100"])
+
+    def test_expand_spec_flat(self):
+        self.assertEqual(
+            Filter.expand_spec("width-100 jpegquality-20"), ["width-100|jpegquality-20"]
+        )
+
+    def test_expand_spec_pipe(self):
+        self.assertEqual(
+            Filter.expand_spec("width-100|jpegquality-20"), ["width-100|jpegquality-20"]
+        )
+
+    def test_expand_spec_list(self):
+        self.assertEqual(
+            Filter.expand_spec(["width-100", "jpegquality-20"]),
+            ["width-100|jpegquality-20"],
+        )
+
+    def test_expand_spec_braced(self):
+        self.assertEqual(
+            Filter.expand_spec("width-{100,200}"), ["width-100", "width-200"]
+        )
+
+    def test_expand_spec_mixed(self):
+        self.assertEqual(
+            Filter.expand_spec("width-{100,200} jpegquality-40"),
+            ["width-100|jpegquality-40", "width-200|jpegquality-40"],
+        )
+
+    def test_expand_spec_mixed_pipe(self):
+        self.assertEqual(
+            Filter.expand_spec("width-{100,200}|jpegquality-40"),
+            ["width-100|jpegquality-40", "width-200|jpegquality-40"],
+        )
+
+    def test_expand_spec_multiple_braces(self):
+        self.assertEqual(
+            Filter.expand_spec("width-{100,200} jpegquality-{40,80} grayscale"),
+            [
+                "width-100|jpegquality-40|grayscale",
+                "width-100|jpegquality-80|grayscale",
+                "width-200|jpegquality-40|grayscale",
+                "width-200|jpegquality-80|grayscale",
+            ],
+        )
+
+
+class TestResponsiveImage(TestCase):
+    def setUp(self):
+        # Create an image for running tests on
+        self.image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+        self.rendition_10 = self.image.get_rendition("width-10")
+
+    def test_construct_empty(self):
+        img = ResponsiveImage({})
+        self.assertEqual(img.renditions, [])
+        self.assertEqual(img.attrs, None)
+
+    def test_construct_with_renditions(self):
+        renditions = {"a": self.rendition_10}
+        img = ResponsiveImage(renditions)
+        self.assertEqual(img.renditions, [self.rendition_10])
+
+    def test_evaluate_value(self):
+        self.assertFalse(ResponsiveImage({}))
+        self.assertFalse(ResponsiveImage({}, {"sizes": "100vw"}))
+
+        renditions = {"a": self.rendition_10}
+        self.assertTrue(ResponsiveImage(renditions))
+
+    def test_compare_value(self):
+        renditions = {"a": self.rendition_10}
+        value1 = ResponsiveImage(renditions)
+        value2 = ResponsiveImage(renditions)
+        value3 = ResponsiveImage({"a": self.image.get_rendition("width-15")})
+        value4 = ResponsiveImage(renditions, {"sizes": "100vw"})
+        self.assertNotEqual(value1, value3)
+        self.assertNotEqual(value1, 12345)
+        self.assertEqual(value1, value2)
+        self.assertNotEqual(value1, value4)
+
+    def test_get_width_srcset(self):
+        renditions = {
+            "width-10": self.rendition_10,
+            "width-90": self.image.get_rendition("width-90"),
+        }
+        filenames = [
+            get_test_image_filename(self.image, "width-10"),
+            get_test_image_filename(self.image, "width-90"),
+        ]
+        self.assertEqual(
+            ResponsiveImage.get_width_srcset(list(renditions.values())),
+            f"{filenames[0]} 10w, {filenames[1]} 90w",
+        )
+
+    def test_get_width_srcset_single_rendition(self):
+        renditions = {"width-10": self.rendition_10}
+        self.assertEqual(
+            ResponsiveImage.get_width_srcset(list(renditions.values())),
+            get_test_image_filename(self.image, "width-10"),
+        )
+
+    def test_render(self):
+        renditions = {
+            "width-10": self.rendition_10,
+            "width-90": self.image.get_rendition("width-90"),
+        }
+        img = ResponsiveImage(renditions)
+        filenames = [
+            get_test_image_filename(self.image, "width-10"),
+            get_test_image_filename(self.image, "width-90"),
+        ]
+        self.assertHTMLEqual(
+            img.__html__(),
+            f"""
+                <img
+                    alt="Test image"
+                    src="{filenames[0]}"
+                    srcset="{filenames[0]} 10w, {filenames[1]} 90w"
+                    width="10"
+                    height="7"
+                >
+            """,
+        )
+
+    def test_render_single_image_same_as_img_tag(self):
+        renditions = {
+            "width-10": self.rendition_10,
+        }
+        img = ResponsiveImage(renditions)
+        self.assertHTMLEqual(
+            img.__html__(),
+            self.rendition_10.img_tag(),
+        )
+
+
 @override_settings(
     CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
 )
@@ -288,6 +430,14 @@ class TestRenditions(TestCase):
         # Get two renditions with the same filter
         first_rendition = self.image.get_rendition("width-400")
         second_rendition = self.image.get_rendition("width-400")
+
+        # Check that they are the same object
+        self.assertEqual(first_rendition, second_rendition)
+
+    def test_get_with_filter_instance(self):
+        # Get two renditions with the same filter
+        first_rendition = self.image.get_rendition("width-400")
+        second_rendition = self.image.get_rendition(Filter("width-400"))
 
         # Check that they are the same object
         self.assertEqual(first_rendition, second_rendition)
@@ -363,6 +513,21 @@ class TestRenditions(TestCase):
             third_rendition = image.get_rendition("height-66")
 
         self.assertIs(second_rendition, third_rendition)
+
+    def test_get_renditions_with_filter_instance(self):
+        # Get two renditions with the same filter
+        first = list(self.image.get_renditions("width-400").values())
+        second = list(self.image.get_renditions(Filter("width-400")).values())
+
+        # Check that they are the same object
+        self.assertEqual(first[0], second[0])
+
+    def test_get_renditions_key_order(self):
+        # Fetch one of the renditions so it exists before the other two.
+        self.image.get_rendition("width-40")
+        specs = ["width-30", "width-40", "width-50"]
+        renditions_keys = list(self.image.get_renditions(*specs).keys())
+        self.assertEqual(renditions_keys, specs)
 
     def _test_get_renditions_performance(
         self,

--- a/wagtail/images/tests/test_shortcuts.py
+++ b/wagtail/images/tests/test_shortcuts.py
@@ -1,6 +1,10 @@
 from django.test import TestCase
 
-from wagtail.images.shortcuts import get_rendition_or_not_found
+from wagtail.images.models import Filter
+from wagtail.images.shortcuts import (
+    get_rendition_or_not_found,
+    get_renditions_or_not_found,
+)
 
 from .utils import Image, get_test_image_file
 
@@ -21,3 +25,41 @@ class TestShortcuts(TestCase):
 
         rendition = get_rendition_or_not_found(bad_image, "width-400")
         self.assertEqual(rendition.file.name, "not-found")
+
+    def test_multiple_fallback_to_not_found(self):
+        bad_image = Image.objects.get(id=1)
+        good_image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+
+        renditions = get_renditions_or_not_found(good_image, ("width-200", "width-400"))
+        self.assertEqual(tuple(renditions.keys()), ("width-200", "width-400"))
+        self.assertEqual(renditions["width-200"].width, 200)
+        self.assertEqual(renditions["width-400"].width, 400)
+
+        renditions = get_renditions_or_not_found(bad_image, ("width-200", "width-400"))
+        self.assertEqual(tuple(renditions.keys()), ("width-200", "width-400"))
+        self.assertEqual(renditions["width-200"].file.name, "not-found")
+        self.assertEqual(renditions["width-400"].file.name, "not-found")
+
+    def test_multiple_fallback_to_not_found_with_filters(self):
+        bad_image = Image.objects.get(id=1)
+        good_image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+
+        renditions = get_renditions_or_not_found(
+            good_image, (Filter("width-200"), Filter("width-400"))
+        )
+        self.assertEqual(tuple(renditions.keys()), ("width-200", "width-400"))
+        self.assertEqual(renditions["width-200"].width, 200)
+        self.assertEqual(renditions["width-400"].width, 400)
+
+        renditions = get_renditions_or_not_found(
+            bad_image, (Filter("width-200"), Filter("width-400"))
+        )
+        self.assertEqual(tuple(renditions.keys()), ("width-200", "width-400"))
+        self.assertEqual(renditions["width-200"].file.name, "not-found")
+        self.assertEqual(renditions["width-400"].file.name, "not-found")

--- a/wagtail/images/tests/test_templatetags.py
+++ b/wagtail/images/tests/test_templatetags.py
@@ -1,9 +1,18 @@
-from django.template import Variable
+from django.template import Context, Engine, TemplateSyntaxError, Variable
 from django.test import TestCase
 
 from wagtail.images.models import Image, Rendition
 from wagtail.images.templatetags.wagtailimages_tags import ImageNode
-from wagtail.images.tests.utils import get_test_image_file, get_test_image_file_svg
+from wagtail.images.tests.utils import (
+    get_test_bad_image,
+    get_test_image_file,
+    get_test_image_file_svg,
+    get_test_image_filename,
+)
+
+LIBRARIES = {
+    "wagtailimages_tags": "wagtail.images.templatetags.wagtailimages_tags",
+}
 
 
 class ImageNodeTestCase(TestCase):
@@ -103,3 +112,207 @@ class ImageNodeTestCase(TestCase):
                 self.assertEqual(
                     node.get_filter(preserve_svg=image.is_svg()).spec, expected
                 )
+
+
+class ImagesTestCase(TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.engine = Engine(
+            app_dirs=True,
+            libraries=LIBRARIES,
+            builtins=[LIBRARIES["wagtailimages_tags"]],
+        )
+
+    @classmethod
+    def setUpTestData(cls):
+        # Create an image for running tests on
+        cls.image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+        cls.svg_image = Image.objects.create(
+            title="Test SVG image",
+            file=get_test_image_file_svg(),
+        )
+        cls.bad_image = get_test_bad_image()
+        cls.bad_image.save()
+
+    def render(self, string, context=None):
+        if context is None:
+            context = {}
+
+        template = self.engine.from_string(string)
+        return template.render(Context(context, autoescape=False))
+
+
+class ImageTagTestCase(ImagesTestCase):
+    def test_image(self):
+        filename_200 = get_test_image_filename(self.image, "width-200")
+
+        rendered = self.render("{% image myimage width-200 %}", {"myimage": self.image})
+        self.assertHTMLEqual(
+            rendered,
+            f'<img alt="Test image" height="150" src="{filename_200}" width="200" />',
+        )
+
+    def test_none(self):
+        rendered = self.render("{% image myimage width-200 %}", {"myimage": None})
+        self.assertEqual(rendered, "")
+
+    def test_missing_image(self):
+        rendered = self.render(
+            "{% image myimage width-200 %}", {"myimage": self.bad_image}
+        )
+        self.assertHTMLEqual(
+            rendered,
+            '<img alt="missing image" src="/media/not-found" width="0" height="0">',
+        )
+
+    def test_not_an_image(self):
+        with self.assertRaisesMessage(
+            ValueError, "Image template tags expect an Image object, got 'not a pipe'"
+        ):
+            self.render(
+                "{% image myimage width-200 %}",
+                {"myimage": "not a pipe"},
+            )
+
+    def test_invalid_character(self):
+        with self.assertRaisesRegex(
+            TemplateSyntaxError, "filter specs in image tags may only"
+        ):
+            self.render(
+                "{% image myimage fill-200×200 %}",
+                {"myimage": self.image},
+            )
+
+    def test_multiple_as_variable(self):
+        with self.assertRaisesRegex(
+            TemplateSyntaxError, "More than one variable name after 'as'"
+        ):
+            self.render(
+                "{% image myimage width-200 as a b %}",
+                {"myimage": self.image},
+            )
+
+    def test_missing_as_variable(self):
+        with self.assertRaisesRegex(
+            TemplateSyntaxError, "Missing a variable name after 'as'"
+        ):
+            self.render(
+                "{% image myimage width-200 as %}",
+                {"myimage": self.image},
+            )
+
+    def test_mixing_as_variable_and_attrs(self):
+        with self.assertRaisesRegex(
+            TemplateSyntaxError, "Do not use attributes with 'as' context assignments"
+        ):
+            self.render(
+                "{% image myimage width-200 alt='Test' as test %}",
+                {"myimage": self.image},
+            )
+
+    def test_missing_filter_spec(self):
+        with self.assertRaisesRegex(
+            TemplateSyntaxError, "Image tags must be used with at least one filter spec"
+        ):
+            self.render(
+                "{% image myimage %}",
+                {"myimage": self.image},
+            )
+
+
+class SrcsetImageTagTestCase(ImagesTestCase):
+    def test_srcset_image(self):
+        filename_20 = get_test_image_filename(self.image, "width-20")
+        filename_40 = get_test_image_filename(self.image, "width-40")
+
+        rendered = self.render(
+            "{% srcset_image myimage width-{20,40} sizes='100vw' %}",
+            {"myimage": self.image},
+        )
+        expected = f"""
+            <img
+                sizes="100vw"
+                src="{filename_20}"
+                srcset="{filename_20} 20w, {filename_40} 40w"
+                alt="Test image"
+                width="20"
+                height="15"
+            >
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_srcset_output_single_image(self):
+        self.assertHTMLEqual(
+            self.render(
+                "{% srcset_image myimage width-20 %}",
+                {"myimage": self.image},
+            ),
+            self.render(
+                "{% image myimage width-20 %}",
+                {"myimage": self.image},
+            ),
+        )
+
+    def test_invalid_character(self):
+        with self.assertRaisesRegex(
+            TemplateSyntaxError, "filter specs in image tags may only contain"
+        ):
+            self.render(
+                "{% srcset_image myimage fill-{200×200,400×400} sizes='100vw' %}",
+                {"myimage": self.image},
+            )
+
+    def test_srcset_image_assignment(self):
+        template = (
+            "{% srcset_image myimage width-{30,60} as bg %}"
+            "width: {{ bg.renditions.0.width }}, url: {{ bg.renditions.0.url }} "
+            "width: {{ bg.renditions.1.width }}, url: {{ bg.renditions.1.url }} "
+        )
+        rendered = self.render(template, {"myimage": self.image})
+        expected = f"""
+            width: 30, url: {get_test_image_filename(self.image, "width-30")}
+            width: 60, url: {get_test_image_filename(self.image, "width-60")}
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_srcset_image_assignment_render_as_is(self):
+        filename_35 = get_test_image_filename(self.image, "width-35")
+        filename_70 = get_test_image_filename(self.image, "width-70")
+
+        rendered = self.render(
+            "{% srcset_image myimage width-{35,70} as bg %}{{ bg }}",
+            {"myimage": self.image},
+        )
+        expected = f"""
+            <img
+                src="{filename_35}"
+                srcset="{filename_35} 35w, {filename_70} 70w"
+                alt="Test image"
+                width="35"
+                height="26"
+            >
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_missing_srcset_image(self):
+        rendered = self.render(
+            "{% srcset_image myimage width-{200,400} sizes='100vw' %}",
+            {"myimage": self.bad_image},
+        )
+        expected = """
+            <img
+                sizes="100vw"
+                src="/media/not-found"
+                srcset="/media/not-found 0w, /media/not-found 0w"
+                alt="missing image"
+                width="0"
+                height="0"
+            >
+        """
+        self.assertHTMLEqual(rendered, expected)

--- a/wagtail/images/tests/test_templatetags.py
+++ b/wagtail/images/tests/test_templatetags.py
@@ -159,7 +159,7 @@ class ImageTagTestCase(ImagesTestCase):
         )
 
     def test_none(self):
-        rendered = self.render("{% image myimage width-200 %}", {"myimage": None})
+        rendered = self.render("{% image myimage width-2 %}", {"myimage": None})
         self.assertEqual(rendered, "")
 
     def test_missing_image(self):
@@ -259,6 +259,10 @@ class SrcsetImageTagTestCase(ImagesTestCase):
             ),
         )
 
+    def test_none(self):
+        rendered = self.render("{% srcset_image myimage width-2 %}", {"myimage": None})
+        self.assertEqual(rendered, "")
+
     def test_invalid_character(self):
         with self.assertRaisesRegex(
             TemplateSyntaxError, "filter specs in image tags may only contain"
@@ -314,5 +318,163 @@ class SrcsetImageTagTestCase(ImagesTestCase):
                 width="0"
                 height="0"
             >
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+
+class PictureTagTestCase(ImagesTestCase):
+    def test_picture_formats_multi_sizes(self):
+        filenames = [
+            get_test_image_filename(self.image, "width-200.format-jpeg"),
+            get_test_image_filename(self.image, "width-400.format-jpeg"),
+            get_test_image_filename(self.image, "width-200.format-webp"),
+            get_test_image_filename(self.image, "width-400.format-webp"),
+            get_test_image_filename(self.image, "width-200.format-gif"),
+            get_test_image_filename(self.image, "width-400.format-gif"),
+        ]
+
+        rendered = self.render(
+            '{% picture myimage width-{200,400} format-{jpeg,webp,gif} sizes="100vw" %}',
+            {"myimage": self.image},
+        )
+        expected = f"""
+            <picture>
+            <source srcset="{filenames[2]} 200w, {filenames[3]} 400w" sizes="100vw" type="image/webp">
+            <source srcset="{filenames[0]} 200w, {filenames[1]} 400w" sizes="100vw" type="image/jpeg">
+            <img
+                sizes="100vw"
+                src="{filenames[4]}"
+                srcset="{filenames[4]} 200w, {filenames[5]} 400w"
+                alt="Test image"
+                width="200"
+                height="150"
+            >
+            </picture>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_picture_formats_only(self):
+        filename_jpeg = get_test_image_filename(self.image, "format-jpeg")
+        filename_webp = get_test_image_filename(self.image, "format-webp")
+
+        rendered = self.render(
+            "{% picture myimage format-{jpeg,webp} %}",
+            {"myimage": self.image},
+        )
+        expected = f"""
+            <picture>
+            <source srcset="{filename_webp}" type="image/webp">
+            <img
+                src="{filename_jpeg}"
+                alt="Test image"
+                width="640"
+                height="480"
+            >
+            </picture>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_picture_sizes_only(self):
+        rendered = self.render(
+            '{% picture myimage width-{350,450} sizes="100vw" %}',
+            {"myimage": self.image},
+        )
+        expected = self.render(
+            '<picture>{% srcset_image myimage width-{350,450} sizes="100vw" %}</picture>',
+            {"myimage": self.image},
+        )
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_picture_single_format(self):
+        rendered = self.render(
+            "{% picture myimage format-jpeg %}",
+            {"myimage": self.image},
+        )
+        expected = self.render(
+            "<picture>{% image myimage format-jpeg %}</picture>",
+            {"myimage": self.image},
+        )
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_none(self):
+        rendered = self.render("{% picture myimage width-2 %}", {"myimage": None})
+        self.assertEqual(rendered, "")
+
+    def test_picture_assignment(self):
+        template = (
+            "{% picture myimage width-{550,600} format-{jpeg,webp} as bg %}"
+            "width: {{ bg.formats.jpeg.0.width }}, url: {{ bg.formats.jpeg.0.url }} "
+            "width: {{ bg.formats.jpeg.1.width }}, url: {{ bg.formats.jpeg.1.url }} "
+            "width: {{ bg.formats.webp.0.width }}, url: {{ bg.formats.webp.0.url }} "
+            "width: {{ bg.formats.webp.1.width }}, url: {{ bg.formats.webp.1.url }} "
+        )
+        rendered = self.render(template, {"myimage": self.image})
+        expected = f"""
+            width: 550, url: {get_test_image_filename(self.image, "width-550.format-jpeg")}
+            width: 600, url: {get_test_image_filename(self.image, "width-600.format-jpeg")}
+            width: 550, url: {get_test_image_filename(self.image, "width-550.format-webp")}
+            width: 600, url: {get_test_image_filename(self.image, "width-600.format-webp")}
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_picture_assignment_render_as_is(self):
+        rendered = self.render(
+            "{% picture myimage width-{2000,4000} format-{jpeg,webp} as bg %}{{ bg }}",
+            {"myimage": self.image},
+        )
+        expected = self.render(
+            "{% picture myimage width-{2000,4000} format-{jpeg,webp} %}",
+            {"myimage": self.image},
+        )
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_missing_picture(self):
+        rendered = self.render(
+            "{% picture myimage width-{200,400} %}",
+            {"myimage": self.bad_image},
+        )
+        expected = """
+            <picture>
+                <img
+                    src="/media/not-found"
+                    srcset="/media/not-found 0w, /media/not-found 0w"
+                    alt="missing image"
+                    width="0"
+                    height="0"
+                >
+            </picture>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_invalid_character(self):
+        with self.assertRaisesRegex(
+            TemplateSyntaxError, "filter specs in image tags may only"
+        ):
+            self.render(
+                '{% picture myimage fill-{20×20,40×40} sizes="100vw" %}',
+                {"myimage": self.image},
+            )
+
+    def test_chaining_filterspecs(self):
+        filename_jpeg = get_test_image_filename(
+            self.image, "format-jpeg.jpegquality-40.webpquality-40"
+        )
+        filename_webp = get_test_image_filename(
+            self.image, "format-webp.jpegquality-40.webpquality-40"
+        )
+        rendered = self.render(
+            "{% picture myimage format-{jpeg,webp} jpegquality-40 webpquality-40 %}",
+            {"myimage": self.image},
+        )
+        expected = f"""
+            <picture>
+            <source srcset="{filename_webp}" type="image/webp">
+            <img
+                src="{filename_jpeg}"
+                alt="Test image"
+                width="640"
+                height="480"
+            >
+            </picture>
         """
         self.assertHTMLEqual(rendered, expected)

--- a/wagtail/images/tests/utils.py
+++ b/wagtail/images/tests/utils.py
@@ -1,11 +1,22 @@
+import os
 from io import BytesIO
 
 import PIL.Image
+from django.conf import settings
+from django.core import serializers
 from django.core.files.images import ImageFile
 
 from wagtail.images import get_image_model
 
 Image = get_image_model()
+
+
+def get_test_image_filename(image, filterspec):
+    """
+    Get the generated filename for a resized image
+    """
+    name, ext = os.path.splitext(os.path.basename(image.file.name))
+    return f"{settings.MEDIA_URL}images/{name}.{filterspec}{ext}"
 
 
 def get_test_image_file(filename="test.png", colour="white", size=(640, 480)):
@@ -54,3 +65,24 @@ def get_test_image_file_svg(
     """
     f = BytesIO(img.strip().encode("utf-8"))
     return ImageFile(f, filename)
+
+
+def get_test_bad_image():
+    # Create an image with a missing file, by deserializing fom a python object
+    # (which bypasses FileField's attempt to read the file)
+    return list(
+        serializers.deserialize(
+            "python",
+            [
+                {
+                    "fields": {
+                        "title": "missing image",
+                        "height": 100,
+                        "file": "original_images/missing-image.jpg",
+                        "width": 100,
+                    },
+                    "model": "wagtailimages.image",
+                }
+            ],
+        )
+    )[0].object

--- a/wagtail/images/tests/utils.py
+++ b/wagtail/images/tests/utils.py
@@ -16,6 +16,11 @@ def get_test_image_filename(image, filterspec):
     Get the generated filename for a resized image
     """
     name, ext = os.path.splitext(os.path.basename(image.file.name))
+    # Use the correct extension if the filterspec is a format operation.
+    if "format-" in filterspec:
+        ext = "." + filterspec.split("format-")[1].split("-")[0].split(".")[0].replace(
+            "jpeg", "jpg"
+        )
     return f"{settings.MEDIA_URL}images/{name}.{filterspec}{ext}"
 
 


### PR DESCRIPTION
Based on [RFC 71](https://github.com/wagtail/rfcs/pull/71) – add `srcset_image` and `picture` tags for responsive images to Wagtail. Fixes #285, #5289. Implementation started by @PaarthAgarwal, completed by @thibaudcolas.

## Demo

To try this out,

- With Jinja: https://github.com/wagtail/bakerydemo/pull/455
- With DTL: https://github.com/wagtail/bakerydemo/pull/456

Here are copy-pasteable examples of the tags demonstrating the most common use cases:

```html
{% srcset_image my_image fill-{100x150,200x300} sizes="80vw" %}
{% picture my_image format-{avif,jpeg} %}
{% picture my_image format-{avif,jpeg} fill-{100x150,200x300} sizes="80vw" %}
```

## Implementation

There are a lot of high-level implementation choices that are important:

- Quite a bit of the images rendering logic is in `wagtail.images.models`, as new wrapper classes (and a big addition to `Filter`). This is so we can reuse said logic between the Jinja and DTL implementations
- Those wrapper classes support rendering the output of `srcset_image` and `picture` as HTML, as well as accessing the renditions. This is to match how the `image` tag works.
- For DTL, we reuse the same `image` parser function for all three image template tags. The difference between the tags on parsing logic is very minimal, so it felt appropriate.
- For renditions with multiple sizes – we define the `srcset` attribute in the order of the format operations provided by the developer. It’s important they have the order in sync with the content of the `sizes` attribute. 
- For renditions with multiple formats – I chose to have the tag always output in the same order, no matter the order the formats are requested in. This is because we should be able to always determine the correct order (always prefer AVIF over anything else, WEBP over anything but AVIF, etc).

## TODOs

- Once this is merged, I’d recommend another PR to update more of the docs to switch to the `picture` tag. 
- And we’ll also want to update the bakerydemo to the new tags – but this can only be merged once v5.2 is released.

## Checklist

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   ~~[ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]~~
-   [x] For new features: Has the documentation been updated accordingly?







