### PR TITLE
Fix dropdown button clickable on wide screens when closed 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changelog
 
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
+ * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix)
  * Maintenance: Update BeautifulSoup upper bound to 4.12.x (scott-8)
  * Maintenance: Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -755,6 +755,7 @@
 * Chinedu Ihedioha
 * scott-8
 * phijma-leukeleu
+* CheesyPhoenix
 
 ## Translators
 

--- a/client/scss/components/_dropdown.legacy.scss
+++ b/client/scss/components/_dropdown.legacy.scss
@@ -33,9 +33,9 @@
     position: absolute;
     overflow: hidden;
     top: 100%;
-    inset-inline-start: -2000px;
     z-index: 500;
     opacity: 0;
+    pointer-events: none;
 
     li {
       float: none;
@@ -127,7 +127,7 @@
   &.open ul {
     box-shadow: 0 3px 3px 0 theme('colors.black-20');
     opacity: 1;
-    inset-inline-start: 0;
+    pointer-events: initial;
     display: block;
   }
 

--- a/docs/releases/5.3.md
+++ b/docs/releases/5.3.md
@@ -20,6 +20,7 @@ depth: 1
 
  * Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
+ * Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix)
 
 ### Documentation
 


### PR DESCRIPTION
We also noticed same issue as #11037. The dropdown button remains clickable when closed and is simply moved 2000px to the left. This means it is possible for the button to invisibly hover over other elements on large screens.

The rationale for using `inset-inline-start: -2000px` seems to be to ensure that the fade in and out animation plays when opening/closing the dropdown.

Fixed the issue by using `pointer-events: none` instead of trying to position the element off-screen, while also preserving the fade in/out animations. 