### PR TITLE
Fixed the autoscrolling issue in rich text editor

### DIFF
--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -414,4 +414,8 @@
       }
     }
   }
+  &.scrollable-container{
+    max-height: 6.25em;
+    overflow-y: auto;
+  }
 }


### PR DESCRIPTION
Fixes #7777 

Fixed the auto scrolling issue in rich text editor which was an issue while typing long content

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
