### PR TITLE
Use admin SlugInput as the default widget for models.SlugField

### DIFF
--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -145,4 +145,48 @@ Django versions prior to 4.2 are no longer supported as of this release; please 
 
 ## Upgrade considerations - changes affecting Wagtail customisations
 
+### `SlugInput` widget is now the default for `SlugField` fields
+
+In Wagtail 5.0 a new `SlugInput` admin widget was added to support slug behavior in Page and Page copy forms. This widget was included by default if the `promote_panels` fields layout was customised, causing confusion.
+
+As of this release, any forms that inherit from `WagtailAdminModelForm` (includes page and snippet model editing) will now use the `SlugInput` by default on all models with `SlugField` fields.
+
+Previously, the widget was needed to be explicitly added.
+
+```python
+from wagtail.admin.widgets.slug import SlugInput
+# ... other imports
+
+class MyPage(Page):
+    promote_panels = [
+        FieldPanel("slug", widget=SlugInput),
+        # ... other panels
+    ]
+```
+
+Keeping the widget as above is fine, but will no longer be required. The JavaScript field behavior will be included by default.
+
+```python
+# ... imports
+
+class MyPage(Page):
+    promote_panels = [
+        FieldPanel("slug"),
+        # ... other panels
+    ]
+```
+
+If you do not want this for some reason, you will now need to declare a different widget.
+
+```python
+from django.forms.widgets import TextInput
+# ... other imports
+
+class MyPage(Page):
+    promote_panels = [
+        FieldPanel("slug", widget=TextInput), # use a plain text field
+        # ... other panels
+    ]
+```
+
 ## Upgrade considerations - changes to undocumented internals

--- a/wagtail/admin/forms/models.py
+++ b/wagtail/admin/forms/models.py
@@ -85,6 +85,12 @@ register_form_field_override(
     ),
 )
 
+# Slug fields
+register_form_field_override(
+    models.SlugField,
+    override={"widget": widgets.SlugInput},
+)
+
 
 # Callback to allow us to override the default form fields provided for each model field.
 def formfield_for_dbfield(db_field, **kwargs):

--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -25,7 +25,7 @@ class CopyForm(forms.Form):
             initial=self.page.slug,
             label=_("New slug"),
             allow_unicode=allow_unicode,
