### PR TITLE
Fix bulk actions checkbox label for screen readers on page listings

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/bulk_actions/listing_checkbox_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/bulk_actions/listing_checkbox_cell.html
@@ -1,9 +1,21 @@
 {% load i18n l10n wagtailadmin_tags %}
+{% comment "text/markdown" %}
+
+    Variables accepted by this template:
+
+    - `instance` - the object being listed
+    - `obj_type` - {string} the bulk actions type, e.g. 'page'
+    - `aria_describedby` - {string} if present, adds aria-describedby to the checkbox,
+                           usually refers to the text in a title column with the id of
+                           `{obj_type}_{instance.pk}_title`
+
+{% endcomment %}
+
 <td class="bulk-action-checkbox-cell">
     <input type="checkbox"
            {% if obj_type == 'page' %}data-page-status="{% if instance.live %}live{% else %}draft{% endif %}"{% endif %}
            data-object-id="{{ instance.pk|unlocalize|admin_urlquote }}" data-bulk-action-checkbox class="bulk-action-checkbox"
-           {% if checkbox_aria_label %}aria-label="{{ checkbox_aria_label }}"{% endif %}
-           {% if aria_labelledby %}aria-labelledby="{{ aria_labelledby_prefix }}{{ aria_labelledby }}{{ aria_labelledby_suffix }}"{% endif %}
+           aria-label="{% trans "Select" %}"
+           {% if aria_describedby %}aria-describedby="{{ aria_describedby }}"{% endif %}
     />
 </td>

--- a/wagtail/admin/templates/wagtailadmin/bulk_actions/listing_checkbox_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/bulk_actions/listing_checkbox_cell.html
@@ -1,9 +1,9 @@
 {% load i18n l10n wagtailadmin_tags %}
 <td class="bulk-action-checkbox-cell">
     <input type="checkbox"
-           {% if obj_type == 'page' %}data-page-status="{% if obj.live %}live{% else %}draft{% endif %}"{% endif %}
-           data-object-id="{{obj.pk|unlocalize|admin_urlquote}}" data-bulk-action-checkbox class="bulk-action-checkbox"
-           {% if checkbox_aria_label %}aria-label="{{checkbox_aria_label}}"{% endif %}
+           {% if obj_type == 'page' %}data-page-status="{% if instance.live %}live{% else %}draft{% endif %}"{% endif %}
+           data-object-id="{{ instance.pk|unlocalize|admin_urlquote }}" data-bulk-action-checkbox class="bulk-action-checkbox"
+           {% if checkbox_aria_label %}aria-label="{{ checkbox_aria_label }}"{% endif %}
            {% if aria_labelledby %}aria-labelledby="{{ aria_labelledby_prefix }}{{ aria_labelledby }}{{ aria_labelledby_suffix }}"{% endif %}
     />
 </td>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_cell.html
@@ -1,5 +1,5 @@
 {% load l10n wagtailadmin_tags %}
-<td id="page_{{ instance.pk|unlocalize }}_title" {% if column.classname %}class="{{ column.classname }}"{% endif %} data-listing-page-title>
+<td {% if column.classname %}class="{{ column.classname }}"{% endif %} data-listing-page-title>
     {% include "wagtailadmin/pages/listing/_page_title_explore.html" with page=instance show_locale_labels=show_locale_labels actions_next_url=actions_next_url %}
     {% if parent_page %}
         <div>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -17,7 +17,7 @@
         without also reading out the buttons and indicators.
     {% endcomment %}
     {% fragment as page_title %}
-        <span id="page_{{ page.pk|unlocalize }}_title">
+        <span id="page_{{ page.pk|unlocalize|admin_urlquote }}_title">
             {% if not page.is_site_root and not page.is_leaf %}{% icon name="folder" classname="initial" %}{% endif %}
             {{ page.get_admin_display_title }}
         </span>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -1,4 +1,4 @@
