### PR TITLE
Allow subclasses of PagesAPIViewSet override default Page model

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ Changelog
  * Add support for `placement` in the `human_readable_date` tooltip template tag (Rohit Sharma)
  * Add breadcrumbs to generic model views (Sage Abdullah)
  * Support passing extra context variables via the `{% component %}` tag (Matt Westcott)
+ * Allow subclasses of `PagesAPIViewSet` override default Page model via the `model` attribute (Neeraj Yetheendran, Herbert Poul)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -732,6 +732,7 @@
 * Faishal Manzar
 * Rohit Sharma
 * Subhajit Ghosh
+* Neeraj Yetheendran
 
 ## Translators
 

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -56,7 +56,21 @@ class CustomPagesAPIViewSet(PagesAPIViewSet):
     renderer_classes = [JSONRenderer]
     name = "pages"
 
-api_router.register_endpoint("pages", ProdPagesAPIViewSet)
+api_router.register_endpoint("pages", CustomPagesAPIViewSet)
+```
+
+Or changing the desired model to use for page results.
+
+```python
+from rest_framework.renderers import JSONRenderer
+
+# ...
+
+class PostPagesAPIViewSet(PagesAPIViewSet):
+    model = models.BlogPage
+    
+
+api_router.register_endpoint("posts", PostPagesAPIViewSet)
 ```
 
 Additionally, there is a base endpoint class you can use for adding different

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -41,6 +41,7 @@ depth: 1
  * Add support for `placement` in `human_readable_date` the tooltip template tag (Rohit Sharma)
  * Add breadcrumbs to generic model views (Sage Abdullah)
  * Support passing extra context variables via the `{% component %}` tag (Matt Westcott)
+ * Allow subclasses of `PagesAPIViewSet` override default Page model via the `model` attribute (Neeraj Yetheendran, Herbert Poul)
 
 ### Bug fixes
 

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1105,6 +1105,14 @@ class TestPageListingSearch(WagtailTestUtils, TransactionTestCase):
 
         self.assertEqual(set(page_id_list), {16, 18, 19})
 
+    def test_search_with_invalid_type(self):
+        # Check that a 400 error is returned when the type doesn't exist
+        response = self.get_response(type="demosite.InvalidPageType", search="blog")
+        content = json.loads(response.content.decode("UTF-8"))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {"message": "type doesn't exist"})
+
     def test_search_with_filter(self):
         response = self.get_response(
             title="Another blog post", search="blog", order="title"
@@ -1808,3 +1816,13 @@ class TestPageCacheInvalidation(TestCase):
         Page.objects.get(id=2).specific.save_revision()
 
         purge.assert_not_called()
+
+
+class TestPageViewSetSubclassing(PagesAPIViewSet):
+    model = models.BlogEntryPage
+
+    def test_get_queryset(self):
+        self.assertEqual(
+            self.get_queryset().model,
+            models.BlogEntryPage,
+        )


### PR DESCRIPTION
Based on #7372 
Fixes #... 
Allows subclassing PagesAPIViewSet to override get_queryset() and only retrieve query set based on the Model attribute of Class

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For new features: Has the documentation been updated accordingly?


