### PR TITLE
Add cross ref to `InlinePanel` DOM events in client-side docs

### DIFF
--- a/docs/extending/extending_client_side.md
+++ b/docs/extending/extending_client_side.md
@@ -43,6 +43,7 @@ Wagtail supports some custom behaviour via listening or dispatching custom DOM e
 
 -   See [Images title generation on upload](images_title_generation_on_upload).
 -   See [Documents title generation on upload](docs_title_generation_on_upload).
+-   See [`InlinePanel` DOM events](inline_panel_events).
 
 (extending_client_side_stimulus)=
 

--- a/docs/reference/pages/panels.md
+++ b/docs/reference/pages/panels.md
@@ -115,6 +115,10 @@ Here are some built-in panel types that you can use in your panel definitions. T
 
 You may want to execute some JavaScript when `InlinePanel` items are ready, added or removed. The `w-formset:ready`, `w-formset:added` and `w-formset:removed` events allow this.
 
+```{versionadded} 5.2
+
+```
+
 For example, given a child model that provides a relationship between Blog and Person on `BlogPage`.
 
 ```python


### PR DESCRIPTION
- Additional cross reference would be good to have in for these newly introduced DOM events
- Also `InlinePanel` DOM events - add `versionadded` admonition
- See #10590 & #10948
