### PR TITLE
Refactor styleguide view - convert to a class based view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Maintenance: Update BeautifulSoup upper bound to 4.12.x (scott-8)
  * Maintenance: Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)
  * Maintenance: Adopt the usage of of translate string literals using `arg=_('...')` in all `wagtailadmin` module templates (Chiemezuo Akujobi)
+ * Maintenance: Migrate the contrib styleguide index view to a class based view (Chiemezuo Akujobi)
 
 
 5.2 LTS (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/5.3.md
+++ b/docs/releases/5.3.md
@@ -31,6 +31,7 @@ depth: 1
  * Update BeautifulSoup upper bound to 4.12.x (scott-8)
  * Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)
  * Adopt the usage of of translate string literals using `arg=_('...')` in all `wagtailadmin` module templates (Chiemezuo Akujobi)
+ * Migrate the contrib styleguide index view to a class based view (Chiemezuo Akujobi)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -1,4 +1,4 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 {% load wagtailadmin_tags i18n %}
 
 {% block extra_css %}
@@ -7,7 +7,6 @@
     {{ example_form.media.css }}
 {% endblock %}
 
-{% block titletag %}{% trans 'Styleguide' %}{% endblock %}
 {% block bodyclass %}styleguide{% endblock %}
 
 {% block content %}

--- a/wagtail/contrib/styleguide/wagtail_hooks.py
+++ b/wagtail/contrib/styleguide/wagtail_hooks.py
@@ -10,7 +10,7 @@ from . import views
 @hooks.register("register_admin_urls")
 def register_admin_urls():
     return [
-        path("styleguide/", views.index, name="wagtailstyleguide"),
+        path("styleguide/", views.IndexView.as_view(), name="wagtailstyleguide"),
     ]
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

I refactored the `index()` function-based view to an `IndexView` class-based view in the `styleguide`.







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
