### PR TITLE
Clarify redirects are enabled by default

### DIFF
--- a/docs/reference/contrib/redirects.md
+++ b/docs/reference/contrib/redirects.md
@@ -10,7 +10,8 @@ The `redirects` module provides the models and user interface for managing arbit
 
 ## Installation
 
-The `redirects` module is not enabled by default. To install it, add `wagtail.contrib.redirects` to `INSTALLED_APPS` and `wagtail.contrib.redirects.middleware.RedirectMiddleware` to `MIDDLEWARE` in your project's Django settings file.
+The `redirects` module is enabled by default. However, if you are upgrading from an older version of Wagtail you may need to manually install it. To install it, add `wagtail.contrib.redirects` to `INSTALLED_APPS` and `wagtail.contrib.redirects.middleware.RedirectMiddleware` to `MIDDLEWARE` in your project's Django settings file.
+
 
 ```python
 INSTALLED_APPS = [

--- a/docs/reference/contrib/redirects.md
+++ b/docs/reference/contrib/redirects.md
@@ -10,7 +10,7 @@ The `redirects` module provides the models and user interface for managing arbit
 
 ## Installation
 
-The `redirects` module is enabled by default. However, if you are upgrading from an older version of Wagtail you may need to manually install it. To install it, add `wagtail.contrib.redirects` to `INSTALLED_APPS` and `wagtail.contrib.redirects.middleware.RedirectMiddleware` to `MIDDLEWARE` in your project's Django settings file.
+The `redirects` module is enabled by default when you create a new Wagtail website using the `wagtail start` command. However, if you are upgrading from an older version of Wagtail you may need to manually install it. To install it, add `wagtail.contrib.redirects` to `INSTALLED_APPS` and `wagtail.contrib.redirects.middleware.RedirectMiddleware` to `MIDDLEWARE` in your project's Django settings file.
 
 
 ```python


### PR DESCRIPTION
Redirects _are_ enabled by default. Tested on Wagtail 5.2.2 with `wagtail start mysite`.
