### PR TITLE
Documentation - fix broken refs & pygments formats

### DIFF
--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -178,7 +178,7 @@ python manage.py migrate
 
 You must run the preceding commands each time you make changes to the model definition. Here is the expected output from the terminal:
 
-```txt
+```text
 Migrations for 'home':
   home/migrations/0003_homepage_body.py
     - Add field body to homepage

--- a/docs/releases/2.13.rst
+++ b/docs/releases/2.13.rst
@@ -110,7 +110,7 @@ Wagtail 2.13 will be the last Wagtail release to support IE11. Users accessing t
 Updated handling of non-required StreamFields
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The rules for determining whether a StreamField is required (i.e. at least one block must be provided) have been simplified and made consistent with other field types. Non-required fields are now indicated by ``blank=True`` on the ``StreamField`` definition; the default is ``blank=False`` (the field is required). In previous versions, to make a field non-required, it was necessary to define a top-level `StreamBlock<wagtail.blocks.StreamBlock>` with ``required=False`` (which applied the validation rule) as well as setting ``blank=True`` (which removed the asterisk from the form field). You should review your use of StreamField to check that ``blank=True`` is used on the fields you wish to make optional.
+The rules for determining whether a StreamField is required (i.e. at least one block must be provided) have been simplified and made consistent with other field types. Non-required fields are now indicated by ``blank=True`` on the ``StreamField`` definition; the default is ``blank=False`` (the field is required). In previous versions, to make a field non-required, it was necessary to define a top-level ``StreamBlock`` with ``required=False`` (which applied the validation rule) as well as setting ``blank=True`` (which removed the asterisk from the form field). You should review your use of StreamField to check that ``blank=True`` is used on the fields you wish to make optional.
 
 
 New client-side implementation for custom StreamField blocks

--- a/docs/releases/2.13.rst
+++ b/docs/releases/2.13.rst
@@ -110,7 +110,7 @@ Wagtail 2.13 will be the last Wagtail release to support IE11. Users accessing t
 Updated handling of non-required StreamFields
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The rules for determining whether a StreamField is required (i.e. at least one block must be provided) have been simplified and made consistent with other field types. Non-required fields are now indicated by ``blank=True`` on the ``StreamField`` definition; the default is ``blank=False`` (the field is required). In previous versions, to make a field non-required, it was necessary to define :ref:`a top-level StreamBlock<wagtail.blocks.StreamBlock>` with ``required=False`` (which applied the validation rule) as well as setting ``blank=True`` (which removed the asterisk from the form field). You should review your use of StreamField to check that ``blank=True`` is used on the fields you wish to make optional.
+The rules for determining whether a StreamField is required (i.e. at least one block must be provided) have been simplified and made consistent with other field types. Non-required fields are now indicated by ``blank=True`` on the ``StreamField`` definition; the default is ``blank=False`` (the field is required). In previous versions, to make a field non-required, it was necessary to define a top-level `StreamBlock<wagtail.blocks.StreamBlock>` with ``required=False`` (which applied the validation rule) as well as setting ``blank=True`` (which removed the asterisk from the form field). You should review your use of StreamField to check that ``blank=True`` is used on the fields you wish to make optional.
 
 
 New client-side implementation for custom StreamField blocks


### PR DESCRIPTION
Fixes the following errors when build the documentation
- .../docs/getting_started/tutorial.md:181: WARNING: Pygments lexer name 'txt' is not known (should be `text` not `txt`)
- .../docs/releases/2.13.rst:113: WARNING: undefined label: 'wagtail.blocks.streamblock' (old ref in old docs, just removing)

There are a few more issues I am not sure how to fix https://github.com/wagtail/wagtail/issues/9778#issuecomment-1760991382