### PR TITLE
Update image documentation to have more details for picture and srcset_image tags

### DIFF
--- a/docs/extending/rich_text_internals.md
+++ b/docs/extending/rich_text_internals.md
@@ -42,7 +42,7 @@ which is converted into an `img` element when rendered:
     alt="A pied wagtail"
     class="richtext-image left"
     height="294"
-    src="/media/images/pied-wagtail.width-500_ENyKffb.jpg"
+    src="/media/images/pied-wagtail.width-500.jpg"
     width="500"
 />
 ```

--- a/docs/reference/jinja2.md
+++ b/docs/reference/jinja2.md
@@ -98,7 +98,7 @@ The [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#size
 This outputs:
 
 ```html
-<img srcset="/media/images/pied-wagtail.width-400_ENyKffb.jpg 400w, /media/images/pied-wagtail.width-800_ENyKffb.jpg 800w" src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" sizes="(max-width: 600px) 400px, 80vw" width="400" height="300">
+<img srcset="/media/images/pied-wagtail.width-400.jpg 400w, /media/images/pied-wagtail.width-800.jpg 800w" src="/media/images/pied-wagtail.width-400.jpg" alt="A pied Wagtail" sizes="(max-width: 600px) 400px, 80vw" width="400" height="300">
 ```
 
 Or resize an image and retrieve the renditions for more bespoke use:
@@ -110,7 +110,7 @@ Or resize an image and retrieve the renditions for more bespoke use:
 
 ### `picture()`
 
-Resize or convert an image, rendering a `<picture>` tag including multiple `source` formats with `srcset` for multiple sizes, and a fallback `<img` tag.
+Resize or convert an image, rendering a `<picture>` tag including multiple `source` formats with `srcset` for multiple sizes, and a fallback `<img>` tag.
 Browsers will select the [first supported image format](https://web.dev/learn/design/picture-element/#image-formats), and pick a size based on [responsive image rules](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
 
 `picture` can render an image in multiple formats:
@@ -123,9 +123,9 @@ This outputs:
 
 ```html
 <picture>
-    <source srcset="/media/images/pied-wagtail.width-400_ENyKffb.avif" type="image/avif">
-    <source srcset="/media/images/pied-wagtail.width-400_ENyKffb.webp" type="image/webp">
-    <img src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" width="400" height="300">
+    <source srcset="/media/images/pied-wagtail.width-400.avif" type="image/avif">
+    <source srcset="/media/images/pied-wagtail.width-400.webp" type="image/webp">
+    <img src="/media/images/pied-wagtail.width-400.jpg" alt="A pied Wagtail" width="400" height="300">
 </picture>
 ```
 
@@ -139,9 +139,9 @@ This outputs:
 
 ```html
 <picture>
-    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.avif 400w, /media/images/pied-wagtail.width-800_ENyKffb.avif 800w" type="image/avif">
-    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.webp 400w, /media/images/pied-wagtail.width-800_ENyKffb.webp 800w" type="image/webp">
-    <img sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.jpg 400w, /media/images/pied-wagtail.width-800_ENyKffb.jpg 800w" src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" width="400" height="300">
+    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400.avif 400w, /media/images/pied-wagtail.width-800.avif 800w" type="image/avif">
+    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400.webp 400w, /media/images/pied-wagtail.width-800.webp 800w" type="image/webp">
+    <img sizes="80vw" srcset="/media/images/pied-wagtail.width-400.jpg 400w, /media/images/pied-wagtail.width-800.jpg 800w" src="/media/images/pied-wagtail.width-400.jpg" alt="A pied Wagtail" width="400" height="300">
 </picture>
 ```
 

--- a/docs/reference/jinja2.md
+++ b/docs/reference/jinja2.md
@@ -92,7 +92,13 @@ Browsers will select the most appropriate image to load based on [responsive ima
 The [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes) attribute is essential unless you store the output of `srcset_image` for later use.
 
 ```html+jinja
