### PR TITLE
Disable breadcrumbs outside of pages, `SnippetViewSet`, and custom `ModelViewSet`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,7 +28,7 @@ Changelog
  * Show the full first published at date within a tooltip on the Page status sidebar on the relative date (Rohit Sharma)
  * Extract generic breadcrumbs functionality from page breadcrumbs (Sage Abdullah)
  * Add support for `placement` in the `human_readable_date` tooltip template tag (Rohit Sharma)
- * Add breadcrumbs to generic model views (Sage Abdullah)
+ * Add breadcrumbs support to custom `ModelViewSet` views (Sage Abdullah)
  * Support passing extra context variables via the `{% component %}` tag (Matt Westcott)
  * Allow subclasses of `PagesAPIViewSet` override default Page model via the `model` attribute (Neeraj Yetheendran, Herbert Poul)
  * Allow `ModelViewSet` to be used with models that have non-integer primary keys (Sage Abdullah)
@@ -45,7 +45,8 @@ Changelog
  * Add a new `picture` template tag for Django Templates and Jinja (Thibaud Colas)
  * Add a new `srcset_image` template tag for Django Templates and Jinja (Thibaud Colas)
  * Support `Filter` instances as input for `AbstractImage.get_renditions()` (Thibaud Colas)
- * Improve error messages for image template tags
+ * Improve error messages for image template tags (Thibaud Colas)
+ * Do not render minimap if there are no panel anchors (Sage Abdullah)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)

