### PR TITLE
Restrict workflow report visibility for users with limited permissions

### DIFF
--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -413,8 +413,7 @@ class TestAgingPagesView(WagtailTestUtils, TestCase):
         self.user.save()
 
         response = self.get()
-        self.assertContains(response, "No pages found.")
-        self.assertNotContains(response, self.home.title)
+        self.assertEqual(response.status_code, 302)
 
     def test_csv_export(self):
         self.publish_home_page()

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -2422,7 +2422,7 @@ class TestPageWorkflowReport(BasePageWorkflowTests):
             )
         return response.getvalue().decode()
 
-    def test_workflow_report(self):
+    def test_workflow_report_not_shown_without_permissions(self):
         response = self.client.get(reverse("wagtailadmin_reports:workflow"))
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse("wagtailadmin_home"))

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -161,6 +161,12 @@ class TestWorkflowsIndexView(WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
 
+    def test_workflow_report_not_shown_to_editors(self):
+        self.login(user=self.editor)
+        response = self.client.get(reverse("wagtailadmin_reports:workflow"))
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse("wagtailadmin_home"))
+
 
 class TestWorkflowsCreateView(WagtailTestUtils, TestCase):
     def setUp(self):
@@ -2422,7 +2428,7 @@ class TestPageWorkflowReport(BasePageWorkflowTests):
             )
         return response.getvalue().decode()
 
-    def test_workflow_report_not_shown_without_permissions(self):
+    def test_workflow_report_not_shown_to_moderators(self):
         response = self.client.get(reverse("wagtailadmin_reports:workflow"))
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse("wagtailadmin_home"))

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -15,14 +15,30 @@ from freezegun import freeze_time
 from openpyxl import load_workbook
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
-from wagtail.admin.utils import (get_admin_base_url, get_latest_str,
-                                 get_user_display_name)
-from wagtail.models import (GroupApprovalTask, Page, PageViewRestriction, Task,
-                            TaskState, Workflow, WorkflowContentType, WorkflowPage,
-                            WorkflowState, WorkflowTask)
+from wagtail.admin.utils import (
+    get_admin_base_url,
+    get_latest_str,
+    get_user_display_name,
+)
+from wagtail.models import (
+    GroupApprovalTask,
+    Page,
+    PageViewRestriction,
+    Task,
+    TaskState,
+    Workflow,
+    WorkflowContentType,
+    WorkflowPage,
+    WorkflowState,
+    WorkflowTask,
+)
 from wagtail.signals import page_published, published
-from wagtail.test.testapp.models import (FullFeaturedSnippet, ModeratedModel,
-                                         SimplePage, SimpleTask)
+from wagtail.test.testapp.models import (
+    FullFeaturedSnippet,
+    ModeratedModel,
+    SimplePage,
+    SimpleTask,
+)
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.users.models import UserProfile
 

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -167,6 +167,18 @@ class TestWorkflowsIndexView(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse("wagtailadmin_home"))
 
+    def test_workflow_report_not_shown_without_permission(self):
+        user = self.editor
+        self.login(user)
+        user.is_superuser = False
+        user.save()
+        edit_permission = Permission.objects.get(codename="add_workflow")
+
+        user.user_permissions.add(edit_permission)
+
+        response = self.client.get(reverse("wagtailadmin_reports:workflow"))
+        self.assertRedirects(response, reverse("wagtailadmin_home"))
+
 
 class TestWorkflowsCreateView(WagtailTestUtils, TestCase):
     def setUp(self):

--- a/wagtail/admin/views/reports/aging_pages.py
+++ b/wagtail/admin/views/reports/aging_pages.py
@@ -1,7 +1,7 @@
 import django_filters
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import OuterRef, Subquery
 from django.utils.translation import gettext_lazy as _
 
@@ -11,7 +11,6 @@ from wagtail.coreutils import get_content_type_label
 from wagtail.models import Page, PageLogEntry, get_page_models
 from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.users.utils import get_deleted_user_display_name
-from django.core.exceptions import PermissionDenied
 
 from .base import PageReportView
 
@@ -113,7 +112,7 @@ class AgingPagesView(PageReportView):
         )
 
         return super().get_queryset()
-    
+
     def dispatch(self, request, *args, **kwargs):
         if not PagePermissionPolicy().user_has_permission(request.user, "publish"):
             raise PermissionDenied

--- a/wagtail/admin/views/reports/aging_pages.py
+++ b/wagtail/admin/views/reports/aging_pages.py
@@ -11,6 +11,7 @@ from wagtail.coreutils import get_content_type_label
 from wagtail.models import Page, PageLogEntry, get_page_models
 from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.users.utils import get_deleted_user_display_name
+from django.core.exceptions import PermissionDenied
 
 from .base import PageReportView
 
@@ -112,3 +113,8 @@ class AgingPagesView(PageReportView):
         )
 
         return super().get_queryset()
+    
+    def dispatch(self, request, *args, **kwargs):
+        if not PagePermissionPolicy().user_has_permission(request.user, "publish"):
+            raise PermissionDenied
+        return super().dispatch(request, *args, **kwargs)

