### PR TITLE
Fix #10789: Display "First Published At" DateTime as Absolute Value in Tooltip for Pages and Snippets

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
  * Add `linked_fields` mechanism on chooser widgets to allow choices to be limited by fields on the calling page (Matt Westcott)
  * Add support for merging cells within `TableBlock` with the `mergedCells` option (Gareth Palmer)
  * When adding a panel within `InlinePanel`, focus will now shift to that content similar to `StreamField` (Faishal Manzar)
+ * Show the full first published at date within a tooltip on the Page status sidebar on the relative date (Rohit Sharma)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -45,6 +45,7 @@ Changelog
  * Maintenance: Migrate form submission listing checkbox toggling to the shared `w-bulk` Stimulus implementation (LB (Ben) Johnston)
  * Maintenance: Allow viewsets to define a common set of view kwargs (Matt Westcott)
  * Maintenance: Migrate the editor unsaved messages popup to be driven by Stimulus using the shared `w-message` controller (LB (Ben) Johnston, Hussain Saherwala)
+ * Maintenance: Add support for tooltip position in `human_readable_date` tooltip (Rohit Sharma)
 
 
 5.1.2 (xx.xx.20xx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -730,6 +730,7 @@
 * Hatim Makki Hoho
 * Hussain Saherwala
 * Faishal Manzar
+* Rohit Sharma
 
 ## Translators
 

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -64,6 +64,7 @@ depth: 1
  * Migrate form submission listing checkbox toggling to the shared `w-bulk` Stimulus implementation (LB (Ben) Johnston)
  * Allow viewsets to define a common set of view kwargs (Matt Westcott)
  * Migrate the editor unsaved messages popup to be driven by Stimulus using the shared `w-message` controller (LB (Ben) Johnston, Hussain Saherwala)
+ * Add support for tooltip position in `human_readable_date` tooltip (Rohit Sharma)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -33,6 +33,7 @@ depth: 1
  * Add `linked_fields` mechanism on chooser widgets to allow choices to be limited by fields on the calling page (Matt Westcott)
  * Add support for merging cells within `TableBlock` with the [`mergedCells` option](table_block_options) (Gareth Palmer)
  * When adding a panel within `InlinePanel`, focus will now shift to that content similar to `StreamField` (Faishal Manzar)
+ * Show the full first published at date within a tooltip on the Page status sidebar on the relative date (Rohit Sharma)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/shared/human_readable_date.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/human_readable_date.html
@@ -1,6 +1,6 @@
 {% load wagtailadmin_tags i18n %}
 
-<button type="button" class="w-human-readable-date" data-tippy-content="{{ date|date:"DATETIME_FORMAT" }}">
+<button type="button" class="w-human-readable-date" data-tippy-content="{{ date|date:"DATETIME_FORMAT" }}" data-tippy-placement="{{ position }}">
     <time class="w-human-readable-date__date" datetime="{{ date|date:"c" }}">
         {{ date|timesince_simple|capfirst }}
     </time>

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/status.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/status.html
@@ -16,7 +16,7 @@
         </div>
         {% if object.first_published_at %}
             <div class="w-help-text">
-                {% trans 'First published ' %}{% timesince_last_update object.first_published_at use_shorthand=True %}
+                {% trans 'First published' %} {% human_readable_date object.first_published_at position="bottom" %}
             </div>
         {% endif %}
     </div>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1196,8 +1196,9 @@ def workflow_status_with_date(workflow_state):
 
 
 @register.inclusion_tag("wagtailadmin/shared/human_readable_date.html")
-def human_readable_date(date, description=None):
+def human_readable_date(date, description=None, position="top"):
     return {
         "date": date,
         "description": description,
+        "position": position,
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10789 I have made some changes that enhances the user experience in the Wagtail CMS side panels by introducing a tooltip feature. Now, when users hover over the 'First published at [time ago]' text, they can easily access the absolute datetime. This improvement simplifies the process of retrieving datetime information, making the CMS more user-friendly and efficient.

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [x] Run `make lint` from the Wagtail root.
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]

### Before changes:
![Screenshot (22)](https://github.com/wagtail/wagtail/assets/111359305/6edab6f3-19e1-464a-90a5-75541af332a2)

### After changes:
![Screenshot (23)](https://github.com/wagtail/wagtail/assets/111359305/39da5193-71ac-44e9-a0f3-d93d27061de3)


