### PR TITLE
Note that the admin should be limited to "trusted" users

### DIFF
--- a/docs/topics/permissions.md
+++ b/docs/topics/permissions.md
@@ -4,6 +4,10 @@
 
 Wagtail adapts and extends [the Django permission system](https://docs.djangoproject.com/en/stable/topics/auth/default/#topic-authorization) to cater for the needs of website content creation, such as moderation workflows, and multiple teams working on different areas of a site (or multiple sites within the same Wagtail installation). Permissions can be configured through the 'Groups' area of the Wagtail admin interface, under 'Settings'.
 
+```{note}
+Whilst Wagtail supports a number of user roles and permissions, the Wagtail Admin should still be restricted to trusted users.
+```
+
 ## Page permissions
 
 Permissions can be attached at any point in the page tree, and propagate down the tree. For example, if a site had the page tree:


### PR DESCRIPTION
_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

Similar to the note [Django has](https://docs.djangoproject.com/en/4.2/ref/contrib/admin/), we should note that the admin, whilst it has a lot of permissions and roles, should still be limited to _trusted_ users.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
