### PR TITLE
Filter out comments on non-existent fields

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Changelog
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)
  * Fix: Fix numbers, booleans, and `None` from being exported as strings (Christer Jensen)
+ * Fix: Filter out comments on Page editing counts that do not correspond to a valid field / block path on the page such as when a field has been removed (Matt Westcott)
  * Docs: Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
  * Docs: Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)
  * Maintenance: Fix snippet search test to work on non-fallback database backends (Matt Westcott)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -37,6 +37,7 @@ depth: 1
  * Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)
  * Fix numbers, booleans, and `None` from being exported as strings (Christer Jensen)
+ * Filter out comments on Page editing counts that do not correspond to a valid field / block path on the page such as when a field has been removed (Matt Westcott)
 
 ### Documentation
 

--- a/wagtail/admin/forms/comments.py
+++ b/wagtail/admin/forms/comments.py
@@ -1,6 +1,7 @@
 from django.forms import BooleanField, ValidationError
 from django.utils.timezone import now
 from django.utils.translation import gettext as _
+from modelcluster.forms import BaseChildFormSet
 
 from .models import WagtailAdminModelForm
 
@@ -73,3 +74,14 @@ class CommentForm(WagtailAdminModelForm):
             self.instance.resolved_by = None
             self.instance.resolved_at = None
         return super().save(*args, **kwargs)
+
+
+class CommentFormSet(BaseChildFormSet):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        valid_comment_ids = [
+            comment.id
+            for comment in self.queryset
+            if comment.has_valid_contentpath(self.instance)
+        ]
+        self.queryset = self.queryset.filter(id__in=valid_comment_ids)

--- a/wagtail/admin/panels/comment_panel.py
+++ b/wagtail/admin/panels/comment_panel.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from modelcluster.models import get_serializable_data_for_fields
 
-from wagtail.admin.forms.comments import CommentForm
+from wagtail.admin.forms.comments import CommentForm, CommentFormSet
 from wagtail.admin.templatetags.wagtailadmin_tags import avatar_url, user_display_name
 from wagtail.models import COMMENTS_RELATION_NAME
 
