### PR TITLE
Display proper restriction message when switched to public

### DIFF
--- a/wagtail/admin/tests/test_audit_log.py
+++ b/wagtail/admin/tests/test_audit_log.py
@@ -92,7 +92,6 @@ class TestAuditLogAdmin(WagtailTestUtils, TestCase):
         self.assertContains(response, "Unlocked", 1)
         self.assertContains(response, "Page scheduled for publishing", 1)
         self.assertContains(response, "Published", 1)
-        self.assertContains(response, "The page is public.", 1)
 
         self.assertContains(
             response,

--- a/wagtail/admin/tests/test_audit_log.py
+++ b/wagtail/admin/tests/test_audit_log.py
@@ -92,6 +92,7 @@ class TestAuditLogAdmin(WagtailTestUtils, TestCase):
         self.assertContains(response, "Unlocked", 1)
         self.assertContains(response, "Page scheduled for publishing", 1)
         self.assertContains(response, "Published", 1)
+        self.assertContains(response, "The page is public.", 1)
 
         self.assertContains(
             response,

--- a/wagtail/admin/tests/test_privacy.py
+++ b/wagtail/admin/tests/test_privacy.py
@@ -197,7 +197,9 @@ class TestSetPrivacyView(WagtailTestUtils, TestCase):
             PageViewRestriction.objects.filter(page=self.private_page).exists()
         )
 
-        history_url = reverse("wagtailadmin_pages:history", kwargs={"page_id": self.private_page.id})
+        history_url = reverse(
+            "wagtailadmin_pages:history", kwargs={"page_id": self.private_page.id}
+        )
         history_response = self.client.get(history_url)
 
         # Check that the expected log message is present

--- a/wagtail/admin/tests/test_privacy.py
+++ b/wagtail/admin/tests/test_privacy.py
@@ -197,6 +197,16 @@ class TestSetPrivacyView(WagtailTestUtils, TestCase):
             PageViewRestriction.objects.filter(page=self.private_page).exists()
         )
 
+        history_url = reverse("wagtailadmin_pages:history", kwargs={"page_id": self.private_page.id})
+        history_response = self.client.get(history_url)
+
+        # Check that the expected log message is present
+        expected_log_message = "Removed the &#x27;Private, accessible with the following password&#x27; view restriction. The page is public."
+        self.assertContains(
+            history_response,
+            expected_log_message,
+        )
+
     def test_get_private_groups(self):
         """
         This tests that the restriction type and group fields as set correctly when a user opens the set_privacy view on a public page

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -3493,7 +3493,7 @@ class PageViewRestriction(BaseViewRestriction):
         specific_instance = self.page.specific
         if specific_instance:
             removed_restriction_type = PageViewRestriction.objects.filter(
-                page=self.page
+                id=self.id
             ).values_list("restriction_type", flat=True)[0]
             log(
                 instance=specific_instance,

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -3489,10 +3489,13 @@ class PageViewRestriction(BaseViewRestriction):
         """
         Custom delete handler to aid in logging
         :param user: the user removing the view restriction
-        :param specific_instance: the specific model instance the restriction applies to
         """
         specific_instance = self.page.specific
         if specific_instance:
+            removed_restriction_type = (
+                PageViewRestriction.objects.filter(page=self.page)
+                .values_list('restriction_type', flat=True)[0]
+            )
             log(
                 instance=specific_instance,
                 action="wagtail.view_restriction.delete",
@@ -3501,7 +3504,7 @@ class PageViewRestriction(BaseViewRestriction):
                     "restriction": {
                         "type": self.restriction_type,
                         "title": force_str(
-                            dict(self.RESTRICTION_CHOICES).get(self.restriction_type)
+                            dict(self.RESTRICTION_CHOICES).get(removed_restriction_type)
                         ),
                     }
                 },

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -3492,10 +3492,7 @@ class PageViewRestriction(BaseViewRestriction):
         """
         specific_instance = self.page.specific
         if specific_instance:
-            removed_restriction_type = (
-                PageViewRestriction.objects.filter(page=self.page)
-                .values_list('restriction_type', flat=True)[0]
-            )
+            removed_restriction_type = (PageViewRestriction.objects.filter(page=self.page).values_list('restriction_type', flat=True)[0])
             log(
                 instance=specific_instance,
                 action="wagtail.view_restriction.delete",

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -3492,7 +3492,9 @@ class PageViewRestriction(BaseViewRestriction):
         """
         specific_instance = self.page.specific
         if specific_instance:
-            removed_restriction_type = (PageViewRestriction.objects.filter(page=self.page).values_list('restriction_type', flat=True)[0])
+            removed_restriction_type = PageViewRestriction.objects.filter(
+                page=self.page
+            ).values_list("restriction_type", flat=True)[0]
             log(
                 instance=specific_instance,
                 action="wagtail.view_restriction.delete",

--- a/wagtail/wagtail_hooks.py
+++ b/wagtail/wagtail_hooks.py
@@ -339,7 +339,7 @@ def register_core_log_actions(actions):
 
         def format_message(self, log_entry):
             try:
-                return _("Removed the '%(restriction)s' view restriction") % {
+                return _("Removed the '%(restriction)s' view restriction. The page is public.") % {
                     "restriction": log_entry.data["restriction"]["title"],
                 }
             except KeyError:

--- a/wagtail/wagtail_hooks.py
+++ b/wagtail/wagtail_hooks.py
@@ -339,7 +339,9 @@ def register_core_log_actions(actions):
 
         def format_message(self, log_entry):
             try:
-                return _("Removed the '%(restriction)s' view restriction. The page is public.") % {
+                return _(
+                    "Removed the '%(restriction)s' view restriction. The page is public."
+                ) % {
                     "restriction": log_entry.data["restriction"]["title"],
                 }
             except KeyError:


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #7567 When changing restrictions, the page and site history do not display proper messages (Specifically when switching to public). I have made some changes following previous suggestions. I have tested the changes locally, and they are working fine. I am also adding a screenshot of the changes.

**Screenshot of changes**

![Add a heading](https://github.com/wagtail/wagtail/assets/111359305/f53ac927-c964-453e-a1f8-a9c9c80588d4)

_Please check the following:_

-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
