### PR TITLE
Bugfix 11307 action controller fix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -380,6 +380,7 @@ Changelog
  * Maintenance: Deprecate `wagtail.contrib.modeladmin` (Sage Abdullah)
  * Maintenance: Upgrade documentation theme `sphinx_wagtail_theme` to v6.1.1 which includes multiple styling fixes and always visible code copy buttons (LB (Ben) Johnston)
  * Maintenance: Don't update the reference index while deleting it (Andy Chosak)
+* Maintenance: Allow `ActionController` to have a `noop` method to more easily leverage standalone Stimulus action options (Nandini Arora)
 
 
 5.0.5 (19.10.2023)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -332,6 +332,7 @@ Changelog
  * Fix: Guard against `TypeError` in `0088_fix_log_entry_json_timestamps` migration (Sage Abdullah)
  * Fix: Add migration to replace JSON null values with empty objects in log entries' data (Sage Abdullah)
  * Fix: Typo in the `page_header_buttons` template tag when accessing the context's request object (Robert Rollins)
+ * Fix: Ensure `ActionController` explicitly checks for elements that allow select functionality (Nandini Arora)
  * Docs: Document how to add non-ModelAdmin views to a `ModelAdminGroup` (Onno Timmerman)
  * Docs: Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Docs: Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -775,6 +775,7 @@
 * Ben Morse
 * Shlomo Markowitz
 * Felipe Lobato
+* Nandini Arora
 
 ## Translators
 

--- a/client/src/controllers/ActionController.test.js
+++ b/client/src/controllers/ActionController.test.js
@@ -276,4 +276,31 @@ describe('ActionController', () => {
       expect(handleChangeEvent).toHaveBeenCalled();
     });
   });
+
+  describe('noop method', () => {
+    beforeEach(async () => {
+      await setup(`
+      <button id="button" data-controller="w-action" data-action="w-action#noop:prevent:stop">
+        Click me!
+      </button>`);
+    });
+
+    it('should a noop method that does nothing, enabling use of action options', async () => {
+      const button = document.getElementById('button');
+
+      const onClick = jest.fn();
+      document.addEventListener('click', onClick);
+
+      button.dispatchEvent(new Event('click', { bubbles: true }));
+
+      expect(onClick).not.toHaveBeenCalled();
+
+      // remove data-action attribute
+      await Promise.resolve(button.removeAttribute('data-action'));
+
+      button.dispatchEvent(new Event('click', { bubbles: true }));
+
+      expect(onClick).toHaveBeenCalled();
+    });
+  });
 });

