### PR TITLE
Add breadcrumbs to generic model views

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changelog
  * Show the full first published at date within a tooltip on the Page status sidebar on the relative date (Rohit Sharma)
  * Extract generic breadcrumbs functionality from page breadcrumbs (Sage Abdullah)
  * Add support for `placement` in the `human_readable_date` tooltip template tag (Rohit Sharma)
+ * Add breadcrumbs to generic model views (Sage Abdullah)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -36,6 +36,7 @@ depth: 1
  * Show the full first published at date within a tooltip on the Page status sidebar on the relative date (Rohit Sharma)
  * Extract generic breadcrumbs functionality from page breadcrumbs (Sage Abdullah)
  * Add support for `placement` in `human_readable_date` the tooltip template tag (Rohit Sharma)
+ * Add breadcrumbs to generic model views (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/generic/base.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/base.html
@@ -5,7 +5,14 @@
 {% block content %}
 
     {% block header %}
-        {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle icon=header_icon only %}
+        {% block slim_header %}
+            {% if breadcrumbs_items %}
+                {% include "wagtailadmin/shared/headers/slim_header.html" %}
+            {% endif %}
+        {% endblock %}
+        {% block main_header %}
+            {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle icon=header_icon only %}
+        {% endblock %}
     {% endblock %}
 
     <div class="nice-padding">

--- a/wagtail/admin/templates/wagtailadmin/generic/index.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index.html
@@ -1,7 +1,7 @@
 {% extends "wagtailadmin/generic/listing.html" %}
 {% load i18n wagtailadmin_tags %}
 
-{% block header %}
+{% block main_header %}
     {% fragment as extra_actions %}
         {% if view.list_export %}
             {% include view.export_buttons_template_name %}

--- a/wagtail/admin/templates/wagtailadmin/generic/listing.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/listing.html
@@ -1,11 +1,13 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 {% load i18n %}
 
-{% block titletag %}{{ page_title }} {{ page_subtitle }}{% endblock %}
+{% block main_header %}
+    {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=header_action_url action_text=header_action_label icon=header_icon only %}
+{% endblock %}
 
 {% block content %}
     {% block header %}
-        {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=header_action_url action_text=header_action_label icon=header_icon only %}
+        {{ block.super }}
     {% endblock %}
 
     {% block listing %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -67,8 +67,6 @@ register.filter("naturaltime", naturaltime)
 
 @register.inclusion_tag("wagtailadmin/shared/breadcrumbs.html")
 def breadcrumbs(items, is_expanded=False, classname=None):
-    # Prepend the Home item to link to the admin dashboard
-    items = [{"url": reverse("wagtailadmin_home"), "label": _("Home")}] + items
     return {"items": items, "is_expanded": is_expanded, "classname": classname}
 
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -67,6 +67,8 @@ register.filter("naturaltime", naturaltime)
 
 @register.inclusion_tag("wagtailadmin/shared/breadcrumbs.html")
 def breadcrumbs(items, is_expanded=False, classname=None):
+    # Prepend the Home item to link to the admin dashboard
+    items = [{"url": reverse("wagtailadmin_home"), "label": _("Home")}] + items
     return {"items": items, "is_expanded": is_expanded, "classname": classname}
 
 

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -676,6 +676,7 @@ class BreadcrumbsTagTest(WagtailTestUtils, SimpleTestCase):
     """
 
     def assertItemsRendered(self, items, soup):
+        items = [{"label": "Home", "url": "/admin/"}] + items
         rendered_items = soup.select("ol > li")
         arrows = soup.select("ol > li > svg")
         self.assertEqual(len(rendered_items), len(items))
@@ -692,7 +693,7 @@ class BreadcrumbsTagTest(WagtailTestUtils, SimpleTestCase):
             self.assertEqual(element.text.strip(), item["label"])
 
     def test_single_item(self):
-        items = [{"label": "Home", "url": "/admin/"}]
+        items = [{"label": "Something", "url": "/admin/something/"}]
         rendered = Template(self.template).render(Context({"items": items}))
         soup = self.get_soup(rendered)
         self.assertItemsRendered(items, soup)

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -676,7 +676,6 @@ class BreadcrumbsTagTest(WagtailTestUtils, SimpleTestCase):
     """
 
     def assertItemsRendered(self, items, soup):
-        items = [{"label": "Home", "url": "/admin/"}] + items
         rendered_items = soup.select("ol > li")
         arrows = soup.select("ol > li > svg")
         self.assertEqual(len(rendered_items), len(items))

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -675,7 +675,6 @@ class TestBreadcrumbs(WagtailTestUtils, TestCase):
         response = self.client.get(reverse("feature_complete_toy:index"))
         items = [
             {
-                "url": reverse("feature_complete_toy:index"),
                 "label": "Feature complete toys",
             }
         ]
@@ -703,7 +702,6 @@ class TestBreadcrumbs(WagtailTestUtils, TestCase):
                 "label": "Feature complete toys",
             },
             {
-                "url": edit_url,
                 "label": str(self.object),
             },
         ]

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -654,6 +654,7 @@ class TestBreadcrumbs(WagtailTestUtils, TestCase):
         cls.object = FeatureCompleteToy.objects.create(name="Test Toy")
 
     def assertItemsRendered(self, items, response):