@@ -17,6 +17,7 @@ class CommentPanel(Panel):
             "fields": ["comment_notifications"],
             "formsets": {
                 COMMENTS_RELATION_NAME: {
+                    "formset": CommentFormSet,
                     "form": CommentForm,
                     "fields": ["text", "contentpath", "position"],
                     "formset_name": "comments",

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 from unittest import mock
 
@@ -39,6 +40,7 @@ from wagtail.test.testapp.models import (
     SimplePage,
     SingleEventPage,
     StandardIndex,
+    StreamPage,
     TaggedPage,
 )
 from wagtail.test.utils import WagtailTestUtils
@@ -3806,3 +3808,67 @@ class TestCommenting(WagtailTestUtils, TestCase):
 
         # No emails should be submitted because subscriber is inactive
         self.assertEqual(len(mail.outbox), 0)
+
+
+class TestCommentOutput(WagtailTestUtils, TestCase):
+    """
+    Test that the correct set of comments is output on the edit page view
+    """
+
+    def setUp(self):
+        # Find root page
+        self.root_page = Page.objects.get(id=2)
+
+        # Add child page
+        self.child_page = StreamPage(
+            title="Hello world!",
+            body=[
+                {
+                    "id": "234",
+                    "type": "product",
+                    "value": {"name": "Cuddly toy", "price": "$9.95"},
+                },
+            ],
+        )
+        self.root_page.add_child(instance=self.child_page)
+        self.child_page.save_revision().publish()
+
+        # Login
+        self.user = self.login()
+
+    def test_only_comments_with_valid_paths_are_shown(self):
+        # add some comments on self.child_page
+        Comment.objects.create(
+            user=self.user,
+            page=self.child_page,
+            text="A test comment",
+            contentpath="title",
+        )
+        Comment.objects.create(
+            user=self.user,
+            page=self.child_page,
+            text="A comment on a field that doesn't exist",
+            contentpath="sillytitle",
+        )
+        Comment.objects.create(
+            user=self.user,
+            page=self.child_page,
+            text="This is quite expensive",
+            contentpath="body.234.price",
+        )
+        Comment.objects.create(
+            user=self.user,
+            page=self.child_page,
+            text="A comment on a block that doesn't exist",
+            contentpath="body.234.colour",
+        )
+
+        response = self.client.get(
+            reverse("wagtailadmin_pages:edit", args=[self.child_page.id])
+        )
+        soup = self.get_soup(response.content)
+        comments_data_json = soup.select_one("#comments-data").string
+        comments_data = json.loads(comments_data_json)
+        comment_text = [comment["text"] for comment in comments_data["comments"]]
+        comment_text.sort()
+        self.assertEqual(comment_text, ["A test comment", "This is quite expensive"])

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -1651,7 +1651,7 @@ class TestCommentPanel(WagtailTestUtils, TestCase):
             page=self.event_page,
             text="test",
             user=self.other_user,
-            contentpath="test_contentpath",
+            contentpath="location",
         )
         self.reply_1 = CommentReply.objects.create(
             comment=self.comment, text="reply_1", user=self.other_user

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -253,6 +253,18 @@ class Block(metaclass=BaseBlock):
     def extract_references(self, value):
         return []
 
+    def get_block_by_content_path(self, value, path_elements):
+        """
+        Given a list of elements from a content path, retrieve the block at that path
+        as a BoundBlock object, or None if the path does not correspond to a valid block.
+        """
+        # In the base case, where a block has no concept of children, the only valid path is
+        # the empty one (which refers to the current block).
+        if path_elements:
+            return None
+        else:
+            return self.bind(value)
+
     def check(self, **kwargs):
         """
         Hook for the Django system checks framework -

--- a/wagtail/blocks/list_block.py
+++ b/wagtail/blocks/list_block.py
@@ -364,6 +364,22 @@ class ListBlock(Block):
                 )
                 yield model, object_id, model_path, content_path
 
+    def get_block_by_content_path(self, value, path_elements):
+        """
+        Given a list of elements from a content path, retrieve the block at that path
+        as a BoundBlock object, or None if the path does not correspond to a valid block.
+        """
+        if path_elements:
+            id, *remaining_elements = path_elements
+            for child in value.bound_blocks:
+                if child.id == id:
+                    return child.block.get_block_by_content_path(
+                        child.value, remaining_elements
+                    )
+        else:
+            # an empty path refers to the list as a whole
+            return self.bind(value)
+
     def check(self, **kwargs):
         errors = super().check(**kwargs)
         errors.extend(self.child_block.check(**kwargs))

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -365,6 +365,22 @@ class BaseStreamBlock(Block):
                 )
                 yield model, object_id, model_path, content_path
 
+    def get_block_by_content_path(self, value, path_elements):
+        """
+        Given a list of elements from a content path, retrieve the block at that path
+        as a BoundBlock object, or None if the path does not correspond to a valid block.
+        """
+        if path_elements:
+            id, *remaining_elements = path_elements
+            for child in value:
+                if child.id == id:
+                    return child.block.get_block_by_content_path(
+                        child.value, remaining_elements
+                    )
+        else:
+            # an empty path refers to the stream as a whole
+            return self.bind(value)
+
     def deconstruct(self):
         """
         Always deconstruct StreamBlock instances as if they were plain StreamBlocks with all of the

--- a/wagtail/blocks/struct_block.py
+++ b/wagtail/blocks/struct_block.py
@@ -271,6 +271,26 @@ class BaseStructBlock(Block):
                 content_path = f"{name}.{content_path}" if content_path else name
                 yield model, object_id, model_path, content_path
 
+    def get_block_by_content_path(self, value, path_elements):
+        """
+        Given a list of elements from a content path, retrieve the block at that path
+        as a BoundBlock object, or None if the path does not correspond to a valid block.
+        """
+        if path_elements:
+            name, *remaining_elements = path_elements
+            try:
+                child_block = self.child_blocks[name]
+            except KeyError:
+                return None
+
+            child_value = value.get(name, child_block.get_default())
+            return child_block.get_block_by_content_path(
+                child_value, remaining_elements
+            )
+        else:
+            # an empty path refers to the struct as a whole
+            return self.bind(value)
+
     def deconstruct(self):
         """
         Always deconstruct StructBlock instances as if they were plain StructBlocks with all of the

--- a/wagtail/fields.py
+++ b/wagtail/fields.py
@@ -257,6 +257,13 @@ class StreamField(models.Field):
     def extract_references(self, value):
         yield from self.stream_block.extract_references(value)
 
+    def get_block_by_content_path(self, value, path_elements):
+        """
+        Given a list of elements from a content path, retrieve the block at that path
+        as a BoundBlock object, or None if the path does not correspond to a valid block.
+        """
+        return self.stream_block.get_block_by_content_path(value, path_elements)
+
     def check(self, **kwargs):
         errors = super().check(**kwargs)
         errors.extend(self.stream_block.check(field=self, **kwargs))


### PR DESCRIPTION
If a user comments on a field or StreamField block, and the page model schema is subsequently updated to remove that field or block, the count against the comments icon in the header will include those comments, even though the comments themselves do not show (since there's no matching field to attach them to).

Fix this by filtering out comments from the formset that have a contentpath that doesn't correspond to a valid field / block path on the page.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?


To test on bakerydemo:

Edit RecipePage in bakerydemo/recipes/models.py to add a field

    subsubtitle = models.CharField(blank=True, max_length=255)

and a corresponding FieldPanel

    FieldPanel("subsubtitle"),

Edit RecipeStepBlock in bakerydemo/recipes/blocks.py to add a child block

    fun_level = CharBlock(required=False)

Run `./manage.py makemigrations` and `./manage.py migrate`

In the admin, edit a recipe page and add several comments, including some on the subsubtitle field and fun_level block, then save the page.

Revert the code changes and rerun `./manage.py makemigrations` and `./manage.py migrate`. Reload the edit view - the comment count in the header should now be reduced to omit the comments on the removed fields/blocks.