--- a/client/src/controllers/ActionController.test.js
+++ b/client/src/controllers/ActionController.test.js
@@ -171,7 +171,7 @@ describe('ActionController', () => {
   });
 
   describe('select method', () => {
-    beforeEach(async () => {
+    it('select should be called when you click on text in textarea', async () => {
       await setup(`
         <textarea
           id="text"
@@ -182,9 +182,7 @@ describe('ActionController', () => {
           some random text
         </textarea>
       `);
-    });
 
-    it('select should be called when you click on text in textarea', () => {
       const textarea = document.getElementById('text');
 
       // check that there is no selection initially
@@ -197,6 +195,47 @@ describe('ActionController', () => {
       // check that there is a selection after focus
       expect(textarea.selectionStart).toBe(0);
       expect(textarea.selectionEnd).toBe(textarea.value.length);
+    });
+
+    it('select should be called for for input elements', async () => {
+      await setup(`
+      <input
+        type="text"
+        id="input"
+        data-controller="w-action"
+        data-action="some-event->w-action#select"
+        value="some random text"
+      />
+      `);
+
+      const input = document.getElementById('input');
+
+      // check that there is no selection initially
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe(0);
+
+      const event = new CustomEvent('some-event');
+      input.dispatchEvent(event);
+
+      // check that there is a selection after the event
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe(16);
+    });
+
+    it('select should not throw errors when called on a button element', async () => {
+      await setup(`
+        <button
+          id="button"
+          data-controller="w-action"
+          data-action="click->w-action#select"
+        >
+          Click me
+        </button>
+      `);
+
+      const button = document.getElementById('button');
+
+      expect(() => button.click()).not.toThrow();
     });
   });
 

--- a/client/src/controllers/ActionController.ts
+++ b/client/src/controllers/ActionController.ts
@@ -41,6 +41,11 @@ import { WAGTAIL_CONFIG } from '../config/wagtailConfig';
  *     This text will all be selected on focus.
  *   </textarea>
  * </form>
+ *
+ * @example - ensuring a button's click does not propagate
+ * <div>
+ *   <button type="button" data-controller="w-action" data-action="w-action#noop:stop">Go</button>
+ * </div>
  */
 export class ActionController extends Controller<
   HTMLButtonElement | HTMLInputElement | HTMLTextAreaElement
@@ -56,6 +61,15 @@ export class ActionController extends Controller<
   click() {
     this.element.click();
   }
+
+  /**
+   * Intentionally does nothing.
+   *
+   * Useful for attaching data-action to leverage the built in
+   * Stimulus options without needing any extra functionality.
+   * e.g. preventDefault (`:prevent`) and stopPropagation (`:stop`).
+   */
+  noop() {}
 
   post(event: Event) {
     event.preventDefault();

--- a/client/src/controllers/ActionController.ts
+++ b/client/src/controllers/ActionController.ts
@@ -114,14 +114,6 @@ export class ActionController extends Controller<
   }
 
   /**
-   * Select all the text in an input or textarea element.
-   */
-  select() {
-    if (this.element instanceof HTMLButtonElement) return;
-    this.element?.select();
-  }
-
-  /**
    * Reset the field to a supplied or the field's initial value (default).
    * Only update if the value to change to is different from the current value.
    */
@@ -146,5 +138,20 @@ export class ActionController extends Controller<
       prefix: '',
       target,
     });
+  }
+
+  /**
+   * Select all the text in an input or textarea element.
+   */
+  select() {
+    const element = this.element;
+
+    if (
+      element &&
+      (element instanceof HTMLInputElement ||
+        element instanceof HTMLTextAreaElement)
+    ) {
+      element.select();
+    }
   }
 }

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -55,6 +55,7 @@ This release adds support for Django 5.0. The support has also been backported t
  * Avoid error when exporting Aging Pages report where a page has an empty `last_published_by_user` (Chiemezuo Akujobi)
  * Ensure Page querysets support using `alias` and `specific` (Tomasz Knapik)
  * Ensure workflow dashboard panels work when the page/snippet is missing (Sage Abdullah)
+ * Ensure `ActionController` explicitly checks for elements that allow select functionality (Nandini Arora)
 
 ### Documentation
 

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -88,6 +88,7 @@ This release adds support for Django 5.0. The support has also been backported t
  * Refactor snippets index view and template to make better use of generic IndexView (Sage Abdullah)
  * Introduce an internal `{% formattedfield %}` tag to replace direct use of `wagtailadmin/shared/field.html` (Matt Westcott)
  * Update Telepath dependency to 0.3.1 (Matt Westcott)
+ * Allow `ActionController` to have a `noop` method to more easily leverage standalone Stimulus action options (Nandini Arora)
 
 ## Upgrade considerations - removal of deprecated features from Wagtail 4.2 - 5.1
 


### PR DESCRIPTION
I have fixed the issue #11307  while clicking non-button elements giving the error, for ` HTMLInputElement ` and ` HTMLTextAreaElement ` to work with the select function as below. All the test cases passed and I am also including the code sample below:

```
select() {
    if (
      this.element &&
      (this.element instanceof HTMLInputElement || this.element instanceof HTMLTextAreaElement) &&
      typeof this.element.select === 'function'
    ) {
      this.element.select();
    }
  }
```

I have also written the Jest Unit Test for the Input as well as Textarea element and it has passed all the tests.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
