### PR TITLE
Add generic `InspectView` to `ModelViewSet`

### DIFF
--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -89,12 +89,16 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: export_filename
    .. autoattribute:: search_fields
    .. autoattribute:: search_backend_name
+   .. autoattribute:: inspect_view_enabled
+   .. autoattribute:: inspect_view_fields
+   .. autoattribute:: inspect_view_fields_exclude
    .. autoattribute:: index_view_class
    .. autoattribute:: add_view_class
    .. autoattribute:: edit_view_class
    .. autoattribute:: delete_view_class
-   .. autoattribute:: history_view_class
    .. autoattribute:: usage_view_class
+   .. autoattribute:: history_view_class
+   .. autoattribute:: inspect_view_class
    .. autoattribute:: template_prefix
    .. autoattribute:: index_template_name
    .. autoattribute:: index_results_template_name
@@ -102,6 +106,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: edit_template_name
    .. autoattribute:: delete_template_name
    .. autoattribute:: history_template_name
+   .. autoattribute:: inspect_template_name
 ```
 
 ## ModelViewSetGroup
@@ -163,9 +168,6 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: model
    .. autoattribute:: chooser_per_page
    .. autoattribute:: ordering
-   .. autoattribute:: inspect_view_enabled
-   .. autoattribute:: inspect_view_fields
-   .. autoattribute:: inspect_view_fields_exclude
    .. autoattribute:: admin_url_namespace
    .. autoattribute:: base_url_path
    .. autoattribute:: chooser_admin_url_namespace
@@ -187,7 +189,6 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: lock_view_class
    .. autoattribute:: unlock_view_class
    .. autoattribute:: chooser_viewset_class
-   .. autoattribute:: inspect_template_name
    .. automethod:: get_queryset
    .. automethod:: get_edit_handler
    .. automethod:: get_form_class

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -956,6 +956,7 @@ class DeleteView(
 
 
 class InspectView(PermissionCheckedMixin, WagtailAdminTemplateMixin, TemplateView):
+    any_permission_required = ["add", "change", "delete"]
     template_name = "wagtailadmin/generic/inspect.html"
     page_title = gettext_lazy("Inspecting")
     model = None

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -102,6 +102,7 @@ class IndexView(
     add_url_name = None
     add_item_label = gettext_lazy("Add")
     edit_url_name = None
+    inspect_url_name = None
     delete_url_name = None
     any_permission_required = ["add", "change", "delete"]
     search_fields = None
@@ -364,6 +365,10 @@ class IndexView(
         if self.edit_url_name:
             return reverse(self.edit_url_name, args=(quote(instance.pk),))
 
+    def get_inspect_url(self, instance):
+        if self.inspect_url_name:
+            return reverse(self.inspect_url_name, args=(quote(instance.pk),))
+
     def get_delete_url(self, instance):
         if self.delete_url_name:
             return reverse(self.delete_url_name, args=(quote(instance.pk),))
@@ -413,6 +418,20 @@ class IndexView(
                         "aria-label": _("Edit '%(title)s'") % {"title": str(instance)}
                     },
                     priority=10,
+                )
+            )
+        inspect_url = self.get_inspect_url(instance)
+        if inspect_url:
+            buttons.append(
+                ListingButton(
+                    _("Inspect"),
+                    url=inspect_url,
+                    icon_name="info-circle",
+                    attrs={
+                        "aria-label": _("Inspect '%(title)s'")
+                        % {"title": str(instance)}
+                    },
+                    priority=20,
                 )
             )
         delete_url = self.get_delete_url(instance)

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -1078,7 +1078,7 @@ class InspectView(PermissionCheckedMixin, WagtailAdminTemplateMixin, TemplateVie
             )
         ):
             return None
-        return reverse(self.edit_url_name, args=(quote(self.pk),))
+        return reverse(self.edit_url_name, args=(quote(self.object.pk),))
 
     def get_delete_url(self):
         if not self.delete_url_name or (
@@ -1088,7 +1088,7 @@ class InspectView(PermissionCheckedMixin, WagtailAdminTemplateMixin, TemplateVie
             )
         ):
             return None
-        return reverse(self.delete_url_name, args=(quote(self.pk),))
+        return reverse(self.delete_url_name, args=(quote(self.object.pk),))
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -171,7 +171,12 @@ class ModelViewSet(ViewSet):
         }
 
     def get_usage_view_kwargs(self, **kwargs):
-        return {**kwargs}
+        return {
+            "template_name": self.get_templates(
+                "usage", fallback=self.usage_view_class.template_name
+            ),
+            **kwargs,
+        }
 
     def get_inspect_view_kwargs(self, **kwargs):
         return {

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -107,7 +107,7 @@ class ModelViewSet(ViewSet):
         return self.model_name
 
     def get_common_view_kwargs(self, **kwargs):
-        return super().get_common_view_kwargs(
+        view_kwargs = super().get_common_view_kwargs(
             **{
                 "model": self.model,
                 "permission_policy": self.permission_policy,
@@ -122,6 +122,9 @@ class ModelViewSet(ViewSet):
                 **kwargs,
             }
         )
+        if self.inspect_view_enabled:
+            view_kwargs["inspect_url_name"] = self.get_url_name("inspect")
+        return view_kwargs
 
     def get_index_view_kwargs(self, **kwargs):
         return {

--- a/wagtail/documents/templates/wagtaildocs/components/document_display.html
+++ b/wagtail/documents/templates/wagtaildocs/components/document_display.html
@@ -1,1 +1,10 @@
-<a href="{{ value.url }}">{{ value.title }} <span class="meta">({{ value.file_extension|upper }}, {{ value.file.size|filesizeformat }})</span></a>
+{% if value is None %}
+    {{ value }}
+{% else %}
+    <a href="{{ value.url }}">
+        {{ value.title }}
+        <span class="meta">
+            ({{ value.file_extension|upper }}, {{ value.file.size|filesizeformat }})
+        </span>
+    </a>
+{% endif %}

--- a/wagtail/images/components.py
+++ b/wagtail/images/components.py
@@ -6,4 +6,6 @@ class ImageDisplay(BaseFieldDisplay):
     rendition_spec = "max-400x400"
 
     def render_html(self, parent_context):
+        if self.value is None:
+            return None
         return get_rendition_or_not_found(self.value, self.rendition_spec).img_tag()

--- a/wagtail/locales/views.py
+++ b/wagtail/locales/views.py
@@ -108,9 +108,11 @@ class LocaleViewSet(ModelViewSet):
 
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(
-            history_url_name=None,
-            usage_url_name=None,
-            **kwargs,
+            **{
+                "history_url_name": None,
+                "usage_url_name": None,
+                **kwargs,
+            }
         )
 
     def get_form_class(self, for_update=False):

--- a/wagtail/sites/views.py
+++ b/wagtail/sites/views.py
@@ -62,9 +62,11 @@ class SiteViewSet(ModelViewSet):
 
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(
-            history_url_name=None,
-            usage_url_name=None,
-            **kwargs,
+            **{
+                "history_url_name": None,
+                "usage_url_name": None,
+                **kwargs,
+            }
         )
 
     def get_form_class(self, for_update=False):

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -1345,6 +1345,7 @@ class TestInspectViewConfiguration(BaseSnippetViewSetTests):
         )
         response = self.client.get(self.get_url("inspect", args=(quote(object.pk),)))
 
+        self.assertEqual(response.status_code, 200)
         self.assertContains(
             response,
             f"<dt>Protected image</dt> <dd>{image.get_rendition('max-400x400').img_tag()}</dd>",
@@ -1355,6 +1356,23 @@ class TestInspectViewConfiguration(BaseSnippetViewSetTests):
         self.assertContains(response, "Test document")
         self.assertContains(response, "TXT")
         self.assertContains(response, f"{document.file.size}\xa0bytes")
+
+    def test_image_and_document_fields_none_values(self):
+        self.model = VariousOnDeleteModel
+        object = self.model.objects.create()
+        response = self.client.get(self.get_url("inspect", args=(quote(object.pk),)))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            "<dt>Protected image</dt> <dd>None</dd>",
+            html=True,
+        )
+        self.assertContains(
+            response,
+            "<dt>Protected document</dt> <dd>None</dd>",
+            html=True,
+        )
 
 
 class TestBreadcrumbs(AdminTemplateTestUtils, BaseSnippetViewSetTests):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -456,7 +456,6 @@ class HistoryView(history.HistoryView):
 
 class InspectView(generic.InspectView):
     view_name = "inspect"
-    any_permission_required = ["add", "change", "delete"]
 
 
 class PreviewOnCreateView(PreviewOnCreate):
@@ -573,25 +572,6 @@ class SnippetViewSet(ModelViewSet):
 
     #: The number of items to display in the chooser view. Defaults to 10.
     chooser_per_page = 10
-
-    #: Whether to enable the inspect view. Defaults to ``False``.
-    inspect_view_enabled = False
-
-    #: The model fields or attributes to display in the inspect view.
-    #:
-    #: If the field has a corresponding :meth:`~django.db.models.Model.get_FOO_display`
-    #: method on the model, the method's return value will be used instead.
-    #:
-    #: If you have ``wagtail.images`` installed, and the field's value is an instance of
-    #: ``wagtail.images.models.AbstractImage``, a thumbnail of that image will be rendered.
-    #:
-    #: If you have ``wagtail.documents`` installed, and the field's value is an instance of
-    #: ``wagtail.docs.models.AbstractDocument``, a link to that document will be rendered,
-    #: along with the document title, file extension and size.
-    inspect_view_fields = []
-
-    #: The fields to exclude from the inspect view.
-    inspect_view_fields_exclude = []
 
     #: The URL namespace to use for the admin views.
     #: If left unset, ``wagtailsnippets_{app_label}_{model_name}`` is used instead.
@@ -791,15 +771,6 @@ class SnippetViewSet(ModelViewSet):
             template_name=self.get_templates(
                 "usage", fallback=self.usage_view_class.template_name
             ),
-        )
-
-    @property
-    def inspect_view(self):
-        return self.construct_view(
-            self.inspect_view_class,
-            template_name=self.get_inspect_template(),
-            fields=self.inspect_view_fields,
-            fields_exclude=self.inspect_view_fields_exclude,
         )
 
     @property

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -765,15 +765,6 @@ class SnippetViewSet(ModelViewSet):
         )
 
     @property
-    def usage_view(self):
-        return self.construct_view(
-            self.usage_view_class,
-            template_name=self.get_templates(
-                "usage", fallback=self.usage_view_class.template_name
-            ),
-        )
-
-    @property
     def revisions_view(self):
         return self.construct_view(self.revisions_view_class)
 

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -1,4 +1,3 @@
-from django.contrib.admin.utils import quote
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.urls import include, path, reverse
@@ -11,7 +10,6 @@ from wagtail.snippets.bulk_actions.delete import DeleteBulkAction
 from wagtail.snippets.models import get_snippet_models
 from wagtail.snippets.permissions import user_can_edit_snippets
 from wagtail.snippets.views import snippets as snippet_views
-from wagtail.snippets.widgets import SnippetListingButton
 
 
 @hooks.register("register_admin_urls")
@@ -55,26 +53,6 @@ def register_snippets_menu_item():
 def register_permissions():
     content_types = ContentType.objects.get_for_models(*get_snippet_models()).values()
     return Permission.objects.filter(content_type__in=content_types)
-
-
-@hooks.register("register_snippet_listing_buttons")
-def register_snippet_listing_buttons(snippet, user, next_url=None):
-    model = type(snippet)
-    viewset = model.snippet_viewset
-    permission_policy = viewset.permission_policy
-
-    if viewset.inspect_view_enabled and permission_policy.user_has_any_permission(
-        user, viewset.inspect_view_class.any_permission_required
-    ):
-        yield SnippetListingButton(
-            _("Inspect"),
-            reverse(
-                viewset.get_url_name("inspect"),
-                args=[quote(snippet.pk)],
-            ),
-            attrs={"aria-label": _("Inspect '%(title)s'") % {"title": str(snippet)}},
-            priority=20,
-        )
 
 
 hooks.register("register_bulk_action", DeleteBulkAction)

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -213,6 +213,8 @@ class FeatureCompleteToyViewSet(ModelViewSet):
     list_per_page = 5
     ordering = ["name", "-release_date"]
     # search_fields derived from the model
+    inspect_view_enabled = True
+    inspect_view_fields = ["strid", "release_date"]
 
 
 class FCToyAlt1ViewSet(ModelViewSet):
@@ -221,6 +223,8 @@ class FCToyAlt1ViewSet(ModelViewSet):
     list_filter = {"name": ["icontains"]}
     form_fields = ["name"]
     menu_label = "FC Toys Alt 1"
+    inspect_view_enabled = True
+    inspect_view_fields_exclude = ["strid", "release_date"]
 
     def get_index_view_kwargs(self, **kwargs):
         return super().get_index_view_kwargs(is_searchable=False, **kwargs)

--- a/wagtail/users/views/groups.py
+++ b/wagtail/users/views/groups.py
@@ -176,9 +176,11 @@ class GroupViewSet(ModelViewSet):
 
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(
-            history_url_name=None,
-            usage_url_name=None,
-            **kwargs,
+            **{
+                "history_url_name": None,
+                "usage_url_name": None,
+                **kwargs,
+            }
         )
 
     def get_form_class(self, for_update=False):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

As part of #10740.

Sorry I missed two small things in #10930:
- f4b18bc2473d65cd85a751569fb2487b2fdea16e: Also extract the logic for using `get_template()` from snippets' usage view
- 04f63d8e273132666d90569025b7f494ed6d2716: Use the established pattern of merging the kwargs in a dictionary before passing it to `super().get_common_view_kwargs()` to prevent error when redefining a kwarg.

I also found two minor bugs with the current `InspectView`, the last two commits fix them and I think we should backport to 5.1:
- e8e542e90b2877a69d24ac234fe3b2fa81a45e92: The edit/delete link on the inspect view might not work if the model has a PK that needs to be `quote()`d, because I mistakenly used `quote(self.pk)` where the `pk` comes from the URL (which is already quoted). I didn't add tests in the commit because the `FullFeaturedSnippet` unfortunately doesn't use a non-integer PK, and we don't have a snippet model with a custom PK that is registered with a custom viewset in our testapp. This is covered by the `FeatureCompleteToy` tests in 5.2 though.
- 351d2532cee72bf250e755b5ba065b4a832ed523: The inspect view would crash if you have a `ForeignKey` to an image but the value is `None`. The document display will also show a broken link instead of showing `None`.

I didn't add tests for the image/document views for the `ModelViewSet` as I believe it's already covered by the tests for `SnippetViewSet`, and `ModelViewSet` would follow the same logic. I don't mind adding tests if we want to, but currently `FeatureCompleteToy` doesn't have foreign keys to image/document. If we want, we can also register the `VariousOnDeleteModel` (which is used for the snippets tests) with a `ModelViewSet`... 


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

Use my bakerydemo branch: https://github.com/laymonage/bakerydemo/tree/country-modelviewset

And see that the County of Origin's index view has an option for you to go to the inspect view.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
