### PR TITLE
Fix various bulk actions bugs

### DIFF
--- a/client/src/includes/bulk-actions.js
+++ b/client/src/includes/bulk-actions.js
@@ -216,11 +216,11 @@ function addBulkActionListeners() {
     el.addEventListener('change', onSelectAllChange);
   });
   document
-    .querySelectorAll(`${BULK_ACTION_FOOTER} .bulk-action-btn`)
+    .querySelectorAll(`${BULK_ACTION_FOOTER} [data-bulk-action-button]`)
     .forEach((elem) => elem.addEventListener('click', onClickActionButton));
   document.addEventListener('w-dropdown:shown', () => {
     document
-      .querySelectorAll(`${BULK_ACTION_FOOTER} .bulk-action-btn`)
+      .querySelectorAll(`${BULK_ACTION_FOOTER} [data-bulk-action-button]`)
       .forEach((elem) => {
         elem.removeEventListener('click', onClickActionButton);
         elem.addEventListener('click', onClickActionButton);

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -10,7 +10,7 @@
         {% include 'wagtailadmin/pages/index_results.html' %}
     </div>
     {% trans "Select all pages in listing" as select_all_text %}
-    {% include 'wagtailadmin/bulk_actions/footer.html' with select_all_obj_text=select_all_text app_label='wagtailcore' model_name='page' objects=pages %}
+    {% include 'wagtailadmin/bulk_actions/footer.html' with select_all_obj_text=select_all_text app_label='wagtailcore' model_name='page' objects=page_obj %}
 {% endblock %}
 
 {% block extra_js %}

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -9,6 +9,8 @@
     <div id="listing-results">
         {% include 'wagtailadmin/pages/index_results.html' %}
     </div>
+    {% trans "Select all pages in listing" as select_all_text %}
+    {% include 'wagtailadmin/bulk_actions/footer.html' with select_all_obj_text=select_all_text app_label='wagtailcore' model_name='page' objects=pages %}
 {% endblock %}
 
 {% block extra_js %}

--- a/wagtail/admin/templates/wagtailadmin/pages/index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index_results.html
@@ -58,6 +58,4 @@
     {% if is_paginated %}
         {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj linkurl=index_url %}
     {% endif %}
-    {% trans "Select all pages in listing" as select_all_text %}
-    {% include 'wagtailadmin/bulk_actions/footer.html' with select_all_obj_text=select_all_text app_label='wagtailcore' model_name='page' objects=pages %}
 </form>

--- a/wagtail/admin/templates/wagtailadmin/pages/search.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/search.html
@@ -17,5 +17,5 @@
         {% include "wagtailadmin/pages/search_results.html" %}
     </div>
     {% trans "Select all pages in listing" as select_all_text %}
-    {% include 'wagtailadmin/bulk_actions/footer.html' with app_label='wagtailcore' model_name='page' objects=pages select_all_obj_text=select_all_text %}
+    {% include 'wagtailadmin/bulk_actions/footer.html' with app_label='wagtailcore' model_name='page' objects=page_obj select_all_obj_text=select_all_text %}
 {% endblock %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -556,7 +556,7 @@ def bulk_action_choices(context, app_label, model_name):
             )
             + "?"
             + urlencode({"next": next_url}),
-            attrs={"aria-label": action.aria_label},
+            attrs={"aria-label": action.aria_label, "data-bulk-action-button": ""},
             priority=action.action_priority,
             classname=" ".join(action.classes | {"bulk-action-btn"}),
         )
@@ -577,9 +577,11 @@ def bulk_action_choices(context, app_label, model_name):
                     )
                     + "?"
                     + urlencode({"next": next_url}),
-                    attrs={"aria-label": action.aria_label},
+                    attrs={
+                        "aria-label": action.aria_label,
+                        "data-bulk-action-button": "",
+                    },
                     priority=action.action_priority,
-                    classname="bulk-action-btn",
                 )
                 for action in bulk_action_more_list
             ],

--- a/wagtail/admin/views/pages/bulk_actions/page_bulk_action.py
+++ b/wagtail/admin/views/pages/bulk_actions/page_bulk_action.py
@@ -16,14 +16,22 @@ class PageBulkAction(BulkAction):
     def get_all_objects_in_listing_query(self, parent_id):
         listing_objects = self.model.objects.all()
 
-        if parent_id is not None:
-            listing_objects = listing_objects.get(id=parent_id).get_children()
-
-        listing_objects = listing_objects.values_list("pk", flat=True)
-
+        q = None
         if "q" in self.request.GET:
             q = self.request.GET.get("q", "")
 
+        if parent_id is not None:
+            listing_objects = listing_objects.get(id=parent_id)
+            # If we're searching, include the descendants as well.
+            # Otherwise, just include the direct children.
+            if q:
+                listing_objects = listing_objects.get_descendants()
+            else:
+                listing_objects = listing_objects.get_children()
+
+        listing_objects = listing_objects.values_list("pk", flat=True)
+
+        if q:
             listing_objects = page_filter_search(q, listing_objects)[0].results()
 
         return listing_objects

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -44,8 +44,8 @@ def page_filter_search(q, pages, all_pages=None, ordering=None):
 
     # Search
     if all_pages is not None:
-        all_pages = all_pages.search(query, order_by_relevance=not ordering)
-    pages = pages.search(query, order_by_relevance=not ordering)
+        all_pages = all_pages.autocomplete(query, order_by_relevance=not ordering)
+    pages = pages.autocomplete(query, order_by_relevance=not ordering)
 
     return pages, all_pages
 


### PR DESCRIPTION
Use data attributes to select the items, because the classname isn't rendered for items inside the dropdown due to the use of `base_attrs_string`.

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes a bunch of issues around bulk actions. Will try to write tests, but it's pretty hard as we currently don't have any custom bulk actions for pages in the testapp...






_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
