### PR TITLE
Display character count to RichTextBlock issue#10640

### DIFF
--- a/client/src/components/StreamField/blocks/FieldBlock.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.js
@@ -155,6 +155,10 @@ export class FieldBlock {
       attributes.required = '';
     }
 
+    if (this.blockDef.meta.maxLength) {
+      attributes.maxLength = this.blockDef.meta.maxLength;
+    }
+
     return attributes;
   }
 

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -378,6 +378,11 @@ class DraftailRichTextArea {
     input.id = id;
     input.name = name;
 
+    if (typeof options?.attributes === 'object') {
+      Object.entries(options.attributes).forEach(([key, value]) => {
+        input.setAttribute(key, value);
+      });
+    }
     // If the initialState is an EditorState, rather than serialized rawContentState, it's
     // easier for us to initialize the widget blank and then setState to the correct state
     const initialiseBlank = !!initialState.getCurrentContent;

--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -120,6 +120,9 @@ class FieldBlockAdapter(Adapter):
         if block.field.help_text:
             meta["helpText"] = block.field.help_text
 
+        if hasattr(block, "max_length") and block.max_length is not None:
+            meta["maxLength"] = block.max_length
+
         return [
             block.name,
             block.field.widget,
@@ -678,6 +681,7 @@ class RichTextBlock(FieldBlock):
             "help_text": help_text,
             "validators": validators,
         }
+        self.max_length = max_length
         self.editor = editor
         self.features = features
         self.search_index = search_index


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #10640 
this PR may solve  "display character count to RichTextBlock" as the main reason 
and also additionally this PR add the  missing attributes to  the `input` element
of `RichTextBlock`   like `maxlength` which the reason of the issue and `aria-describedby`,
These attributes  were applied previously before this PR to most of the `field's blocks`
but for some reason not applied to `RichTextBlock` and now these attributes
 applied to `input` of `RichTextBlock` .

so now the `RichTextBlock` display character count and the count increase and decrease as expected
when add or remove characters as the following attachments show

After 
![After](https://github.com/wagtail/wagtail/assets/90080237/a8f53fab-a396-4cd4-abd5-3d233c5d9b31)

Before
![Before](https://github.com/wagtail/wagtail/assets/90080237/b37dcb2f-a44a-4a0a-b7af-9318c271bb9e)

 and also add the missing attributes to  the `input` element of `RichTextBlock`  like `maxlength` ,`aria-describedby`
  as shown below in Screenshot 
After  
![After](https://github.com/wagtail/wagtail/assets/90080237/bbb23b6a-2f87-48a8-93ca-b465d5033393)

Before
![Before](https://github.com/wagtail/wagtail/assets/90080237/7f03bb43-4042-4744-9aff-b6c8c5a1c763)

_Please check the following:_

-   [√ ] Do the tests still pass?[^1]
-   [ √] Does the code comply with the style guide?
    -   [ √] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

 Please describe additional details for testing this change
for testing simply open any page using  `RichTextBlock` , and you will notice as the attachments
 - `character counter ` now work.
 - `input` element of `RichTextBlock` has the missing attributes like `aria-describedby`  and `maxlength` .

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
