### PR TITLE
Linked fields mechanism for limiting choices in a chooser

### DIFF
--- a/client/src/components/ChooserWidget/index.js
+++ b/client/src/components/ChooserWidget/index.js
@@ -127,6 +127,34 @@ export class Chooser {
   }
 
   getModalOptions() {
+    const filters = {};
+    if (this.opts.linkedFields) {
+      for (const [param, lookup] of Object.entries(this.opts.linkedFields)) {
+        let val;
+        if (typeof lookup === 'string') {
+          val = document.querySelector(lookup).value;
+        } else if (lookup.id) {
+          val = document.getElementById(lookup.id).value;
+        } else if (lookup.selector) {
+          val = document.querySelector(lookup.selector).value;
+        } else if (lookup.match && this.chooserElement.id) {
+          const match = this.chooserElement.id.match(new RegExp(lookup.match));
+          if (match) {
+            let id = match[0];
+            if (lookup.append) {
+              id += lookup.append;
+            }
+            val = document.getElementById(id).value;
+          }
+        }
+        if (val) {
+          filters[param] = val;
+        }
+      }
+    }
+    if (Object.keys(filters).length) {
+      return { linkedFieldFilters: filters };
+    }
     return null;
   }
 

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -353,6 +353,9 @@ class ChooserModal {
     if (opts.multiple) {
       urlParams.multiple = 1;
     }
+    if (opts.linkedFieldFilters) {
+      Object.assign(urlParams, opts.linkedFieldFilters);
+    }
     return urlParams;
   }
 

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -128,6 +128,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: edit_item_text
    .. autoattribute:: per_page
    .. autoattribute:: preserve_url_parameters
+   .. autoattribute:: url_filter_parameters
    .. autoattribute:: choose_view_class
    .. autoattribute:: choose_results_view_class
    .. autoattribute:: chosen_view_class

--- a/wagtail/admin/templates/wagtailadmin/generic/chooser/results.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/chooser/results.html
@@ -26,7 +26,7 @@
         {% endblock %}
     {% else %}
         {% block no_items_message %}
-            <p>{% trans "No items have been created." %}</p>
+            <p>{% trans "There are no results." %}</p>
         {% endblock %}
     {% endif %}
 {% endif %}

--- a/wagtail/admin/tests/viewsets/test_chooser_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_chooser_viewset.py
@@ -12,7 +12,9 @@ class TestChooserViewSetWithFilteredObjects(WagtailTestUtils, TestCase):
 
         Advert.objects.create(text="Head On, apply directly to the forehead")
 
-        advert2 = Advert.objects.create(text="We like the subs")
+        advert2 = Advert.objects.create(
+            url="https://quiznos.com", text="We like the subs"
+        )
         advert2.tags.add("animated")
 
     def test_get(self):
@@ -20,3 +22,16 @@ class TestChooserViewSetWithFilteredObjects(WagtailTestUtils, TestCase):
         response_html = json.loads(response.content)["html"]
         self.assertIn("We like the subs", response_html)
         self.assertNotIn("Head On, apply directly to the forehead", response_html)
+
+    def test_filter_by_url(self):
+        response = self.client.get(
+            "/admin/animated_advert_chooser/", {"url": "https://quiznos.com"}
+        )
+        response_html = json.loads(response.content)["html"]
+        self.assertIn("We like the subs", response_html)
+
+        response = self.client.get(
+            "/admin/animated_advert_chooser/", {"url": "https://subway.com"}
+        )
+        response_html = json.loads(response.content)["html"]
+        self.assertNotIn("We like the subs", response_html)

--- a/wagtail/admin/tests/viewsets/test_chooser_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_chooser_viewset.py
@@ -2,7 +2,9 @@ import json
 
 from django.test import TestCase
 
+from wagtail.admin import widgets
 from wagtail.test.testapp.models import Advert
+from wagtail.test.testapp.views import AdvertChooserWidget
 from wagtail.test.utils.wagtail_tests import WagtailTestUtils
 
 
@@ -35,3 +37,20 @@ class TestChooserViewSetWithFilteredObjects(WagtailTestUtils, TestCase):
         )
         response_html = json.loads(response.content)["html"]
         self.assertNotIn("We like the subs", response_html)
+
+    def test_adapt_widget_with_linked_fields(self):
+        widget = AdvertChooserWidget(linked_fields={"url": "#id_cool_url"})
+
+        js_args = widgets.BaseChooserAdapter().js_args(widget)
+        self.assertInHTML(
+            """<input id="__ID__" name="__NAME__" type="hidden" />""", js_args[0]
+        )
+        self.assertIn("Choose", js_args[0])
+        self.assertEqual(js_args[1], "__ID__")
+        self.assertEqual(
+            js_args[2],
+            {
+                "modalUrl": "/admin/animated_advert_chooser/",
+                "linkedFields": {"url": "#id_cool_url"},
+            },
+        )

