### PR TITLE
Make page index template extend generic index template

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/generic/listing.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/listing.html
@@ -17,6 +17,8 @@
             </div>
         </div>
     {% endblock %}
+
+    {% block bulk_actions %}{% endblock %}
 {% endblock %}
 
 {% block extra_js %}

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -11,6 +11,8 @@
     <div id="listing-results">
         {% include 'wagtailadmin/pages/index_results.html' %}
     </div>
+{% endblock %}
+{% block bulk_actions %}
     {% include 'wagtailadmin/bulk_actions/footer.html' with select_all_obj_text=_("Select all pages in listing") app_label='wagtailcore' model_name='page' objects=page_obj %}
 {% endblock %}
 

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -1,4 +1,4 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/index.html" %}
 {% load wagtailadmin_tags i18n %}
 {% block titletag %}{% blocktrans trimmed with title=parent_page.get_admin_display_title %}Exploring {{ title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}page-explorer {% if ordering == 'ord' %}reordering{% endif %}{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -1,6 +1,5 @@
 {% extends "wagtailadmin/generic/index.html" %}
 {% load wagtailadmin_tags i18n %}
-{% block titletag %}{% blocktrans trimmed with title=parent_page.get_admin_display_title %}Exploring {{ title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}page-explorer {% if ordering == 'ord' %}reordering{% endif %}{% endblock %}
 
 {% block content %}

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -2,9 +2,12 @@
 {% load wagtailadmin_tags i18n %}
 {% block bodyclass %}page-explorer {% if ordering == 'ord' %}reordering{% endif %}{% endblock %}
 
-{% block content %}
+{% block header %}
     {% page_permissions parent_page as parent_page_perms %}
     {% include 'wagtailadmin/pages/page_listing_header.html' with title=parent_page.get_admin_display_title page_perms=parent_page_perms %}
+{% endblock %}
+
+{% block listing %}
     <div id="listing-results">
         {% include 'wagtailadmin/pages/index_results.html' %}
     </div>

--- a/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
@@ -20,16 +20,8 @@
     {% page_header_buttons parent_page user=request.user view_name="index" %}
 {% endblock %}
 {% block actions %}
-    {% if not parent_page.is_root %}
-        {% include "wagtailadmin/shared/side_panel_toggles.html" %}
-        {# Page history #}
-        {% if parent_page.get_latest_revision %}
-            {% url 'wagtailadmin_pages:history' parent_page.id as history_url %}
-            {% include "wagtailadmin/shared/headers/_history_icon_link.html" with history_url=history_url nav_icon_button_classes=nav_icon_button_classes nav_icon_classes=nav_icon_classes only %}
-        {% endif %}
-
-        {% include "wagtailadmin/shared/page_status_tag_new.html" with page=parent_page %}
-    {% endif %}
+    {{ block.super }}
+    {% include "wagtailadmin/shared/page_status_tag_new.html" with page=parent_page %}
 {% endblock %}
 
 {% block search_form %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
@@ -16,12 +16,5 @@
 
 {% block actions %}
     {{ block.super }}
-
-    {# Page history #}
-    {% if page.get_latest_revision %}
-        {% url 'wagtailadmin_pages:history' page.id as history_url %}
-        {% include "wagtailadmin/shared/headers/_history_icon_link.html" with history_url=history_url nav_icon_button_classes=nav_icon_button_classes nav_icon_classes=nav_icon_classes only %}
-    {% endif %}
-
     {% include "wagtailadmin/shared/page_status_tag_new.html" with page=page_for_status %}
 {% endblock %}

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -171,6 +171,15 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             response, reverse("wagtailadmin_pages:usage", args=(self.event_page.id,))
         )
 
+        # test that the link to the history view is shown,
+        # one in the header dropdown button, one beside the side panel toggles,
+        # one in the status side panel
+        self.assertContains(
+            response,
+            reverse("wagtailadmin_pages:history", args=(self.event_page.id,)),
+            count=3,
+        )
+
         # test that AdminURLFinder returns the edit view for the page
         url_finder = AdminURLFinder(self.user)
         expected_url = "/admin/pages/%d/edit/" % self.event_page.id

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -31,6 +31,7 @@ from wagtail.test.testapp.models import (
     EVENT_AUDIENCE_CHOICES,
     Advert,
     AdvertPlacement,
+    CustomPermissionPage,
     EventCategory,
     EventPage,
     EventPageCarouselItem,
@@ -197,6 +198,18 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         self.assertContains(response, "Referenced 1 time")
         self.assertContains(
             response, reverse("wagtailadmin_pages:usage", args=(self.event_page.id,))
+        )
+
+    def test_edit_custom_permissions(self):
+        page = CustomPermissionPage(title="Page with custom perms", slug="custom-perms")
+        self.root_page.add_child(instance=page)
+        response = self.client.get(reverse("wagtailadmin_pages:edit", args=(page.id,)))
+        self.assertEqual(response.status_code, 200)
+        # Respecting PagePermissionTester.can_view_revisions(),
+        # should not contain a link to the history view
+        self.assertNotContains(
+            response,
+            reverse("wagtailadmin_pages:history", args=(page.id,)),
         )
 
     @override_settings(WAGTAIL_WORKFLOW_ENABLED=False)

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -68,6 +68,16 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
 
         self.assertContains(response, "1-3 of 3")
 
+        # Should contain a link to the history view
+        # one in the header dropdown button, one beside the side panel toggles,
+        # one in the status side panel
+        # (root_page is a site root, not the Root page, so it should be shown)
+        self.assertContains(
+            response,
+            reverse("wagtailadmin_pages:history", args=(self.root_page.id,)),
+            count=3,
+        )
+
     def test_explore_results(self):
         explore_results_url = reverse(
             "wagtailadmin_explore_results", args=(self.root_page.id,)
@@ -99,6 +109,11 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
         self.assertEqual(Page.objects.get(id=1), response.context["parent_page"])
         self.assertIn(self.root_page, response.context["pages"])
+        # Should not contain a link to the history view
+        self.assertNotContains(
+            response,
+            reverse("wagtailadmin_pages:history", args=(1,)),
+        )
 
     def test_explore_root_shows_icon(self):
         response = self.client.get(reverse("wagtailadmin_explore_root"))

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -8,7 +8,12 @@ from django.utils.http import urlencode
 from wagtail import hooks
 from wagtail.admin.widgets import Button
 from wagtail.models import GroupPagePermission, Locale, Page, Workflow
-from wagtail.test.testapp.models import SimplePage, SingleEventPage, StandardIndex
+from wagtail.test.testapp.models import (
+    CustomPermissionPage,
+    SimplePage,
+    SingleEventPage,
+    StandardIndex,
+)
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.timestamps import local_datetime
 from wagtail.utils.deprecation import RemovedInWagtail70Warning
@@ -494,6 +499,18 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         page_ids = [page.id for page in response.context["pages"]]
         self.assertEqual(page_ids, [self.old_page.id])
         self.assertContains(response, "Search within 'New page (simple page)'")
+
+    def test_explore_custom_permissions(self):
+        page = CustomPermissionPage(title="Page with custom perms", slug="custom-perms")
+        self.root_page.add_child(instance=page)
+        response = self.client.get(reverse("wagtailadmin_explore", args=(page.id,)))
+        self.assertEqual(response.status_code, 200)
+        # Respecting PagePermissionTester.can_view_revisions(),
+        # should not contain a link to the history view
+        self.assertNotContains(
+            response,
+            reverse("wagtailadmin_pages:history", args=(page.id,)),
+        )
 
 
 class TestBreadcrumb(WagtailTestUtils, TestCase):

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -237,9 +237,13 @@ class PageStatusSidePanel(StatusSidePanel):
         super().__init__(*args, **kwargs)
         if self.object.pk:
             self.usage_url = reverse("wagtailadmin_pages:usage", args=(self.object.pk,))
-            self.history_url = reverse(
-                "wagtailadmin_pages:history", args=(self.object.pk,)
-            )
+
+            permissions = self.object.permissions_for_user(self.request.user)
+            if permissions.can_view_revisions():
+                self.history_url = reverse(
+                    "wagtailadmin_pages:history",
+                    args=(self.object.pk,),
+                )
 
     def get_status_templates(self, context):
         templates = super().get_status_templates(context)

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -840,6 +840,11 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
     def get_preview_url(self):
         return reverse("wagtailadmin_pages:preview_on_edit", args=[self.page.id])
 
+    def get_history_url(self):
+        permissions = self.page.permissions_for_user(self.request.user)
+        if permissions.can_view_revisions():
+            return reverse("wagtailadmin_pages:history", args=[self.page.id])
+
     def get_side_panels(self):
         side_panels = [
             PageStatusSidePanel(
@@ -890,6 +895,7 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
                 "side_panels": side_panels,
                 "form": self.form,
                 "next": self.next_url,
+                "history_url": self.get_history_url(),
                 "has_unsaved_changes": self.has_unsaved_changes,
                 "page_locked": self.locked_for_user,
                 "workflow_state": self.workflow_state

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -243,6 +243,11 @@ class BaseIndexView(PermissionCheckedMixin, BaseListingView):
             }
         return kwargs
 
+    def get_page_title(self):
+        return _("Exploring %(title)s") % {
+            "title": self.parent_page.get_admin_display_title()
+        }
+
     def get_context_data(self, **kwargs):
         self.show_ordering_column = self.ordering == "ord"
         if self.show_ordering_column:

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -229,7 +229,8 @@ class BaseIndexView(PermissionCheckedMixin, BaseListingView):
         return reverse("wagtailadmin_explore_results", args=[self.parent_page.id])
 
     def get_history_url(self):
-        if not self.parent_page.is_root():
+        permissions = self.parent_page.permissions_for_user(self.request.user)
+        if permissions.can_view_revisions():
             return reverse("wagtailadmin_pages:history", args=[self.parent_page.id])
 
     def get_table_kwargs(self):

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -228,6 +228,10 @@ class BaseIndexView(PermissionCheckedMixin, BaseListingView):
     def get_results_url(self):
         return reverse("wagtailadmin_explore_results", args=[self.parent_page.id])
 
+    def get_history_url(self):
+        if not self.parent_page.is_root():
+            return reverse("wagtailadmin_pages:history", args=[self.parent_page.id])
+
     def get_table_kwargs(self):
         kwargs = super().get_table_kwargs()
         kwargs["use_row_ordering_attributes"] = self.show_ordering_column
@@ -278,6 +282,7 @@ class BaseIndexView(PermissionCheckedMixin, BaseListingView):
                 "ordering": self.ordering,
                 "index_url": self.get_index_url(),
                 "results_url": self.get_results_url(),
+                "history_url": self.get_history_url(),
                 "search_form": self.search_form,
                 "is_searching": self.is_searching,
                 "is_searching_whole_tree": self.is_searching_whole_tree,
@@ -302,6 +307,10 @@ class IndexView(BaseIndexView):
     template_name = "wagtailadmin/pages/index.html"
 
     def get_side_panels(self):
+        # Don't show side panels on the root page
+        if self.parent_page.is_root():
+            return MediaContainer()
+
         side_panels = [
             PageStatusSidePanel(
                 self.parent_page.get_latest_revision_as_object(),

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -2193,7 +2193,8 @@ class SearchTestModel(models.Model):
 
 
 class CustomPermissionTester(PagePermissionTester):
-    pass
+    def can_view_revisions(self):
+        return False
 
 
 class CustomPermissionPage(Page):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

As part of our work for #10446, this PR minimises the gap between the generic views' templates and the page views' templates.

This also fixes #10892. ~~Not sure if I should add tests for an overridden `can_view_revisions()` though, given that we're planning to refine the permissions system in the future. FWIW we already have a page model with a custom tester class introduced in #10702 so it should be relatively simple to add the test.~~ Added the tests.

I probably shouldn't have touched too much on the permissions stuff in this PR, but it was very tempting. I know that we discussed potentially reworking `PagePermissionTester` into a stateless class and/or merging it with `PagePermissionPolicy`, but I think that would be too big of a change. For minimising breaking change while still unifying the permission system and allowing for customisation, I think testers and policies will coexist for different purposes. Anyway, that's a discussion for later.



_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
