### PR TITLE
make wagtailadmin html template files use _(" ") over {% trans %} variables.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Maintenance: Update BeautifulSoup upper bound to 4.12.x (scott-8)
  * Maintenance: Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)
+ * Maintenance: Adopt the usage of of translate string literals using `arg=_('...')` in all `wagtailadmin` module templates (Chiemezuo Akujobi)
 
 
 5.2 LTS (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix)
+ * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Maintenance: Update BeautifulSoup upper bound to 4.12.x (scott-8)
  * Maintenance: Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)
 

--- a/docs/contributing/translations.md
+++ b/docs/contributing/translations.md
@@ -38,11 +38,11 @@ These new translations are imported into Wagtail for any subsequent RC and the f
 
 ## Marking strings for translation
 
-In code, strings can be marked for translation with using Django's [translation system](django:topics/i18n/translation), using `gettext` or `gettext_lazy` in Python and `blocktranslate` and `translate` in templates.
+In code, strings can be marked for translation with using Django's [translation system](django:topics/i18n/translation), using `gettext` or `gettext_lazy` in Python and `blocktranslate`, `translate`, and `_(" ")` in templates.
 
 In both Python and templates, make sure to always use named placeholder. In addition, in Python, only use the printf style formatting. This is to ensure compatibility with Transifex and help translators in their work.
 
-For example:
+### Translations within Python
 
 ```python
 from django.utils.translation import gettext_lazy as _
@@ -68,8 +68,43 @@ _("Page {page_title} with status {status}".format(page_title=page.title, status=
 _(f"Page {page.title} with status {page.status_string}")
 ```
 
