### PR TITLE
Prevent error on locked pages report when a user has locked multiple pages

### DIFF
--- a/wagtail/admin/views/reports/locked_pages.py
+++ b/wagtail/admin/views/reports/locked_pages.py
@@ -15,7 +15,11 @@ from .base import PageReportView
 
 def get_users_for_filter():
     User = get_user_model()
-    return User.objects.filter(locked_pages__isnull=False).order_by(User.USERNAME_FIELD)
+    return (
+        User.objects.filter(locked_pages__isnull=False)
+        .order_by(User.USERNAME_FIELD)
+        .distinct()
+    )
 
 
 class LockedPagesReportFilterSet(WagtailFilterSet):


### PR DESCRIPTION
Fixes #10960. Thanks to @richie-blake and @rohitsrma for reporting / investigation.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
