### PR TITLE
Change export headings to match column

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,8 @@ Changelog
  * Add the ability to use filters and to export listings in generic `IndexView` (Sage Abdullah)
  * Move `list_filter`, `filterset_class`, `search_fields`, `search_backend_name`, `list_export`, `export_filename`, `list_per_page`, and `ordering` from `SnippetViewSet` to `ModelViewSet` (Sage Abdullah)
  * Add default header titles to generic `IndexView` and `CreateView` (Sage Abdullah)
+ * Allow overriding `IndexView.export_headings` via `ModelViewSet` (Christer Jensen, Sage Abdullah)
+ * Change spreadsheet export headings to match listing view column headings (Christer Jensen, Sage Abdullah)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -85,6 +85,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: list_export
    .. autoattribute:: list_filter
    .. autoattribute:: filterset_class
+   .. autoattribute:: export_headings
    .. autoattribute:: export_filename
    .. autoattribute:: search_fields
    .. autoattribute:: search_backend_name

--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -126,7 +126,7 @@ class TestLockedPagesView(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
         data_lines = response.getvalue().decode().split("\n")
         self.assertEqual(
-            data_lines[0], "Title,Updated,Status,Type,Locked At,Locked By\r"
+            data_lines[0], "Title,Updated,Status,Type,Locked at,Locked by\r"
         )
         if settings.USE_TZ:
             self.assertEqual(
@@ -163,7 +163,7 @@ class TestLockedPagesView(WagtailTestUtils, TestCase):
         cell_array = [[cell.value for cell in row] for row in worksheet.rows]
         self.assertEqual(
             cell_array[0],
-            ["Title", "Updated", "Status", "Type", "Locked At", "Locked By"],
+            ["Title", "Updated", "Status", "Type", "Locked at", "Locked by"],
         )
         self.assertEqual(
             cell_array[1],

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -506,7 +506,7 @@ class TestListExport(WagtailTestUtils, TestCase):
         )
 
         data_lines = response.getvalue().decode().strip().split("\r\n")
-        self.assertEqual(data_lines[0], "Name,Release Date,is_cool")
+        self.assertEqual(data_lines[0], "Name,Launch date,is_cool")
         self.assertEqual(data_lines[1], "Catso,2010-06-18,False")
         self.assertEqual(data_lines[2], "LEVEL,2010-06-18,True")
         self.assertEqual(data_lines[3], "Racecar,1995-11-19,None")
@@ -526,7 +526,7 @@ class TestListExport(WagtailTestUtils, TestCase):
         )
 
         data_lines = response.getvalue().decode().strip().split("\r\n")
-        self.assertEqual(data_lines[0], "Name,Release Date,is_cool")
+        self.assertEqual(data_lines[0], "Name,Launch date,is_cool")
         self.assertEqual(data_lines[1], "Catso,2010-06-18,False")
         self.assertEqual(data_lines[2], "LEVEL,2010-06-18,True")
         self.assertEqual(len(data_lines), 3)
@@ -544,7 +544,7 @@ class TestListExport(WagtailTestUtils, TestCase):
         workbook_data = response.getvalue()
         worksheet = load_workbook(filename=BytesIO(workbook_data)).active
         cell_array = [[cell.value for cell in row] for row in worksheet.rows]
-        self.assertEqual(cell_array[0], ["Name", "Release Date", "is_cool"])
+        self.assertEqual(cell_array[0], ["Name", "Launch date", "is_cool"])
         self.assertEqual(cell_array[1], ["Catso", datetime.date(2010, 6, 18), "False"])
         self.assertEqual(cell_array[2], ["LEVEL", datetime.date(2010, 6, 18), "True"])
         self.assertEqual(
@@ -568,7 +568,7 @@ class TestListExport(WagtailTestUtils, TestCase):
         workbook_data = response.getvalue()
         worksheet = load_workbook(filename=BytesIO(workbook_data)).active
         cell_array = [[cell.value for cell in row] for row in worksheet.rows]
-        self.assertEqual(cell_array[0], ["Name", "Release Date", "is_cool"])
+        self.assertEqual(cell_array[0], ["Name", "Launch date", "is_cool"])
         self.assertEqual(cell_array[1], ["Catso", datetime.date(2010, 6, 18), "False"])
         self.assertEqual(cell_array[2], ["LEVEL", datetime.date(2010, 6, 18), "True"])
         self.assertEqual(len(cell_array), 3)

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -506,7 +506,7 @@ class TestListExport(WagtailTestUtils, TestCase):
         )
 
         data_lines = response.getvalue().decode().strip().split("\r\n")
-        self.assertEqual(data_lines[0], "Name,Launch date,is_cool")
+        self.assertEqual(data_lines[0], "Name,Launch date,Is Cool")
         self.assertEqual(data_lines[1], "Catso,2010-06-18,False")
         self.assertEqual(data_lines[2], "LEVEL,2010-06-18,True")
         self.assertEqual(data_lines[3], "Racecar,1995-11-19,None")
@@ -526,7 +526,7 @@ class TestListExport(WagtailTestUtils, TestCase):
         )
 
         data_lines = response.getvalue().decode().strip().split("\r\n")
