### PR TITLE
Fix chooser buttons focus color is too dark in dark mode

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -45,7 +45,7 @@ Changelog
  * Add `WAGTAILADMIN_LOGIN_URL` setting to allow customising the login URL (Neeraj Yetheendran)
  * Replace legacy dropdown component with new Tippy dropdown-button (Thibaud Colas)
  * Add ability to filter by existence of child pages in the page listing view (Matt Westcott)
- * Polish dark theme styles and update color tokens (Thibaud Colas)
+ * Polish dark theme styles and update color tokens (Thibaud Colas, Rohit Sharma)
  * Keep database state of pages and snippets updated while in draft state (Stefan Hammer)
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)

--- a/client/scss/components/_chooser.scss
+++ b/client/scss/components/_chooser.scss
@@ -28,7 +28,7 @@ $preview-size: 2.625rem; // 42px
 
   &:hover,
   &:focus {
-    color: theme('colors.surface-button-hover');
+    color: theme('colors.text-link-hover');
     background-color: theme('colors.surface-page');
   }
 }

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -72,7 +72,7 @@ Thank you to Thibaud Colas, Badr Fourane, and Sage Abdullah for their work on th
  * Add `WAGTAILADMIN_LOGIN_URL` setting to allow customising the login URL (Neeraj Yetheendran)
  * Replace legacy dropdown component with new Tippy dropdown-button (Thibaud Colas)
  * Add ability to filter by existence of child pages in the page listing view (Matt Westcott)
- * Polish dark theme styles and update color tokens (Thibaud Colas)
+ * Polish dark theme styles and update color tokens (Thibaud Colas, Rohit Sharma)
  * Keep database state of pages and snippets updated while in draft state (Stefan Hammer)
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10875

**Before**

![Screenshot (41)](https://github.com/wagtail/wagtail/assets/111359305/4f5f0907-2beb-4506-9864-b42ae6c18c7a)

**After (Updated in 2nd commit)**

![Screenshot (42)](https://github.com/wagtail/wagtail/assets/111359305/dc6902d0-86da-4195-bb44-7f90d1823b5c)




_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
