### PR TITLE
Make ChooserViewSet and IndexView work with pseudo model classes

### DIFF
--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -297,7 +297,7 @@ class CreationFormMixin(ModelLookupMixin, PreserveURLParametersMixin):
     def get_permission_policy(self):
         if self.permission_policy:
             return self.permission_policy
-        elif issubclass(self.model_class, Model):
+        elif self.model_class and issubclass(self.model_class, Model):
             return ModelPermissionPolicy(self.model_class)
         else:
             return BlanketPermissionPolicy(None)

--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -9,6 +9,7 @@ from django.core.exceptions import (
     PermissionDenied,
 )
 from django.core.paginator import InvalidPage, Paginator
+from django.db.models import Model
 from django.forms.models import modelform_factory
 from django.http import Http404
 from django.template.loader import render_to_string
@@ -296,7 +297,7 @@ class CreationFormMixin(ModelLookupMixin, PreserveURLParametersMixin):
     def get_permission_policy(self):
         if self.permission_policy:
             return self.permission_policy
-        elif self.model_class:
+        elif issubclass(self.model_class, Model):
             return ModelPermissionPolicy(self.model_class)
         else:
             return BlanketPermissionPolicy(None)

--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -2,6 +2,7 @@ import datetime
 from decimal import Decimal
 
 from django import forms
+from django.db.models import Model
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms.fields import CallableChoiceIterator
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
@@ -831,7 +832,7 @@ class ChooserBlock(FieldBlock):
         return super().clean(value)
 
     def extract_references(self, value):
-        if value is not None:
+        if value is not None and issubclass(self.model_class, Model):
             yield self.model_class, str(value.pk), "", ""
 
     class Meta:

--- a/wagtail/coreutils.py
+++ b/wagtail/coreutils.py
@@ -82,7 +82,7 @@ def resolve_model_string(model_string, default_app=None):
 
         return apps.get_model(app_label, model_name)
 
-    elif isinstance(model_string, type) and issubclass(model_string, Model):
+    elif isinstance(model_string, type):
         return model_string
 
     else:

--- a/wagtail/tests/tests.py
+++ b/wagtail/tests/tests.py
@@ -520,7 +520,8 @@ class TestResolveModelString(TestCase):
         self.assertRaises(ValueError, resolve_model_string, "Page")
 
     def test_resolve_from_class_that_isnt_a_model(self):
-        self.assertRaises(ValueError, resolve_model_string, object)
+        model = resolve_model_string(object)
+        self.assertEqual(model, object)
 
     def test_resolve_from_bad_type(self):
         self.assertRaises(ValueError, resolve_model_string, resolve_model_string)


### PR DESCRIPTION
The [queryish](https://github.com/wagtail/queryish) package has been created to allow data sources such as Django REST Framework endpoints to replicate the Django queryset API, so that they can act as mostly-drop-in replacements for models on listing views. This PR makes some minimal tweaks to ChooserViewSet and IndexView to allow the duck-typing to work.

Once there's a stable / documented release of queryish out, I'll add that to our testing dependencies and give this some proper test coverage - for now https://github.com/gasman/bakerydemo/tree/pokemon will serve as a proof of concept (using queryish to wrap https://pokeapi.co/).