### PR TITLE
Use a single instance of `PagePermissionPolicy` in `wagtail.permissions` module

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Add `extra_actions` blocks to Snippets and generic index templates (Bhuvnesh Sharma)
  * Added page types usage report (Jhonatan Lopes)
  * Add support for defining `panels` / `edit_handler` on `ModelViewSet` (Sage Abdullah)
+ * Use a single instance of `PagePermissionPolicy` in `wagtail.permissions` module (Sage Abdullah)
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -25,6 +25,7 @@ depth: 1
  * Add `extra_actions` blocks to Snippets and generic index templates (Bhuvnesh Sharma)
  * Added page types usage report (Jhonatan Lopes)
  * Add support for defining `panels` / `edit_handler` on `ModelViewSet` (Sage Abdullah)
+ * Use a single instance of `PagePermissionPolicy` in `wagtail.permissions` module (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/api/filters.py
+++ b/wagtail/admin/api/filters.py
@@ -2,7 +2,7 @@ from rest_framework.filters import BaseFilterBackend
 
 from wagtail import hooks
 from wagtail.api.v2.utils import BadRequestError, parse_boolean
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 
 
 class HasChildrenFilter(BaseFilterBackend):
@@ -39,7 +39,7 @@ class ForExplorerFilter(BaseFilterBackend):
                 queryset = hook(parent_page, queryset, request)
 
             queryset = (
-                PagePermissionPolicy().explorable_instances(request.user) & queryset
+                page_permission_policy.explorable_instances(request.user) & queryset
             )
 
         return queryset

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -12,7 +12,7 @@ from django.utils.translation import override
 
 from wagtail.admin import messages
 from wagtail.log_actions import LogContext
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 
 
 def permission_denied(request):
@@ -107,7 +107,7 @@ def user_has_any_page_permission(user):
     Check if a user has any permission to add, edit, or otherwise manage any
     page.
     """
-    return PagePermissionPolicy().user_has_any_permission(
+    return page_permission_policy.user_has_any_permission(
         user, {"add", "change", "publish", "bulk_delete", "lock", "unlock"}
     )
 

--- a/wagtail/admin/forms/account.py
+++ b/wagtail/admin/forms/account.py
@@ -13,7 +13,7 @@ from wagtail.admin.localization import (
     get_available_admin_time_zones,
 )
 from wagtail.admin.widgets import SwitchInput
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 from wagtail.users.models import UserProfile
 
 User = get_user_model()
@@ -23,7 +23,7 @@ class NotificationPreferencesForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        permission_policy = PagePermissionPolicy()
+        permission_policy = page_permission_policy
         if not permission_policy.user_has_permission(self.instance.user, "publish"):
             del self.fields["submitted_notifications"]
         if not permission_policy.user_has_permission(self.instance.user, "change"):

--- a/wagtail/admin/navigation.py
+++ b/wagtail/admin/navigation.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 
 
 def get_site_for_user(user):
-    root_page = PagePermissionPolicy().explorable_root_instance(user)
+    root_page = page_permission_policy.explorable_root_instance(user)
     if root_page:
         root_site = root_page.get_site()
     else:

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -54,7 +54,7 @@ from wagtail.models import (
     Page,
     PageViewRestriction,
 )
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 from wagtail.telepath import JSContext
 from wagtail.users.utils import get_gravatar_url
 from wagtail.utils.deprecation import RemovedInWagtail70Warning
@@ -87,7 +87,7 @@ def page_breadcrumbs(
 
     # find the closest common ancestor of the pages that this user has direct explore permission
     # (i.e. add/edit/publish/lock) over; this will be the root of the breadcrumb
-    cca = PagePermissionPolicy().explorable_root_instance(user)
+    cca = page_permission_policy.explorable_root_instance(user)
     if not cca:
         return {"items": Page.objects.none()}
 

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -26,7 +26,7 @@ from wagtail.models import (
     WorkflowState,
     get_default_page_content_type,
 )
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 
 User = get_user_model()
 
@@ -221,7 +221,7 @@ class LockedPagesPanel(Component):
                     locked=True,
                     locked_by=request.user,
                 ),
-                "can_remove_locks": PagePermissionPolicy().user_has_permission(
+                "can_remove_locks": page_permission_policy.user_has_permission(
                     request.user, "unlock"
                 ),
                 "request": request,

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -22,11 +22,12 @@ from wagtail.admin.ui.tables.pages import (
 )
 from wagtail.admin.views.generic.base import BaseListingView
 from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
-from wagtail.permission_policies.pages import Page, PagePermissionPolicy
+from wagtail.models import Page
+from wagtail.permissions import page_permission_policy
 
 
 class BaseIndexView(PermissionCheckedMixin, BaseListingView):
-    permission_policy = PagePermissionPolicy()
+    permission_policy = page_permission_policy
     any_permission_required = {
         "add",
         "change",

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -20,7 +20,7 @@ from wagtail.admin.ui.tables.pages import (
 from wagtail.admin.views.generic.base import BaseListingView
 from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
 from wagtail.models import Page
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 from wagtail.search.query import MATCH_ALL
 from wagtail.search.utils import parse_query_string
 
@@ -51,7 +51,7 @@ def page_filter_search(q, pages, all_pages=None, ordering=None):
 
 
 class BaseSearchView(PermissionCheckedMixin, BaseListingView):
-    permission_policy = PagePermissionPolicy()
+    permission_policy = page_permission_policy
     any_permission_required = {
         "add",
         "change",

--- a/wagtail/admin/views/reports/aging_pages.py
+++ b/wagtail/admin/views/reports/aging_pages.py
@@ -9,7 +9,7 @@ from wagtail.admin.filters import ContentTypeFilter, WagtailFilterSet
 from wagtail.admin.widgets import AdminDateInput
 from wagtail.coreutils import get_content_type_label
 from wagtail.models import Page, PageLogEntry, get_page_models
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 from wagtail.users.utils import get_deleted_user_display_name
 
 from .base import PageReportView
@@ -99,8 +99,9 @@ class AgingPagesView(PageReportView):
             page=OuterRef("pk"), action__exact="wagtail.publish"
         )
         self.queryset = (
-            PagePermissionPolicy()
-            .instances_user_has_permission_for(self.request.user, "publish")
+            page_permission_policy.instances_user_has_permission_for(
+                self.request.user, "publish"
+            )
             .exclude(last_published_at__isnull=True)
             .prefetch_workflow_states()
             .select_related("content_type")
@@ -114,7 +115,7 @@ class AgingPagesView(PageReportView):
         return super().get_queryset()
 
     def dispatch(self, request, *args, **kwargs):
-        if not PagePermissionPolicy().user_has_any_permission(
+        if not page_permission_policy.user_has_any_permission(
             request.user, ["add", "change", "publish"]
         ):
             raise PermissionDenied

--- a/wagtail/admin/views/reports/locked_pages.py
+++ b/wagtail/admin/views/reports/locked_pages.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.filters import DateRangePickerWidget, WagtailFilterSet
 from wagtail.models import Page
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 
 from .base import PageReportView
 
@@ -51,7 +51,7 @@ class LockedPagesView(PageReportView):
     def get_queryset(self):
         pages = (
             (
-                PagePermissionPolicy().instances_user_has_permission_for(
+                page_permission_policy.instances_user_has_permission_for(
                     self.request.user, "change"
                 )
                 | Page.objects.filter(locked_by=self.request.user)
@@ -67,6 +67,6 @@ class LockedPagesView(PageReportView):
         return super().get_queryset()
 
     def dispatch(self, request, *args, **kwargs):
-        if not PagePermissionPolicy().user_has_permission(request.user, "unlock"):
+        if not page_permission_policy.user_has_permission(request.user, "unlock"):
             raise PermissionDenied
         return super().dispatch(request, *args, **kwargs)

--- a/wagtail/admin/views/reports/page_types_usage.py
+++ b/wagtail/admin/views/reports/page_types_usage.py
@@ -8,7 +8,7 @@ from wagtail.admin.filters import WagtailFilterSet
 from wagtail.admin.views.reports import ReportView
 from wagtail.coreutils import get_content_languages
 from wagtail.models import ContentType, Page, Site, get_page_models
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 
 
 def _get_locale_choices():
@@ -145,7 +145,7 @@ class PageTypesUsageReportView(ReportView):
         return queryset
 
     def dispatch(self, request, *args, **kwargs):
-        if not PagePermissionPolicy().user_has_any_permission(
+        if not page_permission_policy.user_has_any_permission(
             request.user, ["add", "change", "publish"]
         ):
             raise PermissionDenied

--- a/wagtail/admin/views/reports/workflows.py
+++ b/wagtail/admin/views/reports/workflows.py
@@ -23,7 +23,7 @@ from wagtail.models import (
     WorkflowState,
     get_default_page_content_type,
 )
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 from wagtail.snippets.models import get_editable_models
 
 from .base import ReportView
@@ -37,7 +37,7 @@ def get_requested_by_queryset(request):
 
 
 def get_editable_page_ids_query(request):
-    pages = PagePermissionPolicy().instances_user_has_permission_for(
+    pages = page_permission_policy.instances_user_has_permission_for(
         request.user, "change"
     )
     # Need to cast the page ids to string because Postgres doesn't support
@@ -193,7 +193,7 @@ class WorkflowView(ReportView):
         )
 
     def dispatch(self, request, *args, **kwargs):
-        if not PagePermissionPolicy().user_has_any_permission(
+        if not page_permission_policy.user_has_any_permission(
             request.user, ["add", "change", "publish"]
         ):
             raise PermissionDenied

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -37,8 +37,11 @@ from wagtail.models import (
     WorkflowContentType,
     WorkflowState,
 )
-from wagtail.permission_policies.pages import PagePermissionPolicy
-from wagtail.permissions import task_permission_policy, workflow_permission_policy
+from wagtail.permissions import (
+    page_permission_policy,
+    task_permission_policy,
+    workflow_permission_policy,
+)
 from wagtail.snippets.models import get_workflow_enabled_models
 from wagtail.workflows import get_task_types
 
@@ -308,7 +311,7 @@ class Disable(DeleteView):
 def usage(request, pk):
     workflow = get_object_or_404(Workflow, id=pk)
 
-    editable_pages = PagePermissionPolicy().instances_user_has_permission_for(
+    editable_pages = page_permission_policy.instances_user_has_permission_for(
         request.user, "change"
     )
     pages = workflow.all_pages() & editable_pages

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -54,9 +54,9 @@ from wagtail.admin.views.pages.bulk_actions import (
 from wagtail.admin.viewsets import viewsets
 from wagtail.admin.widgets import ButtonWithDropdownFromHook, PageListingButton
 from wagtail.models import Collection, Page, Task, Workflow
-from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.permissions import (
     collection_permission_policy,
+    page_permission_policy,
     task_permission_policy,
     workflow_permission_policy,
 )
@@ -73,7 +73,7 @@ class ExplorerMenuItem(MenuItem):
 
     def get_context(self, request):
         context = super().get_context(request)
-        start_page = PagePermissionPolicy().explorable_root_instance(request.user)
+        start_page = page_permission_policy.explorable_root_instance(request.user)
 
         if start_page:
             context["start_page_id"] = start_page.id
@@ -81,7 +81,7 @@ class ExplorerMenuItem(MenuItem):
         return context
 
     def render_component(self, request):
-        start_page = PagePermissionPolicy().explorable_root_instance(request.user)
+        start_page = page_permission_policy.explorable_root_instance(request.user)
 
         if start_page:
             return PageExplorerMenuItemComponent(
@@ -848,35 +848,35 @@ def register_core_features(features):
 
 class LockedPagesMenuItem(MenuItem):
     def is_shown(self, request):
-        return PagePermissionPolicy().user_has_permission(request.user, "unlock")
+        return page_permission_policy.user_has_permission(request.user, "unlock")
 
 
 class WorkflowReportMenuItem(MenuItem):
     def is_shown(self, request):
         return getattr(
             settings, "WAGTAIL_WORKFLOW_ENABLED", True
-        ) and PagePermissionPolicy().user_has_any_permission(
+        ) and page_permission_policy.user_has_any_permission(
             request.user, ["add", "change", "publish"]
         )
 
 
 class SiteHistoryReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return PagePermissionPolicy().explorable_root_instance(request.user) is not None
+        return page_permission_policy.explorable_root_instance(request.user) is not None
 
 
 class AgingPagesReportMenuItem(MenuItem):
     def is_shown(self, request):
         return getattr(
             settings, "WAGTAIL_AGING_PAGES_ENABLED", True
-        ) and PagePermissionPolicy().user_has_any_permission(
+        ) and page_permission_policy.user_has_any_permission(
             request.user, ["add", "change", "publish"]
         )
 
 
 class PageTypesReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return PagePermissionPolicy().user_has_any_permission(
+        return page_permission_policy.user_has_any_permission(
             request.user, ["add", "change", "publish"]
         )
 

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -3,7 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from wagtail import hooks
 from wagtail.coreutils import safe_snake_case
 from wagtail.models import get_page_models
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 
 _FORM_CONTENT_TYPES = None
 
@@ -35,7 +35,7 @@ def get_forms_for_user(user):
     """
     Return a queryset of form pages that this user is allowed to access the submissions for
     """
-    editable_forms = PagePermissionPolicy().instances_user_has_permission_for(
+    editable_forms = page_permission_policy.instances_user_has_permission_for(
         user, "change"
     )
     editable_forms = editable_forms.filter(content_type__in=get_form_types())

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2930,10 +2930,10 @@ class GroupPagePermission(models.Model):
 
 class PagePermissionTester:
     def __init__(self, user, page):
-        from wagtail.permission_policies.pages import PagePermissionPolicy
+        from wagtail.permissions import page_permission_policy
 
         self.user = user
-        self.permission_policy = PagePermissionPolicy()
+        self.permission_policy = page_permission_policy
         self.page = page
         self.page_is_root = page.depth == 1  # Equivalent to page.is_root()
 
@@ -4362,13 +4362,10 @@ class PageLogEntryManager(BaseLogEntryManager):
         return super().log_action(instance, action, **kwargs)
 
     def viewable_by_user(self, user):
-        from wagtail.permission_policies.pages import PagePermissionPolicy
+        from wagtail.permissions import page_permission_policy
 
-        q = Q(
-            page__in=PagePermissionPolicy()
-            .explorable_instances(user)
-            .values_list("pk", flat=True)
-        )
+        explorable_instances = page_permission_policy.explorable_instances(user)
+        q = Q(page__in=explorable_instances.values_list("pk", flat=True))
 
         root_page_permissions = Page.get_first_root_node().permissions_for_user(user)
         if (

--- a/wagtail/permissions.py
+++ b/wagtail/permissions.py
@@ -1,7 +1,9 @@
-from wagtail.models import Collection, Locale, Site, Task, Workflow
+from wagtail.models import Collection, Locale, Page, Site, Task, Workflow
 from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.permission_policies.collections import CollectionManagementPermissionPolicy
+from wagtail.permission_policies.pages import PagePermissionPolicy
 
+page_permission_policy = PagePermissionPolicy(Page)
 site_permission_policy = ModelPermissionPolicy(Site)
 collection_permission_policy = CollectionManagementPermissionPolicy(Collection)
 task_permission_policy = ModelPermissionPolicy(Task)


### PR DESCRIPTION
Instead of instantiating `PagePermissionPolicy` everywhere we need it, create a single instance of it in `wagtail.permissions`, following the pattern for other permission policies. (I probably should've done this from the start...)

I imagine we could maybe spin `wagtail.permissions` into an actual app later, and you can replace it with your own app that subclasses the app config, with your own permission policies. Or maybe not an app, but something that lives in `wagtail.permissions` for the default instances of permission policies, with `wagtail.permission_policies` (or later rename it to `wagtail.permissions.policies`?) providing the default implementations of the policies.

Later on, we can maybe create a registry that maps model classes to the permission policy instances. This is where you'll register permission policies for your own models, including snippets.

I think instead of having permission policies be defined through the viewsets/views, it makes more sense to have a separate place dedicated for permissions. The reason being, permissions are a central piece that does not have to be tied to views. Views can do permission checks, but if you need to do permission checks elsewhere (e.g. a programmatic action, a background job), you shouldn't need to know the viewset the model is registered with. In most cases, you want the permission checks to have consistent results, regardless where/in what context you're doing it from.

Finally, if we could figure out how `PagePermissionTester` fits in all this, it would be great to have a similar approach for snippets/models managed via `ModelViewSet`.



_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
