### PR TITLE
Add 'undocumented internals' section to 5.2 upgrade considerations

### DIFF
--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -219,61 +219,6 @@ If using custom styling for the breadcrumbs, this class has changed from singula
 | ---------------- | ----------------- |
 | `'w-breadcrumb'` | `'w-breadcrumbs'` |
 
-### Breadcrumbs now use different data attributes and events
-
-The undocumented JavaScript implementation for the header breadcrumbs component has been migrated to a Stimulus controller and now uses different data attributes.
-
-This may impact custom header implementations that relied on the previous approach, custom breadcrumbs that did not use `breadcrumbs` and require the expand/collapse behaviour may be impacted.
-
-#### Events
-
-| Old                              | New                      |
-| -------------------------------- | ------------------------ |
-| `'wagtail:breadcrumbs-expand'`   | `'w-breadcrumbs:opened'` |
-| `'wagtail:breadcrumbs-collapse'` | `'w-breadcrumbs:closed'` |
-
-#### Data attributes
-
-| Old                       | New                                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `data-breadcrumb-next`    | `data-controller="w-breadcrumbs"`                                                                      |
-| `data-toggle-breadcrumbs` | `data-w-breadcrumbs-target="toggle" data-action="w-breadcrumbs#toggle mouseenter->w-breadcrumbs#peek"` |
-| `data-breadcrumb-item`    | `data-w-breadcrumbs-target="content"`                                                                  |
-
-Note that the root DOM element also includes a set of additional data attributes to function as the breadcrumbs:
-
-```
-data-controller="w-breadcrumbs"
-data-action="keyup.esc@document->w-breadcrumbs#close w-breadcrumbs:open@document->w-breadcrumbs#open w-breadcrumbs:close@document->w-breadcrumbs#close"
-data-w-breadcrumbs-close-icon-class="icon-cross"
-data-w-breadcrumbs-closed-value="true"
-data-w-breadcrumbs-open-icon-class="icon-breadcrumb-expand"
-data-w-breadcrumbs-opened-content-class="w-max-w-4xl"
-data-w-breadcrumbs-peek-target-value="header"
-```
-
-### `window.updateFooterSaveWarning` global util removed
-
-The undocumented global util `window.updateFooterSaveWarning` has been removed, this is part of the footer 'unsaved' messages toggling behaviour on page forms.
-This behaviour has now moved to a Stimulus controller and leverages DOM events instead. Calling this function will do nothing and in a future release will throw an error.
-
-You can implement roughly the equivalent functionality with this JavaScript function, however, this will not be guaranteed to work in future releases.
-
-```js
-window.updateFooterSaveWarning = (formDirty, commentsDirty) => {
-  if (!formDirty && !commentsDirty) {
-    document.dispatchEvent(new CustomEvent('w-unsaved:clear'));
-  } else {
-    const [type] = [
-      formDirty && commentsDirty && 'all',
-      commentsDirty && 'comments',
-      formDirty && 'edits',
-    ].filter(Boolean);
-    document.dispatchEvent(new CustomEvent('w-unsaved:add', { detail: { type } }));
-  }
-};
-```
-
 ### Snippets templates refactored to reuse the shared `slim_header.html` template
 
 The templates for the snippets views have been refactored to reuse the shared `slim_header.html` template. If you have customised or extended the templates, e.g. for [](wagtailsnippets_custom_admin_views), you will need to update them to match the new structure. As a result, the following templates have been removed:
@@ -286,47 +231,6 @@ The templates for the snippets views have been refactored to reuse the shared `s
 - `wagtailsnippets/snippets/headers/usage_header.html`
 
 In most cases, the usage of those templates can be replaced with the `wagtailadmin/shared/headers/slim_header.html` template. Refer to the snippets views and templates code for more details.
-
-### `dropdown` template tag argument `toggle_tippy_offset` renamed to `toggle_tooltip_offset`
-
-The naming conventions for `tippy` related attributes have been updated to align with the generic `tooltip` naming.
-
-If you are using the undocumented dropdown template tag with the offset arg, this will need to be updated.
-
-| Old                                                                | New                                                                  |
-| ------------------------------------------------------------------ | -------------------------------------------------------------------- |
-| `{% dropdown toggle_tippy_offset="[0, -2]" %}...{% enddropdown %}` | `{% dropdown toggle_tooltip_offset="[0, -2]" %}...{% enddropdown %}` |
-
-### `escapescript` template tag and `escape_script` functions are deprecated
-
-As of this release, the undocumented `coreutils.escape_script` util and `escapescript` template tag will no longer be supported.
-
-This was used to provide a way for HTML template content in IE11, which is no longer supported, and was non-compliant with CSP support.
-
-The current approach will trigger a deprecation warning and will be removed in a future release.
-
-#### Old
-
-```html+django
-{% load wagtailadmin_tags %}
-<script type="text/django-form-template" id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
-    {% escapescript %}
-        <div>Widget template content</div>
-        <script src="/js/my-widget.js"></script>
-    {% endescapescript %}
-</script>
-```
-
-#### New
-
-Use the HTML [`template`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) element to avoid content from being parsed by the browser on load.
-
-```html+django
-<template id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
-    <div>Widget template content</div>
-    <script src="/js/my-widget.js"></script>
-</template>
-```
 
 ### `BaseSidePanels`, `PageSidePanels` and `SnippetSidePanels` classes are removed
 
@@ -405,6 +309,104 @@ def my_view(request):
 The [`construct_snippet_listing_buttons`](construct_snippet_listing_buttons) hook no longer accepts a `context` argument. If you have implemented this hook, you will need to remove the `context` argument from your implementation. If you need to access values computed by the view, you'll need to override the {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.index_view_class` with a custom `IndexView` subclass. The `get_list_buttons` and `get_list_more_buttons` methods in particular may be overridden to customise the buttons on the listing.
 
 Defining a function for this hook that accepts the `context` argument will raise a warning, and the function will receive an empty dictionary (`{}`) as the `context`. Support for defining the `context` argument will be completely removed in a future Wagtail release.
