### PR TITLE
Use a registry to map models to permission policies

### DIFF
--- a/wagtail/admin/api/filters.py
+++ b/wagtail/admin/api/filters.py
@@ -2,7 +2,8 @@ from rest_framework.filters import BaseFilterBackend
 
 from wagtail import hooks
 from wagtail.api.v2.utils import BadRequestError, parse_boolean
-from wagtail.permissions import page_permission_policy
+from wagtail.models import Page
+from wagtail.permissions import policies_registry as policies
 
 
 class HasChildrenFilter(BaseFilterBackend):
@@ -39,7 +40,7 @@ class ForExplorerFilter(BaseFilterBackend):
                 queryset = hook(parent_page, queryset, request)
 
             queryset = (
-                page_permission_policy.explorable_instances(request.user) & queryset
+                policies.get_by_type(Page).explorable_instances(request.user) & queryset
             )
 
         return queryset

--- a/wagtail/admin/api/filters.py
+++ b/wagtail/admin/api/filters.py
@@ -2,7 +2,7 @@ from rest_framework.filters import BaseFilterBackend
 
 from wagtail import hooks
 from wagtail.api.v2.utils import BadRequestError, parse_boolean
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 
 
 class HasChildrenFilter(BaseFilterBackend):
@@ -39,7 +39,7 @@ class ForExplorerFilter(BaseFilterBackend):
                 queryset = hook(parent_page, queryset, request)
 
             queryset = (
-                PagePermissionPolicy().explorable_instances(request.user) & queryset
+                page_permission_policy.explorable_instances(request.user) & queryset
             )
 
         return queryset

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -12,7 +12,7 @@ from django.utils.translation import override
 
 from wagtail.admin import messages
 from wagtail.log_actions import LogContext
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 
 
 def permission_denied(request):
@@ -107,7 +107,7 @@ def user_has_any_page_permission(user):
     Check if a user has any permission to add, edit, or otherwise manage any
     page.
     """
-    return PagePermissionPolicy().user_has_any_permission(
+    return page_permission_policy.user_has_any_permission(
         user, {"add", "change", "publish", "bulk_delete", "lock", "unlock"}
     )
 

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -12,7 +12,8 @@ from django.utils.translation import override
 
 from wagtail.admin import messages
 from wagtail.log_actions import LogContext
-from wagtail.permissions import page_permission_policy
+from wagtail.models import Page
+from wagtail.permissions import policies_registry as policies
 
 
 def permission_denied(request):
@@ -107,7 +108,7 @@ def user_has_any_page_permission(user):
     Check if a user has any permission to add, edit, or otherwise manage any
     page.
     """
