### PR TITLE
Resize edit form when preview panel is open or expanded

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Changelog
  * Add support for defining `panels` / `edit_handler` on `ModelViewSet` (Sage Abdullah)
  * Use a single instance of `PagePermissionPolicy` in `wagtail.permissions` module (Sage Abdullah)
  * Add max tag length validation for multiple uploads (documents/images) (Temidayo Azeez)
+ * Ensure expanded side panel does not overlap form content for most viewports (Chiemezuo Akujobi)
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)

--- a/client/scss/components/forms/_form-width.scss
+++ b/client/scss/components/forms/_form-width.scss
@@ -3,16 +3,26 @@
 }
 
 @include media-breakpoint-up(md) {
-  .side-panel-open,
   .minimap-open {
     .tab-content {
-      width: theme('width.[2/3]');
+      width: theme('width.[4/5]');
+    }
+  }
+
+  .side-panel-open {
+    .tab-content {
+      // Account for dynamic width of the side panel when open.
+      width: max(theme('width.[1/3]'), calc(100% - var(--side-panel-width)));
     }
   }
 
   .side-panel-open.minimap-open {
     .tab-content {
-      width: theme('width.[3/5]');
+      // Account for additional space taken up by the minimap.
+      width: max(
+        theme('width.[2/5]'),
+        calc(100% - var(--side-panel-width) - 15rem)
+      );
     }
   }
 }

--- a/client/src/includes/sidePanel.js
+++ b/client/src/includes/sidePanel.js
@@ -155,7 +155,7 @@ export default function initSidePanel() {
       newWidth,
     ).replace('%(num)s', newWidth);
 
-    sidePanelWrapper.parentElement.style.setProperty(
+    document.documentElement.style.setProperty(
       '--side-panel-width',
       `${newWidth}px`,
     );

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -27,6 +27,7 @@ depth: 1
  * Add support for defining `panels` / `edit_handler` on `ModelViewSet` (Sage Abdullah)
  * Use a single instance of `PagePermissionPolicy` in `wagtail.permissions` module (Sage Abdullah)
  * Add max tag length validation for multiple uploads (documents/images) (Temidayo Azeez)
+ * Ensure expanded side panel does not overlap form content for most viewports (Chiemezuo Akujobi)
 
 ### Bug fixes
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11038 
This is my attempt at fixing the edit page not resizing when the preview panel opens.
I used a value that was the difference of the modified panel width and something a little above the original panel width

My screen recorder seemed to misbehave, but here is a picture of what it looks like when you open the preview panel now:
![resize edit form](https://github.com/wagtail/wagtail/assets/29470516/78d22ae1-71e3-4dc0-a432-803530d5daea)









_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 118 & Firefox 119, on Windows 10.
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