+        items = [{"label": "Home", "url": "/admin/"}] + items
         soup = self.get_soup(response.content)
         breadcrumbs = soup.select_one('[data-controller="w-breadcrumbs"]')
         rendered_items = breadcrumbs.select("ol > li")

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -1,7 +1,7 @@
 from django.contrib.admin.utils import quote, unquote
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import get_object_or_404, redirect
-from django.urls import reverse
+from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic.base import ContextMixin, TemplateResponseMixin
@@ -22,7 +22,7 @@ class WagtailAdminTemplateMixin(TemplateResponseMixin, ContextMixin):
     page_title = ""
     page_subtitle = ""
     header_icon = ""
-    breadcrumbs_items = []
+    breadcrumbs_items = [{"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")}]
     template_name = "wagtailadmin/generic/base.html"
 
     def get_page_title(self):

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -359,10 +359,7 @@ class IndexView(
         if not self.model:
             return self.breadcrumbs_items
         return self.breadcrumbs_items + [
-            {
-                "url": self.get_index_url(),
-                "label": capfirst(self.model._meta.verbose_name_plural),
-            },
+            {"label": capfirst(self.model._meta.verbose_name_plural)},
         ]
 
     def get_context_data(self, *args, object_list=None, **kwargs):
@@ -601,7 +598,7 @@ class EditView(
                     "label": capfirst(self.model._meta.verbose_name_plural),
                 }
             )