-{% load i18n wagtailadmin_tags %}
+{% load i18n l10n wagtailadmin_tags %}
 
 {# The title field for a page in the page listing, when in 'explore' mode #}
 
@@ -9,14 +9,26 @@
         {% endif %}
     {% endif %}
 
-    {% if page_perms.can_edit %}
-        <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">
+    {% comment %}
+        Instead of adding the "page_{pk}_title" id to the td element
+        in _page_title_cell.html, add it to an element that only contains the
+        page title (and not other things e.g. the buttons or other indicators),
+        so that other elements can refer to title for screen reader purposes
+        without also reading out the buttons and indicators.
+    {% endcomment %}
+    {% fragment as page_title %}
+        <span id="page_{{ page.pk|unlocalize }}_title">
             {% if not page.is_site_root and not page.is_leaf %}{% icon name="folder" classname="initial" %}{% endif %}
             {{ page.get_admin_display_title }}
+        </span>
+    {% endfragment %}
+
+    {% if page_perms.can_edit %}
+        <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">
+            {{ page_title }}
         </a>
     {% else %}
-        {% if not page.is_site_root and not page.is_leaf %}{% icon name="folder" classname="initial" %}{% endif %}
-        {{ page.get_admin_display_title }}
+        {{ page_title }}
     {% endif %}
 
     {% if show_locale_labels %}

--- a/wagtail/admin/templates/wagtailadmin/tables/title_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/title_cell.html
@@ -2,13 +2,18 @@
 
 <td class="{% if column.classname %}{{ column.classname }} {% endif %}title">
     <div class="title-wrapper">
+        {% fragment as title %}
+            {% if title_id %}<span id="{{ title_id }}">{{ value }}</span>
+            {% else %}{{ value }}
+            {% endif %}
+        {% endfragment %}
         {% block title %}
             {% if link_url %}
-                <a {% include "wagtailadmin/shared/attrs.html" with attrs=link_attrs %}>{{ value }}</a>
+                <a {% include "wagtailadmin/shared/attrs.html" with attrs=link_attrs %}>{{ title }}</a>
             {% elif label_id %}
-                <label for="{{ label_id }}">{{ value }}</label>
+                <label for="{{ label_id }}">{{ title }}</label>
             {% else %}
-                {{ value }}
+                {{ title }}
             {% endif %}
         {% endblock %}
     </div>

--- a/wagtail/admin/ui/tables/__init__.py
+++ b/wagtail/admin/ui/tables/__init__.py
@@ -335,7 +335,7 @@ class BulkActionsCheckboxColumn(BaseColumn):
         self.obj_type = obj_type
 
     def get_aria_describedby(self, instance):
-        return f"{self.obj_type}_{instance.pk}_title"
+        return f"{self.obj_type}_{quote(instance.pk)}_title"
 
     def get_cell_context_data(self, instance, parent_context):
         context = super().get_cell_context_data(instance, parent_context)

--- a/wagtail/admin/ui/tables/__init__.py
+++ b/wagtail/admin/ui/tables/__init__.py
@@ -322,11 +322,6 @@ class BulkActionsCheckboxColumn(BaseColumn):
     header_template_name = "wagtailadmin/bulk_actions/select_all_checkbox_cell.html"
     cell_template_name = "wagtailadmin/bulk_actions/listing_checkbox_cell.html"
 
-    def get_cell_context_data(self, instance, parent_context):
-        context = super().get_cell_context_data(instance, parent_context)
-        context["obj"] = instance
-        return context
-
 
 class ReferencesColumn(Column):
     cell_template_name = "wagtailadmin/tables/references_cell.html"

--- a/wagtail/admin/ui/tables/__init__.py
+++ b/wagtail/admin/ui/tables/__init__.py
@@ -319,8 +319,33 @@ class UserColumn(Column):
 
 
 class BulkActionsCheckboxColumn(BaseColumn):
+    """
+    A checkbox column for the bulk actions feature.
+
+    When using this column, there should be another column (e.g. a TitleColumn)
+    that has an element with the id "{obj_type}_{instance.pk}_title" that contains
+    the title of the object (and nothing else) for screen reader purposes.
+    """
+
     header_template_name = "wagtailadmin/bulk_actions/select_all_checkbox_cell.html"
     cell_template_name = "wagtailadmin/bulk_actions/listing_checkbox_cell.html"
+
+    def __init__(self, *args, obj_type, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.obj_type = obj_type
+
+    def get_aria_describedby(self, instance):
+        return f"{self.obj_type}_{instance.pk}_title"
+
+    def get_cell_context_data(self, instance, parent_context):
+        context = super().get_cell_context_data(instance, parent_context)
+        context.update(
+            {
+                "obj_type": self.obj_type,
+                "aria_describedby": self.get_aria_describedby(instance),
+            }
+        )
+        return context
 
 
 class ReferencesColumn(Column):

--- a/wagtail/admin/ui/tables/__init__.py
+++ b/wagtail/admin/ui/tables/__init__.py
@@ -181,6 +181,7 @@ class TitleColumn(Column):
         name,
         url_name=None,
         get_url=None,
+        get_title_id=None,
         label_prefix=None,
         get_label_id=None,
         link_classname=None,
@@ -191,6 +192,7 @@ class TitleColumn(Column):
         super().__init__(name, **kwargs)
         self.url_name = url_name
         self._get_url_func = get_url
+        self._get_title_id_func = get_title_id
         self.label_prefix = label_prefix
         self._get_label_id_func = get_label_id
         self.link_attrs = link_attrs or {}
@@ -205,6 +207,7 @@ class TitleColumn(Column):
         )
         if self.link_classname is not None:
             context["link_attrs"]["class"] = self.link_classname
+        context["title_id"] = self.get_title_id(instance, parent_context)
         context["label_id"] = self.get_label_id(instance, parent_context)
         return context
 
@@ -217,6 +220,10 @@ class TitleColumn(Column):
         elif self.url_name:
             id = multigetattr(instance, self.id_accessor)
             return reverse(self.url_name, args=(quote(id),))
+
+    def get_title_id(self, instance, parent_context):
+        if self._get_title_id_func:
+            return self._get_title_id_func(instance)
 
     def get_label_id(self, instance, parent_context):
         if self._get_label_id_func:

--- a/wagtail/admin/ui/tables/pages.py
+++ b/wagtail/admin/ui/tables/pages.py
@@ -43,24 +43,14 @@ class PageStatusColumn(BaseColumn):
 
 
 class BulkActionsColumn(BulkActionsCheckboxColumn):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, obj_type="page")
