### PR TITLE
Use `hashlib.file_digest` if available

### DIFF
--- a/wagtail/tests/test_utils.py
+++ b/wagtail/tests/test_utils.py
@@ -553,7 +553,7 @@ class HashFileLikeTestCase(SimpleTestCase):
             """
 
             def __init__(self):
-                self.iterations = 20000
+                self.iterations = 5000
 
             def read(self, bytes):
                 self.iterations -= 1
@@ -564,5 +564,5 @@ class HashFileLikeTestCase(SimpleTestCase):
 
         self.assertEqual(
             hash_filelike(FakeLargeFile()),
-            "187cc1db32624dccace20d042f6d631f1a483020",
+            "bd36f0c5a02cd6e9e34202ea3ff8db07b533e025",
         )

--- a/wagtail/tests/test_utils.py
+++ b/wagtail/tests/test_utils.py
@@ -1,5 +1,7 @@
+import hashlib
 import pickle
-from io import BytesIO, StringIO
+import unittest
+from io import BytesIO
 from pathlib import Path
 
 from django.contrib.contenttypes.models import ContentType
@@ -520,12 +522,9 @@ class HashFileLikeTestCase(SimpleTestCase):
         self.assertEqual(
             hash_filelike(BytesIO(b"test")), "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
         )
-        self.assertEqual(
-            hash_filelike(StringIO("test")), "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
-        )
 
     def test_hashes_file(self):
-        with self.test_file.open(mode="r") as f:
+        with self.test_file.open(mode="rb") as f:
             self.assertEqual(
                 hash_filelike(f), "9e58400061ca660ef7b5c94338a5205627c77eda"
             )
@@ -546,6 +545,10 @@ class HashFileLikeTestCase(SimpleTestCase):
             "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         )
 
+    @unittest.skipIf(
+        hasattr(hashlib, "file_digest"),
+        reason="`file_digest` doesn't support this interface",
+    )
     def test_hashes_large_file(self):
         class FakeLargeFile:
             """

--- a/wagtail/utils/file.py
+++ b/wagtail/utils/file.py
@@ -1,8 +1,6 @@
 import hashlib
 from io import UnsupportedOperation
 
-from django.utils.encoding import force_bytes
-
 HASH_READ_SIZE = 2**18  # 256k - matches `hashlib.file_digest`
 
 
@@ -20,23 +18,15 @@ def hash_filelike(filelike):
     except (AttributeError, UnsupportedOperation):
         pass
 
-    hasher = None
-
     if hasattr(hashlib, "file_digest"):
-        try:
-            hasher = hashlib.file_digest(filelike, hashlib.sha1)
-        except ValueError:
-            # If the value can't be accepted by `file_digest` (eg text-mode files), use our fallback implementation
-            pass
-
-    if hasher is None:
+        hasher = hashlib.file_digest(filelike, hashlib.sha1)
+    else:
         hasher = hashlib.sha1()
         while True:
             data = filelike.read(HASH_READ_SIZE)
             if not data:
                 break
-            # Use `force_bytes` to account for files opened as text
-            hasher.update(force_bytes(data))
+            hasher.update(data)
 
     if hasattr(filelike, "seek"):
         # Reset the file handler to where it was before


### PR DESCRIPTION
_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For new features: Has the documentation been updated accordingly?

This implementation is faster / more efficient than ours, but can only be used on binary-mode files.

Also increase the read buffer size to improve efficiency and performance.

This method is only used in 2 places: Image and document hashing. Both places explicitly use binary-mode files, so should benefit from this optimisation. To ensure we can use the optimisation, I've removed support for text-mode files, which we were only using in tests anyway.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
