### PR TITLE
Fix alias() not compatible with specific()

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ Changelog
  * Fix: Avoid error when attempting to moderate a page drafted by a now deleted user (Dan Braghis)
  * Fix: Do not show multiple error messages when editing a Site to use existing hostname and port (Rohit Sharma)
  * Fix: Avoid error when exporting Aging Pages report where a page has an empty `last_published_by_user` (Chiemezuo Akujobi)
+ * Fix: Ensure Page querysets support using `alias` and `specific` (Tomasz Knapik)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)
  * Docs: Add section to testing docs about creating pages and working with page content (Mariana Bedran Lesche)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -47,6 +47,7 @@ depth: 1
  * Avoid error when attempting to moderate a page drafted by a now deleted user (Dan Braghis)
  * Do not show multiple error messages when editing a Site to use existing hostname and port (Rohit Sharma)
  * Avoid error when exporting Aging Pages report where a page has an empty `last_published_by_user` (Chiemezuo Akujobi)
+ * Ensure Page querysets support using `alias` and `specific` (Tomasz Knapik)
 
 ### Documentation
 

--- a/wagtail/query.py
+++ b/wagtail/query.py
@@ -515,7 +515,7 @@ class SpecificIterable(BaseIterable):
         in the same order, with any annotations intact.
         """
         qs = self.queryset
-        annotation_aliases = qs.query.annotations.keys()
+        annotation_aliases = qs.query.annotation_select
         values_qs = qs.values("pk", "content_type", *annotation_aliases)
 
         # Gather items in batches to reduce peak memory usage

--- a/wagtail/tests/test_page_queryset.py
+++ b/wagtail/tests/test_page_queryset.py
@@ -919,6 +919,25 @@ class TestSpecificQuery(WagtailTestUtils, TestCase):
         self.assertEqual(results.first().subscribers_count, 1)
         self.assertEqual(results.last().subscribers_count, 1)
 
+    def test_specific_query_with_alias(self):
+        """
+        Ensure alias() works with specific() queries.
+        See https://github.com/wagtail/wagtail/issues/11285 for more details
+        """
+
+        pages = Page.objects.live()
+        user = self.create_test_user()
+        pages.first().subscribers.create(user=user, comment_notifications=False)
+        pages.last().subscribers.create(user=user, comment_notifications=False)
+
+        # This would previously fail as described in #11285.
+        iter(
+            Page.objects.live()
+            .specific()
+            .alias(subscribers_count=Count("subscribers"))
+            .order_by("subscribers_count")
+        )
+
     def test_specific_gracefully_handles_missing_models(self):
         # 3567 - PageQuerySet.specific should gracefully handle pages whose class definition
         # is missing, by keeping them as basic Page instances.


### PR DESCRIPTION
Fixes #11285.

It adds a test to check for regressions.

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
