### PR TITLE
Add subject and body to mailto links

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ Changelog
  * Allow subclasses of `PagesAPIViewSet` override default Page model via the `model` attribute (Neeraj Yetheendran, Herbert Poul)
  * Allow `ModelViewSet` to be used with models that have non-integer primary keys (Sage Abdullah)
  * Add the ability to set an external link/text for promoted search result entries (TopDevPros, Brad Busenius)
+ * Add support for subject and body in the Email link chooser form (TopDevPros, Alexandre Joly)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -44,6 +44,7 @@ depth: 1
  * Allow subclasses of `PagesAPIViewSet` override default Page model via the `model` attribute (Neeraj Yetheendran, Herbert Poul)
  * Allow `ModelViewSet` to be used with models that have non-integer primary keys (Sage Abdullah)
  * Add the ability to set an external link/text for promoted search result entries (TopDevPros, Brad Busenius)
+ * Add support for subject and body in the Email link chooser form (TopDevPros, Alexandre Joly)
 
 ### Bug fixes
 

--- a/wagtail/admin/forms/choosers.py
+++ b/wagtail/admin/forms/choosers.py
@@ -44,6 +44,8 @@ class AnchorLinkChooserForm(forms.Form):
 class EmailLinkChooserForm(forms.Form):
     email_address = forms.EmailField(required=True)
     link_text = forms.CharField(required=False)
+    subject = forms.CharField(required=False)
+    body = forms.CharField(required=False, widget=forms.Textarea(attrs={"rows": 3}))
 
 
 class PhoneLinkChooserForm(forms.Form):

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -1,4 +1,5 @@
 import json
+import urllib.parse as urlparse
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase, TransactionTestCase, override_settings
@@ -868,6 +869,79 @@ class TestChooserEmailLink(WagtailTestUtils, TestCase):
             result["title"], "contact"
         )  # When link text is given, it is used
         self.assertIs(result["prefer_this_title_as_link_text"], True)
+
+    def test_create_link_with_subject_and_body(self):
+        response = self.post(
+            {
+                "email-link-chooser-email_address": "example@example.com",
+                "email-link-chooser-link_text": "contact",
+                "email-link-chooser-subject": "Awesome Subject",
+                "email-link-chooser-body": "An example body",
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode())["result"]
+        url = result["url"]
+        self.assertEqual(
+            url,
+            "mailto:example@example.com?subject=Awesome%20Subject&body=An%20example%20body",
+        )
+        self.assertEqual(
+            result["title"], "contact"
+        )  # When link text is given, it is used
+        self.assertIs(result["prefer_this_title_as_link_text"], True)
+
+        mail_parts = urlparse.urlparse(url)
+        query = urlparse.parse_qs(mail_parts.query)
+        self.assertEqual(mail_parts.path, "example@example.com")
+        self.assertEqual(query["subject"][0], "Awesome Subject")
+        self.assertEqual(query["body"][0], "An example body")
+
+    def test_create_link_with_subject_only(self):
+        response = self.post(
+            {
+                "email-link-chooser-email_address": "example@example.com",
+                "email-link-chooser-link_text": "contact",
+                "email-link-chooser-subject": "Awesome Subject",
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode())["result"]
+        url = result["url"]
+        self.assertEqual(url, "mailto:example@example.com?subject=Awesome%20Subject")
+        self.assertEqual(
+            result["title"], "contact"
+        )  # When link text is given, it is used
+        self.assertIs(result["prefer_this_title_as_link_text"], True)
+
+        mail_parts = urlparse.urlparse(url)
+        query = urlparse.parse_qs(mail_parts.query)
+        self.assertEqual(mail_parts.path, "example@example.com")
+        self.assertEqual(query["subject"][0], "Awesome Subject")
+        self.assertTrue("body" not in query)
+
+    def test_create_link_with_body_only(self):
+        response = self.post(
+            {
+                "email-link-chooser-email_address": "example@example.com",
+                "email-link-chooser-link_text": "contact",
+                "email-link-chooser-body": "An example body",
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode())["result"]
+        url = result["url"]
+        self.assertEqual(url, "mailto:example@example.com?body=An%20example%20body")
+        self.assertEqual(
+            result["title"], "contact"
+        )  # When link text is given, it is used
+        self.assertIs(result["prefer_this_title_as_link_text"], True)
+
+        mail_parts = urlparse.urlparse(url)
+        query = urlparse.parse_qs(mail_parts.query)
+        self.assertEqual(mail_parts.path, "example@example.com")
+        self.assertEqual(query["body"][0], "An example body")
+        self.assertTrue("subject" not in query)
 
     def test_create_link_without_text(self):
         response = self.post(


### PR DESCRIPTION
Fixes #5950. Updated code from PR #6451 which was abandoned 3 years ago. Added more comprehensive tests.

    [Y] Do the tests still pass?
    [Y] Does the code comply with the style guide?
        [Y] Run make lint from the Wagtail root.
    [Y] For Python changes: Have you added tests to cover the new/fixed behaviour?
    [Y] For front-end changes: Did you test on all of Wagtail’s supported environments?
        Chromium and Firefox on linux
    [N] For new features: Has the documentation been updated accordingly?

        The only possibly related docs are in wagtail/docs/extending/rich_text_internals.md. 
        It appears that we would unnecessarily complicate the current docs with details about
        the new optional fields.
