### PR TITLE
Fix Elasticsearch7 backend to work with pre-7.15 library versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ concurrency:
 # - elasticsearch 5, django 3.2, python 3.8, sqlite
 # - elasticsearch 6, django 3.2, python 3.8, postgres
 # - elasticsearch 7, django 4.1, python 3.8, postgres
+# - opensearch 2, django 4.1, python 3.9, sqlite
 # - elasticsearch 8, django 4.2, python 3.10, sqlite, USE_EMAIL_USER_MODEL=yes
 
 # Some tests are run in parallel by passing --parallel to runtests.py.
@@ -410,6 +411,51 @@ jobs:
           name: coverage-data
           path: .coverage.*
 
+  test-sqlite-opensearch2:
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        include:
+          - python: '3.9'
+            django: 'Django>=4.1,<4.2'
+            experimental: false
+
+    steps:
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+      - uses: ankane/setup-opensearch@v1
+        with:
+          opensearch-version: 2
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[testing]' --config-settings editable_mode=strict
+          pip install "${{ matrix.django }}"
+          pip install "elasticsearch==7.13.4"
+          pip install certifi
+      - name: Test
+        run: |
+          coverage run --parallel-mode --source wagtail runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch7
+        env:
+          DATABASE_ENGINE: django.db.backends.sqlite3
+          USE_EMAIL_USER_MODEL: ${{ matrix.emailuser }}
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: .coverage.*
+
   coverage:
     needs:
       - test-sqlite
@@ -419,6 +465,7 @@ jobs:
       - test-sqlite-elasticsearch8
       - test-postgres-elasticsearch6
       - test-postgres-elasticsearch7
+      - test-sqlite-opensearch2
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/wagtail/search/backends/elasticsearch8.py
+++ b/wagtail/search/backends/elasticsearch8.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ImproperlyConfigured
+from elasticsearch import NotFoundError
 
 from wagtail.search.backends.elasticsearch7 import (
     Elasticsearch7AutocompleteQueryCompiler,
@@ -8,6 +9,7 @@ from wagtail.search.backends.elasticsearch7 import (
     Elasticsearch7SearchQueryCompiler,
     Elasticsearch7SearchResults,
 )
+from wagtail.search.index import class_is_indexed
 
 
 class Elasticsearch8Mapping(Elasticsearch7Mapping):
@@ -15,6 +17,18 @@ class Elasticsearch8Mapping(Elasticsearch7Mapping):
 
 
 class Elasticsearch8Index(Elasticsearch7Index):
+    def put(self):
+        self.es.indices.create(index=self.name, **self.backend.settings)
+
+    def delete(self):
+        try:
+            self.es.indices.delete(index=self.name)
+        except NotFoundError:
+            pass
+
+    def refresh(self):
+        self.es.indices.refresh(index=self.name)
+
     def add_model(self, model):
         # Get mapping
         mapping = self.mapping_class(model)
@@ -22,13 +36,31 @@ class Elasticsearch8Index(Elasticsearch7Index):
         # Put mapping
         self.es.indices.put_mapping(index=self.name, **mapping.get_mapping())
 
+    def add_item(self, item):
+        # Make sure the object can be indexed
+        if not class_is_indexed(item.__class__):
+            return
+
+        # Get mapping
+        mapping = self.mapping_class(item.__class__)
+
+        # Add document to index
+        self.es.index(
+            index=self.name,
+            document=mapping.get_document(item),
+            id=mapping.get_document_id(item),
+        )
+
 
 class Elasticsearch8SearchQueryCompiler(Elasticsearch7SearchQueryCompiler):
     mapping_class = Elasticsearch8Mapping
 
 
 class Elasticsearch8SearchResults(Elasticsearch7SearchResults):
-    pass
+    def _backend_do_search(self, body, **kwargs):
+        # As of Elasticsearch 7.15, the 'body' parameter is deprecated; instead, the top-level
+        # keys of the body dict are now kwargs in their own right
+        return self.backend.es.search(**body, **kwargs)
 
 
 class Elasticsearch8AutocompleteQueryCompiler(Elasticsearch7AutocompleteQueryCompiler):

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -20,6 +20,16 @@ except ImportError:
     ELASTICSEARCH_VERSION = (0, 0, 0)
 
 
+use_new_elasticsearch_api = ELASTICSEARCH_VERSION >= (7, 15)
+
+if use_new_elasticsearch_api:
+    search_query_kwargs = {
+        "query": "QUERY",
+    }
+else:
+    search_query_kwargs = {"body": {"query": "QUERY"}}
+
+
 @unittest.skipIf(ELASTICSEARCH_VERSION[0] != 7, "Elasticsearch 7 required")
 class TestElasticsearch7SearchBackend(ElasticsearchCommonSearchBackendTests, TestCase):
     backend_path = "wagtail.search.backends.elasticsearch7"
@@ -915,12 +925,12 @@ class TestElasticsearch7SearchResults(TestCase):
         list(results)  # Performs search
 
         search.assert_any_call(
-            query="QUERY",
             _source=False,
             stored_fields="pk",
             index="wagtail__searchtests_book",
             scroll="2m",
             size=100,
+            **search_query_kwargs,
         )
 
     @mock.patch("elasticsearch.Elasticsearch.search")
@@ -933,11 +943,11 @@ class TestElasticsearch7SearchResults(TestCase):
 
         search.assert_any_call(
             from_=10,
-            query="QUERY",
             _source=False,
             stored_fields="pk",
             index="wagtail__searchtests_book",
             size=1,
+            **search_query_kwargs,
         )
 
     @mock.patch("elasticsearch.Elasticsearch.search")
@@ -949,11 +959,11 @@ class TestElasticsearch7SearchResults(TestCase):
 
         search.assert_any_call(
             from_=1,
-            query="QUERY",
             _source=False,
             stored_fields="pk",
             index="wagtail__searchtests_book",
             size=3,
+            **search_query_kwargs,
         )
 
     @mock.patch("elasticsearch.Elasticsearch.search")
@@ -965,11 +975,11 @@ class TestElasticsearch7SearchResults(TestCase):
 
         search.assert_any_call(
             from_=10,
-            query="QUERY",
             _source=False,
             stored_fields="pk",
             index="wagtail__searchtests_book",
             size=10,
+            **search_query_kwargs,
         )
 
     @mock.patch("elasticsearch.Elasticsearch.search")
@@ -982,11 +992,11 @@ class TestElasticsearch7SearchResults(TestCase):
 
         search.assert_any_call(
             from_=20,
-            query="QUERY",
             _source=False,
             stored_fields="pk",
             index="wagtail__searchtests_book",
             size=1,
+            **search_query_kwargs,
         )
 
     @mock.patch("elasticsearch.Elasticsearch.search")


### PR DESCRIPTION
Fixes #7920

Modify the Elasticsearch7 backend so that we only patch in the methods with new-style API calls if we are confirmed to be running on version 7.15 or above of the Python library. This allows users of OpenSearch to run against version 7.13.4, the last working version before it removed support for non-Elasticsearch-branded servers.

Also add a test run using OpenSearch to the Github Actions config.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