+
+## Upgrade considerations - changes to undocumented internals
+
+### Breadcrumbs now use different data attributes and events
+
+The undocumented JavaScript implementation for the header breadcrumbs component has been migrated to a Stimulus controller and now uses different data attributes.
+
+This may impact custom header implementations that relied on the previous approach, custom breadcrumbs that did not use `breadcrumbs` and require the expand/collapse behaviour may be impacted.
+
+#### Events
+
+| Old                              | New                      |
+| -------------------------------- | ------------------------ |
+| `'wagtail:breadcrumbs-expand'`   | `'w-breadcrumbs:opened'` |
+| `'wagtail:breadcrumbs-collapse'` | `'w-breadcrumbs:closed'` |
+
+#### Data attributes
+
+| Old                       | New                                                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `data-breadcrumb-next`    | `data-controller="w-breadcrumbs"`                                                                      |
+| `data-toggle-breadcrumbs` | `data-w-breadcrumbs-target="toggle" data-action="w-breadcrumbs#toggle mouseenter->w-breadcrumbs#peek"` |
+| `data-breadcrumb-item`    | `data-w-breadcrumbs-target="content"`                                                                  |
+
+Note that the root DOM element also includes a set of additional data attributes to function as the breadcrumbs:
+
+```
+data-controller="w-breadcrumbs"
+data-action="keyup.esc@document->w-breadcrumbs#close w-breadcrumbs:open@document->w-breadcrumbs#open w-breadcrumbs:close@document->w-breadcrumbs#close"
+data-w-breadcrumbs-close-icon-class="icon-cross"
+data-w-breadcrumbs-closed-value="true"
+data-w-breadcrumbs-open-icon-class="icon-breadcrumb-expand"
+data-w-breadcrumbs-opened-content-class="w-max-w-4xl"
+data-w-breadcrumbs-peek-target-value="header"
+```
+
+### `window.updateFooterSaveWarning` global util removed
+
+The undocumented global util `window.updateFooterSaveWarning` has been removed, this is part of the footer 'unsaved' messages toggling behaviour on page forms.
+This behaviour has now moved to a Stimulus controller and leverages DOM events instead. Calling this function will do nothing and in a future release will throw an error.
+
+You can implement roughly the equivalent functionality with this JavaScript function, however, this will not be guaranteed to work in future releases.
+
+```js
+window.updateFooterSaveWarning = (formDirty, commentsDirty) => {
+  if (!formDirty && !commentsDirty) {
+    document.dispatchEvent(new CustomEvent('w-unsaved:clear'));
+  } else {
+    const [type] = [
+      formDirty && commentsDirty && 'all',
+      commentsDirty && 'comments',
+      formDirty && 'edits',
+    ].filter(Boolean);
+    document.dispatchEvent(new CustomEvent('w-unsaved:add', { detail: { type } }));
+  }
+};
+```
+
+### `dropdown` template tag argument `toggle_tippy_offset` renamed to `toggle_tooltip_offset`
+
+The naming conventions for `tippy` related attributes have been updated to align with the generic `tooltip` naming.
+
+If you are using the undocumented dropdown template tag with the offset arg, this will need to be updated.
+
+| Old                                                                | New                                                                  |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `{% dropdown toggle_tippy_offset="[0, -2]" %}...{% enddropdown %}` | `{% dropdown toggle_tooltip_offset="[0, -2]" %}...{% enddropdown %}` |
+
+### `escapescript` template tag and `escape_script` functions are deprecated
+
+As of this release, the undocumented `coreutils.escape_script` util and `escapescript` template tag will no longer be supported.
+
+This was used to provide a way for HTML template content in IE11, which is no longer supported, and was non-compliant with CSP support.
+
+The current approach will trigger a deprecation warning and will be removed in a future release.
+
+#### Old
+
+```html+django
+{% load wagtailadmin_tags %}
+<script type="text/django-form-template" id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
+    {% escapescript %}
+        <div>Widget template content</div>
+        <script src="/js/my-widget.js"></script>
+    {% endescapescript %}
+</script>
+```
+
+#### New
+
+Use the HTML [`template`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) element to avoid content from being parsed by the browser on load.
+
+```html+django
+<template id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
+    <div>Widget template content</div>
+    <script src="/js/my-widget.js"></script>
+</template>
+```
 
 ### Adoption of `classname` convention within the Image `Format` instance
 


### PR DESCRIPTION
While it's good for us to err on the side of more information in our upgrade notes (because there are always people doing hacks that rely on internals and then complaining that it wasn't mentioned...), the ones for 5.2 are getting pretty big. I therefore propose moving the ones relating to undocumented functionality into their own section - essentially to communicate "you can stop reading here, but if you stumble on something breaking in this release that isn't covered above, here is some stuff that will show up in a documentation search" :-)