### PR TITLE
Add 5.1 release notes for changed `attrs.html` template location

### DIFF
--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -535,3 +535,12 @@ Additionally, two new events will be dispatched when the dialog visibility chang
 | ------ | ----------------- |
 | Show   | `w-dialog:shown`  |
 | Hide   | `w-dialog:hidden` |
+
+## Shared template `.../tables/attrs.html` has been renamed to `.../shared/attrs.html`
+
+The undocumented shared template for rendering a dict of `attrs` to HTML, similar to Django form widgets, has been renamed.
+
+|     | Template location                                         | Usage with `include`                                                   |
+| --- | --------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Old | `wagtail/admin/templates/wagtailadmin/tables/attrs.html ` | `{% include "wagtailadmin/tables/attrs.html" with attrs=link_attrs %}` |
+| New | `wagtail/admin/templates/wagtailadmin/shared/attrs.html`  | `{% include "wagtailadmin/shared/attrs.html" with attrs=link_attrs %}` |


### PR DESCRIPTION
Fixes #10874

To be backported to 5.1.* branch