### PR TITLE
fixed a typo in file: 4.0.md

### DIFF
--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -249,7 +249,7 @@ There are also many improvements to the documentation both under the hood and in
  * Resolve Layout issue with page explorer's inner header item on small device widths (Akash Kumar Sen)
  * Ensure that `BaseSiteSetting` / `BaseGenericSetting` objects can be pickled (Andy Babic)
  * Ensure `DocumentChooserBlock` can be deconstructed for migrations (Matt Westcott)
- * Resolve frontend console error and unintented console logging issues (Matt Westcott, Paarth Agarwal)
+ * Resolve frontend console error and unintended console logging issues (Matt Westcott, Paarth Agarwal)
  * Resolve issue with sites that have not yet migrated away from `BaseSetting` when upgrading to Wagtail 4.0 (Stefan Hammer)
  * Use correct classnames for showing/hiding edit button on chooser widget (Matt Westcott)
  * Render MultiFieldPanel’s heading even when nested (Thibaud Colas)


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #...
In the line number 252 of file 4.0.md, fixed a typo by changing 'unintented' to 'unintended'






_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
