### PR TITLE
Breadcrumbs and slim header design tweaks

### DIFF
--- a/client/src/controllers/RevealController.test.js
+++ b/client/src/controllers/RevealController.test.js
@@ -460,4 +460,68 @@ describe('RevealController', () => {
       expect(document.querySelector('header').outerHTML).toEqual(previousHTML);
     });
   });
+
+  describe('saves and loads the state to localStorage', () => {
+    beforeEach(async () => {
+      jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
+      jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should load and save state if enabled', async () => {
+      localStorage.getItem.mockImplementation(() => 'true');
+
+      await setup(`
+      <section id="demo" class="w-reveal" data-controller="w-reveal" data-w-reveal-save-state-value="true">
+        <button type="button" data-w-reveal-target="toggle" aria-controls="my-content" aria-expanded="false">Toggle</button>
+        <div id="my-content">CONTENT</div>
+      </section>`);
+
+      expect(localStorage.getItem).toHaveBeenCalledWith(
+        'wagtail:reveal-demo-closed',
+      );
+
+      const toggleButton = document.querySelector('button');
+
+      await Promise.resolve(toggleButton.click());
+
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'wagtail:reveal-demo-closed',
+        'true',
+      );
+    });
+
+    it('should not load and save state if disabled', async () => {
+      await setup(`
+      <section id="demo" data-controller="w-reveal">
+        <button type="button" data-w-reveal-target="toggle" aria-controls="my-content" aria-expanded="false">Toggle</button>
+        <div id="my-content">CONTENT</div>
+      </section>`);
+
+      expect(localStorage.getItem).not.toHaveBeenCalled();
+
+      const toggleButton = document.querySelector('button');
+      await Promise.resolve(toggleButton.click());
+
+      expect(localStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it('should not load and save state if id is missing', async () => {
+      await setup(`
+      <section class="w-reveal" data-controller="w-reveal" data-w-reveal-save-state-value="true">
+        <button type="button" data-w-reveal-target="toggle" aria-controls="my-content" aria-expanded="false">Toggle</button>
+        <div id="my-content">CONTENT</div>
+      </section>`);
+
+      expect(localStorage.getItem).not.toHaveBeenCalled();
+
+      const toggleButton = document.querySelector('button');
+      await Promise.resolve(toggleButton.click());
+
+      expect(localStorage.setItem).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/wagtail/admin/templates/wagtailadmin/shared/breadcrumbs.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/breadcrumbs.html
@@ -9,13 +9,13 @@
 {% endcomment %}
 {% with breadcrumb_link_classes='w-flex w-items-center w-h-full w-text-text-label w-pr-0.5 w-text-14 w-no-underline w-outline-offset-inside hover:w-underline hover:w-text-text-label w-h-full' breadcrumb_item_classes='w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0' icon_classes='w-w-4 w-h-4 w-ml-3' %}
     {# Breadcrumbs are visible on mobile by default but hidden on desktop #}
-    <div class="w-breadcrumbs w-flex w-flex-row w-items-center w-overflow-x-auto w-overflow-y-hidden w-scrollbar-thin {{ classname }} {% if is_expanded %} w-pl-3{% endif %}"
+    <div id="breadrumbs" class="w-breadcrumbs w-flex w-flex-row w-items-center w-overflow-x-auto w-overflow-y-hidden w-scrollbar-thin {{ classname }} {% if is_expanded %} w-pl-3{% endif %}"
         {% if not items %}hidden{% endif %}
         {% if not is_expanded %}
             data-controller="w-breadcrumbs"
             data-action="keyup.esc@document->w-breadcrumbs#close w-breadcrumbs:open@document->w-breadcrumbs#open w-breadcrumbs:close@document->w-breadcrumbs#close"
             data-w-breadcrumbs-close-icon-class="icon-cross"
-            data-w-breadcrumbs-closed-value="true"
+            data-w-breadcrumbs-save-state-value="true"
             data-w-breadcrumbs-open-icon-class="icon-breadcrumb-expand"
             data-w-breadcrumbs-opened-content-class="w-max-w-4xl"
             data-w-breadcrumbs-peek-target-value="header"


### PR DESCRIPTION
Fixes #9498, and contains small tweaks to the breadcrumbs / slim header pattern to make it more reusable across Wagtail admin views. See #10446 for wider context.

- The breadcrumb’s visibility is stored in `localStorage`, so users who prefer to always have breadcrumbs visible can do so.
  - This is the case regardless of whether the breadcrumbs are visible from "peeking" or from a click. There’s a fair chance we’ll go further and also remove peeking if people find this confusing.
- When breadcrumbs are visible, only the last item is in bold, so it’s clearer it represents the current page.
- For listing breadcrumbs, use a smaller height and font size so we cover up less of the screen when the header is sticky.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2] No
    -   [X] **Please list the exact browser and operating system versions you tested**: Chrome 117 macOS 14
    -   [X] **Please list which assistive technologies [^3] you tested**: None
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

To test this, I would recommend looking at breadcrumbs separately on:

- On edit views for pages and snippets
- On page listing views
- On snippet listing views