### PR TITLE
Turn on `skipLibCheck` for TypeScript

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -71,6 +71,7 @@ Changelog
  * Maintenance: Introduce an internal `{% formattedfield %}` tag to replace direct use of `wagtailadmin/shared/field.html` (Matt Westcott)
  * Maintenance: Update Telepath dependency to 0.3.1 (Matt Westcott)
  * Maintenance: Upgrade to latest TypeScript and Storybook (Thibaud Colas, Sage Abdullah)
+ * Maintenance: Turn on `skipLibCheck` for TypeScript (LB (Ben) Johnston)
  * Maintenance: Refactor documents listing view to use generic IndexView (Sage Abdullah)
  * Maintenance: Support for the Stimulus `CloneController` to auto clear the added content after a set duration (LB (Ben) Johnston)
  * Maintenance: Refactor images listing view to use generic IndexView (Sage Abdullah)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -93,6 +93,7 @@ This release adds support for Django 5.0. The support has also been backported t
  * Update Telepath dependency to 0.3.1 (Matt Westcott)
  * Allow `ActionController` to have a `noop` method to more easily leverage standalone Stimulus action options (Nandini Arora)
  * Upgrade to latest TypeScript and Storybook (Thibaud Colas, Sage Abdullah)
+ * Turn on `skipLibCheck` for TypeScript (LB (Ben) Johnston)
  * Refactor documents listing view to use generic IndexView (Sage Abdullah)
  * Support for the Stimulus `CloneController` to auto clear the added content after a set duration (LB (Ben) Johnston)
  * Refactor images listing view to use generic IndexView (Sage Abdullah)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "noImplicitAny": false, // TODO: Enable once all existing code is typed
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "skipLibCheck": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "target": "ES2022"


### PR DESCRIPTION
- This avoids our TS checks parsing all library files when running linting & compiling, only the direct usage of libraries will be checked.
- This avoids us needing to consider nested dependencies off other libraries when developing with TypeScript.
- https://www.typescriptlang.org/tsconfig#skipLibCheck
