### PR TITLE
Update table styles for universal listings

### DIFF
--- a/client/scss/components/_bulk_actions.scss
+++ b/client/scss/components/_bulk_actions.scss
@@ -20,7 +20,6 @@
 .listing:not(.full-width) {
   thead th.bulk-actions-filter-checkbox,
   td.bulk-action-checkbox-cell {
-    padding: 0;
     width: 50px;
     text-align: center;
 

--- a/client/scss/components/_dropdown.scss
+++ b/client/scss/components/_dropdown.scss
@@ -1,5 +1,5 @@
 .w-dropdown__toggle {
-  @apply w-p-2 w-text-text-label w-bg-transparent;
+  @apply w-px-2 w-text-text-label w-bg-transparent;
 }
 
 .w-dropdown__toggle--icon {

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -212,6 +212,7 @@ ul.listing {
     h2 {
       @apply w-label-1;
       margin: 0;
+      vertical-align: middle;
 
       a {
         color: inherit;
@@ -222,6 +223,11 @@ ul.listing {
           color: theme('colors.text-link-default');
         }
       }
+    }
+
+    .icon.initial {
+      margin: 5px 0.3em 0 0;
+      vertical-align: top;
     }
   }
 

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -211,6 +211,7 @@ ul.listing {
     .title-wrapper,
     h2 {
       @apply w-label-1;
+      display: inline;
       margin: 0;
       vertical-align: middle;
 

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -25,7 +25,7 @@ ul.listing {
 
   td,
   th {
-    padding: 1.2em 1em;
+    padding: 1em;
 
     &.no-padding {
       padding: 0;
@@ -109,6 +109,7 @@ ul.listing {
   &.align-top td,
   td.align-top {
     vertical-align: top;
+    line-height: 2rem;
   }
 
   &.chooser {
@@ -222,10 +223,9 @@ ul.listing {
   }
 
   .actions {
-    @include clearfix();
-    margin-top: 0.8em;
-    margin-bottom: -0.5em;
+    float: right;
     font-size: 0.8rem;
+    margin: 0;
 
     a {
       text-decoration: none;
@@ -234,9 +234,6 @@ ul.listing {
     > li {
       float: left;
       padding: 0 0.5em 0 0;
-      margin: 0 0 0.5em;
-
-      // line-height: 1em;
     }
   }
 
@@ -280,7 +277,7 @@ ul.listing {
 
     a {
       display: block;
-      padding: 2em 0;
+      padding: 0;
     }
   }
 
@@ -558,16 +555,16 @@ table.listing {
       }
     }
 
-    .actions {
+    .actions .button {
       visibility: hidden;
     }
 
-    .index .actions {
+    .index .actions .button {
       visibility: visible;
     }
 
-    td:hover .actions,
-    td:focus-within .actions {
+    td:hover .actions .button,
+    td:focus-within .actions .button {
       visibility: visible;
     }
 

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -44,7 +44,7 @@ ul.listing {
 
   td.title {
     padding: 1em;
-    line-height: 2rem;
+    line-height: 2em;
   }
 
   thead {
@@ -228,7 +228,7 @@ ul.listing {
     }
 
     .icon.initial {
-      margin: 5px 0.3em 0 0;
+      margin: 3px 0.3em 0 0;
       vertical-align: top;
     }
   }

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -567,19 +567,6 @@ table.listing {
       }
     }
 
-    .actions .button {
-      visibility: hidden;
-    }
-
-    .index .actions .button {
-      visibility: visible;
-    }
-
-    td:hover .actions .button,
-    td:focus-within .actions .button {
-      visibility: visible;
-    }
-
     .bulk-action-checkbox {
       opacity: 0;
 

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -10,6 +10,7 @@ ul.listing {
 
   ul {
     list-style-type: none;
+    margin: 0;
     padding-inline-start: 0;
   }
 

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -25,7 +25,7 @@ ul.listing {
 
   td,
   th {
-    padding: 1em;
+    padding: 1.2em 1em;
 
     &.no-padding {
       padding: 0;
@@ -35,6 +35,15 @@ ul.listing {
   &.small td,
   th {
     padding: 0.6em 1em;
+  }
+
+  td {
+    vertical-align: top;
+  }
+
+  td.title {
+    padding: 1em;
+    line-height: 2rem;
   }
 
   thead {
@@ -104,12 +113,6 @@ ul.listing {
 
   &.full-width tbody {
     border: 0;
-  }
-
-  &.align-top td,
-  td.align-top {
-    vertical-align: top;
-    line-height: 2rem;
   }
 
   &.chooser {
@@ -234,6 +237,7 @@ ul.listing {
     > li {
       float: left;
       padding: 0 0.5em 0 0;
+      vertical-align: middle;
     }
   }
 
@@ -296,6 +300,7 @@ ul.listing {
     color: theme('colors.text-button-outline-default');
     display: block;
     text-align: center;
+    line-height: 3rem;
 
     .icon {
       width: 1.5rem;

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -2,12 +2,5 @@
 {% fragment as toggle_classname %}{{ classes|join:' ' }} {{ button_classes|join:' ' }}{% endfragment %}
 
 {% dropdown attrs=self.attrs toggle_icon="arrow-down" toggle_label=label toggle_aria_label=title toggle_classname=toggle_classname %}
-    {% for button in buttons %}
-        <a href="{{ button.url }}" aria-label="{{ button.attrs.title }}" class="{{ button.classes|join:' ' }}">
-            {% if button.icon_name %}
-                {% icon name=button.icon_name %}
-            {% endif %}
-            {{ button.label }}
-        </a>
-    {% endfor %}
+    {% include "wagtailadmin/pages/listing/_dropdown_items.html" with buttons=buttons only %}
 {% enddropdown %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -1,6 +1,6 @@
 {% load wagtailadmin_tags %}
 {% fragment as toggle_classname %}{{ classes|join:' ' }} {{ button_classes|join:' ' }}{% endfragment %}
 
-{% dropdown attrs=self.attrs toggle_icon="arrow-down" toggle_label=label toggle_aria_label=title toggle_classname=toggle_classname %}
+{% dropdown attrs=self.attrs toggle_icon=icon_name|default:"arrow-down" toggle_label=label toggle_aria_label=title toggle_classname=toggle_classname %}
     {% include "wagtailadmin/pages/listing/_dropdown_items.html" with buttons=buttons only %}
 {% enddropdown %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_dropdown_items.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_dropdown_items.html
@@ -1,7 +1,7 @@
 {% load wagtailadmin_tags %}
 
 {% for button in buttons %}
-    <a href="{{ button.url }}" aria-label="{{ button.attrs.title }}" class="{{ button.classes|join:' ' }}">
+    <a href="{{ button.url }}" aria-label="{{ button.aria_label }}" class="{{ button.classes|join:' ' }}">
         {% if button.icon_name %}
             {% icon name=button.icon_name %}
         {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_dropdown_items.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_dropdown_items.html
@@ -1,0 +1,10 @@
+{% load wagtailadmin_tags %}
+
+{% for button in buttons %}
+    <a href="{{ button.url }}" aria-label="{{ button.attrs.title }}" class="{{ button.classes|join:' ' }}">
+        {% if button.icon_name %}
+            {% icon name=button.icon_name %}
+        {% endif %}
+        {{ button.label }}
+    </a>
+{% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_header_buttons.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_header_buttons.html
@@ -5,14 +5,7 @@
 
     {% dropdown toggle_icon=icon_name toggle_aria_label=title toggle_classname=toggle_classname toggle_tooltip_offset="[0, -2]" %}
         {% block content %}
-            {% for button in buttons %}
-                <a href="{{ button.url }}" aria-label="{{ button.attrs.title }}" class="{{ button.classes|join:' ' }}">
-                    {% if button.icon_name %}
-                        {% icon name=button.icon_name %}
-                    {% endif %}
-                    {{ button.label }}
-                </a>
-            {% endfor %}
+            {% include "wagtailadmin/pages/listing/_dropdown_items.html" with buttons=buttons only %}
         {% endblock %}
     {% enddropdown %}
 </nav>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -10,8 +10,12 @@
     {% endif %}
 
     {% if page_perms.can_edit %}
-        <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>
+        <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">
+            {% if not page.is_site_root and not page.is_leaf %}{% icon name="folder" classname="initial w-align-text-top" %}{% endif %}
+            {{ page.get_admin_display_title }}
+        </a>
     {% else %}
+        {% if not page.is_site_root and not page.is_leaf %}{% icon name="folder" classname="initial w-align-text-top" %}{% endif %}
         {{ page.get_admin_display_title }}
     {% endif %}
 

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -2,7 +2,7 @@
 
 {# The title field for a page in the page listing, when in 'explore' mode #}
 
-<div class="title-wrapper">
+<span class="title-wrapper">
     {% if page.is_site_root %}
         {% if perms.wagtailcore.add_site or perms.wagtailcore.change_site or perms.wagtailcore.delete_site %}
             <a href="{% url 'wagtailsites:index' %}" title="{% trans 'Sites menu' %}">{% icon name="site" classname="initial w-align-text-top" %}</a>
@@ -21,7 +21,7 @@
 
     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
     {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
-</div>
+</span>
 
 <ul class="actions">
     {% page_listing_buttons page page_perms %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -5,17 +5,17 @@
 <div class="title-wrapper">
     {% if page.is_site_root %}
         {% if perms.wagtailcore.add_site or perms.wagtailcore.change_site or perms.wagtailcore.delete_site %}
-            <a href="{% url 'wagtailsites:index' %}" title="{% trans 'Sites menu' %}">{% icon name="site" classname="initial w-align-text-top" %}</a>
+            <a href="{% url 'wagtailsites:index' %}" title="{% trans 'Sites menu' %}">{% icon name="site" classname="initial" %}</a>
         {% endif %}
     {% endif %}
 
     {% if page_perms.can_edit %}
         <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">
-            {% if not page.is_site_root and not page.is_leaf %}{% icon name="folder" classname="initial w-align-text-top" %}{% endif %}
+            {% if not page.is_site_root and not page.is_leaf %}{% icon name="folder" classname="initial" %}{% endif %}
             {{ page.get_admin_display_title }}
         </a>
     {% else %}
-        {% if not page.is_site_root and not page.is_leaf %}{% icon name="folder" classname="initial w-align-text-top" %}{% endif %}
+        {% if not page.is_site_root and not page.is_leaf %}{% icon name="folder" classname="initial" %}{% endif %}
         {{ page.get_admin_display_title }}
     {% endif %}
 

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -2,7 +2,7 @@
 
 {# The title field for a page in the page listing, when in 'explore' mode #}
 
-<span class="title-wrapper">
+<div class="title-wrapper">
     {% if page.is_site_root %}
         {% if perms.wagtailcore.add_site or perms.wagtailcore.change_site or perms.wagtailcore.delete_site %}
             <a href="{% url 'wagtailsites:index' %}" title="{% trans 'Sites menu' %}">{% icon name="site" classname="initial w-align-text-top" %}</a>
@@ -25,7 +25,7 @@
 
     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
     {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
-</span>
+</div>
 
 <ul class="actions">
     {% page_listing_buttons page page_perms %}

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -172,9 +172,8 @@ class TestPageListingMoreButtonsHooks(TestButtonsHooks):
         next_url = "a/random/url/"
         full_url = base_url + "?" + urlencode({"next": next_url})
 
-        delete_button = next(
-            page_listing_more_buttons(page, page_perms, next_url=next_url)
-        )
+        buttons = page_listing_more_buttons(page, page_perms, next_url=next_url)
+        delete_button = next(button for button in buttons if button.label == "Delete")
 
         self.assertEqual(delete_button.url, full_url)
 
@@ -185,7 +184,6 @@ class TestPageListingMoreButtonsHooks(TestButtonsHooks):
         As the page is now deleted and cannot be edited.
         """
 
-        # permissions should yield two buttons, delete and unpublish
         page_perms = DeleteAndUnpublishPagePerms()
         page = self.root_page
 
@@ -194,14 +192,16 @@ class TestPageListingMoreButtonsHooks(TestButtonsHooks):
 
         buttons = page_listing_more_buttons(page, page_perms, next_url=next_url)
 
-        delete_button = next(buttons)
+        delete_button = next(button for button in buttons if button.label == "Delete")
 
         # check that the next_url is NOT included as it will not be available after deletion
         self.assertEqual(delete_button.url, base_url)
 
-        # check that any buttons after do correctly still include the next_url
+        # check that the unpublish button does correctly still include the next_url
         unpublish_base_url = reverse("wagtailadmin_pages:unpublish", args=[page.id])
-        unpublish_button = next(buttons)
+        unpublish_button = next(
+            button for button in buttons if button.label == "Unpublish"
+        )
         full_url = unpublish_base_url + "?" + urlencode({"next": next_url})
         self.assertEqual(unpublish_button.url, full_url)
 
@@ -211,11 +211,16 @@ class TestPageListingMoreButtonsHooks(TestButtonsHooks):
 
         # no button returned
         buttons = page_listing_more_buttons(page, page_perms)
-        self.assertEqual(len(list(buttons)), 0)
+        self.assertEqual(
+            len([button for button in buttons if button.label == "Sort menu order"]), 0
+        )
 
         page_perms = ReorderOnlyPagePerms()
         # page_listing_more_button generator yields only `Sort menu order button`
-        reorder_button = next(page_listing_more_buttons(page, page_perms))
+        buttons = page_listing_more_buttons(page, page_perms)
+        reorder_button = next(
+            button for button in buttons if button.label == "Sort menu order"
+        )
 
         self.assertEqual(reorder_button.url, "?ordering=ord")
 
@@ -254,7 +259,8 @@ class TestPageHeaderButtonsHooks(TestButtonsHooks):
         next_url = "a/random/url/"
         full_url = base_url + "?" + urlencode({"next": next_url})
 
-        delete_button = next(page_header_buttons(page, page_perms, next_url=next_url))
+        buttons = page_header_buttons(page, page_perms, next_url=next_url)
+        delete_button = next(button for button in buttons if button.label == "Delete")
 
         self.assertEqual(delete_button.url, full_url)
 
@@ -274,7 +280,7 @@ class TestPageHeaderButtonsHooks(TestButtonsHooks):
 
         buttons = page_header_buttons(page, page_perms, next_url=next_url)
 
-        delete_button = next(buttons)
+        delete_button = next(button for button in buttons if button.label == "Delete")
 
         # check that the next_url is NOT included as it will not be available after deletion (page listing)
         self.assertEqual(delete_button.url, base_url)
@@ -284,14 +290,16 @@ class TestPageHeaderButtonsHooks(TestButtonsHooks):
 
         buttons = page_header_buttons(page, page_perms, next_url=next_url)
 
-        delete_button = next(buttons)
+        delete_button = next(button for button in buttons if button.label == "Delete")
 
         # check that the next_url is NOT included as it will not be available after deletion (edit page)
         self.assertEqual(delete_button.url, base_url)
 
         # check that any buttons after do correctly still include the next_url
         unpublish_base_url = reverse("wagtailadmin_pages:unpublish", args=[page.id])
-        unpublish_button = next(buttons)
+        unpublish_button = next(
+            button for button in buttons if button.label == "Unpublish"
+        )
         full_url = unpublish_base_url + "?" + urlencode({"next": next_url})
         self.assertEqual(unpublish_button.url, full_url)
 

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -251,7 +251,6 @@ class TestPageHeaderButtonsHooks(TestButtonsHooks):
         Ensure that the built in delete button supports a next_url provided.
         """
 
-        # page_listing_more_button generator yields only `Delete button` with this permission set
         page_perms = DeleteOnlyPagePerms()
         page = self.root_page
         base_url = reverse("wagtailadmin_pages:delete", args=[page.id])
@@ -271,7 +270,6 @@ class TestPageHeaderButtonsHooks(TestButtonsHooks):
         As the page is now deleted and cannot be edited.
         """
 
-        # permissions should yield two buttons, delete and unpublish
         page_perms = DeleteAndUnpublishPagePerms()
         page = self.root_page
 

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -47,14 +47,13 @@ class IndexView(PermissionCheckedMixin, BaseListingView):
             "title",
             label=_("Title"),
             sort_key="title",
-            classname="align-top title",
+            classname="title",
         ),
         DateColumn(
             "latest_revision_created_at",
             label=_("Updated"),
             sort_key="latest_revision_created_at",
             width="12%",
-            classname="align-top",
         ),
         Column(
             "type",
@@ -62,14 +61,12 @@ class IndexView(PermissionCheckedMixin, BaseListingView):
             accessor="page_type_display_name",
             sort_key="content_type",
             width="12%",
-            classname="align-top",
         ),
         PageStatusColumn(
             "status",
             label=_("Status"),
             sort_key="live",
             width="12%",
-            classname="align-top",
         ),
         NavigateToChildrenColumn("navigate", width="10%"),
     ]

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -69,31 +69,28 @@ class BaseSearchView(PermissionCheckedMixin, BaseListingView):
         BulkActionsColumn("bulk_actions", width="10px"),
         PageTitleColumn(
             "title",
+            classname="title",
             label=_("Title"),
             sort_key="title",
-            classname="align-top",
         ),
-        ParentPageColumn("parent", label=_("Parent"), classname="align-top"),
+        ParentPageColumn("parent", label=_("Parent")),
         DateColumn(
             "latest_revision_created_at",
             label=_("Updated"),
             sort_key="latest_revision_created_at",
             width="12%",
-            classname="align-top",
         ),
         Column(
             "type",
             label=_("Type"),
             accessor="page_type_display_name",
             width="12%",
-            classname="align-top",
         ),
         PageStatusColumn(
             "status",
             label=_("Status"),
             sort_key="live",
             width="12%",
-            classname="align-top",
         ),
         NavigateToChildrenColumn("navigate", width="10%"),
     ]

--- a/wagtail/admin/views/pages/usage.py
+++ b/wagtail/admin/views/pages/usage.py
@@ -25,14 +25,14 @@ class ContentTypeUseView(BaseListingView):
     page_kwarg = "p"
     paginate_by = 50
     columns = [
-        PageTitleColumn("title", label=_("Title")),
+        PageTitleColumn("title", classname="title", label=_("Title")),
         ParentPageColumn("parent", label=_("Parent")),
         DateColumn("latest_revision_created_at", label=_("Updated"), width="12%"),
         Column("type", label=_("Type"), accessor="page_type_display_name", width="12%"),
         PageStatusColumn("status", label=_("Status"), width="12%"),
     ]
     table_class = PageTable
-    table_classname = "listing align-top"
+    table_classname = "listing"
 
     def get(self, request, *, content_type_app_name, content_type_model_name):
         try:

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -51,7 +51,7 @@ from wagtail.admin.views.pages.bulk_actions import (
     UnpublishBulkAction,
 )
 from wagtail.admin.viewsets import viewsets
-from wagtail.admin.widgets import Button, ButtonWithDropdownFromHook, PageListingButton
+from wagtail.admin.widgets import Button, ButtonWithDropdownFromHook
 from wagtail.models import Collection, Page, Task, Workflow
 from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.permissions import (
@@ -222,17 +222,6 @@ def register_workflow_tasks_menu_item():
 
 @hooks.register("register_page_listing_buttons")
 def page_listing_buttons(page, page_perms, next_url=None):
-    if page_perms.can_edit():
-        yield PageListingButton(
-            _("Edit"),
-            reverse("wagtailadmin_pages:edit", args=[page.id]),
-            attrs={
-                "aria-label": _("Edit '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
-            priority=10,
-        )
-
     yield ButtonWithDropdownFromHook(
         "",
         hook_name="register_page_listing_more_buttons",
@@ -252,6 +241,18 @@ def page_listing_buttons(page, page_perms, next_url=None):
 
 @hooks.register("register_page_listing_more_buttons")
 def page_listing_more_buttons(page, page_perms, next_url=None):
+    if page_perms.can_edit():
+        yield Button(
+            _("Edit"),
+            reverse("wagtailadmin_pages:edit", args=[page.id]),
+            icon_name="edit",
+            attrs={
+                "aria-label": _("Edit '%(title)s'")
+                % {"title": page.get_admin_display_title()}
+            },
+            priority=2,
+        )
+
     if page.has_unpublished_changes and page.is_previewable():
         yield Button(
             _("View draft"),

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -243,7 +243,7 @@ def page_listing_buttons(page, page_perms, next_url=None):
         attrs={
             "target": "_blank",
             "rel": "noreferrer",
-            "title": _("More options for '%(title)s'")
+            "aria-label": _("More options for '%(title)s'")
             % {"title": page.get_admin_display_title()},
         },
         priority=50,
@@ -294,7 +294,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             reverse("wagtailadmin_pages:move", args=[page.id]),
             icon_name="arrow-right-full",
             attrs={
-                "title": _("Move page '%(title)s'")
+                "aria-label": _("Move page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
             },
             priority=10,
@@ -309,7 +309,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             url,
             icon_name="copy",
             attrs={
-                "title": _("Copy page '%(title)s'")
+                "aria-label": _("Copy page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
             },
             priority=20,
@@ -330,7 +330,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             url,
             icon_name="bin",
             attrs={
-                "title": _("Delete page '%(title)s'")
+                "aria-label": _("Delete page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
             },
             priority=30,
@@ -345,7 +345,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             url,
             icon_name="resubmit",
             attrs={
-                "title": _("Unpublish page '%(title)s'")
+                "aria-label": _("Unpublish page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
             },
             priority=40,
@@ -356,7 +356,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             reverse("wagtailadmin_pages:history", args=[page.id]),
             icon_name="history",
             attrs={
-                "title": _("View page history for '%(title)s'")
+                "aria-label": _("View page history for '%(title)s'")
                 % {"title": page.get_admin_display_title()}
             },
             priority=50,
@@ -368,7 +368,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             "?ordering=ord",
             icon_name="list-ul",
             attrs={
-                "title": _("Change ordering of child pages of '%(title)s'")
+                "aria-label": _("Change ordering of child pages of '%(title)s'")
                 % {"title": page.get_admin_display_title()}
             },
             priority=60,
@@ -383,7 +383,7 @@ def page_header_buttons(page, page_perms, next_url=None):
             reverse("wagtailadmin_pages:edit", args=[page.id]),
             icon_name="edit",
             attrs={
-                "title": _("Edit '%(title)s'")
+                "aria-label": _("Edit '%(title)s'")
                 % {"title": page.get_admin_display_title()}
             },
             priority=10,
@@ -394,7 +394,7 @@ def page_header_buttons(page, page_perms, next_url=None):
             reverse("wagtailadmin_pages:move", args=[page.id]),
             icon_name="arrow-right-full",
             attrs={
-                "title": _("Move page '%(title)s'")
+                "aria-label": _("Move page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
             },
             priority=20,
@@ -409,7 +409,7 @@ def page_header_buttons(page, page_perms, next_url=None):
             url,
             icon_name="copy",
             attrs={
-                "title": _("Copy page '%(title)s'")
+                "aria-label": _("Copy page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
             },
             priority=30,
@@ -445,7 +445,7 @@ def page_header_buttons(page, page_perms, next_url=None):
             url,
             icon_name="bin",
             attrs={
-                "title": _("Delete page '%(title)s'")
+                "aria-label": _("Delete page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
             },
             priority=50,
@@ -460,7 +460,7 @@ def page_header_buttons(page, page_perms, next_url=None):
             url,
             icon_name="download",
             attrs={
-                "title": _("Unpublish page '%(title)s'")
+                "aria-label": _("Unpublish page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
             },
             priority=60,
@@ -473,7 +473,7 @@ def page_header_buttons(page, page_perms, next_url=None):
             url,
             icon_name="list-ul",
             attrs={
-                "title": _("Change ordering of child pages of '%(title)s'")
+                "aria-label": _("Change ordering of child pages of '%(title)s'")
                 % {"title": page.get_admin_display_title()}
             },
             priority=70,

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -232,38 +232,6 @@ def page_listing_buttons(page, page_perms, next_url=None):
             },
             priority=10,
         )
-    if page.has_unpublished_changes and page.is_previewable():
-        yield PageListingButton(
-            _("View draft"),
-            reverse("wagtailadmin_pages:view_draft", args=[page.id]),
-            attrs={
-                "aria-label": _("Preview draft version of '%(title)s'")
-                % {"title": page.get_admin_display_title()},
-                "rel": "noreferrer",
-            },
-            priority=20,
-        )
-    if page.live and page.url:
-        yield PageListingButton(
-            _("View live"),
-            page.url,
-            attrs={
-                "rel": "noreferrer",
-                "aria-label": _("View live version of '%(title)s'")
-                % {"title": page.get_admin_display_title()},
-            },
-            priority=30,
-        )
-    if page_perms.can_add_subpage():
-        yield PageListingButton(
-            _("Add child page"),
-            reverse("wagtailadmin_pages:add_subpage", args=[page.id]),
-            attrs={
-                "aria-label": _("Add a child page to '%(title)s' ")
-                % {"title": page.get_admin_display_title()}
-            },
-            priority=40,
-        )
 
     yield ButtonWithDropdownFromHook(
         "",
@@ -284,6 +252,42 @@ def page_listing_buttons(page, page_perms, next_url=None):
 
 @hooks.register("register_page_listing_more_buttons")
 def page_listing_more_buttons(page, page_perms, next_url=None):
+    if page.has_unpublished_changes and page.is_previewable():
+        yield Button(
+            _("View draft"),
+            reverse("wagtailadmin_pages:view_draft", args=[page.id]),
+            icon_name="draft",
+            attrs={
+                "aria-label": _("Preview draft version of '%(title)s'")
+                % {"title": page.get_admin_display_title()},
+                "rel": "noreferrer",
+            },
+            priority=4,
+        )
+    if page.live and page.url:
+        yield Button(
+            _("View live"),
+            page.url,
+            icon_name="doc-empty",
+            attrs={
+                "rel": "noreferrer",
+                "aria-label": _("View live version of '%(title)s'")
+                % {"title": page.get_admin_display_title()},
+            },
+            priority=6,
+        )
+    if page_perms.can_add_subpage():
+        yield Button(
+            _("Add child page"),
+            reverse("wagtailadmin_pages:add_subpage", args=[page.id]),
+            icon_name="circle-plus",
+            attrs={
+                "aria-label": _("Add a child page to '%(title)s' ")
+                % {"title": page.get_admin_display_title()}
+            },
+            priority=8,
+        )
+
     if page_perms.can_move():
         yield Button(
             _("Move"),

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -389,6 +389,17 @@ def page_header_buttons(page, page_perms, next_url=None):
             },
             priority=10,
         )
+    if page_perms.can_add_subpage():
+        yield Button(
+            _("Add child page"),
+            reverse("wagtailadmin_pages:add_subpage", args=[page.id]),
+            icon_name="circle-plus",
+            attrs={
+                "aria-label": _("Add a child page to '%(title)s' ")
+                % {"title": page.get_admin_display_title()},
+            },
+            priority=15,
+        )
     if page_perms.can_move():
         yield Button(
             _("Move"),
@@ -414,17 +425,6 @@ def page_header_buttons(page, page_perms, next_url=None):
                 % {"title": page.get_admin_display_title()}
             },
             priority=30,
-        )
-    if page_perms.can_add_subpage():
-        yield Button(
-            _("Add child page"),
-            reverse("wagtailadmin_pages:add_subpage", args=[page.id]),
-            icon_name="circle-plus",
-            attrs={
-                "aria-label": _("Add a child page to '%(title)s' ")
-                % {"title": page.get_admin_display_title()},
-            },
-            priority=40,
         )
     if page_perms.can_delete():
         url = reverse("wagtailadmin_pages:delete", args=[page.id])
@@ -465,6 +465,17 @@ def page_header_buttons(page, page_perms, next_url=None):
                 % {"title": page.get_admin_display_title()}
             },
             priority=60,
+        )
+    if page_perms.can_view_revisions():
+        yield Button(
+            _("History"),
+            reverse("wagtailadmin_pages:history", args=[page.id]),
+            icon_name="history",
+            attrs={
+                "aria-label": _("View page history for '%(title)s'")
+                % {"title": page.get_admin_display_title()}
+            },
+            priority=65,
         )
     if page_perms.can_reorder_children():
         url = reverse("wagtailadmin_explore", args=[page.id])

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -266,12 +266,12 @@ def page_listing_buttons(page, page_perms, next_url=None):
         )
 
     yield ButtonWithDropdownFromHook(
-        _("More"),
+        "",
         hook_name="register_page_listing_more_buttons",
         page=page,
         page_perms=page_perms,
         next_url=next_url,
-        classes={"button", "button-secondary", "button-small"},
+        icon_name="dots-horizontal",
         attrs={
             "target": "_blank",
             "rel": "noreferrer",

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -17,16 +17,24 @@ class Button:
         self.classes = classes
         self.icon_name = icon_name
         self.attrs = attrs.copy()
+        # if a 'title' attribute has been passed, correct that to aria-label
+        # as that's what will be picked up in renderings that don't use button.render
+        # directly (e.g. _dropdown_items.html)
+        if "title" in self.attrs and "aria-label" not in self.attrs:
+            self.attrs["aria-label"] = self.attrs.pop("title")
         self.priority = priority
 
     def render(self):
         attrs = {
             "href": self.url,
             "class": " ".join(sorted(self.classes)),
-            "title": self.label,
         }
         attrs.update(self.attrs)
         return format_html("<a{}>{}</a>", flatatt(attrs), self.label)
+
+    @property
+    def aria_label(self):
+        return self.attrs.get("aria-label", "")
 
     def __str__(self):
         return self.render()
@@ -90,7 +98,7 @@ class BaseDropdownMenuButton(Button):
         return {
             "buttons": self.dropdown_buttons,
             "label": self.label,
-            "title": self.attrs.get("title"),
+            "title": self.aria_label,
             "classes": self.classes,
             "icon_name": self.icon_name,
         }

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -92,6 +92,7 @@ class BaseDropdownMenuButton(Button):
             "label": self.label,
             "title": self.attrs.get("title"),
             "classes": self.classes,
+            "icon_name": self.icon_name,
         }
 
     def render(self):

--- a/wagtail/users/wagtail_hooks.py
+++ b/wagtail/users/wagtail_hooks.py
@@ -14,6 +14,7 @@ from wagtail.admin.admin_url_finder import (
 )
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.search import SearchArea
+from wagtail.admin.utils import get_user_display_name
 from wagtail.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.users.urls import users
@@ -148,7 +149,10 @@ def user_listing_buttons(context, user):
         _("Edit"),
         reverse("wagtailusers_users:edit", args=[user.pk]),
         classes={"button-secondary"},
-        attrs={"title": _("Edit this user")},
+        attrs={
+            "aria-label": _("Edit user '%(name)s'")
+            % {"name": get_user_display_name(user)}
+        },
         priority=10,
     )
     if user_can_delete_user(context.request.user, user):
@@ -156,7 +160,10 @@ def user_listing_buttons(context, user):
             _("Delete"),
             reverse("wagtailusers_users:delete", args=[user.pk]),
             classes={"no"},
-            attrs={"title": _("Delete this user")},
+            attrs={
+                "aria-label": _("Delete user '%(name)s'")
+                % {"name": get_user_display_name(user)}
+            },
             priority=20,
         )
 


### PR DESCRIPTION
Update listing table styles for the new universal listing designs (https://github.com/wagtail/wagtail/discussions/10446).

* Make the 'more' button on page listings into a '...' icon (that doesn't disappear on hover)
* Move all buttons other than 'Edit' into the More menu
* Move buttons to the right of title, rather than below
* Adjust cell alignments to be top-aligned as standard
* Add folder icon for pages with children

I've also updated the pre-commit hooks - for some reason, the older version of stylelint fails on my machine with a JS syntax error.

![Screenshot 2023-09-15 at 00 09 15](https://github.com/wagtail/wagtail/assets/85097/30dd0712-6439-45b4-9afd-f292c07013d5)

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
