### PR TITLE
Docs - 5.2 release notes typo fix & links

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,7 +53,7 @@ Changelog
  * Support extending Wagtail client-side with Stimulus (LB (Ben) Johnston)
  * Update all `FieldPanel('title')` examples to use the recommended `TitleFieldPanel('title')` panel (Chinedu Ihedioha)
  * The `purge_revisions` management command now respects revisions that have a `on_delete=PROTECT` foreign key relation and won't delete them (Neeraj P Yetheendran, Meghana Reddy, Sage Abdullah, Storm Heg)
- * Add support for Shift + Click behaviour in form submissions and simple tranlations submissions (LB (Ben) Johnston)
+ * Add support for Shift + Click behaviour in form submissions and simple translations submissions (LB (Ben) Johnston)
  * Improve filtering of audit logging based on the user's permissions (Stefan Hammer)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Fix: Avoid an error when the moderation panel (admin dashboard) contains both snippets and private pages (Matt Westcott)

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -31,6 +31,8 @@ Optionally, you may also want to add `rest_framework` to `INSTALLED_APPS`.
 This would make the API browsable when viewed from a web browser but is not
 required for basic JSON-formatted output.
 
+(api_v2_configure_endpoints)=
+
 ### Configure endpoints
 
 Next, it's time to configure which content will be exposed on the API. Each
@@ -68,7 +70,7 @@ from rest_framework.renderers import JSONRenderer
 
 class PostPagesAPIViewSet(PagesAPIViewSet):
     model = models.BlogPage
-    
+
 
 api_router.register_endpoint("posts", PostPagesAPIViewSet)
 ```

--- a/docs/extending/generic_views.md
+++ b/docs/extending/generic_views.md
@@ -102,6 +102,8 @@ PersonChooserBlock = person_chooser_viewset.get_block_class(
 )
 ```
 
+(chooser_viewsets_limiting_choices)=
+
 ## Limiting choices via linked fields
 
 Chooser viewsets provide a mechanism for limiting the options displayed in the chooser according to another input field on the calling page. For example, suppose the person model has a country field - we can then set up a page model with a country dropdown and a person chooser, where an editor first selects a country from the dropdown and then opens the person chooser to be presented with a list of people from that country.
