### PR TITLE
Add missing `locale` context value in page create and edit views

### DIFF
--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -1743,6 +1743,7 @@ class TestLocaleSelectorOnRootPage(WagtailTestUtils, TestCase):
 
         self.assertContains(response, 'id="status-sidebar-english"')
 
+        # Should show a link to switch to another locale
         add_translation_url = (
             reverse(
                 "wagtailadmin_pages:add",
@@ -1751,6 +1752,50 @@ class TestLocaleSelectorOnRootPage(WagtailTestUtils, TestCase):
             + "?locale=fr"
         )
         self.assertContains(response, f'href="{add_translation_url}"')
+
+        # Should not show a link to switch to the current locale
+        self_translation_url = (
+            reverse(
+                "wagtailadmin_pages:add",
+                args=["demosite", "homepage", self.root_page.id],
+            )
+            + "?locale=en"
+        )
+        self.assertNotContains(response, f'href="{self_translation_url}"')
+
+    def test_locale_selector_selected(self):
+        response = self.client.get(
+            reverse(
+                "wagtailadmin_pages:add",
+                args=["demosite", "homepage", self.root_page.id],
+            )
+            + "?locale=fr"
+        )
+
+        self.assertContains(response, 'id="status-sidebar-french"')
+
+        # Should render the locale input with the currently selected locale
+        self.assertContains(response, '<input type="hidden" name="locale" value="fr">')
+
+        # Should show a link to switch to another locale
+        add_translation_url = (
+            reverse(
+                "wagtailadmin_pages:add",
+                args=["demosite", "homepage", self.root_page.id],
+            )
+            + "?locale=en"
+        )
+        self.assertContains(response, f'href="{add_translation_url}"')
+
+        # Should not show a link to switch to the current locale
+        self_translation_url = (
+            reverse(
+                "wagtailadmin_pages:add",
+                args=["demosite", "homepage", self.root_page.id],
+            )
+            + "?locale=fr"
+        )
+        self.assertNotContains(response, f'href="{self_translation_url}"')
 
     @override_settings(WAGTAIL_I18N_ENABLED=False)
     def test_locale_selector_not_present_when_i18n_disabled(self):

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -390,6 +390,7 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
                 "form": self.form,
                 "next": self.next_url,
                 "has_unsaved_changes": self.has_unsaved_changes,
+                "locale": self.locale,
                 "media": media,
             }
         )
@@ -413,7 +414,8 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
                     + "?"
                     + urlencode({"locale": locale.language_code}),
                 }
-                for locale in Locale.objects.all()
+                # Do not show the switcher for the current locale
+                for locale in Locale.objects.exclude(pk=self.locale.pk)
             ]
 
         else:

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -939,6 +939,7 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
                 and user_perms.can_lock(),
                 "user_can_unlock": isinstance(self.lock, BasicLock)
                 and user_perms.can_unlock(),
+                "locale": self.locale,
                 "media": media,
             }
         )


### PR DESCRIPTION
The `locale` and `translations` context values were moved to the status side panel's context in #10864.

However, the view template still has references to the `locale` for the hidden `<input>` in `create.html`:

https://github.com/wagtail/wagtail/blob/da90f83f941f883ebba5a5254ddb566756cc40b1/wagtail/admin/templates/wagtailadmin/pages/create.html#L16-L20

And also for the `ACTIVE_CONTENT_LOCALE` in both `create.html` and `edit.html`. Not sure if we still use the `ACTIVE_CONTENT_LOCALE`, but I added the `locale` value back to the edit view too just in case.

Not adding back the `translations` context variable as I don't think it's used in any place other than the locale switcher in the status side panel.

Fixes #9702.







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

With bakerydemo, create another locale (if you don't have any). Then, try to create a new page at the root level. Before this commit, the status side panel should show you a locale switcher and allows you to switch to another locale. However, after switching and creating the page, the page will be created in the default locale instead.

With this PR, the page will correctly be created in the selected locale.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
