### PR TITLE
oembed updated , spotify url issue is now fixed by removing the trailing slash in the oembed spotify definition

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,6 +42,7 @@ Changelog
  * Fix: Ensure the admin login template correctly displays all `non_fields_errors` for any custom form validation (Sébastien Corbin)
  * Fix: Ensure 'mark as active' label in workflow bulk action set active form can be translated (Rohit Sharma)
  * Fix: Ensure the panel title for a user's settings correctly reflects the `WAGTAIL_EMAIL_MANAGEMENT_ENABLED` setting by not showing 'email' if disabled (Omkar Jadhav)
+ * Fix: Update Spotify oEmbed provider URL parsing to resolve correctly (Dhrűv)
  * Docs: Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
  * Docs: Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)
  * Docs: Add documentation for building non-model-based choosers using the _queryish_ library (Matt Westcott)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -737,6 +737,7 @@
 * Sandra Ashipala
 * Omkar Jadhav
 * Charlie Sue
+* Dhrűv
 
 ## Translators
 

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -57,6 +57,7 @@ depth: 1
  * Ensure the admin login template correctly displays all `non_fields_errors` for any custom form validation (Sébastien Corbin)
  * Ensure 'mark as active' label in workflow bulk action set active form can be translated (Rohit Sharma)
  * Ensure the panel title for a user's settings correctly reflects the `WAGTAIL_EMAIL_MANAGEMENT_ENABLED` setting by not showing 'email' if disabled (Omkar Jadhav)
+ * Update Spotify oEmbed provider URL parsing to resolve correctly (Dhrűv)
 
 ### Documentation
 

--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -520,7 +520,7 @@ speakerdeck = {
 
 
 spotify = {
-    "endpoint": "https://embed.spotify.com/oembed/",
+    "endpoint": "https://open.spotify.com/oembed",
     "urls": [
         r"^https?://open\.spotify\.com/.+$",
         r"^https?://spoti\.fi/.+$",


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10942







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
