### PR TITLE
Fix locale switcher on snippets create view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -46,6 +46,7 @@ Changelog
  * Fix: Ensure that explorer_results views fill in the correct next_url parameter on action URLs (Matt Westcott)
  * Fix: Fix crash when accessing the history view for a translatable snippet (Sage Abdullah)
  * Fix: Prevent upload of SVG images from failing when image feature detection is enabled (Joshua Munn)
+ * Fix: Fix crash when using the locale switcher on the snippets create view (Sage Abdullah)
  * Docs: Fix code example for `{% picture ... as ... %}` template tag (Rezyapkin)
 
 

--- a/docs/releases/5.2.1.md
+++ b/docs/releases/5.2.1.md
@@ -21,6 +21,7 @@ depth: 1
  * Ensure that explorer_results views fill in the correct next_url parameter on action URLs (Matt Westcott)
  * Fix crash when accessing the history view for a translatable snippet (Sage Abdullah)
  * Prevent upload of SVG images from failing when image feature detection is enabled (Joshua Munn)
+ * Fix crash when using the locale switcher on the snippets create view (Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -1,3 +1,5 @@
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
+
 from django.conf import settings
 from django.utils.http import url_has_allowed_host_and_scheme
 
@@ -52,3 +54,19 @@ def get_user_display_name(user):
         # we were passed None or something else that isn't a valid user object; return
         # empty string to replicate the behaviour of {{ user.get_full_name|default:user.get_username }}
         return ""
+
+
+def set_query_params(url: str, params: dict):
+    """
+    Given a URL and a dictionary of query parameters,
+    returns a new URL with those query parameters added or updated.
+
+    If the value of a query parameter is None, that parameter will be removed from the URL.
+    """
+
+    scheme, netloc, path, query, fragment = urlsplit(url)
+    querydict = parse_qs(query)
+    querydict.update(params)
+    querydict = {key: value for key, value in querydict.items() if value is not None}
+    query = urlencode(querydict)
+    return urlunsplit((scheme, netloc, path, query, fragment))

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -18,7 +18,7 @@ from wagtail import hooks
 from wagtail.admin import messages
 from wagtail.admin.templatetags.wagtailadmin_tags import user_display_name
 from wagtail.admin.ui.tables import TitleColumn
-from wagtail.admin.utils import get_latest_str
+from wagtail.admin.utils import get_latest_str, set_query_params
 from wagtail.locks import BasicLock, ScheduledForPublishLock, WorkflowLock
 from wagtail.log_actions import log
 from wagtail.log_actions import registry as log_registry
@@ -134,6 +134,11 @@ class LocaleMixin:
         context["locale"] = self.locale
         context["translations"] = self.translations
         return context
+
+    def _set_locale_query_param(self, url, locale=None):
+        if not (locale := locale or self.locale):
+            return url
+        return set_query_params(url, {"locale": locale.language_code})
 
 
 class PanelMixin:

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -398,7 +398,7 @@ class IndexView(
         return [
             {
                 "locale": locale,
-                "url": index_url + "?locale=" + locale.language_code,
+                "url": self._set_locale_query_param(index_url, locale),
             }
             for locale in Locale.objects.all().exclude(id=self.locale.id)
         ]
@@ -571,7 +571,7 @@ class CreateView(
                 "Subclasses of wagtail.admin.views.generic.models.CreateView must provide an "
                 "add_url_name attribute or a get_add_url method"
             )
-        return reverse(self.add_url_name)
+        return self._set_locale_query_param(reverse(self.add_url_name))
 
     def get_edit_url(self):
         if not self.edit_url_name:
@@ -587,7 +587,7 @@ class CreateView(
                 "Subclasses of wagtail.admin.views.generic.models.CreateView must provide an "
                 "index_url_name attribute or a get_success_url method"
             )
-        return reverse(self.index_url_name)
+        return self._set_locale_query_param(reverse(self.index_url_name))
 
     def get_success_message(self, instance):
         if self.success_message is None:
@@ -609,10 +609,11 @@ class CreateView(
         return context
 
     def get_translations(self):
+        add_url = self.get_add_url()
         return [
             {
                 "locale": locale,
-                "url": self.get_add_url() + "?locale=" + locale.language_code,
+                "url": self._set_locale_query_param(add_url, locale),
             }
             for locale in Locale.objects.all().exclude(id=self.locale.id)
         ]

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -920,6 +920,32 @@ class TestLocaleSelectorOnCreate(WagtailTestUtils, TestCase):
 
         self.assertContains(response, "Switch locales")
 
+        switch_to_french_url = (
+            reverse("wagtailsnippets_snippetstests_translatablesnippet:add")
+            + "?locale=fr"
+        )
+        self.assertContains(
+            response,
+            f'<a href="{switch_to_french_url}" lang="fr">',
+        )
+
+    def test_locale_selector_with_existing_locale(self):
+        response = self.client.get(
+            reverse("wagtailsnippets_snippetstests_translatablesnippet:add")
+            + "?locale=fr"
+        )
+
+        self.assertContains(response, "Switch locales")
+
+        switch_to_english_url = (
+            reverse("wagtailsnippets_snippetstests_translatablesnippet:add")
+            + "?locale=en"
+        )
+        self.assertContains(
+            response,
+            f'<a href="{switch_to_english_url}" lang="en">',
+        )
+
     @override_settings(WAGTAIL_I18N_ENABLED=False)
     def test_locale_selector_not_present_when_i18n_disabled(self):
         response = self.client.get(
@@ -928,10 +954,28 @@ class TestLocaleSelectorOnCreate(WagtailTestUtils, TestCase):
 
         self.assertNotContains(response, "Switch locales")
 
+        switch_to_french_url = (
+            reverse("wagtailsnippets_snippetstests_translatablesnippet:add")
+            + "?locale=fr"
+        )
+        self.assertNotContains(
+            response,
+            f'<a href="{switch_to_french_url}" lang="fr">',
+        )
+
     def test_locale_selector_not_present_on_non_translatable_snippet(self):
         response = self.client.get(reverse("wagtailsnippets_tests_advert:add"))
 
         self.assertNotContains(response, "Switch locales")
+
+        switch_to_french_url = (
+            reverse("wagtailsnippets_snippetstests_translatablesnippet:add")
+            + "?locale=fr"
+        )
+        self.assertNotContains(
+            response,
+            f'<a href="{switch_to_french_url}" lang="fr">',
+        )
 
 
 class TestCreateDraftStateSnippet(WagtailTestUtils, TestCase):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -39,7 +39,6 @@ from wagtail.admin.viewsets.model import ModelViewSet, ModelViewSetGroup
 from wagtail.admin.widgets.button import BaseDropdownMenuButton, ButtonWithDropdown
 from wagtail.models import (
     DraftStateMixin,
-    Locale,
     LockableMixin,
     PreviewableMixin,
     RevisionMixin,
@@ -244,23 +243,6 @@ class CreateView(generic.CreateEditViewOptionalFeaturesMixin, generic.CreateView
 
     def run_after_hook(self):
         return self.run_hook("after_create_snippet", self.request, self.object)
-
-    def get_add_url(self):
-        url = reverse(self.add_url_name)
-        if self.locale:
-            url += "?locale=" + self.locale.language_code
-        return url
-
-    def get_success_url(self):
-        if self.draftstate_enabled and self.action != "publish":
-            return super().get_success_url()
-
-        # Make sure the redirect to the listing view uses the correct locale
-        urlquery = ""
-        if self.locale and self.object.locale is not Locale.get_default():
-            urlquery = "?locale=" + self.object.locale.language_code
-
-        return reverse(self.index_url_name) + urlquery
 
     def _get_action_menu(self):
         return SnippetActionMenu(self.request, view=self.view_name, model=self.model)


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11230.

I opted to put the fixes in the generic model views because they already extend `LocaleMixin` (and already have references to `self.locale` in a few places). I don't think translatable models work out of the box with these views due to the templates missing the corresponding markup (e.g. the locale switcher on the index view). However, if we want to support it in the future, especially with the upcoming universal listings work and the fact that ModelAdmin supported translatable models to an extent, I think it makes sense to put the logic in the generic views.

If we decide not to support locales in the generic model views at all, we should take out `LocaleMixin` from the views, and apply it from the snippets views instead. View-specific logic for locale can then be moved to the respective `*OptionalFeaturesMixin` classes.

I was thinking of incorporating an updated version of #11133 but I think that can be handled separately to ease reviewing.



_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