+
     def get_header_context_data(self, parent_context):
         context = super().get_header_context_data(parent_context)
         parent_page = parent_context.get("parent_page")
         if parent_page:
             context["parent"] = parent_page.id
-        return context
-
-    def get_cell_context_data(self, instance, parent_context):
-        context = super().get_cell_context_data(instance, parent_context)
-        context.update(
-            {
-                "obj_type": "page",
-                "aria_labelledby_prefix": "page_",
-                "aria_labelledby": str(instance.pk),
-                "aria_labelledby_suffix": "_title",
-                "checkbox_aria_label": gettext("Select page"),
-            }
-        )
         return context
 
 

--- a/wagtail/documents/templates/wagtaildocs/documents/list.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/list.html
@@ -37,7 +37,7 @@
     <tbody>
         {% for doc in documents %}
             <tr>
-                {% fragment as title_id %}document_{{ doc.pk|unlocalize }}_title{% endfragment %}
+                {% fragment as title_id %}document_{{ doc.pk|unlocalize|admin_urlquote }}_title{% endfragment %}
                 {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="document" instance=doc aria_describedby=title_id only %}
                 <td id="{{ title_id }}" class="title">
                     <div class="title-wrapper"><a href="{% url 'wagtaildocs:edit' doc.id %}{% if next %}?next={{ next|urlencode }}{% endif %}">{{ doc.title }}</a></div>

--- a/wagtail/documents/templates/wagtaildocs/documents/list.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/list.html
@@ -35,11 +35,11 @@
         </tr>
     </thead>
     <tbody>
-        {% trans "Select document" as checkbox_aria_label %}
         {% for doc in documents %}
             <tr>
-                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="document" instance=doc aria_labelledby_prefix="document_" aria_labelledby=doc.pk|unlocalize aria_labelledby_suffix="_title" %}
-                <td id="document_{{ doc.pk|unlocalize }}_title" class="title">
+                {% fragment as title_id %}document_{{ doc.pk|unlocalize }}_title{% endfragment %}
+                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="document" instance=doc aria_describedby=title_id only %}
+                <td id="{{ title_id }}" class="title">
                     <div class="title-wrapper"><a href="{% url 'wagtaildocs:edit' doc.id %}{% if next %}?next={{ next|urlencode }}{% endif %}">{{ doc.title }}</a></div>
                 </td>
                 <td><a href="{{ doc.url }}" class="nolink" download>{{ doc.filename }}</a></td>

--- a/wagtail/documents/templates/wagtaildocs/documents/list.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/list.html
@@ -38,7 +38,7 @@
         {% trans "Select document" as checkbox_aria_label %}
         {% for doc in documents %}
             <tr>
-                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="document" obj=doc aria_labelledby_prefix="document_" aria_labelledby=doc.pk|unlocalize aria_labelledby_suffix="_title" %}
+                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="document" instance=doc aria_labelledby_prefix="document_" aria_labelledby=doc.pk|unlocalize aria_labelledby_suffix="_title" %}
                 <td id="document_{{ doc.pk|unlocalize }}_title" class="title">
                     <div class="title-wrapper"><a href="{% url 'wagtaildocs:edit' doc.id %}{% if next %}?next={{ next|urlencode }}{% endif %}">{{ doc.title }}</a></div>
                 </td>

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -16,7 +16,7 @@
     <ul class="listing horiz images">
         {% for image in images %}
             <li>
