### PR TITLE
WagtailTestUtils.get_soup should accept HttpResponse, not HttpRequest

### DIFF
--- a/wagtail/test/utils/wagtail_tests.py
+++ b/wagtail/test/utils/wagtail_tests.py
@@ -4,14 +4,14 @@ from contextlib import contextmanager
 from bs4 import BeautifulSoup
 from django import VERSION as DJANGO_VERSION
 from django.contrib.auth import get_user_model
-from django.http import HttpRequest
+from django.http import HttpResponse
 from django.test.testcases import assert_and_parse_html
 
 
 class WagtailTestUtils:
     @staticmethod
-    def get_soup(request: HttpRequest, parser="html.parser") -> BeautifulSoup:
-        return BeautifulSoup(request.content, parser)
+    def get_soup(response: HttpResponse, parser="html.parser") -> BeautifulSoup:
+        return BeautifulSoup(response.content, parser)
 
     @staticmethod
     def create_test_user():


### PR DESCRIPTION
Error in #10708 - the type annotation for `get_soup` indicates that it will receive an `HttpRequest`, when it should be an `HttpResponse`.