### PR TITLE
Few lines added in the file README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Wagtail works with [Python 3](https://www.python.org/downloads/), on any platfor
 
 To get started with using Wagtail, run the following in a [virtual environment](https://docs.python.org/3/tutorial/venv.html):
 
+# steps for creating virtual environment
+
+```sh
+python -m venv file-name
+cd file-name
+Scripts/activate
+``` 
+
 ![Installing Wagtail](.github/install-animation.gif)
 
 ```sh


### PR DESCRIPTION
The file README.MD contained a link (https://docs.python.org/3/tutorial/venv.html)  which referred to as  how to create a virtual environment.
But it would be great if the process for creating the virtual environment is written in the file README.MD  so that it would be easy for people to just read and understand the procedure at once