### PR TITLE
Fix crash when accessing the history view for a translatable snippet

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,7 @@ Changelog
  * Fix: Ensure text only email notifications for updated comments do not escape HTML characters (Rohit Sharma)
  * Fix: Use logical OR operator to combine search fields for Django ORM in generic IndexView (Varun Kumar)
  * Fix: Ensure that explorer_results views fill in the correct next_url parameter on action URLs (Matt Westcott)
+ * Fix: Fix crash when accessing the history view for a translatable snippet (Sage Abdullah)
  * Docs: Fix code example for `{% picture ... as ... %}` template tag (Rezyapkin)
 
 

--- a/docs/releases/5.2.1.md
+++ b/docs/releases/5.2.1.md
@@ -19,6 +19,7 @@ depth: 1
  * Ensure text only email notifications for updated comments do not escape HTML characters (Rohit Sharma)
  * Use logical OR operator to combine search fields for Django ORM in generic IndexView (Varun Kumar)
  * Ensure that explorer_results views fill in the correct next_url parameter on action URLs (Matt Westcott)
+ * Fix crash when accessing the history view for a translatable snippet (Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -228,7 +228,10 @@ class IndexView(
 
         self.filters, queryset = self.filter_queryset(queryset)
 
-        if self.locale:
+        # Ensure the queryset is of the same model as self.model before filtering,
+        # which may not be the case for views like HistoryView where the queryset
+        # is of a LogEntry model for self.model.
+        if self.locale and queryset.model == self.model:
             queryset = queryset.filter(locale=self.locale)
 
         has_updated_at_column = any(

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -61,6 +61,7 @@ from wagtail.test.testapp.models import (
     AdvertWithTabbedInterface,
     DraftStateCustomPrimaryKeyModel,
     DraftStateModel,
+    FullFeaturedSnippet,
     MultiPreviewModesModel,
     RevisableChildModel,
     RevisableModel,
@@ -4117,10 +4118,10 @@ class TestSnippetHistory(WagtailTestUtils, TestCase):
             timestamp=make_aware(datetime.datetime(2022, 5, 10, 12, 34, 0)),
             object_id="1",
         )
-        self.revisable_snippet = RevisableModel.objects.create(text="Foo")
+        self.revisable_snippet = FullFeaturedSnippet.objects.create(text="Foo")
         self.initial_revision = self.revisable_snippet.save_revision(user=self.user)
         ModelLogEntry.objects.create(
-            content_type=ContentType.objects.get_for_model(RevisableModel),
+            content_type=ContentType.objects.get_for_model(FullFeaturedSnippet),
             label="Foo",
             action="wagtail.create",
             timestamp=make_aware(datetime.datetime(2022, 5, 10, 20, 22, 0)),
@@ -4226,6 +4227,8 @@ class TestSnippetHistory(WagtailTestUtils, TestCase):
     @override_settings(WAGTAIL_I18N_ENABLED=True)
     def test_get_with_i18n_enabled(self):
         response = self.get(self.non_revisable_snippet)
+        self.assertEqual(response.status_code, 200)
+        response = self.get(self.revisable_snippet)
         self.assertEqual(response.status_code, 200)
 
 


### PR DESCRIPTION
Regression in dc049cd88077ca339f00fa438fdbe54b13069546.

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11206.

To test, access the History view for the `FooterText` snippet in bakerydemo.





_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?


[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
