### PR TITLE
Fix Comment Reply Spanning Outside Comment Box

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -63,6 +63,7 @@ Changelog
  * Fix: Prevent TitleFieldPanel from raising an error when the slug field is missing or read-only (Rohit Sharma)
  * Fix: Ensure that the close button on the new dialog designs is visible in the non-message variant (Nandini Arora)
  * Fix: Ensure the sidebar account toggle has no duplicate accessible labels (Nandini Arora)
+ * Fix: Avoid text overflow issues in comment replies and scroll position issues for long comments (Rohit Sharma)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)
  * Docs: Add section to testing docs about creating pages and working with page content (Mariana Bedran Lesche)

--- a/client/src/components/CommentApp/components/CommentReply/style.scss
+++ b/client/src/components/CommentApp/components/CommentReply/style.scss
@@ -12,6 +12,7 @@
     margin-bottom: 0;
     padding-top: 10px;
     padding-bottom: 10px;
+    word-break: break-all;
 
     &--mode-deleting {
       color: theme('colors.text-context');

--- a/client/src/components/CommentApp/main.scss
+++ b/client/src/components/CommentApp/main.scss
@@ -110,7 +110,7 @@ $box-padding: 20px;
 }
 
 .comments-list {
-  position: absolute;
+  position: relative;
   top: 20px;
   inset-inline-end: 20px;
   z-index: calc(theme('zIndex.header') + 5);

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -91,6 +91,7 @@ Thank you to Thibaud Colas and Badr Fourane for their work on this feature.
  * Prevent TitleFieldPanel from raising an error when the slug field is missing or read-only (Rohit Sharma)
  * Ensure that the close button on the new dialog designs is visible in the non-message variant (Nandini Arora)
  * Ensure the sidebar account toggle has no duplicate accessible labels (Nandini Arora)
+ * Avoid text overflow issues in comment replies and scroll position issues for long comments (Rohit Sharma)
 
 
 ### Documentation


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11324 When submitting a response to a comment without word breaks, the reply extends beyond the comment box. Similar to issue outlined in #11048 specific to comments. I have addressed this problem in my PR by incorporating a fix that includes the addition of `'word-break: break-all;'` to ensure proper formatting.

### Before:

![image](https://github.com/wagtail/wagtail/assets/111359305/bea0bf45-af50-4f84-9f58-9b26d79776c8)

### After:

![image](https://github.com/wagtail/wagtail/assets/111359305/96a66102-0e41-4ee2-8195-db7baf972092)

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
