### PR TITLE
Chore: Typo fixed in multiple files

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -748,6 +748,7 @@
 * Chris Shaw
 * claudobahn
 * Florian Delizy
+* Susheel Thapa
 
 ## Translators
 

--- a/docs/extending/custom_bulk_actions.md
+++ b/docs/extending/custom_bulk_actions.md
@@ -129,7 +129,7 @@ def get_context_data(self, **kwargs):
     return context
 ```
 
-Thes `check_perm` method can be overridden to check if an object has some permission or not. Objects for which the `check_perm` returns `False` will be available in the context under the key `'items_with_no_access'`.
+The `check_perm` method can be overridden to check if an object has some permission or not. Objects for which the `check_perm` returns `False` will be available in the context under the key `'items_with_no_access'`.
 
 ```python
 def check_perm(self, obj):

--- a/docs/releases/1.0.rst
+++ b/docs/releases/1.0.rst
@@ -105,7 +105,7 @@ Admin
 * Removed the need to add permission check on admin views (now automated)
 * Reversing ``django.contrib.auth.admin.login`` will no longer lead to Wagtails login view (making it easier to have frontend login views)
 * Added cache-control headers to all admin views. This allows Varnish/Squid/CDN to run on vanilla settings in front of a Wagtail site
-* Date / time pickers now consistently use times without seconds, to prevent JavasSript behaviour glitches when focusing / unfocusing fields
+* Date / time pickers now consistently use times without seconds, to prevent JavaScript behaviour glitches when focusing / unfocusing fields
 * Added hook ``construct_homepage_summary_items`` for customising the site summary panel on the admin homepage
 * Renamed the ``construct_wagtail_edit_bird`` hook to ``construct_wagtail_userbar``
 * 'static' template tags are now used throughout the admin templates, in place of ``STATIC_URL``

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -23,7 +23,7 @@ As part of a [wider redesign](https://github.com/wagtail/wagtail/discussions/773
 
 Wagtail projects using the `wagtail.contrib.redirects` app now benefit from 'automatic redirect creation' - which creates redirects for pages and their descedants whenever a URL-impacting change is made; such as a slug being changed, or a page being moved to a different part of the tree.
 
-This feature should be benefitial to most 'standard' Wagtail projects and, in most cases, will have only a minor impact on responsiveness when making such changes. However, if you find this feature is not a good fit for your project, you can disabled it by adding the following to your project settings:
+This feature should be beneficial to most 'standard' Wagtail projects and, in most cases, will have only a minor impact on responsiveness when making such changes. However, if you find this feature is not a good fit for your project, you can disabled it by adding the following to your project settings:
 
 ```python
 WAGTAILREDIRECTS_AUTO_CREATE = False

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -408,7 +408,7 @@ Above we have adjusted these attributes to add a 'change' event listener to trig
 
 If you are using the `wagtail.admin.widgets.AdminAutoHeightTextInput` only, this change will have no impact when upgrading. However, if you are relying on the global `autosize` function at `window.autosize` on the client, this will no longer work.
 
-It is recommended that the `AdminAutoHeightTextInput` widget be used instead. You can also adopt the `data-controller` attribute and this will now function as before. Alternativey, you can simply add the required Stimulus data controller attribute as shown below.
+It is recommended that the `AdminAutoHeightTextInput` widget be used instead. You can also adopt the `data-controller` attribute and this will now function as before. Alternatively, you can simply add the required Stimulus data controller attribute as shown below.
 
 **Old syntax**
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

This PR fix the typo in multiple files

```pseudo
Thes > The
JavasSript > JavaScript
benefitial > beneficial
Alternativey > Alternatively
```







_Please check the following:_

-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [X] Run `make lint` from the Wagtail root.
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [X] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [X] **Please list the exact browser and operating system versions you tested**:
    -   [X] **Please list which assistive technologies [^3] you tested**:
-   [X] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
