### PR TITLE
Remove search logging from project template

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)
  * Fix: Add a fallback background for the editing preview iframe for sites without a background (Ian Price)
  * Fix: Preserve whitespace in rendered comments (Elhussein Almasri)
+ * Fix: Remove search logging from project template so that new projects without the search promotions module will not error (Matt Westcott)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Maintenance: Update BeautifulSoup upper bound to 4.12.x (scott-8)
  * Maintenance: Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -23,6 +23,7 @@ depth: 1
  * Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)
  * Add a fallback background for the editing preview iframe for sites without a background (Ian Price)
  * Preserve whitespace in rendered comments (Elhussein Almasri)
+ * Remove search logging from project template so that new projects without the search promotions module will not error (Matt Westcott)
 
 ### Documentation
 

--- a/wagtail/project_template/search/views.py
+++ b/wagtail/project_template/search/views.py
@@ -2,7 +2,13 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.template.response import TemplateResponse
 
 from wagtail.models import Page
-from wagtail.search.models import Query
+
+# To enable logging of search queries for use with the "Promoted search results" module
+# <https://docs.wagtail.org/en/stable/reference/contrib/searchpromotions.html>
+# uncomment the following line and the lines indicated in the search function
+# (after adding wagtail.contrib.search_promotions to INSTALLED_APPS):
+
+# from wagtail.contrib.search_promotions.models import Query
 
 
 def search(request):
@@ -12,10 +18,12 @@ def search(request):
     # Search
     if search_query:
         search_results = Page.objects.live().search(search_query)
-        query = Query.get(search_query)
 
-        # Record hit
-        query.add_hit()
+        # To log this query for use with the "Promoted search results" module:
+
+        # query = Query.get(search_query)
+        # query.add_hit()
+
     else:
         search_results = Page.objects.none()
 


### PR DESCRIPTION
Prompted by this Stack Overflow question: https://stackoverflow.com/q/77427464/1853523

The search view on the project template is still attempting to log queries against the now-removed wagtailsearch.Query model - as of 6.0a0 this is causing an ImportError when running initial migrations on a newly-created project.

Since the wagtail.contrib.search_promotions module is optional (and off by default on new projects), I've opted to comment out the query logging code with instructions for developers who wish to re-enable it.
