### PR TITLE
Tag Length Input Validation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Changelog
  * Added page types usage report (Jhonatan Lopes)
  * Add support for defining `panels` / `edit_handler` on `ModelViewSet` (Sage Abdullah)
  * Use a single instance of `PagePermissionPolicy` in `wagtail.permissions` module (Sage Abdullah)
+ * Add max tag length validation for multiple uploads (documents/images) (Temidayo Azeez)
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -26,6 +26,7 @@ depth: 1
  * Added page types usage report (Jhonatan Lopes)
  * Add support for defining `panels` / `edit_handler` on `ModelViewSet` (Sage Abdullah)
  * Use a single instance of `PagePermissionPolicy` in `wagtail.permissions` module (Sage Abdullah)
+ * Add max tag length validation for multiple uploads (documents/images) (Temidayo Azeez)
 
 ### Bug fixes
 

--- a/wagtail/admin/forms/tags.py
+++ b/wagtail/admin/forms/tags.py
@@ -1,9 +1,30 @@
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 from taggit.forms import TagField as TaggitTagField
-from taggit.models import Tag
+from taggit.models import Tag, TagBase
 
 from wagtail.admin.widgets import AdminTagWidget
+
+
+def validate_tag_length(
+    value, max_tag_length=TagBase._meta.get_field("name").max_length
+):
+    if not value:
+        return
+    value_too_long = ""
+    for val in value:
+        if len(val) > max_tag_length:
+            if value_too_long:
+                value_too_long += ", "
+            value_too_long += val
+    if value_too_long:
+        raise ValidationError(
+            _("Tag(s) %(value_too_long)s are over %(max_tag_length)d characters")
+            % {
+                "value_too_long": value_too_long,
+                "max_tag_length": max_tag_length,
+            }
+        )
 
 
 class TagField(TaggitTagField):
@@ -34,22 +55,7 @@ class TagField(TaggitTagField):
 
     def clean(self, value):
         value = super().clean(value)
-
-        max_tag_length = self.tag_model.name.field.max_length
-        value_too_long = ""
-        for val in value:
-            if len(val) > max_tag_length:
-                if value_too_long:
-                    value_too_long += ", "
-                value_too_long += val
-        if value_too_long:
-            raise ValidationError(
-                _("Tag(s) %(value_too_long)s are over %(max_tag_length)d characters")
-                % {
-                    "value_too_long": value_too_long,
-                    "max_tag_length": max_tag_length,
-                }
-            )
+        validate_tag_length(value, self.tag_model.name.field.max_length)
 
         if not self.free_tagging:
             # filter value to just the tags that already exist in tag_model

--- a/wagtail/documents/forms.py
+++ b/wagtail/documents/forms.py
@@ -8,6 +8,7 @@ from wagtail.admin.forms.collections import (
     CollectionChoiceField,
     collection_member_permission_formset_factory,
 )
+from wagtail.admin.forms.tags import validate_tag_length
 from wagtail.admin.widgets import AdminTagWidget
 from wagtail.documents.models import Document
 from wagtail.documents.permissions import (
@@ -60,6 +61,11 @@ class BaseDocumentForm(BaseCollectionMemberForm):
 
     class Meta:
         widgets = {"tags": AdminTagWidget, "file": forms.FileInput()}
+
+    def clean_tags(self):
+        tags = self.cleaned_data["tags"]
+        validate_tag_length(tags)
+        return tags
 
 
 def get_document_base_form():

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -9,6 +9,7 @@ from wagtail.admin.forms.collections import (
     CollectionChoiceField,
     collection_member_permission_formset_factory,
 )
+from wagtail.admin.forms.tags import validate_tag_length
 from wagtail.admin.widgets import AdminTagWidget
 from wagtail.images.fields import WagtailImageField
 from wagtail.images.formats import get_image_formats
@@ -77,6 +78,11 @@ class BaseImageForm(BaseCollectionMemberForm):
                 attrs={"class": "focal_point_height"}
             ),
         }
+
+    def clean_tags(self):
+        tags = self.cleaned_data["tags"]
+        validate_tag_length(tags)
+        return tags
 
 
 def get_image_base_form():

--- a/wagtail/images/tests/test_form_overrides.py
+++ b/wagtail/images/tests/test_form_overrides.py
@@ -33,6 +33,28 @@ class TestImageFormOverride(TestCase):
         self.assertIsInstance(form.fields["tags"].widget, widgets.AdminTagWidget)
         self.assertEqual(form.fields["tags"].widget.tag_model, RestaurantTag)
 
+    def test_tags_longer_than_max_characters(self):
+        long_value = "longtag" * 20
+
+        form_data = {
+            "title": "Image",
+            "file": OverriddenWidget,
+            "tags": [long_value],
+        }
+
+        form_cls = get_image_form(models.Image)
+        form = form_cls(form_data)
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("tags", form.errors)
+        self.assertEqual(
+            form.errors["tags"][0],
+            "Tag(s) ['{val}'] are over {max_tag_length} characters".format(
+                val=long_value,
+                max_tag_length=taggit_models.TagBase._meta.get_field("name").max_length,
+            ),
+        )
+
     @override_settings(
         WAGTAILIMAGES_IMAGE_FORM_BASE="wagtail.test.testapp.media_forms.AlternateImageForm"
     )


### PR DESCRIPTION
This PR resolves #11054. As reported in the issue, the document page throwing a 500-network error, while on the frontend side, the `Update` button spins endlessly. I successfully reproduced the error before attempting a fix. Here is what the fix looks like from the frontend side.

Thanks to @BertrandBordage for pointing out the issue and for making useful suggestions in resolving the issue.

![MgXHZjUrBi](https://github.com/wagtail/wagtail/assets/87539866/0182cd0b-2628-45ee-b2c6-203110d825ec)










_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
