### PR TITLE
multiline-comment-format

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)
  * Fix: Add a fallback background for the editing preview iframe for sites without a background (Ian Price)
+ * Fix: Preserve whitespace in rendered comments (Elhussein Almasri)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Maintenance: Update BeautifulSoup upper bound to 4.12.x (scott-8)
  * Maintenance: Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -759,6 +759,7 @@
 * CheesyPhoenix
 * Vedant Pandey
 * Ian Price
+* Elhussein Almasri
 
 ## Translators
 

--- a/client/src/components/CommentApp/components/Comment/style.scss
+++ b/client/src/components/CommentApp/components/Comment/style.scss
@@ -24,6 +24,7 @@
     padding-top: 10px;
     padding-bottom: 10px;
     word-break: break-all;
+    white-space: pre-wrap;
 
     &--mode-deleting {
       color: theme('colors.text-context');

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -22,6 +22,7 @@ depth: 1
  * Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)
  * Add a fallback background for the editing preview iframe for sites without a background (Ian Price)
+ * Preserve whitespace in rendered comments (Elhussein Almasri)
 
 ### Documentation
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->


 Fixes #11171
when the user write multiline comment , after submit the comment, it don ,t appear like
the user format it  , but now it ,s appear like the user format it. 

for example , if user write comment like this 

![Screenshot1](https://github.com/wagtail/wagtail/assets/90080237/389cbb86-033b-4855-b3f4-5533c066cc10)

after submit the comment , the result will be like this

After :

![Screenshot3](https://github.com/wagtail/wagtail/assets/90080237/fec44671-aefe-4b21-8fac-678bafd92da0)

Before:


![Screenshot2](https://github.com/wagtail/wagtail/assets/90080237/61632a17-9c2b-48ee-887a-27b32e381e81)


_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   :white_check_mark: Does the code comply with the style guide?
    -   :white_check_mark: Run `make lint` from the Wagtail root.

