### PR TITLE
Avoid using aria-label with different content from visible text for "Forgotten password" link

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -62,6 +62,7 @@ Changelog
  * Fix: Populate the correct return value when creating a new snippet within the snippet chooser (claudobahn)
  * Fix: Reinstate missing filter by page type on page search (Matt Westcott)
  * Fix: Ensure very long words can wrap when viewing saved comments (Chiemezuo Akujobi)
+ * Fix: Avoid forgotten password link text conflicting with the supplied aria-label (Thibaud Colas)
  * Docs: Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
  * Docs: Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)
  * Docs: Add documentation for building non-model-based choosers using the _queryish_ library (Matt Westcott)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -77,6 +77,7 @@ depth: 1
  * Populate the correct return value when creating a new snippet within the snippet chooser (claudobahn)
  * Reinstate missing filter by page type on page search (Matt Westcott)
  * Ensure very long words can wrap when viewing saved comments (Chiemezuo Akujobi)
+ * Avoid forgotten password link text conflicting with the supplied aria-label (Thibaud Colas)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -37,7 +37,7 @@
                     {% field field=form.password %}{% endfield %}
 
                     {% if show_password_reset %}
-                        <a class="reset-password" href="{% url 'wagtailadmin_password_reset' %}" aria-label="{% trans 'Reset your password' %}">{% trans "Forgotten password?" %}</a>
+                        <a class="reset-password" href="{% url 'wagtailadmin_password_reset' %}">{% trans "Forgotten password?" %}</a>
                     {% endif %}
 
                     {% block extra_fields %}


### PR DESCRIPTION
The current pattern is very problematic for users of speech recognition software, who might not be able to use the visible label due to us overriding it. It’s also problematic for sighted screen reader users, who will see a big discrepancy between what the screen reader says and what’s on the screen.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: None
    -   [x] **Please list which assistive technologies [^3] you tested**: None
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

Open the login page in a screen reader or other assistive tech and note which label the link is interactible with.