### PR TITLE
Take preferred language into account in JavaScriptCatalog view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~~~~~
 
  * Add `WAGTAIL_` prefix to Wagtail-specific tag settings (Aayushman Singh)
+ * Fix: Take preferred language into account for translatable strings in client-side code (Bernhard Bliem, Sage Abdullah)
  * Docs: Add missing `django.contrib.admin` to list of apps in "add to Django project" guide (Mohamed Rabiaa)
 
 

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -17,7 +17,7 @@ depth: 1
 
 ### Bug fixes
 
- * ...
+ * Take preferred language into account for translatable strings in client-side code (Bernhard Bliem, Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -6,7 +6,6 @@ from django.urls import include, path, re_path
 from django.views.decorators.cache import never_cache
 from django.views.defaults import page_not_found
 from django.views.generic import TemplateView
-from django.views.i18n import JavaScriptCatalog
 
 from wagtail import hooks
 from wagtail.admin.api import urls as api_urls
@@ -20,6 +19,7 @@ from wagtail.admin.urls import workflows as wagtailadmin_workflows_urls
 from wagtail.admin.views import account, chooser, dismissibles, home, tags
 from wagtail.admin.views.bulk_action import index as bulk_actions
 from wagtail.admin.views.generic.preview import StreamFieldBlockPreview
+from wagtail.admin.views.i18n import localized_js_catalog
 from wagtail.admin.views.pages import listing
 from wagtail.utils.urlpatterns import decorate_urlpatterns
 
@@ -147,7 +147,7 @@ urlpatterns += [
     # JS translation catalog
     path(
         "jsi18n/",
-        JavaScriptCatalog.as_view(packages=["wagtail.admin"]),
+        localized_js_catalog,
         name="wagtailadmin_javascript_catalog",
     ),
 ]

--- a/wagtail/admin/views/i18n.py
+++ b/wagtail/admin/views/i18n.py
@@ -1,0 +1,14 @@
+from django.views.i18n import JavaScriptCatalog
+
+from wagtail.admin.localization import get_localized_response
+
+js_catalog = JavaScriptCatalog.as_view(packages=["wagtail.admin"])
+
+
+def localized_js_catalog(request, *args, **kwargs):
+    """
+    Django's JavaScriptCatalog that has been decorated to ensure it is localized
+    in the user's preferred language.
+    https://github.com/wagtail/wagtail/issues/11074
+    """
+    return get_localized_response(js_catalog, request, *args, **kwargs)


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11074 and #9121.

Some parts of Wagtail are displayed not in the preferred language of the logged-in user but in the default language.

This is because the `JavaScriptCatalog` does not take the preferred language of the Wagtail user profile of the current user into account. This means that a user with a non-default language will see some parts of the admin interface (those rendered by Django) in their preferred language and some (those whose strings use `gettext()` in JavaScript code) in the default language.

This affects many things, for example the tooltip "Insert a block" when hovering over the "+" icon in a StreamField, and the available options of the Draftail rich-text editor after pressing `/`.

Moreover, in some cases `gettext()` is used when `gettext_lazy()` would be more appropriate; for example when registering the plugins in the rich-text editor feature registry. In this case, the `description` of the plugins will always be in the default language, because it is evaluated only once using `gettext()` when the registry is populated.

Even if using `gettext_lazy()` instead of `gettext()` in the descriptions of the rich-text editor plugins, there is still one problem: For the headings (h1, ..., h6), interpolation is done as in this example:

```
        draftail_features.BlockFeature(
            {
                "icon": "h6",
                "type": "header-six",
                "description": gettext_lazy("Heading %(level)d") % {"level": 6},
            }
        ),
```

Interpolation immediately turns the promise into a string, thus interfering with our plans to evaluate it lazily and resulting always in a string in the default language.

One solution would be to change this code to something like the following and do the interpolation in JavaScript (e.g., using the function `interpolate()` provided by Django's `JavaScriptCatalog`):

```
        draftail_features.BlockFeature(
            {
                "icon": "h6",
                "type": "header-six",
                "description": gettext_lazy("Heading %(level)d"),
                "description_interpolation": {"level": 6},
            }
        ),
```

Unfortunately this seems to require changes not only to Wagtail but also to Draftail, where it may not be desirable to rely on Django's `JavaScriptCatalog` being present.

As a solution for the time being, it is perhaps easiest to avoid interpolation and use six copies of the heading string (i.e., "Heading 1", ..., "Heading 6").

This PR implements the following changes:
- Activate the user's preferred language when serving the JS catalog.
- Use `gettext_lazy()` instead of `gettext()` for the descriptions of Draftail features.
- Make those descriptions JSON-serializable by using a JSON encoder that can deal with the promises returned by `gettext_lazy()`.
- Replace `_("Heading %(level)d") % {"level": i}` with `_("Heading i")` (for `i` in 1, ..., 6) to work around the issue mentioned above.
- Update translation source files as well as translated strings accordingly.
