### PR TITLE
A more 'django developer friendly' interface for customising tabbed interfaces

### DIFF
--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -301,16 +301,38 @@ See also [django-treebeard](https://django-treebeard.readthedocs.io/en/latest/in
 
         The following fields will always be excluded in a copy - `['id', 'path', 'depth', 'numchild', 'url_path', 'path']`.
 
+    .. automethod:: with_content_json
+
+    .. automethod:: save
+
     .. attribute:: base_form_class
 
-        The form class used as a base for editing Pages of this type in the Wagtail page editor.
+        The form class (or import path to one) to be used as a base for editing Pages of this type in the Wagtail page editor.
         This attribute can be set on a model to customise the Page editor form.
         Forms must be a subclass of :class:`~wagtail.admin.forms.WagtailAdminPageForm`.
         See :ref:`custom_edit_handler_forms` for more information.
 
-    .. automethod:: with_content_json
+    .. automethod:: get_base_form_class
 
-    .. automethod:: save
+    .. autoattribue:: edit_handler_class
+
+    .. automethod:: get_edit_handler_class
+
+    .. autoattribute:: edit_handler_tab_class
+
+    .. automethod:: get_edit_handler_tab_class
+
+    .. autoattribute:: edit_handler_tabs
+
+    .. automethod:: get_edit_handler_tabs
+
+    .. automethod:: get_edit_handler
+
+    .. automethod:: create_edit_handler
+
+    .. automethod:: create_edit_handler_tabs
+
+    .. automethod:: create_edit_handler_tab
 
     .. automethod:: create_alias
 

--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -1,6 +1,7 @@
 import os
 
 from django.core.checks import Error, Tags, Warning, register
+from django.utils.module_loading import import_string
 
 
 @register("staticfiles")
@@ -41,14 +42,17 @@ def base_form_class_check(app_configs, **kwargs):
     errors = []
 
     for cls in get_page_models():
-        if not issubclass(cls.base_form_class, WagtailAdminPageForm):
+        base_form_class = cls.base_form_class
+        if isinstance(base_form_class, str):
+            base_form_class = import_string(base_form_class)
+        if not issubclass(base_form_class, WagtailAdminPageForm):
             errors.append(
                 Error(
                     "{}.base_form_class does not extend WagtailAdminPageForm".format(
                         cls.__name__
                     ),
                     hint="Ensure that {}.{} extends WagtailAdminPageForm".format(
-                        cls.base_form_class.__module__, cls.base_form_class.__name__
+                        base_form_class.__module__, base_form_class.__name__
                     ),
                     obj=cls,
                     id="wagtailadmin.E001",

--- a/wagtail/admin/models.py
+++ b/wagtail/admin/models.py
@@ -3,10 +3,9 @@ from django.db.models import Count, Model
 from modelcluster.fields import ParentalKey
 from taggit.models import Tag
 
-# The panels module extends Page with some additional attributes required by
-# wagtail admin (namely, base_form_class and get_edit_handler). Importing this within
-# wagtail.admin.models ensures that this happens in advance of running wagtail.admin's
-# system checks.
+# The panels module adds `content_panels`, `promote_panels` and `settings_panels`
+# to the Page model. Importing this within wagtail.admin.models ensures that this
+# happens in `advance of running wagtail.admin's system checks.
 from wagtail.admin import panels  # NOQA: F401
 from wagtail.models import Page
 

--- a/wagtail/admin/panels/page_utils.py
+++ b/wagtail/admin/panels/page_utils.py
@@ -1,14 +1,12 @@
 from django.conf import settings
 from django.utils.translation import gettext_lazy
 
-from wagtail.admin.forms.pages import WagtailAdminPageForm
 from wagtail.admin.widgets.slug import SlugInput
 from wagtail.models import Page
-from wagtail.utils.decorators import cached_classmethod
 
 from .comment_panel import CommentPanel
 from .field_panel import FieldPanel
-from .group import MultiFieldPanel, ObjectList, TabbedInterface
+from .group import MultiFieldPanel
 from .publishing_panel import PublishingPanel
 from .title_field_panel import TitleFieldPanel
 
@@ -42,36 +40,5 @@ def set_default_page_edit_handlers(cls):
     if getattr(settings, "WAGTAILADMIN_COMMENTS_ENABLED", True):
         cls.settings_panels.append(CommentPanel())
 
-    cls.base_form_class = WagtailAdminPageForm
-
 
 set_default_page_edit_handlers(Page)
-
-
-@cached_classmethod
-def _get_page_edit_handler(cls):
-    """
-    Get the panel to use in the Wagtail admin when editing this page type.
-    """
-    if hasattr(cls, "edit_handler"):
-        edit_handler = cls.edit_handler
-    else:
-        # construct a TabbedInterface made up of content_panels, promote_panels
-        # and settings_panels, skipping any which are empty
-        tabs = []
-
-        if cls.content_panels:
-            tabs.append(ObjectList(cls.content_panels, heading=gettext_lazy("Content")))
-        if cls.promote_panels:
-            tabs.append(ObjectList(cls.promote_panels, heading=gettext_lazy("Promote")))
-        if cls.settings_panels:
-            tabs.append(
-                ObjectList(cls.settings_panels, heading=gettext_lazy("Settings"))
-            )
-
-        edit_handler = TabbedInterface(tabs, base_form_class=cls.base_form_class)
-
-    return edit_handler.bind_to_model(cls)
-
-
-Page.get_edit_handler = _get_page_edit_handler

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -82,20 +82,20 @@ def set_query_params(url: str, params: dict):
 
 
 class TabbedEditHandlerGeneratorMixin:
-    # A class (or import path to a class) that `create_edit_handler()` should
-    # use to create the edit handler for the model.
+    # The class (or import path to one) that `get_edit_handler_class()` should
+    # return by default.
     edit_handler_class: Union[str, Type] = "wagtail.admin.panels.TabbedInterface"
 
-    # A class (or import path for a class) that `create_edit_handler_tab()` should
-    # use to create tabs for the model's edit handler.
+    # The class (or import path to one) that `get_edit_handler_tab_class()` should
+    # return by default.
     edit_handler_tab_class: Union[str, Type] = "wagtail.admin.panels.ObjectList"
 
-    # A Form class (or import path for a Form class) that `create_edit_handler()`
-    # should pass as the `base_form` to the edit handler it creates.
+    # A Form class (or import path to one) that `create_edit_handler()` should provide
+    # as `base_form_class` when creating the edit interface instance.
     base_form_class: Union[str, "Form"] = "wagtail.admin.forms.WagtailAdminModelForm"
 
-    # An iterable of (`name`, `heading`) tuples for each tab to be
-    # included in the edit handler for this model.
+    # An iterable of (`name`, `heading`) tuples for each tab to be included in the
+    # edit interface for this model (when panels can be found).
     edit_handler_tabs: Iterable[Tuple[str, Any]] = []
 
     @staticmethod
@@ -107,48 +107,45 @@ class TabbedEditHandlerGeneratorMixin:
     @classmethod
     def get_edit_handler_class(cls) -> Type["TabbedInterface"]:
         """
-        Return the class that `create_edit_handler()` should use to
-        generate an edit handler for the model. By default the
-        `edit_handler_class` class attribute value is used.
+        Return the class that `create_edit_handler()` should use to create the edit interface for
+        this model. By default, the `edit_handler_class` class attribute value is used.
         """
         return cls._import_if_string(cls.edit_handler_class)
 
     @classmethod
     def get_edit_handler_tab_class(cls, tab_name: str = None) -> Type["ObjectList"]:
         """
-        Returns the class that `create_edit_handler_tab()` should use to
-        create tab instances. The name of the tab currently being created is
-        provided as `tab_name` to allow subclasses to customise the class
-        for specific tabs only. By default the value of the
-        `edit_handler_tab_class` class attribute is used for all tabs.
+        Returns the class that `create_edit_handler_tab()` should use to create tabs for the edit
+        handler for this model. The name of the tab currently being created is provided as
+        `tab_name` to allow subclasses to return a different value for specific tabs. By default,
+        the `edit_handler_tab_class` class attribute value is used for all tabs.
         """
         return cls._import_if_string(cls.edit_handler_tab_class)
 
     @classmethod
     def get_base_form_class(cls) -> Type["Form"]:
         """
-        Returns the form class that `create_edit_handler()` should pass as the base form
-        to the edit handler it creates. By default, the value of the `base_form_class`
-        class attribute is used.
+        Returns the form class that `create_edit_handler` should provide as `base_form_class` when
+        creating the edit interface instance. By default, the `base_form_class` class attribute value
+        is used.
         """
         return cls._import_if_string(cls.base_form_class)
 
     @classmethod
     def get_edit_handler_tabs(cls) -> Iterable[Tuple[str, Any]]:
         """
-        Returns an iterable of tuples containing the `name` and `heading`
-        of each of the tabs to be potentially included in the edit handler
-        created by `create_edit_handler()`. By default, the value of the
-        `edit_handler_tabs` class attribute is used.
+        Returns an iterable of tuples containing the `name` and `heading` values for each
+        tab that `create_edit_hander_tabs()` should consider returning. By default, the
+        `edit_handler_tabs` class attribute value is used.
         """
         return cls.edit_handler_tabs
 
     @cached_classmethod
     def get_edit_handler(cls) -> "TabbedInterface":
         """
-        Returns a `TabbedInterface` instance that can be used
-        for adding/editing instances of this model, bound to
-        this model class.
+        Returns a `TabbedInterface` instance that can be used for adding/editing instances of this
+        model (bound to this class). By default, one is created by the `create_edit_handler()`
+        class method.
         """
         if hasattr(cls, "edit_handler") and cls.edit_handler is not None:
             obj = cls.edit_handler
@@ -160,8 +157,8 @@ class TabbedEditHandlerGeneratorMixin:
     @classmethod
     def create_edit_handler(cls) -> "TabbedInterface":
         """
-        Returns a `TabbedInterface` instance built using a number of
-        dedicated methods and attribute values from this class:
+        Creates and returns a `TabbedInterface` instance, using a number of dedicated methods and
+        attribute values from this class.
 
         The return value type is determined by `get_edit_handler_class()`.
 
@@ -186,11 +183,9 @@ class TabbedEditHandlerGeneratorMixin:
 
         Individual tabs are created by `create_edit_handler_tab()`.
 
-        NOTE: Tabs for which no panels can be found (or the list is empty)
-        are excluded from the return value. Tabs can also be explicitly
-        hidden for model classes by adding a `hide_{tab_name}_tab`
-        class attribute with a value of `True`, which is sometimes
-        preferential to overriding attributes and methods.
+        NOTE: Tabs for which no panels can be found (or where the list is empty) are not returned
+        by default. Tabs can also be explicitly hidden for model classes by adding a
+        `hide_{tab_name}_tab` class attribute with a value of `True`.
         """
         for name, heading in cls.get_edit_handler_tabs():
             # Allow subclasses to hide tabs without explicitly overridding
@@ -206,25 +201,23 @@ class TabbedEditHandlerGeneratorMixin:
         cls, name: str, heading: str
     ) -> Union["ObjectList", None]:
         """
-        Returns an `ObjectList` instance for this model class for the
-        supplied `name` and heading `values`.
+        Returns an `ObjectList` instance matching the provided `name` and `heading` values, and
+        a list of panels defined elsewhere on the model.
 
-        The return type of the object is determined by `get_edit_handler_tab_class()`
-        (usually the value of the model's `edit_handler_tab_class` attribute).
+        The return type of the object is determined by `get_edit_handler_tab_class()` (usually the
+        value of the model's `edit_handler_tab_class` attribute).
 
-        To determine the panels that appear in the tab, the `name` value is used
-        to search for one of the following (in order of preference):
+        To determine the panels that appear in the tab, the `name` value is used to find one of the
+        following (in order of preference):
 
         1. A classmethod called `get_{name}_panels()`.
         2. A class attribute called `{name}_panels`.
 
-        If neither of these attributes are found, or returns a falsey
-        value, a value of `None` will be returned, and the relevant tab will not be
-        added to the edit handler.
+        If neither of these attributes are found (or if one returns a falsey value), a value of
+        `None` is returned, indicating that the tab should not be included in the edit interface.
 
-        To hide a tab without explicitly overriding the relevant method or
-        attribute, you can add a `hide_{name}_tab` attribute to the class
-        with a value of `True`.
+        To hide a tab without explicitly overriding the relevant panel list method or attribute,
+        you can add a `hide_{name}_tab` attribute to the class with a value of `True`.
         """
         _class = cls.get_edit_handler_tab_class(name)
 

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -1,7 +1,16 @@
+from typing import TYPE_CHECKING, Any, Iterable, Tuple, Type, Union
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 from django.conf import settings
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.module_loading import import_string
+
+from wagtail.utils.decorators import cached_classmethod
+
+if TYPE_CHECKING:
+    from django.forms import Form
+
+    from wagtail.admin.panels.group import ObjectList, TabbedInterface
 
 
 def get_admin_base_url():
@@ -70,3 +79,164 @@ def set_query_params(url: str, params: dict):
     querydict = {key: value for key, value in querydict.items() if value is not None}
     query = urlencode(querydict, doseq=True)
     return urlunsplit((scheme, netloc, path, query, fragment))
+
+
+class TabbedEditHandlerGeneratorMixin:
+    # A class (or import path to a class) that `create_edit_handler()` should
+    # use to create the edit handler for the model.
+    edit_handler_class: Union[str, Type] = "wagtail.admin.panels.TabbedInterface"
+
+    # A class (or import path for a class) that `create_edit_handler_tab()` should
+    # use to create tabs for the model's edit handler.
+    edit_handler_tab_class: Union[str, Type] = "wagtail.admin.panels.ObjectList"
+
+    # A Form class (or import path for a Form class) that `create_edit_handler()`
+    # should pass as the `base_form` to the edit handler it creates.
+    base_form_class: Union[str, "Form"] = "wagtail.admin.forms.WagtailAdminModelForm"
+
+    # An iterable of (`name`, `heading`) tuples for each tab to be
+    # included in the edit handler for this model.
+    edit_handler_tabs: Iterable[Tuple[str, Any]] = []
+
+    @staticmethod
+    def _import_if_string(value: Union[str, Type]) -> Type:
+        if isinstance(value, str):
+            return import_string(value)
+        return value
+
+    @classmethod
+    def get_edit_handler_class(cls) -> Type["TabbedInterface"]:
+        """
+        Return the class that `create_edit_handler()` should use to
+        generate an edit handler for the model. By default the
+        `edit_handler_class` class attribute value is used.
+        """
+        return cls._import_if_string(cls.edit_handler_class)
+
+    @classmethod
+    def get_edit_handler_tab_class(cls, tab_name: str = None) -> Type["ObjectList"]:
+        """
+        Returns the class that `create_edit_handler_tab()` should use to
+        create tab instances. The name of the tab currently being created is
+        provided as `tab_name` to allow subclasses to customise the class
+        for specific tabs only. By default the value of the
+        `edit_handler_tab_class` class attribute is used for all tabs.
+        """
+        return cls._import_if_string(cls.edit_handler_tab_class)
+
+    @classmethod
+    def get_base_form_class(cls) -> Type["Form"]:
+        """
+        Returns the form class that `create_edit_handler()` should pass as the base form
+        to the edit handler it creates. By default, the value of the `base_form_class`
+        class attribute is used.
+        """
+        return cls._import_if_string(cls.base_form_class)
+
+    @classmethod
+    def get_edit_handler_tabs(cls) -> Iterable[Tuple[str, Any]]:
+        """
+        Returns an iterable of tuples containing the `name` and `heading`
+        of each of the tabs to be potentially included in the edit handler
+        created by `create_edit_handler()`. By default, the value of the
+        `edit_handler_tabs` class attribute is used.
+        """
+        return cls.edit_handler_tabs
+
+    @cached_classmethod
+    def get_edit_handler(cls) -> "TabbedInterface":
+        """
+        Returns a `TabbedInterface` instance that can be used
+        for adding/editing instances of this model, bound to
+        this model class.
+        """
+        if hasattr(cls, "edit_handler") and cls.edit_handler is not None:
+            obj = cls.edit_handler
+        else:
+            obj = cls.create_edit_handler()
+
+        return obj.bind_to_model(cls)
+
+    @classmethod
+    def create_edit_handler(cls) -> "TabbedInterface":
+        """
+        Returns a `TabbedInterface` instance built using a number of
+        dedicated methods and attribute values from this class:
+
+        The return value type is determined by `get_edit_handler_class()`.
+
+        The potential list of tabs included in the interface is determined by
+        `get_edit_handler_tabs()`.
+
+        The tabs themselves are created by `create_edit_hander_tabs()`.
+        """
+        _class = cls.get_edit_handler_class()
+        return _class(
+            list(cls.create_edit_hander_tabs()),
+            base_form_class=cls.get_base_form_class(),
+        )
+
+    @classmethod
+    def create_edit_hander_tabs(cls) -> Iterable["ObjectList"]:
+        """
+        Returns an iterable of `ObjectList` instances for each of the tabs to be included in the
+        edit interface for this model. By default, the return value is determined by
+        `get_edit_handler_tabs()` (usually the value of the model's `edit_handler_tabs`
+        attribute), and whether panels can be found for them.
+
+        Individual tabs are created by `create_edit_handler_tab()`.
+
+        NOTE: Tabs for which no panels can be found (or the list is empty)
+        are excluded from the return value. Tabs can also be explicitly
+        hidden for model classes by adding a `hide_{tab_name}_tab`
+        class attribute with a value of `True`, which is sometimes
+        preferential to overriding attributes and methods.
+        """
+        for name, heading in cls.get_edit_handler_tabs():
+            # Allow subclasses to hide tabs without explicitly overridding
+            # the attribute or method to return an empty list.
+            if getattr(cls, f"hide_{name}_tab", False) is True:
+                continue
+
+            if tab := cls.create_edit_handler_tab(name, heading):
+                yield tab
+
+    @classmethod
+    def create_edit_handler_tab(
+        cls, name: str, heading: str
+    ) -> Union["ObjectList", None]:
+        """
+        Returns an `ObjectList` instance for this model class for the
+        supplied `name` and heading `values`.
+
+        The return type of the object is determined by `get_edit_handler_tab_class()`
+        (usually the value of the model's `edit_handler_tab_class` attribute).
+
+        To determine the panels that appear in the tab, the `name` value is used
+        to search for one of the following (in order of preference):
+
+        1. A classmethod called `get_{name}_panels()`.
+        2. A class attribute called `{name}_panels`.
+
+        If neither of these attributes are found, or returns a falsey
+        value, a value of `None` will be returned, and the relevant tab will not be
+        added to the edit handler.
+
+        To hide a tab without explicitly overriding the relevant method or
+        attribute, you can add a `hide_{name}_tab` attribute to the class
+        with a value of `True`.
+        """
+        _class = cls.get_edit_handler_tab_class(name)
+
+        # Find panels to include in this tab
+        if generator_method := getattr(cls, f"get_{name}_panels", None):
+            # Prefer a method if one exists
+            panels = list(generator_method())
+        else:
+            # Fall back to class attribute
+            panels = list(getattr(cls, f"{name}_panels", []))
+
+        if not panels:
+            return None
+
+        return _class(panels, heading=heading)

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -64,6 +64,7 @@ from wagtail.actions.publish_page_revision import PublishPageRevisionAction
 from wagtail.actions.publish_revision import PublishRevisionAction
 from wagtail.actions.unpublish import UnpublishAction
 from wagtail.actions.unpublish_page import UnpublishPageAction
+from wagtail.admin.utils import TabbedEditHandlerGeneratorMixin
 from wagtail.coreutils import (
     WAGTAIL_APPEND_SLASH,
     camelcase_to_underscore,
@@ -1079,6 +1080,7 @@ class AbstractPage(
     RevisionMixin,
     TranslatableMixin,
     SpecificMixin,
+    TabbedEditHandlerGeneratorMixin,
     MP_Node,
 ):
     """
@@ -1089,6 +1091,16 @@ class AbstractPage(
     """
 
     objects = PageManager()
+
+    # The form class used as the base form for the model's edit handler
+    base_form_class = "wagtail.admin.forms.WagtailAdminPageForm"
+
+    # The tabs to include in the model's editing interface.
+    edit_handler_tabs = [
+        ("content", _("Content")),
+        ("promote", _("Promote")),
+        ("settings", _("Settings")),
+    ]
 
     class Meta:
         abstract = True


### PR DESCRIPTION
There are a few reasons for this PR:

1. Overriding the `get_edit_handler()` method for a page type simply isn't very visible as an option. I think having it clearly defined and inherited like this will improve visibility for those poking around in the codebase.
2. The 'messing with class attribute values' that happens a lot for `content_panels`, `promote_panels` and `settings_panels` in Wagtail projects can be messy at times. The option to manipulate panels in methods instead could offer some relief from that.
3. There are occasions where you want to do something 'slightly more clever' with panel lists than what class attributes alone allow for. For example: using another class attribute to determine the `min_num` or `max_num` values for an inline panel (and wanting it to reflect changes made on subclasses). In these situations, being able to use a class method to generate panel lists is super handy too.
4. I often find myself wanting to introduce new tabs site-wide in projects, but the options outlined in the docs currently aren't hugely helpful (override `edit_handler` directly on the model class). In most projects, I'll want to do this sort of thing in my `BasePage` class, then use class attributes and other things to determine which page types use the tab and which don't... I want to make this sort of basic addition really simple to make, and to be able to control visibility in a way that is consistant with all other tabs.
5. I've often had circular import issues when customising `base_form_class` on custom page classes (because the `forms.py` module often needs to import the page type), so allowing this to be specified via import path instead reduces friction a little.  
6. The current patching of the `Page` model that happens in `wagtail.admin.panels.page_utils` is surely undesirable? I know there are circular import issues at play, but we've solved that problem in other places, and can remove some of it.