### PR TITLE
fixes 10764 -Inserting a new InlinePanel focus goes to wrong place

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Support specifying a `get_object_list` method on `ChooserViewSet` (Matt Westcott)
  * Add `linked_fields` mechanism on chooser widgets to allow choices to be limited by fields on the calling page (Matt Westcott)
  * Add support for merging cells within `TableBlock` with the `mergedCells` option (Gareth Palmer)
+ * When adding a panel within `InlinePanel`, focus will now shift to that content similar to `StreamField` (Faishal Manzar)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -729,6 +729,7 @@
 * Gareth Palmer
 * Hatim Makki Hoho
 * Hussain Saherwala
+* Faishal Manzar
 
 ## Translators
 

--- a/client/src/components/InlinePanel/index.js
+++ b/client/src/components/InlinePanel/index.js
@@ -209,6 +209,29 @@ export class InlinePanel extends ExpandingFormset {
     );
   }
 
+  /**
+   * Add tabindex -1 into newly created form if attr not present and
+   * remove attr from old forms on blur event, if not present previously.
+   * Always scroll and then focus on the element.
+   */
+  initialFocus($node) {
+    if (!$node || !$node.length) return;
+
+    // If element does not already have tabindex, set it
+    // then ensure we remove after blur (when it loses focus).
+    if (!$node.attr('tabindex')) {
+      $node.attr('tabindex', -1);
+      $node.one('blur', () => {
+        if ($node.attr('tabindex') === '-1') {
+          $node.removeAttr('tabindex');
+        }
+      });
+    }
+
+    $node[0].scrollIntoView({ behavior: 'smooth' });
+    $node.focus();
+  }
+
   addForm(opts = {}) {
     /*
     Supported opts:
@@ -243,5 +266,7 @@ export class InlinePanel extends ExpandingFormset {
       if (this.opts.onAdd) this.opts.onAdd(formIndex);
       if (this.opts.onInit) this.opts.onInit(formIndex);
     }
+
+    this.initialFocus($(`#inline_child_${newChildPrefix}-panel-content`));
   }
 }

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -32,6 +32,7 @@ depth: 1
  * Support specifying a `get_object_list` method on `ChooserViewSet` (Matt Westcott)
  * Add `linked_fields` mechanism on chooser widgets to allow choices to be limited by fields on the calling page (Matt Westcott)
  * Add support for merging cells within `TableBlock` with the [`mergedCells` option](table_block_options) (Gareth Palmer)
+ * When adding a panel within `InlinePanel`, focus will now shift to that content similar to `StreamField` (Faishal Manzar)
 
 ### Bug fixes
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10764: When inserting a new InlinePanel, focus goes to the wrong place

## What i did?
 -> Added tabindex -1 in newly created inline form and removing tabindex attr from old forms, then scroll to first node of form







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
