### PR TITLE
Deprecate legacy moderation system

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -83,6 +83,7 @@ Changelog
  * Maintenance: Refactor generic view subclasses to better reuse the generic templates and breadcrumbs (Sage Abdullah)
  * Maintenance: Adopt consistent `classname` (not `classnames`) attributes for all `MenuItem` usage, including deprecation warnings (LB (Ben) Johnston)
  * Maintenance: Deprecate `context` argument of `construct_snippet_listing_buttons` hook (Sage Abdullah)
+ * Maintenance: Deprecate legacy moderation system (Sage Abdullah)
 
 
 5.1.3 (xx.xx.20xx) - IN DEVELOPMENT

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -787,9 +787,17 @@ Every time a page is edited, a new `Revision` is created and saved to the databa
 
         Calling this on a revision that's in moderation will mark it as approved and publish it.
 
+        .. versionchanged:: 5.2
+
+            This method is only used for the legacy moderation system. It has been deprecated and will be removed in a future release.
+
     .. automethod:: reject_moderation
 
         Calling this on a revision that's in moderation will mark it as rejected.
+
+        .. versionchanged:: 5.2
+
+            This method is only used for the legacy moderation system. It has been deprecated and will be removed in a future release.
 
     .. automethod:: is_latest_revision
 

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -716,6 +716,11 @@ Every time a page is edited, a new `Revision` is created and saved to the databa
 
         ``True`` if this revision is in moderation.
 
+        .. versionchanged:: 5.2
+
+            This field is only used for the legacy moderation system. It has been deprecated and will be removed in a future release.
+
+
     .. attribute:: created_at
 
         (date/time)
@@ -771,6 +776,10 @@ Every time a page is edited, a new `Revision` is created and saved to the databa
         .. code-block:: python
 
             Revision.submitted_revisions.all()
+
+        .. versionchanged:: 5.2
+
+            This manager is only used for the legacy moderation system. It has been deprecated and will be removed in a future release.
 ```
 
 ### Methods and properties

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -799,13 +799,18 @@ WAGTAIL_MODERATION_ENABLED = True
 
 Changes whether the Submit for Moderation button is displayed in the action menu.
 
+```{versionchanged} 5.2
+
+This setting has been deprecated. Use `WAGTAIL_WORKFLOW_ENABLED` instead.
+```
+
 ### `WAGTAIL_WORKFLOW_ENABLED`
 
 ```python
