### PR TITLE
Reinstate page type filter on page search view

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/search_results.html
@@ -11,7 +11,7 @@
 
         {% search_other %}
 
-        {% if pages.object_list.supports_facet %}
+        {% if object_list.supports_facet %}
             <nav class="listing-filter" aria-labelledby="page-types-title">
                 <h3 id="page-types-title" class="filter-title">{% trans "Page types" %}</h3>
                 <ul class="filter-options">


### PR DESCRIPTION
This was inadvertently dropped in 71b9fb13b93184882a82160050cccf8894ee8bb6 because the context variables in Django's ListView differ from the ones previously used by Wagtail, and the relevant test `pages.object_list.supports_facet` around the filter bar was not updated.

(This wasn't caught by CI because the tests run against the fallback database backend, which doesn't support faceting and so intentionally omits this block :-( )