### PR TITLE
feat: Add support for boosting StreamBlocks

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -83,7 +83,7 @@ def runtests():
 
         argv = [sys.argv[0], "test", "-v2"] + benchmarks + rest
     else:
-        argv = [sys.argv[0], "test"] + rest
+        argv = [sys.argv[0], "test", "-v2"] + rest
 
     try:
         execute_from_command_line(argv)

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -20,6 +20,7 @@ from wagtail.admin.staticfiles import versioned_static
 from wagtail.coreutils import accepts_kwarg
 from wagtail.telepath import JSContext
 from wagtail.utils.deprecation import RemovedInWagtail70Warning
+from wagtail.search.index import SearchableContent
 
 __all__ = [
     "BaseBlock",
@@ -261,9 +262,9 @@ class Block(metaclass=BaseBlock):
 
     def get_searchable_content(self, value):
         """
-        Returns a list of strings containing text content within this block to be used in a search engine.
+        Returns `SearchableContent` to be used in a search engine.
         """
-        return []
+        return SearchableContent()
 
     def extract_references(self, value):
         return []

--- a/wagtail/contrib/table_block/tests.py
+++ b/wagtail/contrib/table_block/tests.py
@@ -10,6 +10,7 @@ from wagtail.contrib.table_block.blocks import DEFAULT_TABLE_OPTIONS, TableBlock
 from wagtail.models import Page
 from wagtail.test.testapp.models import TableBlockStreamPage
 from wagtail.test.utils import WagtailTestUtils
+from wagtail.search.index import SearchableContent
 
 from .blocks import TableInput
 
@@ -268,24 +269,24 @@ class TestTableBlock(TestCase):
                 [None, "Foo", None],
             ],
         }
-        block = TableBlock()
+        block = TableBlock(search_boost=10)
         content = block.get_searchable_content(value)
         self.assertEqual(
             content,
-            [
+            SearchableContent({10: [
                 "Test 1",
                 "Test 2",
                 "Test 3",
                 "Bar",
                 "Foo",
-            ],
+            ]}),
         )
 
     def test_searchable_content_for_null_block(self):
         value = None
         block = TableBlock()
         content = block.get_searchable_content(value)
-        self.assertEqual(content, [])
+        self.assertEqual(content, SearchableContent())
 
     def test_render_with_extra_context(self):
         """
@@ -520,8 +521,8 @@ class TestTableBlockForm(WagtailTestUtils, SimpleTestCase):
         """
         block = TableBlock()
         search_content = block.get_searchable_content(value=self.value)
-        self.assertIn("Galactica", search_content)
-        self.assertIn("Brenik", search_content)
+        self.assertIn("Galactica", search_content.as_list())
+        self.assertIn("Brenik", search_content.as_list())
 
 
 # TODO(telepath) replace this with a functional test

--- a/wagtail/search/tests/test_indexed_class.py
+++ b/wagtail/search/tests/test_indexed_class.py
@@ -155,3 +155,58 @@ class TestSearchFields(TestCase):
                 if error.id == "wagtailsearch.W001"
             ]
             self.assertEqual([], errors)
+
+
+class SearchableContentTest(TestCase):
+    def setUp(self):
+        # Initialize SearchableContent object for testing
+        self.searchable_content = index.SearchableContent()
+
+    def test_add_content(self):
+        # Test adding content with a specific boost value
+        self.searchable_content.add_content(2.0, "first heading")
+        self.searchable_content.add_content(1.0, "first paragraph")
+
+        # Check if content is added correctly
+        self.assertEqual(self.searchable_content.as_dict(), {2.0: ["first heading"], 1.0: ["first paragraph"]})
+
+    def test_merge_content(self):
+        # Test merging content from another SearchableContent object
+        other_content = index.SearchableContent({1.5: ["merged paragraph"]})
+        self.searchable_content.merge_content(other_content)
+
+        # Check if content is merged correctly
+        self.assertEqual(self.searchable_content.as_dict(), {1.5: ["merged paragraph"]})
+
+    def test_multiply_boosts(self):
+        # Test multiplying boost values by a given multiplier
+        self.searchable_content.add_content(1.0, "first paragraph")
+        self.searchable_content.multiply_boosts(2)
+
+        # Check if boosts are multiplied correctly
+        self.assertEqual(self.searchable_content.get_unique_boosts(), {2.0})
+
+    def test_get_unique_boosts(self):
+        # Test getting unique boost values
+        self.searchable_content.add_content(2.0, "first heading")
+        self.searchable_content.add_content(1.0, "first paragraph")
+        self.searchable_content.add_content(2.0, "second heading")
+
+        # Check if unique boosts are obtained correctly
+        self.assertEqual(self.searchable_content.get_unique_boosts(), {1.0, 2.0})
+
+    def test_as_dict(self):
+        # Test getting content as a dictionary
+        self.searchable_content.add_content(2.0, "first heading")
+        self.searchable_content.add_content(1.0, "first paragraph")
+
+        # Check if content is obtained as a dictionary correctly
+        self.assertEqual(self.searchable_content.as_dict(), {2.0: ["first heading"], 1.0: ["first paragraph"]})
+
+    def test_as_list(self):
+        # Test getting content as a single list
+        self.searchable_content.add_content(2.0, "first heading")
+        self.searchable_content.add_content(1.0, "first paragraph")
+
+        # Check if content is obtained as a list correctly
+        self.assertEqual(self.searchable_content.as_list(), ["first heading", "first paragraph"])

