### PR TITLE
Change `WagtailTestUtils.get_soup()` to accept `str`/`bytes` and use it more widely

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,7 +18,7 @@ Changelog
  * Maintenance: Remove unused WorkflowStatus view, urlpattern, and workflow-status.js (Storm Heg)
  * Maintenance: Add support for options/attrs in Telepath widgets so that attrs render on the created DOM (Storm Heg)
  * Maintenance: Update pre-commit hooks to be in sync with latest changes to Eslint & Prettier for client-side changes (Storm Heg)
- * Maintenance: Add `WagtailTestUtils.get_soup()` method to get a `BeautifulSoup` object from an `HttpResponse` object (Storm Heg)
+ * Maintenance: Add `WagtailTestUtils.get_soup()` method for testing HTML content (Storm Heg, Sage Abdullah)
  * Maintenance: Allow `ViewSet` subclasses to customise `url_prefix` and `url_namespace` logic (Matt Westcott)
  * Maintenance: Simplify `SnippetViewSet` registration code (Sage Abdullah)
 

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -37,7 +37,7 @@ depth: 1
  * Remove unused WorkflowStatus view, urlpattern, and workflow-status.js (Storm Heg)
  * Add support for options/attrs in Telepath widgets so that attrs render on the created DOM (Storm Heg)
  * Update pre-commit hooks to be in sync with latest changes to Eslint & Prettier for client-side changes (Storm Heg)
- * Add `WagtailTestUtils.get_soup()` method to get a `BeautifulSoup` object from an `HttpResponse` object (Storm Heg)
+ * Add `WagtailTestUtils.get_soup()` method for testing HTML content (Storm Heg, Sage Abdullah)
  * Allow `ViewSet` subclasses to customise `url_prefix` and `url_namespace` logic (Matt Westcott)
  * Simplify `SnippetViewSet` registration code (Sage Abdullah)
 

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -2,7 +2,6 @@ import datetime
 import unittest
 from unittest import mock
 
-from bs4 import BeautifulSoup
 from django.contrib.auth.models import Group, Permission
 from django.http import HttpRequest, HttpResponse
 from django.test import TestCase
@@ -1022,7 +1021,7 @@ class TestPageCreation(WagtailTestUtils, TestCase):
             )
         )
 
-        html = BeautifulSoup(response.content, "html5lib")
+        html = self.get_soup(response.content)
 
         actual_attrs = html.find("input", {"name": "title"}).attrs
 

--- a/wagtail/admin/tests/test_dbwhitelister.py
+++ b/wagtail/admin/tests/test_dbwhitelister.py
@@ -1,22 +1,22 @@
-from bs4 import BeautifulSoup
 from django.test import TestCase
 
 from wagtail.admin.rich_text.converters.editor_html import EditorHTMLConverter
+from wagtail.test.utils import WagtailTestUtils
 
 
-class TestDbWhitelisterMethods(TestCase):
+class TestDbWhitelisterMethods(WagtailTestUtils, TestCase):
     def setUp(self):
         self.whitelister = EditorHTMLConverter().whitelister
 
     def test_clean_tag_node_div(self):
-        soup = BeautifulSoup("<div>foo</div>", "html5lib")
+        soup = self.get_soup("<div>foo</div>", "html5lib")
         tag = soup.div
         self.assertEqual(tag.name, "div")
         self.whitelister.clean_tag_node(soup, tag)
         self.assertEqual(tag.name, "p")
 
     def test_clean_tag_node_with_data_embedtype(self):
-        soup = BeautifulSoup(
+        soup = self.get_soup(
             '<p><a data-embedtype="image" data-id=1 data-format="left" data-alt="bar" irrelevant="baz">foo</a></p>',
             "html5lib",
         )
@@ -27,7 +27,7 @@ class TestDbWhitelisterMethods(TestCase):
         )
 
     def test_clean_tag_node_with_data_linktype(self):
