### PR TITLE
Skip feature detection if image is an SVG

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -377,6 +377,11 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
             self.focal_point_height = None
 
     def get_suggested_focal_point(self):
+        if self.is_svg():
+            # We can't run feature detection on SVGs, and don't provide a
+            # pathway from SVG -> raster formats, so don't try it.
+            return None
+
         with self.get_willow_image() as willow:
             faces = willow.detect_faces()
 

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -28,7 +28,12 @@ from wagtail.test.testapp.models import (
 )
 from wagtail.test.utils import WagtailTestUtils, override_settings
 
-from .utils import Image, get_test_image_file, get_test_image_filename
+from .utils import (
+    Image,
+    get_test_image_file,
+    get_test_image_file_svg,
+    get_test_image_filename,
+)
 
 
 class CustomStorage(Storage):
@@ -122,6 +127,18 @@ class TestImage(TestCase):
         self.assertEqual(
             self.image.get_file_hash(), "4dd0211870e130b7e1690d2ec53c499a54a48fef"
         )
+
+    def test_get_suggested_focal_point_svg(self):
+        """
+        Feature detection should not be run on SVGs.
+
+        https://github.com/wagtail/wagtail/issues/11172
+        """
+        image = Image.objects.create(
+            title="Test SVG",
+            file=get_test_image_file_svg(),
+        )
+        self.assertIsNone(image.get_suggested_focal_point())
 
 
 class TestImageQuerySet(TransactionTestCase):


### PR DESCRIPTION
Fixes #11172

The error described occurs as a result of trying to run feature detection on SVGs. This isn't currently possible. This PR adds a check for SVGs to the `get_suggested_focal_point` method, returning `None` in that case.

To confirm this fix, upload an SVG on a Wagtail build with SVGs enabled and `WAGTAILIMAGES_FEATURE_DETECTION_ENABLED = True`. The image should be uploaded without issue.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?