### PR TITLE
Use `FileResponse` when serving files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -98,6 +98,7 @@ Changelog
  * Maintenance: Add changelog and issue tracker links to the PyPI project page (Panagiotis H.M. Issaris)
  * Maintenance: Add better deprecation warnings to the `search.Query` & `search.QueryDailyHits` model, move final set of templates from the admin search module to the search promotions contrib module (LB (Ben) Johnston)
  * Maintenance: Add generic `InspectView` to `ModelViewSet` (Sage Abdullah)
+ * Maintenance: Use Django's `FileResponse` when serving files such as Images or Documents (Jake Howard)
 
 5.1.3 (xx.xx.20xx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~~~

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -121,7 +121,7 @@ depth: 1
  * Add changelog and issue tracker links to the PyPI project page (Panagiotis H.M. Issaris)
  * Add better deprecation warnings to the `search.Query` & `search.QueryDailyHits` model, move final set of templates from the admin search module to the search promotions contrib module (LB (Ben) Johnston)
  * Add generic `InspectView` to `ModelViewSet` (Sage Abdullah)
-
+ * Use Django's `FileResponse` when serving files such as Images or Documents (Jake Howard)
 
 ## Upgrade considerations - changes affecting all projects
 

--- a/wagtail/documents/tests/test_views.py
+++ b/wagtail/documents/tests/test_views.py
@@ -1,7 +1,6 @@
 import os.path
 import unittest
 import urllib
-from io import StringIO
 from unittest import mock
 
 from django.conf import settings
@@ -18,11 +17,11 @@ class TestServeView(TestCase):
     def setUp(self):
         self.document = models.Document(title="Test document", file_hash="123456")
         self.document.file.save(
-            "serve_view.doc", ContentFile("A boring example document")
+            "serve_view.doc", ContentFile(b"A boring example document")
         )
         self.pdf_document = models.Document(title="Test document", file_hash="123456")
         self.pdf_document.file.save(
-            "serve_view.pdf", ContentFile("A boring example document")
+            "serve_view.pdf", ContentFile(b"A boring example document")
         )
 
     def tearDown(self):
@@ -74,10 +73,9 @@ class TestServeView(TestCase):
         mock_doc.filename = self.document.filename
         mock_doc.content_type = self.document.content_type
         mock_doc.content_disposition = self.document.content_disposition
-        mock_doc.file = StringIO("file-like object" * 10)
+        mock_doc.file = ContentFile(b"file-like object" * 10)
         mock_doc.file.path = None
         mock_doc.file.url = None
-        mock_doc.file.size = 30
         mock_get_object_or_404.return_value = mock_doc
 
         # Bypass 'before_serve_document' hooks
@@ -108,10 +106,9 @@ class TestServeView(TestCase):
         mock_doc.filename = self.pdf_document.filename
         mock_doc.content_type = self.pdf_document.content_type
         mock_doc.content_disposition = self.pdf_document.content_disposition
-        mock_doc.file = StringIO("file-like object" * 10)
+        mock_doc.file = ContentFile(b"file-like object" * 10)
         mock_doc.file.path = None
         mock_doc.file.url = None
-        mock_doc.file.size = 30
         mock_get_object_or_404.return_value = mock_doc
 
         # Bypass 'before_serve_document' hooks
@@ -384,10 +381,9 @@ class TestServeWithUnicodeFilename(TestCase):
         # Create a mock document to hit the correct code path.
         mock_doc = mock.Mock()
         mock_doc.filename = "TÈST.doc"
-        mock_doc.file = StringIO("file-like object" * 10)
+        mock_doc.file = ContentFile(b"file-like object" * 10)
         mock_doc.file.path = None
         mock_doc.file.url = None
-        mock_doc.file.size = 30
         mock_get_object_or_404.return_value = mock_doc
 
         # Bypass 'before_serve_document' hooks

--- a/wagtail/documents/views/serve.py
+++ b/wagtail/documents/views/serve.py
@@ -1,7 +1,5 @@
-from wsgiref.util import FileWrapper
-
 from django.conf import settings
-from django.http import Http404, HttpResponse, StreamingHttpResponse
+from django.http import FileResponse, Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -98,10 +96,8 @@ def serve(request, document_id, document_filename):
         # (e.g. storages.backends.s3boto.S3BotoStorage) AND the developer has not allowed
         # redirecting to the file url directly.
         # Fall back on pre-sendfile behaviour of reading the file content and serving it
-        # as a StreamingHttpResponse
-
-        wrapper = FileWrapper(doc.file)
-        response = StreamingHttpResponse(wrapper, doc.content_type)
+        # as a FileResponse
+        response = FileResponse(doc.file, doc.content_type)
 
         # set filename and filename* to handle non-ascii characters in filename
         # see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition

--- a/wagtail/images/views/serve.py
+++ b/wagtail/images/views/serve.py
@@ -64,8 +64,7 @@ class ServeView(View):
         with rendition.get_willow_image() as willow_image:
             mime_type = willow_image.mime_type
 
-        # Open and serve the file
-        rendition.file.open("rb")
+        # Serve the file
         return FileResponse(rendition.file, content_type=mime_type)
 
     def redirect(self, rendition):

--- a/wagtail/images/views/serve.py
+++ b/wagtail/images/views/serve.py
@@ -1,7 +1,5 @@
-from wsgiref.util import FileWrapper
-
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
-from django.http import HttpResponse, StreamingHttpResponse
+from django.http import FileResponse, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils.decorators import classonlymethod, method_decorator
@@ -68,9 +66,7 @@ class ServeView(View):
 
         # Open and serve the file
         rendition.file.open("rb")
-        return StreamingHttpResponse(
-            FileWrapper(rendition.file), content_type=mime_type
-        )
+        return FileResponse(rendition.file, content_type=mime_type)
 
     def redirect(self, rendition):
         # Redirect to the file's public location

--- a/wagtail/utils/sendfile_streaming_backend.py
+++ b/wagtail/utils/sendfile_streaming_backend.py
@@ -4,9 +4,8 @@
 import os
 import stat
 from email.utils import mktime_tz, parsedate_tz
-from wsgiref.util import FileWrapper
 
-from django.http import HttpResponseNotModified, StreamingHttpResponse
+from django.http import FileResponse, HttpResponseNotModified
 from django.utils.http import http_date
 
 
@@ -20,7 +19,7 @@ def sendfile(request, filename, **kwargs):
     ):
         return HttpResponseNotModified()
 
-    response = StreamingHttpResponse(FileWrapper(open(filename, "rb")))
+    response = FileResponse(open(filename, "rb"))
 
     response["Last-Modified"] = http_date(statobj[stat.ST_MTIME])
     return response


### PR DESCRIPTION
_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For new features: Has the documentation been updated accordingly?

`FileResponse` is already tuned and intended for serving files - so we should use it.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
