### PR TITLE
Document support for OpenSearch

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ Changelog
 5.2 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~
 
+ * Support OpenSearch as an alternative to Elasticsearch
  * Add preview-aware and page-aware fragment caching template tags, `wagtailcache` & `wagtailpagecache` (Jake Howard)
  * Always set help text element ID for form fields with help text in `field.html` template (Sage Abdullah)
  * Move `SnippetViewSet` menu registration mechanism to base `ViewSet` class (Sage Abdullah)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -11,6 +11,9 @@ depth: 1
 
 ## What's new
 
+### OpenSearch support
+
+[OpenSearch](https://opensearch.org/) is now formally supported as an alternative to Elasticsearch. For configuration details, see [OpenSearch configuration](opensearch).
 
 ### Other features
 

--- a/docs/topics/search/backends.md
+++ b/docs/topics/search/backends.md
@@ -150,9 +150,15 @@ If you prefer not to run an Elasticsearch server in development or production, t
 -   Configure `URLS` in the Elasticsearch entry in `WAGTAILSEARCH_BACKENDS` using the Cluster URL from your Bonsai dashboard
 -   Run `./manage.py update_index`
 
-### Amazon AWS Elasticsearch
+(opensearch)=
 
-The Elasticsearch backend is compatible with [Amazon Elasticsearch Service](https://aws.amazon.com/opensearch-service/), but requires additional configuration to handle IAM based authentication. This can be done with the [requests-aws4auth](https://pypi.org/project/requests-aws4auth/) package along with the following configuration:
+### OpenSearch
+
+OpenSearch is a community-driven search engine originally created as a fork of Elasticsearch 7. Wagtail supports OpenSearch through the `wagtail.search.backends.elasticsearch7` backend and version 7.13.4 of the [Elasticsearch Python library](https://pypi.org/project/elasticsearch/). Later versions of the library only permit connecting to Elastic-branded servers, and are not compatible with OpenSearch.
+
+### Amazon AWS OpenSearch
+
+The Elasticsearch backend is compatible with [Amazon OpenSearch Service](https://aws.amazon.com/opensearch-service/), but requires additional configuration to handle IAM based authentication. This can be done with the [requests-aws4auth](https://pypi.org/project/requests-aws4auth/) package along with the following configuration:
 
 ```python
 from elasticsearch import RequestsHttpConnection
@@ -160,7 +166,7 @@ from requests_aws4auth import AWS4Auth
 
 WAGTAILSEARCH_BACKENDS = {
     'default': {
-        'BACKEND': 'wagtail.search.backends.elasticsearch5',
+        'BACKEND': 'wagtail.search.backends.elasticsearch7',
         'INDEX': 'wagtail',
         'TIMEOUT': 5,
         'HOSTS': [{


### PR DESCRIPTION
Follow-up to #10916 - now that we've added OpenSearch to our CI, we can declare formal support for it.

Have also updated the references to Amazon Elasticsearch Service - I haven't tested that the updated config works with the current AWS service, but I figure that at the very least it's going to be _closer_ to correct than using a backend that pre-dates OpenSearch :-)

Fixes #7920