+### Translations with templates
+
+You can import `i18n` and then translate with the `translate`/`blocktranslate` template tags. You can also translate string literals passed as arguments to tags and filters by using the familiar `_()` syntax.
+
+```html+django
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+<!-- preliminary lines of code -->
+
+<!-- Do this to use the translate tag. -->
+{% translate "Any string of your choosing" %}
+
+<!-- Do this to use the blocktranslate tag. -->
+{% blocktranslate %}
+    A multi-line translatable literal.
+{% endblocktranslate %}
+
+<!-- Do these to translate string literals passed to tags and filters. -->
+
+{% some_tag _("Any string of your choosing") %}
+{% some_tag arg_of_some_tag=_("Any string of your choosing") %}
+{% some_tag value_of_some_tag|filter=_("Any string of your choosing") value|yesno:_("yes,no") %}
+
+<!-- A typical example of when to use translation of string literals is -->
+{% translate "example with literal" as var_name %}
+{% some_tag arg_of_some_tag=var_name %}
+
+<!-- If the variable is only ever used once, you could do this instead -->
+{% some_tag arg_of_some_tag=_("example with literal") %}
+```
+
+**Note**: In Wagtail code, you might see `trans` and `blocktrans` instead of `translate` and `blocktranslate`.
+This still works fine. `trans` and `blocktrans` were the tags earlier on in Django, but were replaced in [Django 3.1](https://docs.djangoproject.com/en/3.1/topics/i18n/translation/#translate-template-tag).
+
 ## Additional resources
 
 -   [](django:topics/i18n/translation)
 -   A screen-share [Wagtail Space US 2020 Lightning Talk](https://www.youtube.com/watch?v=sLI_AuOMUQw&t=17s) that walks through using Transifex step-by-step
 -   [Core development instructions for syncing Wagtail translations with Transifex](https://github.com/wagtail/wagtail/wiki/Managing-Wagtail-translations)
+-   [Django docs](django:topics/i18n/translation)

--- a/docs/releases/5.3.md
+++ b/docs/releases/5.3.md
@@ -24,7 +24,7 @@ depth: 1
 
 ### Documentation
 
- * ...
+ * Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
 
 ### Maintenance
 

--- a/docs/releases/5.3.md
+++ b/docs/releases/5.3.md
@@ -30,6 +30,7 @@ depth: 1
 
  * Update BeautifulSoup upper bound to 4.12.x (scott-8)
  * Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)
+ * Adopt the usage of of translate string literals using `arg=_('...')` in all `wagtailadmin` module templates (Chiemezuo Akujobi)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/templates/wagtailadmin/account/account.html
+++ b/wagtail/admin/templates/wagtailadmin/account/account.html
@@ -3,8 +3,7 @@
 
 {% block titletag %}{% trans "Account" %}{% endblock %}
 {% block content %}
-    {% trans "Account" as account_str %}
-    {% include "wagtailadmin/shared/header.html" with title=account_str icon="user" merged=1 %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Account") icon="user" merged=1 %}
 
     <div class="w-tabs" data-tabs>
         <div class="w-tabs__wrapper">
@@ -14,8 +13,7 @@
                 {% endfor %}
 
                 {% if menu_items %}
-                    {% trans 'More actions' as menu_items_title %}
-                    {% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with tab_id='actions' title=menu_items_title %}
+                    {% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with tab_id='actions' title=_("More actions") %}
                 {% endif %}
             </div>
         </div>

--- a/wagtail/admin/templates/wagtailadmin/bulk_actions/select_all_checkbox_input.html
+++ b/wagtail/admin/templates/wagtailadmin/bulk_actions/select_all_checkbox_input.html
@@ -1,3 +1,2 @@
 {% load i18n %}
-{% trans "Select all" as aria_label %}
-<input {% if parent %}data-bulk-action-parent-id="{{ parent }}"{% endif %} data-bulk-action-select-all-checkbox type="checkbox" aria-label="{{ aria_label }}" />
+<input {% if parent %}data-bulk-action-parent-id="{{ parent }}"{% endif %} data-bulk-action-select-all-checkbox type="checkbox" aria-label="{{ _('Select all') }}"/>

--- a/wagtail/admin/templates/wagtailadmin/chooser/anchor_link.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/anchor_link.html
@@ -1,6 +1,5 @@
 {% load i18n wagtailadmin_tags %}
-{% trans "Add an anchor link" as anchor_str %}
-{% include "wagtailadmin/shared/header.html" with title=anchor_str %}
+{% include "wagtailadmin/shared/header.html" with title=_("Add an anchor link") %}
 
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='anchor' %}

--- a/wagtail/admin/templates/wagtailadmin/chooser/email_link.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/email_link.html
@@ -1,6 +1,5 @@
 {% load i18n wagtailadmin_tags %}
-{% trans "Add an email link" as email_str %}
-{% include "wagtailadmin/shared/header.html" with title=email_str %}
+{% include "wagtailadmin/shared/header.html" with title=_("Add an email link") %}
 
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='email' %}

--- a/wagtail/admin/templates/wagtailadmin/chooser/external_link.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/external_link.html
@@ -1,6 +1,5 @@
 {% load i18n wagtailadmin_tags %}
-{% trans "Add an external link" as add_str %}
-{% include "wagtailadmin/shared/header.html" with title=add_str %}
+{% include "wagtailadmin/shared/header.html" with title=_("Add an external link") %}
 
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='external' %}

--- a/wagtail/admin/templates/wagtailadmin/chooser/phone_link.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/phone_link.html
@@ -1,6 +1,5 @@
 {% load i18n wagtailadmin_tags %}
-{% trans "Add a phone link" as phone_str %}
-{% include "wagtailadmin/shared/header.html" with title=phone_str %}
+{% include "wagtailadmin/shared/header.html" with title=_("Add a phone link") %}
 
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='phone' %}

--- a/wagtail/admin/templates/wagtailadmin/collection_privacy/ancestor_privacy.html
+++ b/wagtail/admin/templates/wagtailadmin/collection_privacy/ancestor_privacy.html
@@ -1,6 +1,5 @@
 {% load i18n %}
-{% trans "Collection privacy" as title_str %}
-{% include "wagtailadmin/shared/header.html" with title=title_str icon="no-view" %}
+{% include "wagtailadmin/shared/header.html" with title=_("Collection privacy") icon="no-view" %}
 
 <div class="nice-padding">
     <p>{% trans "This collection has been made private by a parent collection." %}</p>

