### PR TITLE
Move Stimulus stories to the one location

### DIFF
--- a/client/src/controllers/ActionController.stories.js
+++ b/client/src/controllers/ActionController.stories.js
@@ -4,7 +4,7 @@ import { StimulusWrapper } from '../../storybook/StimulusWrapper';
 import { ActionController } from './ActionController';
 
 export default {
-  title: 'Shared / ActionController',
+  title: 'Stimulus / ActionController',
   argTypes: {
     debug: {
       control: 'boolean',

--- a/client/src/controllers/SubmitController.stories.js
+++ b/client/src/controllers/SubmitController.stories.js
@@ -4,7 +4,7 @@ import { StimulusWrapper } from '../../storybook/StimulusWrapper';
 import { SubmitController } from './SubmitController';
 
 export default {
-  title: 'Shared / SubmitController',
+  title: 'Stimulus / SubmitController',
   argTypes: {
     debug: {
       control: 'boolean',


### PR DESCRIPTION
In our pattern library, we have a `Stimulus` section that was set up for the initial examples integration but it appears we were not using it for the other Stimulus stories.

I have now moved these all into one place.

| Before | After |
|--|--|
|  <img width="1233" alt="Screenshot 2023-10-23 at 8 15 31 am" src="https://github.com/wagtail/wagtail/assets/1396140/3be4bf1e-001d-496f-b5b8-25b490f5a635"> |  <img width="1241" alt="Screenshot 2023-10-23 at 8 15 15 am" src="https://github.com/wagtail/wagtail/assets/1396140/dac4b9fb-8894-4bba-b794-3fe05be27643"> |


Discovered while preparing for another PR which includes a Storybook implementation.

