### PR TITLE
Allow BaseSiteSetting instances retrieved via for_request to be pickled

### DIFF
--- a/wagtail/contrib/settings/models.py
+++ b/wagtail/contrib/settings/models.py
@@ -131,6 +131,12 @@ class BaseSiteSetting(AbstractSetting):
         setattr(request, attr_name, site_settings)
         return site_settings
 
+    def __getstate__(self):
+        # Leave out _request from the pickled state
+        state = super().__getstate__()
+        state.pop("_request", None)
+        return state
+
     @classmethod
     def for_site(cls, site):
         """

--- a/wagtail/contrib/settings/tests/site_specific/base.py
+++ b/wagtail/contrib/settings/tests/site_specific/base.py
@@ -22,4 +22,11 @@ class SiteSettingsTestMixin:
     def get_request(self, site=None):
         if site is None:
             site = self.default_site
-        return get_dummy_request(site=site)
+        request = get_dummy_request(site=site)
+
+        # Requests in general can't be pickled, but dummy requests can. Add an
+        # arbitrary lambda function to the request to make it fail loudly if
+        # someone tries to pickle it.
+        request._fn = lambda: None
+
+        return request

--- a/wagtail/contrib/settings/tests/site_specific/test_model.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_model.py
@@ -44,6 +44,13 @@ class SettingModelTestCase(SiteSettingsTestMixin, TestCase):
                     for i in range(4):
                         TestSiteSetting.for_request(request)
 
+    def test_pickle_after_lookup_via_for_request(self):
+        request = self.get_request()
+        settings = TestSiteSetting.for_request(request)
+        pickled = pickle.dumps(settings)
+        unpickled = pickle.loads(pickled)
+        self.assertEqual(unpickled.title, "Site title")
+
     def _create_importantpagessitesetting_object(self):
         site = self.default_site
         return ImportantPagesSiteSetting.objects.create(


### PR DESCRIPTION
Strip out the cached _request attribute which breaks pickling. Fixes #10879
_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