--- a/wagtail/admin/templates/wagtailadmin/collections/_privacy_switch.html
+++ b/wagtail/admin/templates/wagtailadmin/collections/_privacy_switch.html
@@ -3,10 +3,8 @@
 {% test_collection_is_public collection as is_public %}
 
 {% if not collection.is_root %}
-    {% trans 'Change privacy' as set_privacy_title %}
-    {% trans 'Privacy settings determine who is able to view documents in this collection.' as privacy_message_text %}
     {% url 'wagtailadmin_collections:set_privacy' collection.id as privacy_url %}
-    {% dialog icon_name='view' id='set-privacy' data_url=privacy_url title=set_privacy_title message_status='info' message_heading=privacy_message_text %}
+    {% dialog icon_name='view' id='set-privacy' data_url=privacy_url title=_("Change privacy") message_status='info' message_heading=_("Privacy settings determine who is able to view documents in this collection.") %}
     {% enddialog %}
 
     <div class="privacy-indicator {% if is_public %}public{% else %}private{% endif %}">

--- a/wagtail/admin/templates/wagtailadmin/generic/confirm_unpublish.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/confirm_unpublish.html
@@ -2,8 +2,7 @@
 {% load i18n wagtailadmin_tags %}
 {% block titletag %}{% blocktrans trimmed with title=object_display_title %}Unpublish {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
-    {% trans "Unpublish" as unpublish_str %}
-    {% include "wagtailadmin/shared/header.html" with title=unpublish_str subtitle=object_display_title icon=header_icon %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Unpublish") subtitle=object_display_title icon=header_icon %}
 
     <div class="nice-padding">
         {% if usage_url %}

--- a/wagtail/admin/templates/wagtailadmin/generic/revisions/compare.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/revisions/compare.html
@@ -4,8 +4,7 @@
 {% block titletag %}{% blocktrans trimmed with title=page_subtitle %}Comparing {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
-    {% trans "Comparing" as comparing_str %}
-    {% include "wagtailadmin/shared/header.html" with title=comparing_str subtitle=page_subtitle icon=header_icon %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Comparing") subtitle=page_subtitle icon=header_icon %}
 
     <div class="nice-padding">
 

--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -1,8 +1,7 @@
 {% load i18n wagtailadmin_tags %}
 {% load wagtailcore_tags %}
 {% if locked_pages %}
-    {% trans "Your locked pages" as heading %}
-    {% panel id="locked-pages" heading=heading %}
+    {% panel id="locked-pages" heading=_("Your locked pages") %}
         <table class="listing listing-page">
             <col />
             <col width="30%"/>

--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -1,7 +1,6 @@
 {% load i18n wagtailadmin_tags %}
 {% if page_revisions_for_moderation %}
-    {% trans "Pages awaiting moderation" as heading %}
-    {% panel id="awaiting-moderation" heading=heading %}
+    {% panel id="awaiting-moderation" heading=_("Pages awaiting moderation") %}
         <table class="listing">
             <col />
             <col width="30%"/>

--- a/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
@@ -2,8 +2,7 @@
 {% load wagtailcore_tags %}
 {% load i18n wagtailadmin_tags %}
 {% if last_edits %}
-    {% trans "Your most recent edits" as heading %}
-    {% panel id="recent-edits" heading=heading %}
+    {% panel id="recent-edits" heading=_("Your most recent edits") %}
         <table class="listing listing-page">
             <col />
             <col width="30%"/>

--- a/wagtail/admin/templates/wagtailadmin/home/user_objects_in_workflow_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/user_objects_in_workflow_moderation.html
@@ -2,8 +2,7 @@
 
 {% load i18n wagtailadmin_tags %}
 {% if workflow_states %}
-    {% trans "Your pages and snippets in a workflow" as heading %}
-    {% panel id="objects-in-workflow" heading=heading %}
+    {% panel id="objects-in-workflow" heading=_("Your pages and snippets in a workflow") %}
         <table class="listing">
             <col />
             <col width="30%"/>

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -1,7 +1,6 @@
 {% load i18n wagtailadmin_tags %}
 {% if states %}
-    {% trans "Awaiting your review" as heading %}
-    {% panel id="awaiting-review" heading=heading %}
+    {% panel id="awaiting-review" heading=_("Awaiting your review") %}
         <table class="listing">
             <col />
             <col width="15%"/>

--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -46,8 +46,7 @@
                         {% endfor %}
                     {% endblock extra_fields %}
 
-                    {% trans "Remember me" as checkbox_text %}
-                    {% include "wagtailadmin/shared/forms/single_checkbox.html" with label_classname="remember-me" name="remember" text=checkbox_text %}
+                    {% include "wagtailadmin/shared/forms/single_checkbox.html" with label_classname="remember-me" name="remember" text=_("Remember me") %}
                 {% endblock %}
             {% endblock %}
             <footer class="form-actions">

--- a/wagtail/admin/templates/wagtailadmin/page_privacy/ancestor_privacy.html
+++ b/wagtail/admin/templates/wagtailadmin/page_privacy/ancestor_privacy.html
@@ -1,6 +1,5 @@
 {% load i18n %}
-{% trans "Page privacy" as title_str %}
-{% include "wagtailadmin/shared/header.html" with title=title_str icon="no-view" %}
+{% include "wagtailadmin/shared/header.html" with title=_("Page privacy") icon="no-view" %}
 
 <div class="nice-padding">
     <p>{% trans "This page has been made private by a parent page." %}</p>

--- a/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
@@ -5,8 +5,7 @@
 {% block titletag %}{% blocktrans trimmed with title=parent_page.get_admin_display_title %}Create a page in {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
-    {% trans "Create a page in" as create_str %}
-    {% include "wagtailadmin/shared/header.html" with title=create_str subtitle=parent_page.get_admin_display_title icon="doc-empty-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Create a page in") subtitle=parent_page.get_admin_display_title icon="doc-empty-inverse" %}
 
     <div class="nice-padding">
         {% if page_types %}

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_delete.html
@@ -4,8 +4,7 @@
 {% block titletag %}{% blocktrans trimmed count counter=items|length %}Delete 1 page {% plural %}Delete {{ counter }} pages{% endblocktrans %}{% endblock %}
 
 {% block header %}
-    {% trans "Delete" as del_str %}
-    {% include "wagtailadmin/shared/header.html" with title=del_str icon="doc-empty-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Delete") icon="doc-empty-inverse" %}
 {% endblock header %}
 
 {% block items_with_access %}

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_move.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_move.html
@@ -5,8 +5,7 @@
 {% endblock %}
 
 {% block header %}
-    {% trans "Move" as move_str %}
-    {% include "wagtailadmin/shared/header.html" with title=move_str icon="doc-empty-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Move") icon="doc-empty-inverse" %}
 {% endblock header %}
 
 {% block items_with_access %}

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_publish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_publish.html
@@ -4,8 +4,7 @@
 {% block titletag %}{% blocktrans trimmed count counter=items|length %}Publish 1 page {% plural %}Publish {{ counter }} pages{% endblocktrans %}{% endblock %}
 
 {% block header %}
-    {% trans "Publish" as publish_str %}
-    {% include "wagtailadmin/shared/header.html" with title=publish_str icon="doc-empty-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Publish") icon="doc-empty-inverse" %}
 {% endblock header %}
 
 {% block items_with_access %}

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_unpublish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_unpublish.html
@@ -4,8 +4,7 @@
 {% block titletag %}{% blocktrans trimmed count counter=items|length %}Unpublish 1 page {% plural %}Unpublish {{ counter }} pages{% endblocktrans %}{% endblock %}
 
 {% block header %}
-    {% trans "Unpublish" as unpublish_str %}
-    {% include "wagtailadmin/shared/header.html" with title=unpublish_str icon="doc-empty-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Unpublish") icon="doc-empty-inverse" %}
 {% endblock header %}
 
 {% block items_with_access %}

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_convert_alias.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_convert_alias.html
@@ -3,8 +3,7 @@
 {% block titletag %}{% blocktrans trimmed with title=page.get_admin_display_title %}Convert alias {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
-    {% trans "Convert alias" as del_str %}
-    {% include "wagtailadmin/shared/header.html" with title=del_str subtitle=page.get_admin_display_title icon="doc-empty-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Convert alias") subtitle=page.get_admin_display_title icon="doc-empty-inverse" %}
 
     <div class="nice-padding">
         <p>

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
@@ -3,8 +3,7 @@
 {% block titletag %}{% blocktrans trimmed with title=page.get_admin_display_title %}Delete {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
-    {% trans "Delete" as del_str %}
-    {% include "wagtailadmin/shared/header.html" with title=del_str subtitle=page.get_admin_display_title icon="doc-empty-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Delete") subtitle=page.get_admin_display_title icon="doc-empty-inverse" %}
 
     <div class="nice-padding">
         {% include "wagtailadmin/shared/usage_summary.html" %}

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_move.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_move.html
@@ -2,8 +2,7 @@
 {% load i18n %}
 {% block titletag %}{% blocktrans trimmed with title=page_to_move.get_admin_display_title %}Move {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
-    {% trans "Move" as move_str %}
-    {% include "wagtailadmin/shared/header.html" with title=move_str subtitle=page_to_move.get_admin_display_title icon="doc-empty-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Move") subtitle=page_to_move.get_admin_display_title icon="doc-empty-inverse" %}
 
     <div class="nice-padding">
         <p>

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_workflow_cancellation.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_workflow_cancellation.html
@@ -1,6 +1,5 @@
 {% load i18n %}
