### PR TITLE
Add next_url to Edit and Add Child page listing buttons

### DIFF
--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -375,10 +375,10 @@ class PageListingSortMenuOrderButton(PageListingButton):
 
 @hooks.register("register_page_listing_more_buttons")
 def page_listing_more_buttons(page, user, next_url=None):
-    yield PageListingEditButton(page=page, user=user, priority=2)
+    yield PageListingEditButton(page=page, user=user, next_url=next_url, priority=2)
     yield PageListingViewDraftButton(page=page, user=user, priority=4)
     yield PageListingViewLiveButton(page=page, user=user, url=page.url, priority=6)
-    yield PageListingAddChildPageButton(page=page, user=user, priority=8)
+    yield PageListingAddChildPageButton(page=page, user=user, next_url=next_url, priority=8)
     yield PageListingMoveButton(page=page, user=user, priority=10)
     yield PageListingCopyButton(page=page, user=user, next_url=next_url, priority=20)
     yield PageListingDeleteButton(page=page, user=user, next_url=next_url, priority=30)


### PR DESCRIPTION
The new page_listing_buttons system is pretty great, but the change reminded my team that we've been customizing the Edit and Add Child buttons in our local repo for years, just to add `next_url` to them. This is necessary for us so that the user is brought back to the original page they were on, rather than being dumped back into the Page Explorer.

It's incredibly easy to make this change in the new OOP-based button system, so we figured it was worth making this PR. 