--- a/wagtail/test/customuser/fields.py
+++ b/wagtail/test/customuser/fields.py
@@ -1,6 +1,7 @@
 import random
 
 from django.db import models
+from wagtail.search.index import SearchableContent
 
 LOWER_BOUND = -2147483648
 UPPER_BOUND = 2147483647
@@ -39,6 +40,11 @@ class ConvertedValueField(models.IntegerField):
     """
     Roughly copied from https://github.com/django/django/blob/d6eaf7c0183cd04b78f2a55e1d60bb7e59598310/tests/custom_pk/fields.py
     """
+
+    def __init__(self, *args, **kwargs):
+        self.search_boost = kwargs.pop("search_boost", 1)
+        self.unique_boost = set([self.search_boost])
+        super().__init__(*args, **kwargs)
 
     def pre_save(self, instance, add):
         value = getattr(instance, self.attname, None)
@@ -79,4 +85,4 @@ class ConvertedValueField(models.IntegerField):
     def get_searchable_content(self, value):
         if not value:
             return
-        return ConvertedValue(value).db_value
+        return SearchableContent({self.search_boost: ConvertedValue(value).db_value})

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -12,7 +12,7 @@ from wagtail.rich_text.pages import PageLinkHandler
 from wagtail.rich_text.rewriters import LinkRewriter, extract_attrs
 from wagtail.test.testapp.models import EventIndex, EventPage
 from wagtail.test.utils.form_data import rich_text
-
+from wagtail.search.index import SearchableContent
 
 class TestPageLinktypeHandler(TestCase):
     fixtures = ["test.json"]
@@ -247,7 +247,7 @@ class TestRichTextField(TestCase):
         body_field = christmas_page._meta.get_field("body")
         value = body_field.value_from_object(christmas_page)
         result = body_field.get_searchable_content(value)
-        self.assertEqual(result, ["Merry Christmas from Wagtail! & co."])
+        self.assertEqual(result, SearchableContent({1: ["Merry Christmas from Wagtail! & co."]}))
 
     def test_get_searchable_content_whitespace(self):
         christmas_page = EventPage.objects.get(url_path="/home/events/christmas/")
@@ -257,7 +257,7 @@ class TestRichTextField(TestCase):
         body_field = christmas_page._meta.get_field("body")
         value = body_field.value_from_object(christmas_page)
         result = body_field.get_searchable_content(value)
-        self.assertEqual(result, ["buttery mashed potatoes"])
+        self.assertEqual(result, SearchableContent({1: ["buttery mashed potatoes"]}))
 
     def test_max_length_validation(self):
         EventIndexForm = modelform_factory(model=EventIndex, fields=["intro"])


### PR DESCRIPTION
Fixes: #11277

## Implementation

- [ ] Documentation
- [x] get_searchable_content updated
- [x] search_boost added to relevant blocks
- [x] boost values returned by the children will be multiplied by the block's own boost value
- [x] handling a list being returned from get_searchable_content in versions less than 6
- [x] implemented SearchableContent with merging / multiplying methods
- [x] implemented unique_boosts property which is a set
- [x] StreamField will also provide a unique_boosts method/property that simply returns the result from its top-level block (as it already does for get_searchable_content).
- [ ] `SearchField will also provide a unique_boosts method/property that returns the underlying field's unique_boosts if it provides one - multiplied by its own boost value - or just its own boost value if not.`
- [ ] `wagtail.search.backends.database.postgres.weights.get_boosts should use search_field.unique_boosts instead of search_field.boost` Facing an issue here --> wagtail/search/backends/database/postgres/postgres.py#L550 in the PR
- [x] `Within wagtail.search.backends.database.postgres.postgres.ObjectIndexer, prepare_field on a SearchField will yield multiple values, one for each entry in the get_value_with_boosts dict`
- [ ] For sqlite and mysql, index-time boosting support, we are lacking modules similar to `from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector`
- [ ] Yet to look into Elasticsearch, but taking one step at a time, dealing to get ideal experience with psql first



_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
