### PR TITLE
Fix snippets index.html to use results_template_name for results

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Changelog
  * Fix: Make searching on specific fields work correctly on Elasticsearch when boost is in use (Matt Westcott)
  * Fix: Use a visible border and background color to highlight active formatting in the rich text toolbar (Cassidy Pittman)
  * Fix: Ensure image focal point box can be removed (Gunnar Scherf)
+ * Fix: Ensure that Snippets search results correctly use the `index_results.html` or `index_results_template_name` override on initial load (Stefan Hammer)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)
  * Docs: Add section to testing docs about creating pages and working with page content (Mariana Bedran Lesche)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -37,6 +37,7 @@ depth: 1
  * Make searching on specific fields work correctly on Elasticsearch when boost is in use (Matt Westcott)
  * Use a visible border and background color to highlight active formatting in the rich text toolbar (Cassidy Pittman)
  * Ensure image focal point box can be removed (Gunnar Scherf)
+ * Ensure that Snippets search results correctly use the `index_results.html` or `index_results_template_name` override on initial load (Stefan Hammer)
 
 ### Documentation
 

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/index.html
@@ -24,7 +24,7 @@
     {% include 'wagtailadmin/shared/header.html' with title=model_opts.verbose_name_plural|capfirst icon=header_icon search_url=search_url base_actions=base_action_locale action_url=action_url_add_snippet action_icon="plus" action_text=action_text_snippet extra_actions=extra_actions search_results_url=index_results_url %}
     <div class="nice-padding{% if filters %} filterable{% endif %}">
         <div id="listing-results" class="snippets">
-            {% include "wagtailsnippets/snippets/index_results.html" %}
+            {% include view.results_template_name|default:"wagtailsnippets/snippets/index_results.html" %}
         </div>
         {% if filters %}
             {% include "wagtailadmin/shared/filters.html" %}

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -872,45 +872,61 @@ class TestCustomTemplates(BaseSnippetViewSetTests):
             "with app label and model name": (
                 "add",
                 [],
-                "wagtailsnippets/snippets/tests/fullfeaturedsnippet/create.html",
+                [
+                    "wagtailsnippets/snippets/tests/fullfeaturedsnippet/create.html",
+                ],
             ),
             "with app label": (
                 "edit",
                 [pk],
-                "wagtailsnippets/snippets/tests/edit.html",
+                [
+                    "wagtailsnippets/snippets/tests/edit.html",
+                ],
             ),
             "without app label and model name": (
                 "delete",
                 [pk],
-                "wagtailsnippets/snippets/delete.html",
+                [
+                    "wagtailsnippets/snippets/delete.html",
+                ],
             ),
             "override a view that uses a generic template": (
                 "unpublish",
                 [pk],
-                "wagtailsnippets/snippets/tests/fullfeaturedsnippet/unpublish.html",
+                [
+                    "wagtailsnippets/snippets/tests/fullfeaturedsnippet/unpublish.html",
+                ],
             ),
-            "override with index_template_name": (
+            "override with index_template_name and index results template with namespaced template": (
                 "list",
                 [],
-                "tests/fullfeaturedsnippet_index.html",
+                [
+                    "tests/fullfeaturedsnippet_index.html",
+                    "wagtailsnippets/snippets/tests/fullfeaturedsnippet/index_results.html",
+                ],
             ),
             "override index results template with namespaced template": (
                 # This is technically the same as the first case, but this ensures that
                 # the index results view can be overridden separately from the index view
                 "list_results",
                 [],
-                "wagtailsnippets/snippets/tests/fullfeaturedsnippet/index_results.html",
+                [
+                    "wagtailsnippets/snippets/tests/fullfeaturedsnippet/index_results.html"
+                ],
             ),
             "override with get_history_template": (
                 "history",
                 [pk],
-                "tests/snippet_history.html",
+                [
+                    "tests/snippet_history.html",
+                ],
             ),
         }
-        for case, (view_name, args, template_name) in cases.items():
+        for case, (view_name, args, template_names) in cases.items():
             with self.subTest(case=case):
                 response = self.client.get(self.get_url(view_name, args=args))
-                self.assertTemplateUsed(response, template_name)
+                for template_name in template_names:
+                    self.assertTemplateUsed(response, template_name)
                 self.assertContains(response, "<p>An added paragraph</p>", html=True)
 
 


### PR DESCRIPTION
Until now, if you've set an `index_results_template_name` or used the namespaced template-lookup to override it, it was only used for the ajax-results, but not the normal index requests.

The `{% include ... %}` is now similar to `wagtailadmin/generic/index.html` ([code](https://github.com/wagtail/wagtail/blob/d4c18909dfc87b0ff1dc8cadd97262937557ad01/wagtail/admin/templates/wagtailadmin/generic/index.html#L16)).

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
