### PR TITLE
Fix pages in workflow status showing up as "live + draft"

### DIFF
--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -796,7 +796,7 @@ class TestInWorkflowStatus(WagtailTestUtils, TestCase):
         # Warm up cache
         self.client.get(self.url)
 
-        with self.assertNumQueries(50):
+        with self.assertNumQueries(47):
             response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -73,7 +73,9 @@ class IndexView(PermissionCheckedMixin, BaseListingView):
 
     def get(self, request, parent_page_id=None):
         if parent_page_id:
-            self.parent_page = get_object_or_404(Page, id=parent_page_id)
+            self.parent_page = get_object_or_404(
+                Page.objects.all().prefetch_workflow_states(), id=parent_page_id
+            )
         else:
             self.parent_page = Page.get_first_root_node()
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -1195,6 +1195,20 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         for_concrete_model=False,
     )
 
+    # When using a specific queryset, accessing the _workflow_states GenericRelation
+    # will yield no results. This is because the _workflow_states GenericRelation
+    # uses the base_content_type as the content_type_field, which is not the same
+    # as the content type of the specific queryset. To work around this, we define
+    # a second GenericRelation that uses the specific content_type to be used
+    # when working with specific querysets.
+    _specific_workflow_states = GenericRelation(
+        "wagtailcore.WorkflowState",
+        content_type_field="content_type",
+        object_id_field="object_id",
+        related_query_name="page",
+        for_concrete_model=False,
+    )
+
     # If non-null, this page is an alias of the linked page
     # This means the page is kept in sync with the live version
     # of the linked pages and is not editable by users.

--- a/wagtail/query.py
+++ b/wagtail/query.py
@@ -167,6 +167,16 @@ class SpecificQuerySetMixin:
             clone._iterable_class = SpecificIterable
         return clone
 
+    @property
+    def is_specific(self):
+        """
+        Returns True if this queryset is already specific, False otherwise.
+        """
+        return issubclass(
+            self._iterable_class,
+            (SpecificIterable, DeferredSpecificIterable),
+        )
+
 
 class PageQuerySet(SearchableQuerySetMixin, SpecificQuerySetMixin, TreeQuerySet):
     def live_q(self):
@@ -455,9 +465,13 @@ class PageQuerySet(SearchableQuerySetMixin, SpecificQuerySetMixin, TreeQuerySet)
             "current_task_state__task"
         )
 
+        relation = "_workflow_states"
+        if self.is_specific:
+            relation = "_specific_workflow_states"
+
         return self.prefetch_related(
             Prefetch(
-                "_workflow_states",
+                relation,
                 queryset=workflow_states,
                 to_attr="_current_workflow_states",
             )


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10925

It turns out the fix is literally one liner, changing the `GenericRelation` to use `content_type` instead of `base_content_type`. However, that depends on whether we're working with a specific queryset or the base `Page` queryset. I opted to have two `GenericRelation`s instead so that we can use `prefetch_workflow_states()` with either, and it will pick the correct relation accordingly.

And yeah, it turns out prefetching `GenericRelation`s with a custom queryset still works fine on Django < 5.0. The one that needs Django >= 5.0 is prefetching `GenericForeignKey`s, because the result can be of different models.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

With bakerydemo, the issue in #10925 shouldn't occur anymore.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
