### PR TITLE
Fix display property used on The CommentControl's ToolbarButton

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -66,6 +66,7 @@ Changelog
  * Fix: Ensure that Snippets search results correctly use the `index_results.html` or `index_results_template_name` override on initial load (Stefan Hammer)
  * Fix: Avoid error when attempting to moderate a page drafted by a now deleted user (Dan Braghis)
  * Fix: Ensure workflow dashboard panels work when the page/snippet is missing (Sage Abdullah)
+ * Fix: Prevent custom controls from stacking on top of the comment button in Draftail toolbar (Ben Morse)
 
 
 5.2.1 (16.11.2023)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -772,6 +772,7 @@
 * Gunnar Scherf
 * Mariana Bedran Lesche
 * Bhuvnesh Sharma
+* Ben Morse
 
 ## Translators
 

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.scss
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.scss
@@ -2,7 +2,7 @@
   display: none;
 
   .tab-content--comments-enabled & {
-    display: block;
+    display: inline-block;
   }
 }
 

--- a/docs/releases/5.2.2.md
+++ b/docs/releases/5.2.2.md
@@ -19,5 +19,6 @@ depth: 1
  * Ensure that Snippets search results correctly use the `index_results.html` or `index_results_template_name` override on initial load (Stefan Hammer)
  * Avoid error when attempting to moderate a page drafted by a now deleted user (Dan Braghis)
  * Ensure workflow dashboard panels work when the page/snippet is missing (Sage Abdullah)
+ * Prevent custom controls from stacking on top of the comment button in Draftail toolbar (Ben Morse)
 
 ### Documentation


### PR DESCRIPTION
Fixes #11302 


<details open>
<summary>Before</summary>
<br>
<img width="172" alt="Screenshot 2023-12-04 at 12 22 37" src="https://github.com/wagtail/wagtail/assets/35934884/cd44eb1c-be48-419d-b9cc-a8b76a6a8ea5">
<img width="117" alt="Screenshot 2023-12-04 at 12 22 41" src="https://github.com/wagtail/wagtail/assets/35934884/c297d181-986a-481a-b204-057b6d19e429">
</details>


<details open>
<summary>After</summary>
<br>
<img width="186" alt="Screenshot 2023-12-04 at 11 24 30" src="https://github.com/wagtail/wagtail/assets/35934884/6d89b9e4-8190-434e-8efd-ae3da07e67e4">
<img width="171" alt="Screenshot 2023-12-04 at 11 24 44" src="https://github.com/wagtail/wagtail/assets/35934884/b908eb90-6188-4716-b803-6656af3b6b50">
</details>



_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
