### PR TITLE
Fix Storybook - jest global usage within stubs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,6 +47,7 @@ Changelog
  * Maintenance: Allow viewsets to define a common set of view kwargs (Matt Westcott)
  * Maintenance: Migrate the editor unsaved messages popup to be driven by Stimulus using the shared `w-message` controller (LB (Ben) Johnston, Hussain Saherwala)
  * Maintenance: Add support for tooltip position in `human_readable_date` tooltip (Rohit Sharma)
+ * Maintenance: Do not use jest inside `stubs.js` to prevent Storybook from crashing (LB (Ben) Johnston)
 
 
 5.1.2 (xx.xx.20xx) - IN DEVELOPMENT

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -1,5 +1,9 @@
+/* eslint no-restricted-globals: ["error", { "name": "jest", "message": "jest is not available in Storybook." }] */
+
 /**
- * Test stubs to mirror available global variables.
+ * Test stubs to mirror available global variables in Jest tests
+ * and Storybook, avoid using the jest global as this is not
+ * available in Storybook.
  * Those variables usually come from the back-end via templates.
  * See /wagtailadmin/templates/wagtailadmin/admin_base.html.
  */
@@ -62,7 +66,7 @@ class PageChooserModal {}
 global.PageChooserModal = PageChooserModal;
 
 /** Mock window.scrollTo as not provided via JSDom */
-window.scrollTo = jest.fn();
+window.scrollTo = () => {};
 
 /** Mock console.warn to filter out warnings from React due to Draftail legacy Component API usage.
  * Draftail/Draft-js is unlikely to support these and the warnings are not useful for unit test output.

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -66,6 +66,7 @@ depth: 1
  * Allow viewsets to define a common set of view kwargs (Matt Westcott)
  * Migrate the editor unsaved messages popup to be driven by Stimulus using the shared `w-message` controller (LB (Ben) Johnston, Hussain Saherwala)
  * Add support for tooltip position in `human_readable_date` tooltip (Rohit Sharma)
+ * Do not use jest inside `stubs.js` to prevent Storybook from crashing (LB (Ben) Johnston)
 
 
 ## Upgrade considerations - changes affecting all projects


### PR DESCRIPTION
* Do not use jest inside stubs.js to prevent Storybook from crashing
* Based on a change in #10865 - just adding an Eslint warning so we do not create this issue again