### PR TITLE
System checks for content/promote panel definitions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ Changelog
  * Extract generic breadcrumbs functionality from page breadcrumbs (Sage Abdullah)
  * Add support for `placement` in the `human_readable_date` tooltip template tag (Rohit Sharma)
  * Add breadcrumbs to generic model views (Sage Abdullah)
+ * Add system checks for field panels to warn if linked fields are incorrect (Neeraj Yetheendran, Sandil Ranasinghe)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -732,6 +732,7 @@
 * Faishal Manzar
 * Rohit Sharma
 * Subhajit Ghosh
+* Neeraj Yetheendran
 
 ## Translators
 

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -37,6 +37,7 @@ depth: 1
  * Extract generic breadcrumbs functionality from page breadcrumbs (Sage Abdullah)
  * Add support for `placement` in `human_readable_date` the tooltip template tag (Rohit Sharma)
  * Add breadcrumbs to generic model views (Sage Abdullah)
+ * Add system checks for field panels to warn if linked fields are incorrect (Neeraj Yetheendran, Sandil Ranasinghe)
 
 ### Bug fixes
 

--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -166,6 +166,72 @@ There are no default tabs on non-Page models so there will be no \
     return errors
 
 
+@register("panels")
+def panel_type_check(app_configs, **kwargs):
+    from wagtail.models import get_page_models
+    from wagtail.snippets.models import get_snippet_models
+
+    errors = []
+
+    for cls in get_page_models():
+        errors += traverse_edit_handlers(cls.get_edit_handler())
+
+    for cls in get_snippet_models():
+        if hasattr(cls, "panels"):
+            for panel in cls.panels:
+                # Check if panel is MultiFieldPanel
+                if hasattr(panel, "children"):
+                    for panel_child in panel.children:
+                        errors += traverse_edit_handlers(panel_child.bind_to_model(cls))
+                errors += traverse_edit_handlers(panel.bind_to_model(cls))
+
+    return errors
+
+
+def traverse_edit_handlers(edit_handler):
+    errors = []
+
+    try:
+        for child in edit_handler.children:
+            errors += traverse_edit_handlers(child)
+    except AttributeError:
+        panel_field_error = check_panel_field_valid(edit_handler)
+        if panel_field_error:
+            errors.append(panel_field_error)
+
+    return errors
+
+
+def check_panel_field_valid(edit_handler):
+    from wagtail.admin.panels import CommentPanel, HelpPanel, TabbedInterface
+
+    if isinstance(edit_handler, (CommentPanel, HelpPanel, TabbedInterface)):
+        pass
+    else:
+        model = getattr(edit_handler, "model", None)
+        field_or_relation_name = getattr(edit_handler, "field_name", None)
+        if field_or_relation_name is None:
+            field_or_relation_name = getattr(edit_handler, "relation_name", None)
+
+        if field_or_relation_name in [f.name for f in model._meta.get_fields()]:
+            pass
+        elif hasattr(edit_handler, "relation_name") and field_or_relation_name in [
+            getattr(f, "related_name", None) for f in model._meta.get_fields()
+        ]:
+            pass
+        else:
+            return Warning(
+                "{model} does not have a field named '{field_name}', but a {edit_handler} is pointing to it.".format(
+                    model=model.__name__,
+                    field_name=field_or_relation_name,
+                    edit_handler=edit_handler.__class__.__name__,
+                ),
+                hint="Check whether the field exists on the model or whether there is a spelling issue.",
+                obj=model,
+                id="wagtailadmin.W005",
+            )
+
+
 @register("wagtailadmin_base_url")
 def wagtail_admin_base_url_check(app_configs, **kwargs):
     from django.conf import settings


### PR DESCRIPTION
Updated PR #8258 according to the information provided in the comments.
(related to System checks for content/promote panel definitions https://github.com/wagtail/wagtail/issues/1127 )
Added test to ensure check works for MultiFied edit_handlers


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behavior?