-        self.assertEqual(data_lines[0], "Name,Launch date,is_cool")
+        self.assertEqual(data_lines[0], "Name,Launch date,Is Cool")
         self.assertEqual(data_lines[1], "Catso,2010-06-18,False")
         self.assertEqual(data_lines[2], "LEVEL,2010-06-18,True")
         self.assertEqual(len(data_lines), 3)
@@ -544,7 +544,7 @@ class TestListExport(WagtailTestUtils, TestCase):
         workbook_data = response.getvalue()
         worksheet = load_workbook(filename=BytesIO(workbook_data)).active
         cell_array = [[cell.value for cell in row] for row in worksheet.rows]
-        self.assertEqual(cell_array[0], ["Name", "Launch date", "is_cool"])
+        self.assertEqual(cell_array[0], ["Name", "Launch date", "Is Cool"])
         self.assertEqual(cell_array[1], ["Catso", datetime.date(2010, 6, 18), "False"])
         self.assertEqual(cell_array[2], ["LEVEL", datetime.date(2010, 6, 18), "True"])
         self.assertEqual(
@@ -568,7 +568,7 @@ class TestListExport(WagtailTestUtils, TestCase):
         workbook_data = response.getvalue()
         worksheet = load_workbook(filename=BytesIO(workbook_data)).active
         cell_array = [[cell.value for cell in row] for row in worksheet.rows]
-        self.assertEqual(cell_array[0], ["Name", "Launch date", "is_cool"])
+        self.assertEqual(cell_array[0], ["Name", "Launch date", "Is Cool"])
         self.assertEqual(cell_array[1], ["Catso", datetime.date(2010, 6, 18), "False"])
         self.assertEqual(cell_array[2], ["LEVEL", datetime.date(2010, 6, 18), "True"])
         self.assertEqual(len(cell_array), 3)

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -506,7 +506,7 @@ class TestListExport(WagtailTestUtils, TestCase):
         )
 
         data_lines = response.getvalue().decode().strip().split("\r\n")
-        self.assertEqual(data_lines[0], "Name,Launch date,Is Cool")
+        self.assertEqual(data_lines[0], "Name,Launch date,Is cool")
         self.assertEqual(data_lines[1], "Catso,2010-06-18,False")
         self.assertEqual(data_lines[2], "LEVEL,2010-06-18,True")
         self.assertEqual(data_lines[3], "Racecar,1995-11-19,None")
@@ -526,7 +526,7 @@ class TestListExport(WagtailTestUtils, TestCase):
         )
 
         data_lines = response.getvalue().decode().strip().split("\r\n")
-        self.assertEqual(data_lines[0], "Name,Launch date,Is Cool")
+        self.assertEqual(data_lines[0], "Name,Launch date,Is cool")
         self.assertEqual(data_lines[1], "Catso,2010-06-18,False")
         self.assertEqual(data_lines[2], "LEVEL,2010-06-18,True")
         self.assertEqual(len(data_lines), 3)
@@ -544,7 +544,7 @@ class TestListExport(WagtailTestUtils, TestCase):
         workbook_data = response.getvalue()
         worksheet = load_workbook(filename=BytesIO(workbook_data)).active
         cell_array = [[cell.value for cell in row] for row in worksheet.rows]