-WAGTAIL_WORKFLOW_ENABLED = False
+WAGTAIL_WORKFLOW_ENABLED = True
 ```
 
-Specifies whether moderation workflows are enabled (default: True). When disabled, editors will no longer be given the option to submit pages to a workflow, and the settings areas for admins to configure workflows and tasks will be unavailable.
+Specifies whether moderation workflows are enabled (default: `True`). When disabled, editors will no longer be given the option to submit pages to a workflow, and the settings areas for admins to configure workflows and tasks will be unavailable.
 
 ### `WAGTAIL_WORKFLOW_REQUIRE_REAPPROVAL_ON_EDIT`
 

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -154,6 +154,31 @@ def register_frank_menu_item():
 
 ## Upgrade considerations - deprecation of old functionality
 
+### Legacy moderation system is deprecated
+
+The legacy moderation system, which was replaced by the new workflow system in Wagtail 2.10, is now deprecated. Since Wagtail 2.10, submitting a page for moderation will use the new workflow system. However, the legacy moderation system is still in place for approving and rejecting pages that were submitted for moderation before Wagtail 2.10.
+
+To view all pages that are still in the legacy moderation system backlog, you can sign in as a superuser and see if there is a "Pages awaiting moderation" section in the admin dashboard. You can approve or reject the pages from there. You can also do this programmatically by querying for `Revision.objects.filter(submitted_for_moderation=True)` and calling `revision.approve_moderation()` or `revision.reject_moderation()` on each revision.
+
+The legacy moderation system will be removed in a future release. If you still have pages in the moderation queue that were submitted for moderation before Wagtail 2.10, you should approve or reject them before upgrading. See [](./2.10) for more details.
+
+As a result, the following features are now deprecated:
+
+- {attr}`wagtail.models.Revision.submitted_for_moderation`
+- {attr}`wagtail.models.Revision.submitted_revisions`
+- {meth}`wagtail.models.Revision.approve_moderation`
+- {meth}`wagtail.models.Revision.reject_moderation`
+- The `submitted_for_moderation` argument in {meth}`wagtail.models.RevisionMixin.save_revision`
+- [`WAGTAIL_MODERATION_ENABLED`](wagtail_moderation_enabled)
+- `wagtail.admin.userbar.ModeratePageItem`
+- `wagtail.admin.userbar.ApproveModerationEditPageItem`
+- `wagtail.admin.userbar.RejectModerationEditPageItem`
+- `wagtail.admin.views.home.PagesForModerationPanel`
+- `wagtail.admin.views.pages.moderation`
+- `wagtail.permission_policies.pages.PagePermissionPolicy.revisions_for_moderation`
+
+If you use any of the above features, remove them or replace them with the equivalent features from the new workflow system. The above features will be removed in a future release.
+
 ## Upgrade considerations - changes affecting Wagtail customisations
 
 ### Edit and delete URLs in `ModelViewSet` changed to allow non-integer primary keys

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -104,6 +104,7 @@ depth: 1
  * Refactor generic view subclasses to better reuse the generic templates and breadcrumbs (Sage Abdullah)
  * Adopt consistent `classname` (not `classnames`) attributes for all `MenuItem` usage, including deprecation warnings (LB (Ben) Johnston)
  * Deprecate `context` argument of `construct_snippet_listing_buttons` hook (Sage Abdullah)
+ * Deprecate legacy moderation system (Sage Abdullah)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/actions/copy_page.py
+++ b/wagtail/actions/copy_page.py
@@ -185,6 +185,7 @@ class CopyPageAction:
             for revision in page.revisions.all():
                 use_as_latest_revision = revision.pk == page.latest_revision_id
                 revision.pk = None
+                # RemovedInWagtail60Warning
                 revision.submitted_for_moderation = False
                 revision.approved_go_live_at = None
                 revision.object_id = page_copy.id

--- a/wagtail/actions/publish_revision.py
+++ b/wagtail/actions/publish_revision.py
@@ -168,6 +168,7 @@ class PublishRevisionAction:
 
         object.save()
 
+        # RemovedInWagtail60Warning
         revision.submitted_for_moderation = False
         object.revisions.update(submitted_for_moderation=False)
 

--- a/wagtail/actions/revert_to_page_revision.py
+++ b/wagtail/actions/revert_to_page_revision.py
@@ -24,7 +24,7 @@ class RevertToPageRevisionAction:
         revision,
         user=None,
         log_action="wagtail.revert",
-        submitted_for_moderation=False,
+        submitted_for_moderation=False,  # RemovedInWagtail60Warning
         approved_go_live_at=None,
         changed=True,
         clean=True,

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -1,4 +1,6 @@
 """Handles rendering of the list of actions in the footer of the page create/edit views."""
+import warnings
+
 from django.conf import settings
 from django.forms import Media
 from django.template.loader import render_to_string
@@ -9,6 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.admin.ui.components import Component
 from wagtail.models import UserPagePermissionsProxy
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class ActionMenuItem(Component):
@@ -99,7 +102,16 @@ class SubmitForModerationMenuItem(ActionMenuItem):
     icon_name = "resubmit"
 
     def is_shown(self, context):
-        if not getattr(settings, "WAGTAIL_MODERATION_ENABLED", True):
+        legacy_setting = getattr(settings, "WAGTAIL_MODERATION_ENABLED", None)
+        if legacy_setting is not None:
+            warnings.warn(
+                "WAGTAIL_MODERATION_ENABLED is deprecated. Use WAGTAIL_WORKFLOW_ENABLED instead.",
+                RemovedInWagtail60Warning,
+            )
+            if not legacy_setting:
+                return False
+
+        if not getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True):
             return False
 
         if context["view"] == "create":
@@ -165,7 +177,16 @@ class RestartWorkflowMenuItem(ActionMenuItem):
     icon_name = "login"
 
     def is_shown(self, context):
-        if not getattr(settings, "WAGTAIL_MODERATION_ENABLED", True):
+        legacy_setting = getattr(settings, "WAGTAIL_MODERATION_ENABLED", None)
+        if legacy_setting is not None:
+            warnings.warn(
+                "WAGTAIL_MODERATION_ENABLED is deprecated. Use WAGTAIL_WORKFLOW_ENABLED instead.",
+                RemovedInWagtail60Warning,
+            )
+            if not legacy_setting:
+                return False
+
+        if not getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True):
             return False
         elif context["view"] == "edit":
             workflow_state = context["page"].current_workflow_state

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -27,6 +27,7 @@ from wagtail.test.testapp.models import (
 )
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.timestamps import submittable_timestamp
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class TestPageCreation(WagtailTestUtils, TestCase):
@@ -1228,9 +1229,30 @@ class TestPageCreation(WagtailTestUtils, TestCase):
         )
 
     @override_settings(WAGTAIL_MODERATION_ENABLED=False)
-    def test_hide_moderation_button(self):
+    def test_legacy_hide_moderation_button(self):
         """
         Tests that if WAGTAIL_MODERATION_ENABLED is set to False, the "Submit for Moderation" button is not shown.
+        """
+        # RemovedInWagtail60Warning: Remove this test in favour of test_hide_moderation_button
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "WAGTAIL_MODERATION_ENABLED is deprecated. Use WAGTAIL_WORKFLOW_ENABLED instead.",
+        ):
+            response = self.client.get(
+                reverse(
+                    "wagtailadmin_pages:add",
+                    args=("tests", "simplepage", self.root_page.id),
+                )
+            )
+        self.assertNotContains(
+            response,
+            '<button type="submit" name="action-submit" value="Submit for moderation" class="button">Submit for moderation</button>',
+        )
+
+    @override_settings(WAGTAIL_WORKFLOW_ENABLED=False)
+    def test_hide_moderation_button(self):
+        """
+        Tests that if WAGTAIL_WORKFLOW_ENABLED is set to False, the "Submit for Moderation" button is not shown.
         """
         response = self.client.get(
             reverse(

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -47,6 +47,7 @@ from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.form_data import inline_formset, nested_form_data
 from wagtail.test.utils.timestamps import submittable_timestamp
 from wagtail.users.models import UserProfile
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 from wagtail.utils.timestamps import render_timestamp
 
 
@@ -2542,10 +2543,14 @@ class TestIssue3982(WagtailTestUtils, TestCase):
         revision = Revision.page_revisions.get(object_id=page.id)
         revision.submitted_for_moderation = True
         revision.save()
-        response = self.client.post(
-            reverse("wagtailadmin_pages:approve_moderation", args=(revision.pk,)),
-            follow=True,
-        )
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "Revision.approve_moderation() is deprecated and will be removed in a future release.",
+        ):
+            response = self.client.post(
+                reverse("wagtailadmin_pages:approve_moderation", args=(revision.pk,)),
+                follow=True,
+            )
         page = SimplePage.objects.get()
         self.assertTrue(page.live)
         self.assertRedirects(response, reverse("wagtailadmin_home"))

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -2528,6 +2528,10 @@ class TestIssue3982(WagtailTestUtils, TestCase):
             )
         )
 
+    # RemovedInWagtail60Warning
+    # Remove the following tests when the deprecation period for the legacy
+    # moderation system ends.
+
     def _approve_page(self, parent):
         self.client.post(
             reverse("wagtailadmin_pages:add", args=("tests", "simplepage", parent.pk)),

--- a/wagtail/admin/tests/pages/test_moderation.py
+++ b/wagtail/admin/tests/pages/test_moderation.py
@@ -18,6 +18,10 @@ from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class TestApproveRejectModeration(WagtailTestUtils, TestCase):
+    # RemovedInWagtail60Warning
+    # Remove this test class when the deprecation period for the legacy
+    # moderation system ends.
+
     def setUp(self):
         self.submitter = self.create_superuser(
             username="submitter",
@@ -229,6 +233,11 @@ class TestApproveRejectModeration(WagtailTestUtils, TestCase):
 
 
 class TestNotificationPreferences(WagtailTestUtils, TestCase):
+    # RemovedInWagtail60Warning
+    # Remove this test class when the deprecation period for the legacy
+    # moderation system ends. This test has been replaced by
+    # wagtail.admin.tests.test_workflows.TestPageNotificationPreferences.
+
     def setUp(self):
         # Find root page
         self.root_page = Page.objects.get(id=2)
@@ -431,6 +440,12 @@ class TestNotificationPreferences(WagtailTestUtils, TestCase):
 
 
 class TestApproveRejectModerationWithoutUser(WagtailTestUtils, TestCase):
+    # RemovedInWagtail60Warning
+    # Remove this test class when the deprecation period for the legacy
+    # moderation system ends.
+    # This test works similarly to TestApproveRejectModeration, but it
+    # doesn't specify the user when saving the revision.
+
     def setUp(self):
         self.submitter = self.create_superuser(
             username="submitter",

--- a/wagtail/admin/tests/pages/test_moderation.py
+++ b/wagtail/admin/tests/pages/test_moderation.py
@@ -50,12 +50,17 @@ class TestApproveRejectModeration(WagtailTestUtils, TestCase):
         page_published.connect(mock_handler)
 
         try:
-            # Post
-            response = self.client.post(
-                reverse(
-                    "wagtailadmin_pages:approve_moderation", args=(self.revision.id,)
+            with self.assertWarnsMessage(
+                RemovedInWagtail60Warning,
+                "Revision.approve_moderation() is deprecated and will be removed in a future release.",
+            ):
+                # Post
+                response = self.client.post(
+                    reverse(
+                        "wagtailadmin_pages:approve_moderation",
+                        args=(self.revision.id,),
+                    )
                 )
-            )
 
             # Check that the user was redirected to the dashboard
             self.assertRedirects(response, reverse("wagtailadmin_home"))
@@ -85,9 +90,15 @@ class TestApproveRejectModeration(WagtailTestUtils, TestCase):
         self.page.title = "Goodbye world!"
         self.page.save_revision(user=self.submitter, submitted_for_moderation=False)
 
-        response = self.client.post(
-            reverse("wagtailadmin_pages:approve_moderation", args=(self.revision.id,))
-        )
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "Revision.approve_moderation() is deprecated and will be removed in a future release.",
+        ):
+            response = self.client.post(
+                reverse(
+                    "wagtailadmin_pages:approve_moderation", args=(self.revision.id,)
+                )
+            )
 
         # Check that the user was redirected to the dashboard
         self.assertRedirects(response, reverse("wagtailadmin_home"))
@@ -140,10 +151,16 @@ class TestApproveRejectModeration(WagtailTestUtils, TestCase):
         """
         This posts to the reject moderation view and checks that the page was rejected
         """
-        # Post
-        response = self.client.post(
-            reverse("wagtailadmin_pages:reject_moderation", args=(self.revision.id,))
-        )
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "Revision.reject_moderation() is deprecated and will be removed in a future release.",
+        ):
+            # Post
+            response = self.client.post(
+                reverse(
+                    "wagtailadmin_pages:reject_moderation", args=(self.revision.id,)
+                )
+            )
 
         # Check that the user was redirected to the dashboard
         self.assertRedirects(response, reverse("wagtailadmin_home"))
@@ -288,8 +305,13 @@ class TestNotificationPreferences(WagtailTestUtils, TestCase):
     def test_approved_notifications(self):
         # Set up the page version
         self.silent_submit()
-        # Approve
-        self.approve()
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "Revision.approve_moderation() is deprecated and will be removed in a future release.",
+        ):
+            # Approve
+            self.approve()
 
         # Submitter must receive an approved email
         self.assertEqual(len(mail.outbox), 1)
@@ -306,8 +328,13 @@ class TestNotificationPreferences(WagtailTestUtils, TestCase):
 
         # Set up the page version
         self.silent_submit()
-        # Approve
-        self.approve()
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "Revision.approve_moderation() is deprecated and will be removed in a future release.",
+        ):
+            # Approve
+            self.approve()
 
         # No email to send
         self.assertEqual(len(mail.outbox), 0)
@@ -315,8 +342,13 @@ class TestNotificationPreferences(WagtailTestUtils, TestCase):
     def test_rejected_notifications(self):
         # Set up the page version
         self.silent_submit()
-        # Reject
-        self.reject()
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "Revision.reject_moderation() is deprecated and will be removed in a future release.",
+        ):
+            # Reject
+            self.reject()
 
         # Submitter must receive a rejected email
         self.assertEqual(len(mail.outbox), 1)
@@ -333,8 +365,13 @@ class TestNotificationPreferences(WagtailTestUtils, TestCase):
 
         # Set up the page version
         self.silent_submit()
-        # Reject
-        self.reject()
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "Revision.reject_moderation() is deprecated and will be removed in a future release.",
+        ):
+            # Reject
+            self.reject()
 
         # No email to send
         self.assertEqual(len(mail.outbox), 0)
@@ -364,7 +401,11 @@ class TestNotificationPreferences(WagtailTestUtils, TestCase):
         logging.disable(logging.CRITICAL)
         # Approve
         self.silent_submit()
-        response = self.approve()
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "Revision.approve_moderation() is deprecated and will be removed in a future release.",
+        ):
+            response = self.approve()
         logging.disable(logging.NOTSET)
 
         # An email that fails to send should return a message rather than crash the page
@@ -423,12 +464,17 @@ class TestApproveRejectModerationWithoutUser(WagtailTestUtils, TestCase):
         page_published.connect(mock_handler)
 
         try:
-            # Post
-            response = self.client.post(
-                reverse(
-                    "wagtailadmin_pages:approve_moderation", args=(self.revision.id,)
+            with self.assertWarnsMessage(
+                RemovedInWagtail60Warning,
+                "Revision.approve_moderation() is deprecated and will be removed in a future release.",
+            ):
+                # Post
+                response = self.client.post(
+                    reverse(
+                        "wagtailadmin_pages:approve_moderation",
+                        args=(self.revision.id,),
+                    )
                 )
-            )
 
             # Check that the user was redirected to the dashboard
             self.assertRedirects(response, reverse("wagtailadmin_home"))

--- a/wagtail/admin/tests/pages/test_moderation.py
+++ b/wagtail/admin/tests/pages/test_moderation.py
@@ -14,6 +14,7 @@ from wagtail.signals import page_published
 from wagtail.test.testapp.models import SimplePage
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.users.models import UserProfile
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class TestApproveRejectModeration(WagtailTestUtils, TestCase):
@@ -189,11 +190,20 @@ class TestApproveRejectModeration(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 302)
 
     def test_preview_for_moderation(self):
-        response = self.client.get(
-            reverse(
-                "wagtailadmin_pages:preview_for_moderation", args=(self.revision.id,)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "The simple page 'Hello world! (simple page)' is undergoing moderation "
+            "in the legacy moderation system. Complete the moderation of this page "
+            "before upgrading Wagtail. Support for the legacy moderation system will "
+            "be completely removed in a future release. For more details, refer to "
+            "https://docs.wagtail.org/en/stable/releases/2.10.html#move-to-new-configurable-moderation-system-workflow",
+        ):
+            response = self.client.get(
+                reverse(
+                    "wagtailadmin_pages:preview_for_moderation",
+                    args=(self.revision.id,),
+                )
             )
-        )
 
         # Check response
         self.assertEqual(response.status_code, 200)

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -639,6 +639,9 @@ class TestDisablePreviewButton(WagtailTestUtils, TestCase):
         self.assertNotContains(response, preview_url)
 
     def disable_preview_in_moderation_list(self):
+        # RemovedInWagtail60Warning
+        # Remove this test when the deprecation period for the legacy
+        # moderation system ends.
         stream_page = StreamPage(title="stream page", body=[("text", "hello")])
         self.root_page.add_child(instance=stream_page)
         latest_revision = stream_page.save_revision(

--- a/wagtail/admin/tests/test_moderation_list.py
+++ b/wagtail/admin/tests/test_moderation_list.py
@@ -5,10 +5,17 @@ from django.urls import reverse
 from wagtail.models import GroupPagePermission, Page
 from wagtail.test.testapp.models import SimplePage
 from wagtail.test.utils import WagtailTestUtils
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class TestModerationList(WagtailTestUtils, TestCase):
     """Test moderation list rendered by `wagtailadmin_home` view"""
+
+    # RemovedInWagtail60Warning
+    # Remove this test class when the deprecation period for the legacy
+    # moderation system ends.
+    # For workflows, this has been covered in
+    # wagtail.admin.tests.test_workflows.TestDashboardWithPages
 
     def setUp(self):
         # Create a submitter
@@ -70,7 +77,15 @@ class TestModerationList(WagtailTestUtils, TestCase):
         self.login(moderator)
 
     def get(self):
-        return self.client.get(reverse("wagtailadmin_home"))
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "You have pages undergoing moderation in the legacy moderation system. "
+            "Complete the moderation of these pages before upgrading Wagtail. "
+            "Support for the legacy moderation system will be completely removed "
+            "in a future release. For more details, refer to "
+            "https://docs.wagtail.org/en/stable/releases/2.10.html#move-to-new-configurable-moderation-system-workflow",
+        ):
+            return self.client.get(reverse("wagtailadmin_home"))
 
     def test_edit_page(self):
         # Login as moderator

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -11,6 +11,7 @@ from wagtail.coreutils import get_dummy_request
 from wagtail.models import PAGE_TEMPLATE_VAR, Page, Site
 from wagtail.test.testapp.models import BusinessChild, BusinessIndex, SimplePage
 from wagtail.test.utils import WagtailTestUtils
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class TestUserbarTag(WagtailTestUtils, TestCase):
@@ -61,7 +62,12 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
                 "request": self.dummy_request(self.user, revision_id=revision.id),
             }
         )
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(7), self.assertWarnsRegex(
+            RemovedInWagtail60Warning,
+            "ModerationEditPageItem is deprecated\. "
+            "If you explicitly use this in your code, "
+            "remove it from your construct_wagtail_userbar hook\.",
+        ):
             content = template.render(context)
 
         self.assertIn("<!-- Wagtail user bar embed code -->", content)
@@ -436,6 +442,12 @@ class TestUserbarAddLink(WagtailTestUtils, TestCase):
 
 
 class TestUserbarModeration(WagtailTestUtils, TestCase):
+    # RemovedInWagtail60Warning
+    # Remove this test class when the deprecation period for the legacy
+    # moderation system ends.
+    # The userbar is yet to support workflows:
+    # https://github.com/wagtail/wagtail/issues/9106
+
     def setUp(self):
         self.user = self.login()
         self.request = get_dummy_request(site=Site.objects.first())
@@ -450,7 +462,13 @@ class TestUserbarModeration(WagtailTestUtils, TestCase):
 
     def test_userbar_moderation(self):
         response = self.page.serve(self.request)
-        response.render()
+        with self.assertWarnsRegex(
+            RemovedInWagtail60Warning,
+            "ModerationEditPageItem is deprecated\. "
+            "If you explicitly use this in your code, "
+            "remove it from your construct_wagtail_userbar hook\.",
+        ):
+            response.render()
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<template id="wagtail-userbar-template">')

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -1,5 +1,9 @@
+import warnings
+
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
+
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class BaseItem:
@@ -261,6 +265,13 @@ class ModeratePageItem(BaseItem):
             request.user
         ).can_publish():
             return ""
+
+        warnings.warn(
+            f"{self.__class__.__name__} is deprecated. "
+            "If you explicitly use this in your code, remove it from your "
+            "construct_wagtail_userbar hook.",
+            RemovedInWagtail60Warning,
+        )
 
         return super().render(request)
 

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -104,7 +104,7 @@ class PagesForModerationPanel(Component):
         context = super().get_context_data(parent_context)
         revisions = (
             PagePermissionPolicy()
-            .revisions_for_moderation(request.user)
+            ._revisions_for_moderation(request.user)
             .select_related("user")
             .order_by("-created_at")
         )

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from urllib.parse import quote
 
 from django.conf import settings
@@ -35,6 +36,7 @@ from wagtail.models import (
     PageSubscription,
     WorkflowState,
 )
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 from wagtail.utils.timestamps import render_timestamp
 
 
@@ -58,6 +60,20 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
                 self.request,
                 _("This page is currently awaiting moderation"),
                 buttons=buttons,
+            )
+
+            page_type = self.page._meta.verbose_name
+            page_title = self.page.get_admin_display_title()
+
+            warnings.warn(
+                f"The {page_type} '{page_title}' is undergoing moderation in "
+                "the legacy moderation system. Complete the moderation of this page "
+                "before upgrading Wagtail. Support for the legacy moderation system "
+                "will be completely removed in a future release. For more details, "
+                "refer to "
+                "https://docs.wagtail.org/en/stable/releases/2.10.html#move-to-new-configurable-moderation-system-workflow",
+                RemovedInWagtail60Warning,
+                stacklevel=2,
             )
 
     def add_save_confirmation_message(self):

--- a/wagtail/admin/views/pages/moderation.py
+++ b/wagtail/admin/views/pages/moderation.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
@@ -7,6 +9,7 @@ from django.views.decorators.http import require_GET
 from wagtail.admin import messages
 from wagtail.admin.mail import send_moderation_notification
 from wagtail.models import Revision
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 def approve_moderation(request, revision_id):
@@ -108,6 +111,18 @@ def preview_for_moderation(request, revision_id):
         return redirect("wagtailadmin_home")
 
     page = revision.as_object()
+    page_type = page._meta.verbose_name
+    page_title = page.get_admin_display_title()
+
+    warnings.warn(
+        f"The {page_type} '{page_title}' is undergoing moderation in "
+        "the legacy moderation system. Complete the moderation of this page "
+        "before upgrading Wagtail. Support for the legacy moderation system "
+        "will be completely removed in a future release. For more details, "
+        "refer to "
+        "https://docs.wagtail.org/en/stable/releases/2.10.html#move-to-new-configurable-moderation-system-workflow",
+        RemovedInWagtail60Warning,
+    )
 
     try:
         preview_mode = page.default_preview_mode

--- a/wagtail/management/commands/publish_scheduled.py
+++ b/wagtail/management/commands/publish_scheduled.py
@@ -88,6 +88,9 @@ class Command(BaseCommand):
                     )
 
         # 2. get all object revisions for moderation that have been expired
+        # RemovedInWagtail60Warning
+        # Remove this when the deprecation period for the legacy
+        # moderation system ends.
         expired_revs = [
             r
             for r in Revision.objects.filter(submitted_for_moderation=True)

--- a/wagtail/management/commands/purge_revisions.py
+++ b/wagtail/management/commands/purge_revisions.py
@@ -53,6 +53,9 @@ def purge_revisions(days=None, pages=True, non_pages=True):
         objects = Revision.objects.not_page_revisions()
 
     # exclude revisions which have been submitted for moderation in the old system
+    # RemovedInWagtail60Warning
+    # Remove this when the deprecation period for the legacy
+    # moderation system ends.
     purgeable_revisions = objects.exclude(submitted_for_moderation=True).exclude(
         # and exclude revisions with an approved_go_live_at date
         approved_go_live_at__isnull=False

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -369,7 +369,7 @@ class RevisionMixin(models.Model):
     def save_revision(
         self,
         user=None,
-        submitted_for_moderation=False,
+        submitted_for_moderation=False,  # RemovedInWagtail60Warning
         approved_go_live_at=None,
         changed=True,
         log_action=False,
@@ -2685,6 +2685,9 @@ class RevisionQuerySet(models.QuerySet):
         return self.exclude(self.page_revisions_q())
 
     def submitted(self):
+        # RemovedInWagtail60Warning
+        # Remove this when the deprecation period for the legacy
+        # moderation system ends.
         return self.filter(submitted_for_moderation=True)
 
     def for_instance(self, instance):
@@ -2723,6 +2726,7 @@ class Revision(models.Model):
         max_length=255,
         verbose_name=_("object id"),
     )
+    # RemovedInWagtail60Warning
     submitted_for_moderation = models.BooleanField(
         verbose_name=_("submitted for moderation"), default=False, db_index=True
     )

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -44,7 +44,7 @@ from django.utils import timezone
 from django.utils import translation as translation
 from django.utils.cache import patch_cache_control
 from django.utils.encoding import force_bytes, force_str
-from django.utils.functional import Promise, cached_property
+from django.utils.functional import Promise, cached_property, classproperty
 from django.utils.module_loading import import_string
 from django.utils.text import capfirst, slugify
 from django.utils.translation import gettext_lazy as _
@@ -380,7 +380,7 @@ class RevisionMixin(models.Model):
         Creates and saves a revision.
 
         :param user: The user performing the action.
-        :param submitted_for_moderation: Indicates whether the object was submitted for moderation.
+        :param submitted_for_moderation: **Deprecated** – Indicates whether the object was submitted for moderation.
         :param approved_go_live_at: The date and time the revision is approved to go live.
         :param changed: Indicates whether there were any content changes.
         :param log_action: Flag for logging the action. Pass ``True`` to also create a log entry. Can be passed an action string.
@@ -2745,7 +2745,7 @@ class Revision(models.Model):
 
     objects = RevisionsManager()
     page_revisions = PageRevisionsManager()
-    submitted_revisions = SubmittedRevisionsManager()
+    _submitted_revisions = SubmittedRevisionsManager()
 
     content_object = GenericForeignKey(
         "content_type", "object_id", for_concrete_model=False
@@ -2756,6 +2756,14 @@ class Revision(models.Model):
     @cached_property
     def base_content_object(self):
         return self.base_content_type.get_object_for_this_type(pk=self.object_id)
+
+    @classproperty
+    def submitted_revisions(self):
+        warnings.warn(
+            "SubmittedRevisionsManager is deprecated and will be removed in a future release.",
+            RemovedInWagtail60Warning,
+        )
+        return self._submitted_revisions
 
     def save(self, user=None, *args, **kwargs):
         # Set default value for created_at to now

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2807,6 +2807,11 @@ class Revision(models.Model):
         return self.content_object.with_content_json(self.content)
 
     def approve_moderation(self, user=None):
+        warnings.warn(
+            "Revision.approve_moderation() is deprecated and will be removed in a future release.",
+            RemovedInWagtail60Warning,
+            stacklevel=2,
+        )
         if self.submitted_for_moderation:
             logger.info(
                 'Page moderation approved: "%s" id=%d revision_id=%d',
@@ -2823,6 +2828,11 @@ class Revision(models.Model):
             self.publish()
 
     def reject_moderation(self, user=None):
+        warnings.warn(
+            "Revision.reject_moderation() is deprecated and will be removed in a future release.",
+            RemovedInWagtail60Warning,
+            stacklevel=2,
+        )
         if self.submitted_for_moderation:
             logger.info(
                 'Page moderation rejected: "%s" id=%d revision_id=%d',

--- a/wagtail/permission_policies/pages.py
+++ b/wagtail/permission_policies/pages.py
@@ -1,9 +1,12 @@
+import warnings
+
 from django.contrib.auth import get_permission_codename, get_user_model
 from django.db.models import CharField, Q
 from django.db.models.functions import Cast
 
 from wagtail.models import GroupPagePermission, Page, Revision
 from wagtail.permission_policies.base import OwnershipPermissionPolicy
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class PagePermissionPolicy(OwnershipPermissionPolicy):
@@ -215,7 +218,7 @@ class PagePermissionPolicy(OwnershipPermissionPolicy):
         explorable_pages = explorable_pages.filter(path__startswith=fca_page.path)
         return explorable_pages
 
-    def revisions_for_moderation(self, user):
+    def _revisions_for_moderation(self, user):
         # Deal with the trivial cases first...
         if not user.is_active:
             return Revision.objects.none()
@@ -242,3 +245,10 @@ class PagePermissionPolicy(OwnershipPermissionPolicy):
                 Cast("pk", output_field=CharField()), flat=True
             )
         )
+
+    def revisions_for_moderation(self, user):
+        warnings.warn(
+            "The PagePermissionPolicy.revisions_for_moderation() method is deprecated.",
+            RemovedInWagtail60Warning,
+        )
+        return self._revisions_for_moderation(user)

--- a/wagtail/snippets/action_menu.py
+++ b/wagtail/snippets/action_menu.py
@@ -1,4 +1,5 @@
 """Handles rendering of the list of actions in the footer of the snippet create/edit views."""
+import warnings
 from functools import lru_cache
 
 from django.conf import settings
@@ -13,6 +14,7 @@ from wagtail import hooks
 from wagtail.admin.ui.components import Component
 from wagtail.models import DraftStateMixin, LockableMixin, WorkflowMixin
 from wagtail.snippets.permissions import get_permission_name
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class ActionMenuItem(Component):
@@ -84,7 +86,16 @@ class SubmitForModerationMenuItem(ActionMenuItem):
     icon_name = "resubmit"
 
     def is_shown(self, context):
-        if not getattr(settings, "WAGTAIL_MODERATION_ENABLED", True):
+        legacy_setting = getattr(settings, "WAGTAIL_MODERATION_ENABLED", None)
+        if legacy_setting is not None:
+            warnings.warn(
+                "WAGTAIL_MODERATION_ENABLED is deprecated. Use WAGTAIL_WORKFLOW_ENABLED instead.",
+                RemovedInWagtail60Warning,
+            )
+            if not legacy_setting:
+                return False
+
+        if not getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True):
             return False
 
         if context.get("locked_for_user"):
@@ -165,7 +176,16 @@ class RestartWorkflowMenuItem(ActionMenuItem):
     icon_name = "login"
 
     def is_shown(self, context):
-        if not getattr(settings, "WAGTAIL_MODERATION_ENABLED", True):
+        legacy_setting = getattr(settings, "WAGTAIL_MODERATION_ENABLED", None)
+        if legacy_setting is not None:
+            warnings.warn(
+                "WAGTAIL_MODERATION_ENABLED is deprecated. Use WAGTAIL_WORKFLOW_ENABLED instead.",
+                RemovedInWagtail60Warning,
+            )
+            if not legacy_setting:
+                return False
+
+        if not getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True):
             return False
         if context["view"] != "edit":
             return False

--- a/wagtail/snippets/tests/test_workflows.py
+++ b/wagtail/snippets/tests/test_workflows.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from wagtail.models import Workflow, WorkflowContentType, WorkflowState
 from wagtail.test.testapp.models import FullFeaturedSnippet, ModeratedModel
 from wagtail.test.utils import WagtailTestUtils
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 # This module serves to gather snippets-equivalent of workflows-related tests
 # that are found throughout page-specific test modules, e.g. test_create_page.py,
@@ -69,7 +70,11 @@ class TestCreateView(BaseWorkflowsTestCase):
     @override_settings(WAGTAIL_MODERATION_ENABLED=False)
     def test_get_workflow_buttons_not_shown_when_moderation_disabled(self):
         # Note: remove this when all legacy moderation code has been removed
-        response = self.get()
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "WAGTAIL_MODERATION_ENABLED is deprecated. Use WAGTAIL_WORKFLOW_ENABLED instead.",
+        ):
+            response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'name="action-submit"')
 
@@ -130,7 +135,11 @@ class TestEditView(BaseWorkflowsTestCase):
     @override_settings(WAGTAIL_MODERATION_ENABLED=False)
     def test_get_workflow_buttons_not_shown_when_moderation_disabled(self):
         # Note: remove this when all legacy moderation code has been removed
-        response = self.get()
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "WAGTAIL_MODERATION_ENABLED is deprecated. Use WAGTAIL_WORKFLOW_ENABLED instead.",
+        ):
+            response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'name="action-submit"')
 

--- a/wagtail/tests/test_management_commands.py
+++ b/wagtail/tests/test_management_commands.py
@@ -403,6 +403,9 @@ class TestPublishScheduledPagesCommand(WagtailTestUtils, TestCase):
         self.assertFalse(p.expired)
 
     def test_expired_pages_are_dropped_from_mod_queue(self):
+        # RemovedInWagtail60Warning
+        # Remove this test when the deprecation period for the legacy
+        # moderation system ends.
         page = SimplePage(
             title="Hello world!",
             slug="hello-world",
@@ -657,6 +660,9 @@ class TestPurgeRevisionsCommandForPages(TestCase):
         self.assertRevisionExists(revision_2)
 
     def test_revisions_in_moderation_or_workflow_not_purged(self):
+        # RemovedInWagtail60Warning
+        # Remove the lines until the first assertion when the deprecation period#
+        # for the legacy moderation system ends.
         revision = self.object.save_revision(submitted_for_moderation=True)
 
         # Save a new revision to ensure that the moderated revision

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -1480,6 +1480,9 @@ class TestCopyPage(TestCase):
         )
 
     def test_copy_page_copies_revisions_and_doesnt_submit_for_moderation(self):
+        # RemovedInWagtail60Warning
+        # Remove this test when the deprecation period for the legacy
+        # moderation system ends.
         christmas_event = EventPage.objects.get(url_path="/home/events/christmas/")
         christmas_event.save_revision(submitted_for_moderation=True)
 
@@ -1504,6 +1507,9 @@ class TestCopyPage(TestCase):
 
     def test_copy_page_copies_revisions_and_doesnt_change_created_at(self):
         christmas_event = EventPage.objects.get(url_path="/home/events/christmas/")
+        # RemovedInWagtail60Warning
+        # Remove this line when the deprecation period for the legacy
+        # moderation system ends.
         christmas_event.save_revision(submitted_for_moderation=True)
 
         # Set the created_at of the revision to a time in the past

--- a/wagtail/tests/test_page_permission_policies.py
+++ b/wagtail/tests/test_page_permission_policies.py
@@ -5,6 +5,7 @@ from wagtail.models import GroupPagePermission, Page, get_default_page_content_t
 from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.tests.test_permission_policies import PermissionPolicyTestUtils
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class PermissionPolicyTestCase(PermissionPolicyTestUtils, WagtailTestUtils, TestCase):
@@ -519,3 +520,16 @@ class TestPagePermissionPolicy(PermissionPolicyTestCase):
             ),
             [self.superuser],
         )
+
+    def test_get_revisions_for_moderation(self):
+        # RemovedInWagtail60Warning
+        # Remove this test when the deprecation period for the legacy
+        # moderation system ends.
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "The PagePermissionPolicy.revisions_for_moderation() method is deprecated.",
+        ):
+            revisions = self.policy.revisions_for_moderation(self.superuser)
+
+        revision = self.reports_page.save_revision(submitted_for_moderation=True)
+        self.assertCountEqual(revisions, [revision])

--- a/wagtail/tests/test_revision_model.py
+++ b/wagtail/tests/test_revision_model.py
@@ -10,6 +10,7 @@ from wagtail.test.testapp.models import (
     RevisableModel,
     SimplePage,
 )
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class TestRevisableModel(TestCase):
@@ -168,3 +169,12 @@ class TestRevisableModel(TestCase):
         # The id is used as a tie breaker
         self.assertEqual(first.created_at, second.created_at)
         self.assertLess(first.id, second.id)
+
+    def test_submitted_revisions_manager(self):
+        self.instance.save_revision()
+        revision = self.instance.save_revision(submitted_for_moderation=True)
+        with self.assertWarnsMessage(
+            RemovedInWagtail60Warning,
+            "SubmittedRevisionsManager is deprecated and will be removed in a future release.",
+        ):
+            self.assertEqual(list(Revision.submitted_revisions.all()), [revision])


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Ref: https://docs.wagtail.org/en/stable/releases/2.10.html#move-to-new-configurable-moderation-system-workflow

Workflows have been around since 2.10 and the legacy moderation system (one-step moderation) has been pretty much unused since. Per the release notes, you can't submit pages to the legacy system anymore, and the code is just kept to let people complete the moderations that were still ongoing. It's about time we remove the code for the legacy moderation system. Before doing so, ensure we raise enough warning so people are aware about this and won't have any page that are still in the old moderation system.

After the deprecation, we'll remove all code around the warning. We'll also remove the `submitted_for_moderation` field from the `Revision` model, along with other places where it's unavoidably referenced (e.g. when saving/publishing revisions).

There are places where I didn't raise a `RemovedInWagtail60Warning` explicitly, as I'm afraid that would trigger warnings even when there are no revisions in the old moderation system. I've marked them with comments though, so we can easily find it when we prepare Wagtail 6.0.

Searching the codebase for `moderat`, I think this is everything, but might be worth doing a double check in case I missed anything.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For new features: Has the documentation been updated accordingly?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
