### PR TITLE
Replace usage of text/django-form-template script with template element

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -57,6 +57,7 @@ Changelog
  * Maintenance: Replace `imghdr` with Willow's built-in MIME type detection (Jake Howard)
  * Maintenance: Migrate all other `data-tippy` HTML attribute usage to the Stimulus data-*-value attributes for w-tooltip & w-dropdown (Subhajit Ghosh, LB (Ben) Johnston)
  * Maintenance: Replace `@total_ordering` usage with comparison functions implementation (Virag Jain)
+ * Maintenance: Replace `<script type="text/django-form-template"><-/script>` template approach with HTML `template` elements in InlinePanel and expanding formset (Mansi Gundre, Subhajit Ghosh, LB (Ben) Johnston)
 
 
 5.1.2 (xx.xx.20xx) - IN DEVELOPMENT

--- a/client/src/components/ExpandingFormset/index.js
+++ b/client/src/components/ExpandingFormset/index.js
@@ -17,10 +17,16 @@ export class ExpandingFormset {
     const emptyFormElement = document.getElementById(
       prefix + '-EMPTY_FORM_TEMPLATE',
     );
-    if (emptyFormElement.innerText) {
-      this.emptyFormTemplate = emptyFormElement.innerText;
-    } else if (emptyFormElement.textContent) {
-      this.emptyFormTemplate = emptyFormElement.textContent;
+
+    if (emptyFormElement instanceof HTMLTemplateElement) {
+      this.emptyFormTemplate = emptyFormElement.innerHTML;
+    } else if (emptyFormElement instanceof HTMLScriptElement) {
+      /**
+       * Support legacy `<script type="text/django-form-template">` until removed
+       * @deprecated RemovedInWagtail60
+       */
+      this.emptyFormTemplate =
+        emptyFormElement.innerText || emptyFormElement.textContent;
     }
 
     addButton.on('click', () => {
@@ -28,14 +34,18 @@ export class ExpandingFormset {
     });
   }
 
+  /**
+   * @param {object?} opts
+   * @param {boolean?} opts.runCallbacks - (default: true) - if false, the onAdd and onInit callbacks will not be run
+   */
   addForm(opts = {}) {
-    /*
-    Supported opts:
-    runCallbacks (default: true) - if false, the onAdd and onInit callbacks will not be run
-    */
     const formIndex = this.formCount;
     const newFormHtml = this.emptyFormTemplate
       .replace(/__prefix__(.*?['"])/g, formIndex + '$1')
+      /**
+       * Replace inner escaped `<script>...<-/script>` tags with `<script>` tags
+       * @deprecated RemovedInWagtail60
+       */
       .replace(/<-(-*)\/script>/g, '<$1/script>');
 
     this.formContainer.append(newFormHtml);

--- a/client/src/components/InlinePanel/__snapshots__/index.test.js.snap
+++ b/client/src/components/InlinePanel/__snapshots__/index.test.js.snap
@@ -10,9 +10,9 @@ exports[`InlinePanel should allow inserting a new form and calling an onAdd func
     <div id="id_person_cafe_relationship-FORMS">
         <p id="person_cafe_relationship-0">form for inline child</p>
     </div>
-    <script type="text/django-form-template" id="id_person_cafe_relationship-EMPTY_FORM_TEMPLATE">
+    <template id="id_person_cafe_relationship-EMPTY_FORM_TEMPLATE">
         <p id="person_cafe_relationship-__prefix__">form for inline child</p>
-    </script>
+    </template>
     <button type="button" id="id_person_cafe_relationship-ADD">Add item</button>
 </form>"
 `;

--- a/client/src/components/InlinePanel/index.test.js
+++ b/client/src/components/InlinePanel/index.test.js
@@ -11,9 +11,9 @@ describe('InlinePanel', () => {
     <input name="person_cafe_relationship-MIN_NUM_FORMS" value="1" id="id_person_cafe_relationship-MIN_NUM_FORMS" type="hidden" />
     <input name="person_cafe_relationship-MAX_NUM_FORMS" value="5" id="id_person_cafe_relationship-MAX_NUM_FORMS" type="hidden" />
     <div id="id_person_cafe_relationship-FORMS"></div>
-    <script type="text/django-form-template" id="id_person_cafe_relationship-EMPTY_FORM_TEMPLATE">
+    <template id="id_person_cafe_relationship-EMPTY_FORM_TEMPLATE">
         <p id="person_cafe_relationship-__prefix__">form for inline child</p>
-    </script>
+    </template>
     <button type="button" id="id_person_cafe_relationship-ADD">Add item</button>
 </form>`;
   });

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -76,6 +76,7 @@ depth: 1
  * Replace `imghdr` with Willow's built-in MIME type detection (Jake Howard)
  * Migrate all other `data-tippy` HTML attribute usage to the Stimulus data-*-value attributes for w-tooltip & w-dropdown (Subhajit Ghosh, LB (Ben) Johnston)
  * Replace `@total_ordering` usage with comparison functions implementation (Virag Jain)
+ * Replace `<script type="text/django-form-template"><-/script>` template approach with HTML `template` elements in InlinePanel and expanding formset (Mansi Gundre, Subhajit Ghosh, LB (Ben) Johnston)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
@@ -27,11 +27,9 @@
     {% endfor %}
 </div>
 
-<script type="text/django-form-template" id="id_{{ self.formset.prefix }}-EMPTY_FORM_TEMPLATE">
-    {% escapescript %}
-        {% include "wagtailadmin/panels/inline_panel_child.html" with child=self.empty_child %}
-    {% endescapescript %}
-</script>
+<template id="id_{{ self.formset.prefix }}-EMPTY_FORM_TEMPLATE">
+    {% include "wagtailadmin/panels/inline_panel_child.html" with child=self.empty_child %}
+</template>
 
 {# Align with guiding line of the preceding child panel. #}
 <div class="w-mb-4 -w-ml-4">

--- a/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_formset.html
+++ b/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_formset.html
@@ -45,13 +45,11 @@
         </tbody>
     </table>
 
-    <script type="text/django-form-template" id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
-        {% escapescript %}
-            <tr id="inline_child_{{ formset.empty_form.prefix }}">
+    <template id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
+        <tr id="inline_child_{{ formset.empty_form.prefix }}">
             {% include "wagtailadmin/permissions/includes/collection_member_permissions_form.html" with form=formset.empty_form only %}
-            </tr>
-        {% endescapescript %}
-    </script>
+        </tr>
+    </template>
 
     <p class="add">
         <button class="button bicolor button--icon" id="id_{{ formset.prefix }}-ADD" value="Add" type="button">{% icon name="plus" wrapped=1 %}{% block add_button_label %}{% endblock %}</button>

--- a/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_pages_formset.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_pages_formset.html
@@ -36,13 +36,11 @@
     </tbody>
 </table>
 
-<script type="text/django-form-template" id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
-    {% escapescript %}
-        <tr id="inline_child_{{ formset.empty_form.prefix }}">
+<template id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
+    <tr id="inline_child_{{ formset.empty_form.prefix }}">
         {% include "wagtailadmin/workflows/includes/workflow_pages_form.html" with form=formset.empty_form only %}
-        </tr>
-    {% endescapescript %}
-</script>
+    </tr>
+</template>
 
 <p class="add">
     <button class="button bicolor button--icon" id="id_{{ formset.prefix }}-ADD" value="Add" type="button">{% icon name="plus" wrapped=1 %}{% trans "Assign to another page" %}</button>

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotions_formset.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotions_formset.html
@@ -16,8 +16,6 @@
     </div>
 {% endpanel %}
 
-<script type="text/django-form-template" id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
-    {% escapescript %}
-        {% include "wagtailsearchpromotions/includes/searchpromotion_form.html" with form=formset.empty_form only %}
-    {% endescapescript %}
-</script>
+<template id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
+    {% include "wagtailsearchpromotions/includes/searchpromotion_form.html" with form=formset.empty_form only %}
+</template>

--- a/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_formset.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_formset.html
@@ -44,13 +44,11 @@
         </tbody>
     </table>
 
-    <script type="text/django-form-template" id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
-        {% escapescript %}
-            <tr id="inline_child_{{ formset.empty_form.prefix }}">
+    <template id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
+        <tr id="inline_child_{{ formset.empty_form.prefix }}">
             {% include "wagtailusers/groups/includes/page_permissions_form.html" with form=formset.empty_form only %}
-            </tr>
-        {% endescapescript %}
-    </script>
+        </tr>
+    </template>
 
     <p class="add">
         <button class="button bicolor button--icon" id="id_{{ formset.prefix }}-ADD" value="Add" type="button">{% icon name="plus" wrapped=1 %}{% trans "Add a page permission" %}</button>


### PR DESCRIPTION
Replace usage of text/django-form-template script with template element
Issue - #10034 
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
