### PR TITLE
Use `ignore_conflicts` when inserting references

### DIFF
--- a/wagtail/models/reference_index.py
+++ b/wagtail/models/reference_index.py
@@ -457,12 +457,9 @@ class ReferenceIndex(models.Model):
         # already present in the database
         new_references = references - set(existing_references.keys())
 
-        # ignore_conflicts is not available on MSSQL server
-        # refs https://github.com/wagtail/wagtail/pull/11025#issuecomment-1755253875
-        if connection.vendor == "microsoft":
-            bulk_create_kwargs = {}
-        else:
-            bulk_create_kwargs = {"ignore_conflicts": True}
+        bulk_create_kwargs = {}
+        if connection.features.supports_ignore_conflicts:
+            bulk_create_kwargs["ignore_conflicts"] = True
 
         # Create database records for those reference records
         cls.objects.bulk_create(

--- a/wagtail/models/reference_index.py
+++ b/wagtail/models/reference_index.py
@@ -470,7 +470,8 @@ class ReferenceIndex(models.Model):
                     content_path_hash=cls._get_content_path_hash(content_path),
                 )
                 for to_content_type_id, to_object_id, model_path, content_path in new_references
-            ]
+            ],
+            ignore_conflicts=True,
         )
 
         # Delete removed references


### PR DESCRIPTION
This PR fixes a race condition which can occur when inserting into the `ReferenceIndex`.

`create_or_update_for_object()` attempts to do this safely and the docs say

> This method must be called within a `django.db.transaction.atomic()` block.

but fundamentally, it is still possible to race it.

We run a select here
https://github.com/wagtail/wagtail/blob/953c980976231d6d2e1d26a58595710dcf10cc71/wagtail/models/reference_index.py#L439-L454

The we use that to determine what we're going to insert and do a `bulk_create` here:

https://github.com/wagtail/wagtail/blob/953c980976231d6d2e1d26a58595710dcf10cc71/wagtail/models/reference_index.py#L460-L474

If some other process inserts a record with the same `(base_content_type_id, object_id, to_content_type_id, to_object_id, content_path_hash)` as one of the records we plan to insert inbetween us doing that select and attempting the insert, we will throw an error like

```
IntegrityError

duplicate key value violates unique constraint "wagtailcore_referenceind_base_content_type_id_obj_9e6ccd6a_uniq"
DETAIL:  Key (base_content_type_id, object_id, to_content_type_id, to_object_id, content_path_hash)=(125, 850, 133, 4, 8d8f00fb-91d7-5c14-a491-1624ddbe1421) already exists.
```

`transaction.atomic()` won't save us from this.

This is quite hard to write a test case for as it is a concurrency problem.

My proposed solution is to use `ignore_conflicts=True`. I think based on my (rapidly acquired) understanding of the `ReferenceIndex` this should not actually cause data loss as two `ReferenceIndex` objects with the same `(base_content_type_id, object_id, to_content_type_id, to_object_id, content_path_hash)` would implicitly have the same other fields anyway?

The other options I considered were:

- `update_conflicts`: I discounted this because it is available in Django 4.1+ and django down to 3.2 will still be supported in Wagtail 5.2. `ignore_conflicts` is available in django 3.2
- Completely locking the `ReferenceIndex` table and disallowing dirty reads while `create_or_update_for_object()` is running. This would introduce an unacceptable performance bottleneck IMO. A fairly large subset of write operations are going to call this function.

Also, as I say, I _think_ `ignore_conflicts` will serve our needs in this case anyway.

It is worth noting that `ignore_conflicts` has some MySQL/MariaDB-specific notes in https://docs.djangoproject.com/en/3.2/ref/models/querysets/#bulk-create


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

Basically you need to kick off a bunch of requests that all want to insert the same object into the reference index at the same time. In our application, this manifests when the frontend launches multiple POST requests to different API endpoints in a `Promise.all()`. That would probably be the easiest way to construct a toy repro.