### PR TITLE
Ensure dialog (modal) shows the close button with a visible cross icon

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -60,6 +60,7 @@ Changelog
  * Fix: Prevent a ValueError with `FormSubmissionsPanel` on Django 5.0 when creating a new form page (Matt Westcott)
  * Fix: Avoid duplicate entries in "Recent edits" panel when copying pages (Matt Westcott)
  * Fix: Prevent TitleFieldPanel from raising an error when the slug field is missing or read-only (Rohit Sharma)
+ * Fix: Ensure that the close button on the new dialog designs is visible in the non-message variant (Nandini Arora)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)
  * Docs: Add section to testing docs about creating pages and working with page content (Mariana Bedran Lesche)

--- a/client/scss/components/_dialog.scss
+++ b/client/scss/components/_dialog.scss
@@ -1,4 +1,6 @@
 .w-dialog {
+  --w-dialog-close-icon-color: theme('colors.icon-primary');
+
   position: fixed;
   display: flex;
   inset-inline-start: 0;
@@ -57,7 +59,7 @@
   &__close-icon {
     width: theme('spacing.4');
     height: theme('spacing.4');
-    color: theme('colors.grey.600');
+    color: var(--w-dialog-close-icon-color, #{theme('colors.icon-primary')});
   }
 
   &__content {
@@ -132,6 +134,10 @@
       background: theme('colors.positive.50');
       color: theme('colors.positive.100');
     }
+  }
+
+  &--message {
+    --w-dialog-close-icon-color: theme('colors.grey.600');
   }
 
   &__message-icon {

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -88,6 +88,7 @@ Thank you to Thibaud Colas and Badr Fourane for their work on this feature.
  * Add ability to [customise a page's copy form](custom_page_copy_form) including an auto-incrementing slug example (Neeraj Yetheendran)
  * Avoid duplicate entries in "Recent edits" panel when copying pages (Matt Westcott)
  * Prevent TitleFieldPanel from raising an error when the slug field is missing or read-only (Rohit Sharma)
+ * Ensure that the close button on the new dialog designs is visible in the non-message variant (Nandini Arora)
 
 
 ### Documentation

--- a/wagtail/admin/templates/wagtailadmin/shared/dialog/dialog.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/dialog/dialog.html
@@ -6,7 +6,7 @@
     <div id="{{ id }}"
          aria-labelledby="title-{{ id }}"
          aria-hidden="true"
-         class="w-dialog {% if theme %}w-dialog--{{ theme }}{% endif %} {% if classname %} {{ classname }}{% endif %}"
+         class="w-dialog{% if theme %} w-dialog--{{ theme }}{% endif %}{% if message_heading and message_icon_name %} w-dialog--message{% endif %}{% if classname %} {{ classname }}{% endif %}"
          data-controller="w-dialog"
          data-action="w-dialog:hide->w-dialog#hide w-dialog:show->w-dialog#show"
          {% if theme %}data-w-dialog-theme-value="{{ theme }}"{% endif %}

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -469,7 +469,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             allow_extra_attrs=True,
         )
         self.assertTagInHTML(
-            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-controller="w-dialog">',
+            '<div id="schedule-publishing-dialog" class="w-dialog w-dialog--message publishing" data-controller="w-dialog">',
             html,
             count=1,
             allow_extra_attrs=True,
@@ -561,7 +561,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             allow_extra_attrs=True,
         )
         self.assertTagInHTML(
-            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-controller="w-dialog">',
+            '<div id="schedule-publishing-dialog" class="w-dialog w-dialog--message publishing" data-controller="w-dialog">',
             html,
             count=1,
             allow_extra_attrs=True,
@@ -1279,7 +1279,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             allow_extra_attrs=True,
         )
         self.assertTagInHTML(
-            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-controller="w-dialog">',
+            '<div id="schedule-publishing-dialog" class="w-dialog w-dialog--message publishing" data-controller="w-dialog">',
             html,
             count=1,
             allow_extra_attrs=True,


### PR DESCRIPTION
The fix for #11306

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
