### PR TITLE
Reorder v5.2 release notes to showcase more changes

### DIFF
--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -41,42 +41,64 @@ Wagtail now officially supports client-side admin customisations with [Stimulus]
  * Extending with Stimulus
  * Extending with React
 
-Thank you to core contributor (LB (Ben) Johnston) for writing this documentation.
+Thank you to core contributor LB (Ben) Johnston for writing this documentation.
+
+### `ModelViewSet` improvements
+
+A number of features from {class}`~wagtail.snippets.views.snippets.SnippetViewSet` have been implemented in {class}`~wagtail.admin.viewsets.model.ModelViewSet`, allowing you to use them without registering your models as snippets.
+
+ * Move `SnippetViewSet` menu registration mechanism to base `ViewSet` class (Sage Abdullah)
+ * Move `SnippetViewSet` template override mechanism to `ModelViewSet` (Sage Abdullah)
+ * Move `SnippetViewSet.list_display` to `ModelViewSet` (Sage Abdullah)
+ * Move `list_filter`, `filterset_class`, `search_fields`, `search_backend_name`, `list_export`, `export_filename`, `list_per_page`, and `ordering` from `SnippetViewSet` to `ModelViewSet` (Sage Abdullah)
+ * Add default header titles to generic `IndexView` and `CreateView` (Sage Abdullah)
+ * Add the ability to use filters and to export listings in generic `IndexView` (Sage Abdullah)
+ * Add generic `UsageView` to `ModelViewSet` (Sage Abdullah)
+ * Add generic `InspectView` to `ModelViewSet` (Sage Abdullah)
+ * Extract generic `HistoryView` from snippets and add it to `ModelViewSet` (Sage Abdullah)
+ * Extract generic breadcrumbs functionality from page breadcrumbs (Sage Abdullah)
+ * Add breadcrumbs support to custom `ModelViewSet` views (Sage Abdullah)
+ * Allow `ModelViewSet` to be used with models that have non-integer primary keys (Sage Abdullah)
+ * Enable reference index tracking for models registered with `ModelViewSet` (Sage Abdullah)
+
+In addition, the following new features have been added to the generic admin views as part of `ModelViewSet`, which can also be used with `SnippetViewSet`.
+
+ * Allow overriding `IndexView.export_headings` via `ModelViewSet` (Christer Jensen, Sage Abdullah)
+ * Add the ability to define listing buttons on generic `IndexView` (Sage Abdullah)
+
+### User interface refinements
+
+Several tweaks have been made to the admin user interface which we hope will make it easier to use.
+
+ * Show the full first published at date within a tooltip on the Page status sidebar on the relative date (Rohit Sharma)
+ * Do not render minimap if there are no panel anchors (Sage Abdullah)
+ * Use dropdown buttons on listings in dashboard panels (Sage Abdullah)
+ * Implement breadcrumbs design refinements (Thibaud Colas)
+ * Add support for Shift + Click behaviour in form submissions and simple translations submissions (LB (Ben) Johnston)
+ * Improve filtering of audit logging based on the user's permissions (Stefan Hammer)
+
+### External links in promoted search results
+
+Promoted search result entries can now use an external URL along with custom link text, instead of linking to a page within Wagtail. This makes it easier to manage promoted content across multiple websites. Thank you to TopDevPros, and Brad Busenius from University of Chicago Library.
 
 ### Other features
 
  * Add support for Python 3.12 (Matt Westcott)
  * Add [`wagtailcache`](wagtailcache) and [`wagtailpagecache`](wagtailpagecache) template tags to ensure previewing Pages or Snippets will not be cached (Jake Howard)
  * Always set help text element ID for form fields with help text in `field.html` template (Sage Abdullah)
- * Move `SnippetViewSet` menu registration mechanism to base `ViewSet` class (Sage Abdullah)
- * Enable reference index tracking for models registered with `ModelViewSet` (Sage Abdullah)
  * When copying a page or creating an alias, copy its view restrictions to the destination (Sandeep Choudhary, Suyash Singh)
  * Support pickling of StreamField values (pySilver)
- * Move `SnippetViewSet` template override mechanism to `ModelViewSet` (Sage Abdullah)
- * Move `SnippetViewSet.list_display` to `ModelViewSet` (Sage Abdullah)
  * Remove `wagtail.publish` log action on aliases when they are created from live source pages or the source page is published (Dan Braghis)
  * Remove `wagtail.unpublish` log action on aliases when source page is unpublished (Dan Braghis)
  * Add compare buttons to workflow dashboard panel (Matt Westcott)
