### PR TITLE
Fix performance regression for report views

### DIFF
--- a/wagtail/admin/views/reports/base.py
+++ b/wagtail/admin/views/reports/base.py
@@ -17,8 +17,12 @@ class ReportView(IndexView):
 
     def get(self, request, *args, **kwargs):
         self.filters, self.object_list = self.get_filtered_queryset()
-        self.object_list = self.decorate_paginated_queryset(self.object_list)
         context = self.get_context_data()
+        # Decorate the queryset *after* Django's BaseListView has returned a paginated/reduced
+        # list of objects
+        context["object_list"] = self.decorate_paginated_queryset(
+            context["object_list"]
+        )
         return self.render_to_response(context)
 
     def get_context_data(self, *args, **kwargs):


### PR DESCRIPTION
Fixes #11222

To test: find a Wagtail project with lots of pages and log entries, check http://127.0.0.1:8000/admin/reports/site-history/

Running the test before adding the fix resulted in:

```
======================================================================
FAIL: test_decorated_queryset (wagtail.admin.tests.test_reports_views.TestFilteredLogEntriesView)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/tomkins/Python/wagtail/wagtail/admin/tests/test_reports_views.py", line 464, in test_decorated_queryset
    self.assertEqual(queryset.count(), 1)
AssertionError: 9 != 1
```

Which shows that all 9 log entries in setUp were being fetched on a paginated queryset.

Also, screenshot of a project I'm testing on:
<img width="1723" alt="Screenshot 2023-11-11 at 21 14 22" src="https://github.com/wagtail/wagtail/assets/177332/a0d6add9-4f16-4aac-becb-46c3d7a81e1d">

Shows only 50 arguments to the wagtailcore_pagelogentry IN filtering.

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
