### PR TITLE
Add official Django 5.0 support, and drop 4.1 from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,17 +20,17 @@ concurrency:
 # - test runs with USE_EMAIL_USER_MODEL=yes and DISABLE_TIMEZONE=yes
 
 # Current configuration:
-# - django 3.2, python 3.8, postgres:12, parallel
-# - django 3.2, python 3.9, mysql:8.0
-# - django 4.1, python 3.10, sqlite
-# - django 4.2, python 3.11, mysql:8.1, parallel
-# - django 4.1, python 3.11, postgres:12, parallel, USE_EMAIL_USER_MODEL=yes
-# - django 4.2, python 3.12, postgres:15, parallel, DISABLE_TIMEZONE=yes
+# - django 4.2, python 3.8, postgres:12, parallel
+# - django 4.2, python 3.9, mysql:8.0
+# - django 4.2, python 3.10, sqlite
+# - django 5.0, python 3.12, mysql:8.1, parallel
+# - django 5.0, python 3.11, postgres:12, parallel, USE_EMAIL_USER_MODEL=yes
+# - django 5.0, python 3.12, postgres:15, parallel, DISABLE_TIMEZONE=yes
 # - django stable/5.0.x, python 3.10, postgres (allow failures)
 # - django main, python 3.10, postgres:latest, parallel (allow failures)
-# - elasticsearch 7, django 3.2, python 3.8, postgres:latest
-# - opensearch 2, django 4.1, python 3.9, sqlite
-# - elasticsearch 8, django 4.2, python 3.10, sqlite, USE_EMAIL_USER_MODEL=yes
+# - elasticsearch 7, django 4.2, python 3.8, postgres:latest
+# - opensearch 2, django 4.2, python 3.9, sqlite
+# - elasticsearch 8, django 5.0, python 3.10, sqlite, USE_EMAIL_USER_MODEL=yes
 
 # Some tests are run in parallel by passing --parallel to runtests.py.
 # When running tests in parallel, some errors cannot be pickled and result in
@@ -48,7 +48,7 @@ jobs:
       matrix:
         include:
           - python: '3.10'
-            django: 'Django>=4.1,<4.2'
+            django: 'Django>=4.2,<4.3'
 
     steps:
       - uses: actions/checkout@v3
@@ -80,16 +80,16 @@ jobs:
       matrix:
         include:
           - python: '3.8'
-            django: 'Django>=3.2,<3.3'
+            django: 'Django>=4.2,<4.3'
             experimental: false
             parallel: '--parallel'
           - python: '3.11'
-            django: 'Django>=4.1,<4.2'
+            django: 'Django>=5.0,<5.1'
             experimental: false
             emailuser: emailuser
             parallel: '--parallel'
           - python: '3.12'
-            django: 'Django>=4.2,<4.3'
+            django: 'Django>=5.0,<5.1'
             postgres: 'postgres:15'
             notz: notz
             experimental: false
@@ -153,10 +153,10 @@ jobs:
       matrix:
         include:
           - python: '3.9'
-            django: 'Django>=3.2,<3.3'
-            experimental: false
-          - python: '3.11'
             django: 'Django>=4.2,<4.3'
+            experimental: false
+          - python: '3.12'
+            django: 'Django>=5.0,<5.1'
             experimental: false
             parallel: '--parallel'
             mysql: 'mysql:8.1'
@@ -202,7 +202,7 @@ jobs:
       matrix:
         include:
           - python: '3.10'
-            django: 'Django>=4.2,<4.3'
+            django: 'Django>=5.0,<5.1'
             emailuser: emailuser
     steps:
       - name: Configure sysctl limits
@@ -251,7 +251,7 @@ jobs:
       matrix:
         include:
           - python: '3.8'
-            django: 'Django>=3.2,<3.3'
+            django: 'Django>=4.2,<4.3'
             experimental: false
 
     services:
@@ -309,7 +309,7 @@ jobs:
       matrix:
         include:
           - python: '3.9'
-            django: 'Django>=4.1,<4.2'
+            django: 'Django>=4.2,<4.3'
             experimental: false
 
     steps:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ Changelog
 6.0 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~
 
+ * Added support for Django 5.0
  * Added `search_index` option to StreamField blocks to control whether the block is indexed for searching (Vedant Pandey)
  * Remember previous location on returning from page add/edit actions (Robert Rollins)
  * Update settings file in project settings to address Django 4.2 deprecations (Sage Abdullah)
@@ -58,6 +59,7 @@ Changelog
  * Maintenance: Upgrade frontend tooling to use Node 20 (LB (Ben) Johnston)
  * Maintenance: Upgrade `ruff` and replace `black` with `ruff format` (John-Scott Atlakson)
  * Maintenance: Update Willow upper bound to 2.x (Dan Braghis)
