### PR TITLE
Adopt `classname` instead of `classnames` in all MenuItem/Sidebar usage

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -77,6 +77,7 @@ Changelog
  * Maintenance: Optimise `lru_cache` usage (Jake Howard)
  * Maintenance: Implement `date_since` in `get_most_popular` inside `search_promotions.models.Query` (TopDevPros)
  * Maintenance: Refactor generic view subclasses to better reuse the generic templates and breadcrumbs (Sage Abdullah)
+ * Maintenance: Adopt consistent `classname` (not `classnames`) attributes for all `MenuItem` usage, including deprecation warnings (LB (Ben) Johnston)
 
 
 5.1.3 (xx.xx.20xx) - IN DEVELOPMENT

--- a/client/src/components/Sidebar/menu/ActionMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/ActionMenuItem.tsx
@@ -83,7 +83,7 @@ export class ActionMenuItemDefinition implements MenuItemDefinition {
     action,
     attrs,
     icon_name: iconName = null,
-    classnames = undefined,
+    classname = undefined,
     method = 'POST',
   }) {
     this.name = name;
@@ -91,7 +91,7 @@ export class ActionMenuItemDefinition implements MenuItemDefinition {
     this.action = action;
     this.attrs = attrs;
     this.iconName = iconName;
-    this.classNames = classnames;
+    this.classNames = classname;
     this.method = method;
   }
 

--- a/client/src/components/Sidebar/menu/LinkMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/LinkMenuItem.tsx
@@ -98,14 +98,14 @@ export class LinkMenuItemDefinition implements MenuItemDefinition {
     url,
     attrs,
     icon_name: iconName = null,
-    classnames = undefined,
+    classname = undefined,
   }) {
     this.name = name;
     this.label = label;
     this.url = url;
     this.attrs = attrs;
     this.iconName = iconName;
-    this.classNames = classnames;
+    this.classNames = classname;
   }
 
   render({ path, slim, state, dispatch, navigate }) {

--- a/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
@@ -122,11 +122,11 @@ export class PageExplorerMenuItemDefinition extends LinkMenuItemDefinition {
       url,
       attrs,
       icon_name: iconName = null,
-      classnames = undefined,
+      classname = undefined,
     },
     startPageId: number,
   ) {
-    super({ name, label, url, attrs, icon_name: iconName, classnames });
+    super({ name, label, url, attrs, icon_name: iconName, classname });
     this.startPageId = startPageId;
   }
 

--- a/client/src/components/Sidebar/menu/SubMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/SubMenuItem.tsx
@@ -170,7 +170,7 @@ export class SubMenuItemDefinition implements MenuItemDefinition {
       label,
       attrs,
       icon_name: iconName = null,
-      classnames = undefined,
+      classname = undefined,
       footer_text: footerText = '',
     }: any,
     menuItems: MenuItemDefinition[],
@@ -180,7 +180,7 @@ export class SubMenuItemDefinition implements MenuItemDefinition {
     this.menuItems = menuItems;
     this.attrs = attrs;
     this.iconName = iconName;
-    this.classNames = classnames;
+    this.classNames = classname;
     this.footerText = footerText;
   }
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -244,8 +244,12 @@ Add an item to the Wagtail admin menu. The callable passed to this hook must ret
 
 -   `name` - an internal name used to identify the menu item; defaults to the slugified form of the label.
 -   `icon_name` - icon to display against the menu item; no defaults, optional, but should be set for top-level menu items so they can be identified when collapsed.
--   `classnames` - additional classnames applied to the link
--   `order` - an integer which determines the item's position in the menu
+-   `classname` - additional classes applied to the link.
+-   `order` - an integer which determines the item's position in the menu.
+
+```{versionchanged} 5.2
+Use `classname` as the `classnames` keyword argument is deprecated and will be removed in a future release.
+```
 
 For menu items that are only available to superusers, the subclass `wagtail.admin.menu.AdminOnlyMenuItem` can be used in place of `MenuItem`.
 