-{{ srcset_image(page.header_image, "fill-{512x100,1024x200}", sizes="100vw", class="header-image") }}
+{{ srcset_image(page.photo, "width-{400,800}", sizes="(max-width: 600px) 400px, 80vw") }}
+```
+
+This outputs:
+
+```html
+<img srcset="/media/images/pied-wagtail.width-400_ENyKffb.jpg 400w, /media/images/pied-wagtail.width-800_ENyKffb.jpg 800w" src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" sizes="(max-width: 600px) 400px, 80vw" width="400" height="300">
 ```
 
 Or resize an image and retrieve the renditions for more bespoke use:
@@ -104,19 +110,39 @@ Or resize an image and retrieve the renditions for more bespoke use:
 
 ### `picture()`
 
-Resize or convert an image, rendering a `<picture>` tag including multiple `source` formats with `srcset` for multiple sizes.
+Resize or convert an image, rendering a `<picture>` tag including multiple `source` formats with `srcset` for multiple sizes, and a fallback `<img` tag.
 Browsers will select the [first supported image format](https://web.dev/learn/design/picture-element/#image-formats), and pick a size based on [responsive image rules](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
 
 `picture` can render an image in multiple formats:
 
 ```html+jinja
-{{ picture(page.header_image, "format-{avif,jpeg}") }}
+{{ picture(page.photo, "format-{avif,webp,jpeg}|width-400") }}
+```
+
+This outputs:
+
+```html
+<picture>
+    <source srcset="/media/images/pied-wagtail.width-400_ENyKffb.avif" type="image/avif">
+    <source srcset="/media/images/pied-wagtail.width-400_ENyKffb.webp" type="image/webp">
+    <img src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" width="400" height="300">
+</picture>
 ```
 
 Or render multiple formats and multiple sizes like `srcset_image` does. The [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes) attribute is essential when the picture tag renders images in multiple sizes:
 
 ```html+jinja
-{{ picture(page.header_image, "format-{avif,jpeg}|fill-{512x100,1024x200}", sizes="100vw") }}
+{{ picture(page.header_image, "format-{avif,webp,jpeg}|width-{400,800}", sizes="80vw") }}
+```
+
+This outputs:
+
+```html
+<picture>
+    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.avif 400w, /media/images/pied-wagtail.width-800_ENyKffb.avif 800w" type="image/avif">
+    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.webp 400w, /media/images/pied-wagtail.width-800_ENyKffb.webp 800w" type="image/webp">
+    <img sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.jpg 400w, /media/images/pied-wagtail.width-800_ENyKffb.jpg 800w" src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" width="400" height="300">
+</picture>
 ```
 
 Or resize an image and retrieve the renditions for more bespoke use:

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -40,9 +40,9 @@ This outputs:
 
 ```html
 <picture>
