### PR TITLE
Minor documentation formatting (Prettier)

### DIFF
--- a/docs/advanced_topics/images/title_generation_on_upload.md
+++ b/docs/advanced_topics/images/title_generation_on_upload.md
@@ -12,7 +12,7 @@ You can customise the resolved value of this title using a JavaScript [event lis
 
 The simplest way to add JavaScript to the editor is via the [`insert_global_admin_js` hook](insert_global_admin_js), however any JavaScript that adds the event listener will work.
 
-## DOM Event
+## DOM event
 
 The event name to listen for is `'wagtail:images-upload'`. It will be dispatched on the image upload `form`. The event's `detail` attribute will contain:
 
@@ -30,7 +30,7 @@ The event will 'bubble' up so that you can simply add a global `document` listen
 
 See MDN for more information about [custom JavaScript events](https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events).
 
-## Code Examples
+## Code examples
 
 ### Removing any url unsafe characters from the title
 

--- a/docs/extending/admin_views.md
+++ b/docs/extending/admin_views.md
@@ -273,7 +273,7 @@ def register_viewset():
     return CalendarViewSet()
 ```
 
-Compared to the previous example with the two separate hooks, this will result in a single menu item "Calendar" that takes you to the  `/admin/calendar/` URL. The second URL will not have its own menu item, but it will still be accessible at `/admin/calendar/month/`. This is useful for grouping related views together, that may not necessarily need their own menu items.
+Compared to the previous example with the two separate hooks, this will result in a single menu item "Calendar" that takes you to the `/admin/calendar/` URL. The second URL will not have its own menu item, but it will still be accessible at `/admin/calendar/month/`. This is useful for grouping related views together, that may not necessarily need their own menu items.
 
 For further customisations, refer to the {class}`~wagtail.admin.viewsets.base.ViewSet` documentation.
 

--- a/docs/extending/generic_views.md
+++ b/docs/extending/generic_views.md
@@ -1,4 +1,5 @@
 ```{currentmodule} wagtail.admin.viewsets.model
+
 ```
 
 (generic_views)=

--- a/docs/reference/management_commands.md
+++ b/docs/reference/management_commands.md
@@ -58,8 +58,8 @@ To prevent deleting important revisions when they become stale, you can refer to
 Support for respecting `on_delete=models.PROTECT` is added.
 ```
 
-If the `pages` argument is supplied, only revisions of page models will be deleted. If the `non-pages` argument is supplied, only revisions of non-page models will be deleted. If both or neither arguments are supplied, revisions of all models will be deleted. 
-If deletion of a revision is not desirable, mark `Revision` with `on_delete=models.PROTECT`. 
+If the `pages` argument is supplied, only revisions of page models will be deleted. If the `non-pages` argument is supplied, only revisions of non-page models will be deleted. If both or neither arguments are supplied, revisions of all models will be deleted.
+If deletion of a revision is not desirable, mark `Revision` with `on_delete=models.PROTECT`.
 
 (purge_embeds)=
 

--- a/docs/reference/streamfield/blocks.md
+++ b/docs/reference/streamfield/blocks.md
@@ -37,7 +37,6 @@ body = StreamField([
 The `use_json_field` argument is no longer required.
 ```
 
-
 ## Block options
 
 All block definitions accept the following optional keyword arguments:

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -1,4 +1,5 @@
 ```{module} wagtail.admin.viewsets
+
 ```
 
 (viewsets_reference)=

--- a/docs/topics/snippets/customising.md
+++ b/docs/topics/snippets/customising.md
@@ -1,4 +1,5 @@
 ```{currentmodule} wagtail.snippets.views.snippets
+
 ```
 
 (wagtailsnippets_custom_admin_views)=

--- a/docs/topics/writing_templates.md
+++ b/docs/topics/writing_templates.md
@@ -115,7 +115,7 @@ See [](multiple_formats) for full documentation.
 
 ### Images in multiple sizes
 
-The `srcset_image` tag works like `image`, but allows specifying multiple sizes to generate a `srcset` attribute and leverage  [responsive image rules](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
+The `srcset_image` tag works like `image`, but allows specifying multiple sizes to generate a `srcset` attribute and leverage [responsive image rules](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
 
 For example:
 


### PR DESCRIPTION
- Minor formatting with Prettier (white space)
- Fix two titles in images customisation to use sentence case titles