### PR TITLE
Remove upper bound on django-pattern-library in testing dependencies

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Maintenance: Migrate the contrib styleguide index view to a class-based view (Chiemezuo Akujobi)
  * Maintenance: Update djhtml to 3.0.6 (Matt Westcott)
  * Maintenance: Migrate the contrib settings edit view to a class-based view (Chiemezuo Akujobi, Sage Abdullah)
+ * Maintenance: Remove django-pattern-library upper bound in testing dependencies (Sage Abdullah)
 
 
 5.2.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -38,6 +38,7 @@ depth: 1
  * Migrate the contrib styleguide index view to a class-based view (Chiemezuo Akujobi)
  * Update djhtml to 3.0.6 (Matt Westcott)
  * Migrate the contrib settings edit view to a class-based view (Chiemezuo Akujobi, Sage Abdullah)
+ * Remove django-pattern-library upper bound in testing dependencies (Sage Abdullah)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ testing_extras = [
     "freezegun>=0.3.8",
     "azure-mgmt-cdn>=12.0,<13.0",
     "azure-mgmt-frontdoor>=1.0,<1.1",
-    "django-pattern-library>=0.7,<0.8",
+    "django-pattern-library>=0.7",
     # For coverage and PEP8 linting
     "coverage>=3.7.0",
     "black==22.3.0",

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -1,5 +1,6 @@
 import os
 
+from django import VERSION as DJANGO_VERSION
 from django.contrib.messages import constants as message_constants
 from django.utils.translation import gettext_lazy as _
 
@@ -70,10 +71,10 @@ if os.environ.get("STATICFILES_STORAGE", "") == "manifest":
         "BACKEND"
     ] = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
 
-    # DJANGO_VERSION < 4.2
-    STATICFILES_STORAGE = (
-        "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
-    )
+    if DJANGO_VERSION < (4, 2):
+        STATICFILES_STORAGE = (
+            "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+        )
 
 
 USE_TZ = not os.environ.get("DISABLE_TIMEZONE")


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

[We officially support Django 4.2 as of Wagtail 5.0.](https://docs.wagtail.org/en/stable/releases/5.0.html) However, django-pattern-library didn't officially support Django 4.2 until [v1.1.0](https://github.com/torchbox/django-pattern-library/releases/tag/v1.1.0).

We set the upper limit for django-pattern-library to 0.8 in the testing dependencies. This means that if you want to do `python -m pip install -e .[testing]`, pip won't be able to pick up v1.1.0 if you want to test against Django 4.2.

I opted to remove the upper bound, but if we want to set it to e.g. `<2.0` I can do that.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
