### PR TITLE
Reinstate support for using list/tuple of `ViewSet`/`ViewSetGroup`s in `register_admin_viewset`

### DIFF
--- a/wagtail/admin/viewsets/__init__.py
+++ b/wagtail/admin/viewsets/__init__.py
@@ -11,7 +11,11 @@ class ViewSetRegistry:
     def populate(self):
         for fn in hooks.get_hooks("register_admin_viewset"):
             viewset = fn()
-            self.register(viewset)
+            if isinstance(viewset, (list, tuple)):
+                for vs in viewset:
+                    self.register(vs)
+            else:
+                self.register(viewset)
 
     def register(self, viewset):
         # Allow registering a ViewSetGroup, which will register all of its

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -251,12 +251,7 @@ def add_broken_links_summary_item(request, items):
 
 @hooks.register("register_admin_viewset")
 def register_viewsets():
-    return MiscellaneousViewSetGroup()
-
-
-@hooks.register("register_admin_viewset")
-def register_json_model_viewsets():
-    return JSONModelViewSetGroup()
+    return [MiscellaneousViewSetGroup(), JSONModelViewSetGroup()]
 
 
 @hooks.register("register_admin_viewset")


### PR DESCRIPTION
This PR resolves #11121.  `register_admin_viewset` currently cannot handle a `list` or `tuple` of `ViewSetGroup`. With this PR, it would be able to handle a `list` or `tuple` of `ViewSet`/`ViewSetGroup`.







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
