### PR TITLE
Add `BulkController` support for shift+click behaviour

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -52,6 +52,7 @@ Changelog
  * Support extending Wagtail client-side with Stimulus (LB (Ben) Johnston)
  * Update all `FieldPanel('title')` examples to use the recommended `TitleFieldPanel('title')` panel (Chinedu Ihedioha)
  * The `purge_revisions` management command now respects revisions that have a `on_delete=PROTECT` foreign key relation and won't delete them (Neeraj P Yetheendran, Meghana Reddy, Sage Abdullah, Storm Heg)
+ * Add support for Shift + Click behaviour in form submissions and simple tranlations submissions (LB (Ben) Johnston)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)

--- a/client/src/controllers/BulkController.test.js
+++ b/client/src/controllers/BulkController.test.js
@@ -2,9 +2,9 @@ import { Application } from '@hotwired/stimulus';
 import { BulkController } from './BulkController';
 
 describe('BulkController', () => {
-  beforeEach(() => {
-    document.body.innerHTML = `
-    <div id="bulk-container" data-controller="w-bulk">
+  const setup = async (
+    html = `
+    <div id="bulk-container" data-controller="w-bulk" data-action="custom:event@document->w-bulk#toggleAll">
       <input id="select-all" type="checkbox" data-w-bulk-target="all" data-action="w-bulk#toggleAll">
       <div id="checkboxes">
         <input type="checkbox" data-w-bulk-target="item" disabled data-action="w-bulk#toggle">
@@ -13,12 +13,17 @@ describe('BulkController', () => {
       </div>
       <button id="clear" data-action="w-bulk#toggleAll" data-w-bulk-force-param="false">Clear all</button>
       <button id="set" data-action="w-bulk#toggleAll" data-w-bulk-force-param="true">Select all</button>
-    </div>`;
+    </div>`,
+  ) => {
+    document.body.innerHTML = `<main>${html}</main>`;
+
     const application = Application.start();
     application.register('w-bulk', BulkController);
-  });
+  };
 
-  it('selects all checkboxes when the select all checkbox is clicked', () => {
+  it('selects all checkboxes when the select all checkbox is clicked', async () => {
+    await setup();
+
     const allCheckbox = document.getElementById('select-all');
 
     allCheckbox.click();
@@ -38,7 +43,9 @@ describe('BulkController', () => {
     ).toEqual(0);
   });
 
-  it('should keep the select all checkbox in sync when individual checkboxes are all ticked', () => {
+  it('should keep the select all checkbox in sync when individual checkboxes are all ticked', async () => {
+    await setup();
+
     const allCheckbox = document.getElementById('select-all');
     expect(allCheckbox.checked).toBe(false);
 
@@ -63,7 +70,9 @@ describe('BulkController', () => {
     expect(allCheckbox.checked).toBe(false);
   });
 
-  it('executes the correct action when the Clear all button is clicked', () => {
+  it('executes the correct action when the Clear all button is clicked', async () => {
+    await setup();
+
     const allCheckbox = document.getElementById('select-all');
     const clearAllButton = document.getElementById('clear');
     expect(allCheckbox.checked).toBe(false);
@@ -88,7 +97,9 @@ describe('BulkController', () => {
     expect(allCheckbox.checked).toBe(false);
   });
 
-  it('executes the correct action when the Set all button is clicked', () => {
+  it('executes the correct action when the Set all button is clicked', async () => {
+    await setup();
+
     const allCheckbox = document.getElementById('select-all');
     const setAllButton = document.getElementById('set');
 
@@ -115,7 +126,50 @@ describe('BulkController', () => {
     });
   });
 
+  it('should support using another method (e.g. CustomEvent) to toggle all', async () => {
+    await setup();
+
+    const allCheckbox = document.getElementById('select-all');
+    expect(allCheckbox.checked).toBe(false);
+
+    document.dispatchEvent(new CustomEvent('custom:event'));
+
+    expect(allCheckbox.checked).toBe(true);
+    expect(document.querySelectorAll(':checked')).toHaveLength(3);
+
+    // calling again, should switch the toggles back
+
+    document.dispatchEvent(new CustomEvent('custom:event'));
+
+    expect(allCheckbox.checked).toBe(false);
+    expect(document.querySelectorAll(':checked')).toHaveLength(0);
+  });
+
+  it('should support a force value in a CustomEvent to override the select all checkbox', async () => {
+    await setup();
+
+    const allCheckbox = document.getElementById('select-all');
+    expect(allCheckbox.checked).toBe(false);
+
+    document.dispatchEvent(
+      new CustomEvent('custom:event', { detail: { force: true } }),
+    );
+
+    expect(allCheckbox.checked).toBe(true);
+    expect(document.querySelectorAll(':checked')).toHaveLength(3);
+
+    // calling again, should not change the state of the checkboxes
+    document.dispatchEvent(
+      new CustomEvent('custom:event', { detail: { force: true } }),
+    );
+
+    expect(allCheckbox.checked).toBe(true);
+    expect(document.querySelectorAll(':checked')).toHaveLength(3);
+  });
+
   it('should allow for action targets to have classes toggled when any checkboxes are clicked', async () => {
+    await setup();
+
     const container = document.getElementById('bulk-container');
 
     // create innerActions container that will be conditionally hidden with test classes
@@ -150,5 +204,106 @@ describe('BulkController', () => {
     firstCheckbox.click();
 
     expect(innerActionsElement.className).toEqual('keep-me hidden w-invisible');
+  });
+
+  it('should support shift+click to select a range of checkboxes', async () => {
+    await setup(`
+    <div id="bulk-container-multi" data-controller="w-bulk">
+      <input id="select-all-multi" type="checkbox" data-w-bulk-target="all" data-action="w-bulk#toggleAll">
+      <div id="checkboxes">
+        <input id="c0" type="checkbox" data-w-bulk-target="item" data-action="w-bulk#toggle">
+        <input id="c1" type="checkbox" data-w-bulk-target="item" data-action="w-bulk#toggle">
+        <input id="cx" type="checkbox" data-w-bulk-target="item" data-action="w-bulk#toggle" disabled>
+        <input id="c2" type="checkbox" data-w-bulk-target="item" data-action="w-bulk#toggle">
+        <input id="c3" type="checkbox" data-w-bulk-target="item" data-action="w-bulk#toggle">
+        <input id="c4" type="checkbox" data-w-bulk-target="item" data-action="w-bulk#toggle">
+        <input id="c5" type="checkbox" data-w-bulk-target="item" data-action="w-bulk#toggle">
+      </div>
+    </div>`);
+
+    const getClickedIds = () =>
+      Array.from(document.querySelectorAll(':checked')).map(({ id }) => id);
+
+    const shiftClick = async (element) => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Shift',
+          shiftKey: true,
+        }),
+      );
+      element.click();
+      document.dispatchEvent(
+        new KeyboardEvent('keyup', {
+          key: 'Shift',
+          shiftKey: true,
+        }),
+      );
+      await Promise.resolve();
+    };
+
+    // initial shift usage should have no impact
+    await shiftClick(document.getElementById('c0'));
+    expect(getClickedIds()).toHaveLength(1);
+
+    // shift click should select all checkboxes between the first and last clicked
+    await shiftClick(document.getElementById('c2'));
+    expect(getClickedIds()).toEqual(['c0', 'c1', 'c2']);
+
+    await shiftClick(document.getElementById('c5'));
+    expect(getClickedIds()).toEqual([
+      'select-all-multi',
+      'c0',
+      'c1',
+      'c2',
+      'c3',
+      'c4',
+      'c5',
+    ]);
+
+    // it should allow reverse clicks
+    document.getElementById('c4').click(); // un-click
+    expect(getClickedIds()).toEqual(['c0', 'c1', 'c2', 'c3', 'c5']);
+
+    // now shift click in reverse, un-clicking those between the last (4) and the new click (1)
+    await shiftClick(document.getElementById('c1'));
+    expect(getClickedIds()).toEqual(['c0', 'c5']);
+
+    // reset the clicks, then using shift click should do nothing
+    document.getElementById('select-all-multi').click();
+    document.getElementById('select-all-multi').click();
+    expect(getClickedIds()).toHaveLength(0);
+
+    await shiftClick(document.getElementById('c4'));
+    expect(getClickedIds()).toEqual(['c4']);
+
+    // finally, do a shift click to the first checkbox, check the select all works after a final click
+    await shiftClick(document.getElementById('c0'));
+    expect(getClickedIds()).toEqual(['c0', 'c1', 'c2', 'c3', 'c4']);
+
+    document.getElementById('c5').click();
+
+    expect(getClickedIds()).toEqual([
+      'select-all-multi',
+      'c0',
+      'c1',
+      'c2',
+      'c3',
+      'c4',
+      'c5',
+    ]);
+
+    // now ensure that it still works if some element gets changed (not disabled)
+    document.getElementById('cx').removeAttribute('disabled');
+    document.getElementById('select-all-multi').click();
+    expect(getClickedIds()).toHaveLength(0);
+
+    await Promise.resolve();
+
+    document.getElementById('c3').click(); // click
+
+    await shiftClick(document.getElementById('c1'));
+
+    // it should include the previously disabled element, tracking against the DOM, not indexes
+    expect(getClickedIds()).toEqual(['c1', 'cx', 'c2', 'c3']);
   });
 });

--- a/client/src/controllers/BulkController.ts
+++ b/client/src/controllers/BulkController.ts
@@ -1,5 +1,10 @@
 import { Controller } from '@hotwired/stimulus';
 
+type ToggleAllOptions = {
+  /** Override check all behaviour to either force check or uncheck all */
+  force?: boolean;
+};
+
 /**
  * Adds the ability to collectively toggle a set of (non-disabled) checkboxes.
  *
@@ -27,7 +32,7 @@ import { Controller } from '@hotwired/stimulus';
  *     <input data-action="w-bulk#toggle" data-w-bulk-target="item" type="checkbox" />
  *   </div>
  * </div>
-
+ *
  */
 export class BulkController extends Controller<HTMLElement> {
   static classes = ['actionInactive'];
@@ -45,28 +50,91 @@ export class BulkController extends Controller<HTMLElement> {
   /** Classes to remove on the actions target if any actions are checked */
   declare readonly actionInactiveClasses: string[];
 
-  get activeItems() {
-    return this.itemTargets.filter(({ disabled }) => !disabled);
-  }
+  /** Internal tracking of last clicked for shift+click behaviour */
+  lastChanged?: HTMLElement | null;
+
+  /** Internal tracking of whether the shift key is active for multiple selection */
+  shiftActive?: boolean;
 
   /**
    * On creation, ensure that the select all checkboxes are in sync.
+   * Set up the event listeners for shift+click behaviour.
    */
   connect() {
     this.toggle();
+    this.handleShiftKey = this.handleShiftKey.bind(this);
+    document.addEventListener('keydown', this.handleShiftKey);
+    document.addEventListener('keyup', this.handleShiftKey);
   }
 
   /**
-   * When something is toggled, ensure the select all targets are kept in sync.
-   * Update the classes on the action targets to reflect the current state.
+   * Returns all valid targets (i.e. not disabled).
    */
-  toggle() {
-    const activeItems = this.activeItems;
+  getValidTargets(
+    targets: HTMLInputElement[] = this.itemTargets,
+  ): HTMLInputElement[] {
+    return targets.filter(({ disabled }) => !disabled);
+  }
+
+  /**
+   * Event handler to determine if shift key is pressed.
+   */
+  handleShiftKey(event: KeyboardEvent) {
+    if (!event) return;
+
+    const { shiftKey, type } = event;
+
+    if (type === 'keydown' && shiftKey) {
+      this.shiftActive = true;
+    }
+
+    if (type === 'keyup' && this.shiftActive) {
+      this.shiftActive = false;
+    }
+  }
+
+  /**
+   * When an item is toggled, ensure the select all targets are kept in sync.
+   * Update the classes on the action targets to reflect the current state.
+   * If the shift key is pressed, toggle all the items between the last clicked
+   * item and the current item.
+   */
+  toggle(event?: Event) {
+    const activeItems = this.getValidTargets();
+    const lastChanged = this.lastChanged;
+
+    if (this.shiftActive && lastChanged instanceof HTMLElement) {
+      this.shiftActive = false;
+
+      const lastClickedIndex = activeItems.findIndex(
+        (item) => item === lastChanged,
+      );
+      const currentIndex = activeItems.findIndex(
+        (item) => item === event?.target,
+      );
+
+      const [start, end] = [lastClickedIndex, currentIndex].sort(
+        // eslint-disable-next-line id-length
+        (a, b) => a - b,
+      );
+
+      activeItems.forEach((target, index) => {
+        if (index >= start && index <= end) {
+          // eslint-disable-next-line no-param-reassign
+          target.checked = !!activeItems[lastClickedIndex].checked;
+          this.dispatch('change', { target, bubbles: true });
+        }
+      });
+    }
+
+    this.lastChanged =
+      activeItems.find((item) => item.contains(event?.target as Node)) ?? null;
+
     const totalCheckedItems = activeItems.filter((item) => item.checked).length;
     const isAnyChecked = totalCheckedItems > 0;
     const isAllChecked = totalCheckedItems === activeItems.length;
 
-    this.allTargets.forEach((target) => {
+    this.getValidTargets(this.allTargets).forEach((target) => {
       // eslint-disable-next-line no-param-reassign
       target.checked = isAllChecked;
     });
@@ -82,14 +150,34 @@ export class BulkController extends Controller<HTMLElement> {
   }
 
   /**
-   * Toggles all item checkboxes based on select-all checkbox.
+   * Toggles all item checkboxes, can be used to force check or uncheck all.
+   * If the event used to trigger this method does not have a suitable target,
+   * the first allTarget will be used to determine the current checked value.
    */
-  toggleAll(event: Event & { params?: { force?: boolean } }): void {
-    const force = event?.params?.force;
-    const checkbox = event.target as HTMLInputElement;
-    const isChecked = typeof force === 'boolean' ? force : checkbox.checked;
+  toggleAll(
+    event: CustomEvent<ToggleAllOptions> & { params?: ToggleAllOptions },
+  ) {
+    const { force = null } = {
+      ...event.detail,
+      ...event.params,
+    };
 
-    this.activeItems.forEach((target) => {
+    this.lastChanged = null;
+
+    let isChecked = false;
+
+    if (typeof force === 'boolean') {
+      isChecked = force;
+    } else if (event.target instanceof HTMLInputElement) {
+      isChecked = event.target.checked;
+    } else {
+      const checkbox = this.allTargets[0];
+      // use the opposite of the current state
+      // as this is being triggered by an external call
+      isChecked = !checkbox?.checked;
+    }
+
+    this.getValidTargets().forEach((target) => {
       if (target.checked !== isChecked) {
         // eslint-disable-next-line no-param-reassign
         target.checked = isChecked;
@@ -98,5 +186,10 @@ export class BulkController extends Controller<HTMLElement> {
     });
 
     this.toggle();
+  }
+
+  disconnect() {
+    document?.removeEventListener('keydown', this.handleShiftKey);
+    document?.removeEventListener('keyup', this.handleShiftKey);
   }
 }

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -82,6 +82,7 @@ Thank you to core contributor (LB (Ben) Johnston) for writing this documentation
  * Use dropdown buttons on listings in dashboard panels (Sage Abdullah)
  * Implement breadcrumbs design refinements (Thibaud Colas)
  * The `purge_revisions` management command now respects revisions that have a `on_delete=PROTECT` foreign key relation and won't delete them (Neeraj P Yetheendran, Meghana Reddy, Sage Abdullah, Storm Heg)
+ * Add support for Shift + Click behaviour in form submissions and simple tranlations submissions (LB (Ben) Johnston)
 
 ### Bug fixes
 


### PR DESCRIPTION
- Allow multiple selections or un-selections with shift+click
- Pull out `activeItems` getter and instead use this as a method for select all checkboxes and individual checkboxes
- Pull out ToggleAllOptions to a type and support this being passed in via a CustomEvent also, as per pattern being set up in other Controllers
- Minor refactoring to make code easier to extend, clean up of JSDoc and adjust how we set up tests to make it easier to use different html. 
-   [X] Do the tests still pass? Including Jest tests for all new behaviour introduced by this PR
-   [X] Does the code comply with the style guide?
-   [X] For front-end changes: Did you test on all of Wagtail’s supported environments?
-   [X] For new features: Has the documentation been updated accordingly? **N/A**

**additional details for testing this change**

1. In bakerydemo, navigate to the [form submissions listing](http://localhost:8000/admin/forms/submissions/69/) and have at least 5 form submissions loaded.
2. Click any item near the top, now shift+click any item near the bottom. Observe that the ones in between are now selected.
3. Now select all, then click (to unselect) any item near the bottom, now shift+click any item near the top, observe that the ones in between are all un-clicked.
4. Try this a few different ways.
5. Finally, do the same, on the simple translation form (where you translate a page and you are asked if you want to translate to all other supported translations).

## Recording

[screencast-bulk-actions-shift-click-2023.09.06-07_54_23.webm](https://github.com/wagtail/wagtail/assets/1396140/e46a3317-8fac-46e8-9404-1b7ab83a7ae2)


## Context

This PR builds on the work done in #10292 &  #10613 and sets up the Stimulus controller to be closer to what is needed for the full 'bulk actions' checkbox support. This PR will be one of the final pieces before that work can start.
