### PR TITLE
Support overriding get_object_list from ChooserViewSet

### DIFF
--- a/wagtail/admin/tests/viewsets/test_chooser_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_chooser_viewset.py
@@ -1,0 +1,22 @@
+import json
+
+from django.test import TestCase
+
+from wagtail.test.testapp.models import Advert
+from wagtail.test.utils.wagtail_tests import WagtailTestUtils
+
+
+class TestChooserViewSetWithFilteredObjects(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.user = self.login()
+
+        Advert.objects.create(text="Head On, apply directly to the forehead")
+
+        advert2 = Advert.objects.create(text="We like the subs")
+        advert2.tags.add("animated")
+
+    def test_get(self):
+        response = self.client.get("/admin/animated_advert_chooser/")
+        response_html = json.loads(response.content)["html"]
+        self.assertIn("We like the subs", response_html)
+        self.assertNotIn("Head On, apply directly to the forehead", response_html)

--- a/wagtail/admin/viewsets/chooser.py
+++ b/wagtail/admin/viewsets/chooser.py
@@ -109,8 +109,12 @@ class ChooserViewSet(ViewSet):
 
     @property
     def choose_view(self):
+        view_class = self.inject_view_methods(
+            self.choose_view_class, ["get_object_list"]
+        )
+
         return self.construct_view(
-            self.choose_view_class,
+            view_class,
             icon=self.icon,
             page_title=self.page_title,
             search_tab_label=self.search_tab_label,
@@ -119,7 +123,10 @@ class ChooserViewSet(ViewSet):
 
     @property
     def choose_results_view(self):
-        return self.construct_view(self.choose_results_view_class)
+        view_class = self.inject_view_methods(
+            self.choose_results_view_class, ["get_object_list"]
+        )
+        return self.construct_view(view_class)
 
     @property
     def chosen_view(self):

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -14,9 +14,11 @@ from wagtail.admin.filters import WagtailFilterSet
 from wagtail.admin.ui.tables import BooleanColumn, UpdatedAtColumn
 from wagtail.admin.views.generic import DeleteView, EditView, IndexView
 from wagtail.admin.viewsets.base import ViewSet, ViewSetGroup
+from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.admin.viewsets.model import ModelViewSet, ModelViewSetGroup
 from wagtail.contrib.forms.views import SubmissionsListView
 from wagtail.test.testapp.models import (
+    Advert,
     FeatureCompleteToy,
     JSONBlockCountsStreamModel,
     JSONMinMaxCountStreamModel,
@@ -248,3 +250,16 @@ class ToyViewSetGroup(ModelViewSetGroup):
             search_backend_name=None,
         ),
     )
+
+
+class AnimatedAdvertChooserViewSet(ChooserViewSet):
+    model = Advert
+    register_widget = False  # don't make this the registered widget for Advert
+
+    def get_object_list(self):
+        return Advert.objects.filter(tags__name="animated")
+
+
+animated_advert_chooser_viewset = AnimatedAdvertChooserViewSet(
+    "animated_advert_chooser"
+)

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -34,6 +34,7 @@ from wagtail.test.testapp.views import (
     JSONModelViewSetGroup,
     MiscellaneousViewSetGroup,
     ToyViewSetGroup,
+    animated_advert_chooser_viewset,
 )
 
 from .forms import FavouriteColourForm
@@ -383,3 +384,8 @@ register_snippet(DraftStateModel, viewset=DraftStateModelViewSet)
 register_snippet(ModeratedModelViewSet())
 register_snippet(RevisableViewSetGroup)
 register_snippet(VariousOnDeleteModelViewSet)
+
+
+@hooks.register("register_admin_viewset")
+def register_animated_advert_chooser_viewset():
+    return animated_advert_chooser_viewset


### PR DESCRIPTION
Working proof-of-concept of overriding view methods from a viewset as proposed in [RFC 87](https://github.com/wagtail/rfcs/pull/87).