@@ -133,6 +135,7 @@ class BlogPage(Page):
 ```
 
 A number of other lookup mechanisms are available:
+
 ```python
 PersonChooserWidget(linked_fields={
     'country': {'selector': '#id_country'}  # equivalent to 'country': '#id_country'
@@ -153,6 +156,7 @@ PersonChooserWidget(linked_fields={
 })
 ```
 
+(chooser_viewsets_non_model_data)=
 
 ## Chooser viewsets for non-model datasources
 

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -88,7 +88,7 @@ Thank you to core contributor (LB (Ben) Johnston) for writing this documentation
  * Use dropdown buttons on listings in dashboard panels (Sage Abdullah)
  * Implement breadcrumbs design refinements (Thibaud Colas)
  * The `purge_revisions` management command now respects revisions that have a `on_delete=PROTECT` foreign key relation and won't delete them (Neeraj P Yetheendran, Meghana Reddy, Sage Abdullah, Storm Heg)
- * Add support for Shift + Click behaviour in form submissions and simple tranlations submissions (LB (Ben) Johnston)
+ * Add support for Shift + Click behaviour in form submissions and simple translations submissions (LB (Ben) Johnston)
  * Improve filtering of audit logging based on the user's permissions (Stefan Hammer)
 
 ### Bug fixes

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -62,7 +62,7 @@ Thank you to core contributor (LB (Ben) Johnston) for writing this documentation
  * Add default header titles to generic `IndexView` and `CreateView` (Sage Abdullah)
  * Allow overriding `IndexView.export_headings` via `ModelViewSet` (Christer Jensen, Sage Abdullah)
  * Support specifying a `get_object_list` method on `ChooserViewSet` (Matt Westcott)
- * Add `linked_fields` mechanism on chooser widgets to allow choices to be limited by fields on the calling page (Matt Westcott)
+ * Add [`linked_fields` mechanism on chooser widgets](chooser_viewsets_limiting_choices) to allow choices to be limited by fields on the calling page (Matt Westcott)
  * Add support for merging cells within `TableBlock` with the [`mergedCells` option](table_block_options) (Gareth Palmer)
  * When adding a panel within `InlinePanel`, focus will now shift to that content similar to `StreamField` (Faishal Manzar)
  * Show the full first published at date within a tooltip on the Page status sidebar on the relative date (Rohit Sharma)
@@ -70,7 +70,7 @@ Thank you to core contributor (LB (Ben) Johnston) for writing this documentation
  * Add support for `placement` in `human_readable_date` the tooltip template tag (Rohit Sharma)
  * Add breadcrumbs support to custom `ModelViewSet` views (Sage Abdullah)
  * Support passing extra context variables via the `{% component %}` tag (Matt Westcott)
- * Allow subclasses of `PagesAPIViewSet` override default Page model via the `model` attribute (Neeraj Yetheendran, Herbert Poul)
+ * Allow subclasses of `PagesAPIViewSet` override default [Page model via the `model`](api_v2_configure_endpoints) attribute (Neeraj Yetheendran, Herbert Poul)
  * Allow `ModelViewSet` to be used with models that have non-integer primary keys (Sage Abdullah)
  * Add the ability to set an external link/text for promoted search result entries (TopDevPros, Brad Busenius)
  * Add support for subject and body in the Email link chooser form (TopDevPros, Alexandre Joly)
@@ -87,7 +87,7 @@ Thank you to core contributor (LB (Ben) Johnston) for writing this documentation
  * Do not render minimap if there are no panel anchors (Sage Abdullah)
  * Use dropdown buttons on listings in dashboard panels (Sage Abdullah)
  * Implement breadcrumbs design refinements (Thibaud Colas)
- * The `purge_revisions` management command now respects revisions that have a `on_delete=PROTECT` foreign key relation and won't delete them (Neeraj P Yetheendran, Meghana Reddy, Sage Abdullah, Storm Heg)
+ * The [`purge_revisions` management command](purge_revisions) now respects revisions that have a `on_delete=PROTECT` foreign key relation and won't delete them (Neeraj P Yetheendran, Meghana Reddy, Sage Abdullah, Storm Heg)
  * Add support for Shift + Click behaviour in form submissions and simple translations submissions (LB (Ben) Johnston)
  * Improve filtering of audit logging based on the user's permissions (Stefan Hammer)
 
@@ -121,15 +121,15 @@ Thank you to core contributor (LB (Ben) Johnston) for writing this documentation
 
 ### Documentation
 
- * Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
+ * Document `WAGTAILADMIN_BASE_URL` on ("Integrating Wagtail into a Django project")[integrating_into_django] page (Shreshth Srivastava)
  * Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)
- * Add documentation for building non-model-based choosers using the _queryish_ library (Matt Westcott)
+ * Add documentation for building [non-model-based choosers using the _queryish_ library](chooser_viewsets_non_model_data) (Matt Westcott)
  * Fix incorrect tag library import on focal points example (Hatim Makki Hoho)
  * Add reminder about including your custom Draftail feature in any overridden `WAGTAILADMIN_RICH_TEXT_EDITORS` setting (Charlie Sue)
  * Mention the need to install `python3-venv` on Ubuntu (Brian Mugo)
  * Document the use of the Google developer documentation style guide in documentation (Damilola Oladele)
  * Fix Inconsistent URL Format in Getting Started tutorial (Olumide Micheal)
- * Add more extensive documentation for the `permission` kwarg support in Panels (LB (Ben) Johnston)
+ * Add more extensive documentation for the [`permission` kwarg support in Panels](panels_permissions) (LB (Ben) Johnston)
  * Update all `FieldPanel('title')` examples to use the recommended `TitleFieldPanel('title')` panel (Chinedu Ihedioha)
 
 ### Maintenance


### PR DESCRIPTION
- Small typo fix
- Add supporting links to 5.2 release notes where practical