### PR TITLE
Prevent display of Workflow and Aging Pages Reports without appropriate permissions

### DIFF
--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -591,6 +591,55 @@ class TestAgingPagesView(WagtailTestUtils, TestCase):
         self.assertContains(response, expected_deleted_string)
 
 
+class TestAgingPagesViewPermissions(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.user = self.login()
+
+    def get(self, params={}):
+        return self.client.get(reverse("wagtailadmin_reports:aging_pages"), params)
+
+    def test_simple(self):
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_with_no_permission(self):
+        group = Group.objects.create(name="test group")
+        self.user.is_superuser = False
+        self.user.save()
+        page = Page.objects.first()
+        self.user.groups.add(group)
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            )
+        )
+        # No GroupPagePermission created
+
+        response = self.get()
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse("wagtailadmin_home"))
+
+    def test_get_with_minimal_permissions(self):
+        group = Group.objects.create(name="test group")
+        self.user.is_superuser = False
+        self.user.save()
+        self.user.groups.add(group)
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            )
+        )
+        group_page_permission = GroupPagePermission.objects.create(
+            group=group,
+            page=Page.objects.first(),
+            permission_type="add",
+        )
+
+        response = self.get()
+
+        self.assertEqual(response.status_code, 200)
+
+
 class TestFilteredAgingPagesView(WagtailTestUtils, TestCase):
     fixtures = ["test.json"]
 

--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -515,8 +515,7 @@ class TestAgingPagesView(WagtailTestUtils, TestCase):
         self.user.save()
 
         response = self.get()
-        self.assertContains(response, "No pages found.")
-        self.assertNotContains(response, self.home.title)
+        self.assertEqual(response.status_code, 302)
 
     def test_csv_export(self):
         self.publish_home_page()
@@ -606,7 +605,6 @@ class TestAgingPagesViewPermissions(WagtailTestUtils, TestCase):
         group = Group.objects.create(name="test group")
         self.user.is_superuser = False
         self.user.save()
-        page = Page.objects.first()
         self.user.groups.add(group)
         self.user.user_permissions.add(
             Permission.objects.get(
@@ -629,7 +627,7 @@ class TestAgingPagesViewPermissions(WagtailTestUtils, TestCase):
                 content_type__app_label="wagtailadmin", codename="access_admin"
             )
         )
-        group_page_permission = GroupPagePermission.objects.create(
+        GroupPagePermission.objects.create(
             group=group,
             page=Page.objects.first(),
             permission_type="add",

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -180,7 +180,6 @@ class TestWorkflowPermissions(WagtailTestUtils, TestCase):
         group = Group.objects.create(name="test group")
         self.user.is_superuser = False
         self.user.save()
-        page = Page.objects.first()
         self.user.groups.add(group)
         self.user.user_permissions.add(
             Permission.objects.get(
@@ -203,7 +202,7 @@ class TestWorkflowPermissions(WagtailTestUtils, TestCase):
                 content_type__app_label="wagtailadmin", codename="access_admin"
             )
         )
-        group_page_permission = GroupPagePermission.objects.create(
+        GroupPagePermission.objects.create(
             group=group,
             page=Page.objects.first(),
             permission_type="change",

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -22,6 +22,7 @@ from wagtail.admin.utils import (
 )
 from wagtail.models import (
     GroupApprovalTask,
+    GroupPagePermission,
     Page,
     PageViewRestriction,
     Task,
@@ -161,6 +162,55 @@ class TestWorkflowsIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase)
 
         self.login(user=self.moderator)
         response = self.get()
+        self.assertEqual(response.status_code, 200)
+
+
+class TestWorkflowPermissions(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.user = self.login()
+
+    def get(self, params={}):
+        return self.client.get(reverse("wagtailadmin_reports:workflow"), params)
+
+    def test_simple(self):
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_with_no_permission(self):
+        group = Group.objects.create(name="test group")
+        self.user.is_superuser = False
+        self.user.save()
+        page = Page.objects.first()
+        self.user.groups.add(group)
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            )
+        )
+        # No GroupPagePermission created
+
+        response = self.get()
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse("wagtailadmin_home"))
+
+    def test_get_with_minimal_permissions(self):
+        group = Group.objects.create(name="test group")
+        self.user.is_superuser = False
+        self.user.save()
+        self.user.groups.add(group)
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            )
+        )
+        group_page_permission = GroupPagePermission.objects.create(
+            group=group,
+            page=Page.objects.first(),
+            permission_type="change",
+        )
+
+        response = self.get()
+
         self.assertEqual(response.status_code, 200)
 
 

--- a/wagtail/admin/views/reports/aging_pages.py
+++ b/wagtail/admin/views/reports/aging_pages.py
@@ -1,7 +1,7 @@
 import django_filters
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import OuterRef, Subquery
 from django.utils.translation import gettext_lazy as _
 
@@ -112,3 +112,10 @@ class AgingPagesView(PageReportView):
         )
 
         return super().get_queryset()
+
+    def dispatch(self, request, *args, **kwargs):
+        if not PagePermissionPolicy().user_has_any_permission(
+            request.user, ["add", "change", "publish"]
+        ):
+            raise PermissionDenied
+        return super().dispatch(request, *args, **kwargs)

--- a/wagtail/admin/views/reports/workflows.py
+++ b/wagtail/admin/views/reports/workflows.py
@@ -4,6 +4,7 @@ import django_filters
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import PermissionDenied
 from django.db.models import CharField, Q
 from django.db.models.functions import Cast
 from django.utils.translation import gettext_lazy as _
@@ -190,6 +191,13 @@ class WorkflowView(ReportView):
         return WorkflowState.objects.filter(editable_pages | editable_objects).order_by(
             "-created_at"
         )
+
+    def dispatch(self, request, *args, **kwargs):
+        if not PagePermissionPolicy().user_has_any_permission(
+            request.user, ["add", "change", "publish"]
+        ):
+            raise PermissionDenied
+        return super().dispatch(request, *args, **kwargs)
 
 
 class WorkflowTasksView(ReportView):

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -853,7 +853,11 @@ class LockedPagesMenuItem(MenuItem):
 
 class WorkflowReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True)
+        return getattr(
+            settings, "WAGTAIL_WORKFLOW_ENABLED", True
+        ) and PagePermissionPolicy().user_has_any_permission(
+            request.user, ["add", "change", "publish"]
+        )
 
 
 class SiteHistoryReportMenuItem(MenuItem):
@@ -863,7 +867,11 @@ class SiteHistoryReportMenuItem(MenuItem):
 
 class AgingPagesReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return getattr(settings, "WAGTAIL_AGING_PAGES_ENABLED", True)
+        return getattr(
+            settings, "WAGTAIL_WORKFLOW_ENABLED", True
+        ) and PagePermissionPolicy().user_has_any_permission(
+            request.user, ["add", "change", "publish"]
+        )
 
 
 @hooks.register("register_reports_menu_item")

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -868,7 +868,7 @@ class SiteHistoryReportMenuItem(MenuItem):
 class AgingPagesReportMenuItem(MenuItem):
     def is_shown(self, request):
         return getattr(
-            settings, "WAGTAIL_WORKFLOW_ENABLED", True
+            settings, "WAGTAIL_AGING_PAGES_ENABLED", True
         ) and PagePermissionPolicy().user_has_any_permission(
             request.user, ["add", "change", "publish"]
         )


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #8845 In this PR the workflow and aging pages report visibility has been restricted for users without appropriate permissions.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
