### PR TITLE
Update CI database versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,11 +84,22 @@ jobs:
             django: 'Django>=3.2,<3.3'
             experimental: false
             parallel: '--parallel'
+          - python: '3.8'
+            django: 'Django>=3.2,<3.3'
+            experimental: false
+            parallel: '--parallel'
+            postgres: 'postgres:15'
           - python: '3.11'
             django: 'Django>=4.2,<4.3'
             notz: notz
             experimental: false
             parallel: '--parallel'
+          - python: '3.11'
+            django: 'Django>=4.2,<4.3'
+            notz: notz
+            experimental: false
+            parallel: '--parallel'
+            postgres: 'postgres:15'
           - python: '3.10'
             django: 'Django>=4.1,<4.2'
             experimental: false
@@ -158,10 +169,19 @@ jobs:
             django: 'Django>=4.2,<4.3'
             experimental: false
             parallel: '--parallel'
+          - python: '3.8'
+            django: 'Django>=3.2,<3.3'
+            experimental: false
+            mysql: 'mysql:8.1'
+          - python: '3.10'
+            django: 'Django>=4.2,<4.3'
+            experimental: false
+            parallel: '--parallel'
+            mysql: 'mysql:8.1'
 
     services:
       mysql:
-        image: mysql:8.0
+        image: ${{ matrix.mysql || 'mysql:8.0' }}
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: wagtail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,6 @@ jobs:
             parallel: '--parallel'
           - python: '3.11'
             django: 'Django>=4.2,<4.3'
-            postgres: 'postgres:12'
             notz: notz
             experimental: false
             parallel: '--parallel'
@@ -98,11 +97,9 @@ jobs:
           - python: '3.10'
             django: 'git+https://github.com/django/django.git@stable/4.2.x#egg=Django'
             experimental: true
-            postgres: 'postgres:12'
           - python: '3.10'
             django: 'git+https://github.com/django/django.git@main#egg=Django'
             experimental: true
-            postgres: 'postgres:12'
             parallel: '--parallel'
             install_extras: |
               pip uninstall -y django-modelcluster
@@ -111,7 +108,7 @@ jobs:
 
     services:
       postgres:
-        image: ${{ matrix.postgres || 'postgres:11' }}
+        image: ${{ matrix.postgres || 'postgres:12' }}
         env:
           POSTGRES_PASSWORD: postgres
         ports:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -323,7 +323,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11
+        image: postgres:latest
         env:
           POSTGRES_PASSWORD: postgres
         ports:
@@ -381,7 +381,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11
+        image: postgres:latest
         env:
           POSTGRES_PASSWORD: postgres
         ports:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,7 +161,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:8.0.23
+        image: mysql:8.0
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: wagtail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,17 +20,17 @@ concurrency:
 # - test runs with USE_EMAIL_USER_MODEL=yes and DISABLE_TIMEZONE=yes
 
 # Current configuration:
-# - django 3.2, python 3.8, postgres, parallel
-# - django 3.2, python 3.8, mysql
+# - django 3.2, python 3.8, postgres:12, parallel
+# - django 3.2, python 3.8, mysql:8.0
 # - django 4.1, python 3.9, sqlite
-# - django 4.2, python 3.10, mysql, parallel
-# - django 4.1, python 3.10, postgres, parallel, USE_EMAIL_USER_MODEL=yes
-# - django 4.2, python 3.11, postgres, parallel, DISABLE_TIMEZONE=yes
+# - django 4.2, python 3.10, mysql:8.1, parallel
+# - django 4.1, python 3.10, postgres:12, parallel, USE_EMAIL_USER_MODEL=yes
+# - django 4.2, python 3.11, postgres:15, parallel, DISABLE_TIMEZONE=yes
 # - django stable/4.2.x, python 3.10, postgres (allow failures)
-# - django main, python 3.10, postgres, parallel (allow failures)
+# - django main, python 3.10, postgres:latest, parallel (allow failures)
 # - elasticsearch 5, django 3.2, python 3.8, sqlite
-# - elasticsearch 6, django 3.2, python 3.8, postgres
-# - elasticsearch 7, django 4.1, python 3.8, postgres
+# - elasticsearch 6, django 3.2, python 3.8, postgres:latest
+# - elasticsearch 7, django 4.1, python 3.8, postgres:latest
 # - elasticsearch 8, django 4.2, python 3.10, sqlite, USE_EMAIL_USER_MODEL=yes
 
 # Some tests are run in parallel by passing --parallel to runtests.py.
@@ -84,16 +84,6 @@ jobs:
             django: 'Django>=3.2,<3.3'
             experimental: false
             parallel: '--parallel'
-          - python: '3.8'
-            django: 'Django>=3.2,<3.3'
-            experimental: false
-            parallel: '--parallel'
-            postgres: 'postgres:15'
-          - python: '3.11'
-            django: 'Django>=4.2,<4.3'
-            notz: notz
-            experimental: false
-            parallel: '--parallel'
           - python: '3.11'
             django: 'Django>=4.2,<4.3'
             notz: notz
@@ -112,6 +102,7 @@ jobs:
             django: 'git+https://github.com/django/django.git@main#egg=Django'
             experimental: true
             parallel: '--parallel'
+            postgres: 'postgres:latest'
             install_extras: |
               pip uninstall -y django-modelcluster
               pip install \
@@ -169,16 +160,7 @@ jobs:
             django: 'Django>=4.2,<4.3'
             experimental: false
             parallel: '--parallel'
-          - python: '3.8'
-            django: 'Django>=3.2,<3.3'
-            experimental: false
             mysql: 'mysql:8.1'
-          - python: '3.10'
-            django: 'Django>=4.2,<4.3'
-            experimental: false
-            parallel: '--parallel'
-            mysql: 'mysql:8.1'
-
     services:
       mysql:
         image: ${{ matrix.mysql || 'mysql:8.0' }}


### PR DESCRIPTION
_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

Change the tested against versions of PostgreSQL and MySQL to the earliest still-supported versions.

MySQL follows an LTS schedule based on minor versions. 8.0 is the latest LTS. 8.1 is the latest. No other versions are supported.

PostgreSQL follows semver. 11 is EoL in November, 15 is the latest.

I elected to run oldest and latest versions of both engines, so hopefully best cover any potential issues.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
