### PR TITLE
Sort groups by name in group index view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,7 +34,7 @@ Changelog
  * Remove `wagtail.unpublish` log action on aliases when source page is unpublished (Dan Braghis)
  * Add compare buttons to workflow dashboard panel (Matt Westcott)
  * Add the ability to use filters and to export listings in generic `IndexView` (Sage Abdullah)
- * Move `list_filter`, `filterset_class`, `search_fields`, `search_backend_name`, `list_export`, `export_filename`, `list_per_page`, and `ordering` from `SnippetViewSet` to `ModelViewSet` (Sage Abdullah)
+ * Move `list_filter`, `filterset_class`, `search_fields`, `search_backend_name`, `list_export`, `export_filename`, `list_per_page`, and `ordering` from `SnippetViewSet` to `ModelViewSet` (Sage Abdullah, Cynthia Kiser)
  * Add default header titles to generic `IndexView` and `CreateView` (Sage Abdullah)
  * Allow overriding `IndexView.export_headings` via `ModelViewSet` (Christer Jensen, Sage Abdullah)
  * Support specifying a `get_object_list` method on `ChooserViewSet` (Matt Westcott)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -52,7 +52,7 @@ A number of features from {class}`~wagtail.snippets.views.snippets.SnippetViewSe
  * Move `SnippetViewSet` menu registration mechanism to base `ViewSet` class (Sage Abdullah)
  * Move `SnippetViewSet` template override mechanism to `ModelViewSet` (Sage Abdullah)
  * Move `SnippetViewSet.list_display` to `ModelViewSet` (Sage Abdullah)
- * Move `list_filter`, `filterset_class`, `search_fields`, `search_backend_name`, `list_export`, `export_filename`, `list_per_page`, and `ordering` from `SnippetViewSet` to `ModelViewSet` (Sage Abdullah)
+ * Move `list_filter`, `filterset_class`, `search_fields`, `search_backend_name`, `list_export`, `export_filename`, `list_per_page`, and `ordering` from `SnippetViewSet` to `ModelViewSet` (Sage Abdullah, Cynthia Kiser)
  * Add default header titles to generic `IndexView` and `CreateView` (Sage Abdullah)
  * Add the ability to use filters and to export listings in generic `IndexView` (Sage Abdullah)
  * Add generic `UsageView` to `ModelViewSet` (Sage Abdullah)

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -1347,6 +1347,15 @@ class TestGroupIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["search_form"]["q"].value(), "Hello")
 
+    def test_default_ordering(self):
+        # This group should display after the default groups but will display
+        # before them if default_ordering is lost.
+        Group.objects.create(name="Photographers")
+        response = self.get()
+        # groups should be returned in alpha order by name
+        names = [group.name for group in response.context_data["object_list"]]
+        self.assertEqual(names, ["Editors", "Moderators", "Photographers"])
+
 
 class TestGroupIndexResultsView(WagtailTestUtils, TestCase):
     def setUp(self):

--- a/wagtail/users/views/groups.py
+++ b/wagtail/users/views/groups.py
@@ -59,8 +59,6 @@ class IndexView(generic.IndexView):
     search_fields = ["name"]
     context_object_name = "groups"
     paginate_by = 20
-    ordering = ["name"]
-    default_ordering = "name"
 
     columns = [
         TitleColumn(
@@ -157,6 +155,7 @@ class DeleteView(generic.DeleteView):
 class GroupViewSet(ModelViewSet):
     icon = "group"
     model = Group
+    ordering = ["name"]
     add_to_reference_index = False
     _show_breadcrumbs = False
 


### PR DESCRIPTION
Fixes #11159 

`git bisect` tells me that the sort on the group index view broke at commit 27aabc128be9e9e1f7105244858af602e9749a4b I would have thought that the new code would use the `default_ordering` in the IndexView but it clearly does not. Removing it and moving the ordering to the ViewSet restores ordering by name as the default sort order. 

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)

