### PR TITLE
Restore the ability to have content type facets when searching pages with an empty query

### DIFF
--- a/wagtail/admin/tests/pages/test_page_search.py
+++ b/wagtail/admin/tests/pages/test_page_search.py
@@ -6,7 +6,7 @@ from django.test import TransactionTestCase
 from django.urls import reverse
 
 from wagtail.models import Page
-from wagtail.test.testapp.models import SimplePage, SingleEventPage
+from wagtail.test.testapp.models import EventIndex, SimplePage, SingleEventPage
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.timestamps import local_datetime
 
@@ -212,3 +212,79 @@ class TestPageSearch(WagtailTestUtils, TransactionTestCase):
         # Incorrect content_type
         response = self.get({"content_type": "demosite.standardpage.error"})
         self.assertEqual(response.status_code, 404)
+
+    def test_empty_search_renders_content_type_facets(self):
+        root_page = Page.objects.get(id=2)
+        event_index = EventIndex(
+            title="ALL THE EVENTS",
+            intro="It's just a nod to the canon",
+        )
+        root_page.add_child(instance=event_index)
+
+        params = [{"q": ""}, {}]
+        url = reverse("wagtailadmin_pages:search")
+        for param in params:
+            with self.subTest(param=param):
+                response = self.get(param)
+                self.assertEqual(response.status_code, 200)
+                self.assertTemplateUsed(response, "wagtailadmin/pages/search.html")
+                self.assertEqual(response.context["query_string"], "")
+
+                self.assertContains(response, "Page types")
+                self.assertContains(response, "All (3)")
+                # The test fixture contains the root page and the welcome page
+                # with the base page type
+                self.assertContains(response, "Page (2)")
+
+                self.assertContains(response, "ALL THE EVENTS")
+
+                self.assertContains(response, "Event index (1)")
+                self.assertContains(
+                    response,
+                    f"{url}?q=&amp;content_type=tests.eventindex",
+                )
+
+    def test_empty_search_with_content_type_filter(self):
+        root_page = Page.objects.get(id=2)
+        event_index = EventIndex(
+            title="ALL THE EVENTS",
+            intro="It's just a nod to the canon",
+        )
+        new_event = SingleEventPage(
+            title="Lunar event",
+            location="the moon",
+            audience="public",
+            cost="free",
+            date_from="2001-01-01",
+            latest_revision_created_at=local_datetime(2016, 1, 1),
+        )
+        root_page.add_child(instance=event_index)
+        root_page.add_child(instance=new_event)
+
+        params = [
+            {"q": "", "content_type": "tests.singleeventpage"},
+            {"content_type": "tests.singleeventpage"},
+        ]
+        url = reverse("wagtailadmin_pages:search")
+        for param in params:
+            with self.subTest(param=param):
+                response = self.get(param)
+                self.assertEqual(response.status_code, 200)
+                self.assertTemplateUsed(response, "wagtailadmin/pages/search.html")
+                self.assertEqual(response.context["query_string"], "")
+
+                self.assertContains(response, "Page types")
+                self.assertContains(response, "All (4)")
+                # The test fixture contains the root page and the welcome page
+                # with the base page type
+                self.assertContains(response, "Page (2)")
+                self.assertContains(response, "Single event page (1)")
+
+                self.assertContains(response, "Lunar event")
+                self.assertNotContains(response, "ALL THE EVENTS")
+
+                self.assertContains(response, "Event index (1)")
+                self.assertContains(
+                    response,
+                    f"{url}?q=&amp;content_type=tests.eventindex",
+                )

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -143,20 +143,19 @@ class BaseSearchView(PermissionCheckedMixin, BaseListingView):
         if self.selected_content_type:
             pages = pages.filter(content_type=self.selected_content_type)
 
-        if self.q:
-            # Parse query and filter
-            pages, self.all_pages = page_filter_search(
-                self.q, pages, self.all_pages, self.ordering
-            )
+        # Parse query and filter
+        pages, self.all_pages = page_filter_search(
+            self.q, pages, self.all_pages, self.ordering
+        )
 
-            # Facets
-            if pages.supports_facet:
-                self.content_types = [
-                    (ContentType.objects.get(id=content_type_id), count)
-                    for content_type_id, count in self.all_pages.facet(
-                        "content_type_id"
-                    ).items()
-                ]
+        # Facets
+        if pages.supports_facet:
+            self.content_types = [
+                (ContentType.objects.get(id=content_type_id), count)
+                for content_type_id, count in self.all_pages.facet(
+                    "content_type_id"
+                ).items()
+            ]
 
         return pages
 


### PR DESCRIPTION
This restores the ability to have content type facets when searching pages with an empty query:

<img width="1642" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/a7e0b403-9652-413c-a161-3318d6c01db5">

We lost the ability to do this in 5.1 when the view was refactored from an FBV to a CBV: https://github.com/wagtail/wagtail/pull/10615/commits/52abcee04363ea9dae36ecbd87b01f4137a7ce3e#diff-dc3a1012fc5394a6a1abd8e254ed29cfd5107ba2fc6bb7b6127b4e6386d8dea9L108

The facets are only applied if there's a search query. Previously this was detected with `if "q" in request.GET`, but it was changed to `if self.q` (with `self.q = request.GET.get("q", "")`), so empty queries (e.g. clicking search on the left menu and press enter without typing anything) will not show the content type facets.

In addition, the adoption of #10645 to make the header search use the Stimulus `SwapController` would mean the facets will also be lost if you type something in the header search and clear it afterwards, as the `q` query param will be removed:

https://github.com/wagtail/wagtail/blob/ba17ef19d333570d9cca0195178e5e15babae93c/client/src/controllers/SwapController.ts#L178-L183

To fix this, we can either:
- always do a search and apply the facets even if the query param is empty (which I've done here)
- or, make a distinction between and empty `q` vs a non-existent q, and then also update `SwapController` so that it doesn't remove empty query params. I tried doing it this way in 7ec15f7aa08f25df5d27e273d43d98fe3fe13b4e, but it seems more intrusive.

This will probably be made redundant with page type filters in Universal Listings (#10446), but at the moment there's no alternative when you'd like to see all pages filtered by the page type. (Maybe #10850, but that's a separate topic.)

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
