### PR TITLE
Improve `classnames` template tag (support nested lists)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changelog
  * Maintenance: Adjust Eslint rules for TypeScript files (Karthik Ayangar)
  * Maintenance: Rename the React `Button` that only renders links (a element) to `Link` and remove unused prop & behavior that was non-compliant for aria role usage (Advik Kabra)
  * Maintenance: Set up an `wagtail.models.AbstractWorkflow` model to support future customisations around workflows (Hossein)
+ * Maintenance: Improve `classnames` template tag to handle nested lists of strings (LB (Ben) Johnston)
 
 
 6.0 (07.02.2024)

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -41,6 +41,7 @@ depth: 1
  * Adjust Eslint rules for TypeScript files (Karthik Ayangar)
  * Rename the React `Button` that only renders links (a element) to `Link` and remove unused prop & behavior that was non-compliant for aria role usage (Advik Kabra)
  * Set up an `wagtail.models.AbstractWorkflow` model to support future customisations around workflows (Hossein)
+ * Improve `classnames` template tag to handle nested lists of strings (LB (Ben) Johnston)
 
 
 ## Upgrade considerations

--- a/wagtail/admin/templates/wagtailadmin/panels/multi_field_panel_child.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/multi_field_panel_child.html
@@ -1,5 +1,5 @@
 {% load wagtailadmin_tags %}
-<div class="{% classnames "w-panel__wrapper" child.classes|join:' ' %}" {% include "wagtailadmin/shared/attrs.html" with attrs=child.attrs %}>
+<div class="{% classnames "w-panel__wrapper" child.classes %}" {% include "wagtailadmin/shared/attrs.html" with attrs=child.attrs %}>
     {% if child.heading %}
         {% fragment as label_content %}
             {{ child.heading }}{% if child.is_required %}<span class="w-required-mark">*</span>{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/panels/tabbed_interface.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/tabbed_interface.html
@@ -21,7 +21,7 @@
             {% if child.show_panel_furniture %}
                 <section
                     id="tab-{{ identifier }}"
-                    class="w-tabs__panel {{ child.classes|join:" " }}"
+                    class="{% classnames "w-tabs__panel" child.classes %}"
                     role="tabpanel"
                     aria-labelledby="tab-label-{{ identifier }}"
                     hidden

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -223,7 +223,15 @@ def classnames(*classes):
     Usage <div class="{% classnames "w-base" classname active|yesno:"w-base--active," any_other_var %}"></div>
     Returns any args as a space-separated joined string for using in HTML class names.
     """
-    return " ".join([classname.strip() for classname in classes if classname])
+
+    flattened = []
+    for classname in classes:
+        if isinstance(classname, str):
+            flattened.append(classname)
+        elif hasattr(classname, "__iter__"):
+            flattened.extend(classname)
+
+    return " ".join([classname.strip() for classname in flattened if classname])
 
 
 @register.simple_tag(takes_context=True)

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -479,6 +479,28 @@ class ClassnamesTagTest(SimpleTestCase):
 
         self.assertEqual(expected.strip(), actual.strip())
 
+    def test_with_nested_lists(self):
+        context = Context(
+            {
+                "nested": ["button-add", "button-base "],
+                "has_falsey": ["", False, [], {}],
+                "simple": " wagtail ",
+            }
+        )
+
+        template = """
+            {% load wagtailadmin_tags %}
+            <button class="{% classnames nested "add-second " has_falsey simple %}">Hello!</button>
+        """
+
+        expected = """
+            <button class="button-add button-base add-second wagtail">Hello!</button>
+        """
+
+        actual = Template(template).render(context)
+
+        self.assertEqual(expected.strip(), actual.strip())
+
 
 class IconTagTest(SimpleTestCase):
     def test_basic(self):


### PR DESCRIPTION
- Add support for nested lists within the `classnames` template tag.
- This just makes the template tag a bit easier to work with when merging/joining with lists and avoids the need to include `...|join" "` alongside other classes.