### PR TITLE
Set strip=False to LoginForm,UserForm to ensure consistency with Djan…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -76,6 +76,7 @@ Changelog
  * Fix: Fix log message to record the correct restriction type when removing a page view restriction (Rohit Sharma, Hazh. M. Adam)
  * Fix: Avoid potential race condition with new Page subscriptions on the edit view (Alex Tomkins)
  * Fix: Use the correct action log when creating a redirect (Thibaud Colas)
+ * Fix: Ensure that all password fields consistently allow leading & trailing whitespace (Neeraj P Yetheendran)
  * Docs: Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
  * Docs: Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)
  * Docs: Add documentation for building non-model-based choosers using the _queryish_ library (Matt Westcott)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -109,6 +109,7 @@ Thank you to core contributor (LB (Ben) Johnston) for writing this documentation
  * Fix log message to record the correct restriction type when removing a page view restriction (Rohit Sharma, Hazh. M. Adam)
  * Avoid potential race condition with new Page subscriptions on the edit view (Alex Tomkins)
  * Use the correct action log when creating a redirect (Thibaud Colas)
+ * Ensure that all password fields consistently allow leading & trailing whitespace (Neeraj P Yetheendran)
 
 ### Documentation
 

--- a/wagtail/admin/forms/auth.py
+++ b/wagtail/admin/forms/auth.py
@@ -13,7 +13,8 @@ class LoginForm(AuthenticationForm):
             attrs={
                 "placeholder": gettext_lazy("Enter password"),
             }
-        )
+        ),
+        strip=False,
     )
 
     remember = forms.BooleanField(required=False)

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -371,6 +371,22 @@ class TestAccountSection(WagtailTestUtils, TestCase, TestAccountSectionUtilsMixi
         self.user.refresh_from_db()
         self.assertTrue(self.user.check_password("newpassword"))
 
+    def test_change_password_whitespaced(self):
+        response = self.post_form(
+            {
+                "password-old_password": "password",
+                "password-new_password1": "  whitespaced_password  ",
+                "password-new_password2": "  whitespaced_password  ",
+            }
+        )
+
+        # Check that the user was redirected to the account page
+        self.assertRedirects(response, reverse("wagtailadmin_account"))
+
+        # Check that the password was changed and whitespace was not stripped
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("  whitespaced_password  "))
+
     def test_change_password_post_password_mismatch(self):
         response = self.post_form(
             {

--- a/wagtail/admin/tests/test_views.py
+++ b/wagtail/admin/tests/test_views.py
@@ -154,6 +154,29 @@ class TestLoginView(WagtailTestUtils, TestCase):
         self.assertFalse(self.client.session.get_expire_at_browser_close())
         self.assertEqual(self.client.session.get_expiry_age(), 7)
 
+    def test_password_whitespace_not_stripped(self):
+        user_model = get_user_model()
+        # Create a user
+        user_data = {
+            user_model.USERNAME_FIELD: "test2@email.com",
+            "email": "test2@email.com",
+            "password": "  whitespaced_password  ",
+        }
+        for field in user_model.REQUIRED_FIELDS:
+            if field not in user_data:
+                user_data[field] = field
+
+        user_model.objects.create_superuser(**user_data)
+
+        response = self.client.post(
+            reverse("wagtailadmin_login"),
+            {
+                "username": "test2@email.com",
+                "password": "  whitespaced_password  ",
+            },
+        )
+        self.assertRedirects(response, reverse("wagtailadmin_home"))
+
 
 class TestPasswordResetView(TestCase):
     def test_password_reset_view_uses_correct_form(self):

--- a/wagtail/users/forms.py
+++ b/wagtail/users/forms.py
@@ -89,12 +89,14 @@ class UserForm(UsernameForm):
         required=False,
         widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
         help_text=_("Leave blank if not changing."),
+        strip=False,
     )
     password2 = forms.CharField(
         label=_("Password confirmation"),
         required=False,
         widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
         help_text=_("Enter the same password as above, for verification."),
+        strip=False,
     )
 
     is_superuser = forms.BooleanField(

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -364,6 +364,26 @@ class TestUserCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertEqual(users.first().country, "testcountry")
         self.assertEqual(users.first().attachment.read(), b"Uploaded file")
 
+    def test_create_with_whitespaced_password(self):
+        """Password should not be stripped"""
+        self.post(
+            {
+                "username": "testuser2",
+                "email": "test@user2.com",
+                "first_name": "Test",
+                "last_name": "User",
+                "password1": "  whitespaced_password  ",
+                "password2": "  whitespaced_password  ",
+            },
+            follow=True,
+        )
+        # Try to login with the password
+        self.client.logout()
+        username = "testuser2"
+        if settings.AUTH_USER_MODEL == "emailuser.EmailUser":
+            username = "test@user2.com"
+        self.login(username=username, password="  whitespaced_password  ")
+
     def test_create_with_password_mismatch(self):
         response = self.post(
             {


### PR DESCRIPTION
PR resolves #10839. Sets strip=False in LoginForm and UserForm password fields to ensure whitespaces aren't removed and Forms are consistent with Django's practices.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For new features: Has the documentation been updated accordingly?

