### PR TITLE
Fix issue with closing dialog in the userbar

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/dialog/dialog.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/dialog/dialog.html
@@ -12,9 +12,9 @@
         {% if theme %}data-w-dialog-theme-value="{{ theme }}"{% endif %}
         {% if data_url %}data-url="{{ data_url }}"{% endif %}
     >
-        <div data-a11y-dialog-hide class="w-dialog__overlay"></div>
+        <div class="w-dialog__overlay" data-action="click->w-dialog#hide"></div>
         <div class="w-dialog__box">
-            <button type="button" data-a11y-dialog-hide aria-label="{% trans 'Close dialog' %}" class="w-dialog__close-button">
+            <button type="button" class="w-dialog__close-button" aria-label="{% trans 'Close dialog' %}" data-action="w-dialog#hide">
                 {% icon name='cross' classname="w-dialog__close-icon" %}
             </button>
 


### PR DESCRIPTION
- Remove `data-a11y-dialog-hide` and use Stimulus data action approach
- This ensures that our code is more agnostic to the third party library and can leverage our own DialogController behaviour
- Works around ally-dialog issue https://github.com/KittyGiraudel/a11y-dialog/issues/582
- Re-order `button` attributes to align with the code styleguide
- Fixes #10924

---

-   [X] Do the tests still pass?
-   [X] Does the code comply with the style guide?
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour? **N/A**
-   [X] For front-end changes: Did you test on all of Wagtail’s supported environments? Firefox 115, Chrome 117, Safari 16.1 all on MacOS 13.0