### PR TITLE
fix #11048 with word-break property

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -61,6 +61,7 @@ Changelog
  * Fix: Ignore conflicts when inserting reference index entries to prevent race conditions causing uniqueness errors (Chris Shaw)
  * Fix: Populate the correct return value when creating a new snippet within the snippet chooser (claudobahn)
  * Fix: Reinstate missing filter by page type on page search (Matt Westcott)
+ * Fix: Ensure very long words can wrap when viewing saved comments (Chiemezuo Akujobi)
  * Docs: Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
  * Docs: Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)
  * Docs: Add documentation for building non-model-based choosers using the _queryish_ library (Matt Westcott)

--- a/client/src/components/CommentApp/components/Comment/style.scss
+++ b/client/src/components/CommentApp/components/Comment/style.scss
@@ -23,6 +23,7 @@
     margin-bottom: 0;
     padding-top: 10px;
     padding-bottom: 10px;
+    word-break: break-all;
 
     &--mode-deleting {
       color: theme('colors.text-context');

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -76,6 +76,7 @@ depth: 1
  * Ignore conflicts when inserting reference index entries to prevent race conditions causing uniqueness errors (Chris Shaw)
  * Populate the correct return value when creating a new snippet within the snippet chooser (claudobahn)
  * Reinstate missing filter by page type on page search (Matt Westcott)
+ * Ensure very long words can wrap when viewing saved comments (Chiemezuo Akujobi)
 
 ### Documentation
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11048 







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Google Chrome on Windows 10
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)

**Before my fix:**
![image](https://github.com/wagtail/wagtail/assets/29470516/e2f6dc46-e3ac-490e-9fc2-6cf24e74cce1)

**After my fix:**
![image](https://github.com/wagtail/wagtail/assets/29470516/98cea802-90a0-4f99-954b-d476f4f11230)


