### PR TITLE
Avoid nested selector combinators (Sass clean up)

### DIFF
--- a/client/scss/components/forms/_field-row.scss
+++ b/client/scss/components/forms/_field-row.scss
@@ -12,7 +12,7 @@
     grid-auto-columns: minmax(min-content, 1fr);
   }
 
-  + &,
+  + .w-field-row,
   .w-field__wrapper + &,
   + .w-field__wrapper {
     margin-top: theme('spacing.5');


### PR DESCRIPTION
See https://sass-lang.com/documentation/breaking-changes/bogus-combinators/

Resolve the issue when building the CSS files we get a warning (see below). Ensure we can support a future version of Dart SASS.

```
<w> Deprecation The selector "+ .w-field-row" is invalid CSS.
<w> This will be an error in Dart Sass 2.0.0.
<w> 
<w> More info: https://sass-lang.com/d/bogus-combinators
<w> 
<w> client/scss/components/forms/_field-row.scss 15:3         @import
<w> client/scss/core.scss 126:9                               @import
<w> wagtail/admin/static_src/wagtailadmin/scss/core.scss 1:9  root stylesheet
<w> 
```
