### PR TITLE
Move `SnippetViewSet.get_edit_handler()` to `ModelViewSet`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Changelog
  * Improve visual alignment of explore icon in Page listings for longer content (Krzysztof Jeziorny)
  * Add `extra_actions` blocks to Snippets and generic index templates (Bhuvnesh Sharma)
  * Added page types usage report (Jhonatan Lopes)
+ * Add support for defining `panels` / `edit_handler` on `ModelViewSet` (Sage Abdullah)
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)

--- a/docs/extending/generic_views.md
+++ b/docs/extending/generic_views.md
@@ -86,6 +86,14 @@ If you would like to make further customisations to the filtering mechanism, you
 
 You can add the ability to export the listing view to a spreadsheet by setting the {attr}`~ModelViewSet.list_export` attribute to specify the columns to be exported. The {attr}`~ModelViewSet.export_filename` attribute can be used to customise the file name of the exported spreadsheet.
 
+(modelviewset_create_edit)=
+
+### Create and edit views
+
+You can define a `panels` or `edit_handler` attribute on the `ModelViewSet` or your Django model to use Wagtail's panels mechanism. For more details, see [](forms_panels_overview).
+
+If neither `panels` nor `edit_handler` is defined and the {meth}`~ModelViewSet.get_edit_handler` method is not overridden, the form will be rendered as a plain Django form. You can customise the form by setting the {attr}`~ModelViewSet.form_fields` attribute to specify the fields to be shown on the form. Alternatively, you can set the {attr}`~ModelViewSet.exclude_form_fields` attribute to specify the fields to be excluded from the form. If panels are not used, you must define `form_fields` or `exclude_form_fields`, unless {meth}`~ModelViewSet.get_form_class` is overridden.
+
 (modelviewset_inspect)=
 
 ### Inspect view

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -77,6 +77,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    Used in place of :attr:`form_fields` to indicate that all of the model's fields except the ones listed here should appear in the create / edit forms. Either ``form_fields`` or ``exclude_form_fields`` must be supplied (unless :meth:`get_form_class` is being overridden).
 
    .. automethod:: get_form_class
+   .. automethod:: get_edit_handler
 
    .. autoattribute:: menu_label
 
@@ -195,7 +196,6 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: chooser_viewset_class
    .. automethod:: get_queryset
    .. automethod:: get_edit_handler
-   .. automethod:: get_form_class
    .. automethod:: get_index_template
    .. automethod:: get_index_results_template
    .. automethod:: get_create_template

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -24,6 +24,7 @@ depth: 1
  * Improve visual alignment of explore icon in Page listings for longer content (Krzysztof Jeziorny)
  * Add `extra_actions` blocks to Snippets and generic index templates (Bhuvnesh Sharma)
  * Added page types usage report (Jhonatan Lopes)
