### PR TITLE
Wagtail admin skeleton - use classnames template tag

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,7 +20,7 @@ Changelog
  * Maintenance: Adjust Eslint rules for TypeScript files (Karthik Ayangar)
  * Maintenance: Rename the React `Button` that only renders links (a element) to `Link` and remove unused prop & behavior that was non-compliant for aria role usage (Advik Kabra)
  * Maintenance: Set up an `wagtail.models.AbstractWorkflow` model to support future customisations around workflows (Hossein)
- * Maintenance: Improve `classnames` template tag to handle nested lists of strings (LB (Ben) Johnston)
+ * Maintenance: Improve `classnames` template tag to handle nested lists of strings, use template tag for admin `body` element (LB (Ben) Johnston)
 
 
 6.0 (07.02.2024)

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -41,7 +41,7 @@ depth: 1
  * Adjust Eslint rules for TypeScript files (Karthik Ayangar)
  * Rename the React `Button` that only renders links (a element) to `Link` and remove unused prop & behavior that was non-compliant for aria role usage (Advik Kabra)
  * Set up an `wagtail.models.AbstractWorkflow` model to support future customisations around workflows (Hossein)
- * Improve `classnames` template tag to handle nested lists of strings (LB (Ben) Johnston)
+ * Improve `classnames` template tag to handle nested lists of strings, use template tag for admin `body` element (LB (Ben) Johnston)
 
 
 ## Upgrade considerations

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -15,7 +15,8 @@
         {% block branding_favicon %}{% endblock %}
     </head>
     {% sidebar_collapsed as sidebar_collapsed %}
-    <body id="wagtail" class="{% block bodyclass %}{% endblock %} {% if sidebar_collapsed %}sidebar-collapsed{% endif %} {% if messages %}has-messages{% endif %}" data-controller="w-init" data-w-init-ready-class="ready">
+    {% fragment as bodyclass %}{% block bodyclass %}{% endblock %}{% endfragment %}
+    <body id="wagtail" class="{% classnames bodyclass sidebar_collapsed|yesno:"sidebar-collapsed," messages|yesno:"has-messages," %}" data-controller="w-init" data-w-init-ready-class="ready">
         <div data-sprite></div>
 
         <script src="{% versioned_static 'wagtailadmin/js/icons.js' %}" data-icon-url="{% url 'wagtailadmin_sprite' %}"></script>


### PR DESCRIPTION
Small improvement to the readability and also unwanted extra spaces in the initial HTML payload. 

```diff
- class="homepage  "
+ class="homepage"
```