### PR TITLE
Add bulk toggling of Object Permissions in the User Group edit page

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/forms/single_checkbox.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/forms/single_checkbox.html
@@ -1,5 +1,5 @@
 {# Render a single checkbox with text center-aligned. #}
 <label class="w-flex w-items-center {{ label_classname }}">
-    <input type="checkbox" name="{{ name }}"{% if value %} value="{{ value }}"{% endif %} {% if checked %}checked{% endif %}>
+    <input type="checkbox" name="{{ name }}"{% if value %} value="{{ value }}"{% endif %} {% if checked %}checked{% endif %} {% include "wagtailadmin/shared/attrs.html" with attrs=attrs %}>
     {{ text }}
 </label>

--- a/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
@@ -5,7 +5,7 @@
     <fieldset>
         <legend class="w-sr-only">{% trans "Object permissions" %}</legend>
 
-        <table class="listing">
+        <table class="listing" data-controller="w-bulk">
             <colgroup>
                 <col />
                 <col width="10%" />
@@ -96,7 +96,7 @@
                                     <fieldset class="w-p-0">
                                         <legend class="w-sr-only">{% trans "Custom permissions" %}</legend>
                                         {% for custom_perm in content_perms_dict.custom %}
-                                            {% include "wagtailadmin/shared/forms/single_checkbox.html" with name="permissions" value=custom_perm.perm.id checked=custom_perm.selected text=custom_perm.name %}
+                                            {% include "wagtailadmin/shared/forms/single_checkbox.html" with name="permissions" value=custom_perm.perm.id checked=custom_perm.selected text=custom_perm.name attrs=custom_perm.attrs %}
                                         {% endfor %}
                                     </fieldset>
                                 {% endif %}
@@ -105,6 +105,50 @@
                     </tr>
                 {% endfor %}
             </tbody>
+            <tfoot>
+                <tr>
+                    <th scope="row">
+                        <input id="toggle-all" type="checkbox" data-action="w-bulk#toggleAll" data-w-bulk-target="all">
+                        <label for="toggle-all" >{% trans "Toggle all" %}</label>
+                    </th>
+                    <td>
+                        <label for="toggle-all-add" class="visuallyhidden">{% trans "Toggle all add permissions" %}</label>
+                        <input id="toggle-all-add" type="checkbox" data-action="w-bulk#toggleAll" data-w-bulk-target="all" data-w-bulk-group-param="add">
+                    </td>
+                    <td>
+                        <label for="toggle-all-change" class="visuallyhidden">{% trans "Toggle all change permissions" %}</label>
+                        <input id="toggle-all-change" type="checkbox" data-action="w-bulk#toggleAll" data-w-bulk-target="all" data-w-bulk-group-param="change">
+                    </td>
+                    <td>
+                        <label for="toggle-all-delete" class="visuallyhidden">{% trans "Toggle all delete permissions" %}</label>
+                        <input id="toggle-all-delete" type="checkbox" data-action="w-bulk#toggleAll" data-w-bulk-target="all" data-w-bulk-group-param="delete">
+                    </td>
+                    {% if extra_perms_exist.publish %}
+                        <td>
+                            <label for="toggle-all-publish" class="visuallyhidden">{% trans "Toggle all publish permissions" %}</label>
+                            <input id="toggle-all-publish" type="checkbox" data-action="w-bulk#toggleAll" data-w-bulk-target="all" data-w-bulk-group-param="publish">
+                        </td>
+                    {% endif %}
+                    {% if extra_perms_exist.lock %}
+                        <td>
+                            <label for="toggle-all-lock" class="visuallyhidden">{% trans "Toggle all lock permissions" %}</label>
+                            <input id="toggle-all-lock" type="checkbox" data-action="w-bulk#toggleAll" data-w-bulk-target="all" data-w-bulk-group-param="lock">
+                        </td>
+                    {% endif %}
+                    {% if extra_perms_exist.unlock %}
+                        <td>
+                            <label for="toggle-all-unlock" class="visuallyhidden">{% trans "Toggle all unlock permissions" %}</label>
+                            <input id="toggle-all-unlock" type="checkbox" data-action="w-bulk#toggleAll" data-w-bulk-target="all" data-w-bulk-group-param="unlock">
+                        </td>
+                    {% endif %}
+                    {% if extra_perms_exist.custom %}
+                        <td>
+                            <label for="toggle-all-custom" class="visuallyhidden">{% trans "Toggle all custom permissions" %}</label>
+                            <input id="toggle-all-custom" type="checkbox" data-action="w-bulk#toggleAll" data-w-bulk-target="all" data-w-bulk-group-param="custom">
+                        </td>
+                    {% endif %}
+                </tr>
+            </tfoot>
         </table>
     </fieldset>
 {% endpanel %}

--- a/wagtail/users/templatetags/wagtailusers_tags.py
+++ b/wagtail/users/templatetags/wagtailusers_tags.py
@@ -143,6 +143,7 @@ def format_permissions(permission_bound_field):
         for perm in content_perms:
             content_perms_dict["object"] = perm.content_type.name
             checkbox = checkboxes_by_id[perm.id]
+            attrs = {"data-action": "w-bulk#toggle", "data-w-bulk-target": "item"}
             # identify the main categories of permission, and assign to
             # the relevant dict key, else bung in the 'custom_perms' list
             permission_action = perm.codename.split("_")[0]
@@ -154,16 +155,19 @@ def format_permissions(permission_bound_field):
             if is_known:
                 if permission_action in extra_perms_exist:
                     extra_perms_exist[permission_action] = True
+                checkbox.data["attrs"].update(attrs)
+                checkbox.data["attrs"]["data-w-bulk-group-param"] = permission_action
                 content_perms_dict[permission_action] = {
                     "perm": perm,
                     "checkbox": checkbox,
                 }
             else:
                 extra_perms_exist["custom"] = True
+                attrs["data-w-bulk-group-param"] = "custom"
                 perm_name = normalize_permission_label(perm)
-
                 custom_perms.append(
                     {
+                        "attrs": attrs,
                         "perm": perm,
                         "name": perm_name,
                         "selected": checkbox.data["selected"],


### PR DESCRIPTION
Inspired by #5836 - it seemed like a good candidate to redo that PR with our shared bulk controller code. This uses the same controller but allows us to add 'groups' of toggles that work together. This way we have one controller that can work across 'columns' in a HTML `table`.

Every column supports shift+click and every checkbox will toggle with the global 'toggle all'.

~~However I have intentionally not added a 'toggle all' to the column of 'custom permissions' as this seemed to be not suitable for that kind of behaviour.~~ Update: I have updated this to include a 'toggle all' checkbox for custom permissions also.

Note that **row** shift+click selection will not function, I started building that out but thought it's best to keep this PR as focused as possible. It should be possible and I am happy to add as a future PR.

- Supersedes #5836
- Builds on top of / requires PR #10861 (shift+click behaviour)
-   [X] Do the tests still pass?
-   [X] Does the code comply with the style guide?
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [X] For front-end changes: Did you test on all of Wagtail’s supported environments? Firefox 118, Chrome 118, Safari 16.1
-   [X] For new features: Has the documentation been updated accordingly? **N/A**

## Testing instructions

* Load up bakerydemo with this code branch
* In the side menu, click Settings > Groups, click any group
* Within the Object permissions observe there is a new footer row for toggling all. You can toggle the table as a whole or each column, additionally you can use shift+click to select/unselect sets of toggles in each column.

## Screenshot & recording


<img width="1333" alt="Screenshot 2023-09-08 at 7 13 16 am" src="https://github.com/wagtail/wagtail/assets/1396140/13b34ab9-4549-41e4-8a1e-3b90c47735fc">

[user-group-edit-bulk-select-2023.09.08.webm](https://github.com/wagtail/wagtail/assets/1396140/c6b5f88c-0f48-4319-a54c-8a9d89138b18)


