### PR TITLE
Eslint - allow `new SomeClass()` in unit tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -142,6 +142,7 @@ module.exports = {
         'import/first': 'off',
         'import/no-extraneous-dependencies': 'off',
         'jsx-a11y/control-has-associated-label': 'off',
+        'no-new': 'off',
         'no-unused-expressions': 'off',
         'react/function-component-definition': 'off',
         'react/jsx-props-no-spreading': 'off',

--- a/client/src/components/ExpandingFormset/index.test.js
+++ b/client/src/components/ExpandingFormset/index.test.js
@@ -46,7 +46,6 @@ describe('ExpandingFormset', () => {
     expect(onInit).not.toHaveBeenCalled();
 
     // initialise expanding formset
-    // eslint-disable-next-line no-new
     new ExpandingFormset(prefix, { onInit, onAdd });
 
     // check that init calls only were made for existing items
@@ -130,7 +129,6 @@ describe('ExpandingFormset', () => {
     expect(onInit).not.toHaveBeenCalled();
 
     // initialise expanding formset
-    // eslint-disable-next-line no-new
     new ExpandingFormset(prefix, { onInit, onAdd });
 
     // check that init calls only were made for existing items
@@ -215,7 +213,6 @@ describe('ExpandingFormset', () => {
     expect(onInit).not.toHaveBeenCalled();
 
     // initialise expanding formset
-    // eslint-disable-next-line no-new
     new ExpandingFormset(prefix, { onInit, onAdd });
 
     // check that init calls only were made for existing items

--- a/client/src/components/InlinePanel/index.test.js
+++ b/client/src/components/InlinePanel/index.test.js
@@ -27,7 +27,6 @@ describe('InlinePanel', () => {
       onAdd: onAdd,
     };
 
-    // eslint-disable-next-line no-new
     new InlinePanel(options);
 
     expect(onAdd).not.toHaveBeenCalled();


### PR DESCRIPTION
- This constraint is not required in unit tests where the output of a class is not the main thing being tested
- Avoid noise in tests by just removing disabling this linting rule in these files
