### PR TITLE
[Fix] Your first Wagtail site - Tag posts - Minor grammar adjustment

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -734,6 +734,7 @@
 * Subhajit Ghosh
 * Neeraj Yetheendran
 * TopDevPros
+* Sandra Ashipala
 
 ## Translators
 

--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -924,7 +924,7 @@ Wagtail ecosystem, so that you can give it a title and URL in the
 admin, and so that you can manipulate its contents by returning
 a QuerySet from its `get_context()` method.
 
-Migrate this by running `python manage.py makemigrations` and then `python manage.py`. After migrating the new changes, create a new `BlogTagIndexPage` in the admin interface. To create the `BlogTagIndexPage`, follow the same process you followed in creating the `BlogIndexPage` and give it the slug "tags" on the Promote tab. This means the `BlogTagIndexPage` is a child of the home page and parallel to `Our Blog` in the admin interface.
+Migrate this by running `python manage.py makemigrations` and then `python manage.py migrate`. After migrating the new changes, create a new `BlogTagIndexPage` in the admin interface. To create the `BlogTagIndexPage`, follow the same process you followed in creating the `BlogIndexPage` and give it the slug "tags" on the Promote tab. This means the `BlogTagIndexPage` is a child of the home page and parallel to `Our Blog` in the admin interface.
 
 Access `/tags` and Django will tell you what you probably already knew.
 You need to create the template, `blog/templates/blog/blog_tag_index_page.html` and add the following content to it:


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

This PR fixes #10974  - the typo in the "[Your first Wagtail site](https://docs.wagtail.org/en/stable/getting_started/tutorial.html)" tutorial, specifically in a section under **Tag posts**, where the sentence now reads as follows:

### Suggested  change:

Migrate this by running `python manage.py makemigrations` and then `python manage.py migrate`.



_Please check the following:_

-   [ ] Do the tests still pass?[^1]