-                {% fragment as title_id %}image_{{ image.pk|unlocalize }}_title{% endfragment %}
+                {% fragment as title_id %}image_{{ image.pk|unlocalize|admin_urlquote }}_title{% endfragment %}
                 {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="image" instance=image aria_describedby=title_id only %}
                 <a class="image-choice" title="{% if collections %}{{ image.collection.name }} » {% endif %}{{ image.title }}" href="{% url 'wagtailimages:edit' image.id %}{% if next %}?next={{ next|urlencode }}{% endif %}">
                     <figure>

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -21,10 +21,8 @@
                 <a class="image-choice" title="{% if collections %}{{ image.collection.name }} » {% endif %}{{ image.title }}" href="{% url 'wagtailimages:edit' image.id %}{% if next %}?next={{ next|urlencode }}{% endif %}">
                     <figure>
                         {% include "wagtailimages/images/results_image.html" %}
-                        {% trans "pixels" as translated_pixels %}
                         <figcaption id="{{ title_id }}">
                             {{ image.title|ellipsistrim:60 }}
-                            <span class="visuallyhidden">{{ image.width }} {{ translated_pixels  }} &#215; {{ image.height }} {{ translated_pixels}}</span>
                         </figcaption>
                     </figure>
                 </a>

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -19,7 +19,7 @@
     <ul class="listing horiz images">
         {% for image in images %}
             <li>
-                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="image" obj=image aria_labelledby_prefix="select-image-label image_" aria_labelledby=image.pk|unlocalize aria_labelledby_suffix="_title" %}
+                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="image" instance=image aria_labelledby_prefix="select-image-label image_" aria_labelledby=image.pk|unlocalize aria_labelledby_suffix="_title" %}
                 <a class="image-choice" title="{% if collections %}{{ image.collection.name }} » {% endif %}{{ image.title }}" href="{% url 'wagtailimages:edit' image.id %}{% if next %}?next={{ next|urlencode }}{% endif %}">
                     <figure>
                         {% include "wagtailimages/images/results_image.html" %}

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -13,18 +13,16 @@
         {% search_other %}
     {% endif %}
 
-    {# Used below for the checkbox aria_labelledby #}
-    <p class="visuallyhidden" id="select-image-label">{% trans "Select image" %}</p>
-
     <ul class="listing horiz images">
         {% for image in images %}
             <li>
-                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="image" instance=image aria_labelledby_prefix="select-image-label image_" aria_labelledby=image.pk|unlocalize aria_labelledby_suffix="_title" %}
+                {% fragment as title_id %}image_{{ image.pk|unlocalize }}_title{% endfragment %}
+                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="image" instance=image aria_describedby=title_id only %}
                 <a class="image-choice" title="{% if collections %}{{ image.collection.name }} » {% endif %}{{ image.title }}" href="{% url 'wagtailimages:edit' image.id %}{% if next %}?next={{ next|urlencode }}{% endif %}">
                     <figure>
                         {% include "wagtailimages/images/results_image.html" %}
                         {% trans "pixels" as translated_pixels %}
-                        <figcaption id="image_{{ image.pk|unlocalize }}_title">
+                        <figcaption id="{{ title_id }}">
                             {{ image.title|ellipsistrim:60 }}
                             <span class="visuallyhidden">{{ image.width }} {{ translated_pixels  }} &#215; {{ image.height }} {{ translated_pixels}}</span>
                         </figcaption>

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -316,7 +316,13 @@ class TestSnippetListView(WagtailTestUtils, TestCase):
         # Should use the latest draft title in the listing
         self.assertContains(
             response,
-            f'<a href="{edit_url}">Draft-enabled Bar, In Draft</a>',
+            f"""
+            <a href="{edit_url}">
+                <span id="snippet_{quote(snippet.pk)}_title">
+                    Draft-enabled Bar, In Draft
+                </span>
+            </a>
+            """,
             html=True,
         )
 

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -165,7 +165,7 @@ class IndexView(generic.IndexViewOptionalFeaturesMixin, generic.IndexView):
 
     def get_columns(self):
         return [
-            BulkActionsCheckboxColumn("checkbox"),
+            BulkActionsCheckboxColumn("bulk_actions", obj_type="snippet"),
             *super().get_columns(),
         ]
 

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -165,7 +165,7 @@ class IndexView(generic.IndexViewOptionalFeaturesMixin, generic.IndexView):
 
     def get_columns(self):
         return [
-            BulkActionsCheckboxColumn("checkbox", accessor=lambda obj: obj),
+            BulkActionsCheckboxColumn("checkbox"),
             *super().get_columns(),
         ]
 

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -1,6 +1,7 @@
 from warnings import warn
 
 from django.apps import apps
