### PR TITLE
Fix response_data_title_key for SnippetChooserViewSet.create_view_class

### DIFF
--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -8,6 +8,7 @@ from wagtail.admin.views.generic.chooser import (
     ChooseViewMixin,
     ChosenMultipleView,
     ChosenView,
+    CreateView,
     CreationFormMixin,
 )
 from wagtail.admin.viewsets.chooser import ChooserViewSet
@@ -62,11 +63,16 @@ class SnippetChosenMultipleView(ChosenMultipleView):
     response_data_title_key = "string"
 
 
+class SnippetCreateView(CreateView):
+    response_data_title_key = "string"
+
+
 class SnippetChooserViewSet(ChooserViewSet):
     choose_view_class = ChooseView
     choose_results_view_class = ChooseResultsView
     chosen_view_class = SnippetChosenView
     chosen_multiple_view_class = SnippetChosenMultipleView
+    create_view_class = SnippetCreateView
 
     @cached_property
     def widget_class(self):


### PR DESCRIPTION
With this pull request, the backend response from a snippet chooser when that chooser creates a model matches the front end's expected response_data_title_key (see https://github.com/wagtail/wagtail/blob/a1bd357092bc7107c3d41477536f471a1f3f307d/client/src/components/ChooserWidget/SnippetChooserWidget.js#L21)

I matched the approached taken for SnippetChosenView and SnippetChosenMultipleView

This change can be tested w/ bakerydemo by applying a patch like this:
```
Index: bakerydemo/breads/wagtail_hooks.py
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/bakerydemo/breads/wagtail_hooks.py b/bakerydemo/breads/wagtail_hooks.py
--- a/bakerydemo/breads/wagtail_hooks.py	(revision 2edb8745895916f6090662f13f7e35600fb36727)
+++ b/bakerydemo/breads/wagtail_hooks.py	(date 1696013586874)
@@ -1,4 +1,5 @@
 from wagtail.snippets.models import register_snippet
+from wagtail.snippets.views.chooser import SnippetChooserViewSet
 from wagtail.snippets.views.snippets import SnippetViewSet, SnippetViewSetGroup
 
 from bakerydemo.breads.models import BreadIngredient, BreadType, Country
@@ -11,10 +12,15 @@
     inspect_view_enabled = True
 
 
+class BreadTypeChooserViewSet(SnippetChooserViewSet):
+    form_fields = ["title"]
+
+
 class BreadTypeSnippetViewSet(SnippetViewSet):
     model = BreadType
     ordering = ("title",)
     search_fields = ("title",)
+    chooser_viewset_class = BreadTypeChooserViewSet
 
 
 class CountrySnippetViewSet(SnippetViewSet):
```

Without this fix, the bread type can be created in the modal chooser, but shows up chosen w/o title:
<img width="248" alt="image" src="https://github.com/wagtail/wagtail/assets/2065015/4ca4d3a7-f307-4d35-b2a0-d9d281d8cfd3">

With this fix, the bread type can be created in the modal chooser and then immediately shows up chosen w/ title:
<img width="250" alt="image" src="https://github.com/wagtail/wagtail/assets/2065015/b5a07cf6-f3be-4fc1-a0b7-b05a86a8ab8d">

On a side note, is there a better way to enable creating a snippet in the modal chooser than my example patch for bakerydemo above?