### PR TITLE
add way to set default ordering for child pages in wagtail

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changelog
  * Use a single instance of `PagePermissionPolicy` in `wagtail.permissions` module (Sage Abdullah)
  * Add max tag length validation for multiple uploads (documents/images) (Temidayo Azeez)
  * Ensure expanded side panel does not overlap form content for most viewports (Chiemezuo Akujobi)
+ * Add ability to modify the default ordering for the page explorer view (Shlomo Markowitz)
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -773,6 +773,7 @@
 * Mariana Bedran Lesche
 * Bhuvnesh Sharma
 * Ben Morse
+* Shlomo Markowitz
 
 ## Translators
 

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -218,6 +218,36 @@ See also [django-treebeard](https://django-treebeard.readthedocs.io/en/latest/in
 
     .. automethod:: copy_for_translation
 
+    .. method:: get_admin_default_ordering
+
+       Returns the default sort order for child pages to be sorted in viewing the admin pages index and not seeing search results.
+
+       The following sort orders are available:
+
+       - ``'content_type'``
+       - ``'-content_type'``
+       - ``'latest_revision_created_at'``
+       - ``'-latest_revision_created_at'``
+       - ``'live'``
+       - ``'-live'``
+       - ``'ord'``
+       - ``'title'``
+       - ``'-title'``
+
+       For example to make a page sort by title for all the child pages only if there are < 20 pages.
+
+       .. code-block:: python
+
+           class BreadsIndexPage(Page):
+               def get_admin_default_ordering(self):
+                   if Page.objects.child_of(self).count() < 20:
+                       return 'title'
+                   return self.admin_default_ordering
+
+    .. attribute:: admin_default_ordering
+
+        An attribute version for the method ``get_admin_default_ordering()``, defaults to ``'-latest_revision_created_at'``.
+
     .. autoattribute:: localized
 
     .. autoattribute:: localized_draft

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -28,6 +28,7 @@ depth: 1
  * Use a single instance of `PagePermissionPolicy` in `wagtail.permissions` module (Sage Abdullah)
  * Add max tag length validation for multiple uploads (documents/images) (Temidayo Azeez)
  * Ensure expanded side panel does not overlap form content for most viewports (Chiemezuo Akujobi)
+ * Add ability to [modify the default ordering](page_model_ref) for the page explorer view (Shlomo Markowitz)
 
 ### Bug fixes
 

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -321,6 +321,18 @@ class IndexView(BaseIndexView):
         )
         return context
 
+    def get_ordering(self):
+        """
+        Use the parent Page's `get_admin_default_ordering` method.
+        """
+        if self.query_string:
+            # default to ordering by relevance
+            return None
+        elif not self.request.GET.get("ordering"):
+            return self.parent_page.get_admin_default_ordering()
+
+        return super().get_ordering()
+
 
 class IndexResultsView(BaseIndexView):
     template_name = "wagtailadmin/pages/index_results.html"

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -1245,6 +1245,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
     # Define the maximum number of instances this page can have under a specific parent. Default to unlimited.
     max_count_per_parent = None
 
+    # Set the default order for child pages to be shown in the Page index listing
+    admin_default_ordering = "-latest_revision_created_at"
+
     # An array of additional field names that will not be included when a Page is copied.
     exclude_fields_in_copy = []
     default_exclude_fields_in_copy = [
@@ -1361,6 +1364,13 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             )
 
         return super().get_default_locale()
+
+    def get_admin_default_ordering(self):
+        """
+        Determine the default ordering for child pages in the admin index listing.
+        Returns a string (e.g. 'latest_revision_created_at, title, ord' or 'live').
+        """
+        return self.admin_default_ordering
 
     def full_clean(self, *args, **kwargs):
         # Apply fixups that need to happen before per-field validation occurs


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->
Add a way to set the default sort options for all child pages in the wagtail page view.

for example, in the bakerydemo BreadsIndexPage I can now add:

```
class BreadsIndexPage(Page):
   ...
   # defaults to -latest_revision_created_at
   default_order = ''ord" # can be all the valid orderings ('title', 'live', '-live', '-title', ...)
   
   # or can set method get_default_order() for more control
   def get_default_order(self):
      """"
      orders the children of the page by ord (allows reordering the page) if less then 20 child pages
      if 20 or more pages use the default setting
      """
       if Page.objects.child_of(self).count() < 20:
           return 'ord'
       return '-latest_revision_created_at'
 
```


It is possible that there is a way to do it in wagtail already, but I was not able to find it looking through the docs.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**:
    -   [x] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
