### PR TITLE
Added translatable label in SetActiveStateBulkAction

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ Changelog
  * Fix: Allow `PublishMenuItem` to more easily support overriding its label via `construct_page_action_menu` (Sébastien Corbin)
  * Fix: Allow locale selection when creating a page at the root level (Sage Abdullah)
  * Fix: Ensure the admin login template correctly displays all `non_fields_errors` for any custom form validation (Sébastien Corbin)
+ * Fix: Ensure 'mark as active' label in workflow bulk action set active form can be translated (Rohit Sharma)
  * Docs: Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
  * Docs: Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)
  * Docs: Add documentation for building non-model-based choosers using the _queryish_ library (Matt Westcott)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -55,6 +55,7 @@ depth: 1
  * Allow `PublishMenuItem` to more easily support overriding its label via `construct_page_action_menu` (Sébastien Corbin)
  * Allow locale selection when creating a page at the root level (Sage Abdullah)
  * Ensure the admin login template correctly displays all `non_fields_errors` for any custom form validation (Sébastien Corbin)
+ * Ensure 'mark as active' label in workflow bulk action set active form can be translated (Rohit Sharma)
 
 ### Documentation
 

--- a/wagtail/users/views/bulk_actions/set_active_state.py
+++ b/wagtail/users/views/bulk_actions/set_active_state.py
@@ -9,6 +9,7 @@ from wagtail.users.views.users import change_user_perm
 class ActivityForm(forms.Form):
     mark_as_active = forms.TypedChoiceField(
         choices=((True, _("Active")), (False, _("Inactive"))),
+        label=_("Mark as active"),
         widget=forms.RadioSelect,
         coerce=lambda x: x == "True",
     )


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10963  This PR addresses the issue of "Mark as active" not being translated when using the bulk action in the ActivityForm.

To resolve this issue, I have added a translatable label in the "ActivityForm"