### PR TITLE
Change light theme floating toolbar active color

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changelog
  * Fix: Use the latest draft when copying an unpublished page for translation (Andrey Nehaychik)
  * Fix: Make Workflow and Aging Pages reports only available to users with page-related permissions (Rohit Sharma)
  * Fix: Make searching on specific fields work correctly on Elasticsearch when boost is in use (Matt Westcott)
+ * Fix: Use a visible border and background color to highlight active formatting in the rich text toolbar (Cassidy Pittman)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)
  * Maintenance: Update BeautifulSoup upper bound to 4.12.x (scott-8)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -768,6 +768,7 @@
 * Meli Imelda
 * Kehinde Bobade
 * Joe Tsoi
+* Cassidy Pittman
 
 ## Translators
 

--- a/client/scss/tools/_mixins.general.scss
+++ b/client/scss/tools/_mixins.general.scss
@@ -116,7 +116,7 @@
 /**
  * Apply styles for the light theme only.
  */
- @mixin light-theme() {
+@mixin light-theme() {
   .w-theme-light & {
     @content;
   }

--- a/client/scss/tools/_mixins.general.scss
+++ b/client/scss/tools/_mixins.general.scss
@@ -112,3 +112,18 @@
     }
   }
 }
+
+/**
+ * Apply styles for the light theme only.
+ */
+ @mixin light-theme() {
+  .w-theme-light & {
+    @content;
+  }
+
+  @media (prefers-color-scheme: light) {
+    .w-theme-system & {
+      @content;
+    }
+  }
+}

--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -120,6 +120,10 @@ $draftail-editor-font-family: $font-sans;
     @include light-theme() {
       background-color: theme('colors.surface-header');
       border-color: theme('colors.border-furniture');
+
+      @media (forced-colors: active) {
+        background: Highlight;
+      }
     }
   }
 }

--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -115,6 +115,13 @@ $draftail-editor-font-family: $font-sans;
       top: theme('spacing.slim-header');
     }
   }
+
+  .Draftail-ToolbarButton--active {
+    @include light-theme() {
+      background-color: theme('colors.surface-header');
+      border-color: theme('colors.border-furniture');
+    }
+  }
 }
 
 .Draftail-MetaToolbar {

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -33,6 +33,7 @@ depth: 1
  * Use the latest draft when copying an unpublished page for translation (Andrey Nehaychik)
  * Make Workflow and Aging Pages reports only available to users with page-related permissions (Rohit Sharma)
  * Make searching on specific fields work correctly on Elasticsearch when boost is in use (Matt Westcott)
+ * Use a visible border and background color to highlight active formatting in the rich text toolbar (Cassidy Pittman)
 
 ### Documentation
 


### PR DESCRIPTION
Doing a PR on behalf of @cassidydvl, who did this work but is having trouble with her GitHub account 👀 All of the description below is from Cassidy’s work, and I will review this later.

Fixes one of the issues on #11065:

> We seem to have lost the state in the toolbar icons where it shows which rich text formatting has been applied (I will supply the design for this...) (light theme pinned toolbar only)

This is only an issue for the light theme, hence the new mixin. We don’t want to change the dark theme styles.

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 119, macOS 12.6
    -   [x] **Please list which assistive technologies [^3] you tested**: None
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

Go to the page editor. Make text an h2 or other formatting, and test the four different variations of the toolbar’s active button:

- Light theme, floating toolbar
- Light theme, static toolbar
- Dark theme, floating toolbar
- Dark theme, static toolbar