+ * Maintenance: Removed support for Django < 4.2 (Dan Braghis)
 
 5.2.2 (06.12.2023)
 ~~~~~~~~~~~~~~~~~~

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ _(If you are reading this on GitHub, the details here may not be indicative of t
 
 Wagtail supports:
 
--   Django 3.2.x, 4.1.x and 4.2.x
+-   Django 4.2.x and 5.0.x
 -   Python 3.8, 3.9, 3.10, 3.11 and 3.12
 -   PostgreSQL, MySQL and SQLite (with JSON1) as database backends
 

--- a/docs/getting_started/integrating_into_django.md
+++ b/docs/getting_started/integrating_into_django.md
@@ -2,7 +2,7 @@
 
 Wagtail provides the `wagtail start` command and project template to get you started with a new Wagtail project as quickly as possible, but it's easy to integrate Wagtail into an existing Django project too.
 
-Wagtail is currently compatible with Django 3.2, 4.1, and 4.2. First, install the `wagtail` package from PyPI:
+Wagtail is currently compatible with Django 4.2 and 5.0. First, install the `wagtail` package from PyPI:
 
 ```sh
 pip install wagtail

--- a/docs/releases/5.2.2.md
+++ b/docs/releases/5.2.2.md
@@ -11,6 +11,9 @@ depth: 1
 
 ## What's new
 
+## Django 5.0 support
+
+This release adds support for Django 5.0.
 
 ### Bug fixes
 

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -11,6 +11,9 @@ depth: 1
 
 ## What's new
 
+## Django 5.0 support
+
+This release adds support for Django 5.0. The support has also been backported to Wagtail 5.2 LTS.
 
 ### Other features
 
@@ -122,6 +125,10 @@ The `use_json_field` argument to `StreamField` is no longer required, and can be
 ## Upgrade considerations - changes affecting all projects
 
 ## Upgrade considerations - deprecation of old functionality
+
+### Removed support for Django < 4.2
+
+Django versions prior to 4.2 are no longer supported as of this release; please upgrade to Django 4.2 or above before upgrading Wagtail.
 
 ## Upgrade considerations - changes affecting Wagtail customisations
 

--- a/docs/releases/upgrading.md
+++ b/docs/releases/upgrading.md
@@ -59,8 +59,8 @@ The compatible versions of Django and Python for each Wagtail release are:
 
 | Wagtail release | Compatible Django versions | Compatible Python versions |
 | --------------- | -------------------------- | -------------------------- |
-| 6.0             | 3.2, 4.1, 4.2              | 3.8, 3.9, 3.10, 3.11, 3.12 |
-| 5.2 LTS         | 3.2, 4.1, 4.2              | 3.8, 3.9, 3.10, 3.11, 3.12 |
+| 6.0             | 4.2, 5.0                   | 3.8, 3.9, 3.10, 3.11, 3.12 |
+| 5.2 LTS         | 3.2, 4.1, 4.2, 5.0*        | 3.8, 3.9, 3.10, 3.11, 3.12 |
 | 5.1             | 3.2, 4.1, 4.2              | 3.8, 3.9, 3.10, 3.11       |
 | 5.0             | 3.2, 4.1, 4.2              | 3.7, 3.8, 3.9, 3.10, 3.11  |
 | 4.2             | 3.2, 4.0, 4.1              | 3.7, 3.8, 3.9, 3.10, 3.11  |
@@ -106,3 +106,5 @@ The compatible versions of Django and Python for each Wagtail release are:
 | 0.3             | 1.6                        | 2.6, 2.7                   |
 | 0.2             | 1.6                        | 2.7                        |
 | 0.1             | 1.6                        | 2.7                        |
+
+* Added in a patch release

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 
 
 install_requires = [
-    "Django>=4.2,<5.1",
+    "Django>=4.2,<6.0",
     "django-modelcluster>=6.1,<7.0",
     "django-permissionedforms>=0.1,<1.0",
     "django-taggit>=2.0,<5.0",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 
 
 install_requires = [
-    "Django>=3.2,<4.3",
+    "Django>=4.2,<5.1",
     "django-modelcluster>=6.1,<7.0",
     "django-permissionedforms>=0.1,<1.0",
     "django-taggit>=2.0,<5.0",
@@ -112,10 +112,10 @@ https://github.com/wagtail/wagtail/.",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.0",
         "Framework :: Wagtail",
         "Topic :: Internet :: WWW/HTTP :: Site Management",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{38,39,310,311,312}-dj{32,41,42,50stable,main}-{sqlite,postgres,mysql,mssql}-{elasticsearch8,elasticsearch7,noelasticsearch}-{customuser,emailuser}-{tz,notz},
+envlist = py{38,39,310,311,312}-dj{42,50,50stable,main}-{sqlite,postgres,mysql,mssql}-{elasticsearch8,elasticsearch7,noelasticsearch}-{customuser,emailuser}-{tz,notz},
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -22,9 +22,8 @@ deps =
     django-sendfile==0.3.6
     Embedly
 
-    dj32: Django~=3.2.0
-    dj41: Django~=4.1.0
     dj42: Django~=4.2.0
+    dj50: Django~=5.0.0
     dj50stable: git+https://github.com/django/django.git@stable/5.0.x#egg=Django
     djmain: git+https://github.com/django/django.git@main#egg=Django
 
@@ -54,4 +53,3 @@ setenv =
     mssql: DATABASE_NAME=master
     mssql: DATABASE_USER=sa
     mssql: DATABASE_PASSWORD=Password12!
-

--- a/wagtail/project_template/requirements.txt
+++ b/wagtail/project_template/requirements.txt
@@ -1,2 +1,2 @@
-Django>=4.2,<4.3
-wagtail==5.3a0
+Django>=4.2,<5.1
+wagtail==6.0a0


### PR DESCRIPTION
Making 5.0 support official, and dropping 4.1 from the test matrix as the official support for it ends in 2 days - https://endoflife.date/django