-        items.append({"url": self.get_edit_url(), "label": get_latest_str(self.object)})
+        items.append({"label": get_latest_str(self.object)})
         return self.breadcrumbs_items + items
 
     def get_edit_url(self):

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -816,6 +816,7 @@ class InspectView(PermissionCheckedMixin, WagtailAdminTemplateMixin, TemplateVie
     template_name = "wagtailadmin/generic/inspect.html"
     page_title = gettext_lazy("Inspecting")
     model = None
+    index_url_name = None
     edit_url_name = None
     delete_url_name = None
     fields = []
@@ -833,6 +834,21 @@ class InspectView(PermissionCheckedMixin, WagtailAdminTemplateMixin, TemplateVie
 
     def get_page_subtitle(self):
         return str(self.object)
+
+    def get_breadcrumbs_items(self):
+        items = []
+        if self.index_url_name:
+            items.append(
+                {
+                    "url": reverse(self.index_url_name),
+                    "label": capfirst(self.model._meta.verbose_name_plural),
+                }
+            )
+        edit_url = self.get_edit_url()
+        if edit_url:
+            items.append({"url": edit_url, "label": get_latest_str(self.object)})
+        items.append({"label": _("Inspect")})
+        return self.breadcrumbs_items + items
 
     def get_fields(self):
         fields = self.fields or [

--- a/wagtail/admin/views/generic/usage.py
+++ b/wagtail/admin/views/generic/usage.py
@@ -1,3 +1,5 @@
+from django.contrib.admin.utils import quote
+from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext as _
@@ -20,6 +22,8 @@ class TitleColumn(tables.TitleColumn):
 class UsageView(PermissionCheckedMixin, BaseObjectMixin, BaseListingView):
     paginate_by = 20
     page_title = gettext_lazy("Usage of")
+    index_url_name = None
+    edit_url_name = None
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
@@ -37,6 +41,25 @@ class UsageView(PermissionCheckedMixin, BaseObjectMixin, BaseListingView):
 
     def get_page_subtitle(self):
         return get_latest_str(self.object)
+
+    def get_breadcrumbs_items(self):
+        items = []
+        if self.index_url_name:
+            items.append(
+                {
+                    "url": reverse(self.index_url_name),
+                    "label": self.object._meta.verbose_name_plural,
+                }
+            )
+        if self.edit_url_name:
+            items.append(
+                {
+                    "url": reverse(self.edit_url_name, args=(quote(self.object.pk),)),
+                    "label": get_latest_str(self.object),
+                }
+            )
+        items.append({"label": _("Usage")})
+        return self.breadcrumbs_items + items
 
     def get_queryset(self):
         return ReferenceIndex.get_references_to(self.object).group_by_source_object()

--- a/wagtail/sites/tests.py
+++ b/wagtail/sites/tests.py
@@ -155,7 +155,7 @@ class TestSiteCreateView(WagtailTestUtils, TestCase):
                 Site with this Hostname and Port already exists.
             </div>
         """
-        self.assertTagInHTML(expected_html, str(response.content))
+        self.assertTagInHTML(expected_html, response.content.decode())
 
 
 class TestSiteEditView(WagtailTestUtils, TestCase):
@@ -317,7 +317,7 @@ class TestSiteEditView(WagtailTestUtils, TestCase):
                 Site with this Hostname and Port already exists.
             </div>
         """
-        self.assertTagInHTML(expected_html, str(response.content))
+        self.assertTagInHTML(expected_html, response.content.decode())
 
 
 class TestSiteDeleteView(WagtailTestUtils, TestCase):

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/delete.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/delete.html
@@ -1,6 +1,1 @@
 {% extends "wagtailadmin/generic/confirm_delete.html" %}
-
-{% block content %}
-    {% include 'wagtailadmin/shared/headers/slim_header.html' %}
-    {{ block.super }}
-{% endblock %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/usage.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/usage.html
@@ -1,6 +1,1 @@
 {% extends "wagtailadmin/generic/index.html" %}
-
-{% block content %}
-    {% include 'wagtailadmin/shared/headers/slim_header.html' %}
-    {{ block.super }}
-{% endblock %}

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -3751,7 +3751,7 @@ class TestSnippetDelete(WagtailTestUtils, TestCase):
             + "?describe_on_delete=1",
         )
         self.assertNotContains(response, "Yes, delete")
-        self.assertNotContains(response, f'<form action="{delete_url}" method="POST">')
+        self.assertNotContains(response, delete_url)
 
     def test_delete_post_with_limited_permissions(self):
         self.user.is_superuser = False

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -180,14 +180,6 @@ class IndexView(generic.IndexViewOptionalFeaturesMixin, generic.IndexView):
             *super().get_columns(),
         ]
 
-    def get_breadcrumbs_items(self):
-        return self.breadcrumbs_items + [
-            {
-                "url": self.get_index_url(),
-                "label": capfirst(self.model._meta.verbose_name_plural),
-            },
-        ]
-
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
@@ -261,18 +253,6 @@ class CreateView(generic.CreateEditViewOptionalFeaturesMixin, generic.CreateView
             "for_user": self.request.user,
         }
 
-    def get_breadcrumbs_items(self):
-        return self.breadcrumbs_items + [
-            {
-                "url": reverse(self.index_url_name),
-                "label": capfirst(self.model._meta.verbose_name_plural),
-            },
-            {
-                "label": _("New: %(model_name)s")
-                % {"model_name": capfirst(self.model._meta.verbose_name)},
-            },
-        ]
-
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
@@ -343,15 +323,6 @@ class EditView(generic.CreateEditViewOptionalFeaturesMixin, generic.EditView):
 
     def get_form_kwargs(self):
         return {**super().get_form_kwargs(), "for_user": self.request.user}
-
-    def get_breadcrumbs_items(self):
-        return self.breadcrumbs_items + [
-            {
-                "url": reverse(self.index_url_name),
-                "label": capfirst(self.model._meta.verbose_name_plural),
-            },
-            {"url": self.get_edit_url(), "label": get_latest_str(self.object)},
-        ]
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -424,20 +395,6 @@ class UsageView(generic.UsageView):
     view_name = "usage"
     template_name = "wagtailsnippets/snippets/usage.html"
     permission_required = "change"
-    edit_url_name = None
-
-    def get_breadcrumbs_items(self):
-        return self.breadcrumbs_items + [
-            {
-                "url": reverse(self.index_url_name),
-                "label": capfirst(self.model._meta.verbose_name_plural),
-            },
-            {
-                "url": reverse(self.edit_url_name, args=[quote(self.object.pk)]),
-                "label": get_latest_str(self.object),
-            },
-            {"label": _("Usage")},
-        ]
 
 
 class SnippetHistoryReportFilterSet(WagtailFilterSet):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -419,15 +419,6 @@ class DeleteView(generic.DeleteView):
             "object": self.object,
         }
 
-    def get_breadcrumbs_items(self):
-        return self.breadcrumbs_items + [
-            {
-                "url": reverse(self.index_url_name),
-                "label": capfirst(self.model._meta.verbose_name_plural),
-            },
-            {"url": self.get_delete_url(), "label": _("Delete")},
-        ]
-
 
 class UsageView(generic.UsageView):
     view_name = "usage"

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -1090,6 +1090,7 @@ class SnippetViewSet(ModelViewSet):
         # Use reverse_lazy instead of reverse
         # because this will be passed to the view classes at startup
         return [
+            {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
             {"url": reverse_lazy("wagtailsnippets:index"), "label": _("Snippets")},
         ]
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

This adds breadcrumbs to the generic models index, create, and edit views by extracting them from the snippets views.

I made it so that the last item in the breadcrumbs is a normal text instead of a link, per Ben's (our designer) suggestion and @lb-'s suggestion in https://github.com/wagtail/wagtail/pull/10865#pullrequestreview-1618351538.

I reverted 9ed5b8f07090b1bc50e80c3668e6a06aab105c22 (which I added in #10865, as I thought it'd be more consistent). Ben and I discussed it this morning, and his opinion is that such views are more like a confirmation page that "would ideally be in a dialog instead of a full view", so for now we shouldn't add the breadcrumbs.

I also made it so that with the generic views, the first item in the breadcrumbs is always the admin homepage (dashboard). This was suggested in the Notes section of #8767, and Thibaud suggested this as well. I discussed this with Ben and we decided not to do this for the page breadcrumbs for now, because it may be confusing (one might assume "Home" refers to a Page instance titled "Home").

To test this, you can check out this bakerydemo branch that registers the `Country` with a `ModelViewSet` instead of `SnippetViewSet`: https://github.com/laymonage/bakerydemo/tree/country-modelviewset

Access the "Countries Of Origin" menu, and observe that the index, create, and edit views for this model have breadcrumbs. Also check that for a snippet, the breadcrumbs are still shown on the index, create, edit, history, and usage views.

You'll also see that the views for the following models also have breadcrumbs:
- Sites
- Locales
- Collections (missing in the create view)
- Groups (only in the index view)

The missing ones are because the templates have been overridden and haven't been refactored to take the breadcrumbs into account. This will be addressed in #10884.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
