### PR TITLE
Use the correct action log when creating a redirect

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -69,6 +69,7 @@ Changelog
  * Fix: Avoid forgotten password link text conflicting with the supplied aria-label (Thibaud Colas)
  * Fix: Fix log message to record the correct restriction type when removing a page view restriction (Rohit Sharma, Hazh. M. Adam)
  * Fix: Avoid potential race condition with new Page subscriptions on the edit view (Alex Tomkins)
+ * Fix: Use the correct action log when creating a redirect (Thibaud Colas)
  * Docs: Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
  * Docs: Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)
  * Docs: Add documentation for building non-model-based choosers using the _queryish_ library (Matt Westcott)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -93,6 +93,7 @@ This feature was developed by Paarth Agarwal and Thibaud Colas as part of the Go
  * Avoid forgotten password link text conflicting with the supplied aria-label (Thibaud Colas)
  * Fix log message to record the correct restriction type when removing a page view restriction (Rohit Sharma, Hazh. M. Adam)
  * Avoid potential race condition with new Page subscriptions on the edit view (Alex Tomkins)
+ * Use the correct action log when creating a redirect (Thibaud Colas)
 
 ### Documentation
 

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.contrib.redirects import models
+from wagtail.log_actions import registry as log_registry
 from wagtail.models import Page, Site
 from wagtail.test.routablepage.models import RoutablePageTest
 from wagtail.test.utils import WagtailTestUtils
@@ -653,9 +654,14 @@ class TestRedirectsAddView(WagtailTestUtils, TestCase):
 
         # Check that the redirect was created
         redirects = models.Redirect.objects.filter(old_path="/test")
+        redirect = redirects.first()
         self.assertEqual(redirects.count(), 1)
-        self.assertEqual(redirects.first().redirect_link, "http://www.test.com/")
-        self.assertIsNone(redirects.first().site)
+        self.assertEqual(redirect.redirect_link, "http://www.test.com/")
+        self.assertIsNone(redirect.site)
+
+        # Check that the action log is marked as "created"
+        log_entry = log_registry.get_logs_for_instance(redirect).first()
+        self.assertEqual(log_entry.action, "wagtail.create")
 
     def test_add_with_site(self):
         localhost = Site.objects.get(hostname="localhost")

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -179,7 +179,7 @@ def add(request):
         if form.is_valid():
             with transaction.atomic():
                 theredirect = form.save()
-                log(instance=theredirect, action="wagtail.edit")
+                log(instance=theredirect, action="wagtail.create")
 
             messages.success(
                 request,


### PR DESCRIPTION
Fixes the redirect creation getting logged as an edit. 

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   ~~[ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]~~
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

1. Create a redirect.
2. Open the audit log.
3. Note the type of the action.