### PR TITLE
Use get_or_create for editor page subscriptions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -68,6 +68,7 @@ Changelog
  * Fix: Ensure very long words can wrap when viewing saved comments (Chiemezuo Akujobi)
  * Fix: Avoid forgotten password link text conflicting with the supplied aria-label (Thibaud Colas)
  * Fix: Fix log message to record the correct restriction type when removing a page view restriction (Rohit Sharma, Hazh. M. Adam)
+ * Fix: Avoid potential race condition with new Page subscriptions on the edit view (Alex Tomkins)
  * Docs: Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
  * Docs: Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)
  * Docs: Add documentation for building non-model-based choosers using the _queryish_ library (Matt Westcott)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -92,6 +92,7 @@ This feature was developed by Paarth Agarwal and Thibaud Colas as part of the Go
  * Ensure very long words can wrap when viewing saved comments (Chiemezuo Akujobi)
  * Avoid forgotten password link text conflicting with the supplied aria-label (Thibaud Colas)
  * Fix log message to record the correct restriction type when removing a page view restriction (Rohit Sharma, Hazh. M. Adam)
+ * Avoid potential race condition with new Page subscriptions on the edit view (Alex Tomkins)
 
 ### Documentation
 

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -3105,6 +3105,11 @@ class TestPageSubscriptionSettings(WagtailTestUtils, TestCase):
             response,
             '<input type="checkbox" name="comment_notifications" id="id_comment_notifications">',
         )
+        self.assertTrue(
+            PageSubscription.objects.filter(
+                page=self.child_page, user=self.user, comment_notifications=False
+            ).exists()
+        )
 
     def test_commment_notifications_switched_on(self):
         PageSubscription.objects.create(

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -376,14 +376,13 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         if response:
             return response
 
-        try:
-            self.subscription = PageSubscription.objects.get(
-                page=self.page, user=self.request.user
-            )
-        except PageSubscription.DoesNotExist:
-            self.subscription = PageSubscription(
-                page=self.page, user=self.request.user, comment_notifications=False
-            )
+        self.subscription, created = PageSubscription.objects.get_or_create(
+            page=self.page,
+            user=self.request.user,
+            defaults={
+                "comment_notifications": False,
+            },
+        )
 
         self.edit_handler = self.page_class.get_edit_handler()
         self.form_class = self.edit_handler.get_form_class()


### PR DESCRIPTION
Fixes #11016

A pain to test(!) - you could use https://github.com/tomkins/wagtail-sqlite-benchmark to follow along.

Before: integrity errors when using a tool like locust to load edit page where a subscription didn't exist.
After: no integrity errors

I've tweaked one test to try and add something of value for this case.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?
