### PR TITLE
Resolve multiple errors when editing a Site to use an existing hostname and port

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@ Changelog
  * Fix: Ensure image focal point box can be removed (Gunnar Scherf)
  * Fix: Ensure that Snippets search results correctly use the `index_results.html` or `index_results_template_name` override on initial load (Stefan Hammer)
  * Fix: Avoid error when attempting to moderate a page drafted by a now deleted user (Dan Braghis)
+ * Fix: Do not show multiple error messages when editing a Site to use existing hostname and port (Rohit Sharma)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)
  * Docs: Add section to testing docs about creating pages and working with page content (Mariana Bedran Lesche)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -43,6 +43,7 @@ depth: 1
  * Ensure image focal point box can be removed (Gunnar Scherf)
  * Ensure that Snippets search results correctly use the `index_results.html` or `index_results_template_name` override on initial load (Stefan Hammer)
  * Avoid error when attempting to moderate a page drafted by a now deleted user (Dan Braghis)
+ * Do not show multiple error messages when editing a Site to use existing hostname and port (Rohit Sharma)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -6,12 +6,6 @@
     <form action="{{ action_url }}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
 
-        {% block non_field_errors %}
-            {% for error in form.non_field_errors %}
-                {% help_block status="critical" %}{{ error }}{% endhelp_block %}
-            {% endfor %}
-        {% endblock %}
-
         {% if panel %}
             {{ panel.render_form_content }}
         {% else %}

--- a/wagtail/sites/tests.py
+++ b/wagtail/sites/tests.py
@@ -151,12 +151,17 @@ class TestSiteCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
             {"hostname": "localhost", "port": "80", "root_page": str(self.home_page.id)}
         )
         expected_html = """
-            <div class="help-block help-critical">
-                <svg class="icon icon-warning icon" aria-hidden="true">
+            <li class="error">
+                <svg class="class="icon icon-warning messages-icon"" aria-hidden="true">
                     <use href="#icon-warning"></use>
                 </svg>
+                The site could not be saved due to errors.
+                <ul class="errorlist">
+                <li>
                 Site with this Hostname and Port already exists.
-            </div>
+                </li>
+                </ul>
+            </li>
         """
         self.assertTagInHTML(expected_html, response.content.decode())
 
@@ -314,12 +319,17 @@ class TestSiteEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
             site_id=second_site.id,
         )
         expected_html = """
-            <div class="help-block help-critical">
-                <svg class="icon icon-warning icon" aria-hidden="true">
+            <li class="error">
+                <svg class="class="icon icon-warning messages-icon"" aria-hidden="true">
                     <use href="#icon-warning"></use>
                 </svg>
+                The site could not be saved due to errors.
+                <ul class="errorlist">
+                <li>
                 Site with this Hostname and Port already exists.
-            </div>
+                </li>
+                </ul>
+            </li>
         """
         self.assertTagInHTML(expected_html, response.content.decode())
 

--- a/wagtail/sites/views.py
+++ b/wagtail/sites/views.py
@@ -32,6 +32,7 @@ class IndexView(generic.IndexView):
 class CreateView(generic.CreateView):
     page_title = _("Add site")
     success_message = _("Site '%(object)s' created.")
+    error_message = _("The site could not be saved due to errors.")
 
 
 class EditView(generic.EditView):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11200 This PR addresses multiple errors encountered during the editing of a Site when attempting to use an existing hostname and port. The solution ensures proper error messages are shown.

### Before:

![image](https://github.com/wagtail/wagtail/assets/111359305/3350f987-9c2a-4571-82cb-e6b2ad3495e5)

### After:

![Untitled design (1)](https://github.com/wagtail/wagtail/assets/111359305/9fc602e4-9d37-4e69-bf52-4c9932e94c2b)








_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
