### PR TITLE
Determine if instance type is indexed using `instance._meta.model` instead of `type(instance)`

### DIFF
--- a/wagtail/signal_handlers.py
+++ b/wagtail/signal_handlers.py
@@ -86,7 +86,7 @@ def update_reference_index_on_save(instance, **kwargs):
             # parent is null, so there is no valid object to record references against
             return
 
-    if ReferenceIndex.is_indexed(type(instance)):
+    if ReferenceIndex.is_indexed(instance._meta.model):
         with transaction.atomic():
             ReferenceIndex.create_or_update_for_object(instance)
 


### PR DESCRIPTION
This solves a problem which manifests if a model instance has a `ParentalKey` and the related object is a (`Simple`)`LazyObject`.

In wagtail 4, using `type()` in this situation throws `AttributeError: type object 'SimpleLazyObject' has no attribute '_meta'`.
In wagtail 5, using `type()` this doesn't throw an exception - it just doesn't record the reference properly because https://github.com/wagtail/wagtail/blob/953c980976231d6d2e1d26a58595710dcf10cc71/wagtail/models/reference_index.py#L283-L285 just returns `False`

Switching to using `instance._meta.model` means that if `instance` is lazy, we'll pass the type of the resolved database object, not `LazyObject`, which is what we want.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

Should be clear from the test case