--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -130,6 +130,7 @@ class BaseChooseView(
     template_name = "wagtailadmin/generic/chooser/chooser.html"
     results_template_name = "wagtailadmin/generic/chooser/results.html"
     construct_queryset_hook_name = None
+    url_filter_parameters = []
 
     def get_object_list(self):
         return self.model_class.objects.all()
@@ -174,6 +175,15 @@ class BaseChooseView(
         return FilterForm(self.request.GET)
 
     def filter_object_list(self, objects):
+        filters = {}
+        for filter in self.url_filter_parameters:
+            try:
+                filters[filter] = self.request.GET[filter]
+            except KeyError:
+                pass
+        if filters:
+            objects = objects.filter(**filters)
+
         if self.construct_queryset_hook_name:
             # allow hooks to modify the queryset
             for hook in hooks.get_hooks(self.construct_queryset_hook_name):

--- a/wagtail/admin/viewsets/chooser.py
+++ b/wagtail/admin/viewsets/chooser.py
@@ -35,6 +35,10 @@ class ChooserViewSet(ViewSet):
     #: form submissions within the chooser modal workflow.
     preserve_url_parameters = ["multiple"]
 
+    #: A list of URL query parameters that, if present in the url, should be applied as filters to the queryset.
+    #: (These should also be listed in `preserve_url_parameters`.)
+    url_filter_parameters = []
+
     #: The view class to use for the overall chooser modal; must be a subclass of ``wagtail.admin.views.generic.chooser.ChooseView``.
     choose_view_class = chooser_views.ChooseView
 
@@ -93,6 +97,7 @@ class ChooserViewSet(ViewSet):
                 "model": self.model,
                 "permission_policy": self.permission_policy,
                 "preserve_url_parameters": self.preserve_url_parameters,
+                "url_filter_parameters": self.url_filter_parameters,
                 "create_action_label": self.create_action_label,
                 "create_action_clicked_label": self.create_action_clicked_label,
                 "creation_form_class": self.creation_form_class,

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -32,6 +32,7 @@ class BaseChooser(widgets.Input):
     classname = None
     model = None
     js_constructor = "Chooser"
+    linked_fields = {}
 
     # when looping over form fields, this one should appear in visible_fields, not hidden_fields
     # despite the underlying input being type="hidden"
@@ -39,21 +40,19 @@ class BaseChooser(widgets.Input):
     is_hidden = False
 
     def __init__(self, **kwargs):
-        # allow choose_one_text / choose_another_text to be overridden per-instance
-        if "choose_one_text" in kwargs:
-            self.choose_one_text = kwargs.pop("choose_one_text")
-        if "choose_another_text" in kwargs:
-            self.choose_another_text = kwargs.pop("choose_another_text")
-        if "clear_choice_text" in kwargs:
-            self.clear_choice_text = kwargs.pop("clear_choice_text")
-        if "link_to_chosen_text" in kwargs:
-            self.link_to_chosen_text = kwargs.pop("link_to_chosen_text")
-        if "show_edit_link" in kwargs:
-            self.show_edit_link = kwargs.pop("show_edit_link")
-        if "show_clear_link" in kwargs:
-            self.show_clear_link = kwargs.pop("show_clear_link")
-        if "icon" in kwargs:
-            self.icon = kwargs.pop("icon")
+        # allow attributes to be overridden by kwargs
+        for var in [
+            "choose_one_text",
+            "choose_another_text",
+            "clear_choice_text",
+            "link_to_chosen_text",
+            "show_edit_link",
+            "show_clear_link",
+            "icon",
+            "linked_fields",
+        ]:
+            if var in kwargs:
+                setattr(self, var, kwargs.pop(var))
         super().__init__(**kwargs)
 
     @cached_property
@@ -171,9 +170,12 @@ class BaseChooser(widgets.Input):
     def base_js_init_options(self):
         """The set of options to pass to the JS initialiser that are constant every time this widget
         instance is rendered (i.e. do not vary based on id / name / value)"""
-        return {
+        opts = {
             "modalUrl": self.get_chooser_modal_url(),
         }
+        if self.linked_fields:
+            opts["linkedFields"] = self.linked_fields
+        return opts
 
     def get_js_init_options(self, id_, name, value_data):
         return {**self.base_js_init_options}

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -255,6 +255,8 @@ class ToyViewSetGroup(ModelViewSetGroup):
 class AnimatedAdvertChooserViewSet(ChooserViewSet):
     model = Advert
     register_widget = False  # don't make this the registered widget for Advert
+    url_filter_parameters = ["url"]
+    preserve_url_parameters = ["multiple", "url"]
 
     def get_object_list(self):
         return Advert.objects.filter(tags__name="animated")

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -265,3 +265,5 @@ class AnimatedAdvertChooserViewSet(ChooserViewSet):
 animated_advert_chooser_viewset = AnimatedAdvertChooserViewSet(
     "animated_advert_chooser"
 )
+
+AdvertChooserWidget = animated_advert_chooser_viewset.widget_class


### PR DESCRIPTION
This PR implements the "linked fields" mechanism [first introduced in the wagtail-generic-chooser package](https://github.com/wagtail/wagtail-generic-chooser/#limiting-choices-via-linked-fields) to allow the choices within a chooser modal to be filtered based on the values of other fields on the calling page. For example, a page edit form could have a 'country' dropdown alongside a 'town' chooser widget, which opens up to display just the towns from that country.

This (alongside the support for API-based choosers via queryish) brings Wagtail's ChooserViewSet module to feature parity with the wagtail-generic-chooser package, allowing wagtail-generic-chooser to be retired.