### PR TITLE
Vertically align the arrow in the children cell

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Allow `UniqueConstraint` in place of `unique_together` for `TranslatableMixin`'s system check (Temidayo Azeez, Sage Abdullah)
  * Make use of `IndexView.get_add_url()` in snippets index view template (Christer Jensen, Sage Abdullah)
  * Allow `Page.permissions_for_user()` to be overridden by specific page types (Sébastien Corbin)
+ * Improve visual alignment of explore icon in Page listings for longer content (Krzysztof Jeziorny)
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -283,6 +283,7 @@ ul.listing {
   .children,
   .no-children {
     padding: 0;
+    vertical-align: middle;
 
     a {
       display: block;

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -21,6 +21,7 @@ depth: 1
  * Allow `UniqueConstraint` in place of `unique_together` for {class}`~wagtail.models.TranslatableMixin`'s system check (Temidayo Azeez, Sage Abdullah)
  * Make use of `IndexView.get_add_url()` in snippets index view template (Christer Jensen, Sage Abdullah)
  * Allow `Page.permissions_for_user()` to be overridden by specific page types (Sébastien Corbin)
+ * Improve visual alignment of explore icon in Page listings for longer content (Krzysztof Jeziorny)
 
 ### Bug fixes
 


### PR DESCRIPTION
Fixing vertical alignment of svg arrow icons in 'children' table cells. Especially visible, when title cells are higher with more content or longer page titles.

<img width="713" alt="Wagtail admin list of pages with two arrow alignments - unset/top and middle shown" src="https://github.com/wagtail/wagtail/assets/872730/0590ed0b-3da1-4ba4-b659-3df63c64925e">

_Please check the following:_

-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [X] Run `make lint` from the Wagtail root.
-   [X] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [X] **Please list the exact browser and operating system versions you tested**:
      macOS 13.6.1: Firefox 119, Safari 17.1, Safari 183, Chromium 118

`npm run build` run, but `webpack` did not create a css file (should have?) - I'm commiting a small change in scss only.
