### PR TITLE
Fix typo and expression in 5.1 release notes

### DIFF
--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -70,7 +70,7 @@ This release includes a number of changes to permissions, to make them easier to
 
 ### Snippet enhancements
 
-we have made a number of improvements to snippets as part of [RFC 85: Snippets parity with ModelAdmin](https://github.com/wagtail/rfcs/pull/85), ahead of the deprecation of ModelAdmin contrib app.
+We have made a number of improvements to snippets as part of [RFC 85: Snippets parity with ModelAdmin](https://github.com/wagtail/rfcs/pull/85), ahead of the deprecation of ModelAdmin contrib app.
 
 * Add the ability to export snippets listing via `SnippetViewSet.list_export` (Sage Abdullah)
 * Add Inspect view to snippets (Sage Abdullah)
@@ -264,9 +264,9 @@ During the deprecation period, the `permission_type` field will still be availab
 ### The default ordering of Group Editing Permissions models has changed
 
 The ordering for "Object permissions" and "Other permissions" now follows a predictable order equivalent to Django's default `Model` ordering.
-This will be different to the previous ordering which never intentionally implemented.
+This will be different to the previous indeterminate ordering.
 
-The default ordering is now `["content_type__app_label", "content_type__model"]`, which can now be customised [](customising_group_views_permissions_order).
+The default ordering is now `["content_type__app_label", "content_type__model"]`. See [](customising_group_views_permissions_order) for details on how to customise this order.
 
 ### JSON-timestamps stored in `ModelLogEntry` and `PageLogEntry` are now ISO-formatted and UTC
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

This PR fixes [a typo](https://docs.wagtail.org/en/v5.1/releases/5.1.html#snippet-enhancements) and some [odd expression](https://docs.wagtail.org/en/v5.1/releases/5.1.html#the-default-ordering-of-group-editing-permissions-models-has-changed) in the 5.1 release notes.

I suggest this should be backported to any 5.1 branches.

_Please check the following:_

-   [-] Documentation change only