-            widget=widgets.slug.SlugInput,
+            widget=widgets.SlugInput,
         )
         self.fields["new_parent_page"] = forms.ModelChoiceField(
             initial=self.page.get_parent(),

--- a/wagtail/admin/panels/page_utils.py
+++ b/wagtail/admin/panels/page_utils.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.utils.translation import gettext_lazy
 
 from wagtail.admin.forms.pages import WagtailAdminPageForm
-from wagtail.admin.widgets.slug import SlugInput
 from wagtail.models import Page
 from wagtail.utils.decorators import cached_classmethod
 
@@ -21,7 +20,7 @@ def set_default_page_edit_handlers(cls):
     cls.promote_panels = [
         MultiFieldPanel(
             [
-                FieldPanel("slug", widget=SlugInput),
+                FieldPanel("slug"),
                 FieldPanel("seo_title"),
                 FieldPanel("search_description"),
             ],

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1724,7 +1724,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         )
 
         input_field_for_draft_slug = '<input type="text" name="slug" value="revised-slug-in-draft-only" data-controller="w-slug" data-action="blur-&gt;w-slug#slugify w-sync:check-&gt;w-slug#compare w-sync:apply-&gt;w-slug#urlify:prevent" data-w-slug-compare-as-param="urlify" data-w-slug-allow-unicode-value maxlength="255" aria-describedby="panel-child-promote-child-for_search_engines-child-slug-helptext" required id="id_slug">'
-        input_field_for_live_slug = '<input type="text" name="slug" value="hello-world" maxlength="255" aria-describedby="panel-child-promote-child-for_search_engines-child-slug-helptext" required id="id_slug" />'
+        input_field_for_live_slug = '<input type="text" name="slug" value="hello-world" data-controller="w-slug" data-action="blur-&gt;w-slug#slugify w-sync:check-&gt;w-slug#compare w-sync:apply-&gt;w-slug#urlify:prevent" data-w-slug-compare-as-param="urlify" data-w-slug-allow-unicode-value maxlength="255" aria-describedby="panel-child-promote-child-for_search_engines-child-slug-helptext" required id="id_slug" />'
 
         # Status Link should be the live page (not revision)
         self.assertNotContains(
@@ -1749,8 +1749,8 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             reverse("wagtailadmin_pages:edit", args=(self.single_event_page.id,))
         )
 
-        input_field_for_draft_slug = '<input type="text" name="slug" value="revised-slug-in-draft-only" maxlength="255" aria-describedby="panel-child-promote-child-common_page_configuration-child-slug-helptext" required id="id_slug" />'
-        input_field_for_live_slug = '<input type="text" name="slug" value="mars-landing" maxlength="255" aria-describedby="panel-child-promote-child-common_page_configuration-child-slug-helptext" required id="id_slug" />'
+        input_field_for_draft_slug = '<input type="text" name="slug" value="revised-slug-in-draft-only" data-controller="w-slug" data-action="blur-&gt;w-slug#slugify w-sync:check-&gt;w-slug#compare w-sync:apply-&gt;w-slug#urlify:prevent" data-w-slug-compare-as-param="urlify" data-w-slug-allow-unicode-value maxlength="255" aria-describedby="panel-child-promote-child-common_page_configuration-child-slug-helptext" required id="id_slug" />'
+        input_field_for_live_slug = '<input type="text" name="slug" value="mars-landing" data-controller="w-slug" data-action="blur-&gt;w-slug#slugify w-sync:check-&gt;w-slug#compare w-sync:apply-&gt;w-slug#urlify:prevent" data-w-slug-compare-as-param="urlify" data-w-slug-allow-unicode-value maxlength="255" aria-describedby="panel-child-promote-child-common_page_configuration-child-slug-helptext" required id="id_slug" />'
 
         # Status Link should be the live page (not revision)
         self.assertNotContains(

--- a/wagtail/admin/widgets/__init__.py
+++ b/wagtail/admin/widgets/__init__.py
@@ -4,5 +4,6 @@ from wagtail.admin.widgets.button import *  # NOQA: F403
 from wagtail.admin.widgets.chooser import *  # NOQA: F403
 from wagtail.admin.widgets.datetime import *  # NOQA: F403
 from wagtail.admin.widgets.filtered_select import *  # NOQA: F403
+from wagtail.admin.widgets.slug import *  # NOQA: F403
 from wagtail.admin.widgets.switch import *  # NOQA: F403
 from wagtail.admin.widgets.tags import *  # NOQA: F403

--- a/wagtail/admin/widgets/slug.py
+++ b/wagtail/admin/widgets/slug.py
@@ -3,6 +3,13 @@ from django.forms import widgets
 
 
 class SlugInput(widgets.TextInput):
+    """
+    Associates the input field with the Stimulus w-slug (SlugController).
+    Slugifies content based on `WAGTAIL_ALLOW_UNICODE_SLUGS` and supports
+    fields syncing their value to this field (see `TitleFieldPanel`) if
+    also used.
+    """
+
     def __init__(self, attrs=None):
         default_attrs = {
             "data-controller": "w-slug",


### PR DESCRIPTION
- Register the admin SlugInput as the default widget for model SlugField usage
- Add a docstring to SlugInput to make it a bit clearer what it's doing
- Add SlugInput to the admin widgets module exports file
- Copy form is still needed as it's not a model field but a form field
- 6.0 release considerations added
- Closes #11185

## Manual Testing

1. Check that a non-published page title correctly syncs its value with the slug field (only if the title is the same as the slugified value on load)
2. Check that any page still uses the correct slug input (moving away from the field after typing should slugify the value)
3. Check the copy form slug field also correctly slugifies the value.
4. Modify a page (as follows below) and check that the slug field still works as expected for item 1 & 2
5. Modify a page model now with the Slug field using another widget, check it works as expected (not slugifying the content)


```
# bakerydemo/breads/models.py
# ... all other stuff

class BreadsIndexPage(Page):
    # .. fields, etc

    promote_panels = [ FieldPanel("slug") ] # add this line intentionally without the widget
```



```
# bakerydemo/breads/models.py
# ... all other stuff
from django.forms.widgets import TextInput

class BreadsIndexPage(Page):
    # .. fields, etc

    promote_panels = [ FieldPanel("slug", widget=TextInput) ] # adding with a different widget
```