-        soup = BeautifulSoup(
+        soup = self.get_soup(
             '<a data-linktype="document" data-id="1" irrelevant="baz">foo</a>',
             "html5lib",
         )
@@ -36,13 +36,13 @@ class TestDbWhitelisterMethods(TestCase):
         self.assertEqual(str(tag), '<a id="1" linktype="document">foo</a>')
 
     def test_clean_tag_node(self):
-        soup = BeautifulSoup('<a irrelevant="baz">foo</a>', "html5lib")
+        soup = self.get_soup('<a irrelevant="baz">foo</a>', "html5lib")
         tag = soup.a
         self.whitelister.clean_tag_node(soup, tag)
         self.assertEqual(str(tag), "<a>foo</a>")
 
 
-class TestDbWhitelister(TestCase):
+class TestDbWhitelister(WagtailTestUtils, TestCase):
     def setUp(self):
         self.whitelister = EditorHTMLConverter().whitelister
 
@@ -52,7 +52,7 @@ class TestDbWhitelister(TestCase):
         (necessary because we can't guarantee the order that attributes are output in)
         """
         self.assertEqual(
-            BeautifulSoup(str1, "html5lib"), BeautifulSoup(str2, "html5lib")
+            self.get_soup(str1, "html5lib"), self.get_soup(str2, "html5lib")
         )
 
     def test_page_link_is_rewritten(self):

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -3,7 +3,6 @@ from functools import wraps
 from typing import Any, List, Mapping, Optional
 from unittest import mock
 
-from bs4 import BeautifulSoup
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -2223,7 +2222,7 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
             instance=instance,
         )
         html = bound_edit_handler.render_form_content()
-        return BeautifulSoup(html, "html5lib")
+        return self.get_soup(html)
 
     @clear_edit_handler(Page)
     def test_default_page_content_panels_uses_title_field(self):

--- a/wagtail/admin/tests/test_privacy.py
+++ b/wagtail/admin/tests/test_privacy.py
@@ -364,7 +364,7 @@ class TestPrivacyIndicators(WagtailTestUtils, TestCase):
         # Check the response
         self.assertEqual(response.status_code, 200)
 
-        soup = self.get_soup(response)
+        soup = self.get_soup(response.content)
 
         # Check the private privacy indicator is visible
         private_indicator = soup.select_one("[data-privacy-sidebar-private]")

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -1,6 +1,5 @@
 import unittest
 
-from bs4 import BeautifulSoup
 from django.conf import settings
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import override_settings
@@ -431,11 +430,11 @@ class TestDraftailWithAdditionalFeatures(
         self.assertNotContains(response, '"type": "ITALIC"')
 
 
-class TestPageLinkHandler(TestCase):
+class TestPageLinkHandler(WagtailTestUtils, TestCase):
     fixtures = ["test.json"]
 
     def test_get_db_attributes(self):
-        soup = BeautifulSoup('<a data-id="test-id">foo</a>', "html5lib")
+        soup = self.get_soup('<a data-id="test-id">foo</a>')
         tag = soup.a
         result = PageLinkHandler.get_db_attributes(tag)
         self.assertEqual(result, {"id": "test-id"})

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -1,6 +1,5 @@
 import json
 
-from bs4 import BeautifulSoup
 from django.contrib.auth.models import AnonymousUser, Permission
 from django.template import Context, Template
 from django.test import TestCase
@@ -193,7 +192,7 @@ class TestAccessibilityCheckerConfig(WagtailTestUtils, TestCase):
     def get_script(self):
         template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")
         content = template.render(Context({"request": self.request}))
-        soup = BeautifulSoup(content, "html.parser")
+        soup = self.get_soup(content)
 
         # Should include the configuration as a JSON script with the specific id
         return soup.find("script", id="accessibility-axe-configuration")

--- a/wagtail/documents/tests/test_rich_text.py
+++ b/wagtail/documents/tests/test_rich_text.py
@@ -1,4 +1,3 @@
-from bs4 import BeautifulSoup
 from django.test import TestCase
 
 from wagtail.documents import get_document_model
@@ -9,13 +8,14 @@ from wagtail.documents.rich_text.editor_html import (
     DocumentLinkHandler as EditorHtmlDocumentLinkHandler,
 )
 from wagtail.fields import RichTextField
+from wagtail.test.utils import WagtailTestUtils
 
 
-class TestEditorHtmlDocumentLinkHandler(TestCase):
+class TestEditorHtmlDocumentLinkHandler(WagtailTestUtils, TestCase):
     fixtures = ["test.json"]
 
     def test_get_db_attributes(self):
-        soup = BeautifulSoup('<a data-id="test-id">foo</a>', "html5lib")
+        soup = self.get_soup('<a data-id="test-id">foo</a>')
         tag = soup.a
         result = EditorHtmlDocumentLinkHandler.get_db_attributes(tag)
         self.assertEqual(result, {"id": "test-id"})

--- a/wagtail/embeds/tests/test_rich_text.py
+++ b/wagtail/embeds/tests/test_rich_text.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-from bs4 import BeautifulSoup
 from django.test import TestCase, override_settings
 
 from wagtail.embeds.exceptions import EmbedNotFoundException
@@ -10,11 +9,12 @@ from wagtail.embeds.rich_text.editor_html import (
     MediaEmbedHandler as EditorHtmlMediaEmbedHandler,
 )
 from wagtail.rich_text import expand_db_html
+from wagtail.test.utils import WagtailTestUtils
 
 
-class TestEditorHtmlMediaEmbedHandler(TestCase):
+class TestEditorHtmlMediaEmbedHandler(WagtailTestUtils, TestCase):
     def test_get_db_attributes(self):
-        soup = BeautifulSoup('<b data-url="test-url">foo</b>', "html5lib")
+        soup = self.get_soup('<b data-url="test-url">foo</b>')
         tag = soup.b
         result = EditorHtmlMediaEmbedHandler.get_db_attributes(tag)
         self.assertEqual(result, {"url": "test-url"})

--- a/wagtail/images/tests/test_rich_text.py
+++ b/wagtail/images/tests/test_rich_text.py
@@ -1,4 +1,3 @@
-from bs4 import BeautifulSoup
 from django.test import TestCase
 
 from wagtail.fields import RichTextField
@@ -13,9 +12,8 @@ from .utils import Image, get_test_image_file
 
 class TestEditorHtmlImageEmbedHandler(WagtailTestUtils, TestCase):
     def test_get_db_attributes(self):
-        soup = BeautifulSoup(
+        soup = self.get_soup(
             '<b data-id="test-id" data-format="test-format" data-alt="test-alt">foo</b>',
-            "html5lib",
         )
         tag = soup.b
         result = EditorHtmlImageEmbedHandler.get_db_attributes(tag)

--- a/wagtail/test/utils/form_data.py
+++ b/wagtail/test/utils/form_data.py
@@ -10,6 +10,8 @@ from django.http import QueryDict
 
 from wagtail.admin.rich_text import get_rich_text_editor_widget
 
+from .wagtail_tests import WagtailTestUtils
+
 
 def _nested_form_data(data):
     if isinstance(data, dict):
@@ -186,7 +188,7 @@ def _querydict_from_form(form: bs4.Tag, exclude_csrf: bool = True) -> QueryDict:
 def querydict_from_html(
     html: str, form_id: str = None, form_index: int = 0, exclude_csrf: bool = True
 ) -> QueryDict:
-    soup = bs4.BeautifulSoup(html, "html5lib")
+    soup = WagtailTestUtils.get_soup(html)
     if form_id is not None:
         form = soup.find("form", attrs={"id": form_id})
         if form is None:

--- a/wagtail/test/utils/wagtail_tests.py
+++ b/wagtail/test/utils/wagtail_tests.py
@@ -1,17 +1,17 @@
 import warnings
 from contextlib import contextmanager
+from typing import Union
 
 from bs4 import BeautifulSoup
 from django import VERSION as DJANGO_VERSION
 from django.contrib.auth import get_user_model
-from django.http import HttpResponse
 from django.test.testcases import assert_and_parse_html
 
 
 class WagtailTestUtils:
     @staticmethod
-    def get_soup(response: HttpResponse, parser="html.parser") -> BeautifulSoup:
-        return BeautifulSoup(response.content, parser)
+    def get_soup(markup: Union[str, bytes], parser="html.parser") -> BeautifulSoup:
+        return BeautifulSoup(markup, parser)
 
     @staticmethod
     def create_test_user():


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Modify `WagtailTestUtils.get_soup()` method to accept `str`/`bytes` instead of `HttpResponse` so we can use it more widely.







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
