### PR TITLE
White bg on preview panel

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)
+ * Fix: Add a fallback background for the editing preview iframe for sites without a background (Ian Price)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Maintenance: Update BeautifulSoup upper bound to 4.12.x (scott-8)
  * Maintenance: Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -758,6 +758,7 @@
 * phijma-leukeleu
 * CheesyPhoenix
 * Vedant Pandey
+* Ian Price
 
 ## Translators
 

--- a/client/scss/components/_preview-panel.scss
+++ b/client/scss/components/_preview-panel.scss
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
 
+  --w-preview-background-color: var(--w-color-white);
   --preview-width-ratio: min(
     1,
     var(--preview-panel-width, 450) / var(--preview-device-width, 375)
@@ -32,6 +33,11 @@
     height: calc(100% / var(--preview-width-ratio));
     transform: scale(var(--preview-width-ratio));
     display: block;
+
+    &:empty {
+      // Ensure that sites without a background show with a fallback, only when iframe has loaded
+      background-color: var(--w-preview-background-color);
+    }
 
     [dir='rtl'] & {
       // Transform with the top-right physical corner as the origin since the layout is reversed.

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -21,6 +21,7 @@ depth: 1
  * Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)
+ * Add a fallback background for the editing preview iframe for sites without a background (Ian Price)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/preview.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/preview.html
@@ -54,7 +54,11 @@
         </div>
 
         <div class="preview-panel__wrapper">
-            <iframe loading="lazy" title="{% trans 'Preview' %}" class="preview-panel__iframe" data-preview-iframe aria-describedby="preview-panel-error-banner"></iframe>
+            <iframe loading="lazy" title="{% trans 'Preview' %}" class="preview-panel__iframe" data-preview-iframe aria-describedby="preview-panel-error-banner">
+                <div>
+                     {# Add placeholder element to support styling content when iframe has loaded #}
+                </div>
+            </iframe>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Iframe for preview panel in admin updated to have white background (acting as almost any browser would for page with no background set)

Fixes #11174 



_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

Strictly adds a 'background-color' css prop to the 'preview-panel__iframe' class used by the preview iframe. This is supported by all modern browsers.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
