### PR TITLE
Resolve comment rendering escaped strings in email notification

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.txt
@@ -27,8 +27,8 @@
 
 {% trans "New replies:" %}{% for thread in replied_comments %}
 
-  {% trans 'New replies to:' %} "{{ thread.comment.text }}"{% for reply in thread.replies %}
-   - "{{ reply.text }}"{% endfor %}{% endfor %}{% endif %}
+  {% trans 'New replies to:' %} "{{ thread.comment.text|safe }}"{% for reply in thread.replies %}
+   - "{{ reply.text|safe }}"{% endfor %}{% endfor %}{% endif %}
 
 {% trans "You can edit the page here:" %} {{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}


### PR DESCRIPTION

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11143 Resolve comment rendering escaped some characters in email notification by updating the updated_comments.txt template.

**Output in Terminal After Changes**

```
Hello rohit,

Testuser has updated comments on "Bread and Circuses".    

New replies:

  New replies to: "good job"
   - "<>'"

You can edit the page here: http://localhost:8000/admin/pages/68/edit/

Edit your notification preferences here: http://localhost:8000/admin/account/#tab-notifications
```

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
