### PR TITLE
SwapController - Ensure untrusted data sources are logged correctly

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -57,6 +57,7 @@ Changelog
  * Maintenance: Refactor `page_breadcrumbs` tag to use shared `breadcrumbs.html` template (Sage Abdullah)
  * Maintenance: Add `keyboard` icon to admin icon set (Rohit Sharma)
  * Maintenance: Remove dead code in the minimap when elements are not found (LB (Ben) Johnston)
+ * Maintenance: Ensure untrusted data sources are logged correctly in the Stimulus `SwapController` (LB (Ben) Johnston)
 
 
 6.0.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/controllers/SwapController.test.js
+++ b/client/src/controllers/SwapController.test.js
@@ -410,7 +410,8 @@ describe('SwapController', () => {
 
       // eslint-disable-next-line no-console
       expect(console.error).toHaveBeenLastCalledWith(
-        'Error fetching /admin/images/results/?q=alpha',
+        'Error fetching %s',
+        '/admin/images/results/?q=alpha',
         expect.any(Error),
       );
 

--- a/client/src/controllers/SwapController.ts
+++ b/client/src/controllers/SwapController.ts
@@ -303,7 +303,7 @@ export class SwapController extends Controller<
           target,
         });
         // eslint-disable-next-line no-console
-        console.error(`Error fetching ${requestUrl}`, error);
+        console.error('Error fetching %s', requestUrl, error);
       })
       .finally(() => {
         if (signal === this.abortController?.signal) {

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -79,6 +79,7 @@ depth: 1
  * Refactor `page_breadcrumbs` tag to use shared `breadcrumbs.html` template (Sage Abdullah)
  * Add `keyboard` icon to admin icon set (Rohit Sharma)
  * Remove dead code in the minimap when elements are not found (LB (Ben) Johnston)
+ * Ensure untrusted data sources are logged correctly in the Stimulus `SwapController` (LB (Ben) Johnston)
 
 
 ## Upgrade considerations


### PR DESCRIPTION
Avoids the rare case of `requestUrl` being used to log out an object in an unhanded way.

See https://developer.mozilla.org/en-US/docs/Web/API/console#s

Fixes #11212