-        self.assertEqual(cell_array[0], ["Name", "Launch date", "Is Cool"])
+        self.assertEqual(cell_array[0], ["Name", "Launch date", "Is cool"])
         self.assertEqual(cell_array[1], ["Catso", datetime.date(2010, 6, 18), "False"])
         self.assertEqual(cell_array[2], ["LEVEL", datetime.date(2010, 6, 18), "True"])
         self.assertEqual(
@@ -568,7 +568,7 @@ class TestListExport(WagtailTestUtils, TestCase):
         workbook_data = response.getvalue()
         worksheet = load_workbook(filename=BytesIO(workbook_data)).active
         cell_array = [[cell.value for cell in row] for row in worksheet.rows]
-        self.assertEqual(cell_array[0], ["Name", "Launch date", "Is Cool"])
+        self.assertEqual(cell_array[0], ["Name", "Launch date", "Is cool"])
         self.assertEqual(cell_array[1], ["Catso", datetime.date(2010, 6, 18), "False"])
         self.assertEqual(cell_array[2], ["LEVEL", datetime.date(2010, 6, 18), "True"])
         self.assertEqual(len(cell_array), 3)

--- a/wagtail/admin/views/mixins.py
+++ b/wagtail/admin/views/mixins.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from django.utils.dateformat import Formatter
 from django.utils.encoding import force_str
 from django.utils.formats import get_format
+from django.utils.text import capfirst
 from openpyxl import Workbook
 from openpyxl.cell import WriteOnlyCell
 
@@ -225,7 +226,7 @@ class SpreadsheetExportMixin:
         if heading_override:
             return force_str(heading_override)
         try:
-            return force_str(label_for_field(field, queryset.model)).title()
+            return capfirst(force_str(label_for_field(field, queryset.model)))
         except (AttributeError, FieldDoesNotExist):
             return force_str(field)
 

--- a/wagtail/admin/views/mixins.py
+++ b/wagtail/admin/views/mixins.py
@@ -3,6 +3,7 @@ import datetime
 from collections import OrderedDict
 from io import BytesIO
 
+from django.contrib.admin.utils import label_for_field
 from django.core.exceptions import FieldDoesNotExist
 from django.http import FileResponse, StreamingHttpResponse
 from django.utils import timezone
@@ -224,7 +225,7 @@ class SpreadsheetExportMixin:
         if heading_override:
             return force_str(heading_override)
         try:
-            return force_str(queryset.model._meta.get_field(field).verbose_name.title())
+            return force_str(label_for_field(field, queryset.model)).title()
         except (AttributeError, FieldDoesNotExist):
             return force_str(field)
 

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -87,6 +87,7 @@ class ModelViewSet(ViewSet):
             "list_display": self.list_display,
             "list_filter": self.list_filter,
             "list_export": self.list_export,
+            "export_headings": self.export_headings,
             "export_filename": self.export_filename,
             "filterset_class": self.filterset_class,
             "search_fields": self.search_fields,
@@ -331,6 +332,14 @@ class ModelViewSet(ViewSet):
         or a single-argument callable on the model to be exported.
         """
         return self.index_view_class.list_export
+
+    @cached_property
+    def export_headings(self):
+        """
+        A dictionary of export column heading overrides in the format
+        ``{field_name: heading}``.
+        """
+        return self.index_view_class.export_headings
 
     @cached_property
     def export_filename(self):

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -774,7 +774,7 @@ class TestListExport(BaseSnippetViewSetTests):
         data_lines = response.getvalue().decode().split("\n")
         self.assertEqual(
             data_lines[0],
-            "Text,Country Code,get_foo_country_code,Some Date,First Published At\r",
+            "Text,Country Code,Custom Foo Column,Some Date,First Published At\r",
         )
         self.assertEqual(
             data_lines[1],
@@ -802,7 +802,7 @@ class TestListExport(BaseSnippetViewSetTests):
             [
                 "Text",
                 "Country Code",
-                "get_foo_country_code",
+                "Custom Foo Column",
                 "Some Date",
                 "First Published At",
             ],

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -774,7 +774,7 @@ class TestListExport(BaseSnippetViewSetTests):
         data_lines = response.getvalue().decode().split("\n")
         self.assertEqual(
             data_lines[0],
-            "Text,Country Code,Custom Foo Column,Some Date,First Published At\r",
+            "Text,Country code,Custom FOO column,Some date,First published at\r",
         )
         self.assertEqual(
             data_lines[1],
@@ -801,10 +801,10 @@ class TestListExport(BaseSnippetViewSetTests):
             cell_array[0],
             [
                 "Text",
-                "Country Code",
-                "Custom Foo Column",
-                "Some Date",
-                "First Published At",
+                "Country code",
+                "Custom FOO column",
+                "Some date",
+                "First published at",
             ],
         )
         self.assertEqual(

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -207,6 +207,7 @@ class FeatureCompleteToyViewSet(ModelViewSet):
     list_filter = ["name", "release_date"]
     list_export = ["name", "release_date", "is_cool"]
     export_filename = "feature-complete-toys"
+    export_headings = {"release_date": "Launch date"}
     list_per_page = 5
     ordering = ["name", "-release_date"]
     # search_fields derived from the model


### PR DESCRIPTION
The heading for spreadsheet export used different logic than listing columns and is hard to customise. This pull requests does two things.

Firstly, it changes the logic for setting the heading of an exported field to use django's `django.contrib.admin.utils.label_for_field()` which is the same a listing columns' uses. This handles more cases like methods with the `short_description` property set instead of only using `verbose_name`.

Secondly, it exposes `export_headings` directly in the `SnippetViewSet` class. This allows users to directly set/override headings from the viewset rather than having to create a custom `IndexView` to achieve the same.

_Please check the following:_

-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [X] Run `make lint` from the Wagtail root.
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [X] For new features: Has the documentation been updated accordingly?
