### PR TITLE
Create w-init stimulus controller and use in skeleton.html

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Maintenance: Update BeautifulSoup upper bound to 4.12.x (scott-8)
+ * Maintenance: Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)
 
 
 5.2 LTS (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/components/Sidebar/Sidebar.stories.tsx
+++ b/client/src/components/Sidebar/Sidebar.stories.tsx
@@ -204,9 +204,6 @@ function renderSidebarStory(
     return Promise.resolve();
   };
 
-  // Add ready class to body to enable CSS transitions
-  document.body.classList.add('ready');
-
   const onExpandCollapse = (collapsed: boolean) => {
     if (collapsed) {
       document.body.classList.add('sidebar-collapsed');

--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -51,7 +51,6 @@ export function initSidebar() {
       />,
       element,
       () => {
-        document.body.classList.add('ready');
         document
           .querySelector('[data-wagtail-sidebar]')
           ?.classList.remove('sidebar-loading');

--- a/client/src/controllers/InitController.test.js
+++ b/client/src/controllers/InitController.test.js
@@ -1,0 +1,106 @@
+import { Application } from '@hotwired/stimulus';
+import { InitController } from './InitController';
+
+jest.useFakeTimers();
+
+describe('InitController', () => {
+  let application;
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  describe('default behaviour', () => {
+    const handleEvent = jest.fn();
+    document.addEventListener('w-init:ready', handleEvent);
+
+    beforeAll(() => {
+      jest.clearAllMocks();
+
+      application?.stop();
+      document.body.innerHTML = `
+        <div
+          id="test"
+          class="hide-me"
+          data-controller="w-init"
+          data-w-init-remove-class="hide-me"
+          data-w-init-ready-class="ready"
+        >
+          Test body
+        </div>
+      `;
+
+      application = Application.start();
+    });
+
+    it('should add a "ready" class and remove specified classes after connection', async () => {
+      const testDiv = document.getElementById('test');
+
+      application.register('w-init', InitController);
+      expect(testDiv.classList).toContain('hide-me');
+      expect(testDiv.classList).not.toContain('ready');
+
+      await Promise.resolve(); // no delay, just wait for the next tick
+
+      expect(testDiv.classList).toContain('ready');
+      expect(testDiv.classList).not.toContain('hide-me');
+    });
+
+    it('should remove the controller correctly', () => {
+      const testDiv = document.getElementById('test');
+
+      expect(handleEvent).toHaveBeenCalledTimes(1);
+      expect(testDiv.getAttribute('data-controller')).toBeNull();
+    });
+  });
+
+  describe('with a delay', () => {
+    const handleEvent = jest.fn();
+    document.addEventListener('w-init:ready', handleEvent);
+
+    beforeAll(() => {
+      jest.clearAllMocks();
+
+      application?.stop();
+      document.body.innerHTML = `
+        <div
+          id="test"
+          class="hide-me"
+          data-controller="w-init"
+          data-w-init-delay-value="1_000"
+          data-w-init-ready-class="ready"
+          data-w-init-remove-class="hide-me"
+        >
+          Test body
+        </div>
+      `;
+
+      application = Application.start();
+    });
+
+    it('should add a "ready" class and remove specified classes after the delay', async () => {
+      const testDiv = document.getElementById('test');
+
+      // expect that before loading finishes (delay), that the div's properties are the same
+      application.register('w-init', InitController);
+
+      expect(testDiv.classList).toContain('hide-me');
+      expect(testDiv.classList).not.toContain('ready');
+      expect(handleEvent).not.toHaveBeenCalled();
+
+      await Promise.resolve(jest.advanceTimersByTime(500));
+
+      expect(testDiv.classList).toContain('hide-me');
+      expect(testDiv.classList).not.toContain('ready');
+      expect(handleEvent).not.toHaveBeenCalled();
+
+      await Promise.resolve(jest.advanceTimersByTime(1000));
+
+      expect(testDiv.classList).toContain('ready');
+      expect(testDiv.classList).not.toContain('hide-me');
+
+      await jest.runAllTimersAsync();
+      expect(handleEvent).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/client/src/controllers/InitController.ts
+++ b/client/src/controllers/InitController.ts
@@ -1,0 +1,63 @@
+import { Controller } from '@hotwired/stimulus';
+import { debounce } from '../utils/debounce';
+
+/**
+ * Adds the ability for a controlled element to add or remove classes
+ * when ready to be interacted with.
+ *
+ * @example
+ * <div class="keep-me hide-me" data-controller="w-init" data-w-init-remove-class="hide-me" data-w-init-ready-class="loaded">
+ *   When the DOM is ready, this div will have the class 'loaded' added and 'hide-me' removed.
+ * </div>
+ */
+export class InitController extends Controller<HTMLElement> {
+  static classes = ['ready', 'remove'];
+
+  static values = {
+    delay: { default: -1, type: Number },
+  };
+
+  declare readonly readyClasses: string[];
+  declare readonly removeClasses: string[];
+
+  declare delayValue: number;
+
+  connect() {
+    this.ready();
+  }
+
+  /**
+   * Add the ready classes and remove the remove classes after a delay.
+   * By default, the action will be immediate (negative value).
+   * Even when immediate, allow for a microtask delay to allow for other
+   * controllers to connect, then do any updates do classes/dispatch events.
+   */
+  ready() {
+    const delayValue = this.delayValue;
+
+    debounce(() => true, delayValue < 0 ? null : delayValue)().then(() => {
+      this.element.classList.add(...this.readyClasses);
+      this.element.classList.remove(...this.removeClasses);
+      this.dispatch('ready', { bubbles: true, cancelable: false });
+      this.remove();
+    });
+  }
+
+  /**
+   * Allow the controller to remove itself as it's no longer needed when the init has completed.
+   */
+  remove() {
+    const element = this.element;
+    const controllerAttribute = this.application.schema.controllerAttribute;
+    const controllers =
+      element.getAttribute(controllerAttribute)?.split(' ') ?? [];
+    const newControllers = controllers
+      .filter((identifier) => identifier !== this.identifier)
+      .join(' ');
+    if (newControllers) {
+      element.setAttribute(controllerAttribute, newControllers);
+    } else {
+      element.removeAttribute(controllerAttribute);
+    }
+  }
+}

--- a/client/src/controllers/RevealController.test.js
+++ b/client/src/controllers/RevealController.test.js
@@ -143,13 +143,12 @@ describe('RevealController', () => {
     it('should update classes when opened/closed', async () => {
       await setup(`
       <section
-        class="container remove-me-when-connected"
+        class="container"
         id="section"
         data-controller="w-reveal"
         data-w-reveal-close-icon-class="icon-collapse"
         data-w-reveal-closed-class="collapsed"
         data-w-reveal-closed-value="true"
-        data-w-reveal-initial-class="remove-me-when-connected"
         data-w-reveal-open-icon-class="icon-expand"
         data-w-reveal-opened-class="open--container"
         data-w-reveal-opened-content-class="show-max-width"
@@ -170,10 +169,6 @@ describe('RevealController', () => {
       const icon = document.querySelector('.icon');
       const useElement = icon.querySelector('use');
 
-      // initially closed
-      expect(document.getElementById('section').className).toEqual(
-        'container collapsed', // should not have 'remove-me-when-connected'
-      );
       expect(
         [...document.querySelectorAll('li')].every(
           (li) => li.className === 'item',

--- a/client/src/controllers/RevealController.ts
+++ b/client/src/controllers/RevealController.ts
@@ -17,7 +17,6 @@ export class RevealController extends Controller<HTMLElement> {
   static classes = [
     'closed',
     'closeIcon',
-    'initial',
     'opened',
     'openedContent',
     'openIcon',
@@ -76,18 +75,14 @@ export class RevealController extends Controller<HTMLElement> {
 
     new Promise((resolve) => {
       setTimeout(resolve);
-    })
-      .then(() => {
-        this.element.classList.remove(...this.initialClasses);
-      })
-      .then(() => {
-        this.dispatch('ready', {
-          cancelable: false,
-          detail: {
-            closed: this.closedValue,
-          },
-        });
+    }).then(() => {
+      this.dispatch('ready', {
+        cancelable: false,
+        detail: {
+          closed: this.closedValue,
+        },
       });
+    });
   }
 
   closedValueChanged(shouldClose: boolean, previouslyClosed?: boolean) {

--- a/client/src/controllers/index.ts
+++ b/client/src/controllers/index.ts
@@ -4,11 +4,12 @@ import type { Definition } from '@hotwired/stimulus';
 import { ActionController } from './ActionController';
 import { AutosizeController } from './AutosizeController';
 import { BulkController } from './BulkController';
+import { CloneController } from './CloneController';
 import { CountController } from './CountController';
 import { DialogController } from './DialogController';
 import { DismissibleController } from './DismissibleController';
 import { DropdownController } from './DropdownController';
-import { CloneController } from './CloneController';
+import { InitController } from './InitController';
 import { ProgressController } from './ProgressController';
 import { RevealController } from './RevealController';
 import { SkipLinkController } from './SkipLinkController';
@@ -35,6 +36,7 @@ export const coreControllerDefinitions: Definition[] = [
   { controllerConstructor: DialogController, identifier: 'w-dialog' },
   { controllerConstructor: DismissibleController, identifier: 'w-dismissible' },
   { controllerConstructor: DropdownController, identifier: 'w-dropdown' },
+  { controllerConstructor: InitController, identifier: 'w-init' },
   { controllerConstructor: ProgressController, identifier: 'w-progress' },
   { controllerConstructor: RevealController, identifier: 'w-breadcrumbs' },
   { controllerConstructor: RevealController, identifier: 'w-reveal' },

--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -211,9 +211,6 @@ function enableDirtyFormCheck(formSelector, options) {
 window.enableDirtyFormCheck = enableDirtyFormCheck;
 
 $(() => {
-  // Add class to the body from which transitions may be hung so they don't appear to transition as the page loads
-  $('body').addClass('ready');
-
   // eslint-disable-next-line func-names
   $('.dropdown').each(function () {
     const $dropdown = $(this);

--- a/client/storybook/preview.js
+++ b/client/storybook/preview.js
@@ -1,5 +1,6 @@
-import '../tests/stubs';
+import { domReady } from '../src/utils/domReady';
 
+import '../tests/stubs';
 import '../../wagtail/admin/static_src/wagtailadmin/scss/core.scss';
 import './preview.scss';
 
@@ -43,5 +44,11 @@ const loadIconSprite = () => {
       }
     });
 };
+
+domReady().then(() => {
+  // Add ready class to body to enable CSS transitions
+  // Emulates what happens in Wagtail admin when initial content is loaded
+  document.body.classList.add('ready');
+});
 
 loadIconSprite();

--- a/docs/releases/5.3.md
+++ b/docs/releases/5.3.md
@@ -28,6 +28,7 @@ depth: 1
 ### Maintenance
 
  * Update BeautifulSoup upper bound to 4.12.x (scott-8)
+ * Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -15,7 +15,7 @@
         {% block branding_favicon %}{% endblock %}
     </head>
     {% sidebar_collapsed as sidebar_collapsed %}
-    <body id="wagtail" class="{% block bodyclass %}{% endblock %} {% if sidebar_collapsed %}sidebar-collapsed{% endif %} {% if messages %}has-messages{% endif %}">
+    <body id="wagtail" class="{% block bodyclass %}{% endblock %} {% if sidebar_collapsed %}sidebar-collapsed{% endif %} {% if messages %}has-messages{% endif %}" data-controller="w-init" data-w-init-ready-class="ready">
         <div data-sprite></div>
 
         <script src="{% versioned_static 'wagtailadmin/js/icons.js' %}" data-icon-url="{% url 'wagtailadmin_sprite' %}"></script>


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11071

In line with steps 1-5:
I created the InitController to replace the jQuery part for adding a `ready` class to HTML elements.
I also wrote unit tests, and used the controller in the `skeleton.html` file.







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
