### PR TITLE
Fixed Chooser buttons are dulled after opening modal

### DIFF
--- a/client/scss/components/_chooser.scss
+++ b/client/scss/components/_chooser.scss
@@ -33,6 +33,18 @@ $preview-size: 2.625rem; // 42px
   }
 }
 
+.button.chooser__choose-button, .button.chooser__choose-button:visited {
+  align-items: center;
+  border-color: #0000;
+  color: var(--w-color-text-label);
+  color: var(--w-color-text-button-outline-default);
+  display: flex;
+  font-size: .875rem;
+  font-weight: 500;
+  line-height: 1.3;
+  padding: .375rem;
+}
+
 .chosen {
   display: flex;
   gap: theme('spacing.4');

--- a/client/scss/components/_chooser.scss
+++ b/client/scss/components/_chooser.scss
@@ -12,7 +12,8 @@ $preview-size: 2.625rem; // 42px
 
 // Very subdued button style specifically for choosers, as there can be a lot of
 // chooser fields left unused on a page editing form.
-.button.chooser__choose-button, .button.chooser__choose-button:visited  {
+.button.chooser__choose-button,
+.button.chooser__choose-button:visited {
   @apply w-label-3;
   display: flex;
   align-items: center;

--- a/client/scss/components/_chooser.scss
+++ b/client/scss/components/_chooser.scss
@@ -12,7 +12,7 @@ $preview-size: 2.625rem; // 42px
 
 // Very subdued button style specifically for choosers, as there can be a lot of
 // chooser fields left unused on a page editing form.
-.button.chooser__choose-button {
+.button.chooser__choose-button, .button.chooser__choose-button:visited  {
   @apply w-label-3;
   display: flex;
   align-items: center;
@@ -31,18 +31,6 @@ $preview-size: 2.625rem; // 42px
     color: theme('colors.surface-button-hover');
     background-color: theme('colors.surface-page');
   }
-}
-
-.button.chooser__choose-button, .button.chooser__choose-button:visited {
-  align-items: center;
-  border-color: #0000;
-  color: var(--w-color-text-label);
-  color: var(--w-color-text-button-outline-default);
-  display: flex;
-  font-size: .875rem;
-  font-weight: 500;
-  line-height: 1.3;
-  padding: .375rem;
 }
 
 .chosen {


### PR DESCRIPTION
Fixed Chooser buttons are dulled after opening modal
Issue - #10875 
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #...







_Please check the following:_

-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [X] Run `make lint` from the Wagtail root.
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [X] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [X] **Please list the exact browser and operating system versions you tested**:
    -   [X] **Please list which assistive technologies [^3] you tested**:
-   [X] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