-{% trans 'Publish page' as publish_title %}
-{% include "wagtailadmin/shared/header.html" with title=publish_title icon="clipboard-list" %}
+{% include "wagtailadmin/shared/header.html" with title=_("Publish page") icon="clipboard-list" %}
 
 <div class="nice-padding">
     <p>

--- a/wagtail/admin/templates/wagtailadmin/pages/copy.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/copy.html
@@ -2,8 +2,7 @@
 {% load i18n %}
 {% block titletag %}{% blocktrans trimmed with title=page.specific_deferred.get_admin_display_title %}Copy {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
-    {% trans "Copy" as copy_str %}
-    {% include "wagtailadmin/shared/header.html" with title=copy_str subtitle=page.specific_deferred.get_admin_display_title icon="doc-empty-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Copy") subtitle=page.specific_deferred.get_admin_display_title icon="doc-empty-inverse" %}
 
     <div class="nice-padding">
         <form action="{% url 'wagtailadmin_pages:copy' page.id %}" method="POST" novalidate>

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -9,8 +9,7 @@
     <div id="listing-results">
         {% include 'wagtailadmin/pages/index_results.html' %}
     </div>
-    {% trans "Select all pages in listing" as select_all_text %}
-    {% include 'wagtailadmin/bulk_actions/footer.html' with select_all_obj_text=select_all_text app_label='wagtailcore' model_name='page' objects=page_obj %}
+    {% include 'wagtailadmin/bulk_actions/footer.html' with select_all_obj_text=_("Select all pages in listing") app_label='wagtailcore' model_name='page' objects=page_obj %}
 {% endblock %}
 
 {% block extra_js %}