--- a/client/src/components/Minimap/index.tsx
+++ b/client/src/components/Minimap/index.tsx
@@ -110,6 +110,12 @@ export const initMinimap = (
   if (!container) {
     return;
   }
+  const anchors = document.body.querySelectorAll<HTMLAnchorElement>(
+    '[data-panel-anchor]',
+  );
+  if (!anchors.length) {
+    return;
+  }
 
   const updateMinimap = debounce(renderMinimap.bind(null, container), 100);
 

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -51,7 +51,7 @@ This feature was developed by Paarth Agarwal and Thibaud Colas as part of the Go
  * Show the full first published at date within a tooltip on the Page status sidebar on the relative date (Rohit Sharma)
  * Extract generic breadcrumbs functionality from page breadcrumbs (Sage Abdullah)
  * Add support for `placement` in `human_readable_date` the tooltip template tag (Rohit Sharma)
- * Add breadcrumbs to generic model views (Sage Abdullah)
+ * Add breadcrumbs support to custom `ModelViewSet` views (Sage Abdullah)
  * Support passing extra context variables via the `{% component %}` tag (Matt Westcott)
  * Allow subclasses of `PagesAPIViewSet` override default Page model via the `model` attribute (Neeraj Yetheendran, Herbert Poul)
  * Allow `ModelViewSet` to be used with models that have non-integer primary keys (Sage Abdullah)
@@ -67,6 +67,7 @@ This feature was developed by Paarth Agarwal and Thibaud Colas as part of the Go
  * Add [`InlinePanel` DOM events](inline_panel_events) for when ready and when items added or removed (Faishal Manzar)
  * Support `Filter` instances as input for [`AbstractImage.get_renditions()`](image_renditions_multiple) (Thibaud Colas)
  * Improve error messages for image template tags (Thibaud Colas)
+ * Do not render minimap if there are no panel anchors (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/tests/test_collections_views.py
+++ b/wagtail/admin/tests/test_collections_views.py
@@ -70,9 +70,7 @@ class TestCollectionsIndexViewAsSuperuser(
         self.assertTemplateUsed(response, "wagtailadmin/collections/index.html")
         self.assertNotContains(response, "No collections have been created.")
         self.assertContains(response, "Holiday snaps")
-        self.assertBreadcrumbsItemsRendered(
-            [{"url": "", "label": "Collections"}], response.content
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
     def test_ordering(self):
         root_collection = Collection.get_first_root_node()
@@ -207,13 +205,7 @@ class TestAddCollectionAsSuperuser(AdminTemplateTestUtils, WagtailTestUtils, Tes
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.root_collection.name)
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {"label": "Collections", "url": "/admin/collections/"},
-                {"label": "New: Collection", "url": ""},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
     def test_post(self):
         response = self.post(
@@ -332,13 +324,7 @@ class TestEditCollectionAsSuperuser(AdminTemplateTestUtils, WagtailTestUtils, Te
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Delete collection")
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {"url": "/admin/collections/", "label": "Collections"},
-                {"url": "", "label": str(self.collection)},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
     def test_cannot_edit_root_collection(self):
         response = self.get(collection_id=self.root_collection.id)

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -116,10 +116,7 @@ class TestWorkflowsIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase)
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/workflows/index.html")
-        self.assertBreadcrumbsItemsRendered(
-            [{"url": "", "label": "Workflows"}],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
         # Initially there should be no workflows listed
         self.assertContains(response, "There are no enabled workflows.")
@@ -207,13 +204,7 @@ class TestWorkflowsCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/workflows/create.html")
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {"label": "Workflows", "url": "/admin/workflows/list/"},
-                {"label": "New: Workflow", "url": ""},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
     def test_post(self):
         response = self.post(
@@ -437,13 +428,7 @@ class TestWorkflowsEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/workflows/edit.html")
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {"url": "/admin/workflows/list/", "label": "Workflows"},
-                {"url": "", "label": str(self.workflow)},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
         # Check that the list of pages has the page to which this workflow is assigned
         self.assertContains(response, self.page.title)
@@ -756,10 +741,7 @@ class TestTaskIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/workflows/task_index.html")
-        self.assertBreadcrumbsItemsRendered(
-            [{"url": "", "label": "Tasks"}],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
         # Initially there should be no tasks listed
         self.assertContains(response, "There are no enabled tasks")
@@ -854,13 +836,7 @@ class TestCreateTaskView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/workflows/create_task.html")
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {"label": "Tasks", "url": "/admin/workflows/tasks/index/"},
-                {"label": "New: Simple task", "url": ""},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
     def test_get_with_non_task_model(self):
         response = self.get(
@@ -978,13 +954,7 @@ class TestEditTaskView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/workflows/edit_task.html")
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {"url": "/admin/workflows/tasks/index/", "label": "Tasks"},
-                {"url": "", "label": str(self.task)},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
     def test_post(self):
         self.assertEqual(self.task.groups.count(), 0)

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -22,6 +22,8 @@ class WagtailAdminTemplateMixin(TemplateResponseMixin, ContextMixin):
     page_title = ""
     page_subtitle = ""
     header_icon = ""
+    # Breadcrumbs are opt-in until we have a design that can be consistently applied
+    _show_breadcrumbs = False
     breadcrumbs_items = [{"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")}]
     template_name = "wagtailadmin/generic/base.html"
 
@@ -42,7 +44,9 @@ class WagtailAdminTemplateMixin(TemplateResponseMixin, ContextMixin):
         context["page_title"] = self.get_page_title()
         context["page_subtitle"] = self.get_page_subtitle()
         context["header_icon"] = self.get_header_icon()
-        context["breadcrumbs_items"] = self.get_breadcrumbs_items()
+        context["breadcrumbs_items"] = None
+        if self._show_breadcrumbs:
+            context["breadcrumbs_items"] = self.get_breadcrumbs_items()
         return context
 
     def get_template_names(self):

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -52,6 +52,9 @@ class ModelViewSet(ViewSet):
     #: The view class to use for the inspect view; must be a subclass of ``wagtail.admin.views.generic.InspectView``.
     inspect_view_class = generic.InspectView
 
+    # Breadcrumbs can be turned off until we have a design that can be consistently applied
+    _show_breadcrumbs = True
+
     #: The prefix of template names to look for when rendering the admin views.
     template_prefix = ""
 
@@ -119,6 +122,7 @@ class ModelViewSet(ViewSet):
                 "edit_url_name": self.get_url_name("edit"),
                 "delete_url_name": self.get_url_name("delete"),
                 "header_icon": self.icon,
+                "_show_breadcrumbs": self._show_breadcrumbs,
                 **kwargs,
             }
         )

--- a/wagtail/locales/tests.py
+++ b/wagtail/locales/tests.py
@@ -20,10 +20,7 @@ class TestLocaleIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/generic/index.html")
-        self.assertBreadcrumbsItemsRendered(
-            [{"url": "", "label": "Locales"}],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
 
 class TestLocaleCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
@@ -46,13 +43,7 @@ class TestLocaleCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtaillocales/create.html")
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {"label": "Locales", "url": "/admin/locales/"},
-                {"label": "New: Locale", "url": ""},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
         self.assertEqual(
             response.context["form"].fields["language_code"].choices, [("fr", "French")]
@@ -127,13 +118,7 @@ class TestLocaleEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtaillocales/edit.html")
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {"url": "/admin/locales/", "label": "Locales"},
-                {"url": "", "label": str(self.english)},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
         self.assertEqual(
             response.context["form"].fields["language_code"].choices,

--- a/wagtail/locales/views.py
+++ b/wagtail/locales/views.py
@@ -98,6 +98,7 @@ class LocaleViewSet(ModelViewSet):
     model = Locale
     permission_policy = locale_permission_policy
     add_to_reference_index = False
+    _show_breadcrumbs = False
 
     index_view_class = IndexView
     add_view_class = CreateView

--- a/wagtail/sites/tests.py
+++ b/wagtail/sites/tests.py
@@ -20,10 +20,7 @@ class TestSiteIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/generic/index.html")
-        self.assertBreadcrumbsItemsRendered(
-            [{"url": "", "label": "Sites"}],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
 
 class TestSiteCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
@@ -60,13 +57,7 @@ class TestSiteCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailsites/create.html")
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {"label": "Sites", "url": "/admin/sites/"},
-                {"label": "New: Site", "url": ""},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
     def test_create(self):
         response = self.post(
@@ -206,13 +197,7 @@ class TestSiteEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailsites/edit.html")
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {"url": "/admin/sites/", "label": "Sites"},
-                {"url": "", "label": str(self.localhost)},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
         url_finder = AdminURLFinder(self.user)
         expected_url = "/admin/sites/edit/%d/" % self.localhost.id

--- a/wagtail/sites/views.py
+++ b/wagtail/sites/views.py
@@ -52,6 +52,7 @@ class SiteViewSet(ModelViewSet):
     model = Site
     permission_policy = site_permission_policy
     add_to_reference_index = False
+    _show_breadcrumbs = False
 
     index_view_class = IndexView
     add_view_class = CreateView

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -79,6 +79,7 @@ class ModelIndexView(generic.IndexView):
     header_icon = "snippet"
     index_url_name = "wagtailsnippets:index"
     default_ordering = "name"
+    _show_breadcrumbs = True
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -11,7 +11,6 @@ from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from django.utils.text import capfirst
 
 from wagtail import hooks
 from wagtail.admin.admin_url_finder import AdminURLFinder
@@ -118,10 +117,7 @@ class TestGroupUsersView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertContains(response, "testuser")
         # response should contain page furniture, including the "Add a user" button
         self.assertContains(response, "Add a user")
-        self.assertBreadcrumbsItemsRendered(
-            [{"url": "", "label": capfirst(User._meta.verbose_name_plural)}],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
     def test_inexisting_group(self):
         response = self.get(group_id=9999)
@@ -207,10 +203,7 @@ class TestUserIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertContains(response, "testuser")
         # response should contain page furniture, including the "Add a user" button
         self.assertContains(response, "Add a user")
-        self.assertBreadcrumbsItemsRendered(
-            [{"url": "", "label": capfirst(User._meta.verbose_name_plural)}],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
     @unittest.skipIf(
         settings.AUTH_USER_MODEL == "emailuser.EmailUser", "Negative UUID not possible"
@@ -314,16 +307,7 @@ class TestUserCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailusers/users/create.html")
         self.assertContains(response, "Password")
         self.assertContains(response, "Password confirmation")
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {
-                    "url": "/admin/users/",
-                    "label": capfirst(User._meta.verbose_name_plural),
-                },
-                {"url": "", "label": f"New: {capfirst(User._meta.verbose_name)}"},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
     def test_create(self):
         response = self.post(
@@ -842,16 +826,7 @@ class TestUserEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailusers/users/edit.html")
         self.assertContains(response, "Password")
         self.assertContains(response, "Password confirmation")
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {
-                    "url": "/admin/users/",
-                    "label": capfirst(User._meta.verbose_name_plural),
-                },
-                {"url": "", "label": str(self.test_user)},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
         url_finder = AdminURLFinder(self.current_user)
         expected_url = "/admin/users/%s/" % self.test_user.pk
@@ -1345,10 +1320,7 @@ class TestGroupIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailadmin/generic/index.html")
         # response should contain page furniture, including the "Add a group" button
         self.assertContains(response, "Add a group")
-
-        self.assertBreadcrumbsItemsRendered(
-            [{"url": "", "label": "Groups"}], response.content
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
     def test_search(self):
         response = self.get({"q": "Hello"})
@@ -1412,13 +1384,7 @@ class TestGroupCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailusers/groups/create.html")
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {"url": "/admin/groups/", "label": "Groups"},
-                {"url": "", "label": "New: Group"},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
     def test_create_group(self):
         response = self.post({"name": "test group"})
@@ -1660,16 +1626,7 @@ class TestGroupEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailusers/groups/edit.html")
-        self.assertBreadcrumbsItemsRendered(
-            [
-                {
-                    "url": "/admin/groups/",
-                    "label": "Groups",
-                },
-                {"url": "", "label": str(self.test_group)},
-            ],
-            response.content,
-        )
+        self.assertBreadcrumbsNotRendered(response.content)
 
         url_finder = AdminURLFinder(self.user)
         expected_url = "/admin/groups/edit/%d/" % self.test_group.id

--- a/wagtail/users/views/groups.py
+++ b/wagtail/users/views/groups.py
@@ -158,6 +158,7 @@ class GroupViewSet(ModelViewSet):
     icon = "group"
     model = Group
     add_to_reference_index = False
+    _show_breadcrumbs = False
 
     index_view_class = IndexView
     add_view_class = CreateView


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Undo the breadcrumbs unintentionally added in #10880 and intentionally added in #10884 until we can implement the designs that are better suited for various use cases throughout the admin.

To re-enable in the future, revert the first two commits from this PR.

I also added a commit to disable the minimap if there are no panel anchors found, to prevent the minimap from rendering on the ModelViewSet views as they currently don't use panels. When they do support panels after #10830, the minimap should be rendered automatically.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

Use my bakerydemo branch: https://github.com/laymonage/bakerydemo/tree/country-modelviewset

And see that:

- The views for County of Origin still have breadcrumbs (and status side panel)
- The views for all snippets still have breadcrumbs
- The following views do not have breadcrumbs at all:
  - Workflows
  - Workflow tasks
  - Users
  - Groups
  - Sites
  - Locales
  - Collections

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
