### PR TITLE
Allow viewsets to define a common set of view kwargs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,7 @@ Changelog
  * Maintenance: Simplify `SnippetViewSet` registration code (Sage Abdullah)
  * Maintenance: Rename groups `IndexView.results_template_name` to `results.html` (Sage Abdullah)
  * Maintenance: Migrate form submission listing checkbox toggling to the shared `w-bulk` Stimulus implementation (LB (Ben) Johnston)
+ * Maintenance: Allow viewsets to define a common set of view kwargs (Matt Westcott)
 
 
 5.1.1 (14.08.2023)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -58,6 +58,7 @@ depth: 1
  * Simplify `SnippetViewSet` registration code (Sage Abdullah)
  * Rename groups `IndexView.results_template_name` to `results.html` (Sage Abdullah)
  * Migrate form submission listing checkbox toggling to the shared `w-bulk` Stimulus implementation (LB (Ben) Johnston)
+ * Allow viewsets to define a common set of view kwargs (Matt Westcott)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/viewsets/base.py
+++ b/wagtail/admin/viewsets/base.py
@@ -28,6 +28,26 @@ class ViewSet(WagtailMenuRegisterable):
         for key, value in kwargs.items():
             self.__dict__[key] = value
 
+    def get_common_view_kwargs(self, **kwargs):
+        """
+        Returns a dictionary of keyword arguments to be passed to all views within this viewset.
+        """
+        return kwargs
+
+    def construct_view(self, view_class, **kwargs):
+        """
+        Wrapper for view_class.as_view() which passes the kwargs returned from get_common_view_kwargs
+        in addition to any kwargs passed to this method. Items from get_common_view_kwargs will be
+        filtered to only include those that are valid for the given view_class.
+        """
+        filtered_kwargs = {
+            key: value
+            for key, value in self.get_common_view_kwargs().items()
+            if hasattr(view_class, key)
+        }
+        filtered_kwargs.update(kwargs)
+        return view_class.as_view(**filtered_kwargs)
+
     @cached_property
     def url_prefix(self):
         """

--- a/wagtail/admin/viewsets/chooser.py
+++ b/wagtail/admin/viewsets/chooser.py
@@ -87,70 +87,51 @@ class ChooserViewSet(ViewSet):
         if self.page_title is None:
             self.page_title = self.choose_one_text
 
+    def get_common_view_kwargs(self, **kwargs):
+        return super().get_common_view_kwargs(
+            **{
+                "model": self.model,
+                "permission_policy": self.permission_policy,
+                "preserve_url_parameters": self.preserve_url_parameters,
+                "create_action_label": self.create_action_label,
+                "create_action_clicked_label": self.create_action_clicked_label,
+                "creation_form_class": self.creation_form_class,
+                "form_fields": self.form_fields,
+                "exclude_form_fields": self.exclude_form_fields,
+                "chosen_url_name": self.get_url_name("chosen"),
+                "chosen_multiple_url_name": self.get_url_name("chosen_multiple"),
+                "results_url_name": self.get_url_name("choose_results"),
+                "create_url_name": self.get_url_name("create"),
+                "per_page": self.per_page,
+                **kwargs,
+            }
+        )
+
     @property
     def choose_view(self):
-        return self.choose_view_class.as_view(
-            model=self.model,
-            chosen_url_name=self.get_url_name("chosen"),
-            chosen_multiple_url_name=self.get_url_name("chosen_multiple"),
-            results_url_name=self.get_url_name("choose_results"),
-            create_url_name=self.get_url_name("create"),
+        return self.construct_view(
+            self.choose_view_class,
             icon=self.icon,
             page_title=self.page_title,
-            per_page=self.per_page,
-            creation_form_class=self.creation_form_class,
-            form_fields=self.form_fields,
-            exclude_form_fields=self.exclude_form_fields,
             search_tab_label=self.search_tab_label,
             creation_tab_label=self.creation_tab_label,
-            create_action_label=self.create_action_label,
-            create_action_clicked_label=self.create_action_clicked_label,
-            permission_policy=self.permission_policy,
-            preserve_url_parameters=self.preserve_url_parameters,
         )
 
     @property
     def choose_results_view(self):
-        return self.choose_results_view_class.as_view(
-            model=self.model,
-            chosen_url_name=self.get_url_name("chosen"),
-            chosen_multiple_url_name=self.get_url_name("chosen_multiple"),
-            results_url_name=self.get_url_name("choose_results"),
-            per_page=self.per_page,
-            creation_form_class=self.creation_form_class,
-            form_fields=self.form_fields,
-            exclude_form_fields=self.exclude_form_fields,
-            create_action_label=self.create_action_label,
-            create_action_clicked_label=self.create_action_clicked_label,
-            permission_policy=self.permission_policy,
-            preserve_url_parameters=self.preserve_url_parameters,
-        )
+        return self.construct_view(self.choose_results_view_class)
 
     @property
     def chosen_view(self):
-        return self.chosen_view_class.as_view(
-            model=self.model,
-        )
+        return self.construct_view(self.chosen_view_class)
 
     @property
     def chosen_multiple_view(self):
-        return self.chosen_multiple_view_class.as_view(
-            model=self.model,
-        )
+        return self.construct_view(self.chosen_multiple_view_class)
 
     @property
     def create_view(self):
-        return self.create_view_class.as_view(
-            model=self.model,
-            create_url_name=self.get_url_name("create"),
-            creation_form_class=self.creation_form_class,
-            form_fields=self.form_fields,
-            exclude_form_fields=self.exclude_form_fields,
-            create_action_label=self.create_action_label,
-            create_action_clicked_label=self.create_action_clicked_label,
-            permission_policy=self.permission_policy,
-            preserve_url_parameters=self.preserve_url_parameters,
-        )
+        return self.construct_view(self.create_view_class)
 
     @cached_property
     def model_name(self):

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -75,15 +75,17 @@ class ModelViewSet(ViewSet):
 
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(
-            model=self.model,
-            permission_policy=self.permission_policy,
-            index_url_name=self.get_url_name("index"),
-            index_results_url_name=self.get_url_name("index_results"),
-            add_url_name=self.get_url_name("add"),
-            edit_url_name=self.get_url_name("edit"),
-            delete_url_name=self.get_url_name("delete"),
-            header_icon=self.icon,
-            **kwargs,
+            **{
+                "model": self.model,
+                "permission_policy": self.permission_policy,
+                "index_url_name": self.get_url_name("index"),
+                "index_results_url_name": self.get_url_name("index_results"),
+                "add_url_name": self.get_url_name("add"),
+                "edit_url_name": self.get_url_name("edit"),
+                "delete_url_name": self.get_url_name("delete"),
+                "header_icon": self.icon,
+                **kwargs,
+            }
         )
 
     def get_index_view_kwargs(self, **kwargs):

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -73,17 +73,23 @@ class ModelViewSet(ViewSet):
         """
         return self.model_name
 
