### PR TITLE
Fix error on xlsx export for Aging Pages report when last_published_by_user is blank

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Changelog
  * Fix: Ensure that Snippets search results correctly use the `index_results.html` or `index_results_template_name` override on initial load (Stefan Hammer)
  * Fix: Avoid error when attempting to moderate a page drafted by a now deleted user (Dan Braghis)
  * Fix: Do not show multiple error messages when editing a Site to use existing hostname and port (Rohit Sharma)
+ * Fix: Avoid error when exporting Aging Pages report where a page has an empty `last_published_by_user` (Chiemezuo Akujobi)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)
  * Docs: Add section to testing docs about creating pages and working with page content (Mariana Bedran Lesche)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -44,6 +44,7 @@ depth: 1
  * Ensure that Snippets search results correctly use the `index_results.html` or `index_results_template_name` override on initial load (Stefan Hammer)
  * Avoid error when attempting to moderate a page drafted by a now deleted user (Dan Braghis)
  * Do not show multiple error messages when editing a Site to use existing hostname and port (Rohit Sharma)
+ * Avoid error when exporting Aging Pages report where a page has an empty `last_published_by_user` (Chiemezuo Akujobi)
 
 ### Documentation
 

--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -631,6 +631,48 @@ class TestAgingPagesView(WagtailTestUtils, TestCase):
 
         self.assertEqual(worksheet["C2"].number_format, ExcelDateFormatter().get())
 
+    def test_xlsx_export_without_published_by(self):
+        """
+        Test that the xlsx export works when a page has no 'published_by' set.
+        See https://github.com/wagtail/wagtail/issues/10821
+        """
+
+        self.home.save_revision().publish()
+
+        if settings.USE_TZ:
+            self.home.last_published_at = "2013-01-01T12:00:00.000Z"
+        else:
+            self.home.last_published_at = "2013-01-01T12:00:00"
+
+        # mimic a page that does not have a 'published_by' on creation
+        self.home.last_published_by = None
+        self.home.save()
+
+        response = self.get(params={"export": "xlsx"})
+        self.assertEqual(response.status_code, 200)
+
+        workbook_data = response.getvalue()
+        worksheet = load_workbook(filename=BytesIO(workbook_data))["Sheet1"]
+        cell_array = [[cell.value for cell in row] for row in worksheet.rows]
+
+        self.assertEqual(
+            cell_array[0],
+            ["Title", "Status", "Last published at", "Last published by", "Type"],
+        )
+        self.assertEqual(
+            cell_array[1],
+            [
+                "Welcome to your new Wagtail site!",
+                "live + draft",
+                datetime.datetime(2013, 1, 1, 12, 0),
+                None,
+                "Page",
+            ],
+        )
+        self.assertEqual(len(cell_array), 2)
+
+        self.assertEqual(worksheet["C2"].number_format, ExcelDateFormatter().get())
+
     def test_report_renders_when_page_publisher_deleted(self):
         temp_user = self.create_superuser(
             "temp", email="temp@user.com", password="tempuser"

--- a/wagtail/admin/views/reports/aging_pages.py
+++ b/wagtail/admin/views/reports/aging_pages.py
@@ -82,6 +82,8 @@ class AgingPagesView(PageReportView):
                 user_id_value, get_deleted_user_display_name(user_id=user_id_value)
             )
             page.last_published_by_user = last_published_by_user
+        else:
+            page.last_published_by_user = ""
 
     def decorate_paginated_queryset(self, queryset):
         user_ids = set(queryset.values_list("last_published_by", flat=True))


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10821
This issue happened, because the script that modified the database with parsed items from the CSV did so completely independent of the `AgingPages `view. It also meant that there was no `PageLogEntry`. The download button broke down because every time it was clicked, the `add_last_publisher_name_to_page` got called, and the resulting value of `page.last_published_by_user` would always be `None`.
The fix I did was to assign it to an empty string so that the download button would stop breaking.







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
