### PR TITLE
Fix create_extra_permissions creates Permission in the wrong database

### DIFF
--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -4,7 +4,7 @@ from django.contrib.admin.utils import quote
 from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.db import DEFAULT_DB_ALIAS, models
+from django.db import DEFAULT_DB_ALIAS, models, router
 from django.urls import reverse
 from django.utils.module_loading import import_string
 
@@ -121,6 +121,10 @@ def register_deferred_snippets():
 
 
 def create_extra_permissions(*args, using=DEFAULT_DB_ALIAS, **kwargs):
+    permissions_db = router.db_for_write(Permission)
+    if using != permissions_db:
+        return
+
     model_cts = ContentType.objects.get_for_models(
         *get_snippet_models(), for_concrete_models=False
     )


### PR DESCRIPTION
If you run Django with multiple databases, the `post_migrate` signal will get run for every database after `./manage.py migrate`. This propgates to the `using` arg in the `create_extra_permissions` signal. This adds an early return if the signal came from a database that doesn't have the `auth_permission` table.

Discovered when I tried to run migration `wagtailcore.0084` https://github.com/wagtail/wagtail/blob/main/wagtail/migrations/0084_add_default_page_permissions.py
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #...







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