@@ -337,10 +341,14 @@ Add an item to the Wagtail admin search "Other Searches". Behaviour of this hook
 -   `label` - text displayed in the "Other Searches" option box.
 -   `name` - an internal name used to identify the search option; defaults to the slugified form of the label.
 -   `url` - the URL of the target search page.
--   `classnames` - arbitrary CSS classnames applied to the link
+-   `classname` - additional CSS classes applied to the link.
 -   `icon_name` - icon to display next to the label.
 -   `attrs` - additional HTML attributes to apply to the link.
 -   `order` - an integer which determines the item's position in the list of options.
+
+```{versionchanged} 5.2
+Use `classname` as the `classnames` keyword argument is deprecated and will be removed in a future release.
+```
 
 Setting the URL can be achieved using reverse() on the target search page. The GET parameter 'q' will be appended to the given URL.
 

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -98,6 +98,7 @@ depth: 1
  * Optimise `lru_cache` usage (Jake Howard)
  * Implement `date_since`` in `get_most_popular`` inside `search_promotions.models.Query (TopDevPros)
  * Refactor generic view subclasses to better reuse the generic templates and breadcrumbs (Sage Abdullah)
+ * Adopt consistent `classname` (not `classnames`) attributes for all `MenuItem` usage, including deprecation warnings (LB (Ben) Johnston)
 
 
 ## Upgrade considerations - changes affecting all projects
@@ -107,6 +108,44 @@ depth: 1
 [`imghdr`](https://docs.python.org/3/library/imghdr.html) is deprecated, and will be removed in Python 3.13.
 
 Wagtail now uses the Willow feature of providing the image MIME type, which uses the [`filetype`](https://pypi.org/project/filetype/) package.
+
+### Adoption of `classname` convention for `MenuItem` related classes and hooks
+
+Wagtail `MenuItem` and menu hooks have been updated to use the more consistent naming of `classname` (singular) instead of `classnames` (plural), a convention that started in Wagtail 4.2.
+
+The current `classnames` keyword argument naming will be supported, but will trigger a deprecation warning. Support for this variant will be removed in a future release.
+
+The following classes will adopt this new convention.
+
+-   `admin.menu.MenuItem`
+-   `admin.ui.sidebar.ActionMenuItem`
+-   `admin.ui.sidebar.LinkMenuItem`
+-   `admin.ui.sidebar.PageExplorerMenuItem`
+-   `contrib.settings.registry.SettingMenuItem`
+
+The following hooks usage may be impacted if `classnames` were used when generating menu items.
+
+-   `register_admin_menu_item`
+-   `register_settings_menu_item`
+
+### Example
+
+```python
+from django.urls import reverse
+
+from wagtail import hooks
+from wagtail.admin.menu import MenuItem
+
+@hooks.register('register_admin_menu_item')
+def register_frank_menu_item():
+  return MenuItem(
+    'Frank',
+    reverse('frank'),
+    icon_name='folder-inverse',
+    order=10000,
+    classname="highlight-menu" # not classnames=...
+  )
+```
 
 ## Upgrade considerations - deprecation of old functionality
 

--- a/wagtail/admin/menu.py
+++ b/wagtail/admin/menu.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from django.core.exceptions import ImproperlyConfigured
 from django.forms import Media, MediaDefiningClass
 from django.utils.functional import cached_property
@@ -6,15 +8,29 @@ from wagtail import hooks
 from wagtail.admin.ui.sidebar import LinkMenuItem as LinkMenuItemComponent
 from wagtail.admin.ui.sidebar import SubMenuItem as SubMenuItemComponent
 from wagtail.coreutils import cautious_slugify
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class MenuItem(metaclass=MediaDefiningClass):
     def __init__(
-        self, label, url, name=None, classnames="", icon_name="", attrs=None, order=1000
+        self,
+        label,
+        url,
+        name=None,
+        classname="",
+        classnames="",
+        icon_name="",
+        attrs=None,
+        order=1000,
     ):
+        if classnames:
+            warn(
+                "The `classnames` kwarg for MenuItem is deprecated - use `classname` instead.",
+                category=RemovedInWagtail60Warning,
+            )
         self.label = label
         self.url = url
-        self.classnames = classnames
+        self.classname = classname or classnames
         self.icon_name = icon_name
         self.name = name or cautious_slugify(str(label))
         self.attrs = attrs or {}
@@ -36,7 +52,7 @@ class MenuItem(metaclass=MediaDefiningClass):
             self.label,
             self.url,
             icon_name=self.icon_name,
-            classnames=self.classnames,
+            classname=self.classname,
             attrs=self.attrs,
         )
 
@@ -147,7 +163,7 @@ class SubmenuMenuItem(MenuItem):
             self.label,
             self.menu.render_component(request),
             icon_name=self.icon_name,
-            classnames=self.classnames,
+            classname=self.classname,
             attrs=self.attrs,
         )
 

--- a/wagtail/admin/search.py
+++ b/wagtail/admin/search.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from django.forms import Media, MediaDefiningClass
 from django.forms.utils import flatatt
 from django.template.loader import render_to_string
@@ -7,17 +9,31 @@ from django.utils.text import slugify
 
 from wagtail import hooks
 from wagtail.admin.forms.search import SearchForm
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class SearchArea(metaclass=MediaDefiningClass):
     template = "wagtailadmin/shared/search_area.html"
 
     def __init__(
-        self, label, url, name=None, classnames="", icon_name="", attrs=None, order=1000
+        self,
+        label,
+        url,
+        name=None,
+        classname="",
+        classnames="",
+        icon_name="",
+        attrs=None,
+        order=1000,
     ):
+        if classnames:
+            warn(
+                "The `classnames` kwarg for SearchArea is deprecated - use `classname` instead.",
+                category=RemovedInWagtail60Warning,
+            )
         self.label = label
         self.url = url
-        self.classnames = classnames
+        self.classname = classname or classnames
         self.icon_name = icon_name
         self.name = name or slugify(str(label))
         self.order = order
@@ -71,7 +87,7 @@ class SearchArea(metaclass=MediaDefiningClass):
             {
                 "name": self.name,
                 "url": self.url,
-                "classnames": self.classnames,
+                "classname": self.classname,
                 "icon_name": self.icon_name,
                 "attr_string": self.attr_string,
                 "label": self.label,

--- a/wagtail/admin/templates/wagtailadmin/shared/search_area.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/search_area.html
@@ -1,4 +1,4 @@
 {% load wagtailadmin_tags %}
 <li>
-    <a href="{{ url }}?q={{ query_string|urlencode }}" class="{{ classnames }}{% if active %} nolink{% endif %}"{{ attr_string }}>{% if icon_name %}{% icon name=icon_name classname="filter-options__icon" %}{% endif %}{{ label }}</a>
+    <a href="{{ url }}?q={{ query_string|urlencode }}" class="{{ classname }}{% if active %} nolink{% endif %}"{{ attr_string }}>{% if icon_name %}{% icon name=icon_name classname="filter-options__icon" %}{% endif %}{{ label }}</a>
 </li>

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -37,13 +37,13 @@ class TestHome(WagtailTestUtils, TestCase):
         # check that custom menu items (including classname / icon_name) are pulled in
         self.assertContains(
             response,
-            '{"name": "kittens", "label": "Kittens!", "icon_name": "kitten", "classnames": "kitten--test", "attrs": {"data-is-custom": "true"}, "url": "http://www.tomroyal.com/teaandkittens/"}',
+            '{"name": "kittens", "label": "Kittens!", "icon_name": "kitten", "classname": "kitten--test", "attrs": {"data-is-custom": "true"}, "url": "http://www.tomroyal.com/teaandkittens/"}',
         )
 
         # Check that the explorer menu item is here, with the right start page.
         self.assertContains(
             response,
-            '[{"name": "explorer", "label": "Pages", "icon_name": "folder-open-inverse", "classnames": "", "attrs": {}, "url": "/admin/pages/"}, 1]',
+            '[{"name": "explorer", "label": "Pages", "icon_name": "folder-open-inverse", "classname": "", "attrs": {}, "url": "/admin/pages/"}, 1]',
         )
 
         # There should be a link to the friend admin in on the home page.
@@ -56,7 +56,7 @@ class TestHome(WagtailTestUtils, TestCase):
         response = self.client.get(reverse("wagtailadmin_home") + "?hide-kittens=true")
         self.assertNotContains(
             response,
-            '{"name": "kittens", "label": "Kittens!", "icon_name": "kitten", "classnames": "kitten--test", "attrs": {"data-is-custom": "true"}, "url": "http://www.tomroyal.com/teaandkittens/"}',
+            '{"name": "kittens", "label": "Kittens!", "icon_name": "kitten", "classname": "kitten--test", "attrs": {"data-is-custom": "true"}, "url": "http://www.tomroyal.com/teaandkittens/"}',
         )
 
     def test_dashboard_panels(self):
@@ -408,6 +408,26 @@ class TestMenuItem(WagtailTestUtils, TestCase):
     def test_menuitem_reverse_lazy_url_pass(self):
         menuitem = MenuItem(_("Test"), reverse_lazy("wagtailadmin_home"))
         self.assertIs(menuitem.is_active(self.request), True)
+
+    def test_menuitem_with_classname(self):
+        menuitem = MenuItem(
+            _("Test"),
+            reverse_lazy("wagtailadmin_home"),
+            classname="highlight-item",
+        )
+        self.assertEqual(menuitem.classname, "highlight-item")
+
+    def test_menuitem_with_deprecated_classnames(self):
+        with self.assertWarnsRegex(
+            RemovedInWagtail60Warning,
+            "The `classnames` kwarg for MenuItem is deprecated - use `classname` instead.",
+        ):
+            menuitem = MenuItem(
+                _("Test"),
+                reverse_lazy("wagtailadmin_home"),
+                classnames="is-dimmed",
+            )
+        self.assertEqual(menuitem.classname, "is-dimmed")
 
 
 class TestUserPassesTestPermissionDecorator(WagtailTestUtils, TestCase):

--- a/wagtail/admin/tests/ui/test_sidebar.py
+++ b/wagtail/admin/tests/ui/test_sidebar.py
@@ -14,6 +14,7 @@ from wagtail.admin.ui.sidebar import (
 )
 from wagtail.telepath import JSContext
 from wagtail.test.utils import WagtailTestUtils
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class TestAdaptLinkMenuItem(TestCase):
@@ -26,7 +27,7 @@ class TestAdaptLinkMenuItem(TestCase):
                 "_type": "wagtail.sidebar.LinkMenuItem",
                 "_args": [
                     {
-                        "classnames": "",
+                        "classname": "",
                         "icon_name": "",
                         "label": "Link",
                         "name": "link",
@@ -44,7 +45,7 @@ class TestAdaptLinkMenuItem(TestCase):
                 "Link",
                 "/link/",
                 icon_name="link-icon",
-                classnames="some classes",
+                classname="some classes",
                 attrs={"data-is-custom": "true"},
             )
         )
@@ -55,12 +56,39 @@ class TestAdaptLinkMenuItem(TestCase):
                 "_type": "wagtail.sidebar.LinkMenuItem",
                 "_args": [
                     {
-                        "classnames": "some classes",
+                        "classname": "some classes",
                         "icon_name": "link-icon",
                         "label": "Link",
                         "name": "link",
                         "url": "/link/",
                         "attrs": {"data-is-custom": "true"},
+                    }
+                ],
+            },
+        )
+
+    def test_adapt_with_deprecated_classnames(self):
+
+        with self.assertWarnsRegex(
+            RemovedInWagtail60Warning,
+            "The `classnames` kwarg for sidebar LinkMenuItem is deprecated - use `classname` instead.",
+        ):
+            packed = JSContext().pack(
+                LinkMenuItem("link", "Link", "/link/", classnames="legacy-classes")
+            )
+
+        self.assertEqual(
+            packed,
+            {
+                "_type": "wagtail.sidebar.LinkMenuItem",
+                "_args": [
+                    {
+                        "classname": "legacy-classes",  # mapped to new name but raises warning
+                        "icon_name": "",
+                        "label": "Link",
+                        "name": "link",
+                        "url": "/link/",
+                        "attrs": {},
                     }
                 ],
             },
@@ -89,7 +117,7 @@ class TestAdaptSubMenuItem(TestCase):
                         "name": "sub-menu",
                         "label": "Sub menu",
                         "icon_name": "",
-                        "classnames": "",
+                        "classname": "",
                         "footer_text": "Footer text",
                         "attrs": {},
                     },
@@ -101,7 +129,7 @@ class TestAdaptSubMenuItem(TestCase):
                                     "name": "link",
                                     "label": "Link",
                                     "icon_name": "link-icon",
-                                    "classnames": "",
+                                    "classname": "",
                                     "url": "/link/",
                                     "attrs": {},
                                 }
@@ -132,7 +160,7 @@ class TestAdaptSubMenuItem(TestCase):
                         "name": "sub-menu",
                         "label": "Sub menu",
                         "icon_name": "",
-                        "classnames": "",
+                        "classname": "",
                         "footer_text": "",
                         "attrs": {},
                     },
@@ -144,7 +172,7 @@ class TestAdaptSubMenuItem(TestCase):
                                     "name": "link",
                                     "label": "Link",
                                     "icon_name": "link-icon",
-                                    "classnames": "",
+                                    "classname": "",
                                     "url": "/link/",
                                     "attrs": {},
                                 }
@@ -167,7 +195,7 @@ class TestAdaptPageExplorerMenuItem(TestCase):
                 "_args": [
                     {
                         "attrs": {},
-                        "classnames": "",
+                        "classname": "",
                         "icon_name": "",
                         "label": "Pages",
                         "name": "pages",
@@ -218,7 +246,7 @@ class TestAdaptMainMenuModule(WagtailTestUtils, DjangoTestCase):
                                     "name": "pages",
                                     "label": "Pages",
                                     "icon_name": "",
-                                    "classnames": "",
+                                    "classname": "",
                                     "url": "/pages/",
                                     "attrs": {},
                                 }
@@ -233,7 +261,7 @@ class TestAdaptMainMenuModule(WagtailTestUtils, DjangoTestCase):
                                     "name": "account",
                                     "label": "Account",
                                     "icon_name": "user",
-                                    "classnames": "",
+                                    "classname": "",
                                     "url": reverse("wagtailadmin_account"),
                                     "attrs": {},
                                 }
@@ -246,7 +274,7 @@ class TestAdaptMainMenuModule(WagtailTestUtils, DjangoTestCase):
                                     "name": "logout",
                                     "label": "Logout",
                                     "icon_name": "logout",
-                                    "classnames": "",
+                                    "classname": "",
                                     "action": reverse("wagtailadmin_logout"),
                                     "method": "POST",
                                     "attrs": {},

--- a/wagtail/admin/ui/sidebar.py
+++ b/wagtail/admin/ui/sidebar.py
@@ -1,4 +1,5 @@
 from typing import Any, List, Mapping
+from warnings import warn
 
 from django import forms
 from django.urls import reverse
@@ -6,6 +7,7 @@ from django.utils.functional import cached_property
 
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.telepath import Adapter, adapter
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class BaseSidebarAdapter(Adapter):
@@ -27,13 +29,19 @@ class MenuItem:
         name: str,
         label: str,
         icon_name: str = "",
+        classname: str = "",
         classnames: str = "",
         attrs: Mapping[str, Any] = None,
     ):
+        if classnames:
+            warn(
+                "The `classnames` kwarg for sidebar MenuItem is deprecated - use `classname` instead.",
+                category=RemovedInWagtail60Warning,
+            )
         self.name = name
         self.label = label
         self.icon_name = icon_name
-        self.classnames = classnames
+        self.classname = classname or classnames
         self.attrs = attrs or {}
 
     def js_args(self):
@@ -42,7 +50,7 @@ class MenuItem:
                 "name": self.name,
                 "label": self.label,
                 "icon_name": self.icon_name,
-                "classnames": self.classnames,
+                "classname": self.classname,
                 "attrs": self.attrs,
             }
         ]
@@ -56,14 +64,20 @@ class LinkMenuItem(MenuItem):
         label: str,
         url: str,
         icon_name: str = "",
+        classname: str = "",
         classnames: str = "",
         attrs: Mapping[str, Any] = None,
     ):
+        if classnames:
+            warn(
+                "The `classnames` kwarg for sidebar LinkMenuItem is deprecated - use `classname` instead.",
+                category=RemovedInWagtail60Warning,
+            )
         super().__init__(
             name,
             label,
             icon_name=icon_name,
-            classnames=classnames,
+            classname=classname or classnames,
             attrs=attrs,
         )
         self.url = url
@@ -80,7 +94,7 @@ class LinkMenuItem(MenuItem):
             and self.label == other.label
             and self.url == other.url
             and self.icon_name == other.icon_name
-            and self.classnames == other.classnames
+            and self.classname == other.classname
             and self.attrs == other.attrs
         )
 
@@ -93,15 +107,21 @@ class ActionMenuItem(MenuItem):
         label: str,
         action: str,
         icon_name: str = "",
+        classname: str = "",
         classnames: str = "",
         method: str = "POST",
         attrs: Mapping[str, Any] = None,
     ):
+        if classnames:
+            warn(
+                "The `classnames` kwarg for sidebar ActionMenuItem is deprecated - use `classname` instead.",
+                category=RemovedInWagtail60Warning,
+            )
         super().__init__(
             name,
             label,
             icon_name=icon_name,
-            classnames=classnames,
+            classname=classname or classnames,
             attrs=attrs,
         )
         self.action = action
@@ -121,7 +141,7 @@ class ActionMenuItem(MenuItem):
             and self.action == other.action
             and self.method == other.method
             and self.icon_name == other.icon_name
-            and self.classnames == other.classnames
+            and self.classname == other.classname
             and self.attrs == other.attrs
         )
 
@@ -134,15 +154,21 @@ class SubMenuItem(MenuItem):
         label: str,
         menu_items: List[MenuItem],
         icon_name: str = "",
+        classname: str = "",
         classnames: str = "",
         footer_text: str = "",
         attrs: Mapping[str, Any] = None,
     ):
+        if classnames:
+            warn(
+                "The `classnames` kwarg for sidebar SubMenuItem is deprecated - use `classname` instead.",
+                category=RemovedInWagtail60Warning,
+            )
         super().__init__(
             name,
             label,
             icon_name=icon_name,
-            classnames=classnames,
+            classname=classname or classnames,
             attrs=attrs,
         )
         self.menu_items = menu_items
@@ -161,7 +187,7 @@ class SubMenuItem(MenuItem):
             and self.label == other.label
             and self.menu_items == other.menu_items
             and self.icon_name == other.icon_name
-            and self.classnames == other.classnames
+            and self.classname == other.classname
             and self.footer_text == other.footer_text
             and self.attrs == other.attrs
         )
@@ -176,15 +202,21 @@ class PageExplorerMenuItem(LinkMenuItem):
         url: str,
         start_page_id: int,
         icon_name: str = "",
+        classname: str = "",
         classnames: str = "",
         attrs: Mapping[str, Any] = None,
     ):
+        if classnames:
+            warn(
+                "The `classnames` kwarg for sidebar PageExplorerMenuItem is deprecated - use `classname` instead.",
+                category=RemovedInWagtail60Warning,
+            )
         super().__init__(
             name,
             label,
             url,
             icon_name=icon_name,
-            classnames=classnames,
+            classname=classname or classnames,
             attrs=attrs,
         )
         self.start_page_id = start_page_id
@@ -202,7 +234,7 @@ class PageExplorerMenuItem(LinkMenuItem):
             and self.url == other.url
             and self.start_page_id == other.start_page_id
             and self.icon_name == other.icon_name
-            and self.classnames == other.classnames
+            and self.classname == other.classname
             and self.attrs == other.attrs
         )
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -90,7 +90,7 @@ class ExplorerMenuItem(MenuItem):
                 self.url,
                 start_page.id,
                 icon_name=self.icon_name,
-                classnames=self.classnames,
+                classname=self.classname,
             )
         else:
             return super().render_component(request)
@@ -114,7 +114,7 @@ class SettingsMenuItem(SubmenuMenuItem):
             self.label,
             self.menu.render_component(request),
             icon_name=self.icon_name,
-            classnames=self.classnames,
+            classname=self.classname,
             footer_text="Wagtail v" + __version__,
         )
 

--- a/wagtail/contrib/modeladmin/menus.py
+++ b/wagtail/contrib/modeladmin/menus.py
@@ -12,16 +12,16 @@ class ModelAdminMenuItem(MenuItem):
         url = model_admin.url_helper.index_url
         menu_icon = model_admin.get_menu_icon()
         if menu_icon[:3] == "fa-":
-            classnames = "icon icon-%s" % menu_icon
+            classname = "icon icon-%s" % menu_icon
             icon_name = None
         else:
-            classnames = ""
+            classname = ""
             icon_name = menu_icon
         super().__init__(
             label=model_admin.get_menu_label(),
             url=url,
             name=model_admin.get_menu_item_name(),
-            classnames=classnames,
+            classname=classname,
             icon_name=icon_name,
             order=order,
         )
@@ -40,16 +40,16 @@ class GroupMenuItem(SubmenuMenuItem):
     def __init__(self, modeladmingroup, order, menu):
         menu_icon = modeladmingroup.get_menu_icon()
         if menu_icon[:3] == "fa-":
-            classnames = "icon icon-%s" % menu_icon
+            classname = "icon icon-%s" % menu_icon
             icon_name = None
         else:
-            classnames = ""
+            classname = ""
             icon_name = menu_icon
         super().__init__(
             label=modeladmingroup.get_menu_label(),
             menu=menu,
             name=modeladmingroup.get_menu_item_name(),
-            classnames=classnames,
+            classname=classname,
             icon_name=icon_name,
             order=order,
         )

--- a/wagtail/contrib/settings/registry.py
+++ b/wagtail/contrib/settings/registry.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from django.apps import apps
 from django.contrib.auth.models import Permission
 from django.urls import reverse
@@ -10,21 +12,27 @@ from wagtail.admin.admin_url_finder import (
 )
 from wagtail.admin.menu import MenuItem
 from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 from .permissions import user_can_edit_setting_type
 
 
 class SettingMenuItem(MenuItem):
-    def __init__(self, model, icon="cog", classnames="", **kwargs):
-
+    def __init__(self, model, icon="cog", classname="", classnames="", **kwargs):
+        if classnames:
+            warn(
+                "The `classnames` kwarg for SettingMenuItem is deprecated - use `classname` instead.",
+                category=RemovedInWagtail60Warning,
+            )
+        classname = classname or classnames
         # Special-case FontAwesome icons to avoid the breaking changes for those customisations.
         if icon.startswith("fa-"):
             icon_name = ""
             icon_classes = "icon icon-" + icon
-            if classnames:
-                classnames += " " + icon_classes
+            if classname:
+                classname += " " + icon_classes
             else:
-                classnames = icon_classes
+                classname = icon_classes
         else:
             icon_name = icon
 
@@ -35,7 +43,7 @@ class SettingMenuItem(MenuItem):
                 "wagtailsettings:edit",
                 args=[model._meta.app_label, model._meta.model_name],
             ),
-            classnames=classnames,
+            classname=classname,
             icon_name=icon_name,
             **kwargs,
         )

--- a/wagtail/contrib/settings/tests/generic/test_admin.py
+++ b/wagtail/contrib/settings/tests/generic/test_admin.py
@@ -52,18 +52,18 @@ class TestGenericSettingMenu(WagtailTestUtils, TestCase):
 
     def test_menu_item_icon(self):
         menu_item = SettingMenuItem(
-            IconGenericSetting, icon="tag", classnames="test-class"
+            IconGenericSetting, icon="tag", classname="test-class"
         )
         self.assertEqual(menu_item.icon_name, "tag")
-        self.assertEqual(menu_item.classnames, "test-class")
+        self.assertEqual(menu_item.classname, "test-class")
 
     def test_menu_item_icon_fontawesome(self):
         menu_item = SettingMenuItem(
-            IconGenericSetting, icon="fa-suitcase", classnames="test-class"
+            IconGenericSetting, icon="fa-suitcase", classname="test-class"
         )
         self.assertEqual(menu_item.icon_name, "")
         self.assertEqual(
-            set(menu_item.classnames.split(" ")),
+            set(menu_item.classname.split(" ")),
             {"icon", "icon-fa-suitcase", "test-class"},
         )
 

--- a/wagtail/contrib/settings/tests/site_specific/test_admin.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_admin.py
@@ -50,19 +50,17 @@ class TestSiteSettingMenu(WagtailTestUtils, TestCase):
         )
 
     def test_menu_item_icon(self):
-        menu_item = SettingMenuItem(
-            IconSiteSetting, icon="tag", classnames="test-class"
-        )
+        menu_item = SettingMenuItem(IconSiteSetting, icon="tag", classname="test-class")
         self.assertEqual(menu_item.icon_name, "tag")
-        self.assertEqual(menu_item.classnames, "test-class")
+        self.assertEqual(menu_item.classname, "test-class")
 
     def test_menu_item_icon_fontawesome(self):
         menu_item = SettingMenuItem(
-            IconSiteSetting, icon="fa-suitcase", classnames="test-class"
+            IconSiteSetting, icon="fa-suitcase", classname="test-class"
         )
         self.assertEqual(menu_item.icon_name, "")
         self.assertEqual(
-            set(menu_item.classnames.split(" ")),
+            set(menu_item.classname.split(" ")),
             {"icon", "icon-fa-suitcase", "test-class"},
         )
 

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -73,7 +73,7 @@ def register_kittens_menu_item():
     return KittensMenuItem(
         "Kittens!",
         "http://www.tomroyal.com/teaandkittens/",
-        classnames="kitten--test",
+        classname="kitten--test",
         name="kittens",
         icon_name="kitten",
         attrs={"data-is-custom": "true"},
@@ -95,7 +95,7 @@ def register_custom_search_area():
     return MyCustomSearchArea(
         "My Search",
         "/customsearch/",
-        classnames="search--custom-class",
+        classname="search--custom-class",
         icon_name="custom",
         attrs={"is-custom": "true"},
         order=10000,


### PR DESCRIPTION
In Wagtail 4.2 we started being more consistent with how we support `classname` kwargs in various components and templates, this seemed to be received well and means our code is more predictable.

At the time we avoided changing anything that was not yet fully documented or just had a small surface area. In this PR I propose we adjust one documented use case `MenuItem` (and related) with a clear deprecation path.

I think this will make using Wagtail more intuitive for developers and sets us up for easier customisation in the long term.

## Details

- Adds a deprecation path, including documentation to further remove unpredictable naming of adding `classname` in Python APIs
- Intentionally keeps `classNames` in Telepath adaptor inner usage as this convention is not set, however, the server side value passed in will use `classname`
- See https://docs.wagtail.org/en/stable/contributing/general_guidelines.html#use-classname-in-python-html-template-tag-variables
- See previous rounds of clean up related to this - #9769 & #9770
- Avoiding touching the image template tag but if there is a desire, I can do that one as a future PR.

## Checklist

-   [X] Do the tests still pass?
-   [X] Does the code comply with the style guide?
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [X] For front-end changes: Did you test on all of Wagtail’s supported environments?
-   [X] For new features: Has the documentation been updated accordingly?