-    return page_permission_policy.user_has_any_permission(
+    return policies.get_by_type(Page).user_has_any_permission(
         user, {"add", "change", "publish", "bulk_delete", "lock", "unlock"}
     )
 

--- a/wagtail/admin/forms/account.py
+++ b/wagtail/admin/forms/account.py
@@ -13,7 +13,8 @@ from wagtail.admin.localization import (
     get_available_admin_time_zones,
 )
 from wagtail.admin.widgets import SwitchInput
-from wagtail.permissions import page_permission_policy
+from wagtail.models import Page
+from wagtail.permissions import policies_registry as policies
 from wagtail.users.models import UserProfile
 
 User = get_user_model()
@@ -23,7 +24,8 @@ class NotificationPreferencesForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        permission_policy = page_permission_policy
+        # TODO: Consider permissions for snippets with workflows enabled
+        permission_policy = policies.get_by_type(Page)
         if not permission_policy.user_has_permission(self.instance.user, "publish"):
             del self.fields["submitted_notifications"]
         if not permission_policy.user_has_permission(self.instance.user, "change"):

--- a/wagtail/admin/forms/account.py
+++ b/wagtail/admin/forms/account.py
@@ -13,7 +13,7 @@ from wagtail.admin.localization import (
     get_available_admin_time_zones,
 )
 from wagtail.admin.widgets import SwitchInput
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 from wagtail.users.models import UserProfile
 
 User = get_user_model()
@@ -23,7 +23,7 @@ class NotificationPreferencesForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        permission_policy = PagePermissionPolicy()
+        permission_policy = page_permission_policy
         if not permission_policy.user_has_permission(self.instance.user, "publish"):
             del self.fields["submitted_notifications"]
         if not permission_policy.user_has_permission(self.instance.user, "change"):

--- a/wagtail/admin/navigation.py
+++ b/wagtail/admin/navigation.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 
 
 def get_site_for_user(user):
-    root_page = PagePermissionPolicy().explorable_root_instance(user)
+    root_page = page_permission_policy.explorable_root_instance(user)
     if root_page:
         root_site = root_page.get_site()
     else:

--- a/wagtail/admin/navigation.py
+++ b/wagtail/admin/navigation.py
@@ -1,10 +1,11 @@
 from django.conf import settings
 
-from wagtail.permissions import page_permission_policy
+from wagtail.models import Page
+from wagtail.permissions import policies_registry as policies
 
 
 def get_site_for_user(user):
-    root_page = page_permission_policy.explorable_root_instance(user)
+    root_page = policies.get_by_type(Page).explorable_root_instance(user)
     if root_page:
         root_site = root_page.get_site()
     else:

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -54,7 +54,7 @@ from wagtail.models import (
     Page,
     PageViewRestriction,
 )
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 from wagtail.telepath import JSContext
 from wagtail.users.utils import get_gravatar_url
 from wagtail.utils.deprecation import RemovedInWagtail70Warning
@@ -87,7 +87,7 @@ def page_breadcrumbs(
 
     # find the closest common ancestor of the pages that this user has direct explore permission
     # (i.e. add/edit/publish/lock) over; this will be the root of the breadcrumb
-    cca = PagePermissionPolicy().explorable_root_instance(user)
+    cca = page_permission_policy.explorable_root_instance(user)
     if not cca:
         return {"items": Page.objects.none()}
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -54,7 +54,7 @@ from wagtail.models import (
     Page,
     PageViewRestriction,
 )
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry as policies
 from wagtail.telepath import JSContext
 from wagtail.users.utils import get_gravatar_url
 from wagtail.utils.deprecation import RemovedInWagtail70Warning
@@ -87,7 +87,7 @@ def page_breadcrumbs(
 
     # find the closest common ancestor of the pages that this user has direct explore permission
     # (i.e. add/edit/publish/lock) over; this will be the root of the breadcrumb
-    cca = page_permission_policy.explorable_root_instance(user)
+    cca = policies.get_by_type(Page).explorable_root_instance(user)
     if not cca:
         return {"items": Page.objects.none()}
 

--- a/wagtail/admin/views/collection_privacy.py
+++ b/wagtail/admin/views/collection_privacy.py
@@ -4,12 +4,12 @@ from django.shortcuts import get_object_or_404
 from wagtail.admin.forms.collections import CollectionViewRestrictionForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.models import Collection, CollectionViewRestriction
-from wagtail.permissions import collection_permission_policy
+from wagtail.permissions import policies_registry as policies
 
 
 def set_privacy(request, collection_id):
     collection = get_object_or_404(Collection, id=collection_id)
-    if not collection_permission_policy.user_has_permission(request.user, "change"):
+    if not policies.get_by_type(Collection).user_has_permission(request.user, "change"):
         raise PermissionDenied
 
     # fetch restriction records in depth order so that ancestors appear first

--- a/wagtail/admin/views/collections.py
+++ b/wagtail/admin/views/collections.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy
 
 from wagtail import hooks
@@ -7,11 +8,10 @@ from wagtail.admin import messages
 from wagtail.admin.forms.collections import CollectionForm
 from wagtail.admin.views.generic import CreateView, DeleteView, EditView, IndexView
 from wagtail.models import Collection
-from wagtail.permissions import collection_permission_policy
+from wagtail.permissions import policies_registry as policies
 
 
 class Index(IndexView):
-    permission_policy = collection_permission_policy
     model = Collection
     context_object_name = "collections"
     template_name = "wagtailadmin/collections/index.html"
@@ -21,6 +21,10 @@ class Index(IndexView):
     add_item_label = gettext_lazy("Add a collection")
     header_icon = "folder-open-1"
 
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(Collection)
+
     def get_queryset(self):
         return self.permission_policy.instances_user_has_any_permission_for(
             self.request.user, ["add", "change", "delete"]
@@ -28,7 +32,6 @@ class Index(IndexView):
 
 
 class Create(CreateView):
-    permission_policy = collection_permission_policy
     model = Collection
     form_class = CollectionForm
     page_title = gettext_lazy("Add collection")
@@ -37,6 +40,10 @@ class Create(CreateView):
     edit_url_name = "wagtailadmin_collections:edit"
     index_url_name = "wagtailadmin_collections:index"
     header_icon = "folder-open-1"
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(Collection)
 
     def get_form(self, form_class=None):
         form = super().get_form(form_class)
@@ -55,7 +62,6 @@ class Create(CreateView):
 
 
 class Edit(EditView):
-    permission_policy = collection_permission_policy
     model = Collection
     form_class = CollectionForm
     template_name = "wagtailadmin/collections/edit.html"
@@ -67,6 +73,10 @@ class Edit(EditView):
     delete_url_name = "wagtailadmin_collections:delete"
     context_object_name = "collection"
     header_icon = "folder-open-1"
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(Collection)
 
     def _user_may_move_collection(self, user, instance):
         """
@@ -135,7 +145,6 @@ class Edit(EditView):
 
 
 class Delete(DeleteView):
-    permission_policy = collection_permission_policy
     model = Collection
     success_message = gettext_lazy("Collection '%(object)s' deleted.")
     index_url_name = "wagtailadmin_collections:index"
@@ -146,6 +155,10 @@ class Delete(DeleteView):
         "Are you sure you want to delete this collection?"
     )
     header_icon = "folder-open-1"
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(Collection)
 
     def get_queryset(self):
         return self.permission_policy.instances_user_has_permission_for(

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -26,7 +26,7 @@ from wagtail.models import (
     WorkflowState,
     get_default_page_content_type,
 )
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry as policies
 
 User = get_user_model()
 
@@ -221,7 +221,7 @@ class LockedPagesPanel(Component):
                     locked=True,
                     locked_by=request.user,
                 ),
-                "can_remove_locks": page_permission_policy.user_has_permission(
+                "can_remove_locks": policies.get_by_type(Page).user_has_permission(
                     request.user, "unlock"
                 ),
                 "request": request,

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -26,7 +26,7 @@ from wagtail.models import (
     WorkflowState,
     get_default_page_content_type,
 )
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 
 User = get_user_model()
 
@@ -221,7 +221,7 @@ class LockedPagesPanel(Component):
                     locked=True,
                     locked_by=request.user,
                 ),
-                "can_remove_locks": PagePermissionPolicy().user_has_permission(
+                "can_remove_locks": page_permission_policy.user_has_permission(
                     request.user, "unlock"
                 ),
                 "request": request,

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -22,11 +22,12 @@ from wagtail.admin.ui.tables.pages import (
 )
 from wagtail.admin.views.generic.base import BaseListingView
 from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
-from wagtail.permission_policies.pages import Page, PagePermissionPolicy
+from wagtail.models import Page
+from wagtail.permissions import page_permission_policy
 
 
 class BaseIndexView(PermissionCheckedMixin, BaseListingView):
-    permission_policy = PagePermissionPolicy()
+    permission_policy = page_permission_policy
     any_permission_required = {
         "add",
         "change",

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db.models import Count
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 
@@ -23,11 +24,10 @@ from wagtail.admin.ui.tables.pages import (
 from wagtail.admin.views.generic.base import BaseListingView
 from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
 from wagtail.models import Page
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry as policies
 
 
 class BaseIndexView(PermissionCheckedMixin, BaseListingView):
-    permission_policy = page_permission_policy
     any_permission_required = {
         "add",
         "change",
@@ -71,6 +71,10 @@ class BaseIndexView(PermissionCheckedMixin, BaseListingView):
         ),
         NavigateToChildrenColumn("navigate", width="10%"),
     ]
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(Page)
 
     def get(self, request, parent_page_id=None):
         if parent_page_id:

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models.query import QuerySet
 from django.http import Http404
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.forms.search import SearchForm
@@ -20,7 +21,7 @@ from wagtail.admin.ui.tables.pages import (
 from wagtail.admin.views.generic.base import BaseListingView
 from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
 from wagtail.models import Page
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry as policies
 from wagtail.search.query import MATCH_ALL
 from wagtail.search.utils import parse_query_string
 
@@ -51,7 +52,6 @@ def page_filter_search(q, pages, all_pages=None, ordering=None):
 
 
 class BaseSearchView(PermissionCheckedMixin, BaseListingView):
-    permission_policy = page_permission_policy
     any_permission_required = {
         "add",
         "change",
@@ -94,6 +94,10 @@ class BaseSearchView(PermissionCheckedMixin, BaseListingView):
         ),
         NavigateToChildrenColumn("navigate", width="10%"),
     ]
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(Page)
 
     def get(self, request):
         self.show_locale_labels = getattr(settings, "WAGTAIL_I18N_ENABLED", False)

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -20,7 +20,7 @@ from wagtail.admin.ui.tables.pages import (
 from wagtail.admin.views.generic.base import BaseListingView
 from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
 from wagtail.models import Page
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 from wagtail.search.query import MATCH_ALL
 from wagtail.search.utils import parse_query_string
 
@@ -51,7 +51,7 @@ def page_filter_search(q, pages, all_pages=None, ordering=None):
 
 
 class BaseSearchView(PermissionCheckedMixin, BaseListingView):
-    permission_policy = PagePermissionPolicy()
+    permission_policy = page_permission_policy
     any_permission_required = {
         "add",
         "change",

--- a/wagtail/admin/views/reports/aging_pages.py
+++ b/wagtail/admin/views/reports/aging_pages.py
@@ -9,7 +9,7 @@ from wagtail.admin.filters import ContentTypeFilter, WagtailFilterSet
 from wagtail.admin.widgets import AdminDateInput
 from wagtail.coreutils import get_content_type_label
 from wagtail.models import Page, PageLogEntry, get_page_models
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 from wagtail.users.utils import get_deleted_user_display_name
 
 from .base import PageReportView
@@ -99,8 +99,9 @@ class AgingPagesView(PageReportView):
             page=OuterRef("pk"), action__exact="wagtail.publish"
         )
         self.queryset = (
-            PagePermissionPolicy()
-            .instances_user_has_permission_for(self.request.user, "publish")
+            page_permission_policy.instances_user_has_permission_for(
+                self.request.user, "publish"
+            )
             .exclude(last_published_at__isnull=True)
             .prefetch_workflow_states()
             .select_related("content_type")
@@ -114,7 +115,7 @@ class AgingPagesView(PageReportView):
         return super().get_queryset()
 
     def dispatch(self, request, *args, **kwargs):
-        if not PagePermissionPolicy().user_has_any_permission(
+        if not page_permission_policy.user_has_any_permission(
             request.user, ["add", "change", "publish"]
         ):
             raise PermissionDenied

--- a/wagtail/admin/views/reports/locked_pages.py
+++ b/wagtail/admin/views/reports/locked_pages.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.filters import DateRangePickerWidget, WagtailFilterSet
 from wagtail.models import Page
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 
 from .base import PageReportView
 
@@ -51,7 +51,7 @@ class LockedPagesView(PageReportView):
     def get_queryset(self):
         pages = (
             (
-                PagePermissionPolicy().instances_user_has_permission_for(
+                page_permission_policy.instances_user_has_permission_for(
                     self.request.user, "change"
                 )
                 | Page.objects.filter(locked_by=self.request.user)
@@ -67,6 +67,6 @@ class LockedPagesView(PageReportView):
         return super().get_queryset()
 
     def dispatch(self, request, *args, **kwargs):
-        if not PagePermissionPolicy().user_has_permission(request.user, "unlock"):
+        if not page_permission_policy.user_has_permission(request.user, "unlock"):
             raise PermissionDenied
         return super().dispatch(request, *args, **kwargs)

--- a/wagtail/admin/views/reports/locked_pages.py
+++ b/wagtail/admin/views/reports/locked_pages.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.filters import DateRangePickerWidget, WagtailFilterSet
 from wagtail.models import Page
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry as policies
 
 from .base import PageReportView
 
@@ -51,7 +51,7 @@ class LockedPagesView(PageReportView):
     def get_queryset(self):
         pages = (
             (
-                page_permission_policy.instances_user_has_permission_for(
+                policies.get_by_type(Page).instances_user_has_permission_for(
                     self.request.user, "change"
                 )
                 | Page.objects.filter(locked_by=self.request.user)
@@ -67,6 +67,6 @@ class LockedPagesView(PageReportView):
         return super().get_queryset()
 
     def dispatch(self, request, *args, **kwargs):
-        if not page_permission_policy.user_has_permission(request.user, "unlock"):
+        if not policies.get_by_type(Page).user_has_permission(request.user, "unlock"):
             raise PermissionDenied
         return super().dispatch(request, *args, **kwargs)

--- a/wagtail/admin/views/reports/workflows.py
+++ b/wagtail/admin/views/reports/workflows.py
@@ -17,13 +17,14 @@ from wagtail.admin.filters import (
 from wagtail.admin.utils import get_latest_str
 from wagtail.coreutils import get_content_type_label
 from wagtail.models import (
+    Page,
     Task,
     TaskState,
     Workflow,
     WorkflowState,
     get_default_page_content_type,
 )
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry as policies
 from wagtail.snippets.models import get_editable_models
 
 from .base import ReportView
@@ -37,7 +38,7 @@ def get_requested_by_queryset(request):
 
 
 def get_editable_page_ids_query(request):
-    pages = page_permission_policy.instances_user_has_permission_for(
+    pages = policies.get_by_type(Page).instances_user_has_permission_for(
         request.user, "change"
     )
     # Need to cast the page ids to string because Postgres doesn't support
@@ -193,7 +194,7 @@ class WorkflowView(ReportView):
         )
 
     def dispatch(self, request, *args, **kwargs):
-        if not page_permission_policy.user_has_any_permission(
+        if not policies.get_by_type(Page).user_has_any_permission(
             request.user, ["add", "change", "publish"]
         ):
             raise PermissionDenied

--- a/wagtail/admin/views/reports/workflows.py
+++ b/wagtail/admin/views/reports/workflows.py
@@ -23,7 +23,7 @@ from wagtail.models import (
     WorkflowState,
     get_default_page_content_type,
 )
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 from wagtail.snippets.models import get_editable_models
 
 from .base import ReportView
@@ -37,7 +37,7 @@ def get_requested_by_queryset(request):
 
 
 def get_editable_page_ids_query(request):
-    pages = PagePermissionPolicy().instances_user_has_permission_for(
+    pages = page_permission_policy.instances_user_has_permission_for(
         request.user, "change"
     )
     # Need to cast the page ids to string because Postgres doesn't support
@@ -193,7 +193,7 @@ class WorkflowView(ReportView):
         )
 
     def dispatch(self, request, *args, **kwargs):
-        if not PagePermissionPolicy().user_has_any_permission(
+        if not page_permission_policy.user_has_any_permission(
             request.user, ["add", "change", "publish"]
         ):
             raise PermissionDenied

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -37,8 +37,11 @@ from wagtail.models import (
     WorkflowContentType,
     WorkflowState,
 )
-from wagtail.permission_policies.pages import PagePermissionPolicy
-from wagtail.permissions import task_permission_policy, workflow_permission_policy
+from wagtail.permissions import (
+    page_permission_policy,
+    task_permission_policy,
+    workflow_permission_policy,
+)
 from wagtail.snippets.models import get_workflow_enabled_models
 from wagtail.workflows import get_task_types
 
@@ -308,7 +311,7 @@ class Disable(DeleteView):
 def usage(request, pk):
     workflow = get_object_or_404(Workflow, id=pk)
 
-    editable_pages = PagePermissionPolicy().instances_user_has_permission_for(
+    editable_pages = page_permission_policy.instances_user_has_permission_for(
         request.user, "change"
     )
     pages = workflow.all_pages() & editable_pages

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -13,7 +13,7 @@ from wagtail.admin.admin_url_finder import (
 from wagtail.admin.views import generic
 from wagtail.admin.views.generic import history, usage
 from wagtail.models import ReferenceIndex
-from wagtail.permissions import ModelPermissionPolicy
+from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.utils.deprecation import RemovedInWagtail70Warning
 
 from .base import ViewSet, ViewSetGroup

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -54,9 +54,9 @@ from wagtail.admin.views.pages.bulk_actions import (
 from wagtail.admin.viewsets import viewsets
 from wagtail.admin.widgets import ButtonWithDropdownFromHook, PageListingButton
 from wagtail.models import Collection, Page, Task, Workflow
-from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.permissions import (
     collection_permission_policy,
+    page_permission_policy,
     task_permission_policy,
     workflow_permission_policy,
 )
@@ -73,7 +73,7 @@ class ExplorerMenuItem(MenuItem):
 
     def get_context(self, request):
         context = super().get_context(request)
-        start_page = PagePermissionPolicy().explorable_root_instance(request.user)
+        start_page = page_permission_policy.explorable_root_instance(request.user)
 
         if start_page:
             context["start_page_id"] = start_page.id
@@ -81,7 +81,7 @@ class ExplorerMenuItem(MenuItem):
         return context
 
     def render_component(self, request):
-        start_page = PagePermissionPolicy().explorable_root_instance(request.user)
+        start_page = page_permission_policy.explorable_root_instance(request.user)
 
         if start_page:
             return PageExplorerMenuItemComponent(
@@ -848,28 +848,28 @@ def register_core_features(features):
 
 class LockedPagesMenuItem(MenuItem):
     def is_shown(self, request):
-        return PagePermissionPolicy().user_has_permission(request.user, "unlock")
+        return page_permission_policy.user_has_permission(request.user, "unlock")
 
 
 class WorkflowReportMenuItem(MenuItem):
     def is_shown(self, request):
         return getattr(
             settings, "WAGTAIL_WORKFLOW_ENABLED", True
-        ) and PagePermissionPolicy().user_has_any_permission(
+        ) and page_permission_policy.user_has_any_permission(
             request.user, ["add", "change", "publish"]
         )
 
 
 class SiteHistoryReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return PagePermissionPolicy().explorable_root_instance(request.user) is not None
+        return page_permission_policy.explorable_root_instance(request.user) is not None
 
 
 class AgingPagesReportMenuItem(MenuItem):
     def is_shown(self, request):
         return getattr(
             settings, "WAGTAIL_AGING_PAGES_ENABLED", True
-        ) and PagePermissionPolicy().user_has_any_permission(
+        ) and page_permission_policy.user_has_any_permission(
             request.user, ["add", "change", "publish"]
         )
 

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -2,8 +2,8 @@ from django.contrib.contenttypes.models import ContentType
 
 from wagtail import hooks
 from wagtail.coreutils import safe_snake_case
-from wagtail.models import get_page_models
-from wagtail.permissions import page_permission_policy
+from wagtail.models import Page, get_page_models
+from wagtail.permissions import policies_registry as policies
 
 _FORM_CONTENT_TYPES = None
 
@@ -35,7 +35,7 @@ def get_forms_for_user(user):
     """
     Return a queryset of form pages that this user is allowed to access the submissions for
     """
-    editable_forms = page_permission_policy.instances_user_has_permission_for(
+    editable_forms = policies.get_by_type(Page).instances_user_has_permission_for(
         user, "change"
     )
     editable_forms = editable_forms.filter(content_type__in=get_form_types())

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -3,7 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from wagtail import hooks
 from wagtail.coreutils import safe_snake_case
 from wagtail.models import get_page_models
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import page_permission_policy
 
 _FORM_CONTENT_TYPES = None
 
@@ -35,7 +35,7 @@ def get_forms_for_user(user):
     """
     Return a queryset of form pages that this user is allowed to access the submissions for
     """
-    editable_forms = PagePermissionPolicy().instances_user_has_permission_for(
+    editable_forms = page_permission_policy.instances_user_has_permission_for(
         user, "change"
     )
     editable_forms = editable_forms.filter(content_type__in=get_form_types())

--- a/wagtail/documents/__init__.py
+++ b/wagtail/documents/__init__.py
@@ -31,3 +31,15 @@ def get_document_model():
             "WAGTAILDOCS_DOCUMENT_MODEL refers to model '%s' that has not been installed"
             % model_string
         )
+
+
+def get_permission_policy():
+    from wagtail.permission_policies.collections import (
+        CollectionOwnershipPermissionPolicy,
+    )
+
+    return CollectionOwnershipPermissionPolicy(
+        get_document_model_string(),
+        auth_model="wagtaildocs.Document",
+        owner_field_name="uploaded_by_user",
+    )

--- a/wagtail/documents/apps.py
+++ b/wagtail/documents/apps.py
@@ -27,3 +27,9 @@ class WagtailDocsAppConfig(AppConfig):
         from wagtail.models.reference_index import ReferenceIndex
 
         ReferenceIndex.register_model(Document)
+
+        from wagtail.permissions import register_permission_policy
+
+        from . import get_permission_policy
+
+        register_permission_policy(Document, get_permission_policy())

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext_lazy as _
 from taggit.managers import TaggableManager
 
 from wagtail.models import CollectionMember, ReferenceIndex
+from wagtail.permissions import policies_registry as policies
 from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
 from wagtail.utils.file import hash_filelike
@@ -173,9 +174,11 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
         return reverse("wagtaildocs:document_usage", args=(self.id,))
 
     def is_editable_by_user(self, user):
-        from wagtail.documents.permissions import permission_policy
+        from wagtail.documents import get_document_model
 
-        return permission_policy.user_has_permission_for_instance(user, "change", self)
+        return policies.get_by_type(
+            get_document_model()
+        ).user_has_permission_for_instance(user, "change", self)
 
     @property
     def content_type(self):

--- a/wagtail/documents/permissions.py
+++ b/wagtail/documents/permissions.py
@@ -1,8 +1,7 @@
-from wagtail.documents import get_document_model_string
-from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
+from wagtail.documents import get_document_model
+from wagtail.permissions import policies_registry as policies
 
-permission_policy = CollectionOwnershipPermissionPolicy(
-    get_document_model_string(),
-    auth_model="wagtaildocs.Document",
-    owner_field_name="uploaded_by_user",
-)
+# This is deprecated, but kept for backwards compatibility
+# The policy should be retrieved using `policies.get_by_type(get_document_model())`
+# TODO: Add deprecation warning
+permission_policy = policies.get_by_type(get_document_model())

--- a/wagtail/documents/tests/__init__.py
+++ b/wagtail/documents/tests/__init__.py
@@ -1,0 +1,18 @@
+from django.test.signals import setting_changed
+
+from wagtail.documents import get_document_model, get_permission_policy
+from wagtail.permissions import policies_registry as policies
+
+
+def update_permission_policy(signal, sender, setting, **kwargs):
+    """
+    Register the permission policy when the `WAGTAILDOCS_DOCUMENT_MODEL` setting changes.
+    This is useful in tests where we override the document model setting and expect the
+    permission policy to have changed accordingly.
+    """
+
+    if setting == "WAGTAILDOCS_DOCUMENT_MODEL":
+        policies.register(get_document_model(), get_permission_policy())
+
+
+setting_changed.connect(update_permission_policy)

--- a/wagtail/documents/views/bulk_actions/add_to_collection.py
+++ b/wagtail/documents/views/bulk_actions/add_to_collection.py
@@ -2,7 +2,9 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
+from wagtail.documents import get_document_model
 from wagtail.documents.views.bulk_actions.document_bulk_action import DocumentBulkAction
+from wagtail.permissions import policies_registry as policies
 
 
 class CollectionForm(forms.Form):
@@ -11,9 +13,9 @@ class CollectionForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields["collection"] = forms.ModelChoiceField(
             label=_("Collection"),
-            queryset=DocumentBulkAction.permission_policy.collections_user_has_permission_for(
-                user, "add"
-            ),
+            queryset=policies.get_by_type(
+                get_document_model()
+            ).collections_user_has_permission_for(user, "add"),
         )
 
 

--- a/wagtail/documents/views/bulk_actions/document_bulk_action.py
+++ b/wagtail/documents/views/bulk_actions/document_bulk_action.py
@@ -1,13 +1,16 @@
+from django.utils.functional import cached_property
+
 from wagtail.admin.views.bulk_action import BulkAction
 from wagtail.documents import get_document_model
-from wagtail.documents.permissions import (
-    permission_policy as documents_permission_policy,
-)
+from wagtail.permissions import policies_registry as policies
 
 
 class DocumentBulkAction(BulkAction):
-    permission_policy = documents_permission_policy
     models = [get_document_model()]
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(get_document_model())
 
     def get_all_objects_in_listing_query(self, parent_id):
         listing_objects = self.model.objects.all()

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -19,7 +19,7 @@ from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.admin.widgets import BaseChooser, BaseChooserAdapter
 from wagtail.blocks import ChooserBlock
 from wagtail.documents import get_document_model, get_document_model_string
-from wagtail.documents.permissions import permission_policy
+from wagtail.permissions import policies_registry as policies
 
 
 class DocumentChosenResponseMixin(ChosenResponseMixin):
@@ -187,7 +187,6 @@ class DocumentChooserViewSet(ChooserViewSet):
     base_widget_class = BaseAdminDocumentChooser
     widget_telepath_adapter_class = DocumentChooserAdapter
     base_block_class = BaseDocumentChooserBlock
-    permission_policy = permission_policy
 
     icon = "doc-full-inverse"
     choose_one_text = _("Choose a document")
@@ -195,6 +194,10 @@ class DocumentChooserViewSet(ChooserViewSet):
     create_action_clicked_label = _("Uploading…")
     choose_another_text = _("Choose another document")
     edit_item_text = _("Edit this document")
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(get_document_model())
 
 
 viewset = DocumentChooserViewSet(

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -1,5 +1,7 @@
 import os.path
 
+from django.utils.functional import cached_property
+
 from wagtail.admin.views.generic.multiple_upload import AddView as BaseAddView
 from wagtail.admin.views.generic.multiple_upload import (
     CreateFromUploadView as BaseCreateFromUploadView,
@@ -9,15 +11,14 @@ from wagtail.admin.views.generic.multiple_upload import (
 )
 from wagtail.admin.views.generic.multiple_upload import DeleteView as BaseDeleteView
 from wagtail.admin.views.generic.multiple_upload import EditView as BaseEditView
+from wagtail.permissions import policies_registry as policies
 
 from .. import get_document_model
 from ..forms import get_document_form, get_document_multi_form
 from ..models import UploadedDocument
-from ..permissions import permission_policy
 
 
 class AddView(BaseAddView):
-    permission_policy = permission_policy
     template_name = "wagtaildocs/multiple/add.html"
     upload_model = UploadedDocument
 
@@ -32,6 +33,10 @@ class AddView(BaseAddView):
     edit_upload_form_prefix = "uploaded-document"
     context_upload_name = "uploaded_document"
     context_upload_id_name = "uploaded_document_id"
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(self.model)
 
     def get_model(self):
         return get_document_model()
@@ -63,13 +68,16 @@ class AddView(BaseAddView):
 
 
 class EditView(BaseEditView):
-    permission_policy = permission_policy
     pk_url_kwarg = "doc_id"
     edit_object_form_prefix = "doc"
     context_object_name = "doc"
     context_object_id_name = "doc_id"
     edit_object_url_name = "wagtaildocs:edit_multiple"
     delete_object_url_name = "wagtaildocs:delete_multiple"
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(self.model)
 
     def get_model(self):
         return get_document_model()
@@ -79,9 +87,12 @@ class EditView(BaseEditView):
 
 
 class DeleteView(BaseDeleteView):
-    permission_policy = permission_policy
     pk_url_kwarg = "doc_id"
     context_object_id_name = "doc_id"
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(self.model)
 
     def get_model(self):
         return get_document_model()

--- a/wagtail/images/__init__.py
+++ b/wagtail/images/__init__.py
@@ -32,3 +32,15 @@ def get_image_model():
             "WAGTAILIMAGES_IMAGE_MODEL refers to model '%s' that has not been installed"
             % model_string
         )
+
+
+def get_permission_policy():
+    from wagtail.permission_policies.collections import (
+        CollectionOwnershipPermissionPolicy,
+    )
+
+    return CollectionOwnershipPermissionPolicy(
+        get_image_model(),
+        auth_model="wagtailimages.Image",
+        owner_field_name="uploaded_by_user",
+    )

--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -45,3 +45,9 @@ class WagtailImagesAppConfig(AppConfig):
         from wagtail.models.reference_index import ReferenceIndex
 
         ReferenceIndex.register_model(Image)
+
+        from wagtail.permissions import register_permission_policy
+
+        from . import get_permission_policy
+
+        register_permission_policy(Image, get_permission_policy())

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -32,6 +32,7 @@ from taggit.managers import TaggableManager
 
 from wagtail import hooks
 from wagtail.coreutils import string_to_ascii
+from wagtail.images import get_image_model
 from wagtail.images.exceptions import (
     InvalidFilterSpecError,
     UnknownOutputImageFormatError,
@@ -45,6 +46,7 @@ from wagtail.images.image_operations import (
 )
 from wagtail.images.rect import Rect
 from wagtail.models import CollectionMember, ReferenceIndex
+from wagtail.permissions import policies_registry as policies
 from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
 from wagtail.utils.file import hash_filelike
@@ -800,8 +802,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         return self.title
 
     def is_editable_by_user(self, user):
-        from wagtail.images.permissions import permission_policy
-
+        permission_policy = policies.get_by_type(get_image_model())
         return permission_policy.user_has_permission_for_instance(user, "change", self)
 
     class Meta:

--- a/wagtail/images/permissions.py
+++ b/wagtail/images/permissions.py
@@ -1,46 +1,7 @@
-from django.dispatch import receiver
-from django.test.signals import setting_changed
-
 from wagtail.images import get_image_model
-from wagtail.images.models import Image
-from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
+from wagtail.permissions import policies_registry as policies
 
-permission_policy = None
-
-
-class ImagesPermissionPolicyGetter:
-    """
-    A helper to retrieve the current permission policy dynamically.
-    Following the descriptor protocol, this should be used as a class attribute::
-
-        class MyImageView(PermissionCheckedMixin, ...):
-            permission_policy = ImagesPermissionPolicyGetter()
-    """
-
-    def __get__(self, obj, objtype=None):
-        return permission_policy
-
-
-def set_permission_policy():
-    """Sets the permission policy for the current image model."""
-
-    global permission_policy
-    permission_policy = CollectionOwnershipPermissionPolicy(
-        get_image_model(), auth_model=Image, owner_field_name="uploaded_by_user"
-    )
-
-
-@receiver(setting_changed)
-def update_permission_policy(signal, sender, setting, **kwargs):
-    """
-    Updates the permission policy when the `WAGTAILIMAGES_IMAGE_MODEL` setting changes.
-    This is useful in tests where we override the base image model and expect the
-    permission policy to have changed accordingly.
-    """
-
-    if setting == "WAGTAILIMAGES_IMAGE_MODEL":
-        set_permission_policy()
-
-
-# Set the permission policy for the first time.
-set_permission_policy()
+# This is deprecated, but kept for backwards compatibility
+# The policy should be retrieved using `policies.get_by_type(get_image_model())`
+# TODO: Add deprecation warning
+permission_policy = policies.get_by_type(get_image_model())

--- a/wagtail/images/tests/__init__.py
+++ b/wagtail/images/tests/__init__.py
@@ -1,0 +1,18 @@
+from django.test.signals import setting_changed
+
+from wagtail.images import get_image_model, get_permission_policy
+from wagtail.permissions import policies_registry as policies
+
+
+def update_permission_policy(signal, sender, setting, **kwargs):
+    """
+    Register the permission policy when the `WAGTAILIMAGES_IMAGE_MODEL` setting changes.
+    This is useful in tests where we override the image model setting and expect the
+    permission policy to have changed accordingly.
+    """
+
+    if setting == "WAGTAILIMAGES_IMAGE_MODEL":
+        policies.register(get_image_model(), get_permission_policy())
+
+
+setting_changed.connect(update_permission_policy)

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -16,8 +16,8 @@ from wagtail.images.fields import WagtailImageField
 from wagtail.images.formats import Format, get_image_format, register_image_format
 from wagtail.images.forms import get_image_form
 from wagtail.images.models import Image as WagtailImage
-from wagtail.images.permissions import update_permission_policy
 from wagtail.images.rect import Rect, Vector
+from wagtail.images.tests import update_permission_policy
 from wagtail.images.utils import generate_signature, verify_signature
 from wagtail.images.views.serve import ServeView
 from wagtail.test.testapp.models import CustomImage, CustomImageFilePath

--- a/wagtail/images/views/bulk_actions/add_to_collection.py
+++ b/wagtail/images/views/bulk_actions/add_to_collection.py
@@ -2,18 +2,19 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
+from wagtail.images import get_image_model
 from wagtail.images.views.bulk_actions.image_bulk_action import ImageBulkAction
+from wagtail.permissions import policies_registry as policies
 
 
 class CollectionForm(forms.Form):
     def __init__(self, *args, **kwargs):
         user = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
+        permission_policy = policies.get_by_type(get_image_model())
         self.fields["collection"] = forms.ModelChoiceField(
             label=_("Collection"),
-            queryset=ImageBulkAction.permission_policy.collections_user_has_permission_for(
-                user, "add"
-            ),
+            queryset=permission_policy.collections_user_has_permission_for(user, "add"),
         )
 
 

--- a/wagtail/images/views/bulk_actions/image_bulk_action.py
+++ b/wagtail/images/views/bulk_actions/image_bulk_action.py
@@ -1,11 +1,16 @@
+from django.utils.functional import cached_property
+
 from wagtail.admin.views.bulk_action import BulkAction
 from wagtail.images import get_image_model
-from wagtail.images.permissions import permission_policy as images_permission_policy
+from wagtail.permissions import policies_registry as policies
 
 
 class ImageBulkAction(BulkAction):
-    permission_policy = images_permission_policy
     models = [get_image_model()]
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(get_image_model())
 
     def get_all_objects_in_listing_query(self, parent_id):
         listing_objects = self.model.objects.all()

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -2,6 +2,7 @@ import os.path
 
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.functional import cached_property
 
 from wagtail.admin.views.generic.multiple_upload import AddView as BaseAddView
 from wagtail.admin.views.generic.multiple_upload import (
@@ -16,12 +17,11 @@ from wagtail.images import get_image_model
 from wagtail.images.fields import get_allowed_image_extensions
 from wagtail.images.forms import get_image_form, get_image_multi_form
 from wagtail.images.models import UploadedImage
-from wagtail.images.permissions import ImagesPermissionPolicyGetter, permission_policy
 from wagtail.images.utils import find_image_duplicates
+from wagtail.permissions import policies_registry as policies
 
 
 class AddView(BaseAddView):
-    permission_policy = ImagesPermissionPolicyGetter()
     template_name = "wagtailimages/multiple/add.html"
     upload_model = UploadedImage
 
@@ -36,6 +36,10 @@ class AddView(BaseAddView):
     edit_upload_form_prefix = "uploaded-image"
     context_upload_name = "uploaded_image"
     context_upload_id_name = "uploaded_image_id"
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(get_image_model())
 
     def get_model(self):
         return get_image_model()
@@ -104,13 +108,16 @@ class AddView(BaseAddView):
 
 
 class EditView(BaseEditView):
-    permission_policy = permission_policy
     pk_url_kwarg = "image_id"
     edit_object_form_prefix = "image"
     context_object_name = "image"
     context_object_id_name = "image_id"
     edit_object_url_name = "wagtailimages:edit_multiple"
     delete_object_url_name = "wagtailimages:delete_multiple"
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(get_image_model())
 
     def get_model(self):
         return get_image_model()
@@ -120,9 +127,12 @@ class EditView(BaseEditView):
 
 
 class DeleteView(BaseDeleteView):
-    permission_policy = permission_policy
     pk_url_kwarg = "image_id"
     context_object_id_name = "image_id"
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(get_image_model())
 
     def get_model(self):
         return get_image_model()

--- a/wagtail/locales/views.py
+++ b/wagtail/locales/views.py
@@ -1,3 +1,4 @@
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy
 
 from wagtail.admin import messages
@@ -5,7 +6,7 @@ from wagtail.admin.ui.tables import Column, TitleColumn
 from wagtail.admin.views import generic
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.models import Locale
-from wagtail.permissions import locale_permission_policy
+from wagtail.permissions import policies_registry as policies
 
 from .forms import LocaleForm
 from .utils import get_locale_usage
@@ -96,7 +97,6 @@ class DeleteView(generic.DeleteView):
 class LocaleViewSet(ModelViewSet):
     icon = "site"
     model = Locale
-    permission_policy = locale_permission_policy
     add_to_reference_index = False
     _show_breadcrumbs = False
 
@@ -106,6 +106,10 @@ class LocaleViewSet(ModelViewSet):
     delete_view_class = DeleteView
 
     template_prefix = "wagtaillocales/"
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(Locale)
 
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(

--- a/wagtail/locales/wagtail_hooks.py
+++ b/wagtail/locales/wagtail_hooks.py
@@ -4,7 +4,8 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
-from wagtail.permissions import site_permission_policy
+from wagtail.models import Site
+from wagtail.permissions import policies_registry as policies
 
 from .views import LocaleViewSet
 
@@ -16,7 +17,7 @@ def register_viewset():
 
 class LocalesMenuItem(MenuItem):
     def is_shown(self, request):
-        return site_permission_policy.user_has_any_permission(
+        return policies.get_by_type(Site).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2930,10 +2930,10 @@ class GroupPagePermission(models.Model):
 
 class PagePermissionTester:
     def __init__(self, user, page):
-        from wagtail.permission_policies.pages import PagePermissionPolicy
+        from wagtail.permissions import page_permission_policy
 
         self.user = user
-        self.permission_policy = PagePermissionPolicy()
+        self.permission_policy = page_permission_policy
         self.page = page
         self.page_is_root = page.depth == 1  # Equivalent to page.is_root()
 
@@ -4362,13 +4362,10 @@ class PageLogEntryManager(BaseLogEntryManager):
         return super().log_action(instance, action, **kwargs)
 
     def viewable_by_user(self, user):
-        from wagtail.permission_policies.pages import PagePermissionPolicy
+        from wagtail.permissions import page_permission_policy
 
-        q = Q(
-            page__in=PagePermissionPolicy()
-            .explorable_instances(user)
-            .values_list("pk", flat=True)
-        )
+        explorable_instances = page_permission_policy.explorable_instances(user)
+        q = Q(page__in=explorable_instances.values_list("pk", flat=True))
 
         root_page_permissions = Page.get_first_root_node().permissions_for_user(user)
         if (

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2930,10 +2930,10 @@ class GroupPagePermission(models.Model):
 
 class PagePermissionTester:
     def __init__(self, user, page):
-        from wagtail.permissions import page_permission_policy
+        from wagtail.permissions import policies_registry as policies
 
         self.user = user
-        self.permission_policy = page_permission_policy
+        self.permission_policy = policies.get_by_type(Page)
         self.page = page
         self.page_is_root = page.depth == 1  # Equivalent to page.is_root()
 
@@ -4362,9 +4362,9 @@ class PageLogEntryManager(BaseLogEntryManager):
         return super().log_action(instance, action, **kwargs)
 
     def viewable_by_user(self, user):
-        from wagtail.permissions import page_permission_policy
+        from wagtail.permissions import policies_registry as policies
 
-        explorable_instances = page_permission_policy.explorable_instances(user)
+        explorable_instances = policies.get_by_type(Page).explorable_instances(user)
         q = Q(page__in=explorable_instances.values_list("pk", flat=True))
 
         root_page_permissions = Page.get_first_root_node().permissions_for_user(user)

--- a/wagtail/permissions.py
+++ b/wagtail/permissions.py
@@ -1,7 +1,16 @@
 from wagtail.models import Collection, Locale, Page, Site, Task, Workflow
 from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permission_policies.base import BasePermissionPolicy
 from wagtail.permission_policies.collections import CollectionManagementPermissionPolicy
 from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.utils.registry import ObjectTypeRegistry
+
+policies_registry = ObjectTypeRegistry[BasePermissionPolicy]()
+
+
+def register_permission_policy(model, policy):
+    policies_registry.register(model, value=policy)
+
 
 page_permission_policy = PagePermissionPolicy(Page)
 site_permission_policy = ModelPermissionPolicy(Site)
@@ -9,3 +18,10 @@ collection_permission_policy = CollectionManagementPermissionPolicy(Collection)
 task_permission_policy = ModelPermissionPolicy(Task)
 workflow_permission_policy = ModelPermissionPolicy(Workflow)
 locale_permission_policy = ModelPermissionPolicy(Locale)
+
+register_permission_policy(Page, page_permission_policy)
+register_permission_policy(Site, site_permission_policy)
+register_permission_policy(Collection, collection_permission_policy)
+register_permission_policy(Task, task_permission_policy)
+register_permission_policy(Workflow, workflow_permission_policy)
+register_permission_policy(Locale, locale_permission_policy)

--- a/wagtail/permissions.py
+++ b/wagtail/permissions.py
@@ -1,7 +1,9 @@
-from wagtail.models import Collection, Locale, Site, Task, Workflow
+from wagtail.models import Collection, Locale, Page, Site, Task, Workflow
 from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.permission_policies.collections import CollectionManagementPermissionPolicy
+from wagtail.permission_policies.pages import PagePermissionPolicy
 
+page_permission_policy = PagePermissionPolicy(Page)
 site_permission_policy = ModelPermissionPolicy(Site)
 collection_permission_policy = CollectionManagementPermissionPolicy(Collection)
 task_permission_policy = ModelPermissionPolicy(Task)

--- a/wagtail/sites/views.py
+++ b/wagtail/sites/views.py
@@ -1,10 +1,11 @@
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.ui.tables import Column, StatusFlagColumn, TitleColumn
 from wagtail.admin.views import generic
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.models import Site
-from wagtail.permissions import site_permission_policy
+from wagtail.permissions import policies_registry as policies
 from wagtail.sites.forms import SiteForm
 
 
@@ -50,7 +51,6 @@ class DeleteView(generic.DeleteView):
 class SiteViewSet(ModelViewSet):
     icon = "site"
     model = Site
-    permission_policy = site_permission_policy
     add_to_reference_index = False
     _show_breadcrumbs = False
 
@@ -60,6 +60,10 @@ class SiteViewSet(ModelViewSet):
     delete_view_class = DeleteView
 
     template_prefix = "wagtailsites/"
+
+    @cached_property
+    def permission_policy(self):
+        return policies.get_by_type(Site)
 
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(

--- a/wagtail/sites/wagtail_hooks.py
+++ b/wagtail/sites/wagtail_hooks.py
@@ -4,7 +4,8 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
-from wagtail.permissions import site_permission_policy
+from wagtail.models import Site
+from wagtail.permissions import policies_registry as policies
 
 from .views import SiteViewSet
 
@@ -16,7 +17,7 @@ def register_viewset():
 
 class SitesMenuItem(MenuItem):
     def is_shown(self, request):
-        return site_permission_policy.user_has_any_permission(
+        return policies.get_by_type(Site).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -44,7 +44,7 @@ from wagtail.models import (
     RevisionMixin,
     WorkflowMixin,
 )
-from wagtail.permissions import ModelPermissionPolicy
+from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.snippets.action_menu import SnippetActionMenu
 from wagtail.snippets.models import SnippetAdminURLFinder, get_snippet_models
 from wagtail.snippets.permissions import user_can_edit_snippet_type


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #2907 (see [RFC 102: Permissions registry](https://github.com/wagtail/rfcs/pull/102))

Built on top of #11267. This adds a registry to `wagtail.permissions` that maps models to permission policies. Afterwards, instead of directly importing the default permission policy instances that we have for Wagtail's built-in models, we fetch the policy from the registry whenever we need it. This means that developers can register their own permission policies (either for their custom model or Wagtail's built-in models), and Wagtail's code will automatically pick them up instead of being hardcoded to the existing instance.

Done: pages and documents

TODO: `wagtail.images`, `wagtail.snippets`, `wagtail.contrib`, `ModelViewSet`