### PR TITLE
Ensure that explorer_results views fill in the correct next_url parameter on action URLs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,6 +33,7 @@ Changelog
  * Fix: Remove search logging from project template so that new projects without the search promotions module will not error (Matt Westcott)
  * Fix: Ensure text only email notifications for updated comments do not escape HTML characters (Rohit Sharma)
  * Fix: Use logical OR operator to combine search fields for Django ORM in generic IndexView (Varun Kumar)
+ * Fix: Ensure that explorer_results views fill in the correct next_url parameter on action URLs (Matt Westcott)
  * Docs: Fix code example for `{% picture ... as ... %}` template tag (Rezyapkin)
 
 

--- a/docs/releases/5.2.1.md
+++ b/docs/releases/5.2.1.md
@@ -18,6 +18,7 @@ depth: 1
  * Remove search logging from project template so that new projects without the search promotions module will not error (Matt Westcott)
  * Ensure text only email notifications for updated comments do not escape HTML characters (Rohit Sharma)
  * Use logical OR operator to combine search fields for Django ORM in generic IndexView (Varun Kumar)
+ * Ensure that explorer_results views fill in the correct next_url parameter on action URLs (Matt Westcott)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_cell.html
@@ -1,6 +1,6 @@
 {% load l10n %}
 <td id="page_{{ instance.pk|unlocalize }}_title" {% if column.classname %}class="{{ column.classname }}"{% endif %} data-listing-page-title>
-    {% include "wagtailadmin/pages/listing/_page_title_explore.html" with page=instance show_locale_labels=show_locale_labels %}
+    {% include "wagtailadmin/pages/listing/_page_title_explore.html" with page=instance show_locale_labels=show_locale_labels actions_next_url=actions_next_url %}
     {% if parent_page %}
         <div>
             <a href="{% url 'wagtailadmin_explore' parent_page.id %}" class="icon icon-arrow-right">{{ parent_page.get_admin_display_title }}</a>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -28,5 +28,5 @@
 </div>
 
 <ul class="actions">
-    {% page_listing_buttons page request.user %}
+    {% page_listing_buttons page request.user next_url=actions_next_url %}
 </ul>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -444,8 +444,8 @@ def paginate(context, page, base_url="", page_key="p", classname=""):
 
 
 @register.inclusion_tag("wagtailadmin/shared/buttons.html", takes_context=True)
-def page_listing_buttons(context, page, user):
-    next_url = context["request"].path
+def page_listing_buttons(context, page, user, next_url=None):
+    next_url = next_url or context["request"].path
     button_hooks = hooks.get_hooks("register_page_listing_buttons")
 
     buttons = []

--- a/wagtail/admin/ui/tables/pages.py
+++ b/wagtail/admin/ui/tables/pages.py
@@ -27,6 +27,7 @@ class PageTitleColumn(BaseColumn):
         context["parent_page"] = getattr(instance, "annotated_parent_page", None)
         context["show_locale_labels"] = parent_context.get("show_locale_labels")
         context["perms"] = parent_context.get("perms")
+        context["actions_next_url"] = parent_context.get("actions_next_url")
         return context
 
 
@@ -90,6 +91,7 @@ class PageTable(Table):
         use_row_ordering_attributes=False,
         parent_page=None,
         show_locale_labels=False,
+        actions_next_url=None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -114,6 +116,7 @@ class PageTable(Table):
                 )
 
         self.show_locale_labels = show_locale_labels
+        self.actions_next_url = actions_next_url
 
     def get_ascending_title_text(self, column):
         return self.ascending_title_text_format % {
@@ -149,5 +152,8 @@ class PageTable(Table):
         context["is_searching"] = parent_context.get("is_searching")
         context["is_searching_whole_tree"] = parent_context.get(
             "is_searching_whole_tree"
+        )
+        context["actions_next_url"] = (
+            self.actions_next_url or parent_context.get("request").path
         )
         return context

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -232,6 +232,7 @@ class BaseIndexView(PermissionCheckedMixin, BaseListingView):
         kwargs["use_row_ordering_attributes"] = self.show_ordering_column
         kwargs["parent_page"] = self.parent_page
         kwargs["show_locale_labels"] = self.i18n_enabled and self.parent_page.is_root()
+        kwargs["actions_next_url"] = self.get_index_url()
 
         if self.show_ordering_column:
             kwargs["attrs"] = {


### PR DESCRIPTION
Fixes #11177, by adding the option to pass an actions_next_url argument to the table as per https://github.com/wagtail/wagtail/pull/11175#discussion_r1381892130

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
