### PR TITLE
Universal listings - Pagination / search-whole-site toggle in table header

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -63,7 +63,7 @@ ul.listing {
       border: 0;
     }
 
-    th a {
+    th a.label {
       text-decoration: none;
       color: inherit;
       position: relative;

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
@@ -1,0 +1,7 @@
+{% extends "wagtailadmin/tables/column_header.html" %}
+
+{% block after_label %}
+    {% if page_obj %}
+        {{ page_obj.start_index }}-{{ page_obj.end_index }} of {{ page_obj.paginator.count }}
+    {% endif %}
+{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
@@ -1,15 +1,30 @@
 {% extends "wagtailadmin/tables/column_header.html" %}
-{% load wagtailadmin_tags %}
+{% load wagtailadmin_tags i18n %}
 
 {% block after_label %}
     {% if page_obj %}
-        {{ page_obj.start_index }}-{{ page_obj.end_index }} of {{ page_obj.paginator.count }}
-        {% if is_searching %}
-            {% if is_searching_whole_tree %}
-                across entire site. <a href="{{ table.base_url }}{% querystring p=None search_all=None %}">Search within '{{ parent_page.get_admin_display_title }}'</a>
+        {% with start_index=page_obj.start_index end_index=page_obj.end_index result_count=page_obj.paginator.count %}
+            {% if is_searching %}
+                {% if is_searching_whole_tree %}
+                    {% blocktranslate trimmed %}
+                        {{ start_index }}-{{ end_index }} of {{ result_count }} across entire site.
+                    {% endblocktranslate %}
+                    <a href="{{ table.base_url }}{% querystring p=None search_all=None %}">
+                        {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}Search within '{{ title }}'{% endblocktranslate %}
+                    </a>
+                {% else %}
+                    {% blocktrans trimmed with title=parent_page.get_admin_display_title %}
+                        {{ start_index }}-{{ end_index }} of {{ result_count }} within '{{ title }}'.
+                    {% endblocktrans %}
+                    <a href="{{ table.base_url }}{% querystring p=None search_all=1 %}">
+                        {% translate "Search the whole site" %}
+                    </a>
+                {% endif %}
             {% else %}
-                within '{{ parent_page.get_admin_display_title }}'. <a href="{{ table.base_url }}{% querystring p=None search_all=1 %}">Search the whole site</a>
+                {% blocktrans trimmed %}
+                    {{ start_index }}-{{ end_index }} of {{ result_count }}
+                {% endblocktrans %}
             {% endif %}
-        {% endif %}
+        {% endwith %}
     {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
@@ -1,7 +1,15 @@
 {% extends "wagtailadmin/tables/column_header.html" %}
+{% load wagtailadmin_tags %}
 
 {% block after_label %}
     {% if page_obj %}
         {{ page_obj.start_index }}-{{ page_obj.end_index }} of {{ page_obj.paginator.count }}
+        {% if is_searching %}
+            {% if is_searching_whole_tree %}
+                across entire site. <a href="{{ table.base_url }}{% querystring p=None search_all=None %}">Search within '{{ parent_page.get_admin_display_title }}'</a>
+            {% else %}
+                within '{{ parent_page.get_admin_display_title }}'. <a href="{{ table.base_url }}{% querystring p=None search_all=1 %}">Search the whole site</a>
+            {% endif %}
+        {% endif %}
     {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/tables/column_header.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/column_header.html
@@ -2,15 +2,15 @@
 <th {% if column.classname %}class="{{ column.classname }}"{% endif %}>
     {% if is_orderable %}
         {% if is_ascending %}
-            <a href="{{ table.base_url }}{% querystring p=None ordering='-'|add:column.sort_key %}" {% if descending_title_text %}title="{{ descending_title_text }}"{% endif %} class="icon icon-arrow-up-after teal">
+            <a href="{{ table.base_url }}{% querystring p=None ordering='-'|add:column.sort_key %}" {% if descending_title_text %}title="{{ descending_title_text }}"{% endif %} class="icon icon-arrow-up-after teal label">
                 {{ column.label }}
             </a>
         {% elif is_descending %}
-            <a href="{{ table.base_url }}{% querystring p=None ordering=column.sort_key %}" {% if ascending_title_text %}title="{{ ascending_title_text }}"{% endif %} class="icon icon-arrow-down-after teal">
+            <a href="{{ table.base_url }}{% querystring p=None ordering=column.sort_key %}" {% if ascending_title_text %}title="{{ ascending_title_text }}"{% endif %} class="icon icon-arrow-down-after teal label">
                 {{ column.label }}
             </a>
         {% else %}
-            <a href="{{ table.base_url }}{% querystring p=None ordering=column.sort_key %}" {% if ascending_title_text %}title="{{ ascending_title_text }}"{% endif %} class="icon icon-arrow-down-after">
+            <a href="{{ table.base_url }}{% querystring p=None ordering=column.sort_key %}" {% if ascending_title_text %}title="{{ ascending_title_text }}"{% endif %} class="icon icon-arrow-down-after label">
                 {{ column.label }}
             </a>
         {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/tables/column_header.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/column_header.html
@@ -17,4 +17,5 @@
     {% else %}
         {{ column.label }}
     {% endif %}
+    {% block after_label %}{% endblock %}
 </th>

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -59,6 +59,7 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertEqual(
             page_ids, [self.new_page.id, self.old_page.id, self.child_page.id]
         )
+        self.assertContains(response, "1-3 of 3")
 
     def test_explore_root(self):
         response = self.client.get(reverse("wagtailadmin_explore_root"))
@@ -250,6 +251,7 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
 
         # Check that we got the correct page
         self.assertEqual(response.context["page_obj"].number, 2)
+        self.assertContains(response, "51-100 of 153")
 
     def test_pagination_invalid(self):
         self.make_pages()
@@ -412,6 +414,7 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
 
         page_ids = [page.id for page in response.context["pages"]]
         self.assertEqual(page_ids, [self.old_page.id])
+        self.assertContains(response, "1-1 of 1")
 
     def test_search_searches_descendants(self):
         response = self.client.get(reverse("wagtailadmin_explore_root"), {"q": "old"})

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -403,6 +403,7 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
 
         page_ids = [page.id for page in response.context["pages"]]
         self.assertEqual(page_ids, [self.old_page.id])
+        self.assertContains(response, "Search the whole site")
 
     def test_search_results(self):
         response = self.client.get(
@@ -430,6 +431,16 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
         page_ids = [page.id for page in response.context["pages"]]
         self.assertEqual(page_ids, [])
+
+    def test_search_whole_tree(self):
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=(self.new_page.id,)),
+            {"q": "old", "search_all": "1"},
+        )
+        self.assertEqual(response.status_code, 200)
+        page_ids = [page.id for page in response.context["pages"]]
+        self.assertEqual(page_ids, [self.old_page.id])
+        self.assertContains(response, "Search within 'New page (simple page)'")
 
 
 class TestBreadcrumb(WagtailTestUtils, TestCase):

--- a/wagtail/admin/ui/tables/pages.py
+++ b/wagtail/admin/ui/tables/pages.py
@@ -12,6 +12,11 @@ class PageTitleColumn(BaseColumn):
     def get_header_context_data(self, parent_context):
         context = super().get_header_context_data(parent_context)
         context["page_obj"] = parent_context.get("page_obj")
+        context["parent_page"] = parent_context.get("parent_page")
+        context["is_searching"] = parent_context.get("is_searching")
+        context["is_searching_whole_tree"] = parent_context.get(
+            "is_searching_whole_tree"
+        )
         return context
 
     def get_cell_context_data(self, instance, parent_context):
@@ -139,4 +144,9 @@ class PageTable(Table):
         context["show_locale_labels"] = self.show_locale_labels
         context["perms"] = parent_context.get("perms")
         context["page_obj"] = parent_context.get("page_obj")
+        context["parent_page"] = parent_context.get("parent_page")
+        context["is_searching"] = parent_context.get("is_searching")
+        context["is_searching_whole_tree"] = parent_context.get(
+            "is_searching_whole_tree"
+        )
         return context

--- a/wagtail/admin/ui/tables/pages.py
+++ b/wagtail/admin/ui/tables/pages.py
@@ -5,8 +5,14 @@ from wagtail.admin.ui.tables import BaseColumn, BulkActionsCheckboxColumn, Colum
 
 
 class PageTitleColumn(BaseColumn):
+    header_template_name = "wagtailadmin/pages/listing/_page_title_column_header.html"
     cell_template_name = "wagtailadmin/pages/listing/_page_title_cell.html"
     classname = "title"
+
+    def get_header_context_data(self, parent_context):
+        context = super().get_header_context_data(parent_context)
+        context["page_obj"] = parent_context.get("page_obj")
+        return context
 
     def get_cell_context_data(self, instance, parent_context):
         context = super().get_cell_context_data(instance, parent_context)
@@ -132,4 +138,5 @@ class PageTable(Table):
         context = super().get_context_data(parent_context)
         context["show_locale_labels"] = self.show_locale_labels
         context["perms"] = parent_context.get("perms")
+        context["page_obj"] = parent_context.get("page_obj")
         return context

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -437,13 +437,13 @@ class TestListViewOrdering(WagtailTestUtils, TestCase):
         # The Updated column header should be a link with the correct query param
         self.assertContains(
             response,
-            f'<th><a href="{sort_updated_url}" title="Sort by &#x27;Updated&#x27; in ascending order." class="icon icon-arrow-down-after">Updated</a></th>',
+            f'<th><a href="{sort_updated_url}" title="Sort by &#x27;Updated&#x27; in ascending order." class="icon icon-arrow-down-after label">Updated</a></th>',
             html=True,
         )
         # Should not contain the Status column header
         self.assertNotContains(
             response,
-            f'<th><a href="{sort_live_url}" title="Sort by &#x27;Status&#x27; in ascending order." class="icon icon-arrow-down-after">Status</a></th>',
+            f'<th><a href="{sort_live_url}" title="Sort by &#x27;Status&#x27; in ascending order." class="icon icon-arrow-down-after label">Status</a></th>',
             html=True,
         )
 
@@ -459,13 +459,13 @@ class TestListViewOrdering(WagtailTestUtils, TestCase):
         # The Updated column header should be a link with the correct query param
         self.assertContains(
             response,
-            f'<th><a href="{sort_updated_url}" title="Sort by &#x27;Updated&#x27; in ascending order." class="icon icon-arrow-down-after">Updated</a></th>',
+            f'<th><a href="{sort_updated_url}" title="Sort by &#x27;Updated&#x27; in ascending order." class="icon icon-arrow-down-after label">Updated</a></th>',
             html=True,
         )
         # The Status column header should be a link with the correct query param
         self.assertContains(
             response,
-            f'<th><a href="{sort_live_url}" title="Sort by &#x27;Status&#x27; in ascending order." class="icon icon-arrow-down-after">Status</a></th>',
+            f'<th><a href="{sort_live_url}" title="Sort by &#x27;Status&#x27; in ascending order." class="icon icon-arrow-down-after label">Status</a></th>',
             html=True,
         )
 


### PR DESCRIPTION
Add pagination details and toggle between searching the current section and the whole site, to the table header.

~Incorporates #11027~

![Screenshot 2023-10-11 at 15 46 02](https://github.com/wagtail/wagtail/assets/85097/784c4e22-b5d2-4dae-b357-efbf1877c5fc)
