### PR TITLE
Minimap - Ensure that we correctly handle no data-panel found scenarios

### DIFF
--- a/client/src/components/Minimap/Minimap.tsx
+++ b/client/src/components/Minimap/Minimap.tsx
@@ -38,8 +38,9 @@ const mapIntersections = (
   acc: LinkIntersections,
   { target, isIntersecting }: IntersectionObserverEntry,
 ) => {
-  const href = `#${target.closest('[data-panel]')?.id}` || '';
-  acc[href] = isIntersecting;
+  const id = target.closest('[data-panel]')?.id;
+  if (!id) return acc;
+  acc[`#${id}`] = isIntersecting;
   return acc;
 };
 


### PR DESCRIPTION
- Low priority bug fix, it's unlikely this code path would ever be an issue as we will always find at least one parent `data-panel`, however, the code itself will not work as expected if this does happen so we should probably fix it.
- Currently the code appears to try to fallback to an empty id, however this will never happen as we are building a non-empty string
- Instead if we have not found any closest panel, simply return the intersection map as is Closes #11210
- Fixes #11210 

# Testing

This logic governs the intersecting 'line' on  the minimap that shows where you are.

<img width="1185" alt="Screenshot 2023-11-10 at 6 19 20 am" src="https://github.com/wagtail/wagtail/assets/1396140/d1db4de7-e1af-45e8-aa86-7d369a7009f8">
