### PR TITLE
Support passing extra context variables via the {% component %} tag

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ Changelog
  * Extract generic breadcrumbs functionality from page breadcrumbs (Sage Abdullah)
  * Add support for `placement` in the `human_readable_date` tooltip template tag (Rohit Sharma)
  * Add breadcrumbs to generic model views (Sage Abdullah)
+ * Support passing extra context variables via the `{% component %}` tag (Matt Westcott)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)

--- a/docs/extending/template_components.md
+++ b/docs/extending/template_components.md
@@ -115,6 +115,26 @@ the `my_app/welcome.html` template could render the panels as follows:
 {% endfor %}
 ```
 
+You can pass additional context variables to the component using the keyword `with`:
+
+```html+django
+{% component panel with username=request.user.username %}
+```
+
+To render the component with only the variables provided (and no others from the calling template's context), use `only`:
+
+```html+django
+{% component panel with username=request.user.username only %}
+```
+
+To store the component's rendered output in a variable rather than outputting it immediately, use `as` followed by the variable name:
+
+```html+django
+{% component panel as panel_html %}
+
+{{ panel_html }}
+```
+
 Note that it is your template's responsibility to output any media declarations defined on the components. For a Wagtail admin view, this is best done by constructing a media object for the whole page within the view, passing this to the template, and outputting it via the base template's `extra_js` and `extra_css` blocks:
 
 ```python

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -40,6 +40,7 @@ depth: 1
  * Extract generic breadcrumbs functionality from page breadcrumbs (Sage Abdullah)
  * Add support for `placement` in `human_readable_date` the tooltip template tag (Rohit Sharma)
  * Add breadcrumbs to generic model views (Sage Abdullah)
+ * Support passing extra context variables via the `{% component %}` tag (Matt Westcott)
 
 ### Bug fixes
 


### PR DESCRIPTION
Enhance the `{% component %}` tag to allow passing extra context variables, such as:

```
{% component panel with username=request.user.username %}
```
or
```
{% component panel with username=request.user.username only %}
```

I considered surfacing these as actual keyword arguments to the component's `render_html` / `get_context_data` methods rather than using the context dict, to make the action of passing parameters to the component more explicit - but A) that would break backwards compatibility, and B) it wouldn't match what people are used to with the `{% include %}` tag.

_Please check the following:_

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For new features: Has the documentation been updated accordingly?