+ * Add support for defining `panels` / `edit_handler` on `ModelViewSet` (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/generic/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/edit.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block actions %}
-    <input type="submit" value="{% trans 'Save' %}" class="button" />
+    {{ block.super }}
     {% if delete_url %}
         <a href="{{ delete_url }}" class="button no">{{ delete_item_label }}</a>
     {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -12,19 +12,23 @@
             {% endfor %}
         {% endblock %}
 
-        {% block hidden_fields %}
-            {% for field in form.hidden_fields %}{{ field }}{% endfor %}
-        {% endblock %}
-
-        <ul class="fields">
-            {% block visible_fields %}
-                {% for field in form.visible_fields %}
-                    <li>
-                        {% include "wagtailadmin/shared/field.html" %}
-                    </li>
-                {% endfor %}
+        {% if panel %}
+            {{ panel.render_form_content }}
+        {% else %}
+            {% block hidden_fields %}
+                {% for field in form.hidden_fields %}{{ field }}{% endfor %}
             {% endblock %}
-        </ul>
+
+            <ul class="fields">
+                {% block visible_fields %}
+                    {% for field in form.visible_fields %}
+                        <li>
+                            {% include "wagtailadmin/shared/field.html" %}
+                        </li>
+                    {% endfor %}
+                {% endblock %}
+            </ul>
+        {% endif %}
 
         {% block actions %}
             <button type="submit" class="button">{{ submit_button_label }}</button>

--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -24,13 +24,11 @@
                     </li>
                 {% endfor %}
             {% endblock %}
-
-            <li>
-                {% block actions %}
-                    <input type="submit" value="{{ submit_button_label }}" class="button" />
-                {% endblock %}
-            </li>
         </ul>
+
+        {% block actions %}
+            <button type="submit" class="button">{{ submit_button_label }}</button>
+        {% endblock %}
     </form>
 {% endblock %}
 

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -1250,3 +1250,33 @@ class TestListingButtons(WagtailTestUtils, TestCase):
             self.assertEqual(rendered_button.text.strip(), label)
             self.assertEqual(rendered_button.attrs.get("aria-label"), aria_label)
             self.assertEqual(rendered_button.attrs.get("href"), url)
+
+
+class TestEditHandler(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.user = self.login()
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.object = FeatureCompleteToy.objects.create(name="Test Toy")
+        cls.url = reverse("feature_complete_toy:edit", args=(quote(cls.object.pk),))
+
+    def test_edit_form_rendered_with_panels(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/shared/panel.html")
+
+        soup = self.get_soup(response.content)
+
+        # Minimap should be rendered
+        minimap_container = soup.select_one("[data-minimap-container]")
+        self.assertIsNotNone(minimap_container)
+
+        # Form should be rendered using panels
+        panels = soup.select("[data-panel]")
+        self.assertEqual(len(panels), 2)
+        headings = ["Name", "Release date"]
+        for expected_heading, panel in zip(headings, panels):
+            rendered_heading = panel.select_one("[data-panel-heading-text]")
+            self.assertIsNotNone(rendered_heading)
+            self.assertEqual(rendered_heading.text.strip(), expected_heading)

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -13,8 +13,7 @@ from django.utils.translation import gettext_lazy
 
 from wagtail import hooks
 from wagtail.admin.checks import check_panels_in_model
-from wagtail.admin.panels.group import ObjectList
-from wagtail.admin.panels.model_utils import extract_panel_definitions_from_model_class
+from wagtail.admin.panels import ObjectList, extract_panel_definitions_from_model_class
 from wagtail.admin.ui.components import MediaContainer
 from wagtail.admin.ui.side_panels import PreviewSidePanel
 from wagtail.admin.ui.tables import (
@@ -548,6 +547,12 @@ class WorkflowHistoryDetailView(
 class SnippetViewSet(ModelViewSet):
     """
     A viewset that instantiates the admin views for snippets.
+
+    All attributes and methods from
+    :class:`~wagtail.admin.viewsets.model.ModelViewSet` are available.
+
+    For more information on how to use this class,
+    see :ref:`wagtailsnippets_custom_admin_views`.
     """
 
     #: The model class to be registered as a snippet with this viewset.
@@ -667,9 +672,6 @@ class SnippetViewSet(ModelViewSet):
             self, "menu_item_is_registered", bool(self.menu_hook)
         )
 
-        # This edit handler has been bound to the model and is used for the views.
-        self._edit_handler = self.get_edit_handler()
-
     @cached_property
     def url_prefix(self):
         # SnippetViewSet historically allows overriding the URL prefix via the
@@ -731,14 +733,12 @@ class SnippetViewSet(ModelViewSet):
 
     def get_add_view_kwargs(self, **kwargs):
         return super().get_add_view_kwargs(
-            panel=self._edit_handler,
             preview_url_name=self.get_url_name("preview_on_add"),
             **kwargs,
         )
 
     def get_edit_view_kwargs(self, **kwargs):
         return super().get_edit_view_kwargs(
-            panel=self._edit_handler,
             preview_url_name=self.get_url_name("preview_on_edit"),
             workflow_history_url_name=self.get_url_name("workflow_history"),
             confirm_workflow_cancellation_url_name=self.get_url_name(
@@ -1257,31 +1257,19 @@ class SnippetViewSet(ModelViewSet):
 
     def get_edit_handler(self):
         """
-        Returns the appropriate edit handler for this ``SnippetViewSet`` class.
-        It can be defined either on the model itself or on the ``SnippetViewSet``,
-        as the ``edit_handler`` or ``panels`` properties. Falls back to
-        extracting panel / edit handler definitions from the model class.
+        Like :meth:`ModelViewSet.get_edit_handler()
+        <wagtail.admin.viewsets.model.ModelViewSet.get_edit_handler>`,
+        but falls back to extracting panel definitions from the model class
+        if no edit handler is defined.
         """
-        if hasattr(self, "edit_handler"):
-            edit_handler = self.edit_handler
-        elif hasattr(self, "panels"):
-            panels = self.panels
-            edit_handler = ObjectList(panels)
-        elif hasattr(self.model, "edit_handler"):
-            edit_handler = self.model.edit_handler
-        elif hasattr(self.model, "panels"):
-            panels = self.model.panels
-            edit_handler = ObjectList(panels)
-        else:
-            exclude = self.get_exclude_form_fields()
-            panels = extract_panel_definitions_from_model_class(
-                self.model, exclude=exclude
-            )
-            edit_handler = ObjectList(panels)
-        return edit_handler.bind_to_model(self.model)
+        edit_handler = super().get_edit_handler()
+        if edit_handler:
+            return edit_handler
 
-    def get_form_class(self, for_update=False):
-        return self._edit_handler.get_form_class()
+        exclude = self.get_exclude_form_fields()
+        panels = extract_panel_definitions_from_model_class(self.model, exclude=exclude)
+        edit_handler = ObjectList(panels)
+        return edit_handler.bind_to_model(self.model)
 
     def register_chooser_viewset(self):
         viewsets.register(self.chooser_viewset)

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -11,6 +11,7 @@ from django.utils.translation import gettext_lazy
 from wagtail.admin import messages
 from wagtail.admin.auth import user_passes_test
 from wagtail.admin.filters import WagtailFilterSet
+from wagtail.admin.panels import FieldPanel
 from wagtail.admin.ui.tables import BooleanColumn, UpdatedAtColumn
 from wagtail.admin.views.generic import DeleteView, EditView, IndexView
 from wagtail.admin.viewsets.base import ViewSet, ViewSetGroup
@@ -206,7 +207,6 @@ class FeatureCompleteToyViewSet(ModelViewSet):
     url_prefix = "feature-complete-toy"
     menu_label = "Feature Complete Toys"
     icon = "media"
-    exclude_form_fields = ()
     template_prefix = "customprefix/"
     index_template_name = "tests/fctoy_index.html"
     list_display = ["name", BooleanColumn("is_cool"), UpdatedAtColumn()]
@@ -219,6 +219,11 @@ class FeatureCompleteToyViewSet(ModelViewSet):
     # search_fields derived from the model
     inspect_view_enabled = True
     inspect_view_fields = ["strid", "release_date"]
+
+    panels = [
+        FieldPanel("name"),
+        FieldPanel("release_date"),
+    ]
 
 
 class FCToyAlt1ViewSet(ModelViewSet):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Part of #10740. This allows using the Panels mechanism to render the form for `ModelViewSet` by defining `panels` or `edit_handler` on the `ModelViewSet` or model class. 

One difference from `SnippetViewSet` is that `ModelViewSet` does not fall back to extracting the panel definitions from the model class if neither `panels` nor `edit_handler` is defined, and instead will fall back to the original behaviour of requiring either `form_fields`, `exclude_form_fields`, or overriding `get_form_class`.

To test, you can use my [bakerydemo branch](https://github.com/laymonage/bakerydemo/tree/country-modelviewset) where the `Country` model has been configured to use a `ModelViewSet` with `panels`.

When reviewing, hide whitespace to get better diffs.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For new features: Has the documentation been updated accordingly?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
