### PR TITLE
Documentation - Updated FieldPanel('title'...) to use TitleFieldPanel('title'...) in docs folder

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -50,6 +50,7 @@ Changelog
  * Use dropdown buttons on listings in dashboard panels (Sage Abdullah)
  * Implement breadcrumbs design refinements (Thibaud Colas)
  * Support extending Wagtail client-side with Stimulus (LB (Ben) Johnston)
+ * Update all `FieldPanel('title')` examples to use the recommended `TitleFieldPanel('title')` panel (Chinedu Ihedioha)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -752,6 +752,7 @@
 * Hazh. M. Adam
 * Chris Lawton
 * Meghana Reddy
+* Chinedu Ihedioha
 
 ## Translators
 

--- a/docs/advanced_topics/customisation/page_editing_interface.md
+++ b/docs/advanced_topics/customisation/page_editing_interface.md
@@ -7,13 +7,13 @@
 As standard, Wagtail organises panels for pages into two tabs: 'Content' and 'Promote'. For snippets Wagtail puts all panels into one page. Depending on the requirements of your site, you may wish to customise this for specific page types or snippets - for example, adding an additional tab for sidebar content. This can be done by specifying an `edit_handler` attribute on the page or snippet model. For example:
 
 ```python
-from wagtail.admin.panels import TabbedInterface, ObjectList
+from wagtail.admin.panels import TabbedInterface, TitleFieldPanel, ObjectList
 
 class BlogPage(Page):
     # field definitions omitted
 
     content_panels = [
-        FieldPanel('title', classname="title"),
+        TitleFieldPanel('title', classname="title"),
         FieldPanel('date'),
         FieldPanel('body'),
     ]
@@ -32,13 +32,13 @@ class BlogPage(Page):
 Permissions can be set using `permission` on the `ObjectList` to restrict entire groups of panels to specific users.
 
 ```python
-from wagtail.admin.panels import TabbedInterface, ObjectList
+from wagtail.admin.panels import TabbedInterface, TitleFieldPanel, ObjectList
 
 class FundingPage(Page):
     # field definitions omitted
 
     shared_panels = [
-        FieldPanel('title', classname="title"),
+        TitleFieldPanel('title', classname="title"),
         FieldPanel('date'),
         FieldPanel('body'),
     ]
@@ -179,7 +179,7 @@ or to add custom validation logic for your models:
 from django import forms
 from django.db import models
 import geocoder  # not in Wagtail, for example only - https://geocoder.readthedocs.io/
-from wagtail.admin.panels import FieldPanel
+from wagtail.admin.panels import TitleFieldPanel, FieldPanel
 from wagtail.admin.forms import WagtailAdminPageForm
 from wagtail.models import Page
 
@@ -219,7 +219,7 @@ class EventPage(Page):
     location = models.CharField(max_length=255)
 
     content_panels = [
-        FieldPanel('title'),
+        TitleFieldPanel('title'),
         FieldPanel('start_date'),
         FieldPanel('end_date'),
         FieldPanel('address'),

--- a/docs/reference/pages/panels.md
+++ b/docs/reference/pages/panels.md
@@ -377,7 +377,7 @@ class Book(models.Model):
     )
 
     panels = [
-        FieldPanel('title', widget=title_widget), # then add them as a variable
+        TitleFieldPanel('title', widget=title_widget), # then add them as a variable
         FieldPanel('release_date', widget=date_widget),
         FieldPanel('price', widget=forms.NumberInput(attrs={'placeholder': 'Retail price on release'})) # or directly inline
     ]

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -121,6 +121,7 @@ Thank you to core contributor (LB (Ben) Johnston) for writing this documentation
  * Document the use of the Google developer documentation style guide in documentation (Damilola Oladele)
  * Fix Inconsistent URL Format in Getting Started tutorial (Olumide Micheal)
  * Add more extensive documentation for the `permission` kwarg support in Panels (LB (Ben) Johnston)
+ * Update all `FieldPanel('title')` examples to use the recommended `TitleFieldPanel('title')` panel (Chinedu Ihedioha)
 
 ### Maintenance
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11078 







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
