### PR TITLE
Relax Django dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
             emailuser: emailuser
             parallel: '--parallel'
           - python: '3.12'
-            django: 'Django>=4.2,<4.3'
+            django: 'Django>=4.2,<5.2'
             postgres: 'postgres:15'
             notz: notz
             experimental: false
@@ -158,7 +158,7 @@ jobs:
             django: 'Django>=3.2,<3.3'
             experimental: false
           - python: '3.11'
-            django: 'Django>=4.2,<4.3'
+            django: 'Django>=4.2,<5.2'
             experimental: false
             parallel: '--parallel'
             mysql: 'mysql:8.1'
@@ -252,7 +252,7 @@ jobs:
       matrix:
         include:
           - python: '3.10'
-            django: 'Django>=4.2,<4.3'
+            django: 'Django>=4.2,<5.2'
             emailuser: emailuser
     steps:
       - name: Configure sysctl limits

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 
 
 install_requires = [
-    "Django>=3.2,<4.3",
+    "Django>=3.2,<5.2",
     "django-modelcluster>=6.1,<7.0",
     "django-permissionedforms>=0.1,<1.0",
     "django-taggit>=2.0,<5.0",


### PR DESCRIPTION
Now that Wagtail is tested against Django 5.x, we can loosen the dependency on it.

This will allow easier testing against Django 5 with the latest development status of Wagtail.

See #10995 