+    def get_common_view_kwargs(self, **kwargs):
+        return super().get_common_view_kwargs(
+            model=self.model,
+            permission_policy=self.permission_policy,
+            index_url_name=self.get_url_name("index"),
+            index_results_url_name=self.get_url_name("index_results"),
+            add_url_name=self.get_url_name("add"),
+            edit_url_name=self.get_url_name("edit"),
+            delete_url_name=self.get_url_name("delete"),
+            header_icon=self.icon,
+            **kwargs,
+        )
+
     def get_index_view_kwargs(self, **kwargs):
         return {
-            "model": self.model,
-            "permission_policy": self.permission_policy,
             "template_name": self.index_template_name,
             "results_template_name": self.index_results_template_name,
-            "index_url_name": self.get_url_name("index"),
-            "index_results_url_name": self.get_url_name("index_results"),
-            "add_url_name": self.get_url_name("add"),
-            "edit_url_name": self.get_url_name("edit"),
-            "header_icon": self.icon,
             "list_display": self.list_display,
             "list_filter": self.list_filter,
             "list_export": self.list_export,
@@ -99,70 +105,48 @@ class ModelViewSet(ViewSet):
 
     def get_add_view_kwargs(self, **kwargs):
         return {
-            "model": self.model,
-            "permission_policy": self.permission_policy,
             "form_class": self.get_form_class(),
             "template_name": self.create_template_name,
-            "index_url_name": self.get_url_name("index"),
-            "add_url_name": self.get_url_name("add"),
-            "edit_url_name": self.get_url_name("edit"),
-            "header_icon": self.icon,
             **kwargs,
         }
 
     def get_edit_view_kwargs(self, **kwargs):
         return {
-            "model": self.model,
-            "permission_policy": self.permission_policy,
             "form_class": self.get_form_class(for_update=True),
             "template_name": self.edit_template_name,
-            "index_url_name": self.get_url_name("index"),
-            "edit_url_name": self.get_url_name("edit"),
-            "delete_url_name": self.get_url_name("delete"),
-            "header_icon": self.icon,
             **kwargs,
         }
 
     def get_delete_view_kwargs(self, **kwargs):
         return {
-            "model": self.model,
-            "permission_policy": self.permission_policy,
             "template_name": self.delete_template_name,
-            "index_url_name": self.get_url_name("index"),
-            "delete_url_name": self.get_url_name("delete"),
-            "header_icon": self.icon,
             **kwargs,
         }
 
     @property
     def index_view(self):
-        return self.index_view_class.as_view(
-            **self.get_index_view_kwargs(),
+        return self.construct_view(
+            self.index_view_class, **self.get_index_view_kwargs()
         )
 
     @property
     def index_results_view(self):
-        return self.index_view_class.as_view(
-            **self.get_index_view_kwargs(),
-            results_only=True,
+        return self.construct_view(
+            self.index_view_class, **self.get_index_view_kwargs(), results_only=True
         )
 
     @property
     def add_view(self):
-        return self.add_view_class.as_view(
-            **self.get_add_view_kwargs(),
-        )
+        return self.construct_view(self.add_view_class, **self.get_add_view_kwargs())
 
     @property
     def edit_view(self):
-        return self.edit_view_class.as_view(
-            **self.get_edit_view_kwargs(),
-        )
+        return self.construct_view(self.edit_view_class, **self.get_edit_view_kwargs())
 
     @property
     def delete_view(self):
-        return self.delete_view_class.as_view(
-            **self.get_delete_view_kwargs(),
+        return self.construct_view(
+            self.delete_view_class, **self.get_delete_view_kwargs()
         )
 
     def get_templates(self, name="index", fallback=""):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -823,23 +823,21 @@ class SnippetViewSet(ModelViewSet):
 
     @property
     def usage_view(self):
-        return self.usage_view_class.as_view(
-            model=self.model,
+        return self.construct_view(
+            self.usage_view_class,
             template_name=self.get_templates(
                 "usage", fallback=self.usage_view_class.template_name
             ),
-            header_icon=self.icon,
-            permission_policy=self.permission_policy,
             index_url_name=self.get_url_name("list"),
             edit_url_name=self.get_url_name("edit"),
         )
 
     @property
     def history_view(self):
-        return self.history_view_class.as_view(
-            model=self.model,
+        return self.construct_view(
+            self.history_view_class,
             template_name=self.get_history_template(),
-            permission_policy=self.permission_policy,
+            header_icon="history",
             index_url_name=self.get_url_name("list"),
             edit_url_name=self.get_url_name("edit"),
             revisions_view_url_name=self.get_url_name("revisions_view"),
@@ -850,10 +848,9 @@ class SnippetViewSet(ModelViewSet):
 
     @property
     def inspect_view(self):
-        return self.inspect_view_class.as_view(
-            model=self.model,
+        return self.construct_view(
+            self.inspect_view_class,
             template_name=self.get_inspect_template(),
-            permission_policy=self.permission_policy,
             edit_url_name=self.get_url_name("edit"),
             delete_url_name=self.get_url_name("delete"),
             fields=self.inspect_view_fields,
@@ -862,10 +859,7 @@ class SnippetViewSet(ModelViewSet):
 
     @property
     def revisions_view(self):
-        return self.revisions_view_class.as_view(
-            model=self.model,
-            permission_policy=self.permission_policy,
-        )
+        return self.construct_view(self.revisions_view_class)
 
     @property
     def revisions_revert_view(self):
@@ -877,29 +871,25 @@ class SnippetViewSet(ModelViewSet):
 
     @property
     def revisions_compare_view(self):
-        return self.revisions_compare_view_class.as_view(
-            model=self.model,
+        return self.construct_view(
+            self.revisions_compare_view_class,
             edit_handler=self._edit_handler,
             template_name=self.get_templates(
                 "revisions_compare",
                 fallback=self.revisions_compare_view_class.template_name,
             ),
-            header_icon=self.icon,
-            permission_policy=self.permission_policy,
             edit_url_name=self.get_url_name("edit"),
             history_url_name=self.get_url_name("history"),
         )
 
     @property
     def revisions_unschedule_view(self):
-        return self.revisions_unschedule_view_class.as_view(
-            model=self.model,
+        return self.construct_view(
+            self.revisions_unschedule_view_class,
             template_name=self.get_templates(
                 "revisions_unschedule",
                 fallback=self.revisions_unschedule_view_class.template_name,
             ),
-            header_icon=self.icon,
-            permission_policy=self.permission_policy,
             edit_url_name=self.get_url_name("edit"),
             history_url_name=self.get_url_name("history"),
             revisions_unschedule_url_name=self.get_url_name("revisions_unschedule"),
@@ -907,13 +897,11 @@ class SnippetViewSet(ModelViewSet):
 
     @property
     def unpublish_view(self):
-        return self.unpublish_view_class.as_view(
-            model=self.model,
+        return self.construct_view(
+            self.unpublish_view_class,
             template_name=self.get_templates(
                 "unpublish", fallback=self.unpublish_view_class.template_name
             ),
-            header_icon=self.icon,
-            permission_policy=self.permission_policy,
             index_url_name=self.get_url_name("list"),
             edit_url_name=self.get_url_name("edit"),
             unpublish_url_name=self.get_url_name("unpublish"),
@@ -922,68 +910,64 @@ class SnippetViewSet(ModelViewSet):
 
     @property
     def preview_on_add_view(self):
-        return self.preview_on_add_view_class.as_view(
-            model=self.model,
+        return self.construct_view(
+            self.preview_on_add_view_class,
             form_class=self.get_form_class(),
         )
 
     @property
     def preview_on_edit_view(self):
-        return self.preview_on_edit_view_class.as_view(
-            model=self.model,
+        return self.construct_view(
+            self.preview_on_edit_view_class,
             form_class=self.get_form_class(for_update=True),
         )
 
     @property
     def lock_view(self):
-        return self.lock_view_class.as_view(
-            model=self.model,
-            permission_policy=self.permission_policy,
+        return self.construct_view(
+            self.lock_view_class,
             success_url_name=self.get_url_name("edit"),
         )
 
     @property
     def unlock_view(self):
-        return self.unlock_view_class.as_view(
-            model=self.model,
-            permission_policy=self.permission_policy,
+        return self.construct_view(
+            self.unlock_view_class,
             success_url_name=self.get_url_name("edit"),
         )
 
     @property
     def workflow_action_view(self):
-        return self.workflow_action_view_class.as_view(
-            model=self.model,
+        return self.construct_view(
+            self.workflow_action_view_class,
             redirect_url_name=self.get_url_name("edit"),
             submit_url_name=self.get_url_name("workflow_action"),
         )
 
     @property
     def collect_workflow_action_data_view(self):
-        return self.collect_workflow_action_data_view_class.as_view(
-            model=self.model,
+        return self.construct_view(
+            self.collect_workflow_action_data_view_class,
             redirect_url_name=self.get_url_name("edit"),
             submit_url_name=self.get_url_name("collect_workflow_action_data"),
         )
 
     @property
     def confirm_workflow_cancellation_view(self):
-        return self.confirm_workflow_cancellation_view_class.as_view(model=self.model)
+        return self.construct_view(self.confirm_workflow_cancellation_view_class)
 
     @property
     def workflow_preview_view(self):
-        return self.workflow_preview_view_class.as_view(model=self.model)
+        return self.construct_view(self.workflow_preview_view_class)
 
     @property
     def workflow_history_view(self):
-        return self.workflow_history_view_class.as_view(
-            model=self.model,
+        return self.construct_view(
+            self.workflow_history_view_class,
             template_name=self.get_templates(
                 "workflow_history/index",
                 fallback=self.workflow_history_view_class.template_name,
             ),
-            header_icon=self.icon,
-            permission_policy=self.permission_policy,
             workflow_history_url_name=self.get_url_name("workflow_history"),
             workflow_history_detail_url_name=self.get_url_name(
                 "workflow_history_detail"
@@ -992,14 +976,14 @@ class SnippetViewSet(ModelViewSet):
 
     @property
     def workflow_history_detail_view(self):
-        return self.workflow_history_detail_view_class.as_view(
-            model=self.model,
+        return self.construct_view(
+            self.workflow_history_detail_view_class,
             template_name=self.get_templates(
                 "workflow_history/detail",
                 fallback=self.workflow_history_detail_view_class.template_name,
             ),
             object_icon=self.icon,
-            permission_policy=self.permission_policy,
+            header_icon="list-ul",
             workflow_history_url_name=self.get_url_name("workflow_history"),
         )
 

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -779,19 +779,35 @@ class SnippetViewSet(ModelViewSet):
     def permission_policy(self):
         return ModelPermissionPolicy(self.model)
 
+    def get_common_view_kwargs(self, **kwargs):
+        return super().get_common_view_kwargs(
+            **{
+                "index_url_name": self.get_url_name("list"),
+                "index_results_url_name": self.get_url_name("list_results"),
+                "usage_url_name": self.get_url_name("usage"),
+                "history_url_name": self.get_url_name("history"),
+                "lock_url_name": self.get_url_name("lock"),
+                "unlock_url_name": self.get_url_name("unlock"),
+                "revisions_view_url_name": self.get_url_name("revisions_view"),
+                "revisions_revert_url_name": self.get_url_name("revisions_revert"),
+                "revisions_compare_url_name": self.get_url_name("revisions_compare"),
+                "revisions_unschedule_url_name": self.get_url_name(
+                    "revisions_unschedule"
+                ),
+                "unpublish_url_name": self.get_url_name("unpublish"),
+                **kwargs,
+            }
+        )
+
     def get_index_view_kwargs(self, **kwargs):
         return super().get_index_view_kwargs(
             queryset=self.get_queryset,
-            index_url_name=self.get_url_name("list"),
-            index_results_url_name=self.get_url_name("list_results"),
-            delete_url_name=self.get_url_name("delete"),
             **kwargs,
         )
 
     def get_add_view_kwargs(self, **kwargs):
         return super().get_add_view_kwargs(
             panel=self._edit_handler,
-            index_url_name=self.get_url_name("list"),
             preview_url_name=self.get_url_name("preview_on_add"),
             **kwargs,
         )
@@ -799,25 +815,11 @@ class SnippetViewSet(ModelViewSet):
     def get_edit_view_kwargs(self, **kwargs):
         return super().get_edit_view_kwargs(
             panel=self._edit_handler,
-            index_url_name=self.get_url_name("list"),
-            history_url_name=self.get_url_name("history"),
             preview_url_name=self.get_url_name("preview_on_edit"),
-            lock_url_name=self.get_url_name("lock"),
-            unlock_url_name=self.get_url_name("unlock"),
-            usage_url_name=self.get_url_name("usage"),
-            revisions_compare_url_name=self.get_url_name("revisions_compare"),
-            revisions_unschedule_url_name=self.get_url_name("revisions_unschedule"),
             workflow_history_url_name=self.get_url_name("workflow_history"),
             confirm_workflow_cancellation_url_name=self.get_url_name(
                 "confirm_workflow_cancellation"
             ),
-            **kwargs,
-        )
-
-    def get_delete_view_kwargs(self, **kwargs):
-        return super().get_delete_view_kwargs(
-            index_url_name=self.get_url_name("list"),
-            usage_url_name=self.get_url_name("usage"),
             **kwargs,
         )
 
@@ -828,8 +830,6 @@ class SnippetViewSet(ModelViewSet):
             template_name=self.get_templates(
                 "usage", fallback=self.usage_view_class.template_name
             ),
-            index_url_name=self.get_url_name("list"),
-            edit_url_name=self.get_url_name("edit"),
         )
 
     @property
@@ -838,12 +838,6 @@ class SnippetViewSet(ModelViewSet):
             self.history_view_class,
             template_name=self.get_history_template(),
             header_icon="history",
-            index_url_name=self.get_url_name("list"),
-            edit_url_name=self.get_url_name("edit"),
-            revisions_view_url_name=self.get_url_name("revisions_view"),
-            revisions_revert_url_name=self.get_url_name("revisions_revert"),
-            revisions_compare_url_name=self.get_url_name("revisions_compare"),
-            revisions_unschedule_url_name=self.get_url_name("revisions_unschedule"),
         )
 
     @property
@@ -851,8 +845,6 @@ class SnippetViewSet(ModelViewSet):
         return self.construct_view(
             self.inspect_view_class,
             template_name=self.get_inspect_template(),
-            edit_url_name=self.get_url_name("edit"),
-            delete_url_name=self.get_url_name("delete"),
             fields=self.inspect_view_fields,
             fields_exclude=self.inspect_view_fields_exclude,
         )
@@ -866,7 +858,6 @@ class SnippetViewSet(ModelViewSet):
         return self.construct_view(
             self.revisions_revert_view_class,
             **self.get_edit_view_kwargs(),
-            revisions_revert_url_name=self.get_url_name("revisions_revert"),
         )
 
     @property
@@ -878,8 +869,6 @@ class SnippetViewSet(ModelViewSet):
                 "revisions_compare",
                 fallback=self.revisions_compare_view_class.template_name,
             ),
-            edit_url_name=self.get_url_name("edit"),
-            history_url_name=self.get_url_name("history"),
         )
 
     @property
@@ -890,9 +879,6 @@ class SnippetViewSet(ModelViewSet):
                 "revisions_unschedule",
                 fallback=self.revisions_unschedule_view_class.template_name,
             ),
-            edit_url_name=self.get_url_name("edit"),
-            history_url_name=self.get_url_name("history"),
-            revisions_unschedule_url_name=self.get_url_name("revisions_unschedule"),
         )
 
     @property
@@ -902,10 +888,6 @@ class SnippetViewSet(ModelViewSet):
             template_name=self.get_templates(
                 "unpublish", fallback=self.unpublish_view_class.template_name
             ),
-            index_url_name=self.get_url_name("list"),
-            edit_url_name=self.get_url_name("edit"),
-            unpublish_url_name=self.get_url_name("unpublish"),
-            usage_url_name=self.get_url_name("usage"),
         )
 
     @property

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -869,7 +869,8 @@ class SnippetViewSet(ModelViewSet):
 
     @property
     def revisions_revert_view(self):
-        return self.revisions_revert_view_class.as_view(
+        return self.construct_view(
+            self.revisions_revert_view_class,
             **self.get_edit_view_kwargs(),
             revisions_revert_url_name=self.get_url_name("revisions_revert"),
         )


### PR DESCRIPTION
Simplify ModelViewSet, SnippetViewSet and ChooserViewSet by adding helper methods to the base ViewSet allowing us to specify a set of common kwargs that will be passed to all views (with a filtering step to ensure that those kwargs are actually accepted).

This is a scaled-back version of the pattern proposed in [RFC 87](https://github.com/wagtail/rfcs/pull/87) without the metaclass / `__init_subclass__` magic to auto-generate the get_foo_view_kwargs / foo_view methods.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
