### PR TITLE
Check for ContentType and Permission models before migration

### DIFF
--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -1,10 +1,11 @@
 from functools import lru_cache
 
+from django.apps import apps as global_apps
 from django.contrib.admin.utils import quote
 from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.db import DEFAULT_DB_ALIAS, models
+from django.db import DEFAULT_DB_ALIAS, models, router
 from django.urls import reverse
 from django.utils.module_loading import import_string
 
@@ -120,8 +121,24 @@ def register_deferred_snippets():
         _register_snippet_immediately(registerable, viewset)
 
 
-def create_extra_permissions(*args, using=DEFAULT_DB_ALIAS, **kwargs):
-    model_cts = ContentType.objects.get_for_models(
+def create_extra_permissions(
+    app_config, *args, using=DEFAULT_DB_ALIAS, apps=global_apps, **kwargs
+):
+    if not app_config.models_module:
+        return
+
+    app_label = app_config.label
+    try:
+        app_config = apps.get_app_config(app_label)
+        apps.get_model("contenttypes", "ContentType")
+        apps.get_model("auth", "Permission")
+    except LookupError:
+        return
+
+    if not router.allow_migrate_model(using, Permission):
+        return
+
+    model_cts = ContentType.objects.db_manager(using).get_for_models(
         *get_snippet_models(), for_concrete_models=False
     )
 

--- a/wagtail/tests/test_management.py
+++ b/wagtail/tests/test_management.py
@@ -1,0 +1,26 @@
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+from django.db import migrations
+from django.test import TestCase
+
+from wagtail.snippets.models import create_extra_permissions
+
+
+class TestCreatePermissions(TestCase):
+    def setUp(self):
+        self.app_config = apps.get_app_config("auth")
+
+    def tearDown(self):
+        ContentType.objects.clear_cache()
+
+    def test_unavailable_models(self):
+        state = migrations.state.ProjectState()
+
+        # Unavailable contenttypes.ContentType
+        with self.assertNumQueries(0):
+            create_extra_permissions(self.app_config, verbosity=0, apps=state.apps)
+
+        # Unavailable auth.Permission
+        state = migrations.state.ProjectState(real_apps={"contenttypes"})
+        with self.assertNumQueries(0):
+            create_extra_permissions(self.app_config, verbosity=0, apps=state.apps)


### PR DESCRIPTION
Hi!

We're using wagtail in a large django project and recently ran into this issue preventing us from upgrading to the latest version of wagtail. When we run migrations for our app using multiple database we run into

```
relation "auth_permission" does not exist
LINE 1: ...ntent_type_id", "auth_permission"."codename" FROM "auth_perm...
```
For all databases except the default one. I've largely copied what django does https://github.com/django/django/blob/f9e9526800c921ae393ff58826daed51587b1727/django/contrib/auth/management/__init__.py#L65 in  https://code.djangoproject.com/ticket/24075 and bail early if the `ContentType` or `Permission` models don't exist


This prevents `create_extra_permissions` from querying or creating ContentType or Permission objects if the models cannot be found. When using multiple databases which do not have the auth_permission table `create_extra_permissions` will cause migrate to fail.

This is similar to https://code.djangoproject.com/ticket/24075.

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #...







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
