### PR TITLE
Allow `UniqueConstraint` in place of `unique_together` for `TranslatableMixin`'s system check

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
  * Remember previous location on returning from page add/edit actions (Robert Rollins)
  * Update settings file in project settings to address Django 4.2 deprecations (Sage Abdullah)
  * Improve layout and accessibility of the image URL generator page, reduce reliance on JavaScript (Temidayo Azeez)
+ * Allow `UniqueConstraint` in place of `unique_together` for `TranslatableMixin`'s system check (Temidayo Azeez, Sage Abdullah)
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -453,8 +453,6 @@ Pages already include this mixin, so there is no need to add it.
 
 ### Database fields
 
-The `locale` and `translation_key` fields have a unique key constraint to prevent the object being translated into a language more than once.
-
 ```{eval-rst}
 .. class:: TranslatableMixin
 
@@ -470,6 +468,18 @@ The `locale` and `translation_key` fields have a unique key constraint to preven
 
         A UUID that is randomly generated whenever a new model instance is created.
         This is shared with all translations of that instance so can be used for querying translations.
+```
+
+The `translation_key` and `locale` fields have a unique key constraint to prevent the object being translated into a language more than once.
+
+```{note}
+This is currently enforced via {attr}`~django.db.models.Options.unique_together` in `TranslatableMixin.Meta`, but may be replaced with a {class}`~django.db.models.UniqueConstraint` in `TranslatableMixin.Meta.constraints` in the future.
+
+If your model defines a [`Meta` class](django:ref/models/options) (either with a new definition or inheriting `TranslatableMixin.Meta` explicitly), be mindful when setting `unique_together` or {attr}`~django.db.models.Options.constraints`. Ensure that there is either a `unique_together` or a `UniqueConstraint` (not both) on `translation_key` and `locale`. There is a system check for this.
+```
+
+```{versionchanged} 6.0
+The system check for `translation_key` and `locale` unique key constraint now allows a `UniqueConstraint` in `Meta.constraints` instead of `unique_together` in `Meta`.
 ```
 
 ### Methods and properties

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -18,6 +18,7 @@ depth: 1
  * Remember previous location on returning from page add/edit actions (Robert Rollins)
  * Update settings file in project settings to address Django 4.2 deprecations (Sage Abdullah)
  * Improve layout and accessibility of the image URL generator page, reduce reliance on JavaScript (Temidayo Azeez)
+ * Allow `UniqueConstraint` in place of `unique_together` for {class}`~wagtail.models.TranslatableMixin`'s system check (Temidayo Azeez, Sage Abdullah)
 
 ### Bug fixes
 


### PR DESCRIPTION
Django `unique_together` may be deprecated in the future. `models.UniqueConstraint` is recommended [in Django documentation as a good replacement as it also offer more functionality](https://docs.djangoproject.com/en/4.2/ref/models/options/#unique-together:~:text=UniqueConstraint%20provides%20more%20functionality%20than%20unique_together.%20unique_together%20may%20be%20deprecated%20in%20the%20future.). This pull request resolves this issue #11098







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
