### PR TITLE
Fix Screen Shakes When Adding Long Comments

### DIFF
--- a/client/src/components/CommentApp/main.scss
+++ b/client/src/components/CommentApp/main.scss
@@ -116,7 +116,7 @@ $box-padding: 20px;
 }
 
 .comments-list {
-  position: absolute;
+  position: relative;
   top: 20px;
   inset-inline-end: 20px;
   z-index: calc(theme('zIndex.header') + 5);


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10984 This update addresses an issue where entering a long comment caused screen shaking and unexpected changes.

### Before:

https://github.com/wagtail/wagtail/assets/111359305/d8e2d602-0d6f-452a-bfe0-42dfee4bfc85

### After:

https://github.com/wagtail/wagtail/assets/111359305/921ccbbd-6693-4e49-885d-66d6f421e5b6

Also, when adding a long comment that exceeds the visible area of the fields, the entire comment is now fully visible.

![image](https://github.com/wagtail/wagtail/assets/111359305/5cf33586-0c0a-4afb-973b-0d786ebd795e)

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
