### PR TITLE
get_gravatar_url: allow custom default

### DIFF
--- a/wagtail/users/tests/test_utils.py
+++ b/wagtail/users/tests/test_utils.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+
+from wagtail.users.utils import get_gravatar_url
+
+
+class TestGravatar(TestCase):
+    def test_gravatar(self):
+        self.assertEqual(
+            get_gravatar_url("something@example.com"),
+            "//www.gravatar.com/avatar/76ebd6fecabc982c205dd056e8f0415a?s=100&d=mp",
+        )
+        self.assertEqual(
+            get_gravatar_url("something@example.com", default="robohash"),
+            "//www.gravatar.com/avatar/76ebd6fecabc982c205dd056e8f0415a"
+            "?s=100&d=robohash",
+        )

--- a/wagtail/users/utils.py
+++ b/wagtail/users/utils.py
@@ -26,9 +26,8 @@ def user_can_delete_user(current_user, user_to_delete):
 
 
 def get_gravatar_url(email, size=50, default="mp"):
-    size = (
-        int(size) * 2
-    )  # requested at retina size by default and scaled down at point of use with css
+    # requested at retina size by default and scaled down at point of use with css
+    size = int(size) * 2
     gravatar_provider_url = getattr(
         settings, "WAGTAIL_GRAVATAR_PROVIDER_URL", "//www.gravatar.com/avatar"
     )

--- a/wagtail/users/utils.py
+++ b/wagtail/users/utils.py
@@ -25,8 +25,7 @@ def user_can_delete_user(current_user, user_to_delete):
     return True
 
 
-def get_gravatar_url(email, size=50):
-    default = "mm"
+def get_gravatar_url(email, size=50, default="mp"):
     size = (
         int(size) * 2
     )  # requested at retina size by default and scaled down at point of use with css


### PR DESCRIPTION
Hi,

This allow users get a clear 404 or a variety of generated images based on the hash.

While here, fix default mm into mp,
ref. https://gravatar.com/site/implement/images/

Also add a test for this.

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
