### PR TITLE
Ensure comment panels can get focus correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,14 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: pipenv-v1-{{ checksum "setup.py" }}
+          key: pipenv-v2-{{ checksum "setup.py" }}
       # Only install if .venv wasn’t cached.
       - run: |
           if [[ ! -e ".venv" ]]; then
               pipenv install -e .[testing,docs]
           fi
       - save_cache:
-          key: pipenv-v1-{{ checksum "setup.py" }}
+          key: pipenv-v2-{{ checksum "setup.py" }}
           paths:
             - .venv
       - run: pipenv run ruff check .

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -629,8 +629,12 @@ export default class CommentComponent extends React.Component<CommentProps> {
                 }),
               );
             },
+            // Allow delay for side panel to open & comment card to fade in with animation.
+            checkCanFocusTrap: () =>
+              new Promise((resolve) => {
+                setTimeout(resolve, 250);
+              }),
             initialFocus: '[data-focus-target="true"]',
-            delayFocus: false,
           } as any
         } // For some reason, the types for FocusTrap props don't yet include preventScroll.
         active={this.props.isFocused && this.props.forceFocus}


### PR DESCRIPTION
Fixes #11021

### **Notes**

- Not sure if `delayFocus` was ever an option but I cannot find this in the docs anywhere, so it's possible this never did anything (or at least has not done anything for a while). https://github.com/focus-trap/focus-trap#createoptions
- I opted for a hard-coded 250ms delay, this gives enough time for the side panel and the comment panel (card) itself to become visible. I initially tried to set up something more complex that checked if the side panel was visible but this felt too complex. 250ms is not too much of a delay and gives time for any animations to resolve.

#### Validation screenshot

![Screenshot 2023-10-10 at 6 07 16 am](https://github.com/wagtail/wagtail/assets/1396140/d57492c8-0623-4b01-b7dc-4b64e0d84da6)

### **Checklist**

-   [X] Do the tests still pass?
-   [X] Does the code comply with the style guide?
-   [X] For front-end changes: Did you test on all of Wagtail’s supported environments? Chrome 118, Firefox 117, Safari 16.1
-   [X] For new features: Has the documentation been updated accordingly? N/A
