### PR TITLE
Icon fonts stylesheets cleanup

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ Changelog
  * Maintenance: Refine styling of listings, account settings panels and the block chooser (Meli Imelda)
  * Maintenance: Remove icon font support (Matt Westcott)
  * Maintenance: Remove deprecated SVG icons (Matt Westcott)
+ * Maintenance: Remove icon font styles (Thibaud Colas)
  * Maintenance: Migrate account editing view to a class-based view (Kehinde Bobade)
  * Maintenance: Upgrade frontend tooling to use Node 20 (LB (Ben) Johnston)
  * Maintenance: Upgrade `ruff` and replace `black` with `ruff format` (John-Scott Atlakson)

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -287,17 +287,9 @@
 
     @include media-breakpoint-up(sm) {
       &.icon {
-        &:before {
-          line-height: 2.1em;
-        }
-
         &.button-small {
           width: 1.75em;
           height: 1.75em;
-
-          &:before {
-            line-height: 1.7em;
-          }
         }
       }
     }
@@ -314,17 +306,8 @@
     &.bicolor {
       padding-inline-start: 3.5em;
 
-      &:before {
-        width: 2em;
-        font-size: theme('fontSize.16');
-      }
-
       &.button-small {
         padding-inline-start: 3em;
-
-        &:before {
-          width: 1.75em;
-        }
       }
     }
   }

