### PR TITLE
Use dropdown buttons on listings in dashboard panels

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,6 +47,7 @@ Changelog
  * Support `Filter` instances as input for `AbstractImage.get_renditions()` (Thibaud Colas)
  * Improve error messages for image template tags (Thibaud Colas)
  * Do not render minimap if there are no panel anchors (Sage Abdullah)
+ * Use dropdown buttons on listings in dashboard panels (Sage Abdullah)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)
  * Fix: When deleting collections, ensure the collection name is correctly shown in the success message (LB (Ben) Johnston)

--- a/client/scss/components/_dropdown.scss
+++ b/client/scss/components/_dropdown.scss
@@ -15,7 +15,7 @@
 }
 
 .w-dropdown__content :where(a, button) {
-  @apply w-bg-transparent w-inline-flex w-items-center w-text-left w-font-bold w-text-text-label-menus-default w-py-3 w-px-6 w-no-underline w-transition w-outline-offset-inside;
+  @apply w-bg-transparent w-inline-flex w-items-center w-text-left w-font-bold w-text-text-label-menus-default w-py-3 w-px-6 w-no-underline w-transition w-outline-offset-inside w-w-full;
 
   .icon {
     @apply w-w-4 w-h-4 w-mr-3 w-transition w-opacity-50 w-shrink-0;

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -68,6 +68,7 @@ This feature was developed by Paarth Agarwal and Thibaud Colas as part of the Go
  * Support `Filter` instances as input for [`AbstractImage.get_renditions()`](image_renditions_multiple) (Thibaud Colas)
  * Improve error messages for image template tags (Thibaud Colas)
  * Do not render minimap if there are no panel anchors (Sage Abdullah)
+ * Use dropdown buttons on listings in dashboard panels (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -32,7 +32,7 @@
                             </div>
                             <ul class="actions">
                                 <li>
-                                    {% dropdown toggle_icon="dots-horizontal" %}
+                                    {% dropdown toggle_icon="dots-horizontal" toggle_aria_label=_("Actions") %}
                                         {% if can_remove_locks %}
                                             <button
                                                 data-controller="w-action"

--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -31,29 +31,30 @@
                                 {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
                             </div>
                             <ul class="actions">
-                                {% if can_remove_locks %}
-                                    <li>
-                                        <button
-                                            class="button button-small button-secondary"
-                                            data-controller="w-action"
-                                            data-action="w-action#post"
-                                            data-w-action-next-value="{% url 'wagtailadmin_home' %}"
-                                            data-w-action-url-value="{% url 'wagtailadmin_pages:unlock' page.id %}"
-                                        >
-                                            {% trans "Unlock" %}
-                                        </button>
-                                    </li>
-                                {% endif %}
-                                <li><a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans "Edit" %}</a></li>
-                                {% if page.has_unpublished_changes and page.is_previewable %}
-                                    <li><a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" class="button button-small button-secondary" target="_blank" rel="noreferrer">{% trans 'Draft' %}</a></li>
-                                {% endif %}
-                                {% if page.live %}
-                                    {% pageurl page as page_url %}
-                                    {% if page_url is not None %}
-                                        <li><a href="{{ page_url }}" class="button button-small button-secondary" target="_blank" rel="noreferrer">{% trans 'Live' %}</a></li>
-                                    {% endif %}
-                                {% endif %}
+                                <li>
+                                    {% dropdown toggle_icon="dots-horizontal" %}
+                                        {% if can_remove_locks %}
+                                            <button
+                                                data-controller="w-action"
+                                                data-action="w-action#post"
+                                                data-w-action-next-value="{% url 'wagtailadmin_home' %}"
+                                                data-w-action-url-value="{% url 'wagtailadmin_pages:unlock' page.id %}"
+                                            >
+                                                {% trans "Unlock" %}
+                                            </button>
+                                        {% endif %}
+                                        <a href="{% url 'wagtailadmin_pages:edit' page.id %}">{% trans "Edit" %}</a>
+                                        {% if page.has_unpublished_changes and page.is_previewable %}
+                                            <a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" target="_blank" rel="noreferrer">{% trans 'Draft' %}</a>
+                                        {% endif %}
+                                        {% if page.live %}
+                                            {% pageurl page as page_url %}
+                                            {% if page_url is not None %}
+                                                <a href="{{ page_url }}" target="_blank" rel="noreferrer">{% trans 'Live' %}</a>
+                                            {% endif %}
+                                        {% endif %}
+                                    {% enddropdown %}
+                                </li>
                             </ul>
                         </td>
                         <td>{# Deliberately empty #}</td>

--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -39,23 +39,24 @@
                             </div>
                             <ul class="actions">
                                 <li>
-                                    <form action="{% url 'wagtailadmin_pages:approve_moderation' revision.id %}" method="POST">
-                                        {% csrf_token %}
-                                        <input type="submit" class="button button-small button-secondary" value="{% trans 'Approve' %}">
-                                    </form>
+                                    {% dropdown toggle_icon="dots-horizontal" %}
+
+                                        <form action="{% url 'wagtailadmin_pages:approve_moderation' revision.id %}" method="POST">
+                                            {% csrf_token %}
+                                            <button type="submit">{% trans 'Approve' %}</button>
+                                        </form>
+                                        <form action="{% url 'wagtailadmin_pages:reject_moderation' revision.id %}" method="POST">
+                                            {% csrf_token %}
+                                            <button type="submit">{% trans 'Reject' %}</button>
+                                        </form>
+                                        {% if page_perms.can_edit %}
+                                            <a href="{% url 'wagtailadmin_pages:edit' revision.object_id %}">{% trans 'Edit' %}</a>
+                                        {% endif %}
+                                        {% if revision.content_object.is_previewable %}
+                                            <a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" target="_blank" rel="noreferrer">{% trans 'Preview' %}</a>
+                                        {% endif %}
+                                    {% enddropdown %}
                                 </li>
-                                <li class="no-border">
-                                    <form action="{% url 'wagtailadmin_pages:reject_moderation' revision.id %}" method="POST">
-                                        {% csrf_token %}
-                                        <input type="submit" class="button button-small no" value="{% trans 'Reject' %}">
-                                    </form>
-                                </li>
-                                {% if page_perms.can_edit %}
-                                    <li><a href="{% url 'wagtailadmin_pages:edit' revision.object_id %}" class="button button-small button-secondary">{% trans 'Edit' %}</a></li>
-                                {% endif %}
-                                {% if revision.content_object.is_previewable %}
-                                    <li><a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" class="button button-small button-secondary" target="_blank" rel="noreferrer">{% trans 'Preview' %}</a></li>
-                                {% endif %}
                             </ul>
                         </td>
                         <td valign="top">

--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -39,8 +39,7 @@
                             </div>
                             <ul class="actions">
                                 <li>
-                                    {% dropdown toggle_icon="dots-horizontal" %}
-
+                                    {% dropdown toggle_icon="dots-horizontal" toggle_aria_label=_("Actions") %}
                                         <form action="{% url 'wagtailadmin_pages:approve_moderation' revision.id %}" method="POST">
                                             {% csrf_token %}
                                             <button type="submit">{% trans 'Approve' %}</button>

--- a/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
@@ -31,16 +31,20 @@
                                 {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
                             </div>
                             <ul class="actions">
-                                <li><a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans "Edit" %}</a></li>
-                                {% if page.has_unpublished_changes and page.is_previewable %}
-                                    <li><a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" class="button button-small button-secondary" target="_blank" rel="noreferrer">{% trans 'Draft' %}</a></li>
-                                {% endif %}
-                                {% if page.live %}
-                                    {% pageurl page as page_url %}
-                                    {% if page_url is not None %}
-                                        <li><a href="{{ page_url }}" class="button button-small button-secondary" target="_blank" rel="noreferrer">{% trans 'Live' %}</a></li>
-                                    {% endif %}
-                                {% endif %}
+                                <li>
+                                    {% dropdown toggle_icon="dots-horizontal" %}
+                                        <a href="{% url 'wagtailadmin_pages:edit' page.id %}">{% trans "Edit" %}</a>
+                                        {% if page.has_unpublished_changes and page.is_previewable %}
+                                            <a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" target="_blank" rel="noreferrer">{% trans 'Draft' %}</a>
+                                        {% endif %}
+                                        {% if page.live %}
+                                            {% pageurl page as page_url %}
+                                            {% if page_url is not None %}
+                                                <a href="{{ page_url }}" target="_blank" rel="noreferrer">{% trans 'Live' %}</a>
+                                            {% endif %}
+                                        {% endif %}
+                                    {% enddropdown %}
+                                </li>
                             </ul>
                         </td>
                         <td valign="top">

--- a/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
@@ -32,7 +32,7 @@
                             </div>
                             <ul class="actions">
                                 <li>
-                                    {% dropdown toggle_icon="dots-horizontal" %}
+                                    {% dropdown toggle_icon="dots-horizontal" toggle_aria_label=_("Actions") %}
                                         <a href="{% url 'wagtailadmin_pages:edit' page.id %}">{% trans "Edit" %}</a>
                                         {% if page.has_unpublished_changes and page.is_previewable %}
                                             <a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" target="_blank" rel="noreferrer">{% trans 'Draft' %}</a>

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -44,31 +44,25 @@
                                 </div>
                                 {% if actions %}
                                     <ul class="actions">
-                                        {% for action_name, action_label, modal in actions %}
-                                            <li>
-                                                <button class="button button-small button-secondary" data-workflow-action-url="{% url state.workflow_action_url_name obj.pk|admin_urlquote action_name task_state.id %}" {% if modal %}data-launch-modal{% endif %}>{{ action_label }}</button>
-                                            </li>
-                                        {% endfor %}
-                                        {% if page_perms.can_edit or not is_page and edit_url %}
-                                            <li>
-                                                <a href="{{ edit_url }}" class="button button-small button-secondary">{% trans 'Edit' %}</a>
-                                            </li>
-                                        {% endif %}
-                                        {% if obj.is_previewable %}
-                                            <li>
-                                                <a href="{% url state.workflow_preview_url_name obj.pk|admin_urlquote task_state.task.id %}" class="button button-small button-secondary" target="_blank" rel="noreferrer">{% trans 'Preview' %}</a>
-                                            </li>
-                                        {% endif %}
-                                        {% if state.live_revision %}
-                                            <li>
-                                                <a href="{% url state.revisions_compare_url_name obj.pk|admin_urlquote 'live' revision.id %}" class="button button-small button-secondary">{% trans "Compare with live version" %}</a>
-                                            </li>
-                                        {% endif %}
-                                        {% if state.previous_revision %}
-                                            <li>
-                                                <a href="{% url state.revisions_compare_url_name obj.pk|admin_urlquote state.previous_revision.id revision.id %}" class="button button-small button-secondary">{% trans "Compare with previous version" %}</a>
-                                            </li>
-                                        {% endif %}
+                                        <li>
+                                            {% dropdown toggle_icon="dots-horizontal" %}
+                                                {% for action_name, action_label, modal in actions %}
+                                                    <button data-workflow-action-url="{% url state.workflow_action_url_name obj.pk|admin_urlquote action_name task_state.id %}" {% if modal %}data-launch-modal{% endif %}>{{ action_label }}</button>
+                                                {% endfor %}
+                                                {% if page_perms.can_edit or not is_page and edit_url %}
+                                                    <a href="{{ edit_url }}">{% trans 'Edit' %}</a>
+                                                {% endif %}
+                                                {% if obj.is_previewable %}
+                                                    <a href="{% url state.workflow_preview_url_name obj.pk|admin_urlquote task_state.task.id %}" target="_blank" rel="noreferrer">{% trans 'Preview' %}</a>
+                                                {% endif %}
+                                                {% if state.live_revision %}
+                                                    <a href="{% url state.revisions_compare_url_name obj.pk|admin_urlquote 'live' revision.id %}">{% trans "Compare with live version" %}</a>
+                                                {% endif %}
+                                                {% if state.previous_revision %}
+                                                    <a href="{% url state.revisions_compare_url_name obj.pk|admin_urlquote state.previous_revision.id revision.id %}">{% trans "Compare with previous version" %}</a>
+                                                {% endif %}
+                                            {% enddropdown %}
+                                        </li>
                                     </ul>
                                 {% endif %}
                             </td>

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -45,7 +45,7 @@
                                 {% if actions %}
                                     <ul class="actions">
                                         <li>
-                                            {% dropdown toggle_icon="dots-horizontal" %}
+                                            {% dropdown toggle_icon="dots-horizontal" toggle_aria_label=_("Actions") %}
                                                 {% for action_name, action_label, modal in actions %}
                                                     <button data-workflow-action-url="{% url state.workflow_action_url_name obj.pk|admin_urlquote action_name task_state.id %}" {% if modal %}data-launch-modal{% endif %}>{{ action_label }}</button>
                                                 {% endfor %}


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

This wraps the buttons on listings in dashboard panels inside a dropdown for better consistency with the changes we made to the listing views.

<details><summary>Screenshots</summary>

## Before

![localhost_8000_admin_ (7)](https://github.com/wagtail/wagtail/assets/6379424/c10c53fe-9cfa-4084-95b9-6a5e880e11f2)

## After

![localhost_8000_admin_ (10)](https://github.com/wagtail/wagtail/assets/6379424/7516ab4c-c09d-44ec-ba33-40fe34f4ebbe)

</details> 

Marking as draft as I think I still need to add the toggle labels?...



_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
