### PR TITLE
Fix CallableChoiceIterator import on Django 5.0+

### DIFF
--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -4,7 +4,6 @@ from decimal import Decimal
 from django import forms
 from django.db.models import Model
 from django.db.models.fields import BLANK_CHOICE_DASH
-from django.forms.fields import CallableChoiceIterator
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
 from django.utils.encoding import force_str
 from django.utils.functional import cached_property
@@ -23,6 +22,12 @@ from wagtail.rich_text import (
 from wagtail.telepath import Adapter, register
 
 from .base import Block
+
+try:
+    from django.utils.choices import CallableChoiceIterator
+except ImportError:
+    # DJANGO_VERSION < 5.0
+    from django.forms.fields import CallableChoiceIterator
 
 
 class FieldBlock(Block):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

This was changed in django/django#16943. It's not enough to make our tests pass against Django's `main` branch though, as some fixes need to be done in the upstream `django-filter` package.