--- a/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
@@ -2,8 +2,7 @@
 {% load i18n %}
 {% block titletag %}{% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Move {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
-    {% trans "Move" as header_title %}
-    {% include "wagtailadmin/shared/header.html" with title=header_title subtitle=page_to_move.specific_deferred.get_admin_display_title icon="doc-empty-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Move") subtitle=page_to_move.specific_deferred.get_admin_display_title icon="doc-empty-inverse" %}
 
     <div class="nice-padding">
         <form action="{% url 'wagtailadmin_pages:move' page_to_move.id %}" method="POST" novalidate>

--- a/wagtail/admin/templates/wagtailadmin/pages/search.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/search.html
@@ -10,9 +10,8 @@
 {% endblock %}
 
 {% block content %}
-    {% trans "Search" as search_str %}
     {% url 'wagtailadmin_pages:search_results' as search_results_url %}
-    {% include "wagtailadmin/shared/header.html" with title=search_str search_url="wagtailadmin_pages:search" icon="search" search_results_url=search_results_url search_target="#page-results" %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Search") search_url="wagtailadmin_pages:search" icon="search" search_results_url=search_results_url search_target="#page-results" %}
     <div id="page-results">
         {% include "wagtailadmin/pages/search_results.html" %}
     </div>

--- a/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
@@ -1,6 +1,5 @@
 {% load i18n wagtailadmin_tags %}
 
-{% trans 'Set publishing schedule' as schedule_publishing_dialog_title %}
 {% blocktrans trimmed with model_name=model_opts.verbose_name asvar schedule_publishing_dialog_subtitle %}
     Choose when this {{ model_name }} should go live and/or expire
 {% endblocktrans%}
@@ -16,7 +15,7 @@
     {% endif %}
 {% endif %}
 
-{% dialog id='schedule-publishing-dialog' dialog_root_selector='[data-edit-form]' classname=classname icon_name='calendar-alt' title=schedule_publishing_dialog_title subtitle=schedule_publishing_dialog_subtitle|capfirst message_icon_name='info' message_status='info' message_heading=message_heading message_description=message_description %}
+{% dialog id='schedule-publishing-dialog' dialog_root_selector='[data-edit-form]' classname=classname icon_name='calendar-alt' title=_("Set publishing schedule") subtitle=schedule_publishing_dialog_subtitle|capfirst message_icon_name='info' message_status='info' message_heading=message_heading message_description=message_description %}
     {% include 'wagtailadmin/panels/multi_field_panel.html' %}
 
     <button

--- a/wagtail/admin/templates/wagtailadmin/shared/collection_chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/collection_chooser.html
@@ -1,7 +1,6 @@
 {% load wagtailadmin_tags i18n l10n %}
 
-{% trans "Collection" as label_text %}
-{% field label_text=label_text id_for_label="collection_chooser_collection_id" %}
+{% field label_text=_("Collection") id_for_label="collection_chooser_collection_id" %}
     <select id="collection_chooser_collection_id" name="collection_id" data-controller="w-submit" data-action="change->w-submit#submit">
         <option value="">{% trans "All collections" %}</option>
         {% for pk, display_name in collections.get_indented_choices %}

--- a/wagtail/admin/templates/wagtailadmin/shared/revisions/confirm_unschedule.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/revisions/confirm_unschedule.html
@@ -2,8 +2,7 @@
 {% load i18n %}
 {% block titletag %}{% blocktrans trimmed with title=object_display_title %}Unschedule Revision {{ revision.id }} for {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
-    {% trans "Unschedule" as unschedule_str %}
-    {% include "wagtailadmin/shared/header.html" with title=unschedule_str subtitle=subtitle icon=header_icon %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Unschedule") subtitle=subtitle icon=header_icon %}
 
     <div class="nice-padding">
         <p>{% trans "Are you sure you want to unschedule this revision?" %}</p>

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/preview.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/preview.html
@@ -43,8 +43,7 @@
                 </div>
             </div>
             {% if has_multiple_modes %}
-                {% trans 'Preview mode' as label_text %}
-                {% field label_text=label_text id_for_label="id_preview_mode" classname="preview-panel__modes" %}
+                {% field label_text=_("Preview mode") id_for_label="id_preview_mode" classname="preview-panel__modes" %}
                     <select id="id_preview_mode" name="preview_mode" class="preview-panel__mode-select" data-preview-mode-select>
                         {% for internal_name, display_name in object.preview_modes %}
                             <option value="{{ internal_name }}"{% if internal_name == object.default_preview_mode %} selected{% endif %}>{{ display_name }}</option>

--- a/wagtail/admin/templates/wagtailadmin/shared/workflow_history/detail.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/workflow_history/detail.html
@@ -28,10 +28,8 @@
     <div class="w-tabs" data-tabs>
         <div class="w-tabs__wrapper">
             <div role="tablist" class="w-tabs__list ">
-                {% trans "Tasks" as tasks_title %}
-                {% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with tab_id="tasks" title=tasks_title %}
-                {% trans "Timeline" as timeline_title %}
-                {% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with tab_id="timeline" title=timeline_title %}
+                {% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with tab_id="tasks" title=_("Tasks") %}
+                {% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with tab_id="timeline" title=_("Timeline") %}
             </div>
         </div>
         <div class="tab-content">

--- a/wagtail/admin/templates/wagtailadmin/shared/workflow_history/index.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/workflow_history/index.html
@@ -5,8 +5,7 @@
 
 {% block content %}
     {% latest_str object as object_str %}
-    {% trans "Workflow history for" as workflow_history_str %}
-    {% include "wagtailadmin/shared/header.html" with title=workflow_history_str subtitle=object_str icon=header_icon %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Workflow history for") subtitle=object_str icon=header_icon %}
 
     <div class="nice-padding">
         <p style="margin-bottom: 30px;">

--- a/wagtail/admin/templates/wagtailadmin/shared/workflow_history/list.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/workflow_history/list.html
@@ -32,14 +32,12 @@
                                 {{ workflow_state.workflow.name }}
                             </a>
                         </h2>
-                        {% trans 'Approved task' as approved_title %}
-                        {% trans 'Incomplete task' as incomplete_title %}
                         {% for task in workflow_state.all_tasks_with_status %}
                             <span tabindex="0" data-controller="w-tooltip" data-w-tooltip-content-value="{{ task.name }}: {{ task.status_display }}">
                                 {% if task.status == 'approved' %}
-                                    {% icon "success" title=approved_title classname="initial" %}
+                                    {% icon "success" title=_("Approved task") classname="initial" %}
                                 {% else %}
-                                    {% icon "radio-empty" title=incomplete_title classname="initial" %}
+                                    {% icon "radio-empty" title=_("Incomplete task") classname="initial" %}
                                 {% endif %}
                             </span>
                         {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/widgets/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/chooser.html
@@ -17,8 +17,7 @@
             <div class="chooser__title" data-chooser-title id="{{ title_id }}">{{ display_title }}</div>
         {% endblock %}
 
-        {% trans "Actions" as toggle_label %}
-        {% dropdown toggle_icon="dots-horizontal" toggle_aria_label=toggle_label toggle_describedby=title_id hide_on_click=True %}
+        {% dropdown toggle_icon="dots-horizontal" toggle_aria_label=_("Actions") toggle_describedby=title_id hide_on_click=True %}
             <button type="button" data-chooser-action-choose aria-describedby="{{ title_id }}">
                 {% icon name="resubmit" %}
                 {{ widget.choose_another_text }}

--- a/wagtail/admin/templates/wagtailadmin/workflows/create.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/create.html
@@ -27,14 +27,12 @@
         <div class="nice-padding w-form-width">
             {% block form %}{{ edit_handler.render_form_content }}{% endblock %}
 
-            {% trans "Assign your workflow to pages" as heading %}
-            {% panel id="workflow-pages" icon="doc-empty-inverse" heading=heading %}
+            {% panel id="workflow-pages" icon="doc-empty-inverse" heading=_("Assign your workflow to pages") %}
                 {% include "wagtailadmin/workflows/includes/workflow_pages_formset.html" with formset=pages_formset %}
             {% endpanel %}
 
             {% if has_workflow_enabled_models %}
-                {% trans "Assign your workflow to snippets" as heading %}
-                {% panel id="workflow-content-types" icon="snippet" heading=heading %}
+                {% panel id="workflow-content-types" icon="snippet" heading=_("Assign your workflow to snippets") %}
                     {% include "wagtailadmin/shared/field.html" with field=content_type_form.content_types sr_only_label=True only %}
                 {% endpanel %}
             {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/edit.html
@@ -27,8 +27,7 @@
         <div class="nice-padding w-form-width">
             {% block form %}{{ edit_handler.render_form_content }}{% endblock %}
 
-            {% trans "Assign your workflow to pages" as heading %}
-            {% panel id="workflow-pages" icon="doc-empty-inverse" heading=heading %}
+            {% panel id="workflow-pages" icon="doc-empty-inverse" heading=_("Assign your workflow to pages") %}
                 {% if workflow.active %}
                     <p class="help-block help-info">
                         {% icon name='help' %}
@@ -49,8 +48,7 @@
             {% endpanel %}
 
             {% if has_workflow_enabled_models %}
-                {% trans "Assign your workflow to snippets" as heading %}
-                {% panel id="workflow-content-types" icon="snippet" heading=heading %}
+                {% panel id="workflow-content-types" icon="snippet" heading=_("Assign your workflow to snippets") %}
                     {% if workflow.active %}
                         {% include "wagtailadmin/shared/field.html" with field=content_type_form.content_types sr_only_label=True only %}
                     {% else %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/includes/task_title_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/includes/task_title_cell.html
@@ -3,6 +3,5 @@
 
 {% block title %}
     {{ block.super }}
-    {% trans "Disabled" as status_label %}
-    {% if not instance.active %}{% status status_label %}{% endif %}
+    {% if not instance.active %}{% status _("Disabled") %}{% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -38,8 +38,7 @@
                             <td class="title">
                                 <div class="title-wrapper">
                                     <a href="{% url view.edit_url_name workflow.pk %}">{{ workflow }}</a>
-                                    {% trans "Disabled" as status_label %}
-                                    {% if not workflow.active %}{% status status_label %}{% endif %}
+                                    {% if not workflow.active %}{% status _("Disabled") %}{% endif %}
                                 </div>
                             </td>
                             <td class="title">

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/chooser.html
@@ -1,15 +1,12 @@
 {% load i18n %}
-{% trans "Choose a task" as  choose_str %}
-{% include "wagtailadmin/shared/header.html" with title=choose_str merged=1 icon="thumbtack" %}
+{% include "wagtailadmin/shared/header.html" with title=_("Choose a task") merged=1 icon="thumbtack" %}
 
 {% if can_create %}
     <div class="w-tabs" data-tabs data-tabs-disable-url>
         <div class="w-tabs__wrapper w-overflow-hidden">
             <div role="tablist" class="w-tabs__list w-w-full">
-                {% trans "New" as new_text %}
-                {% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with tab_id='new' title=new_text %}
-                {% trans "Existing" as existing_text %}
-                {% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with tab_id='existing' title=existing_text %}
+                {% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with tab_id='new' title=_("New") %}
+                {% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with tab_id='existing' title=_("Existing") %}
             </div>
         </div>
 

--- a/wagtail/admin/templates/wagtailadmin/workflows/usage.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/usage.html
@@ -2,8 +2,7 @@
 {% load i18n %}
 {% block titletag %}{% blocktrans trimmed with name=workflow.name %}Pages that use workflow '{{ name }}'{% endblocktrans %}{% endblock %}
 {% block content %}
-    {% trans "Pages that use workflow" as usage_str %}
-    {% include "wagtailadmin/shared/header.html" with title=usage_str subtitle=workflow.name %}
+    {% include "wagtailadmin/shared/header.html" with title=_("Pages that use workflow") subtitle=workflow.name %}
 
     <div class="nice-padding">
         <table class="listing">

--- a/wagtail/admin/templates/wagtailadmin/workflows/workflow_status.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/workflow_status.html
@@ -9,10 +9,9 @@
     </li>
 
     {# Workflow tasks #}
-    {% trans "Not started" as not_started_text %}
     {% if workflow_state %}
         {% for task in workflow_state.all_tasks_with_state %}
-            {% with status=task.task_state.status status_display=task.task_state.get_status_display|default:not_started_text %}
+            {% with status=task.task_state.status status_display=task.task_state.get_status_display|default:_("Not started") %}
                 <li class="workflow-timeline__item workflow-timeline__item--{{ status|default:"pending" }}" {% if status == "in_progress" %}aria-current="step"{% endif %}>
                     <div class="workflow-timeline__line"></div>
                     {% if status == "rejected" %}


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

This is the first step in fixing #10126.
I ran the `./scripts/rebuild-translation-sources.sh` file to be sure the changes reflected, and they did. 
I've also updated the documentation with some code snippets. There are more files that can be refactored across the project, but these changes are good for the scope of a single PR.






_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
