### PR TITLE
Add missing links on the PyPI project page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
     author_email="hello@wagtail.org",  # For support queries, please see https://docs.wagtail.org/en/stable/support.html
     url="https://wagtail.org/",
     project_urls={
+        "Changelog": "https://github.com/wagtail/wagtail/blob/main/CHANGELOG.txt",
         "Documentation": "https://docs.wagtail.org",
         "Source": "https://github.com/wagtail/wagtail",
     },

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
         "Changelog": "https://github.com/wagtail/wagtail/blob/main/CHANGELOG.txt",
         "Documentation": "https://docs.wagtail.org",
         "Source": "https://github.com/wagtail/wagtail",
+        "Tracker": "https://github.com/wagtail/wagtail/issues",
     },
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
The PyPI project page currently has no links to the change log and issue tracker. This pull request adds those links.