--- a/wagtail/admin/views/reports/workflows.py
+++ b/wagtail/admin/views/reports/workflows.py
@@ -4,25 +4,17 @@ import django_filters
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import PermissionDenied
 from django.db.models import CharField, Q
 from django.db.models.functions import Cast
 from django.utils.translation import gettext_lazy as _
-from django.core.exceptions import PermissionDenied
 
-from wagtail.admin.filters import (
-    DateRangePickerWidget,
-    FilteredModelChoiceFilter,
-    WagtailFilterSet,
-)
+from wagtail.admin.filters import (DateRangePickerWidget, FilteredModelChoiceFilter,
+                                   WagtailFilterSet)
 from wagtail.admin.utils import get_latest_str
 from wagtail.coreutils import get_content_type_label
-from wagtail.models import (
-    Task,
-    TaskState,
-    Workflow,
-    WorkflowState,
-    get_default_page_content_type,
-)
+from wagtail.models import (Task, TaskState, Workflow, WorkflowState,
+                            get_default_page_content_type)
 from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.snippets.models import get_editable_models
 
@@ -191,7 +183,7 @@ class WorkflowView(ReportView):
         return WorkflowState.objects.filter(editable_pages | editable_objects).order_by(
             "-created_at"
         )
-    
+
     def dispatch(self, request, *args, **kwargs):
         if not PagePermissionPolicy().user_has_permission(request.user, "edit"):
             raise PermissionDenied

--- a/wagtail/admin/views/reports/workflows.py
+++ b/wagtail/admin/views/reports/workflows.py
@@ -7,6 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import CharField, Q
 from django.db.models.functions import Cast
 from django.utils.translation import gettext_lazy as _
+from django.core.exceptions import PermissionDenied
 
 from wagtail.admin.filters import (
     DateRangePickerWidget,
@@ -190,6 +191,11 @@ class WorkflowView(ReportView):
         return WorkflowState.objects.filter(editable_pages | editable_objects).order_by(
             "-created_at"
         )
+    
+    def dispatch(self, request, *args, **kwargs):
+        if not PagePermissionPolicy().user_has_permission(request.user, "edit"):
+            raise PermissionDenied
+        return super().dispatch(request, *args, **kwargs)
 
 
 class WorkflowTasksView(ReportView):

--- a/wagtail/admin/views/reports/workflows.py
+++ b/wagtail/admin/views/reports/workflows.py
@@ -9,12 +9,20 @@ from django.db.models import CharField, Q
 from django.db.models.functions import Cast
 from django.utils.translation import gettext_lazy as _
 
-from wagtail.admin.filters import (DateRangePickerWidget, FilteredModelChoiceFilter,
-                                   WagtailFilterSet)
+from wagtail.admin.filters import (
+    DateRangePickerWidget,
+    FilteredModelChoiceFilter,
+    WagtailFilterSet,
+)
 from wagtail.admin.utils import get_latest_str
 from wagtail.coreutils import get_content_type_label
-from wagtail.models import (Task, TaskState, Workflow, WorkflowState,
-                            get_default_page_content_type)
+from wagtail.models import (
+    Task,
+    TaskState,
+    Workflow,
+    WorkflowState,
+    get_default_page_content_type,
+)
 from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.snippets.models import get_editable_models
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -938,7 +938,9 @@ class LockedPagesMenuItem(MenuItem):
 
 class WorkflowReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True) and PagePermissionPolicy().user_has_permission(request.user, "edit")
+        return getattr(
+            settings, "WAGTAIL_WORKFLOW_ENABLED", True
+        ) and PagePermissionPolicy().user_has_permission(request.user, "edit")
 
 
 class SiteHistoryReportMenuItem(MenuItem):
@@ -948,7 +950,9 @@ class SiteHistoryReportMenuItem(MenuItem):
 
 class AgingPagesReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return getattr(settings, "WAGTAIL_AGING_PAGES_ENABLED", True) and PagePermissionPolicy().user_has_permission(request.user, "publish")
+        return getattr(
+            settings, "WAGTAIL_AGING_PAGES_ENABLED", True
+        ) and PagePermissionPolicy().user_has_permission(request.user, "publish")
 
 
 @hooks.register("register_reports_menu_item")

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -938,7 +938,7 @@ class LockedPagesMenuItem(MenuItem):
 
 class WorkflowReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True)
+        return getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True) and PagePermissionPolicy().user_has_permission(request.user, "edit")
 
 
 class SiteHistoryReportMenuItem(MenuItem):
@@ -948,7 +948,7 @@ class SiteHistoryReportMenuItem(MenuItem):
 
 class AgingPagesReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return getattr(settings, "WAGTAIL_AGING_PAGES_ENABLED", True)
+        return getattr(settings, "WAGTAIL_AGING_PAGES_ENABLED", True) and PagePermissionPolicy().user_has_permission(request.user, "publish")
 
 
 @hooks.register("register_reports_menu_item")


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #8872 This PR addresses the issue mentioned in #8872  . As suggested, the workflow report visibility has been restricted for users with limited permissions. The previous implementation in #8845 has been superseded by this update.

I have also included a screenshot showcasing the visibility changes

**Screenshot of changes**

![Screenshot (32)](https://github.com/wagtail/wagtail/assets/111359305/0c88320a-c757-4cf3-abc2-599b33943877)

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
