### PR TITLE
Add Block.__reduce__ to use pickling on Block

### DIFF
--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -2,6 +2,7 @@ import base64
 import collections
 import copy
 import json
+import pickle
 import unittest
 from decimal import Decimal
 
@@ -50,6 +51,15 @@ class ContextCharBlock(blocks.CharBlock):
 
 
 class TestFieldBlock(WagtailTestUtils, SimpleTestCase):
+    def test_pickling_blocks(self):
+        block = blocks.CharBlock(help_text="some help")
+        dumped_block = pickle.dumps(block)
+        block_rebirth = pickle.loads(dumped_block)
+        self.assertEqual(block_rebirth.field.help_text, "some help")
+        self.assertEqual(dumped_block, pickle.dumps(block_rebirth))
+        self.assertEqual(block_rebirth, block)
+        self.assertIsNot(block_rebirth, block)
+
     def test_charfield_render(self):
         block = blocks.CharBlock()
         html = block.render("Hello world!")


### PR DESCRIPTION
Some third party apps may cache data, and depending the django cache engine configured in settings, it can use the pickling module to serialize data.

`django-parler` is a good exemple of a 3rd party which need it via [_cache_translations](https://github.com/django-parler/django-parler/blob/master/parler/cache.py#L142)

This bug has been found via [wagtail_parler](https://pypi.org/project/wagtail-parler/) which use `django_parler` but it could be any other apps which need to cache or pickle a `Block` instance.



_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] ~~For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]~~
    -   [ ] ~~**Please list the exact browser and operating system versions you tested**:~~
    -   [ ] ~~**Please list which assistive technologies [^3] you tested**:~~
-   [ ] ~~For new features: Has the documentation been updated accordingly?~~