### PR TITLE
Ensure workflow dashboard panels work when the page/snippet is missing

### DIFF
--- a/docs/topics/snippets/features.md
+++ b/docs/topics/snippets/features.md
@@ -113,7 +113,11 @@ class Advert(index.Indexed, models.Model):
 
 ## Saving revisions of snippets
 
-If a snippet model inherits from {class}`~wagtail.models.RevisionMixin`, Wagtail will automatically save revisions when you save any changes in the snippets admin. In addition to inheriting the mixin, it is recommended to define a {class}`~django.contrib.contenttypes.fields.GenericRelation` to the {class}`~wagtail.models.Revision` model as the {attr}`~wagtail.models.RevisionMixin.revisions` attribute so that you can do related queries. If you need to customise how the revisions are fetched (for example, to handle the content type to use for models with multi-table inheritance), you can define a property instead. For example, the `Advert` snippet could be made revisable as follows:
+If a snippet model inherits from {class}`~wagtail.models.RevisionMixin`, Wagtail will automatically save revisions when you save any changes in the snippets admin.
+
+In addition to inheriting the mixin, it is highly recommended to define a {class}`~django.contrib.contenttypes.fields.GenericRelation` to the {class}`~wagtail.models.Revision` model as the {attr}`~wagtail.models.RevisionMixin.revisions` attribute so that you can do related queries. Defining the `GenericRelation` is also necessary to ensure that `Revision` instances are automatically deleted when the snippet instance is deleted. If you need to customise how the revisions are fetched (for example, to handle the content type to use for models with multi-table inheritance), you can define the `revisions` as a property.
+
+For example, the `Advert` snippet could be made revisable as follows:
 
 ```python
 # ...
@@ -280,7 +284,9 @@ Locking and unlocking a snippet instance requires `lock` and `unlock` permission
 
 If a snippet model inherits from {class}`~wagtail.models.WorkflowMixin`, Wagtail will automatically add the ability to assign a workflow to the model. With a workflow assigned to the snippet model, a "Submit for moderation" and other workflow action menu items will be shown in the editor. The status side panel will also show the information of the current workflow.
 
-Since the `WorkflowMixin` utilises revisions and publishing mechanisms in Wagtail, inheriting from this mixin also requires inheriting from `RevisionMixin` and `DraftStateMixin`. In addition, it is also recommended to enable locking by inheriting from `LockableMixin`, so that the snippet instance can be locked and only editable by reviewers when it is in a workflow. See the above sections for more details.
+Since the `WorkflowMixin` utilises revisions and publishing mechanisms in Wagtail, inheriting from this mixin also requires inheriting from `RevisionMixin` and `DraftStateMixin`. It is also recommended to enable locking by inheriting from `LockableMixin`, so that the snippet instance can be locked and only editable by reviewers when it is in a workflow. See the above sections for more details.
+
+In addition to inheriting the mixins, it is highly recommended to define a {class}`~django.contrib.contenttypes.fields.GenericRelation` to the {class}`~wagtail.models.WorkflowState` model so that you can do related queries and that the workflow-related data is properly cleaned up when the snippet instance is deleted.
 
 For example, workflows (with locking) can be enabled for the `Advert` snippet by defining it as follows:
 

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -163,6 +163,7 @@ class WorkflowObjectsToModeratePanel(Component):
                 "revision",
                 "task",
                 "revision__user",
+                "workflow_state",
             )
             .prefetch_related(
                 "revision__content_object",

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -1124,6 +1124,22 @@ class FullFeaturedSnippet(
 
     some_attribute = "some value"
 
+    workflow_states = GenericRelation(
+        "wagtailcore.WorkflowState",
+        content_type_field="base_content_type",
+        object_id_field="object_id",
+        related_query_name="full_featured_snippet",
+        for_concrete_model=False,
+    )
+
+    revisions = GenericRelation(
+        "wagtailcore.Revision",
+        content_type_field="base_content_type",
+        object_id_field="object_id",
+        related_query_name="full_featured_snippet",
+        for_concrete_model=False,
+    )
+
     search_fields = [
         index.SearchField("text"),
         index.AutocompleteField("text"),

--- a/wagtail/tests/test_revision_model.py
+++ b/wagtail/tests/test_revision_model.py
@@ -6,6 +6,7 @@ from freezegun import freeze_time
 
 from wagtail.models import Page, Revision, get_default_page_content_type
 from wagtail.test.testapp.models import (
+    FullFeaturedSnippet,
     RevisableGrandChildModel,
     RevisableModel,
     SimplePage,
@@ -168,3 +169,25 @@ class TestRevisableModel(TestCase):
         # The id is used as a tie breaker
         self.assertEqual(first.created_at, second.created_at)
         self.assertLess(first.id, second.id)
+
+    def test_revision_cascade_on_object_delete(self):
+        page = self.create_page()
+        full_featured_snippet = FullFeaturedSnippet.objects.create(text="foo")
+        cases = [
+            # Tuple of (instance, cascades)
+            # For models that define a GenericRelation to Revision, the revision
+            # should be deleted when the instance is deleted.
+            (page, True),
+            (full_featured_snippet, True),
+            (self.instance, False),  # No GenericRelation to Revision
+        ]
+        for instance, cascades in cases:
+            with self.subTest(instance=instance):
+                revision = instance.save_revision()
+                query = {
+                    "base_content_type": instance.get_base_content_type(),
+                    "object_id": str(instance.pk),
+                }
+                self.assertEqual(Revision.objects.filter(**query).first(), revision)
+                instance.delete()
+                self.assertIs(Revision.objects.filter(**query).exists(), not cascades)


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11300.

I couldn't replicate the issue exactly as described, i.e. somehow having an object's revision instance that points to an `object_id` of a different object instance (which I doubt could ever happen without manually tampering the revisions). However, a similar issue can be triggered by deleting a revisions/workflows-enabled snippet instance where the model does not define a `GenericRelation` to `Revision` and/or `WorkflowState`.

For example, using the latest bakerydemo, if you delete a Person snippet that's in moderation and access the dashboard as a user that has moderation access, you'll trigger the error. The easiest way to test this is by spinning up bakerydemo with a fresh db, loading its fixtures, and deleting the Muddy Waters snippet via the CMS using the admin user.

Unfortunately, if the cause of the reporter's issue is not about the missing `GenericRelation`s, then there might be something else that's causing this. It is very similar in nature to #9236, but since we can't find a different way to replicate it, I guess we just have to kick the can a bit further down the road for now.

Side note: we also need to update bakerydemo to define `GenericRelation`s where `RevisionMixin` or `WorkflowMixin` is used.



_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
