### PR TITLE
Bump telepath to 0.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
     "l18n>=2018.5",
     "openpyxl>=3.0.10,<4.0",
     "anyascii>=0.1.5",
-    "telepath>=0.1.1,<1",
+    "telepath>=0.3.1,<1",
     "laces>=0.1,<0.2",
 ]
 


### PR DESCRIPTION
This ensures that people upgrading to Django 5.0 will have a compatible version. Now that Python <3.8 and Django <3.2 are EOL, there's no reason for anyone to be running an older version.

Prompted by a report on Slack #support. I suggest this is merged into the stable/5.2.x branch (although it probably doesn't warrant a 5.2.3 release by itself).