### PR TITLE
fix validation error on save from autocomplete

### DIFF
--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -419,6 +419,20 @@ class TestAccountSection(WagtailTestUtils, TestCase, TestAccountSectionUtilsMixi
         self.user.refresh_from_db()
         self.assertTrue(self.user.check_password("password"))
 
+    def test_ignore_change_password_if_only_old_password_supplied(self):
+        response = self.post_form(
+            {
+                "password-old_password": "password",
+            }
+        )
+
+        # Check that everything runs as usual (with a redirect), instead of a validation error
+        self.assertRedirects(response, reverse("wagtailadmin_account"))
+
+        # Check that the password was not changed
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("password"))
+
     def test_change_notifications(self):
         response = self.post_form(
             {

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -423,6 +423,8 @@ class TestAccountSection(WagtailTestUtils, TestCase, TestAccountSectionUtilsMixi
         response = self.post_form(
             {
                 "password-old_password": "password",
+                "password-new_password1": "",
+                "password-new_password2": "",
             }
         )
 

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -209,7 +209,6 @@ class ChangePasswordPanel(BaseSettingsPanel):
         if self.request.method == "POST":
             bind_form = any(
                 [
-                    self.request.POST.get(self.name + "-old_password"),
                     self.request.POST.get(self.name + "-new_password1"),
                     self.request.POST.get(self.name + "-new_password2"),
                 ]


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10564 

Some browsers generally autofill passwords once a page loads, regardless of whether or not the user clicks on a password field. 
This will lead to a validation error when a user makes a save after other changes in the `admin/accounts` URL. This fix stops the `old password` field from causing the smaller password-change form to be bound to the larger account-settings form.







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
