### PR TITLE
Fix minor typos in the docs

### DIFF
--- a/docs/advanced_topics/documents/title_generation_on_upload.md
+++ b/docs/advanced_topics/documents/title_generation_on_upload.md
@@ -26,7 +26,7 @@ You can prevent the default behaviour by calling `event.preventDefault()`. For t
 
 The event will 'bubble' up so that you can simply add a global `document` listener to capture all of these events, or you can scope your listener or handler logic as needed to ensure you only adjust titles in some specific scenarios.
 
-See MDN for more information about [custom JavasScript events](https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events).
+See MDN for more information about [custom JavaScript events](https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events).
 
 ## Code Examples
 

--- a/docs/advanced_topics/images/title_generation_on_upload.md
+++ b/docs/advanced_topics/images/title_generation_on_upload.md
@@ -26,7 +26,7 @@ You can prevent the default behaviour by calling `event.preventDefault()`. For t
 
 The event will 'bubble' up so that you can simply add a global `document` listener to capture all of these events, or you can scope your listener or handler logic as needed to ensure you only adjust titles in some specific scenarios.
 
-See MDN for more information about [custom JavasScript events](https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events).
+See MDN for more information about [custom JavaScript events](https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events).
 
 ## Code Examples
 


### PR DESCRIPTION
"JavasScript" -> "JavaScript"