### PR TITLE
Universal listings - move "Add child page" action to a top-level button in the header

### DIFF
--- a/docs/reference/contrib/modeladmin/tips_and_tricks/reversing_urls.md
+++ b/docs/reference/contrib/modeladmin/tips_and_tricks/reversing_urls.md
@@ -52,7 +52,7 @@ class AuthorModelAdmin(ModelAdmin):
 author_modeladmin = AuthorModelAdmin()
 
 @hooks.register('register_page_listing_buttons')
-def add_author_edit_buttons(page, page_perms, next_url=None):
+def add_author_edit_buttons(page, user, next_url=None):
     """
     For pages that have an author, add an additional button to the page listing,
     linking to the 'edit' page for that author.

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -551,7 +551,7 @@ This example will add a simple button to the secondary dropdown menu:
 from wagtail.admin import widgets as wagtailadmin_widgets
 
 @hooks.register('register_page_header_buttons')
-def page_header_buttons(page, user, next_url=None):
+def page_header_buttons(page, user, view_name, next_url=None):
     yield wagtailadmin_widgets.Button(
         'A dropdown button',
         '/goes/to/a/url/',
@@ -563,12 +563,13 @@ The arguments passed to the hook are as follows:
 
 -   `page` - the page object to generate the button for
 -   `user` - the logged-in user
+-   `view_name` - either `index` or `edit`, depending on whether the button is being generated for the page listing or edit view
 -   `next_url` - the URL that the linked action should redirect back to on completion of the action, if the view supports it
 
 The `priority` argument controls the order the buttons are displayed in the dropdown. Buttons are ordered from low to high priority, so a button with `priority=10` will be displayed before a button with `priority=60`.
 
 ```{versionchanged} 5.2
-The hook function now receives a `user` argument instead of a `page_perms` argument. To check the user's permissions on the page, use `page.permissions_for_user(user)`.
+The hook function now receives a `user` argument instead of a `page_perms` argument, and a `view_name` argument. To check the user's permissions on the page, use `page.permissions_for_user(user)`.
 ```
 
 ## Editor workflow

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -1023,7 +1023,7 @@ This example will add a simple button to the listing:
 from wagtail.admin import widgets as wagtailadmin_widgets
 
 @hooks.register('register_page_listing_buttons')
-def page_listing_buttons(page, page_perms, next_url=None):
+def page_listing_buttons(page, user, next_url=None):
     yield wagtailadmin_widgets.PageListingButton(
         'A page listing button',
         '/goes/to/a/url/',
@@ -1034,10 +1034,14 @@ def page_listing_buttons(page, page_perms, next_url=None):
 The arguments passed to the hook are as follows:
 
 -   `page` - the page object to generate the button for
--   `page_perms` - a `PagePermissionTester` object that can be queried to determine the current user's permissions on the given page
+-   `user` - the logged-in user
 -   `next_url` - the URL that the linked action should redirect back to on completion of the action, if the view supports it
 
 The `priority` argument controls the order the buttons are displayed in. Buttons are ordered from low to high priority, so a button with `priority=10` will be displayed before a button with `priority=20`.
+
+```{versionchanged} 5.2
+The hook function now receives a `user` argument instead of a `page_perms` argument. To check the user's permissions on the page, use `page.permissions_for_user(user)`.
+```
 
 (register_page_listing_more_buttons)=
 
@@ -1080,12 +1084,12 @@ This example shows how Wagtail's default admin dropdown is implemented. You can 
 from wagtail.admin import widgets as wagtailadmin_widgets
 
 @hooks.register('register_page_listing_buttons')
-def page_custom_listing_buttons(page, page_perms, next_url=None):
+def page_custom_listing_buttons(page, user, next_url=None):
     yield wagtailadmin_widgets.ButtonWithDropdownFromHook(
         'More actions',
         hook_name='my_button_dropdown_hook',
         page=page,
-        page_perms=page_perms,
+        page_perms=page.permissions_for_user(user),
         next_url=next_url,
         priority=50
     )

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -837,13 +837,17 @@ def make_publish_default_action(menu_items, request, context):
 
 ### `construct_page_listing_buttons`
 
-Modify the final list of page listing buttons in the page explorer. The callable passed to this hook receives a list of `PageListingButton` objects, a page, a page perms object, and a context dictionary as per `register_page_listing_buttons`, and should modify the list of listing items in-place.
+Modify the final list of page listing buttons in the page explorer. The callable passed to this hook receives a list of `PageListingButton` objects, a page, a user object, and a context dictionary, and should modify the list of listing items in-place.
 
 ```python
 @hooks.register('construct_page_listing_buttons')
-def remove_page_listing_button_item(buttons, page, page_perms, context=None):
+def remove_page_listing_button_item(buttons, page, user, context=None):
     if page.is_root:
         buttons.pop() # removes the last 'more' dropdown button on the root page listing buttons
+```
+
+```{versionchanged} 5.2
+The hook function now receives a `user` argument instead of a `page_perms` argument. To check the user's permissions on the page, use `page.permissions_for_user(user)`.
 ```
 
 (construct_wagtail_userbar)=

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -833,23 +833,6 @@ def make_publish_default_action(menu_items, request, context):
             break
 ```
 
-(construct_page_listing_buttons)=
-
-### `construct_page_listing_buttons`
-
-Modify the final list of page listing buttons in the page explorer. The callable passed to this hook receives a list of `PageListingButton` objects, a page, a user object, and a context dictionary, and should modify the list of listing items in-place.
-
-```python
-@hooks.register('construct_page_listing_buttons')
-def remove_page_listing_button_item(buttons, page, user, context=None):
-    if page.is_root:
-        buttons.pop() # removes the last 'more' dropdown button on the root page listing buttons
-```
-
-```{versionchanged} 5.2
-The hook function now receives a `user` argument instead of a `page_perms` argument. To check the user's permissions on the page, use `page.permissions_for_user(user)`.
-```
-
 (construct_wagtail_userbar)=
 
 ### `construct_wagtail_userbar`
@@ -1109,6 +1092,23 @@ def page_custom_listing_more_buttons(page, page_perms, next_url=None):
 ```
 
 The template for the dropdown button can be customised by overriding `wagtailadmin/pages/listing/_button_with_dropdown.html`. Make sure to leave the dropdown UI component itself as-is.
+
+(construct_page_listing_buttons)=
+
+### `construct_page_listing_buttons`
+
+Modify the final list of page listing buttons in the page explorer. The callable passed to this hook receives a list of `PageListingButton` objects, a page, a user object, and a context dictionary, and should modify the list of listing items in-place.
+
+```python
+@hooks.register('construct_page_listing_buttons')
+def remove_page_listing_button_item(buttons, page, user, context=None):
+    if page.is_root:
+        buttons.pop() # removes the last 'more' dropdown button on the root page listing buttons
+```
+
+```{versionchanged} 5.2
+The hook function now receives a `user` argument instead of a `page_perms` argument. To check the user's permissions on the page, use `page.permissions_for_user(user)`.
+```
 
 ## Page serving
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -551,7 +551,7 @@ This example will add a simple button to the secondary dropdown menu:
 from wagtail.admin import widgets as wagtailadmin_widgets
 
 @hooks.register('register_page_header_buttons')
-def page_header_buttons(page, page_perms, next_url=None):
+def page_header_buttons(page, user, next_url=None):
     yield wagtailadmin_widgets.Button(
         'A dropdown button',
         '/goes/to/a/url/',
@@ -562,10 +562,14 @@ def page_header_buttons(page, page_perms, next_url=None):
 The arguments passed to the hook are as follows:
 
 -   `page` - the page object to generate the button for
--   `page_perms` - a `PagePermissionTester` object that can be queried to determine the current user's permissions on the given page
+-   `user` - the logged-in user
 -   `next_url` - the URL that the linked action should redirect back to on completion of the action, if the view supports it
 
 The `priority` argument controls the order the buttons are displayed in the dropdown. Buttons are ordered from low to high priority, so a button with `priority=10` will be displayed before a button with `priority=60`.
+
+```{versionchanged} 5.2
+The hook function now receives a `user` argument instead of a `page_perms` argument. To check the user's permissions on the page, use `page.permissions_for_user(user)`.
+```
 
 ## Editor workflow
 

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -310,6 +310,21 @@ The [`construct_snippet_listing_buttons`](construct_snippet_listing_buttons) hoo
 
 Defining a function for this hook that accepts the `context` argument will raise a warning, and the function will receive an empty dictionary (`{}`) as the `context`. Support for defining the `context` argument will be completely removed in a future Wagtail release.
 
+### Hooks for page listing and page header buttons no longer accept a `page_perms` argument
+
+The arguments passed to the hooks [`register_page_header_buttons`](register_page_header_buttons), [`register_page_listing_buttons`](register_page_listing_buttons), [`construct_page_listing_buttons`](construct_page_listing_buttons) and [`register_page_listing_more_buttons`](register_page_listing_more_buttons) have changed. For all of these hooks, the `page_perms` argument has been replaced by `user`; in addition, `register_page_header_buttons` is now passed a `view_name` argument, which is either `'edit'` or `'index'`, depending on whether the button is being generated for the page listing or edit view. In summary, the changes are:
+
+* `register_page_header_buttons`: Previously `func(page, page_perms, next_url)`, now `func(page, user, next_url, view_name)`.
+* `register_page_listing_buttons`: Previously `func(page, page_perms, next_url)`, now `func(page, user, next_url)`.
+* `construct_page_listing_buttons`: Previously `func(buttons, page, page_perms, context)`, now `fn(buttons, page, user, context)`.
+* `register_page_listing_more_buttons`: Previously `func(page, page_perms, next_url)`, now `func(page, user, next_url)`.
+
+Additionally, the `ButtonWithDropdownFromHook` constructor, and the resulting hook it creates, should now be passed a `user` argument instead of `page_perms`.
+
+Existing code that performs permission checks using `page_perms` can retrieve the same permission tester object using `page.permissions_for_user(user)`.
+
+Hook functions using the old `page_perms` signature will continue to work, but this is deprecated and will raise a warning. Support for the old signature will be removed in a future Wagtail release.
+
 ## Upgrade considerations - changes to undocumented internals
 
 ### Breadcrumbs now use different data attributes and events

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -28,5 +28,5 @@
 </div>
 
 <ul class="actions">
-    {% page_listing_buttons page page_perms %}
+    {% page_listing_buttons page request.user %}
 </ul>

--- a/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
@@ -10,6 +10,12 @@
     {% page_breadcrumbs parent_page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' is_expanded=parent_page.is_root classname='sm:w-py-3 lg:w-py-7' %}
     {# Actions divider #}
     <div class="w-w-px w-h-[30px] w-ml-auto sm:w-ml-0 w-bg-border-furniture"></div>
+
+    {% page_permissions parent_page as parent_page_perms %}
+    {% if parent_page_perms.can_add_subpage %}
+        <a href="{% url "wagtailadmin_pages:add_subpage" parent_page.id %}" class="button button-small bicolor button--icon button-secondary w-ml-3">{% icon name="plus" wrapped=1 %}{% trans "Add child page" %}</a>
+    {% endif %}
+
     {# Page actions dropdown #}
     {% page_header_buttons parent_page user=request.user view_name="index" %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
@@ -11,7 +11,7 @@
     {# Actions divider #}
     <div class="w-w-px w-h-[30px] w-ml-auto sm:w-ml-0 w-bg-border-furniture"></div>
     {# Page actions dropdown #}
-    {% page_header_buttons parent_page page_perms=page_perms %}
+    {% page_header_buttons parent_page user=request.user %}
 {% endblock %}
 {% block actions %}
     {% if not parent_page.is_root %}

--- a/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
@@ -11,7 +11,7 @@
     {# Actions divider #}
     <div class="w-w-px w-h-[30px] w-ml-auto sm:w-ml-0 w-bg-border-furniture"></div>
     {# Page actions dropdown #}
-    {% page_header_buttons parent_page user=request.user %}
+    {% page_header_buttons parent_page user=request.user view_name="index" %}
 {% endblock %}
 {% block actions %}
     {% if not parent_page.is_root %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
@@ -11,7 +11,7 @@
     {# Actions divider #}
     <div class="w-w-px w-h-[30px] w-ml-auto sm:w-ml-0 w-bg-border-furniture"></div>
     {# Page actions dropdown #}
-    {% page_header_buttons page user=request.user %}
+    {% page_header_buttons page user=request.user view_name="edit" %}
 {% endblock %}
 
 {% block actions %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
@@ -11,7 +11,7 @@
     {# Actions divider #}
     <div class="w-w-px w-h-[30px] w-ml-auto sm:w-ml-0 w-bg-border-furniture"></div>
     {# Page actions dropdown #}
-    {% page_header_buttons page page_perms=page_perms %}
+    {% page_header_buttons page user=request.user %}
 {% endblock %}
 
 {% block actions %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -505,7 +505,7 @@ def page_listing_buttons(context, page, user):
 @register.inclusion_tag(
     "wagtailadmin/pages/listing/_page_header_buttons.html", takes_context=True
 )
-def page_header_buttons(context, page, user):
+def page_header_buttons(context, page, user, view_name):
     next_url = context["request"].path
     page_perms = page.permissions_for_user(user)
     button_hooks = hooks.get_hooks("register_page_header_buttons")
@@ -513,7 +513,9 @@ def page_header_buttons(context, page, user):
     buttons = []
     for hook in button_hooks:
         if accepts_kwarg(hook, "user"):
-            buttons.extend(hook(page=page, user=user, next_url=next_url))
+            buttons.extend(
+                hook(page=page, user=user, next_url=next_url, view_name=view_name)
+            )
         else:
             # old-style hook that accepts page_perms instead of user
             warn(

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -486,7 +486,18 @@ def page_listing_buttons(context, page, user):
 
     page_perms = page.permissions_for_user(user)
     for hook in hooks.get_hooks("construct_page_listing_buttons"):
-        hook(buttons, page, page_perms, context)
+        if accepts_kwarg(hook, "user"):
+            hook(buttons, page=page, user=user, context=context)
+        else:
+            # old-style hook that accepts page_perms instead of user
+            warn(
+                "`construct_page_listing_buttons` hook functions should accept a `user` argument instead of `page_perms` -"
+                f" {hook.__module__}.{hook.__name__} needs to be updated",
+                category=RemovedInWagtail60Warning,
+            )
+
+            page_perms = page.permissions_for_user(user)
+            hook(buttons, page, page_perms, context)
 
     return {"page": page, "buttons": buttons}
 

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -1,14 +1,16 @@
-from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.models import AbstractBaseUser, Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core import paginator
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from wagtail import hooks
+from wagtail.admin.widgets import Button
 from wagtail.models import GroupPagePermission, Locale, Page
 from wagtail.test.testapp.models import SimplePage, SingleEventPage, StandardIndex
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.timestamps import local_datetime
+from wagtail.utils.deprecation import RemovedInWagtail60Warning
 
 
 class TestPageExplorer(WagtailTestUtils, TestCase):
@@ -179,13 +181,47 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
             page_ids, [self.old_page.id, self.new_page.id, self.child_page.id]
         )
 
-    def test_construct_page_listing_buttons_hook(self):
-        # testapp implements a construct_page_listing_buttons hook
-        # that add's an dummy button with the label 'Dummy Button' which points
-        # to '/dummy-button'
-        response = self.client.get(
-            reverse("wagtailadmin_explore", args=(self.root_page.id,)),
-        )
+    def test_construct_page_listing_buttons_hook_with_old_signature(self):
+        def add_dummy_button(buttons, page, page_perms, context=None):
+            item = Button(
+                label="Dummy Button",
+                url="/dummy-button",
+                priority=10,
+            )
+            buttons.append(item)
+
+        with hooks.register_temporarily(
+            "construct_page_listing_buttons", add_dummy_button
+        ):
+            with self.assertWarnsMessage(
+                RemovedInWagtail60Warning,
+                "`construct_page_listing_buttons` hook functions should accept a `user` argument instead of `page_perms`",
+            ):
+                response = self.client.get(
+                    reverse("wagtailadmin_explore", args=(self.root_page.id,))
+                )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
+        self.assertContains(response, "Dummy Button")
+        self.assertContains(response, "/dummy-button")
+
+    def test_construct_page_listing_buttons_hook_with_new_signature(self):
+        def add_dummy_button(buttons, page, user, context=None):
+            if not isinstance(user, AbstractBaseUser):
+                raise TypeError("expected a user instance")
+            item = Button(
+                label="Dummy Button",
+                url="/dummy-button",
+                priority=10,
+            )
+            buttons.append(item)
+
+        with hooks.register_temporarily(
+            "construct_page_listing_buttons", add_dummy_button
+        ):
+            response = self.client.get(
+                reverse("wagtailadmin_explore", args=(self.root_page.id,))
+            )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
         self.assertContains(response, "Dummy Button")

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -345,9 +345,12 @@ class TestPageHeaderButtonsHooks(TestButtonsHooks):
         self.assertContains(response, "Another useless header button")
 
     def test_register_page_header_buttons_new_signature(self):
-        def custom_page_header_buttons(page, user, next_url=None):
+        def custom_page_header_buttons(page, user, view_name, next_url=None):
             if not isinstance(user, AbstractBaseUser):
                 raise TypeError("expected a user instance")
+
+            if view_name != "edit":
+                raise ValueError("expected view_name to be 'edit'")
 
             yield wagtailadmin_widgets.Button(
                 "Another useless header button", "/custom-url", priority=10
@@ -378,7 +381,9 @@ class TestPageHeaderButtonsHooks(TestButtonsHooks):
         next_url = "a/random/url/"
         full_url = base_url + "?" + urlencode({"next": next_url})
 
-        buttons = page_header_buttons(page, self.user, next_url=next_url)
+        buttons = page_header_buttons(
+            page, self.user, view_name="index", next_url=next_url
+        )
         delete_button = next(button for button in buttons if button.label == "Delete")
 
         self.assertEqual(delete_button.url, full_url)
@@ -395,7 +400,9 @@ class TestPageHeaderButtonsHooks(TestButtonsHooks):
         base_url = reverse("wagtailadmin_pages:delete", args=[page.id])
         next_url = reverse("wagtailadmin_explore", args=[page.id])
 
-        buttons = page_header_buttons(page, self.user, next_url=next_url)
+        buttons = page_header_buttons(
+            page, self.user, view_name="index", next_url=next_url
+        )
 
         delete_button = next(button for button in buttons if button.label == "Delete")
 
@@ -405,7 +412,9 @@ class TestPageHeaderButtonsHooks(TestButtonsHooks):
         base_url = reverse("wagtailadmin_pages:delete", args=[page.id])
         next_url = reverse("wagtailadmin_pages:edit", args=[page.id])
 
-        buttons = page_header_buttons(page, self.user, next_url=next_url)
+        buttons = page_header_buttons(
+            page, self.user, view_name="index", next_url=next_url
+        )
 
         delete_button = next(button for button in buttons if button.label == "Delete")
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -375,125 +375,32 @@ class PageListingSortMenuOrderButton(PageListingButton):
 
 @hooks.register("register_page_listing_more_buttons")
 def page_listing_more_buttons(page, user, next_url=None):
-    page_perms = page.permissions_for_user(user)
-    yield PageListingEditButton(
-        page=page,
-        page_perms=page_perms,
-        priority=2,
-    )
-
-    yield PageListingViewDraftButton(
-        page=page,
-        page_perms=page_perms,
-        priority=4,
-    )
-
-    yield PageListingViewLiveButton(
-        page=page,
-        page_perms=page_perms,
-        url=page.url,
-        priority=6,
-    )
-
-    yield PageListingAddChildPageButton(
-        page=page,
-        page_perms=page_perms,
-        priority=8,
-    )
-
-    yield PageListingMoveButton(
-        page=page,
-        page_perms=page_perms,
-        priority=10,
-    )
-
-    yield PageListingCopyButton(
-        page=page,
-        page_perms=page_perms,
-        next_url=next_url,
-        priority=20,
-    )
-
-    yield PageListingDeleteButton(
-        page=page,
-        page_perms=page_perms,
-        next_url=next_url,
-        priority=30,
-    )
-
+    yield PageListingEditButton(page=page, user=user, priority=2)
+    yield PageListingViewDraftButton(page=page, user=user, priority=4)
+    yield PageListingViewLiveButton(page=page, user=user, url=page.url, priority=6)
+    yield PageListingAddChildPageButton(page=page, user=user, priority=8)
+    yield PageListingMoveButton(page=page, user=user, priority=10)
+    yield PageListingCopyButton(page=page, user=user, next_url=next_url, priority=20)
+    yield PageListingDeleteButton(page=page, user=user, next_url=next_url, priority=30)
     yield PageListingUnpublishButton(
-        page=page,
-        page_perms=page_perms,
-        next_url=next_url,
-        priority=40,
+        page=page, user=user, next_url=next_url, priority=40
     )
-
-    yield PageListingHistoryButton(
-        page=page,
-        page_perms=page_perms,
-        priority=50,
-    )
-
-    yield PageListingSortMenuOrderButton(
-        page=page,
-        page_perms=page_perms,
-        priority=60,
-    )
+    yield PageListingHistoryButton(page=page, user=user, priority=50)
+    yield PageListingSortMenuOrderButton(page=page, user=user, priority=60)
 
 
 @hooks.register("register_page_header_buttons")
 def page_header_buttons(page, user, view_name, next_url=None):
-    page_perms = page.permissions_for_user(user)
-    yield PageListingEditButton(
-        page=page,
-        page_perms=page_perms,
-        priority=10,
-    )
-
-    yield PageListingAddChildPageButton(
-        page=page,
-        page_perms=page_perms,
-        priority=15,
-    )
-
-    yield PageListingMoveButton(
-        page=page,
-        page_perms=page_perms,
-        priority=20,
-    )
-
-    yield PageListingCopyButton(
-        page=page,
-        page_perms=page_perms,
-        next_url=next_url,
-        priority=30,
-    )
-
-    yield PageListingDeleteButton(
-        page=page,
-        page_perms=page_perms,
-        next_url=next_url,
-        priority=50,
-    )
-
+    yield PageListingEditButton(page=page, user=user, priority=10)
+    yield PageListingAddChildPageButton(page=page, user=user, priority=15)
+    yield PageListingMoveButton(page=page, user=user, priority=20)
+    yield PageListingCopyButton(page=page, user=user, next_url=next_url, priority=30)
+    yield PageListingDeleteButton(page=page, user=user, next_url=next_url, priority=50)
     yield PageListingUnpublishButton(
-        page=page,
-        page_perms=page_perms,
-        next_url=next_url,
-        priority=60,
+        page=page, user=user, next_url=next_url, priority=60
     )
-
-    yield PageListingHistoryButton(
-        page=page,
-        page_perms=page_perms,
-        priority=65,
-    )
-
-    yield PageListingSortMenuOrderButton(
-        page=page,
-        page_perms=page_perms,
-        priority=70,
-    )
+    yield PageListingHistoryButton(page=page, user=user, priority=65)
+    yield PageListingSortMenuOrderButton(page=page, user=user, priority=70)
 
 
 @hooks.register("register_admin_urls")

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -442,7 +442,7 @@ def page_listing_more_buttons(page, user, next_url=None):
 
 
 @hooks.register("register_page_header_buttons")
-def page_header_buttons(page, user, next_url=None):
+def page_header_buttons(page, user, view_name, next_url=None):
     page_perms = page.permissions_for_user(user)
     yield PageListingEditButton(
         page=page,

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -442,7 +442,8 @@ def page_listing_more_buttons(page, user, next_url=None):
 
 
 @hooks.register("register_page_header_buttons")
-def page_header_buttons(page, page_perms, next_url=None):
+def page_header_buttons(page, user, next_url=None):
+    page_perms = page.permissions_for_user(user)
     yield PageListingEditButton(
         page=page,
         page_perms=page_perms,

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -222,12 +222,12 @@ def register_workflow_tasks_menu_item():
 
 
 @hooks.register("register_page_listing_buttons")
-def page_listing_buttons(page, page_perms, next_url=None):
+def page_listing_buttons(page, user, next_url=None):
     yield ButtonWithDropdownFromHook(
         "",
         hook_name="register_page_listing_more_buttons",
         page=page,
-        page_perms=page_perms,
+        page_perms=page.permissions_for_user(user),
         next_url=next_url,
         icon_name="dots-horizontal",
         attrs={

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -227,7 +227,7 @@ def page_listing_buttons(page, user, next_url=None):
         "",
         hook_name="register_page_listing_more_buttons",
         page=page,
-        page_perms=page.permissions_for_user(user),
+        user=user,
         next_url=next_url,
         icon_name="dots-horizontal",
         attrs={
@@ -374,7 +374,8 @@ class PageListingSortMenuOrderButton(PageListingButton):
 
 
 @hooks.register("register_page_listing_more_buttons")
-def page_listing_more_buttons(page, page_perms, next_url=None):
+def page_listing_more_buttons(page, user, next_url=None):
+    page_perms = page.permissions_for_user(user)
     yield PageListingEditButton(
         page=page,
         page_perms=page_perms,

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -392,7 +392,11 @@ def page_listing_more_buttons(page, user, next_url=None):
 @hooks.register("register_page_header_buttons")
 def page_header_buttons(page, user, view_name, next_url=None):
     yield PageListingEditButton(page=page, user=user, priority=10)
-    yield PageListingAddChildPageButton(page=page, user=user, priority=15)
+
+    # "add child" is a separate primary action on the index page
+    if view_name != "index":
+        yield PageListingAddChildPageButton(page=page, user=user, priority=15)
+
     yield PageListingMoveButton(page=page, user=user, priority=20)
     yield PageListingCopyButton(page=page, user=user, next_url=next_url, priority=30)
     yield PageListingDeleteButton(page=page, user=user, next_url=next_url, priority=50)

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -113,11 +113,9 @@ class PageListingButton(ListingButton):
     aria_label_format = None
     url_name = None
 
-    def __init__(
-        self, *args, page=None, next_url=None, attrs={}, page_perms=None, **kwargs
-    ):
+    def __init__(self, *args, page=None, next_url=None, attrs={}, user=None, **kwargs):
         self.page = page
-        self.page_perms = page_perms
+        self.user = user
         self.next_url = next_url
 
         attrs = attrs.copy()
@@ -138,6 +136,11 @@ class PageListingButton(ListingButton):
             if self.next_url:
                 url += "?" + urlencode({"next": self.next_url})
             return url
+
+    @cached_property
+    def page_perms(self):
+        if self.page:
+            return self.page.permissions_for_user(self.user)
 
 
 class BaseDropdownMenuButton(Button):

--- a/wagtail/contrib/simple_translation/tests/test_wagtail_hooks.py
+++ b/wagtail/contrib/simple_translation/tests/test_wagtail_hooks.py
@@ -66,10 +66,6 @@ class TestWagtailHooksPermission(Utils):
 
 
 class TestWagtailHooksButtons(Utils):
-    class PagePerms:
-        def __init__(self, user):
-            self.user = user
-
     def test_page_listing_more_buttons(self):
         # Root, no button
         root_page = self.en_blog_index.get_root()
@@ -78,11 +74,11 @@ class TestWagtailHooksButtons(Utils):
             user = get_user_model().objects.create_user(email="jos@example.com")
         else:
             user = get_user_model().objects.create_user(username="jos")
-        assert list(page_listing_more_buttons(root_page, self.PagePerms(user))) == []
+        assert list(page_listing_more_buttons(root_page, user)) == []
 
         # No permissions, no button
         home_page = self.en_homepage
-        assert list(page_listing_more_buttons(root_page, self.PagePerms(user))) == []
+        assert list(page_listing_more_buttons(root_page, user)) == []
 
         # Homepage is translated to all languages, no button
         perm = Permission.objects.get(codename="submit_translation")
@@ -96,13 +92,12 @@ class TestWagtailHooksButtons(Utils):
         user.user_permissions.add(perm)
         group = Group.objects.get(name="Editors")
         user.groups.add(group)
-        page_perms = self.PagePerms(user)
-        assert list(page_listing_more_buttons(home_page, page_perms)) == []
+        assert list(page_listing_more_buttons(home_page, user)) == []
 
         # Page does not have translations yet... button!
         blog_page = self.en_blog_post
         assert isinstance(
-            list(page_listing_more_buttons(blog_page, page_perms))[0],
+            list(page_listing_more_buttons(blog_page, user))[0],
             wagtailadmin_widgets.Button,
         )
 

--- a/wagtail/contrib/simple_translation/wagtail_hooks.py
+++ b/wagtail/contrib/simple_translation/wagtail_hooks.py
@@ -64,10 +64,8 @@ def page_listing_more_buttons(page, user, next_url=None):
 
 
 @hooks.register("register_page_header_buttons")
-def page_header_buttons(page, page_perms, next_url=None):
-    if not page.is_root() and page_perms.user.has_perm(
-        "simple_translation.submit_translation"
-    ):
+def page_header_buttons(page, user, next_url=None):
+    if not page.is_root() and user.has_perm("simple_translation.submit_translation"):
         # If there's at least one locale that we haven't translated into yet,
         # show "Translate this page" button
         has_locale_to_translate_to = Locale.objects.exclude(

--- a/wagtail/contrib/simple_translation/wagtail_hooks.py
+++ b/wagtail/contrib/simple_translation/wagtail_hooks.py
@@ -48,11 +48,8 @@ def register_submit_translation_permission():
 
 
 @hooks.register("register_page_listing_more_buttons")
-def page_listing_more_buttons(page, page_perms, next_url=None):
-    if (
-        page_perms.user.has_perm("simple_translation.submit_translation")
-        and not page.is_root()
-    ):
+def page_listing_more_buttons(page, user, next_url=None):
+    if user.has_perm("simple_translation.submit_translation") and not page.is_root():
         # If there's at least one locale that we haven't translated into yet,
         # show "Translate this page" button
         has_locale_to_translate_to = Locale.objects.exclude(

--- a/wagtail/contrib/simple_translation/wagtail_hooks.py
+++ b/wagtail/contrib/simple_translation/wagtail_hooks.py
@@ -64,7 +64,7 @@ def page_listing_more_buttons(page, user, next_url=None):
 
 
 @hooks.register("register_page_header_buttons")
-def page_header_buttons(page, user, next_url=None):
+def page_header_buttons(page, user, view_name, next_url=None):
     if not page.is_root() and user.has_perm("simple_translation.submit_translation"):
         # If there's at least one locale that we haven't translated into yet,
         # show "Translate this page" button

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -188,16 +188,6 @@ def register_relax_menu_item(menu_items, request, context):
     menu_items.append(RelaxMenuItem())
 
 
-@hooks.register("construct_page_listing_buttons")
-def register_page_listing_button_item(buttons, page, page_perms, context=None):
-    item = Button(
-        label="Dummy Button",
-        url="/dummy-button",
-        priority=10,
-    )
-    buttons.append(item)
-
-
 @hooks.register("construct_snippet_listing_buttons")
 def register_snippet_listing_button_item(buttons, snippet, user, context=None):
     item = Button(


### PR DESCRIPTION
Lots of changes to the page listing button hooks to achieve one fairly small thing...

* Updated the `register_page_header_buttons`, `register_page_listing_buttons`, `construct_page_listing_buttons` and `register_page_listing_more_buttons` hooks to take a `user` argument instead of `page_perms`, as per https://github.com/wagtail/wagtail/pull/10935#discussion_r1334167851
* Also pass a `view_name` parameter to `register_page_header_buttons`, so that the dropdown can differ between the index and edit views
* On the index view, move "Add child page" to its own top-level button, as per the universal listings design.
![Screenshot 2023-10-06 at 19 07 54](https://github.com/wagtail/wagtail/assets/85097/37d89744-2d1f-4502-85a8-c0e9fa2d2cf3)
