### PR TITLE
Update Stimulus version to v3.2.2

### DIFF
--- a/client/src/controllers/DropdownController.ts
+++ b/client/src/controllers/DropdownController.ts
@@ -71,10 +71,7 @@ export class DropdownController extends Controller<HTMLElement> {
     }
 
     const onShown = () => {
-      this.dispatch('shown', {
-        // work around for target type bug https://github.com/hotwired/stimulus/issues/642
-        target: ((key = 'document') => window[key])(),
-      });
+      this.dispatch('shown', { target: window.document });
     };
 
     return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "wagtail",
       "version": "1.0.0",
       "dependencies": {
-        "@hotwired/stimulus": "^3.2.1",
+        "@hotwired/stimulus": "^3.2.2",
         "@tippyjs/react": "^4.2.6",
         "a11y-dialog": "^8.0.0",
         "autosize": "^6.0.1",
@@ -2112,9 +2112,9 @@
       "license": "MIT"
     },
     "node_modules/@hotwired/stimulus": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.1.tgz",
-      "integrity": "sha512-HGlzDcf9vv/EQrMJ5ZG6VWNs8Z/xMN+1o2OhV1gKiSG6CqZt5MCBB1gRg5ILiN3U0jEAxuDTNPRfBcnZBDmupQ=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
+      "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
@@ -35389,9 +35389,9 @@
       "dev": true
     },
     "@hotwired/stimulus": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.1.tgz",
-      "integrity": "sha512-HGlzDcf9vv/EQrMJ5ZG6VWNs8Z/xMN+1o2OhV1gKiSG6CqZt5MCBB1gRg5ILiN3U0jEAxuDTNPRfBcnZBDmupQ=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
+      "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.10",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "webpack-cli": "^4.9.1"
   },
   "dependencies": {
-    "@hotwired/stimulus": "^3.2.1",
+    "@hotwired/stimulus": "^3.2.2",
     "@tippyjs/react": "^4.2.6",
     "a11y-dialog": "^8.0.0",
     "autosize": "^6.0.1",


### PR DESCRIPTION
* Builds on PR #10748 (to avoid package-lock.json conflicts)
* Updates Stimulus to the latest version so we can adopt the fix for dispatch target TypeScript problems - See https://github.com/hotwired/stimulus/issues/642
* Refine `SwapController` to avoid the added workarounds for setting up the 'target' element, instead, just change this to a get method.