### PR TITLE
Refactoring wagtail.contrib.redirects.views into a class based views

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -98,6 +98,10 @@ Changelog
  * Maintenance: Add changelog and issue tracker links to the PyPI project page (Panagiotis H.M. Issaris)
  * Maintenance: Add better deprecation warnings to the `search.Query` & `search.QueryDailyHits` model, move final set of templates from the admin search module to the search promotions contrib module (LB (Ben) Johnston)
  * Maintenance: Add generic `InspectView` to `ModelViewSet` (Sage Abdullah)
+ * Maintenance: Adopt `wagtail.admin.views.generic.IndexView` for Redirects index listing and search results (Temidayo Azeez)
+ * Maintenance: Adopt  `wagtail.views.generic.EditView for Redirects Edit View` (Temidayo Azeez)
+ *Maintenance: Adopt `wagtail.admin.views.generic.CreateView` for Redirects Create view (Temidayo Azeez)
+ * Maintenance: Adopt `wagtail.admin.views.generic.DeleteView` for Redirects Delete View (Temidayo Azeez)
 
 5.1.3 (xx.xx.20xx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -98,10 +98,6 @@ Changelog
  * Maintenance: Add changelog and issue tracker links to the PyPI project page (Panagiotis H.M. Issaris)
  * Maintenance: Add better deprecation warnings to the `search.Query` & `search.QueryDailyHits` model, move final set of templates from the admin search module to the search promotions contrib module (LB (Ben) Johnston)
  * Maintenance: Add generic `InspectView` to `ModelViewSet` (Sage Abdullah)
- * Maintenance: Adopt `wagtail.admin.views.generic.IndexView` for Redirects index listing and search results (Temidayo Azeez)
- * Maintenance: Adopt  `wagtail.views.generic.EditView for Redirects Edit View` (Temidayo Azeez)
- *Maintenance: Adopt `wagtail.admin.views.generic.CreateView` for Redirects Create view (Temidayo Azeez)
- * Maintenance: Adopt `wagtail.admin.views.generic.DeleteView` for Redirects Delete View (Temidayo Azeez)
 
 5.1.3 (xx.xx.20xx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~~~

--- a/wagtail/contrib/redirects/templates/wagtailredirects/confirm_delete.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/confirm_delete.html
@@ -7,7 +7,7 @@
 
     <div class="row row-flush nice-padding">
         <p>{% trans "Are you sure you want to delete this redirect?" %}</p>
-        <form action="{% url 'wagtailredirects:delete' redirect.id %}" method="POST">
+        <form action="{% url 'wagtailredirects:delete' redirect.pk %}" method="POST">
             {% csrf_token %}
             <input type="submit" value="{% trans 'Yes, delete' %}" class="button serious" />
         </form>

--- a/wagtail/contrib/redirects/templates/wagtailredirects/edit.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/edit.html
@@ -7,7 +7,7 @@
 
     {% include "wagtailadmin/shared/non_field_errors.html" %}
 
-    <form action="{% url 'wagtailredirects:edit' redirect.id %}" method="POST" class="nice-padding" novalidate>
+    <form action="{% url 'wagtailredirects:edit' redirect.pk %}" method="POST" class="nice-padding" novalidate>
         {% csrf_token %}
 
         <ul class="fields">

--- a/wagtail/contrib/redirects/templates/wagtailredirects/edit.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/edit.html
@@ -19,7 +19,7 @@
 
             <li>
                 <input type="submit" value="{% trans 'Save' %}" class="button" />
-                {% if user_can_delete %}
+                {% if can_delete %}
                     <a href="{% url 'wagtailredirects:delete' redirect.id %}" class="button no">{% trans "Delete redirect" %}</a>
                 {% endif %}
             </li>

--- a/wagtail/contrib/redirects/templates/wagtailredirects/index.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/index.html
@@ -1,10 +1,10 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 {% load i18n %}
 {% load static wagtailadmin_tags %}
 
 {% block bodyclass %}redirects{% endblock %}
 
-{% block titletag %}{% trans "Redirects" %}{% endblock %}
+<!-- {% block titletag %}{% trans "Redirects" %}{% endblock %} -->
 
 {% block content %}
     {% trans "Redirects" as redirects_str %}

--- a/wagtail/contrib/redirects/templates/wagtailredirects/index.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/index.html
@@ -7,7 +7,7 @@
 {% block content %}
     {% trans "Redirects" as redirects_str %}
     {% url 'wagtailredirects:index' as search_results_url %}
-    {% if user_can_add %}
+    {% if can_add %}
         {% url "wagtailredirects:add" as add_link %}
         {% trans "Add redirect" as add_str %}
         {% url "wagtailredirects:start_import" as import_link %}

--- a/wagtail/contrib/redirects/templates/wagtailredirects/index.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/index.html
@@ -4,8 +4,6 @@
 
 {% block bodyclass %}redirects{% endblock %}
 
-<!-- {% block titletag %}{% trans "Redirects" %}{% endblock %} -->
-
 {% block content %}
     {% trans "Redirects" as redirects_str %}
     {% url 'wagtailredirects:index' as search_results_url %}

--- a/wagtail/contrib/redirects/templates/wagtailredirects/results.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/results.html
@@ -2,7 +2,7 @@
 {% if redirects %}
     {% if query_string %}
         <h2 role="alert">
-            {% blocktrans trimmed count counter=redirects.paginator.count %}
+            {% blocktrans trimmed count counter=redirects.count %}
                 There is {{ counter }} match
             {% plural %}
                 There are {{ counter }} matches

--- a/wagtail/contrib/redirects/templates/wagtailredirects/results.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/results.html
@@ -2,7 +2,7 @@
 {% if redirects %}
     {% if query_string %}
         <h2 role="alert">
-            {% blocktrans trimmed count counter=redirects.count %}
+            {% blocktrans trimmed count counter=redirects|length %}
                 There is {{ counter }} match
             {% plural %}
                 There are {{ counter }} matches
@@ -12,7 +12,7 @@
 
     {% include "wagtailredirects/list.html" %}
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=redirects linkurl="wagtailredirects:index" %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj linkurl="wagtailredirects:index" %}
 {% else %}
     {% if query_string %}
         <p role="alert">{% blocktrans trimmed %}Sorry, no redirects match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -581,7 +581,7 @@ class TestRedirectsIndexView(WagtailTestUtils, TestCase):
     def test_simple(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailadmin/generic/index.html")
+        self.assertTemplateUsed(response, "wagtailredirects/index.html")
 
     def test_search(self):
         response = self.get({"q": "Hello"})

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -581,7 +581,7 @@ class TestRedirectsIndexView(WagtailTestUtils, TestCase):
     def test_simple(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailredirects/index.html")
+        self.assertTemplateUsed(response, "wagtailadmin/generic/index.html")
 
     def test_search(self):
         response = self.get({"q": "Hello"})
@@ -618,8 +618,8 @@ class TestRedirectsIndexView(WagtailTestUtils, TestCase):
 
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        last_index = len(response.context["redirects"]) - 1
-        self.assertEqual(response.context["redirects"][last_index].old_path, "/aaargh")
+        first_index = 0
+        self.assertEqual(response.context["redirects"][first_index].old_path, "/aaargh")
 
 
 class TestRedirectsAddView(WagtailTestUtils, TestCase):
@@ -799,7 +799,7 @@ class TestRedirectsEditView(WagtailTestUtils, TestCase):
     def test_simple(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailredirects/edit.html")
+        self.assertTemplateUsed(response, "wagtailadmin/generic/edit.html")
 
         url_finder = AdminURLFinder(self.user)
         expected_url = "/admin/redirects/%d/" % self.redirect.id
@@ -907,7 +907,7 @@ class TestRedirectsDeleteView(WagtailTestUtils, TestCase):
     def test_simple(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailredirects/confirm_delete.html")
+        self.assertTemplateUsed(response, "wagtailadmin/generic/confirm_delete.html")
 
     def test_nonexistant_redirect(self):
         self.assertEqual(self.get(redirect_id=100000).status_code, 404)

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -618,7 +618,8 @@ class TestRedirectsIndexView(WagtailTestUtils, TestCase):
 
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["redirects"][0].old_path, "/aaargh")
+        last_index = len(response.context["redirects"]) - 1
+        self.assertEqual(response.context["redirects"][last_index].old_path, "/aaargh")
 
 
 class TestRedirectsAddView(WagtailTestUtils, TestCase):

--- a/wagtail/contrib/redirects/urls.py
+++ b/wagtail/contrib/redirects/urls.py
@@ -4,7 +4,8 @@ from wagtail.contrib.redirects import views
 
 app_name = "wagtailredirects"
 urlpatterns = [
-    path("", views.index, name="index"),
+    path("", views.Index.as_view(), name="index"),
+    path("results/", views.Index.as_view(results_only=True), name="index_results"),
     path("add/", views.add, name="add"),
     path("<int:redirect_id>/", views.edit, name="edit"),
     path("<int:redirect_id>/delete/", views.delete, name="delete"),

--- a/wagtail/contrib/redirects/urls.py
+++ b/wagtail/contrib/redirects/urls.py
@@ -6,9 +6,9 @@ app_name = "wagtailredirects"
 urlpatterns = [
     path("", views.Index.as_view(), name="index"),
     path("results/", views.Index.as_view(results_only=True), name="index_results"),
-    path("add/", views.add, name="add"),
-    path("<int:redirect_id>/", views.edit, name="edit"),
-    path("<int:redirect_id>/delete/", views.delete, name="delete"),
+    path("add/", views.Create.as_view(), name="add"),
+    path("<int:pk>/", views.Edit.as_view(), name="edit"),
+    path("<int:pk>/delete/", views.Delete.as_view(), name="delete"),
     path("import/", views.start_import, name="start_import"),
     path("import/process/", views.process_import, name="process_import"),
     path("report", views.RedirectsReportView.as_view(), name="report"),

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -42,6 +42,7 @@ class Index(IndexView):
     Lists all redirects for management within the admin.
     """
 
+    template_name = "wagtailredirects/index.html"
     results_template_name = "wagtailredirects/results.html"
     any_permission_required = ["add", "change", "delete"]
     permission_policy = permission_policy

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -33,7 +33,6 @@ from wagtail.contrib.redirects.utils import (
     write_to_file_storage,
 )
 from wagtail.log_actions import log
-from wagtail.permission_policies import ModelPermissionPolicy
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 
@@ -45,7 +44,7 @@ class Index(IndexView):
 
     results_template_name = "wagtailredirects/results.html"
     any_permission_required = ["add", "change", "delete"]
-    permission_policy = ModelPermissionPolicy(Redirect)
+    permission_policy = permission_policy
     model = Redirect
     header_icon = "redirects"
     add_item_label = _("Add redirect")
@@ -104,7 +103,7 @@ class Edit(EditView):
     """
 
     model = Redirect
-    permission_policy = ModelPermissionPolicy(Redirect)
+    permission_policy = permission_policy
     form_class = RedirectForm
     header_icon = "redirects"
     index_url_name = "wagtailredirects:index"
@@ -129,7 +128,7 @@ class Delete(DeleteView):
     Provide the ability to delete a redirect within the admin
     """
 
-    permission_policy = ModelPermissionPolicy(Redirect)
+    permission_policy = permission_policy
     model = Redirect
     index_url_name = "wagtailredirects:index"
     edit_url_name = "wagtailredirects:edit"
@@ -149,7 +148,7 @@ class Create(CreateView):
     Provide the ability to create a redirect within the admin
     """
 
-    permission_policy = ModelPermissionPolicy(Redirect)
+    permission_policy = permission_policy
     permission_required = "add"
     model = Redirect
     form_class = RedirectForm

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -160,7 +160,7 @@ class Create(CreateView):
     header_icon = "redirect"
     page_title = gettext_lazy("Add redirect")
     success_message = gettext_lazy("Redirect '%(object)s' created.")
-    error_message = "The redirect could not be created due to errors."
+    error_message = gettext_lazy("The redirect could not be created due to errors.")
 
 
 @permission_checker.require_any("add")

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -43,7 +43,6 @@ class Index(IndexView):
     Lists all redirects for management within the admin.
     """
 
-    template_name = "wagtailredirects/index.html"
     results_template_name = "wagtailredirects/results.html"
     any_permission_required = ["add", "change", "delete"]
     permission_policy = ModelPermissionPolicy(Redirect)
@@ -95,8 +94,7 @@ class Index(IndexView):
         )
 
         context_data["ordering"] = self.default_ordering
-        context_data["redirects"] = self.redirects
-
+        context_data["redirects"] = self.get_queryset()
         return context_data
 
 
@@ -109,7 +107,6 @@ class Edit(EditView):
     permission_policy = ModelPermissionPolicy(Redirect)
     form_class = RedirectForm
     header_icon = "redirects"
-    template_name = "wagtailredirects/edit.html"
     index_url_name = "wagtailredirects:index"
     edit_url_name = "wagtailredirects:edit"
     delete_url_name = "wagtailredirects:delete"
@@ -134,7 +131,6 @@ class Delete(DeleteView):
 
     permission_policy = ModelPermissionPolicy(Redirect)
     model = Redirect
-    template_name = "wagtailredirects/confirm_delete.html"
     index_url_name = "wagtailredirects:index"
     edit_url_name = "wagtailredirects:edit"
     delete_url_name = "wagtailredirects:delete"


### PR DESCRIPTION
This pull request references issue #8365. This addresses the `wagtail/contrib/redirects/views.py`.  The following `views` were refactored:
- `wagtail/contrib/redirects/view.Index`
- `wagtail/contrib/redirects/view.Edit`
- `wagtail/contrib/redirects/view.Delete`
- `wagtail/contrib/redirects/view.Create`
