### PR TITLE
Update next_url in page_listing_buttons within wagtailadmin_tags.py

### DIFF
--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -446,6 +446,9 @@ def paginate(context, page, base_url="", page_key="p", classname=""):
 @register.inclusion_tag("wagtailadmin/shared/buttons.html", takes_context=True)
 def page_listing_buttons(context, page, user):
     next_url = context["request"].path
+    # When searching a page title, the next_url gets index results path
+    if next_url.endswith('/results/'):
+        next_url = next_url.replace('/results/', '/')
     button_hooks = hooks.get_hooks("register_page_listing_buttons")
 
     buttons = []


### PR DESCRIPTION
When using the search bar, the listing buttons get updated with the `wagtailadmin_explore_results` path. So if the move action button was used, after a successful move, I'll be redirect the the `IndexResultsView` rather than the `IndexView`.

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Purpose: To not break the view on a success redirect.

Fixes #...

The `next_url` in `page_listing_buttons` template tag that might retrieve the `IndexResultsView` path rather than the `IndexView` path. Not sure if a replace is the proper way to do this, you're welcomed to change it.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

Go to the page explorer, type in a title in the search bar, hover over a the page listing button that receives `next_url` (like "Copy"),  and see if the `next_path` in the URL ends with `/results/`.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