- * Add the ability to use filters and to export listings in generic `IndexView` (Sage Abdullah)
- * Move `list_filter`, `filterset_class`, `search_fields`, `search_backend_name`, `list_export`, `export_filename`, `list_per_page`, and `ordering` from `SnippetViewSet` to `ModelViewSet` (Sage Abdullah)
- * Add default header titles to generic `IndexView` and `CreateView` (Sage Abdullah)
- * Allow overriding `IndexView.export_headings` via `ModelViewSet` (Christer Jensen, Sage Abdullah)
  * Support specifying a `get_object_list` method on `ChooserViewSet` (Matt Westcott)
  * Add [`linked_fields` mechanism on chooser widgets](chooser_viewsets_limiting_choices) to allow choices to be limited by fields on the calling page (Matt Westcott)
  * Add support for merging cells within `TableBlock` with the [`mergedCells` option](table_block_options) (Gareth Palmer)
  * When adding a panel within `InlinePanel`, focus will now shift to that content similar to `StreamField` (Faishal Manzar)
- * Show the full first published at date within a tooltip on the Page status sidebar on the relative date (Rohit Sharma)
- * Extract generic breadcrumbs functionality from page breadcrumbs (Sage Abdullah)
  * Add support for `placement` in `human_readable_date` the tooltip template tag (Rohit Sharma)
- * Add breadcrumbs support to custom `ModelViewSet` views (Sage Abdullah)
  * Support passing extra context variables via the `{% component %}` tag (Matt Westcott)
  * Allow subclasses of `PagesAPIViewSet` override default [Page model via the `model`](api_v2_configure_endpoints) attribute (Neeraj Yetheendran, Herbert Poul)
- * Allow `ModelViewSet` to be used with models that have non-integer primary keys (Sage Abdullah)
- * Add the ability to set an external link/text for promoted search result entries (TopDevPros, Brad Busenius)
  * Add support for subject and body in the Email link chooser form (TopDevPros, Alexandre Joly)
- * Extract generic `HistoryView` from snippets and add it to `ModelViewSet` (Sage Abdullah)
- * Add generic `UsageView` to `ModelViewSet` (Sage Abdullah)
- * Add the ability to define listing buttons on generic `IndexView` (Sage Abdullah)
  * Add a visual progress bar to the output of the `wagtail_update_image_renditions` management command (Faishal Manzar)
  * Increase the read buffer size to improve efficiency and performance when generating file hashes for document or image uploads, use `hashlib.file_digest` if available (Python 3.11+) (Jake Howard)
  * API ordering now [supports multiple fields](api_v2_usage_ordering) (Rohit Sharma, Jake Howard)
@@ -84,12 +106,7 @@ Thank you to core contributor (LB (Ben) Johnston) for writing this documentation
  * Add [`InlinePanel` DOM events](inline_panel_events) for when ready and when items added or removed (Faishal Manzar)
  * Support `Filter` instances as input for [`AbstractImage.get_renditions()`](image_renditions_multiple) (Thibaud Colas)
  * Improve error messages for image template tags (Thibaud Colas)
- * Do not render minimap if there are no panel anchors (Sage Abdullah)
- * Use dropdown buttons on listings in dashboard panels (Sage Abdullah)
- * Implement breadcrumbs design refinements (Thibaud Colas)
- * The [`purge_revisions` management command](purge_revisions) now respects revisions that have a `on_delete=PROTECT` foreign key relation and won't delete them (Neeraj P Yetheendran, Meghana Reddy, Sage Abdullah, Storm Heg)
- * Add support for Shift + Click behaviour in form submissions and simple translations submissions (LB (Ben) Johnston)
- * Improve filtering of audit logging based on the user's permissions (Stefan Hammer)
+ * The [`purge_revisions` management command](purge_revisions) now respects revisions that have an `on_delete=PROTECT` foreign key relation and won't delete them (Neeraj P Yetheendran, Meghana Reddy, Sage Abdullah, Storm Heg)
 
 ### Bug fixes
 
@@ -134,26 +151,37 @@ Thank you to core contributor (LB (Ben) Johnston) for writing this documentation
 
 ### Maintenance
 
