### PR TITLE
Support ordering by multiple fields in Wagtail API

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -509,6 +509,7 @@ Changelog
  * Delay hiding the contents of the side panels when closing, so the animation is smoother (Thibaud Colas)
  * ListBlock now shows item-by-item differences when comparing versions (Tidiane Dia)
  * Implement a new design for chooser buttons with better accessibility (Thibaud Colas)
+ * API ordering now supports multiple fields (Rohit Sharma, Jake Howard)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/docs/advanced_topics/api/v2/usage.md
+++ b/docs/advanced_topics/api/v2/usage.md
@@ -1,3 +1,5 @@
+(api_v2_usage)=
+
 # Wagtail API v2 Usage Guide
 
 The Wagtail API module exposes a public, read only, JSON-formatted API which
@@ -162,6 +164,8 @@ either a number (the new maximum value) or `None` (which disables maximum
 value check).
 ```
 
+(api_v2_usage_ordering)=
+
 ### Ordering
 
 The results can be ordered by any field by setting the `?order` parameter to
@@ -205,6 +209,30 @@ Content-Type: application/json
 ```{note}
 Ordering is case-sensitive so lowercase letters are always ordered after
 uppercase letters when in ascending order.
+```
+
+#### Multiple ordering
+
+Multiple fields cab be passed into the `?order` for consecutive ordering.
+
+```
+GET /api/v2/pages/?order=title,-slug
+
+HTTP 200 OK
+Content-Type: application/json
+
+{
+    "meta": {
+        "total_count": 50
+    },
+    "items": [
+        pages will be ordered by title and for all matching titles (a-z), then sorted by slug (z-a).
+    ]
+}
+```
+
+```{versionadded} 5.2
+
 ```
 
 #### Random ordering

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -51,6 +51,7 @@ depth: 1
  * Add the ability to define listing buttons on generic `IndexView` (Sage Abdullah)
  * Add a visual progress bar to the output of the `wagtail_update_image_renditions` management command (Faishal Manzar)
  * Increase the read buffer size to improve efficiency and performance when generating file hashes for document or image uploads, use `hashlib.file_digest` if available (Python 3.11+) (Jake Howard)
+ * API ordering now [supports multiple fields](api_v2_usage_ordering) (Rohit Sharma, Jake Howard)
 
 ### Bug fixes
 

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -941,6 +941,71 @@ class TestPageListing(WagtailTestUtils, TestCase):
             content, {"message": "cannot order by 'not_a_field' (unknown field)"}
         )
 
+    def test_random_ordering_with_unknown_field_gives_error(self):
+        response = self.get_response(order=["random,id"])
+        content = json.loads(response.content.decode("UTF-8"))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            content, {"message": "random ordering cannot be combined with other fields"}
+        )
+
+    def test_ordering_by_id_and_slug(self):
+        response = self.get_response(order=["id,slug"])
+        content = json.loads(response.content.decode("UTF-8"))
+
+        page_id_list = self.get_page_id_list(content)
+        expected_order = [
+            2,
+            4,
+            5,
+            6,
+            8,
+            9,
+            10,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+        ]
+        self.assertEqual(page_id_list[:15], expected_order[:15])
+
+    def test_ordering_by_title_and_id_backwards(self):
+        response = self.get_response(order=["title,-id"])
+        content = json.loads(response.content.decode("UTF-8"))
+
+        page_id_list = self.get_page_id_list(content)
+        expected_order = [
+            15,
+            10,
+            6,
+            17,
+            20,
+            13,
+            2,
+            4,
+            9,
+            8,
+            14,
+            12,
+            18,
+            16,
+            5,
+            23,
+            19,
+            22,
+            21,
+        ]
+        self.assertEqual(page_id_list[:5], expected_order[:5])
+
     # LIMIT
 
     def test_limit_only_two_items_returned(self):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #7429 I have extended the API to allow ordering by multiple fields. Specifically, I've added support for the `order` query parameter, which accepts a comma-separated list of fields to order by.

I've made the following changes to implement multiple field ordering:

- Modified the API endpoint to accept the order query parameter, which can include one or more fields separated by commas.
- Updated the filtering logic to handle multiple fields in the desired order.
- Added Unit tests

### Screenshot of Working

![Final](https://github.com/wagtail/wagtail/assets/111359305/a076fa5b-a74c-4d35-bf20-b4f53d5b0fe8)

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

