### PR TITLE
Clean up page listing buttons

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -1,6 +1,4 @@
 {% load wagtailadmin_tags %}
-{% fragment as toggle_classname %}{{ classes|join:' ' }}{% endfragment %}
-
 {% dropdown attrs=self.attrs toggle_icon=icon_name|default:"arrow-down" toggle_label=label toggle_aria_label=title toggle_classname=toggle_classname %}
     {% include "wagtailadmin/pages/listing/_dropdown_items.html" with buttons=buttons only %}
 {% enddropdown %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -1,5 +1,5 @@
 {% load wagtailadmin_tags %}
-{% fragment as toggle_classname %}{{ classes|join:' ' }} {{ button_classes|join:' ' }}{% endfragment %}
+{% fragment as toggle_classname %}{{ classes|join:' ' }}{% endfragment %}
 
 {% dropdown attrs=self.attrs toggle_icon=icon_name|default:"arrow-down" toggle_label=label toggle_aria_label=title toggle_classname=toggle_classname %}
     {% include "wagtailadmin/pages/listing/_dropdown_items.html" with buttons=buttons only %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_buttons.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_buttons.html
@@ -1,5 +1,5 @@
 {% for button in buttons %}
     {% if button.show %}
-        <li>{{ button|safe }}</li>
+        <li>{{ button }}</li>
     {% endif %}
 {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_buttons.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_buttons.html
@@ -1,5 +1,6 @@
+{% load wagtailadmin_tags %}
 {% for button in buttons %}
     {% if button.show %}
-        <li>{{ button }}</li>
+        <li>{% component button %}</li>
     {% endif %}
 {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_dropdown_items.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_dropdown_items.html
@@ -1,7 +1,7 @@
 {% load wagtailadmin_tags %}
 
 {% for button in buttons %}
-    <a href="{{ button.url }}" aria-label="{{ button.aria_label }}" class="{{ button.classes|join:' ' }}">
+    <a href="{{ button.url }}" aria-label="{{ button.aria_label }}" class="{{ button.classname }}">
         {% if button.icon_name %}
             {% icon name=button.icon_name %}
         {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_dropdown_items.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_dropdown_items.html
@@ -1,7 +1,7 @@
 {% load wagtailadmin_tags %}
 
 {% for button in buttons %}
-    <a href="{{ button.url }}" aria-label="{{ button.aria_label }}">
+    <a href="{{ button.url }}" {{ button.base_attrs_string }}>
         {% if button.icon_name %}
             {% icon name=button.icon_name %}
         {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_dropdown_items.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_dropdown_items.html
@@ -1,7 +1,7 @@
 {% load wagtailadmin_tags %}
 
 {% for button in buttons %}
-    <a href="{{ button.url }}" aria-label="{{ button.aria_label }}" class="{{ button.classname }}">
+    <a href="{{ button.url }}" aria-label="{{ button.aria_label }}">
         {% if button.icon_name %}
             {% icon name=button.icon_name %}
         {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_header_buttons.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_header_buttons.html
@@ -1,9 +1,8 @@
 {% load wagtailadmin_tags i18n %}
 
+{% trans "Actions" as title %}
 <nav aria-label="{{ title }}">
-    {% fragment as toggle_classname %}{{ button_classes|join:' ' }}{% endfragment %}
-
-    {% dropdown toggle_icon=icon_name toggle_aria_label=title toggle_classname=toggle_classname toggle_tooltip_offset="[0, -2]" %}
+    {% dropdown toggle_icon="dots-horizontal" toggle_aria_label=title toggle_classname="w-p-0 w-w-12 w-h-slim-header hover:w-scale-110 w-transition w-outline-offset-inside w-relative w-z-30" toggle_tooltip_offset="[0, -2]" %}
         {% block content %}
             {% include "wagtailadmin/pages/listing/_dropdown_items.html" with buttons=buttons only %}
         {% endblock %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -485,6 +485,7 @@ def page_header_buttons(context, page, page_perms):
     for hook in button_hooks:
         buttons.extend(hook(page, page_perms, next_url))
 
+    buttons = [b for b in buttons if b.show]
     buttons.sort()
     return {
         "buttons": buttons,

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -487,20 +487,7 @@ def page_header_buttons(context, page, page_perms):
 
     buttons.sort()
     return {
-        "page": page,
         "buttons": buttons,
-        "title": _("Actions"),
-        "icon_name": "dots-horizontal",
-        "button_classes": [
-            "w-p-0",
-            "w-w-12",
-            "w-h-slim-header",
-            "hover:w-scale-110",
-            "w-transition",
-            "w-outline-offset-inside",
-            "w-relative",
-            "w-z-30",
-        ],
     }
 
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -498,10 +498,8 @@ def bulk_action_choices(context, app_label, model_name):
     )
     bulk_actions_list.sort(key=lambda x: x.action_priority)
 
-    bulk_action_more_list = []
-    if len(bulk_actions_list) > 4:
-        bulk_action_more_list = bulk_actions_list[4:]
-        bulk_actions_list = bulk_actions_list[:4]
+    bulk_action_more_list = bulk_actions_list[4:]
+    bulk_actions_list = bulk_actions_list[:4]
 
     next_url = get_valid_next_url_from_request(context["request"])
     if not next_url:

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -526,7 +526,7 @@ def bulk_action_choices(context, app_label, model_name):
         more_button = ButtonWithDropdown(
             label=_("More"),
             attrs={"title": _("More bulk actions")},
-            button_classes={"button", "button-secondary", "button-small"},
+            classes={"button", "button-secondary", "button-small"},
             buttons=[
                 Button(
                     label=action.display_name,

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -39,7 +39,7 @@ from wagtail.admin.utils import (
     get_valid_next_url_from_request,
 )
 from wagtail.admin.views.bulk_action.registry import bulk_action_registry
-from wagtail.admin.widgets import ButtonWithDropdown, PageListingButton
+from wagtail.admin.widgets import Button, ButtonWithDropdown, PageListingButton
 from wagtail.coreutils import (
     camelcase_to_underscore,
     escape_script,
@@ -540,19 +540,19 @@ def bulk_action_choices(context, app_label, model_name):
             label=_("More"),
             attrs={"title": _("More bulk actions")},
             button_classes={"button", "button-secondary", "button-small"},
-            buttons_data=[
-                {
-                    "label": action.display_name,
-                    "url": reverse(
+            buttons=[
+                Button(
+                    label=action.display_name,
+                    url=reverse(
                         "wagtail_bulk_action",
                         args=[app_label, model_name, action.action_type],
                     )
                     + "?"
                     + urlencode({"next": next_url}),
-                    "attrs": {"aria-label": action.aria_label},
-                    "priority": action.action_priority,
-                    "classes": {"bulk-action-btn"},
-                }
+                    attrs={"aria-label": action.aria_label},
+                    priority=action.action_priority,
+                    classes={"bulk-action-btn"},
+                )
                 for action in bulk_action_more_list
             ],
         )

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -515,7 +515,7 @@ def bulk_action_choices(context, app_label, model_name):
             + urlencode({"next": next_url}),
             attrs={"aria-label": action.aria_label},
             priority=action.action_priority,
-            classes=action.classes | {"bulk-action-btn"},
+            classname=" ".join(action.classes | {"bulk-action-btn"}),
         )
         for action in bulk_actions_list
     ]
@@ -524,7 +524,7 @@ def bulk_action_choices(context, app_label, model_name):
         more_button = ButtonWithDropdown(
             label=_("More"),
             attrs={"title": _("More bulk actions")},
-            classes={"button", "button-secondary", "button-small"},
+            classname="button button-secondary button-small",
             buttons=[
                 Button(
                     label=action.display_name,
@@ -536,7 +536,7 @@ def bulk_action_choices(context, app_label, model_name):
                     + urlencode({"next": next_url}),
                     attrs={"aria-label": action.aria_label},
                     priority=action.action_priority,
-                    classes={"bulk-action-btn"},
+                    classname="bulk-action-btn",
                 )
                 for action in bulk_action_more_list
             ],

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -210,14 +210,22 @@ class TestPageListingMoreButtonsHooks(TestButtonsHooks):
         page_perms = BasePagePerms()
 
         # no button returned
-        buttons = page_listing_more_buttons(page, page_perms)
+        buttons = [
+            button
+            for button in page_listing_more_buttons(page, page_perms)
+            if button.show
+        ]
         self.assertEqual(
             len([button for button in buttons if button.label == "Sort menu order"]), 0
         )
 
         page_perms = ReorderOnlyPagePerms()
         # page_listing_more_button generator yields only `Sort menu order button`
-        buttons = page_listing_more_buttons(page, page_perms)
+        buttons = [
+            button
+            for button in page_listing_more_buttons(page, page_perms)
+            if button.show
+        ]
         reorder_button = next(
             button for button in buttons if button.label == "Sort menu order"
         )

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -230,7 +230,7 @@ class TestPageListingMoreButtonsHooks(TestButtonsHooks):
             button for button in buttons if button.label == "Sort menu order"
         )
 
-        self.assertEqual(reorder_button.url, "?ordering=ord")
+        self.assertEqual(reorder_button.url, "/admin/pages/%d/?ordering=ord" % page.id)
 
 
 class TestPageHeaderButtonsHooks(TestButtonsHooks):

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -307,16 +307,16 @@ class ButtonComparisonTestCase(SimpleTestCase):
 
     def setUp(self):
         self.button1 = Button(
-            "Label 1", "/url1", classes={"class1", "class2"}, priority=100
+            "Label 1", "/url1", classname="class1 class2", priority=100
         )
         self.button2 = Button(
-            "Label 2", "/url2", classes={"class2", "class3"}, priority=200
+            "Label 2", "/url2", classname="class2 class3", priority=200
         )
         self.button3 = Button(
-            "Label 1", "/url3", classes={"class1", "class2"}, priority=300
+            "Label 1", "/url3", classname="class1 class2", priority=300
         )
         self.button4 = Button(
-            "Label 1", "/url1", classes={"class1", "class2"}, priority=100
+            "Label 1", "/url1", classname="class1 class2", priority=100
         )
 
     def test_eq(self):

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -239,13 +239,61 @@ def page_listing_buttons(page, page_perms, next_url=None):
     )
 
 
+class PageListingEditButton(PageListingButton):
+    label = _("Edit")
+    icon_name = "edit"
+
+
+class PageListingViewDraftButton(PageListingButton):
+    label = _("View draft")
+    icon_name = "draft"
+
+
+class PageListingViewLiveButton(PageListingButton):
+    label = _("View live")
+    icon_name = "doc-empty"
+
+
+class PageListingAddChildPageButton(PageListingButton):
+    label = _("Add child page")
+    icon_name = "circle-plus"
+
+
+class PageListingMoveButton(PageListingButton):
+    label = _("Move")
+    icon_name = "arrow-right-full"
+
+
+class PageListingCopyButton(PageListingButton):
+    label = _("Copy")
+    icon_name = "copy"
+
+
+class PageListingDeleteButton(PageListingButton):
+    label = _("Delete")
+    icon_name = "bin"
+
+
+class PageListingUnpublishButton(PageListingButton):
+    label = _("Unpublish")
+    icon_name = "download"
+
+
+class PageListingHistoryButton(PageListingButton):
+    label = _("History")
+    icon_name = "history"
+
+
+class PageListingSortMenuOrderButton(PageListingButton):
+    label = _("Sort menu order")
+    icon_name = "list-ul"
+
+
 @hooks.register("register_page_listing_more_buttons")
 def page_listing_more_buttons(page, page_perms, next_url=None):
     if page_perms.can_edit():
-        yield PageListingButton(
-            _("Edit"),
-            reverse("wagtailadmin_pages:edit", args=[page.id]),
-            icon_name="edit",
+        yield PageListingEditButton(
+            url=reverse("wagtailadmin_pages:edit", args=[page.id]),
             attrs={
                 "aria-label": _("Edit '%(title)s'")
                 % {"title": page.get_admin_display_title()}
@@ -254,10 +302,8 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         )
 
     if page.has_unpublished_changes and page.is_previewable():
-        yield PageListingButton(
-            _("View draft"),
-            reverse("wagtailadmin_pages:view_draft", args=[page.id]),
-            icon_name="draft",
+        yield PageListingViewDraftButton(
+            url=reverse("wagtailadmin_pages:view_draft", args=[page.id]),
             attrs={
                 "aria-label": _("Preview draft version of '%(title)s'")
                 % {"title": page.get_admin_display_title()},
@@ -266,10 +312,8 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             priority=4,
         )
     if page.live and page.url:
-        yield PageListingButton(
-            _("View live"),
-            page.url,
-            icon_name="doc-empty",
+        yield PageListingViewLiveButton(
+            url=page.url,
             attrs={
                 "rel": "noreferrer",
                 "aria-label": _("View live version of '%(title)s'")
@@ -278,10 +322,8 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             priority=6,
         )
     if page_perms.can_add_subpage():
-        yield PageListingButton(
-            _("Add child page"),
-            reverse("wagtailadmin_pages:add_subpage", args=[page.id]),
-            icon_name="circle-plus",
+        yield PageListingAddChildPageButton(
+            url=reverse("wagtailadmin_pages:add_subpage", args=[page.id]),
             attrs={
                 "aria-label": _("Add a child page to '%(title)s' ")
                 % {"title": page.get_admin_display_title()}
@@ -290,10 +332,8 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         )
 
     if page_perms.can_move():
-        yield PageListingButton(
-            _("Move"),
-            reverse("wagtailadmin_pages:move", args=[page.id]),
-            icon_name="arrow-right-full",
+        yield PageListingMoveButton(
+            url=reverse("wagtailadmin_pages:move", args=[page.id]),
             attrs={
                 "aria-label": _("Move page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
@@ -305,10 +345,8 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         if next_url:
             url += "?" + urlencode({"next": next_url})
 
-        yield PageListingButton(
-            _("Copy"),
-            url,
-            icon_name="copy",
+        yield PageListingCopyButton(
+            url=url,
             attrs={
                 "aria-label": _("Copy page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
@@ -326,10 +364,8 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         if next_url and include_next_url:
             url += "?" + urlencode({"next": next_url})
 
-        yield PageListingButton(
-            _("Delete"),
-            url,
-            icon_name="bin",
+        yield PageListingDeleteButton(
+            url=url,
             attrs={
                 "aria-label": _("Delete page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
@@ -341,10 +377,8 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         if next_url:
             url += "?" + urlencode({"next": next_url})
 
-        yield PageListingButton(
-            _("Unpublish"),
-            url,
-            icon_name="resubmit",
+        yield PageListingUnpublishButton(
+            url=url,
             attrs={
                 "aria-label": _("Unpublish page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
@@ -352,10 +386,8 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             priority=40,
         )
     if page_perms.can_view_revisions():
-        yield PageListingButton(
-            _("History"),
-            reverse("wagtailadmin_pages:history", args=[page.id]),
-            icon_name="history",
+        yield PageListingHistoryButton(
+            url=reverse("wagtailadmin_pages:history", args=[page.id]),
             attrs={
                 "aria-label": _("View page history for '%(title)s'")
                 % {"title": page.get_admin_display_title()}
@@ -364,10 +396,8 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         )
 
     if page_perms.can_reorder_children():
-        yield PageListingButton(
-            _("Sort menu order"),
-            "?ordering=ord",
-            icon_name="list-ul",
+        yield PageListingSortMenuOrderButton(
+            url="?ordering=ord",
             attrs={
                 "aria-label": _("Change ordering of child pages of '%(title)s'")
                 % {"title": page.get_admin_display_title()}
@@ -379,10 +409,8 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
 @hooks.register("register_page_header_buttons")
 def page_header_buttons(page, page_perms, next_url=None):
     if page_perms.can_edit():
-        yield PageListingButton(
-            _("Edit"),
-            reverse("wagtailadmin_pages:edit", args=[page.id]),
-            icon_name="edit",
+        yield PageListingEditButton(
+            url=reverse("wagtailadmin_pages:edit", args=[page.id]),
             attrs={
                 "aria-label": _("Edit '%(title)s'")
                 % {"title": page.get_admin_display_title()}
@@ -390,10 +418,8 @@ def page_header_buttons(page, page_perms, next_url=None):
             priority=10,
         )
     if page_perms.can_add_subpage():
-        yield PageListingButton(
-            _("Add child page"),
-            reverse("wagtailadmin_pages:add_subpage", args=[page.id]),
-            icon_name="circle-plus",
+        yield PageListingAddChildPageButton(
+            url=reverse("wagtailadmin_pages:add_subpage", args=[page.id]),
             attrs={
                 "aria-label": _("Add a child page to '%(title)s' ")
                 % {"title": page.get_admin_display_title()},
@@ -401,10 +427,8 @@ def page_header_buttons(page, page_perms, next_url=None):
             priority=15,
         )
     if page_perms.can_move():
-        yield PageListingButton(
-            _("Move"),
-            reverse("wagtailadmin_pages:move", args=[page.id]),
-            icon_name="arrow-right-full",
+        yield PageListingMoveButton(
+            url=reverse("wagtailadmin_pages:move", args=[page.id]),
             attrs={
                 "aria-label": _("Move page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
@@ -416,10 +440,8 @@ def page_header_buttons(page, page_perms, next_url=None):
         if next_url:
             url += "?" + urlencode({"next": next_url})
 
-        yield PageListingButton(
-            _("Copy"),
-            url,
-            icon_name="copy",
+        yield PageListingCopyButton(
+            url=url,
             attrs={
                 "aria-label": _("Copy page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
@@ -441,10 +463,8 @@ def page_header_buttons(page, page_perms, next_url=None):
         if next_url and include_next_url:
             url += "?" + urlencode({"next": next_url})
 
-        yield PageListingButton(
-            _("Delete"),
-            url,
-            icon_name="bin",
+        yield PageListingDeleteButton(
+            url=url,
             attrs={
                 "aria-label": _("Delete page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
@@ -456,10 +476,8 @@ def page_header_buttons(page, page_perms, next_url=None):
         if next_url:
             url += "?" + urlencode({"next": next_url})
 
-        yield PageListingButton(
-            _("Unpublish"),
-            url,
-            icon_name="download",
+        yield PageListingUnpublishButton(
+            url=url,
             attrs={
                 "aria-label": _("Unpublish page '%(title)s'")
                 % {"title": page.get_admin_display_title()}
@@ -467,10 +485,8 @@ def page_header_buttons(page, page_perms, next_url=None):
             priority=60,
         )
     if page_perms.can_view_revisions():
-        yield PageListingButton(
-            _("History"),
-            reverse("wagtailadmin_pages:history", args=[page.id]),
-            icon_name="history",
+        yield PageListingHistoryButton(
+            url=reverse("wagtailadmin_pages:history", args=[page.id]),
             attrs={
                 "aria-label": _("View page history for '%(title)s'")
                 % {"title": page.get_admin_display_title()}
@@ -480,10 +496,8 @@ def page_header_buttons(page, page_perms, next_url=None):
     if page_perms.can_reorder_children():
         url = reverse("wagtailadmin_explore", args=[page.id])
         url += "?ordering=ord"
-        yield PageListingButton(
-            _("Sort menu order"),
-            url,
-            icon_name="list-ul",
+        yield PageListingSortMenuOrderButton(
+            url=url,
             attrs={
                 "aria-label": _("Change ordering of child pages of '%(title)s'")
                 % {"title": page.get_admin_display_title()}

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -250,12 +250,14 @@ class PageListingViewDraftButton(PageListingButton):
     icon_name = "draft"
     aria_label_format = _("Preview draft version of '%(title)s'")
     url_name = "wagtailadmin_pages:view_draft"
+    attrs = {"rel": "noreferrer"}
 
 
 class PageListingViewLiveButton(PageListingButton):
     label = _("View live")
     icon_name = "doc-empty"
     aria_label_format = _("View live version of '%(title)s'")
+    attrs = {"rel": "noreferrer"}
 
 
 class PageListingAddChildPageButton(PageListingButton):
@@ -317,18 +319,12 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
     if page.has_unpublished_changes and page.is_previewable():
         yield PageListingViewDraftButton(
             page=page,
-            attrs={
-                "rel": "noreferrer",
-            },
             priority=4,
         )
     if page.live and page.url:
         yield PageListingViewLiveButton(
             page=page,
             url=page.url,
-            attrs={
-                "rel": "noreferrer",
-            },
             priority=6,
         )
     if page_perms.can_add_subpage():

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -368,6 +368,10 @@ class PageListingSortMenuOrderButton(PageListingButton):
     def show(self):
         return self.page_perms.can_reorder_children()
 
+    @cached_property
+    def url(self):
+        return reverse("wagtailadmin_explore", args=[self.page.id]) + "?ordering=ord"
+
 
 @hooks.register("register_page_listing_more_buttons")
 def page_listing_more_buttons(page, page_perms, next_url=None):
@@ -432,7 +436,6 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
     yield PageListingSortMenuOrderButton(
         page=page,
         page_perms=page_perms,
-        url="?ordering=ord",
         priority=60,
     )
 
@@ -487,7 +490,6 @@ def page_header_buttons(page, page_perms, next_url=None):
     yield PageListingSortMenuOrderButton(
         page=page,
         page_perms=page_perms,
-        url=reverse("wagtailadmin_explore", args=[page.id]) + "?ordering=ord",
         priority=70,
     )
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -51,7 +51,7 @@ from wagtail.admin.views.pages.bulk_actions import (
     UnpublishBulkAction,
 )
 from wagtail.admin.viewsets import viewsets
-from wagtail.admin.widgets import Button, ButtonWithDropdownFromHook
+from wagtail.admin.widgets import ButtonWithDropdownFromHook, PageListingButton
 from wagtail.models import Collection, Page, Task, Workflow
 from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.permissions import (
@@ -242,7 +242,7 @@ def page_listing_buttons(page, page_perms, next_url=None):
 @hooks.register("register_page_listing_more_buttons")
 def page_listing_more_buttons(page, page_perms, next_url=None):
     if page_perms.can_edit():
-        yield Button(
+        yield PageListingButton(
             _("Edit"),
             reverse("wagtailadmin_pages:edit", args=[page.id]),
             icon_name="edit",
@@ -254,7 +254,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         )
 
     if page.has_unpublished_changes and page.is_previewable():
-        yield Button(
+        yield PageListingButton(
             _("View draft"),
             reverse("wagtailadmin_pages:view_draft", args=[page.id]),
             icon_name="draft",
@@ -266,7 +266,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             priority=4,
         )
     if page.live and page.url:
-        yield Button(
+        yield PageListingButton(
             _("View live"),
             page.url,
             icon_name="doc-empty",
@@ -278,7 +278,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             priority=6,
         )
     if page_perms.can_add_subpage():
-        yield Button(
+        yield PageListingButton(
             _("Add child page"),
             reverse("wagtailadmin_pages:add_subpage", args=[page.id]),
             icon_name="circle-plus",
@@ -290,7 +290,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         )
 
     if page_perms.can_move():
-        yield Button(
+        yield PageListingButton(
             _("Move"),
             reverse("wagtailadmin_pages:move", args=[page.id]),
             icon_name="arrow-right-full",
@@ -305,7 +305,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         if next_url:
             url += "?" + urlencode({"next": next_url})
 
-        yield Button(
+        yield PageListingButton(
             _("Copy"),
             url,
             icon_name="copy",
@@ -326,7 +326,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         if next_url and include_next_url:
             url += "?" + urlencode({"next": next_url})
 
-        yield Button(
+        yield PageListingButton(
             _("Delete"),
             url,
             icon_name="bin",
@@ -341,7 +341,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         if next_url:
             url += "?" + urlencode({"next": next_url})
 
-        yield Button(
+        yield PageListingButton(
             _("Unpublish"),
             url,
             icon_name="resubmit",
@@ -352,7 +352,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             priority=40,
         )
     if page_perms.can_view_revisions():
-        yield Button(
+        yield PageListingButton(
             _("History"),
             reverse("wagtailadmin_pages:history", args=[page.id]),
             icon_name="history",
@@ -364,7 +364,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         )
 
     if page_perms.can_reorder_children():
-        yield Button(
+        yield PageListingButton(
             _("Sort menu order"),
             "?ordering=ord",
             icon_name="list-ul",
@@ -379,7 +379,7 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
 @hooks.register("register_page_header_buttons")
 def page_header_buttons(page, page_perms, next_url=None):
     if page_perms.can_edit():
-        yield Button(
+        yield PageListingButton(
             _("Edit"),
             reverse("wagtailadmin_pages:edit", args=[page.id]),
             icon_name="edit",
@@ -390,7 +390,7 @@ def page_header_buttons(page, page_perms, next_url=None):
             priority=10,
         )
     if page_perms.can_add_subpage():
-        yield Button(
+        yield PageListingButton(
             _("Add child page"),
             reverse("wagtailadmin_pages:add_subpage", args=[page.id]),
             icon_name="circle-plus",
@@ -401,7 +401,7 @@ def page_header_buttons(page, page_perms, next_url=None):
             priority=15,
         )
     if page_perms.can_move():
-        yield Button(
+        yield PageListingButton(
             _("Move"),
             reverse("wagtailadmin_pages:move", args=[page.id]),
             icon_name="arrow-right-full",
@@ -416,7 +416,7 @@ def page_header_buttons(page, page_perms, next_url=None):
         if next_url:
             url += "?" + urlencode({"next": next_url})
 
-        yield Button(
+        yield PageListingButton(
             _("Copy"),
             url,
             icon_name="copy",
@@ -441,7 +441,7 @@ def page_header_buttons(page, page_perms, next_url=None):
         if next_url and include_next_url:
             url += "?" + urlencode({"next": next_url})
 
-        yield Button(
+        yield PageListingButton(
             _("Delete"),
             url,
             icon_name="bin",
@@ -456,7 +456,7 @@ def page_header_buttons(page, page_perms, next_url=None):
         if next_url:
             url += "?" + urlencode({"next": next_url})
 
-        yield Button(
+        yield PageListingButton(
             _("Unpublish"),
             url,
             icon_name="download",
@@ -467,7 +467,7 @@ def page_header_buttons(page, page_perms, next_url=None):
             priority=60,
         )
     if page_perms.can_view_revisions():
-        yield Button(
+        yield PageListingButton(
             _("History"),
             reverse("wagtailadmin_pages:history", args=[page.id]),
             icon_name="history",
@@ -480,7 +480,7 @@ def page_header_buttons(page, page_perms, next_url=None):
     if page_perms.can_reorder_children():
         url = reverse("wagtailadmin_explore", args=[page.id])
         url += "?ordering=ord"
-        yield Button(
+        yield PageListingButton(
             _("Sort menu order"),
             url,
             icon_name="list-ul",

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -242,102 +242,101 @@ def page_listing_buttons(page, page_perms, next_url=None):
 class PageListingEditButton(PageListingButton):
     label = _("Edit")
     icon_name = "edit"
+    aria_label_format = _("Edit '%(title)s'")
 
 
 class PageListingViewDraftButton(PageListingButton):
     label = _("View draft")
     icon_name = "draft"
+    aria_label_format = _("Preview draft version of '%(title)s'")
 
 
 class PageListingViewLiveButton(PageListingButton):
     label = _("View live")
     icon_name = "doc-empty"
+    aria_label_format = _("View live version of '%(title)s'")
 
 
 class PageListingAddChildPageButton(PageListingButton):
     label = _("Add child page")
     icon_name = "circle-plus"
+    aria_label_format = _("Add a child page to '%(title)s'")
 
 
 class PageListingMoveButton(PageListingButton):
     label = _("Move")
     icon_name = "arrow-right-full"
+    aria_label_format = _("Move page '%(title)s'")
 
 
 class PageListingCopyButton(PageListingButton):
     label = _("Copy")
     icon_name = "copy"
+    aria_label_format = _("Copy page '%(title)s'")
 
 
 class PageListingDeleteButton(PageListingButton):
     label = _("Delete")
     icon_name = "bin"
+    aria_label_format = _("Delete page '%(title)s'")
 
 
 class PageListingUnpublishButton(PageListingButton):
     label = _("Unpublish")
     icon_name = "download"
+    aria_label_format = _("Unpublish page '%(title)s'")
 
 
 class PageListingHistoryButton(PageListingButton):
     label = _("History")
     icon_name = "history"
+    aria_label_format = _("View page history for '%(title)s'")
 
 
 class PageListingSortMenuOrderButton(PageListingButton):
     label = _("Sort menu order")
     icon_name = "list-ul"
+    aria_label_format = _("Change ordering of child pages of '%(title)s'")
 
 
 @hooks.register("register_page_listing_more_buttons")
 def page_listing_more_buttons(page, page_perms, next_url=None):
     if page_perms.can_edit():
         yield PageListingEditButton(
+            page=page,
             url=reverse("wagtailadmin_pages:edit", args=[page.id]),
-            attrs={
-                "aria-label": _("Edit '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=2,
         )
 
     if page.has_unpublished_changes and page.is_previewable():
         yield PageListingViewDraftButton(
+            page=page,
             url=reverse("wagtailadmin_pages:view_draft", args=[page.id]),
             attrs={
-                "aria-label": _("Preview draft version of '%(title)s'")
-                % {"title": page.get_admin_display_title()},
                 "rel": "noreferrer",
             },
             priority=4,
         )
     if page.live and page.url:
         yield PageListingViewLiveButton(
+            page=page,
             url=page.url,
             attrs={
                 "rel": "noreferrer",
-                "aria-label": _("View live version of '%(title)s'")
-                % {"title": page.get_admin_display_title()},
             },
             priority=6,
         )
     if page_perms.can_add_subpage():
         yield PageListingAddChildPageButton(
+            page=page,
             url=reverse("wagtailadmin_pages:add_subpage", args=[page.id]),
-            attrs={
-                "aria-label": _("Add a child page to '%(title)s' ")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=8,
         )
 
     if page_perms.can_move():
         yield PageListingMoveButton(
+            page=page,
             url=reverse("wagtailadmin_pages:move", args=[page.id]),
-            attrs={
-                "aria-label": _("Move page '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=10,
         )
     if page_perms.can_copy():
@@ -346,11 +345,8 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             url += "?" + urlencode({"next": next_url})
 
         yield PageListingCopyButton(
+            page=page,
             url=url,
-            attrs={
-                "aria-label": _("Copy page '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=20,
         )
     if page_perms.can_delete():
@@ -365,11 +361,8 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             url += "?" + urlencode({"next": next_url})
 
         yield PageListingDeleteButton(
+            page=page,
             url=url,
-            attrs={
-                "aria-label": _("Delete page '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=30,
         )
     if page_perms.can_unpublish():
@@ -378,30 +371,21 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
             url += "?" + urlencode({"next": next_url})
 
         yield PageListingUnpublishButton(
+            page=page,
             url=url,
-            attrs={
-                "aria-label": _("Unpublish page '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=40,
         )
     if page_perms.can_view_revisions():
         yield PageListingHistoryButton(
+            page=page,
             url=reverse("wagtailadmin_pages:history", args=[page.id]),
-            attrs={
-                "aria-label": _("View page history for '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=50,
         )
 
     if page_perms.can_reorder_children():
         yield PageListingSortMenuOrderButton(
+            page=page,
             url="?ordering=ord",
-            attrs={
-                "aria-label": _("Change ordering of child pages of '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=60,
         )
 
@@ -410,29 +394,20 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
 def page_header_buttons(page, page_perms, next_url=None):
     if page_perms.can_edit():
         yield PageListingEditButton(
+            page=page,
             url=reverse("wagtailadmin_pages:edit", args=[page.id]),
-            attrs={
-                "aria-label": _("Edit '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=10,
         )
     if page_perms.can_add_subpage():
         yield PageListingAddChildPageButton(
+            page=page,
             url=reverse("wagtailadmin_pages:add_subpage", args=[page.id]),
-            attrs={
-                "aria-label": _("Add a child page to '%(title)s' ")
-                % {"title": page.get_admin_display_title()},
-            },
             priority=15,
         )
     if page_perms.can_move():
         yield PageListingMoveButton(
+            page=page,
             url=reverse("wagtailadmin_pages:move", args=[page.id]),
-            attrs={
-                "aria-label": _("Move page '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=20,
         )
     if page_perms.can_copy():
@@ -441,11 +416,8 @@ def page_header_buttons(page, page_perms, next_url=None):
             url += "?" + urlencode({"next": next_url})
 
         yield PageListingCopyButton(
+            page=page,
             url=url,
-            attrs={
-                "aria-label": _("Copy page '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=30,
         )
     if page_perms.can_delete():
@@ -464,11 +436,8 @@ def page_header_buttons(page, page_perms, next_url=None):
             url += "?" + urlencode({"next": next_url})
 
         yield PageListingDeleteButton(
+            page=page,
             url=url,
-            attrs={
-                "aria-label": _("Delete page '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=50,
         )
     if page_perms.can_unpublish():
@@ -477,31 +446,22 @@ def page_header_buttons(page, page_perms, next_url=None):
             url += "?" + urlencode({"next": next_url})
 
         yield PageListingUnpublishButton(
+            page=page,
             url=url,
-            attrs={
-                "aria-label": _("Unpublish page '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=60,
         )
     if page_perms.can_view_revisions():
         yield PageListingHistoryButton(
+            page=page,
             url=reverse("wagtailadmin_pages:history", args=[page.id]),
-            attrs={
-                "aria-label": _("View page history for '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=65,
         )
     if page_perms.can_reorder_children():
         url = reverse("wagtailadmin_explore", args=[page.id])
         url += "?ordering=ord"
         yield PageListingSortMenuOrderButton(
+            page=page,
             url=url,
-            attrs={
-                "aria-label": _("Change ordering of child pages of '%(title)s'")
-                % {"title": page.get_admin_display_title()}
-            },
             priority=70,
         )
 

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -94,7 +94,15 @@ class ListingButton(Button):
 
 
 class PageListingButton(ListingButton):
-    pass
+    aria_label_format = None
+
+    def __init__(self, *args, page=None, attrs={}, **kwargs):
+        attrs = attrs.copy()
+        if page and self.aria_label_format is not None and "aria-label" not in attrs:
+            attrs["aria-label"] = self.aria_label_format % {
+                "title": page.get_admin_display_title()
+            }
+        super().__init__(*args, attrs=attrs, **kwargs)
 
 
 class BaseDropdownMenuButton(Button):

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -108,14 +108,8 @@ class ButtonWithDropdown(BaseDropdownMenuButton):
     template_name = "wagtailadmin/pages/listing/_button_with_dropdown.html"
 
     def __init__(self, *args, **kwargs):
-        self.button_classes = kwargs.pop("button_classes", set())
         self.dropdown_buttons = kwargs.pop("buttons", [])
         super().__init__(*args, **kwargs)
-
-    def get_context_data(self, parent_context):
-        context = super().get_context_data(parent_context)
-        context["button_classes"] = self.button_classes
-        return context
 
 
 class ButtonWithDropdownFromHook(BaseDropdownMenuButton):

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -13,6 +13,7 @@ class Button(Component):
     label = ""
     icon_name = None
     url = None
+    attrs = {}
 
     def __init__(
         self, label="", url=None, classname="", icon_name=None, attrs={}, priority=1000
@@ -28,7 +29,9 @@ class Button(Component):
         if icon_name:
             self.icon_name = icon_name
 
-        self.attrs = attrs.copy()
+        self.attrs = self.attrs.copy()
+        self.attrs.update(attrs)
+
         # if a 'title' attribute has been passed, correct that to aria-label
         # as that's what will be picked up in renderings that don't use button.render
         # directly (e.g. _dropdown_items.html)

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -48,6 +48,14 @@ class Button(Component):
             return format_html("<a{}>{}</a>", flatatt(attrs), self.label)
 
     @property
+    def base_attrs_string(self):
+        # The set of attributes to be included on all renderings of
+        # the button, as a string. Does not include the href or class
+        # attributes (since the classnames intended for the button styling
+        # should not be applied to dropdown items)
+        return flatatt(self.attrs)
+
+    @property
     def aria_label(self):
         return self.attrs.get("aria-label", "")
 

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -10,11 +10,11 @@ class Button(Component):
     show = True
 
     def __init__(
-        self, label, url, classes=set(), icon_name=None, attrs={}, priority=1000
+        self, label, url, classname="", icon_name=None, attrs={}, priority=1000
     ):
         self.label = label
         self.url = url
-        self.classes = classes
+        self.classname = classname
         self.icon_name = icon_name
         self.attrs = attrs.copy()
         # if a 'title' attribute has been passed, correct that to aria-label
@@ -30,7 +30,7 @@ class Button(Component):
         else:
             attrs = {
                 "href": self.url,
-                "class": " ".join(sorted(self.classes)),
+                "class": self.classname,
             }
             attrs.update(self.attrs)
             return format_html("<a{}>{}</a>", flatatt(attrs), self.label)
@@ -68,7 +68,7 @@ class Button(Component):
         return (
             self.label == other.label
             and self.url == other.url
-            and self.classes == other.classes
+            and self.classname == other.classname
             and self.attrs == other.attrs
             and self.priority == other.priority
         )
@@ -77,9 +77,13 @@ class Button(Component):
 # Base class for all listing buttons
 # This is also used by SnippetListingButton defined in wagtail.snippets.widgets
 class ListingButton(Button):
-    def __init__(self, label, url, classes=set(), **kwargs):
-        classes = {"button", "button-small", "button-secondary"} | set(classes)
-        super().__init__(label, url, classes=classes, **kwargs)
+    def __init__(self, label, url, classname="", **kwargs):
+        if classname:
+            classname += " button button-small button-secondary"
+        else:
+            classname = "button button-small button-secondary"
+
+        super().__init__(label, url, classname=classname, **kwargs)
 
 
 class PageListingButton(ListingButton):
@@ -101,7 +105,7 @@ class BaseDropdownMenuButton(Button):
             "buttons": self.dropdown_buttons,
             "label": self.label,
             "title": self.aria_label,
-            "toggle_classname": " ".join(self.classes),
+            "toggle_classname": self.classname,
             "icon_name": self.icon_name,
         }
 

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -113,8 +113,11 @@ class PageListingButton(ListingButton):
     aria_label_format = None
     url_name = None
 
-    def __init__(self, *args, page=None, next_url=None, attrs={}, **kwargs):
+    def __init__(
+        self, *args, page=None, next_url=None, attrs={}, page_perms=None, **kwargs
+    ):
         self.page = page
+        self.page_perms = page_perms
         self.next_url = next_url
 
         attrs = attrs.copy()
@@ -183,6 +186,8 @@ class ButtonWithDropdownFromHook(BaseDropdownMenuButton):
         buttons = []
         for hook in button_hooks:
             buttons.extend(hook(self.page, self.page_perms, self.next_url))
+
+        buttons = [b for b in buttons if b.show]
 
         buttons.sort()
         return buttons

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -112,17 +112,13 @@ class ButtonWithDropdown(BaseDropdownMenuButton):
 
     def __init__(self, *args, **kwargs):
         self.button_classes = kwargs.pop("button_classes", set())
-        self.buttons_data = kwargs.pop("buttons_data", [])
+        self.dropdown_buttons = kwargs.pop("buttons", [])
         super().__init__(*args, **kwargs)
 
     def get_context_data(self):
         context = super().get_context_data()
         context["button_classes"] = self.button_classes
         return context
-
-    @cached_property
-    def dropdown_buttons(self):
-        return [Button(**button) for button in self.buttons_data]
 
 
 class ButtonWithDropdownFromHook(BaseDropdownMenuButton):

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -87,6 +87,8 @@ class PageListingButton(ListingButton):
 
 
 class BaseDropdownMenuButton(Button):
+    template_name = "wagtailadmin/pages/listing/_button_with_dropdown.html"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, url=None, **kwargs)
 
@@ -99,22 +101,18 @@ class BaseDropdownMenuButton(Button):
             "buttons": self.dropdown_buttons,
             "label": self.label,
             "title": self.aria_label,
-            "classes": self.classes,
+            "toggle_classname": " ".join(self.classes),
             "icon_name": self.icon_name,
         }
 
 
 class ButtonWithDropdown(BaseDropdownMenuButton):
-    template_name = "wagtailadmin/pages/listing/_button_with_dropdown.html"
-
     def __init__(self, *args, **kwargs):
         self.dropdown_buttons = kwargs.pop("buttons", [])
         super().__init__(*args, **kwargs)
 
 
 class ButtonWithDropdownFromHook(BaseDropdownMenuButton):
-    template_name = "wagtailadmin/pages/listing/_button_with_dropdown.html"
-
     def __init__(self, label, hook_name, page, page_perms, next_url=None, **kwargs):
         self.hook_name = hook_name
         self.page = page

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -101,11 +101,7 @@ class Button(Component):
 # This is also used by SnippetListingButton defined in wagtail.snippets.widgets
 class ListingButton(Button):
     def __init__(self, label="", url=None, classname="", **kwargs):
-        if classname:
-            classname += " button button-small button-secondary"
-        else:
-            classname = "button button-small button-secondary"
-
+        classname = f"{classname} button button-small button-secondary".strip()
         super().__init__(label=label, url=url, classname=classname, **kwargs)
 
 

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -8,14 +8,21 @@ from wagtail.admin.ui.components import Component
 
 class Button(Component):
     show = True
+    label = ""
+    icon_name = None
 
     def __init__(
-        self, label, url, classname="", icon_name=None, attrs={}, priority=1000
+        self, label="", url=None, classname="", icon_name=None, attrs={}, priority=1000
     ):
-        self.label = label
+        if label:
+            self.label = label
+
         self.url = url
         self.classname = classname
-        self.icon_name = icon_name
+
+        if icon_name:
+            self.icon_name = icon_name
+
         self.attrs = attrs.copy()
         # if a 'title' attribute has been passed, correct that to aria-label
         # as that's what will be picked up in renderings that don't use button.render
@@ -77,13 +84,13 @@ class Button(Component):
 # Base class for all listing buttons
 # This is also used by SnippetListingButton defined in wagtail.snippets.widgets
 class ListingButton(Button):
-    def __init__(self, label, url, classname="", **kwargs):
+    def __init__(self, label="", url=None, classname="", **kwargs):
         if classname:
             classname += " button button-small button-secondary"
         else:
             classname = "button button-small button-secondary"
 
-        super().__init__(label, url, classname=classname, **kwargs)
+        super().__init__(label=label, url=url, classname=classname, **kwargs)
 
 
 class PageListingButton(ListingButton):

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/listing_buttons.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/listing_buttons.html
@@ -1,5 +1,5 @@
 {% for button in buttons %}
     {% if button.show %}
-        <li>{{ button|safe }}</li>
+        <li>{{ button }}</li>
     {% endif %}
 {% endfor %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/listing_buttons.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/listing_buttons.html
@@ -1,5 +1,6 @@
+{% load wagtailadmin_tags %}
 {% for button in buttons %}
     {% if button.show %}
-        <li>{{ button }}</li>
+        <li>{% component button %}</li>
     {% endif %}
 {% endfor %}

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -80,7 +80,6 @@ def register_snippet_listing_buttons(snippet, user, next_url=None):
     if viewset.inspect_view_enabled and permission_policy.user_has_any_permission(
         user, viewset.inspect_view_class.any_permission_required
     ):
-
         yield SnippetListingButton(
             _("Inspect"),
             reverse(
@@ -100,7 +99,7 @@ def register_snippet_listing_buttons(snippet, user, next_url=None):
             ),
             attrs={"aria-label": _("Delete '%(title)s'") % {"title": str(snippet)}},
             priority=30,
-            classes=["no"],
+            classname="no",
         )
 
 

--- a/wagtail/users/wagtail_hooks.py
+++ b/wagtail/users/wagtail_hooks.py
@@ -148,7 +148,7 @@ def user_listing_buttons(context, user):
     yield UserListingButton(
         _("Edit"),
         reverse("wagtailusers_users:edit", args=[user.pk]),
-        classes={"button-secondary"},
+        classname="button-secondary",
         attrs={
             "aria-label": _("Edit user '%(name)s'")
             % {"name": get_user_display_name(user)}
@@ -159,7 +159,7 @@ def user_listing_buttons(context, user):
         yield UserListingButton(
             _("Delete"),
             reverse("wagtailusers_users:delete", args=[user.pk]),
-            classes={"no"},
+            classname="no",
             attrs={
                 "aria-label": _("Delete user '%(name)s'")
                 % {"name": get_user_display_name(user)}

--- a/wagtail/users/widgets.py
+++ b/wagtail/users/widgets.py
@@ -2,6 +2,9 @@ from wagtail.admin.widgets import Button
 
 
 class UserListingButton(Button):
-    def __init__(self, label, url, classes=set(), **kwargs):
-        classes = {"button", "button-small"} | set(classes)
-        super().__init__(label, url, classes=classes, **kwargs)
+    def __init__(self, label, url, classname="", **kwargs):
+        if classname:
+            classname += " button button-small"
+        else:
+            classname = "button button-small"
+        super().__init__(label, url, classname=classname, **kwargs)

--- a/wagtail/users/widgets.py
+++ b/wagtail/users/widgets.py
@@ -3,8 +3,5 @@ from wagtail.admin.widgets import Button
 
 class UserListingButton(Button):
     def __init__(self, label, url, classname="", **kwargs):
-        if classname:
-            classname += " button button-small"
-        else:
-            classname = "button button-small"
+        classname = f"{classname} button button-small".strip()
         super().__init__(label, url, classname=classname, **kwargs)


### PR DESCRIPTION
General cleanup aimed at reducing sprawl and duplicate definitions in wagtail/admin/wagtail_hooks.py. This was supposed to be the first step of updating the actions menu in the page header for the new universal listings design, but it ended up being a deep enough rabbit-hole that it made sense as a PR in its own right :-)