### PR TITLE
Make admin login template display non_fields_errors

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ Changelog
  * Fix: Filter out comments on Page editing counts that do not correspond to a valid field / block path on the page such as when a field has been removed (Matt Westcott)
  * Fix: Allow `PublishMenuItem` to more easily support overriding its label via `construct_page_action_menu` (Sébastien Corbin)
  * Fix: Allow locale selection when creating a page at the root level (Sage Abdullah)
+ * Fix: Ensure the admin login template correctly displays all `non_fields_errors` for any custom form validation (Sébastien Corbin)
  * Docs: Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
  * Docs: Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)
  * Docs: Add documentation for building non-model-based choosers using the _queryish_ library (Matt Westcott)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -52,6 +52,7 @@ depth: 1
  * Filter out comments on Page editing counts that do not correspond to a valid field / block path on the page such as when a field has been removed (Matt Westcott)
  * Allow `PublishMenuItem` to more easily support overriding its label via `construct_page_action_menu` (Sébastien Corbin)
  * Allow locale selection when creating a page at the root level (Sage Abdullah)
+ * Ensure the admin login template correctly displays all `non_fields_errors` for any custom form validation (Sébastien Corbin)
 
 ### Documentation
 

--- a/wagtail/admin/forms/auth.py
+++ b/wagtail/admin/forms/auth.py
@@ -18,6 +18,13 @@ class LoginForm(AuthenticationForm):
 
     remember = forms.BooleanField(required=False)
 
+    error_messages = {
+        **AuthenticationForm.error_messages,
+        "invalid_login": gettext_lazy(
+            "Your %(username_field)s and password didn't match. Please try again."
+        ),
+    }
+
     def __init__(self, request=None, *args, **kwargs):
         super().__init__(request=request, *args, **kwargs)
         self.fields["username"].widget.attrs["placeholder"] = gettext_lazy(
@@ -30,6 +37,13 @@ class LoginForm(AuthenticationForm):
         for field_name in self.fields.keys():
             if field_name not in ["username", "password", "remember"]:
                 yield field_name, self[field_name]
+
+    def get_invalid_login_error(self):
+        return forms.ValidationError(
+            self.error_messages["invalid_login"],
+            code="invalid_login",
+            params={"username_field": self.username_field.verbose_name},
+        )
 
 
 class PasswordResetForm(DjangoPasswordResetForm):

--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -12,7 +12,9 @@
             {% if messages or form.errors %}
                 <ul>
                     {% if form.errors %}
-                        <li class="error">{% blocktrans trimmed %}Your {{ username_field }} and password didn't match. Please try again.{% endblocktrans %}</li>
+                        {% for error in form.non_field_errors %}
+                            <li class="error">{{ error }}</li>
+                        {% endfor %}
                     {% endif %}
                     {% for message in messages %}
                         <li class="{{ message.tags }}">{{ message }}</li>

--- a/wagtail/admin/tests/test_forms.py
+++ b/wagtail/admin/tests/test_forms.py
@@ -7,6 +7,12 @@ from wagtail.admin.forms.auth import LoginForm, PasswordResetForm
 class CustomLoginForm(LoginForm):
     captcha = CharField(label="Captcha", help_text="should be in extra_fields()")
 
+    def clean(self):
+        cleaned_data = super().clean()
+        if not cleaned_data.get("captcha") == "solved":
+            self.add_error(None, "Captcha is invalid")
+        return cleaned_data
+
 
 class CustomPasswordResetForm(PasswordResetForm):
     captcha = CharField(label="Captcha", help_text="should be in extra_fields()")


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10912 


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.