### PR TITLE
define jcropapi var and fixing javascript TypeError when clicking "Remove focal area"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Fix: Make Workflow and Aging Pages reports only available to users with page-related permissions (Rohit Sharma)
  * Fix: Make searching on specific fields work correctly on Elasticsearch when boost is in use (Matt Westcott)
  * Fix: Use a visible border and background color to highlight active formatting in the rich text toolbar (Cassidy Pittman)
+ * Fix: Ensure image focal point box can be removed (Gunnar Scherf)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)
  * Maintenance: Update BeautifulSoup upper bound to 4.12.x (scott-8)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -769,6 +769,7 @@
 * Kehinde Bobade
 * Joe Tsoi
 * Cassidy Pittman
+* Gunnar Scherf
 
 ## Translators
 

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -35,6 +35,7 @@ depth: 1
  * Make Workflow and Aging Pages reports only available to users with page-related permissions (Rohit Sharma)
  * Make searching on specific fields work correctly on Elasticsearch when boost is in use (Matt Westcott)
  * Use a visible border and background color to highlight active formatting in the rich text toolbar (Cassidy Pittman)
+ * Ensure image focal point box can be removed (Gunnar Scherf)
 
 ### Documentation
 

--- a/wagtail/images/static_src/wagtailimages/js/focal-point-chooser.js
+++ b/wagtail/images/static_src/wagtailimages/js/focal-point-chooser.js
@@ -25,6 +25,9 @@ function setupJcrop(image, original, focalPointOriginal, fields) {
       },
     },
     function () {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      jcropapi = this;
+
       // Set alt="" on the image so its src is not read out loud to screen reader users.
       var $holderImage = $('img', this.ui.holder);
       $holderImage.attr('alt', '');


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11254

jcropapi was never initialized since last change in focal-point-chooser.js






_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