+from django.contrib.admin.utils import quote
 from django.core import checks
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.http import Http404
@@ -168,6 +169,13 @@ class IndexView(generic.IndexViewOptionalFeaturesMixin, generic.IndexView):
             BulkActionsCheckboxColumn("bulk_actions", obj_type="snippet"),
             *super().get_columns(),
         ]
+
+    def _get_title_column(self, *args, **kwargs):
+        return super()._get_title_column(
+            *args,
+            **kwargs,
+            get_title_id=lambda instance: f"snippet_{quote(instance.pk)}_title",
+        )
 
     def get_list_buttons(self, instance):
         more_buttons = self.get_list_more_buttons(instance)

--- a/wagtail/users/templates/wagtailusers/users/list.html
+++ b/wagtail/users/templates/wagtailusers/users/list.html
@@ -33,11 +33,12 @@
     <tbody>
         {% for user in users %}
             <tr>
-                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="user" instance=user aria_labelledby_prefix="user_" aria_labelledby=user.pk|unlocalize aria_labelledby_suffix="_title" %}
-                <td id="user_{{ user.pk|unlocalize }}_title" class="title" valign="top">
+                {% fragment as title_id %}user_{{ user.pk|unlocalize }}_title{% endfragment %}
+                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="user" instance=user aria_describedby=title_id only %}
+                <td class="title" valign="top">
                     <div class="title-wrapper">
                         {% avatar user=user size="small" %}
-                        <a href="{% url 'wagtailusers_users:edit' user.pk %}">{{ user|user_display_name }}</a>
+                        <a id="{{ title_id }}" href="{% url 'wagtailusers_users:edit' user.pk %}">{{ user|user_display_name }}</a>
                     </div>
                     <ul class="actions">
                         {% user_listing_buttons user %}

--- a/wagtail/users/templates/wagtailusers/users/list.html
+++ b/wagtail/users/templates/wagtailusers/users/list.html
@@ -33,7 +33,7 @@
     <tbody>
         {% for user in users %}
             <tr>
-                {% fragment as title_id %}user_{{ user.pk|unlocalize }}_title{% endfragment %}
+                {% fragment as title_id %}user_{{ user.pk|unlocalize|admin_urlquote }}_title{% endfragment %}
                 {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="user" instance=user aria_describedby=title_id only %}
                 <td class="title" valign="top">
                     <div class="title-wrapper">

--- a/wagtail/users/templates/wagtailusers/users/list.html
+++ b/wagtail/users/templates/wagtailusers/users/list.html
@@ -33,7 +33,7 @@
     <tbody>
         {% for user in users %}
             <tr>
-                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="user" obj=user aria_labelledby_prefix="user_" aria_labelledby=user.pk|unlocalize aria_labelledby_suffix="_title" %}
+                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="user" instance=user aria_labelledby_prefix="user_" aria_labelledby=user.pk|unlocalize aria_labelledby_suffix="_title" %}
                 <td id="user_{{ user.pk|unlocalize }}_title" class="title" valign="top">
                     <div class="title-wrapper">
                         {% avatar user=user size="small" %}


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Using VoiceOver with Chrome, with page title e.g. "Breads" the checkbox is read as "Breads More options for 'Breads', unticked, tick box". With Safari, it reads "Breads, unticked, tick box".

In addition, the checkbox elements have both `aria-label` and `aria-labelledby`, even though `aria-labelledby` will take precedence. Looking at the current state of the checkbox's aria labels in image listings (which only uses `aria-labelledby` but with multiple ids), it seems the intention was to make it read "Select <type> <title>", e.g. "Select page Breads".

Unfortunately, if the aria-label is too specific, it is hard for voice control users to click on the checkbox because they have to specify the full label.

With this PR, we instead enforce a simple 'Select' `aria-label` and use `aria-describedby`
to describe the checkbox by referring to the title in the title column.

To test, use a screen reader and point to the checkbox element on Pages, Images, Documents, Snippets, and Users listing views.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 119, Firefox 120, Safari 17.1 on macOS Sonoma 14.1.1
    -   [x] **Please list which assistive technologies [^3] you tested**: VoiceOver

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
