### PR TITLE
Update help block link contrast

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -46,6 +46,7 @@ Changelog
  * Fix: Ensure 'mark as active' label in workflow bulk action set active form can be translated (Rohit Sharma)
  * Fix: Ensure the panel title for a user's settings correctly reflects the `WAGTAIL_EMAIL_MANAGEMENT_ENABLED` setting by not showing 'email' if disabled (Omkar Jadhav)
  * Fix: Update Spotify oEmbed provider URL parsing to resolve correctly (Dhrűv)
+ * Fix: Update link colours within help blocks to meet accessible contrast requirements (Rohit Sharma)
  * Docs: Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
  * Docs: Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)
  * Docs: Add documentation for building non-model-based choosers using the _queryish_ library (Matt Westcott)

--- a/client/scss/components/_help-block.scss
+++ b/client/scss/components/_help-block.scss
@@ -16,13 +16,13 @@
   }
 
   a {
-    color: theme('colors.secondary.DEFAULT');
+    color: theme('colors.secondary.400');
     text-decoration: underline;
     text-decoration-thickness: 2px;
     text-underline-offset: 3px;
 
     &:hover {
-      color: theme('colors.secondary.400');
+      color: theme('colors.secondary.600');
       text-decoration: none;
     }
   }

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -61,6 +61,7 @@ depth: 1
  * Ensure 'mark as active' label in workflow bulk action set active form can be translated (Rohit Sharma)
  * Ensure the panel title for a user's settings correctly reflects the `WAGTAIL_EMAIL_MANAGEMENT_ENABLED` setting by not showing 'email' if disabled (Omkar Jadhav)
  * Update Spotify oEmbed provider URL parsing to resolve correctly (Dhrűv)
+ * Update link colours within help blocks to meet accessible contrast requirements (Rohit Sharma)
 
 ### Documentation
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10990  This pull request addresses the issue by adjusting the link colors within the help block's warning, info, and error variants to provide better contrast and readability.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