--- a/client/scss/components/_dropdown.legacy.scss
+++ b/client/scss/components/_dropdown.legacy.scss
@@ -88,12 +88,6 @@
 
       &.icon {
         padding-inline-end: 5em;
-
-        // stylelint-disable-next-line max-nesting-depth
-        &:before,
-        &:after {
-          inset-inline-end: 1em;
-        }
       }
 
       &.shortcut {
@@ -161,16 +155,6 @@
     inset-inline-end: 0;
     padding: 0 0.5em;
     text-align: center;
-
-    &:before,
-    &:after {
-      margin: 0;
-    }
-
-    &:before {
-      width: 1em;
-      font-size: 1.2rem;
-    }
 
     &:hover {
       background-color: theme('colors.surface-button-hover');

--- a/client/scss/components/_icons.scss
+++ b/client/scss/components/_icons.scss
@@ -15,15 +15,12 @@
   color: theme('colors.surface-page');
 }
 
-.icon:after {
-  text-align: end;
-}
-
 // =============================================================================
 // Icon factory methods
 // =============================================================================
 
-$icons-after: ('arrow-down', 'arrow-right', 'arrow-up');
+// Legacy icons still implemented via CSS due to the markup being hard to change.
+$icons-after: ('arrow-down', 'arrow-up');
 
 @each $icon in $icons-after {
   .icon-#{$icon}-after::after {
@@ -39,20 +36,13 @@ $icons-after: ('arrow-down', 'arrow-right', 'arrow-up');
 // =============================================================================
 // Custom config for various icons
 // =============================================================================
-.icon-download {
-  // Credit: Icon made by Freepik from Flaticon.com
-}
 
-// For SVG icons, add spinner styles onto the use element,
+// Add spinner styles onto the use element,
 // so an icon can be turned into a spinner by changing the href only.
 // This allows us to switch any icon to a spinner with much less boilerplate.
 use[href='#icon-spinner'] {
   animation: spin-wag 0.5s infinite linear;
   transform-origin: center;
-}
-
-.icon-larger:before {
-  font-size: 1.5em;
 }
 
 .text-replace {
@@ -73,11 +63,6 @@ use[href='#icon-spinner'] {
   100% {
     transform: rotate(360deg);
   }
-}
-
-.icon-spinner:after {
-  display: inline-block;
-  line-height: 1;
 }
 
 // stylelint-disable-next-line no-duplicate-selectors

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -543,6 +543,7 @@ table.listing {
           text-align: center;
           height: 180px;
 
+          // Vertically center the image.
           &:before {
             content: '';
             display: inline-block;

--- a/client/scss/components/_userbar.scss
+++ b/client/scss/components/_userbar.scss
@@ -82,13 +82,6 @@ $positions: (
   text-decoration: none;
   position: relative;
 
-  .w-icon:before {
-    transition: color 0.2s ease;
-    font-size: 2rem;
-    width: auto;
-    margin: 0;
-  }
-
   .w-userbar-axe-count {
     display: flex;
     justify-content: center;
@@ -212,17 +205,6 @@ $positions: (
 
     .w-a11y-result__count {
       margin-inline-end: theme('spacing.2');
-    }
-  }
-
-  .w-icon {
-    position: relative;
-
-    &:before {
-      position: absolute;
-      top: 50%;
-      transform: translateY(-50%);
-      inset-inline-start: 14px;
     }
   }
 

--- a/client/scss/objects/_avatar.scss
+++ b/client/scss/objects/_avatar.scss
@@ -37,9 +37,5 @@
 
   &.square {
     border-radius: 0;
-
-    &:before {
-      border-radius: 0;
-    }
   }
 }

--- a/client/scss/overrides/_vendor.tagit.scss
+++ b/client/scss/overrides/_vendor.tagit.scss
@@ -82,10 +82,6 @@
     mask-image: url('#{$images-root}icons/cross.svg');
     mask-repeat: no-repeat;
   }
-
-  .ui-icon-close:hover:before {
-    color: theme('colors.critical.200');
-  }
 }
 
 @media (forced-colors: active) {

--- a/client/src/components/PageExplorer/PageExplorerItem.scss
+++ b/client/src/components/PageExplorer/PageExplorerItem.scss
@@ -35,10 +35,6 @@
   line-height: 1;
   font-size: 2em;
   cursor: pointer;
-
-  .icon::before {
-    margin-inline-end: 0;
-  }
 }
 
 .c-page-explorer__item__action--small {

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -35,25 +35,6 @@
       color: theme('colors.text-label-menus-active');
       text-shadow: -1px -1px 0 theme('colors.black-35');
     }
-
-    &:before {
-      width: 1rem;
-      height: 1rem;
-      font-size: 1rem;
-      display: flex;
-      align-items: center;
-      // Ensure consistent button height in collapsed state where no text line-height is adding 1.5px.
-      margin: 0.046875rem 0;
-    }
-
-    // only really used for spinners and settings menu
-    &:after {
-      font-size: 1.5em;
-      margin: 0;
-      position: absolute;
-      inset-inline-end: 0.5em;
-      top: 0.5em;
-    }
   }
 
   &--in-sub-menu {

--- a/client/src/components/Sidebar/menu/SubMenuItem.scss
+++ b/client/src/components/Sidebar/menu/SubMenuItem.scss
@@ -37,15 +37,6 @@
   > h2 {
     // w-min-h-[160px] and w-mt-[35px] classes are to vertically align the title and icon combination to the search input on the left
     @apply w-min-h-[180px] w-px-4 w-box-border w-text-center w-text-text-label-menus-default w-mb-0 w-inline-flex w-flex-col w-justify-center w-items-center w-transition-sidebar;
-
-    &:before {
-      font-size: 4em;
-      display: block;
-      text-align: center;
-      margin: 0 0 0.2em;
-      width: 100%;
-      opacity: 0.15;
-    }
   }
 
   ul > li {

--- a/client/src/components/Sidebar/modules/MainMenu.scss
+++ b/client/src/components/Sidebar/modules/MainMenu.scss
@@ -57,12 +57,6 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-
-      &:before {
-        font-size: 1rem;
-        margin-inline-end: 0.5em;
-        vertical-align: -10%;
-      }
     }
   }
 

--- a/docs/contributing/ui_guidelines.md
+++ b/docs/contributing/ui_guidelines.md
@@ -90,7 +90,7 @@ This is an area of active improvement for Wagtail, with [ongoing discussions](ht
 
 -   Always use the `trimmed` attribute on `blocktranslate` tags to prevent unnecessary whitespace from being added to the translation strings.
 
-## SVG icons
+## Icons
 
 We use inline SVG elements for Wagtail’s icons, for performance and so icons can be styled with CSS. View [](icons) for information on how icons are set up for Wagtail users.
 

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -53,6 +53,7 @@ depth: 1
  * Refine styling of listings, account settings panels and the block chooser (Meli Imelda)
  * Remove icon font support (Matt Westcott)
  * Remove deprecated SVG icons (Matt Westcott)
+ * Remove icon font styles (Thibaud Colas)
  * Migrate account editing view to a class-based view (Kehinde Bobade)
  * Upgrade frontend tooling to use Node 20 (LB (Ben) Johnston)
  * Upgrade `ruff` and replace `black` with `ruff format` (John-Scott Atlakson)

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -1014,7 +1014,7 @@ def register_icons(icons):
         "doc-empty-inverse.svg",
         "doc-empty.svg",
         "doc-full-inverse.svg",
-        "doc-full.svg",  # aka file-text-alt
+        "doc-full.svg",
         "dots-horizontal.svg",
         "download.svg",
         "draft.svg",
@@ -1038,7 +1038,7 @@ def register_icons(icons):
         "help.svg",
         "history.svg",
         "home.svg",
-        "image.svg",  # aka picture
+        "image.svg",
         "info-circle.svg",
         "italic.svg",
         "key.svg",
@@ -1062,7 +1062,7 @@ def register_icons(icons):
         "password.svg",
         "pick.svg",
         "pilcrow.svg",
-        "placeholder.svg",  # aka marquee
+        "placeholder.svg",
         "plus-inverse.svg",
         "plus.svg",
         "radio-empty.svg",


### PR DESCRIPTION
The last item to complete #6107. This is largely just removal of now-unused icon styles overrides – which have been unused in Wagtail core for a while, but could have remained used in third-party code while the icon font was deprecated but not removed.

I also did small bits of related cleanup, explained in individual comments.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 119, Firefox 119, Safari 17 on macOS 14
    -   [x] **Please list which assistive technologies [^3] you tested**: None
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

Tested with a [visual regression test suite](https://github.com/thibaudcolas/wagtail-tooling) to confirm there were no visual changes before-after the removal of those styles.