+#### Stimulus adoption
+
+As part of our [adoption of Stimulus](https://github.com/wagtail/rfcs/blob/main/text/078-adopt-stimulus-js.md), in addition to the new documentation, we have migrated a number of existing components to the framework. Thank you to our core contributor LB who oversees this project, and to all contributors who refactored specific components.
+
+ * Migrate form submission listing checkbox toggling to the shared `w-bulk` Stimulus implementation (LB (Ben) Johnston)
+ * Migrate the editor unsaved messages popup to be driven by Stimulus using the shared `w-message` controller (LB (Ben) Johnston, Hussain Saherwala)
+ * Migrate all other `data-tippy` HTML attribute usage to the Stimulus data-*-value attributes for w-tooltip & w-dropdown (Subhajit Ghosh, LB (Ben) Johnston)
+ * Migrate select all on focus/click behavior to Stimulus, used on the image URL generator (Chiemezuo Akujobi)
+ * Add support for a `reset` method to support Stimulus driven dynamic field resets via the `w-action` controller (Chiemezuo Akujobi)
+ * Add support for a `notify` target on the Stimulus dialog for dispatching events internally (Chiemezuo Akujobi)
+ * Migrate publishing schedule dialog field resets to Stimulus (Chiemezuo Akujobi)
+
+#### Other maintenance
+
  * Fix snippet search test to work on non-fallback database backends (Matt Westcott)
- * Update Eslint, Prettier & Jest npm packages (LB (Ben) Johnston)
+ * Update ESLint, Prettier & Jest npm packages (LB (Ben) Johnston)
  * Add npm scripts for TypeScript checks and formatting SCSS files (LB (Ben) Johnston)
  * Run tests in parallel in some of the CI setup (Sage Abdullah)
  * Remove unused WorkflowStatus view, urlpattern, and workflow-status.js (Storm Heg)
  * Add support for options/attrs in Telepath widgets so that attrs render on the created DOM (Storm Heg)
- * Update pre-commit hooks to be in sync with latest changes to Eslint & Prettier for client-side changes (Storm Heg)
+ * Update pre-commit hooks to be in sync with latest changes to ESLint & Prettier for client-side changes (Storm Heg)
  * Add `WagtailTestUtils.get_soup()` method for testing HTML content (Storm Heg, Sage Abdullah)
  * Allow `ViewSet` subclasses to customise `url_prefix` and `url_namespace` logic (Matt Westcott)
  * Simplify `SnippetViewSet` registration code (Sage Abdullah)
  * Rename groups `IndexView.results_template_name` to `results.html` (Sage Abdullah)
- * Migrate form submission listing checkbox toggling to the shared `w-bulk` Stimulus implementation (LB (Ben) Johnston)
  * Allow viewsets to define a common set of view kwargs (Matt Westcott)
- * Migrate the editor unsaved messages popup to be driven by Stimulus using the shared `w-message` controller (LB (Ben) Johnston, Hussain Saherwala)
  * Do not use jest inside `stubs.js` to prevent Storybook from crashing (LB (Ben) Johnston)
  * Refactor snippets templates to reuse the shared `slim_header.html` template (Sage Abdullah)
  * Refactor `slim_header.html` template to reduce code duplication (Sage Abdullah)
  * Upgrade Willow to v1.6.2 to support MIME type data without reliance on `imghdr` (Jake Howard)
  * Replace `imghdr` with Willow's built-in MIME type detection (Jake Howard)
- * Migrate all other `data-tippy` HTML attribute usage to the Stimulus data-*-value attributes for w-tooltip & w-dropdown (Subhajit Ghosh, LB (Ben) Johnston)
  * Replace `@total_ordering` usage with comparison functions implementation (Virag Jain)
  * Replace `<script type="text/django-form-template"><-/script>` template approach with HTML `template` elements in InlinePanel and expanding formset (Mansi Gundre, Subhajit Ghosh, LB (Ben) Johnston)
  * Refactor side panels code for better reuse in pages and snippets (Sage Abdullah)
@@ -170,11 +198,6 @@ Thank you to core contributor (LB (Ben) Johnston) for writing this documentation
  * Update CI database versions (Jake Howard)
  * Add changelog and issue tracker links to the PyPI project page (Panagiotis H.M. Issaris)
  * Add better deprecation warnings to the `search.Query` & `search.QueryDailyHits` model, move final set of templates from the admin search module to the search promotions contrib module (LB (Ben) Johnston)
- * Add generic `InspectView` to `ModelViewSet` (Sage Abdullah)
- * Migrate select all on focus/click behavior to Stimulus, used on the image URL generator (Chiemezuo Akujobi)
- * Add support for a `reset` method to support Stimulus driven dynamic field resets via the `w-action` controller (Chiemezuo Akujobi)
- * Add support for a `notify` target on the Stimulus dialog for dispatching events internally (Chiemezuo Akujobi)
- * Migrate publishing schedule dialog field resets to Stimulus (Chiemezuo Akujobi)
 
 
 ## Upgrade considerations - changes affecting all projects


### PR DESCRIPTION
Changes the v5.2 release notes to have additional top-level sections:

- `ModelViewSet` improvements
- User interface refinements
- xternal links in promoted search results
- Under Maintenance – Stimulus adoption

Also includes fixing a few typos