### PR TITLE
Fix tests against Django `main`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,12 +103,13 @@ jobs:
           - python: '3.10'
             django: 'git+https://github.com/django/django.git@main#egg=Django'
             experimental: true
-            postgres: 'postgres:12'
+            postgres: 'postgres:13'
             parallel: '--parallel'
             install_extras: |
-              pip uninstall -y django-modelcluster
+              pip uninstall -y django-modelcluster django-taggit
               pip install \
-                git+https://github.com/wagtail/django-modelcluster.git@main#egg=django-modelcluster
+                git+https://github.com/wagtail/django-modelcluster.git@main#egg=django-modelcluster \
+                git+https://github.com/laymonage/django-taggit.git@django-5.1#egg=django-taggit
 
     services:
       postgres:

--- a/wagtail/admin/staticfiles.py
+++ b/wagtail/admin/staticfiles.py
@@ -2,7 +2,6 @@ import hashlib
 
 from django.conf import settings
 from django.contrib.staticfiles.storage import HashedFilesMixin
-from django.core.files.storage import get_storage_class
 from django.templatetags.static import static
 
 from wagtail import __version__
@@ -23,7 +22,17 @@ except AttributeError:
         use_version_strings = True
     else:
         # see if we're using a storage backend using hashed filenames
-        storage = get_storage_class(settings.STATICFILES_STORAGE)
+        try:
+            from django.conf import STATICFILES_STORAGE_ALIAS
+            from django.core.files.storage import storages
+
+            storage = storages[STATICFILES_STORAGE_ALIAS].__class__
+        except ImportError:
+            # DJANGO_VERSION < 4.2
+            from django.core.files.storage import get_storage_class
+
+            storage = get_storage_class(settings.STATICFILES_STORAGE)
+
         use_version_strings = not issubclass(storage, HashedFilesMixin)
 
 

--- a/wagtail/documents/tests/test_serializers.py
+++ b/wagtail/documents/tests/test_serializers.py
@@ -1,9 +1,9 @@
 from django.core.files.base import ContentFile
 from django.test import TestCase
-from django.test.utils import override_settings
 from django.urls import reverse
 
 from wagtail.documents import models
+from wagtail.test.utils import override_settings
 
 
 class TestCorrectDownloadUrlSerialization(TestCase):

--- a/wagtail/documents/tests/test_views.py
+++ b/wagtail/documents/tests/test_views.py
@@ -7,10 +7,10 @@ from unittest import mock
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.test import TestCase
-from django.test.utils import override_settings
 from django.urls import reverse
 
 from wagtail.documents import models
+from wagtail.test.utils import override_settings
 
 
 @override_settings(WAGTAILDOCS_SERVE_METHOD=None)

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import Group, Permission
 from django.core.files.uploadedfile import SimpleUploadedFile, TemporaryUploadedFile
 from django.template.defaultfilters import filesizeformat
 from django.template.loader import render_to_string
-from django.test import RequestFactory, TestCase, TransactionTestCase, override_settings
+from django.test import RequestFactory, TestCase, TransactionTestCase
 from django.urls import reverse
 from django.utils.encoding import force_str
 from django.utils.html import escape, escapejs
@@ -29,7 +29,7 @@ from wagtail.test.testapp.models import (
     EventPage,
     VariousOnDeleteModel,
 )
-from wagtail.test.utils import WagtailTestUtils
+from wagtail.test.utils import WagtailTestUtils, override_settings
 
 from .utils import Image, get_test_image_file, get_test_image_file_svg
 

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -8,7 +8,6 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models import Prefetch
 from django.db.utils import IntegrityError
 from django.test import TestCase, TransactionTestCase
-from django.test.utils import override_settings
 from django.urls import reverse
 from willow.image import Image as WillowImage
 
@@ -25,7 +24,7 @@ from wagtail.test.testapp.models import (
     EventPageCarouselItem,
     ReimportedImageModel,
 )
-from wagtail.test.utils import WagtailTestUtils
+from wagtail.test.utils import WagtailTestUtils, override_settings
 
 from .utils import Image, get_test_image_file
 

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -54,7 +54,23 @@ STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 )
 
+# Default storage settings
+# https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-STORAGES
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
 if os.environ.get("STATICFILES_STORAGE", "") == "manifest":
+    STORAGES["staticfiles"][
+        "BACKEND"
+    ] = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+
+    # DJANGO_VERSION < 4.2
     STATICFILES_STORAGE = (
         "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
     )


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

- Replace usage of deprecated `get_storage_class()`
- Use PostgreSQL 13
- Use a branch on my fork based on jazzband/django-taggit#869 (currently identical, but I opted to use a branch that can be controlled on our side so we can update it later as necessary, without updating the CI config again).
- Add `override_settings` shims for overriding the staticfiles and default storage classes.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
