### PR TITLE
Fix: Remove need for inline scripts to enable commenting client-side

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -101,6 +101,8 @@ Changelog
  * Maintenance: Move logic for django-filters filtering into `BaseListingView` (Matt Westcott)
  * Maintenance: Refactor listing views to share more queryset ordering logic (Matt Westcott)
  * Maintenance: Remove `initTooltips` in favour of Stimulus controller (LB (Ben) Johnston)
+ * Maintenance: Enhance the Stimulus `InitController` to allow for custom event dispatching when ready (ADITYA, LB (Ben) Johnston)
+ * Maintenance: Remove inline script usage for comment initialization and adopt an event listener/dispatch approach for better CSP compliance (ADITYA, LB (Ben) Johnston)
 
 
 5.2.3 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/entrypoints/admin/comments.js
+++ b/client/src/entrypoints/admin/comments.js
@@ -338,6 +338,17 @@ window.comments = (() => {
     updateCommentCount();
   }
 
+  /** Add support for initializing comments via event dispatching. */
+  document.addEventListener(
+    'w-comments:init',
+    ({ target }) => {
+      setTimeout(() => {
+        initCommentsInterface(target);
+      });
+    },
+    { once: true },
+  );
+
   return {
     commentApp,
     getContentPath,

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -139,6 +139,8 @@ Thank you to Thibaud Colas and Badr Fourane for their work on this feature.
  * Remove invalid CSS styles / Sass selector concatenation (Thibaud Colas)
  * Refactor listing views to share more queryset ordering logic (Matt Westcott)
  * Remove `initTooltips` in favour of Stimulus controller (LB (Ben) Johnston)
+ * Enhance the Stimulus `InitController` to allow for custom event dispatching when ready (ADITYA, LB (Ben) Johnston)
+ * Remove inline script usage for comment initialization and adopt an event listener/dispatch approach for better CSP compliance (ADITYA, LB (Ben) Johnston)
 
 ## Upgrade considerations - removal of deprecated features from Wagtail 4.2 - 5.1
 

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -4,10 +4,11 @@
 {% block bodyclass %}editor-view{% endblock %}
 
 {% block content %}
+    {% get_comments_enabled as comments_enabled %}
 
     {% include 'wagtailadmin/shared/headers/page_create_header.html' with title=header_title %}
 
-    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %} data-edit-form>
+    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %} data-edit-form{% if comments_enabled %} data-controller="w-init" data-w-init-event-value="w-comments:init"{% endif %}>
         {% csrf_token %}
 
         <input type="hidden" name="next" value="{{ next }}">
@@ -81,12 +82,6 @@
                     commentApp: window.comments.commentApp
                 }
             );
-
-            {% get_comments_enabled as comments_enabled %}
-            {% if comments_enabled %}
-                // Initialise comments UI
-                window.comments.initCommentsInterface(document.getElementById('page-edit-form'));
-            {% endif %}
         });
     </script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -5,13 +5,14 @@
 {% block bodyclass %}editor-view {% if page.live %}page-is-live{% endif %} {% if page_locked %}content-locked{% endif %}{% endblock %}
 
 {% block content %}
+    {% get_comments_enabled as comments_enabled %}
     {% page_permissions page as page_perms %}
 
     {% include 'wagtailadmin/shared/headers/page_edit_header.html' with title=header_title %}
 
     {% block form %}
 
-        <form id="page-edit-form" action="{% url 'wagtailadmin_pages:edit' page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %} data-edit-form>
+        <form id="page-edit-form" action="{% url 'wagtailadmin_pages:edit' page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %} data-edit-form{% if comments_enabled %} data-controller="w-init" data-w-init-event-value="w-comments:init"{% endif %}>
             {% csrf_token %}
 
             <input type="hidden" name="next" value="{{ next }}">
@@ -81,12 +82,6 @@
                     commentApp: window.comments.commentApp
                 }
             );
-
-            {% get_comments_enabled as comments_enabled %}
-            {% if comments_enabled %}
-                // Initialise comments UI
-                window.comments.initCommentsInterface(document.getElementById('page-edit-form'));
-            {% endif %}
         });
     </script>
 

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -1874,3 +1874,46 @@ class TestPageSubscriptionSettings(WagtailTestUtils, TestCase):
 
         self.assertEqual(subscription.user, self.user)
         self.assertFalse(subscription.comment_notifications)
+
+
+class TestCommenting(WagtailTestUtils, TestCase):
+    """
+    Tests the commenting related logic of the create page view.
+    """
+
+    def setUp(self):
+        # Find root page
+        self.root_page = Page.objects.get(id=2)
+
+        # Login
+        self.user = self.login()
+
+    def test_commments_enabled_by_default(self):
+        response = self.client.get(
+            reverse(
+                "wagtailadmin_pages:add",
+                args=["tests", "simplepage", self.root_page.id],
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'data-edit-form data-controller="w-init" data-w-init-event-value="w-comments:init"',
+        )
+
+    @override_settings(WAGTAILADMIN_COMMENTS_ENABLED=False)
+    def test_commments_disabled(self):
+        response = self.client.get(
+            reverse(
+                "wagtailadmin_pages:add",
+                args=["tests", "simplepage", self.root_page.id],
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "data-edit-form")
+        self.assertNotContains(
+            response,
+            'data-controller="w-init" data-w-init-event-value="w-comments:init"',
+        )

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -3215,6 +3215,31 @@ class TestCommenting(WagtailTestUtils, TestCase):
             [to for email in mail.outbox for to in email.to],
         )
 
+    def test_commments_enabled_by_default(self):
+        response = self.client.get(
+            reverse("wagtailadmin_pages:edit", args=[self.child_page.id])
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "data-edit-form")
+        self.assertContains(
+            response,
+            'data-edit-form data-controller="w-init" data-w-init-event-value="w-comments:init"',
+        )
+
+    @override_settings(WAGTAILADMIN_COMMENTS_ENABLED=False)
+    def test_commments_disabled(self):
+        response = self.client.get(
+            reverse("wagtailadmin_pages:edit", args=[self.child_page.id])
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "data-edit-form")
+        self.assertNotContains(
+            response,
+            'data-controller="w-init" data-w-init-event-value="w-comments:init"',
+        )
+
     def test_new_comment(self):
         post_data = {
             "title": "I've been edited!",


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #https://github.com/wagtail/wagtail/issues/11287







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
