### PR TITLE
Optimise LRU cache uses

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -73,6 +73,7 @@ Changelog
  * Maintenance: Deprecate legacy URL redirects in `ModelViewSet` and `SnippetViewSet` (Sage Abdullah)
  * Maintenance: Simplify code for registering page listing action buttons (Matt Westcott)
  * Maintenance: Removed the unused, legacy, Wagtail userbar views set up for an old iframe approach (Sage Abdullah)
+ * Maintenance: Optimise `lru_cache` usage (Jake Howard)
 
 
 5.1.2 (25.09.2023)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -94,6 +94,7 @@ depth: 1
  * Deprecate legacy URL redirects in `ModelViewSet` and `SnippetViewSet` (Sage Abdullah)
  * Simplify code for registering page listing action buttons (Matt Westcott)
  * Removed the unused, legacy, Wagtail userbar views set up for an old iframe approach (Sage Abdullah)
+ * Optimise `lru_cache` usage (Jake Howard)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -312,7 +312,8 @@ class TestComponentTag(SimpleTestCase):
         ("fr", "French"),
         ("ro", "Romanian"),
         ("ru", "Russian"),
-    ]
+    ],
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
 )
 class TestInternationalisationTags(TestCase):
     def setUp(self):

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -614,7 +614,7 @@ class BlockField(forms.Field):
         )
 
 
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=None)
 def get_help_icon():
     return render_to_string(
         "wagtailadmin/shared/icon.html", {"name": "help", "classname": "default"}

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -35,7 +35,7 @@ def get_model_from_url_params(app_name, model_name):
     return model
 
 
-@lru_cache
+@lru_cache(maxsize=None)
 def get_setting_edit_handler(model):
     if hasattr(model, "edit_handler"):
         edit_handler = model.edit_handler

--- a/wagtail/coreutils.py
+++ b/wagtail/coreutils.py
@@ -256,7 +256,7 @@ def find_available_slug(parent, requested_slug, ignore_page_id=None):
     return slug
 
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=None)
 def get_content_languages():
     """
     Cache of settings.WAGTAIL_CONTENT_LANGUAGES in a dictionary for easy lookups by key.

--- a/wagtail/images/checks.py
+++ b/wagtail/images/checks.py
@@ -5,7 +5,7 @@ from django.core.checks import Warning, register
 from willow.image import Image
 
 
-@lru_cache
+@lru_cache(maxsize=None)
 def has_jpeg_support():
     wagtail_jpg = os.path.join(os.path.dirname(__file__), "check_files", "wagtail.jpg")
     succeeded = True
@@ -19,7 +19,7 @@ def has_jpeg_support():
     return succeeded
 
 
-@lru_cache
+@lru_cache(maxsize=None)
 def has_png_support():
     wagtail_png = os.path.join(os.path.dirname(__file__), "check_files", "wagtail.png")
     succeeded = True

--- a/wagtail/images/templatetags/wagtailimages_tags.py
+++ b/wagtail/images/templatetags/wagtailimages_tags.py
@@ -1,5 +1,4 @@
 import re
-from functools import lru_cache
 
 from django import template
 from django.core.exceptions import ImproperlyConfigured
@@ -106,7 +105,6 @@ class ImageNode(template.Node):
         self.filter_specs = filter_specs
         self.preserve_svg = preserve_svg
 
-    @lru_cache
     def get_filter(self, preserve_svg=False):
         if preserve_svg:
             return Filter(to_svg_safe_spec(self.filter_specs))

--- a/wagtail/rich_text/__init__.py
+++ b/wagtail/rich_text/__init__.py
@@ -19,7 +19,7 @@ features = FeatureRegistry()
 # with the feature registry
 
 
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=None)
 def get_rewriter():
     embed_rules = features.get_embed_types()
     link_rules = features.get_link_types()

--- a/wagtail/signal_handlers.py
+++ b/wagtail/signal_handlers.py
@@ -2,6 +2,7 @@ import logging
 from contextlib import contextmanager
 
 from asgiref.local import Local
+from django.core.cache import cache
 from django.db import transaction
 from django.db.models.signals import (
     post_delete,
@@ -12,7 +13,6 @@ from django.db.models.signals import (
 )
 from modelcluster.fields import ParentalKey
 
-from wagtail.coreutils import get_locales_display_names
 from wagtail.models import Locale, Page, ReferenceIndex, Site
 
 logger = logging.getLogger("wagtail")
@@ -39,7 +39,7 @@ def post_delete_page_log_deletion(sender, instance, **kwargs):
 
 
 def reset_locales_display_names_cache(sender, instance, **kwargs):
-    get_locales_display_names.cache_clear()
+    cache.delete("wagtail_locales_display_name")
 
 
 reference_index_auto_update_disabled = Local()


### PR DESCRIPTION
_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

There are 3 independent changes here (split by commit):

1. Stop relying on `lru_cache.cache_clear` to clear caches. `cache_clear` will only clear the cache for the current process, of which there are likely multiple in a production environment. This moves the cache to Django's cache framework, which whilst may increase latency, will ensure the cache is cleared entirely.
2. Use `maxsize=None` on as many `lru_cache`s as we can. The implementation is faster, simpler, and doesn't require a thread lock. For methods with no arguments, this makes no difference to the cache characteristics. For methods with arguments, we'll be caching more, but in the cases I've seen this shouldn't be an issue.
3. Remove cache from `ImageNode.get_filter`. This operations is incredibly efficient, and not often called.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
