### PR TITLE
Deprecate `escape_script` util & `escapescript` template tag

### DIFF
--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -208,3 +208,34 @@ If you are using the undocumented dropdown template tag with the offset arg, thi
 | Old                                                                | New                                                                  |
 | ------------------------------------------------------------------ | -------------------------------------------------------------------- |
 | `{% dropdown toggle_tippy_offset="[0, -2]" %}...{% enddropdown %}` | `{% dropdown toggle_tooltip_offset="[0, -2]" %}...{% enddropdown %}` |
+
+### `escapescript` template tag and `escape_script` functions are deprecated
+
+As of this release, the undocumented `coreutils.escape_script` util and `escapescript` template tag will no longer be supported.
+
+This was used to provide a way for HTML template content in IE11, which is no longer supported, and was non-compliant with CSP support.
+
+The current approach will trigger a deprecation warning and will be removed in a future release.
+
+#### Old
+
+```html+django
+{% load wagtailadmin_tags %}
+<script type="text/django-form-template" id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
+    {% escapescript %}
+        <div>Widget template content</div>
+        <script src="/js/my-widget.js"></script>
+    {% endescapescript %}
+</script>
+```
+
+#### New
+
+Use the HTML [`template`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) element to avoid content from being parsed by the browser on load.
+
+```html+django
+<template id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
+    <div>Widget template content</div>
+    <script src="/js/my-widget.js"></script>
+</template>
+```

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -314,6 +314,10 @@ class EscapeScriptNode(template.Node):
 
     def __init__(self, nodelist):
         super().__init__()
+        warn(
+            "The `escapescript` template tag is deprecated - use `template` elements instead.",
+            category=RemovedInWagtail60Warning,
+        )
         self.nodelist = nodelist
 
     def render(self, context):

--- a/wagtail/coreutils.py
+++ b/wagtail/coreutils.py
@@ -5,6 +5,7 @@ import re
 import unicodedata
 from hashlib import md5
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Union
+from warnings import warn
 
 from anyascii import anyascii
 from django.apps import apps
@@ -22,6 +23,8 @@ from django.utils.encoding import force_str
 from django.utils.text import capfirst, slugify
 from django.utils.translation import check_for_language, get_supported_language_variant
 from django.utils.translation import gettext_lazy as _
+
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 if TYPE_CHECKING:
     from wagtail.models import Site
@@ -98,6 +101,10 @@ def escape_script(text):
     accidentally closing it. A '-' character will be inserted for each time it is escaped:
     `<-/script>`, `<--/script>` etc.
     """
+    warn(
+        "The `escape_script` hook is deprecated - use `template` elements instead.",
+        category=RemovedInWagtail60Warning,
+    )
     return SCRIPT_RE.sub(r"<-\1/script>", text)
 
 


### PR DESCRIPTION
- Add deprecation warning for usage of escape_script
- Add release considerations
- JS deprecation comments on client/src/components/InlinePanel/index.js were added in changes introduced in #10893
- Relates to #10034

Question: Is the deprecation warning approach OK or is it best to just fully remove this in 5.2 (inc. the JS support).