-    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.avif 400w, /media/images/pied-wagtail.width-800_ENyKffb.avif 800w" type="image/avif">
-    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.webp 400w, /media/images/pied-wagtail.width-800_ENyKffb.webp 800w" type="image/webp">
-    <img sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.jpg 400w, /media/images/pied-wagtail.width-800_ENyKffb.jpg 800w" src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" width="400" height="300">
+    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400.avif 400w, /media/images/pied-wagtail.width-800.avif 800w" type="image/avif">
+    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400.webp 400w, /media/images/pied-wagtail.width-800.webp 800w" type="image/webp">
+    <img sizes="80vw" srcset="/media/images/pied-wagtail.width-400.jpg 400w, /media/images/pied-wagtail.width-800.jpg 800w" src="/media/images/pied-wagtail.width-400.jpg" alt="A pied Wagtail" width="400" height="300">
 </picture>
 ```
 

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -25,10 +25,26 @@ The page explorer listing view has been redesigned to allow improved navigation 
 
 ### Responsive & multi-format images with the picture tag
 
-Wagtail has new template tags to reduce the performance and environmental footprint of images:
+Wagtail has new template tags to reduce the loading time and environmental footprint of images:
 
  * The `picture` tag generates images in multiple formats and-or sizes in one batch, creating an HTML `<picture>` tag.
  * The `srcset_image` tag generates images in multiple sizes, creating an `<img>` tag with a `srcset` attribute.
+
+As an example, the `picture` tag allows generating six variants of an image in one go:
+
+```html+django
+{% picture page.photo format-{avif,webp,jpeg} width-{400,800} sizes="80vw" %}
+```
+
+This outputs:
+
+```html
+<picture>
+    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.avif 400w, /media/images/pied-wagtail.width-800_ENyKffb.avif 800w" type="image/avif">
+    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.webp 400w, /media/images/pied-wagtail.width-800_ENyKffb.webp 800w" type="image/webp">
+    <img sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.jpg 400w, /media/images/pied-wagtail.width-800_ENyKffb.jpg 800w" src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" width="400" height="300">
+</picture>
+```
 
 We expect those changes to greatly reduce the weight of images for all Wagtail sites. We encourage all site implementers to consider using them to improve the performance of the sites and reduce their carbon footprint. For further details, For more details, see [](multiple_formats) and [](responsive_images). Those new template tags are also supported in Jinja templates, see [](jinja2) for the Jinja API.
 

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -51,7 +51,7 @@ Compared to `image`, this will render a `<picture>` element with a fallback `<im
 
 In this case, if the browser supports the [AVIF](https://en.wikipedia.org/wiki/AVIF) format it will load the AVIF file. Otherwise, if the browser supports the [WebP](https://en.wikipedia.org/wiki/WebP) format, it will try to load the WebP file. If none of those formats are supported, the browser will load the JPEG image. The order of the provided formats isn’t configurable – Wagtail will always output source elements in the following order: AVIF, WebP, JPEG, PNG, GIF. This ensures the most optimized format is provided whenever possible.
 
-`picture` can also be used with multiple image resize rules, to generate responsive images.
+The `picture` tag can also be used with multiple image resize rules to generate responsive images.
 
 (responsive_images)=
 

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -49,7 +49,7 @@ Compared to `image`, this will render a `<picture>` element with a fallback `<im
 </picture>
 ```
 
-In this case, if the browser supports the [AVIF](https://en.wikipedia.org/wiki/AVIF) format it will load this file. If not, it will load the JPEG image. The order formats are provided in isn’t configurable – Wagtail will always output source elements as: AVIF, WebP, JPEG, PNG, GIF.
+In this case, if the browser supports the [AVIF](https://en.wikipedia.org/wiki/AVIF) format it will load the AVIF file. Otherwise, if the browser supports the [WebP](https://en.wikipedia.org/wiki/WebP) format, it will try to load the WebP file. If none of those formats are supported, the browser will load the JPEG image. The order of the provided formats isn’t configurable – Wagtail will always output source elements in the following order: AVIF, WebP, JPEG, PNG, GIF. This ensures the most optimized format is provided whenever possible.
 
 `picture` can also be used with multiple image resize rules, to generate responsive images.
 

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -36,35 +36,65 @@ Note that a space separates `[image]` and `[resize-rule]`, but the resize rule m
 To render an image in multiple formats, you can use the `picture` tag:
 
 ```html+django
-{% picture page.photo width-400 format-{avif,jpeg} %}
+{% picture page.photo format-{avif,webp,jpeg} width-400 %}
 ```
 
-Compared to `image`, this will render a `<picture>` element with one `<source>` element per format. The browser [picks the first format it supports](https://web.dev/learn/design/picture-element/#source), or defaults to a fallback `<img>` element.
+Compared to `image`, this will render a `<picture>` element with a fallback `<img>` within and one `<source>` element per extra format. The browser [picks the first format it supports](https://web.dev/learn/design/picture-element/#source), or defaults to the fallback `<img>` element. For example, the above will render HTML similar to:
 
-`picture` can also be used with responsive image resize rules.
+```html
+<picture>
+    <source srcset="/media/images/pied-wagtail.width-400_ENyKffb.avif" type="image/avif">
+    <source srcset="/media/images/pied-wagtail.width-400_ENyKffb.webp" type="image/webp">
+    <img src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" width="400" height="300">
+</picture>
+```
+
+In this case, if the browser supports the [AVIF](https://en.wikipedia.org/wiki/AVIF) format it will load this file. If not, it will load the JPEG image. The order formats are provided in isn’t configurable – Wagtail will always output source elements as: AVIF, WebP, JPEG, PNG, GIF.
+
+`picture` can also be used with multiple image resize rules, to generate responsive images.
 
 (responsive_images)=
 
 ## Responsive images
 
-Wagtail provides `picture` and `srcset_image` template tags which can generate an `<img>` tag with a `srcset` attribute. This allows browsers to select the most appropriate image file to load based on [responsive image rules](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
+Wagtail provides `picture` and `srcset_image` template tags which can generate image elements with `srcset` attributes. This allows browsers to select the most appropriate image file to load based on [responsive image rules](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
 
-The syntax for `srcset_image` is the same as `image, with two exceptions:
+The syntax for `srcset_image` is the same as `image`, with two exceptions:
 
 ```html+django
-{% srcset_image [image] [resize-rule-with-brace-expansion] sizes="100vw" %}
+{% srcset_image [image] [resize-rule-with-brace-expansion] sizes="[my source sizes]" %}
 ```
 
-- The resize rule should be provided with multiple sizes in a brace-expansion pattern, like `width-{200,400}`. This will generate the `srcset` attribute, with as many URLs as there are sizes defined in the resize rule.
+- The resize rule should be provided with multiple sizes in a brace-expansion pattern, like `width-{200,400}`. This will generate the `srcset` attribute, with as many URLs as there are sizes defined in the resize rule, and one width descriptor per URL. The first provided size will always be used as the `src` attribute, and define the image’s width and height attributes, as a fallback.
 - The [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes) attribute is essential. This tells the browser how large the image will be displayed on the page, so that it can select the most appropriate image to load.
 
-Here is an example with the `picture` tag:
+Here is an example of `srcset_image` in action, generating an `srcset` attribute:
 
 ```html+django
-{% picture page.photo fill-{512x100,1024x200} format-{avif,jpeg} sizes="100vw" %}
+{% srcset_image page.photo width-{400,800} sizes="(max-width: 600px) 400px, 80vw" %}
 ```
 
-This will generate a `<picture>` element with one `<source>` for AVIF and one fallback `<img>` with JPEG. Both the source and fallback image will have the `sizes` attribute, and a `srcset` with two URLs each.
+This outputs:
+
+```html
+<img srcset="/media/images/pied-wagtail.width-400_ENyKffb.jpg 400w, /media/images/pied-wagtail.width-800_ENyKffb.jpg 800w" src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" sizes="(max-width: 600px) 400px, 80vw" width="400" height="300">
+```
+
+And here is an example with the `picture` tag:
+
+```html+django
+{% picture page.photo format-{avif,webp,jpeg} width-{400,800} sizes="80vw" %}
+```
+
+This outputs:
+
+```html
+<picture>
+    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.avif 400w, /media/images/pied-wagtail.width-800_ENyKffb.avif 800w" type="image/avif">
+    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.webp 400w, /media/images/pied-wagtail.width-800_ENyKffb.webp 800w" type="image/webp">
+    <img sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.jpg 400w, /media/images/pied-wagtail.width-800_ENyKffb.jpg 800w" src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" width="400" height="300">
+</picture>
+```
 
 (available_resizing_methods)=
 

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -43,9 +43,9 @@ Compared to `image`, this will render a `<picture>` element with a fallback `<im
 
 ```html
 <picture>
-    <source srcset="/media/images/pied-wagtail.width-400_ENyKffb.avif" type="image/avif">
-    <source srcset="/media/images/pied-wagtail.width-400_ENyKffb.webp" type="image/webp">
-    <img src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" width="400" height="300">
+    <source srcset="/media/images/pied-wagtail.width-400.avif" type="image/avif">
+    <source srcset="/media/images/pied-wagtail.width-400.webp" type="image/webp">
+    <img src="/media/images/pied-wagtail.width-400.jpg" alt="A pied Wagtail" width="400" height="300">
 </picture>
 ```
 
@@ -77,7 +77,7 @@ Here is an example of `srcset_image` in action, generating an `srcset` attribute
 This outputs:
 
 ```html
-<img srcset="/media/images/pied-wagtail.width-400_ENyKffb.jpg 400w, /media/images/pied-wagtail.width-800_ENyKffb.jpg 800w" src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" sizes="(max-width: 600px) 400px, 80vw" width="400" height="300">
+<img srcset="/media/images/pied-wagtail.width-400.jpg 400w, /media/images/pied-wagtail.width-800.jpg 800w" src="/media/images/pied-wagtail.width-400.jpg" alt="A pied Wagtail" sizes="(max-width: 600px) 400px, 80vw" width="400" height="300">
 ```
 
 And here is an example with the `picture` tag:
@@ -90,9 +90,9 @@ This outputs:
 
 ```html
 <picture>
-    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.avif 400w, /media/images/pied-wagtail.width-800_ENyKffb.avif 800w" type="image/avif">
-    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.webp 400w, /media/images/pied-wagtail.width-800_ENyKffb.webp 800w" type="image/webp">
-    <img sizes="80vw" srcset="/media/images/pied-wagtail.width-400_ENyKffb.jpg 400w, /media/images/pied-wagtail.width-800_ENyKffb.jpg 800w" src="/media/images/pied-wagtail.width-400_ENyKffb.jpg" alt="A pied Wagtail" width="400" height="300">
+    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400.avif 400w, /media/images/pied-wagtail.width-800.avif 800w" type="image/avif">
+    <source sizes="80vw" srcset="/media/images/pied-wagtail.width-400.webp 400w, /media/images/pied-wagtail.width-800.webp 800w" type="image/webp">
+    <img sizes="80vw" srcset="/media/images/pied-wagtail.width-400.jpg 400w, /media/images/pied-wagtail.width-800.jpg 800w" src="/media/images/pied-wagtail.width-400.jpg" alt="A pied Wagtail" width="400" height="300">
 </picture>
 ```
 

--- a/docs/topics/writing_templates.md
+++ b/docs/topics/writing_templates.md
@@ -98,6 +98,42 @@ For example:
 
 See [](image_tag) for full documentation.
 
+### Images in multiple formats
+
+The `picture` tag works like `image`, but allows specifying multiple formats to generate a `<picture>` element with `<source>` elements and a fallback `<img>`.
+
+For example:
+
+```html+django
+{% load wagtailimages_tags %}
+...
+
+{% picture page.photo format-{avif,webp,jpeg} width-400 %}
+```
+
+See [](multiple_formats) for full documentation.
+
+### Images in multiple sizes
+
+The `srcset_image` tag works like `image`, but allows specifying multiple sizes to generate a `srcset` attribute and leverage  [responsive image rules](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
+
+For example:
+
+```html+django
+{% load wagtailimages_tags %}
+...
+
+{% srcset_image page.photo width-{400,800} sizes="(max-width: 600px) 400px, 80vw" %}
+```
+
+This can also be done with `picture`, to generate multiple formats and sizes at once:
+
+```html+django
+{% picture page.photo format-{avif,webp,jpeg} width-{400,800} sizes="80vw" %}
+```
+
+See [](responsive_images) for full documentation.
+
 (rich_text_filter)=
 
 ## Rich text (filter)


### PR DESCRIPTION
Helps towards #11068. In particular,

- Adds sample output of the two tags
- Further guidance on how responsive images work
- Missing docs in `docs/topics/writing_templates.md`