### PR TITLE
 NameEmailSettingsPanel should be titled "Name" when email management is disabled 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,7 @@ Changelog
  * Fix: Allow locale selection when creating a page at the root level (Sage Abdullah)
  * Fix: Ensure the admin login template correctly displays all `non_fields_errors` for any custom form validation (Sébastien Corbin)
  * Fix: Ensure 'mark as active' label in workflow bulk action set active form can be translated (Rohit Sharma)
+ * Fix: Ensure the panel title for a user's settings correctly reflects the `WAGTAIL_EMAIL_MANAGEMENT_ENABLED` setting by not showing 'email' if disabled (Omkar Jadhav)
  * Docs: Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
  * Docs: Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)
  * Docs: Add documentation for building non-model-based choosers using the _queryish_ library (Matt Westcott)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -735,6 +735,7 @@
 * Neeraj Yetheendran
 * TopDevPros
 * Sandra Ashipala
+* Omkar Jadhav
 
 ## Translators
 

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -56,6 +56,7 @@ depth: 1
  * Allow locale selection when creating a page at the root level (Sage Abdullah)
  * Ensure the admin login template correctly displays all `non_fields_errors` for any custom form validation (Sébastien Corbin)
  * Ensure 'mark as active' label in workflow bulk action set active form can be translated (Rohit Sharma)
+ * Ensure the panel title for a user's settings correctly reflects the `WAGTAIL_EMAIL_MANAGEMENT_ENABLED` setting by not showing 'email' if disabled (Omkar Jadhav)
 
 ### Documentation
 

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -273,6 +273,9 @@ class TestAccountSection(WagtailTestUtils, TestCase, TestAccountSectionUtilsMixi
         # Form media should be included on the page
         self.assertContains(response, "vendor/colorpicker.js")
 
+        # Check if the default title exists
+        self.assertContains(response, "Name and Email")
+
     def test_change_name_post(self):
         response = self.post_form(
             {
@@ -331,6 +334,11 @@ class TestAccountSection(WagtailTestUtils, TestCase, TestAccountSectionUtilsMixi
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/account/account.html")
         self.assertNotContains(response, "id_name_email-email")
+
+        # Check if the default title does not exist
+        self.assertNotContains(response, "Name and Email")
+        # When WAGTAIL_EMAIL_MANAGEMENT_ENABLED=False, Check if title is "Name"
+        self.assertContains(response, "Name")
 
     @override_settings(WAGTAIL_PASSWORD_MANAGEMENT_ENABLED=False)
     def test_account_view_with_password_management_disabled(self):

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from functools import cached_property
 
 from django.conf import settings
 from django.contrib import messages
@@ -138,9 +139,16 @@ class BaseSettingsPanel:
 
 class NameEmailSettingsPanel(BaseSettingsPanel):
     name = "name_email"
-    title = gettext_lazy("Name and Email")
     order = 100
     form_class = NameEmailForm
+
+    @cached_property
+    def title(self):
+        from wagtail.admin.views.account import email_management_enabled
+
+        if email_management_enabled():
+            return _("Name and Email")
+        return _("Name")
 
 
 class AvatarSettingsPanel(BaseSettingsPanel):


### PR DESCRIPTION
# Pull Request: Fix for Issue #10937

## Description
This PR addresses Issue #10937, which was about updating the title of the `NameEmailSettingsPanel` when email management is disabled. The issue was confirmed and a potential fix was suggested.

## Changes Made
- Updated the `title` property of the `NameEmailSettingsPanel` class to be dynamic based on the `email_management_enabled()` setting.

## Screenshots
### With issue
![without-changes](https://github.com/wagtail/wagtail/assets/106991458/cea973bd-606d-408b-aaac-52a87a0fdd4d)


## Testing Done
### With WAGTAIL_EMAIL_MANAGEMENT_ENABLED=False (Issue solved)
![with it](https://github.com/wagtail/wagtail/assets/106991458/c1781352-be51-433d-80c8-71c1c5f7869a)
I've written the test and also tested the same. All are passing

## Checklist
- [x] I have read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] I have created unit tests that cover the changes made in this PR.
- [x] All new tests passed.
- [x] The code follows the project's code style and formatting guidelines.
- [x] I have updated the documentation, if necessary.