### PR TITLE
Provided a robust way to add extra buttons to the snippet index header.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Make use of `IndexView.get_add_url()` in snippets index view template (Christer Jensen, Sage Abdullah)
  * Allow `Page.permissions_for_user()` to be overridden by specific page types (Sébastien Corbin)
  * Improve visual alignment of explore icon in Page listings for longer content (Krzysztof Jeziorny)
+ * Add `extra_actions` blocks to Snippets and generic index templates (Bhuvnesh Sharma)
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -771,6 +771,7 @@
 * Cassidy Pittman
 * Gunnar Scherf
 * Mariana Bedran Lesche
+* Bhuvnesh Sharma
 
 ## Translators
 

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -22,6 +22,7 @@ depth: 1
  * Make use of `IndexView.get_add_url()` in snippets index view template (Christer Jensen, Sage Abdullah)
  * Allow `Page.permissions_for_user()` to be overridden by specific page types (Sébastien Corbin)
  * Improve visual alignment of explore icon in Page listings for longer content (Krzysztof Jeziorny)
+ * Add `extra_actions` blocks to Snippets and generic index templates (Bhuvnesh Sharma)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/generic/index.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index.html
@@ -3,9 +3,11 @@
 
 {% block main_header %}
     {% fragment as extra_actions %}
-        {% if view.list_export %}
-            {% include view.export_buttons_template_name %}
-        {% endif %}
+        {% block extra_actions %}
+            {% if view.list_export %}
+                {% include view.export_buttons_template_name %}
+            {% endif %}
+        {% endblock %}
     {% endfragment %}
     {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=header_action_url action_text=header_action_label action_icon=header_action_icon extra_actions=extra_actions icon=header_icon search_url=search_url search_form=search_form search_results_url=index_results_url only %}
 {% endblock %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/index.html
@@ -17,9 +17,11 @@
     {% fragment as action_url_add_snippet %}{% if can_add_snippet %}{{ add_url }}{% endif %}{% endfragment %}
     {% fragment as action_text_snippet %}{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}{% endfragment %}
     {% fragment as extra_actions %}
-        {% if view.list_export %}
-            {% include view.export_buttons_template_name %}
-        {% endif %}
+        {% block extra_actions %}
+            {% if view.list_export %}
+                {% include view.export_buttons_template_name %}
+            {% endif %}
+        {% endblock %}
     {% endfragment %}
     {% include 'wagtailadmin/shared/header.html' with title=model_opts.verbose_name_plural|capfirst icon=header_icon search_url=search_url base_actions=base_action_locale action_url=action_url_add_snippet action_icon="plus" action_text=action_text_snippet extra_actions=extra_actions search_results_url=index_results_url %}
     <div class="nice-padding{% if filters %} filterable{% endif %}">


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11275 

Added a new block inside the `extra_actions` fragment in `wagtailsnippets/snippets/index.html` to simplify adding extra buttons to the snippet index header.


<img width="1512" alt="Screenshot 2023-11-26 at 9 47 09 PM" src="https://github.com/wagtail/wagtail/assets/83907321/c64baa38-ba97-43e0-acd6-d55c1de4aae8">




_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
