### PR TITLE
Clean up - Align html template literal usage in (JS) tests

### DIFF
--- a/client/src/controllers/ActionController.test.js
+++ b/client/src/controllers/ActionController.test.js
@@ -32,8 +32,7 @@ describe('ActionController', () => {
       data-w-action-url-value="https://www.github.com"
     >
       Enable
-    </button>
-    `;
+    </button>`;
 
       app = Application.start();
       app.register('w-action', ActionController);
@@ -64,8 +63,7 @@ describe('ActionController', () => {
         data-action="some-event->w-action#click"
       >
         Button
-      </button>
-      `;
+      </button>`;
 
       app = Application.start();
       app.register('w-action', ActionController);
@@ -91,8 +89,7 @@ describe('ActionController', () => {
       <select name="url" data-controller="w-action" data-action="change->w-action#redirect">
         <option value="http://localhost/place?option=1">1</option>
         <option value="http://localhost/place?option=2" selected>2</option>
-      </select>
-      `;
+      </select>`;
 
       app = Application.start();
       app.register('w-action', ActionController);

--- a/client/src/controllers/AutosizeController.test.js
+++ b/client/src/controllers/AutosizeController.test.js
@@ -25,8 +25,7 @@ describe('AutosizeController', () => {
       <textarea
         data-controller="w-autosize"
         id="text"
-      ></textarea>
-      `;
+      ></textarea>`;
     });
 
     afterEach(() => {

--- a/client/src/controllers/BulkController.test.js
+++ b/client/src/controllers/BulkController.test.js
@@ -13,8 +13,7 @@ describe('BulkController', () => {
       </div>
       <button id="clear" data-action="w-bulk#toggleAll" data-w-bulk-force-param="false">Clear all</button>
       <button id="set" data-action="w-bulk#toggleAll" data-w-bulk-force-param="true">Select all</button>
-    </div>
-    `;
+    </div>`;
     const application = Application.start();
     application.register('w-bulk', BulkController);
   });

--- a/client/src/controllers/DismissibleController.test.js
+++ b/client/src/controllers/DismissibleController.test.js
@@ -28,8 +28,7 @@ describe('DismissibleController', () => {
       data-w-dismissible-target="content"
     >
       <button type="button" data-action="w-dismissible#toggle">X</button>
-    </section>
-    `;
+    </section>`;
 
     application = Application.start();
     application.register('w-dismissible', DismissibleController);

--- a/client/src/controllers/ProgressController.test.js
+++ b/client/src/controllers/ProgressController.test.js
@@ -9,20 +9,19 @@ describe('ProgressController', () => {
 
   beforeEach(() => {
     document.body.innerHTML = `
-      <form id="form">
-        <button
-          id="button"
-          type="submit"
-          class="button button-longrunning"
-          data-controller="w-progress"
-          data-action="w-progress#activate"
-          data-w-progress-active-value="Loading"
-        >
-          <svg>...</svg>
-          <em data-w-progress-target="label" id="em-el">Sign in</em>
-        </button>
-      </form>
-    `;
+    <form id="form">
+      <button
+        id="button"
+        type="submit"
+        class="button button-longrunning"
+        data-controller="w-progress"
+        data-action="w-progress#activate"
+        data-w-progress-active-value="Loading"
+      >
+        <svg>...</svg>
+        <em data-w-progress-target="label" id="em-el">Sign in</em>
+      </button>
+    </form>`;
 
     document.getElementById('form').addEventListener('submit', mockSubmit);
 

--- a/client/src/controllers/RevealController.test.js
+++ b/client/src/controllers/RevealController.test.js
@@ -34,8 +34,7 @@ describe('RevealController', () => {
     <section data-controller="w-reveal">
       <button type="button" data-action="w-reveal#toggle" data-w-reveal-target="toggle" aria-controls="my-content">Toggle</button>
       <div class="content" id="my-content" data-w-reveal-target="content">CONTENT</div>
-    </section>
-    `,
+    </section>`,
     identifier = 'w-reveal',
   ) => {
     document.body.innerHTML = `<main>${html}</main>`;
@@ -73,8 +72,7 @@ describe('RevealController', () => {
       <section class="w-reveal collapsed" data-controller="w-reveal" data-w-reveal-closed-class="collapsed">
         <button type="button" data-w-reveal-target="toggle" aria-controls="my-content" aria-expanded="true">Toggle</button>
         <div id="my-content">CONTENT</div>
-      </section>
-      `);
+      </section>`);
 
       expect(
         document.querySelector('button').getAttribute('aria-expanded'),
@@ -127,8 +125,7 @@ describe('RevealController', () => {
         <button id="close" type="button" data-action="w-reveal#close">close</button>
       </div>
       <div id="content" data-w-reveal-target="content">CONTENT</div>
-    </section>
-      `);
+    </section>`);
 
       const content = document.getElementById('content');
       expect(content.hidden).toEqual(false);
@@ -168,8 +165,7 @@ describe('RevealController', () => {
           <li class="item" data-w-reveal-target="content">CONTENT B</li>
           <li class="item" data-w-reveal-target="content">CONTENT C</li>
         </ul>
-      </section>
-        `);
+      </section>`);
 
       const icon = document.querySelector('.icon');
       const useElement = icon.querySelector('use');
@@ -219,8 +215,7 @@ describe('RevealController', () => {
           <button type="button" aria-controls="panel-blue-content" data-w-reveal-target="toggle" data-action="w-reveal#toggle">Toggle</button>
           <div data-w-reveal-target="content" id="panel-blue-content">CONTENT</div>
         </aside>
-      </main>
-      `);
+      </main>`);
 
       expect(events['w-reveal:ready']).toHaveLength(2);
       expect(events['w-reveal:toggled']).toHaveLength(0);
@@ -349,8 +344,7 @@ describe('RevealController', () => {
             </li>
           </ol>
         </div>
-      </header>
-      `,
+      </header>`,
         'w-breadcrumbs',
       );
 

--- a/client/src/controllers/SkipLinkController.test.js
+++ b/client/src/controllers/SkipLinkController.test.js
@@ -6,8 +6,7 @@ describe('skip to the main content on clicking the skiplink', () => {
   document.body.innerHTML = `
   <a id="skip" class="button" data-controller="w-skip-link" data-action="click->w-skip-link#skip">Skip to main content</a>
   <main>Main content</main>
-  <button id="other-content">other</button>
-  `;
+  <button id="other-content">other</button>`;
 
   const application = Application.start();
 

--- a/client/src/controllers/SubmitController.test.js
+++ b/client/src/controllers/SubmitController.test.js
@@ -10,8 +10,7 @@ describe('SubmitController', () => {
       <option value="A-Z" selected>A to Z</option>
       <option value="Z-A">Z to A</option>
     </select>
-  </form>
-  `;
+  </form>`;
 
     Application.start().register('w-submit', SubmitController);
   });

--- a/client/src/controllers/TagController.test.js
+++ b/client/src/controllers/TagController.test.js
@@ -32,8 +32,7 @@ describe('TagController', () => {
     document.body.innerHTML = `
     <main>
       <input id="tag-input" type="text" value="abc" />
-    </main>
-    `;
+    </main>`;
 
     window.initTagField('tag-input', '/path/to/autocomplete/', {
       someOther: 'option',

--- a/client/src/controllers/TooltipController.test.js
+++ b/client/src/controllers/TooltipController.test.js
@@ -25,7 +25,7 @@ describe('TooltipController', () => {
   >
     CONTENT
   </button>
-</section`;
+</section>`;
 
     application = Application.start();
     application.register('w-tooltip', TooltipController);

--- a/client/src/controllers/UpgradeController.test.js
+++ b/client/src/controllers/UpgradeController.test.js
@@ -22,8 +22,7 @@ describe('UpgradeController', () => {
         New version: <strong id="latest-version" data-w-upgrade-target="latestVersion">_</strong>.
         <a href="" id="link" data-w-upgrade-target="link">Release notes</a>
       </div>
-    </div>
-    `;
+    </div>`;
   });
 
   afterEach(() => {

--- a/client/src/includes/chooserModal.test.js
+++ b/client/src/includes/chooserModal.test.js
@@ -14,8 +14,7 @@ describe('chooserModal', () => {
           <input id="input" required type="text" />
         </div>
         <button id="button" type="submit" data-controller="w-progress" data-w-progress-loading-value="true">Update</button>
-      </form>
-      `;
+      </form>`;
 
       form = document.getElementById('form');
     });


### PR DESCRIPTION
- There is one case where the closing tag was malformed
- All other cases are just ensuring the final backtick is on the closing tag's line
- This allows IDEs to better pick up on html within template tags
