### PR TITLE
Add upgrade consideration about searchable snippets

### DIFF
--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -250,6 +250,24 @@ To revert to the previous partial word matching behaviour, use the `autocomplete
 
 The `partial_match` argument on `search` and `SearchField` is now deprecated, and should be removed from your code; it will be dropped entirely in Wagtail 6.
 
+### Snippet choosers for searchable Snippet models now require an `AutoCompleteField` for search to function
+
+Previously, if no `index.AutocompleteField` was configured for a model field, a snippet chooser search field would fall back to calling `.search()`. This fallback behaviour is removed in Wagtail 5.0.
+
+To retain the search filter functionality, make sure your searchable snippet model has corresponding autocomplete fields configured:
+
+```python
+from wagtail.search import index
+# ... other imports
+
+@register_snippet
+class MySnippet(index.Indexed, models.Model):
+     search_fields = [
+         index.SearchField("name"),
+         index.AutocompleteField("name"),
+     ]
+```
+
 ### ReferenceIndex no longer tracks models used outside of Wagtail
 
 When introduced in Wagtail 4.1, the `ReferenceIndex` model recorded references across all of a project's models by default. The default set of models being indexed has now been changed to only those used within the Wagtail admin, specifically:


### PR DESCRIPTION
This adds detail to the Wagtail 5.0 release notes upgrade considerations.

Changes made to the implementation of the form SearchFilterMixin for SnippetChooserPanel remove a fallback behaviour that could silently break this functionality if the model is not updated. In this situation, snippet choosers with searchable snippets will display the search box, but not return any results when the user enters a search query.

* [Wagtail 4.2](https://github.com/wagtail/wagtail/blob/v4.2.4/wagtail/admin/forms/choosers.py#L83-L95) used to fall back to a partial_match search if there was no autocomplete option available in the Snippet's `.search_fields`
* [Wagtail 5.0](https://github.com/wagtail/wagtail/blob/v5.0/wagtail/admin/forms/choosers.py#L77-L79) expects there to be an AutocompleteField.
 
This was done as part of a [commit](db691b5f1ba525fa4f822af1e158eb96b0756e20) that was mostly about removing the partial match behaviour, and may have gone unnoticed when updating the documentation. The [release notes](https://docs.wagtail.org/en/stable/releases/5.0.html#elasticsearch-backend-no-longer-performs-partial-matching-on-search) mention the deprecation of partial_match, but don't mention the removal of the fallback.

The fix is to make sure that your Snippet has an AutocompleteField configured:

```
     search_fields = [
+        index.AutocompleteField("title"),
         index.SearchField("title"),
     ]
```

I have added a description, and an example code block.