### PR TITLE
Fix theme of logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <h1 align="center">
-    <img width="343" src=".github/wagtail.svg#gh-light-mode-only" alt="Wagtail">
-    <img width="343" src=".github/wagtail-inverse.svg#gh-dark-mode-only" alt="Wagtail">
+    <picture>
+        <source media="(prefers-color-scheme: light)" srcset=".github/wagtail.svg">
+        <source media="(prefers-color-scheme: dark)" srcset=".github/wagtail-inverse.svg">
+        <img width="343" src=".github/wagtail.svg" alt="Wagtail">
+    </picture>
 </h1>
 <p align="center">
     <br>


### PR DESCRIPTION
Github seems to have removed the dark-mode/light-mode switch using an URL-fragment.

![wagtail_readme_logo_issue](https://github.com/wagtail/wagtail/assets/468164/7bacfa08-beef-4881-87c7-b65ca9eac9c1)

The docs mention, that it will be removed: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to

> The old method of specifying images based on the theme, by using a fragment appended to the URL (#gh-dark-mode-only or #gh-light-mode-only), is deprecated and will be removed in favor of the new method described above.

My change just follows the new approach from the docs.