### PR TITLE
Docs: Clarify appropriate use of MultipleChooserPanel

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -44,6 +44,7 @@ Changelog
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)
  * Docs: Add section to testing docs about creating pages and working with page content (Mariana Bedran Lesche)
  * Docs: Add more nuance to the database recommendations in performance page (Jadesola Kareem)
+ * Docs: Add clarity that MultipleChooserPanel may require a chooser viewset and how the functionality is expected to work (Andy Chosak)
  * Maintenance: Update BeautifulSoup upper bound to 4.12.x (scott-8)
  * Maintenance: Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)
  * Maintenance: Adopt the usage of of translate string literals using `arg=_('...')` in all `wagtailadmin` module templates (Chiemezuo Akujobi)

--- a/docs/extending/generic_views.md
+++ b/docs/extending/generic_views.md
@@ -136,6 +136,8 @@ Various additional attributes are available to customise the viewset - see the {
 The ability to customise the menu item, listing view, inspect view, templates, and reference indexing were added.
 ```
 
+(chooserviewset)=
+
 ## ChooserViewSet
 
 The {class}`~wagtail.admin.viewsets.chooser.ChooserViewSet` class provides the views that make up a modal chooser interface, allowing users to select from a list of model instances to populate a ForeignKey field. Using the same `Person` model, the following definition (to be placed in `views.py`) will generate the views for a person chooser modal:

--- a/docs/reference/pages/panels.md
+++ b/docs/reference/pages/panels.md
@@ -165,7 +165,10 @@ Events will be dispatched and can trigger custom JavaScript logic such as settin
 
 ````{class} MultipleChooserPanel(relation_name, chooser_field_name=None, panels=None, label='', min_num=None, max_num=None, **kwargs)
 
-This is a variant of `InlinePanel` that improves the editing experience when the main feature of the child panel is a chooser for a `ForeignKey` relation (usually to an image, document, snippet or another page). Rather than the "Add" button inserting a new form to be filled in individually, it immediately opens up the chooser interface for that related object, in a mode that allows multiple items to be selected. The user is then returned to the main edit form with the appropriate number of child panels added and pre-filled.
+This panel is a variant of `InlinePanel` that can be used when the inline model includes a `ForeignKey` relation to a model that implements Wagtail's chooser interface.
+Wagtail images, documents, snippets, and pages all implement this interface, and other models may do so by [registering a custom ChooserViewSet](chooserviewset).
+
+Rather than the "Add" button inserting a new form to be filled in individually, it immediately opens up the chooser interface for that related object, in a mode that allows multiple items to be selected. The user is then returned to the main edit form with the appropriate number of child panels added and pre-filled.
 
 `MultipleChooserPanel` accepts an additional required argument `chooser_field_name`, specifying the name of the `ForeignKey` relation that the chooser is linked to.
 

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -62,6 +62,7 @@ This release adds support for Django 5.0. The support has also been backported t
  * Document all features for the Documents app in one location, see [](../advanced_topics/documents/index) (Neeraj Yetheendran)
  * Add section to [testing docs](../advanced_topics/testing) about creating pages and working with page content (Mariana Bedran Lesche)
  * Add more nuance to the database recommendations in [](performance_overview) (Jadesola Kareem)
+ * Add clarity that [`MultipleChooserPanel`](multiple_chooser_panel) may require a chooser viewset and how the functionality is expected to work (Andy Chosak)
 
 ### Maintenance
 


### PR DESCRIPTION
This documentation change clarifies that MultipleChooserPanel can only be used when the inline model has a ForeignKey to a model that implements Wagtail's chooser interface. Currently the docs mention "a chooser for a ForeignKey relation" but it's not obvious how that restricts which models can be pointed to or how to implement this for a non-(image, document, snippet, page) model.

Addresses possible cause of #10646.

|Before|After|
|-|-|
|![image](https://github.com/wagtail/wagtail/assets/654645/5a907068-9f5a-49f5-a7c0-2da76557e35b)|![image](https://github.com/wagtail/wagtail/assets/654645/58ff56cf-a566-4381-8825-a159f7b3c822)|