### PR TITLE
Avoid unnecessary import of `email_management_enabled` in account views

### DIFF
--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -144,8 +144,6 @@ class NameEmailSettingsPanel(BaseSettingsPanel):
 
     @cached_property
     def title(self):
-        from wagtail.admin.views.account import email_management_enabled
-
         if email_management_enabled():
             return _("Name and Email")
         return _("Name")


### PR DESCRIPTION
- Cleanup from #10956
- `email_management_enabled` is declared in the same file
- See https://github.com/wagtail/wagtail/pull/10956/files#r1344317294
