### PR TITLE
Update docs on get_language_info tag

### DIFF
--- a/docs/advanced_topics/i18n.md
+++ b/docs/advanced_topics/i18n.md
@@ -412,9 +412,11 @@ the name of the locale in its own language. We also add `rel` and `hreflang` att
 `translation.locale` is an instance of the [Locale model](locale_model_ref).
 
 Alternatively, a built-in tag from Django that gets info about the language of the translation.
-For more information, see [get_language_info() in the Django docs](https://docs.djangoproject.com/en/stable/topics/i18n/translation/#django.utils.translation.get_language_info).
+For more information, see [get_language_info in the Django docs](https://docs.djangoproject.com/en/stable/topics/i18n/translation/#get-language-info).
 
 ```html+django
+{% load i18n %}
+
 {% get_language_info for translation.locale.language_code as lang %}
 ```
 


### PR DESCRIPTION
Prompted by https://stackoverflow.com/q/77646918/1853523 - link to the docs for the tag rather than the function, and include the `{% load i18n %}` line.
