### PR TITLE
Allow IndexView's base queryset to be customised via ModelViewSet.get_base_queryset()

### DIFF
--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -71,6 +71,8 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    as the URL prefix and namespace, unless these are specified explicitly via the :attr:`~.ViewSet.name`, :attr:`~.ViewSet.url_prefix` or
    :attr:`~.ViewSet.url_namespace` attributes.
 
+   .. automethod:: get_base_queryset
+
    .. attribute:: form_fields
 
    A list of model field names that should be included in the create / edit forms.

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -804,6 +804,44 @@ class TestOrdering(WagtailTestUtils, TestCase):
         )
 
 
+class TestCustomQuerySet(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.user = self.login()
+
+    @classmethod
+    def setUpTestData(cls):
+        objects = [
+            FeatureCompleteToy(name="[HIDDEN] Secret Toy"),
+            FeatureCompleteToy(name="Public Toy"),
+        ]
+        FeatureCompleteToy.objects.bulk_create(objects)
+
+    def test_superuser(self):
+        response = self.client.get(reverse("feature_complete_toy:index"))
+        self.assertContains(response, "[HIDDEN] Secret Toy")
+        self.assertContains(response, "Public Toy")
+        response = self.client.get(reverse("feature_complete_toy:index_results"))
+        self.assertContains(response, "[HIDDEN] Secret Toy")
+        self.assertContains(response, "Public Toy")
+
+    def test_non_superuser(self):
+        self.user.is_superuser = False
+        self.user.save()
+        admin_permission = Permission.objects.get(
+            content_type__app_label="wagtailadmin", codename="access_admin"
+        )
+        toy_edit_permission = Permission.objects.get(
+            content_type__app_label="tests", codename="change_featurecompletetoy"
+        )
+        self.user.user_permissions.add(admin_permission, toy_edit_permission)
+        response = self.client.get(reverse("feature_complete_toy:index"))
+        self.assertNotContains(response, "[HIDDEN] Secret Toy")
+        self.assertContains(response, "Public Toy")
+        response = self.client.get(reverse("feature_complete_toy:index_results"))
+        self.assertNotContains(response, "[HIDDEN] Secret Toy")
+        self.assertContains(response, "Public Toy")
+
+
 class TestBreadcrumbs(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def setUp(self):
         self.user = self.login()

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -376,6 +376,10 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
         return queryset.order_by(*ordering)
 
     def get_base_queryset(self):
+        # Allow the queryset to be a callable that takes a request
+        # so that it can be evaluated in the context of the request
+        if callable(self.queryset):
+            self.queryset = self.queryset(self.request)
         if self.queryset is not None:
             queryset = self.queryset
             if isinstance(queryset, models.QuerySet):

--- a/wagtail/admin/viewsets/listing.py
+++ b/wagtail/admin/viewsets/listing.py
@@ -75,6 +75,15 @@ class ListingViewSetMixin:
             "export_headings": self.export_headings,
             "export_filename": self.export_filename,
             "filterset_class": self.filterset_class,
+            "queryset": self.get_base_queryset,
             **kwargs,
         }
         return view_kwargs
+
+    def get_base_queryset(self, request):
+        """
+        Returns a QuerySet of all model instances to be shown on the index view.
+        If ``None`` is returned (the default), the logic in
+        ``index_view.get_base_queryset()`` will be used instead.
+        """
+        return None

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -167,13 +167,6 @@ class ModelIndexView(generic.BaseListingView):
 class IndexView(generic.IndexViewOptionalFeaturesMixin, generic.IndexView):
     view_name = "list"
 
-    def get_base_queryset(self):
-        # Allow the queryset to be a callable that takes a request
-        # so that it can be evaluated in the context of the request
-        if callable(self.queryset):
-            self.queryset = self.queryset(self.request)
-        return super().get_base_queryset()
-
     @cached_property
     def columns(self):
         return [
@@ -684,12 +677,6 @@ class SnippetViewSet(ModelViewSet):
             }
         )
 
-    def get_index_view_kwargs(self, **kwargs):
-        return super().get_index_view_kwargs(
-            queryset=self.get_queryset,
-            **kwargs,
-        )
-
     def get_add_view_kwargs(self, **kwargs):
         return super().get_add_view_kwargs(
             preview_url_name=self.get_url_name("preview_on_add"),
@@ -922,11 +909,16 @@ class SnippetViewSet(ModelViewSet):
 
         return breadcrumbs
 
+    def get_base_queryset(self, request):
+        return self.get_queryset(request)
+
     def get_queryset(self, request):
         """
         Returns a QuerySet of all model instances to be shown on the index view.
         If ``None`` is returned (the default), the logic in
         ``index_view.get_base_queryset()`` will be used instead.
+
+        **Deprecated** – use :meth:`get_base_queryset` instead.
         """
         return None
 

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -273,6 +273,11 @@ class FeatureCompleteToyViewSet(ModelViewSet):
         FieldPanel("release_date", permission="tests.can_set_release_date"),
     ]
 
+    def get_base_queryset(self, request):
+        if not request.user.is_superuser:
+            return self.model._default_manager.exclude(name__startswith="[HIDDEN]")
+        return self.model._default_manager.all()
+
 
 class FCToyAlt1InspectView(InspectView):
     def get_name_display_value(self):


### PR DESCRIPTION
Partially fixes #10746.

Refactor `SnippetViewSet.get_queryset()` customisation into `ModelViewSet.get_base_queryset()` as part of #10740.

Not sure if we want this, and not using `inject_view_methods` per the conversation in https://github.com/wagtail/wagtail/pull/10851#discussion_r1315047040.

We might want to extract `IndexView.get_base_queryset` into a standardised method that is used across the views in `ModelViewSet`, and put the `queryset` kwarg override into `get_common_view_kwargs` instead. Therefore, the queryset returned by `ModelViewSet.get_base_queryset` will be enforced across all views. See also the discussion at https://github.com/wagtail/wagtail/pull/10621#issuecomment-1712039247


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
