### PR TITLE
Fix some warnings when building docs

### DIFF
--- a/docs/advanced_topics/customisation/page_editing_interface.md
+++ b/docs/advanced_topics/customisation/page_editing_interface.md
@@ -54,7 +54,7 @@ class FundingPage(Page):
 
 For more details on how to work with `Panel`s and `PanelGroup`, see [](forms_panels_overview).
 
-(rich_text)=
+(rich_text_field)=
 
 ## Rich Text (HTML)
 

--- a/docs/advanced_topics/deploying.md
+++ b/docs/advanced_topics/deploying.md
@@ -60,7 +60,7 @@ The django-storages Amazon S3 backends (`storages.backends.s3boto.S3BotoStorage`
 
 ### Cache
 
-Wagtail is designed to make huge advantage of Django's [cache framework](django:topics/cache/index) when available to accelerate page loads. The cache is especially useful for the Wagtail admin, which can't take advantage of conventional CDN caching.
+Wagtail is designed to make huge advantage of Django's [cache framework](django:topics/cache) when available to accelerate page loads. The cache is especially useful for the Wagtail admin, which can't take advantage of conventional CDN caching.
 
 Wagtail supports any of Django's cache backend, however we recommend against using one tied to the specific process or environment Django is running (eg `FileBasedCache` or `LocMemCache`).
 

--- a/docs/advanced_topics/documents/custom_document_model.md
+++ b/docs/advanced_topics/documents/custom_document_model.md
@@ -1,3 +1,5 @@
+(custom_document_model)=
+
 # Custom document model
 
 An alternate `Document` model can be used to add custom behaviour and

--- a/docs/advanced_topics/documents/overview.md
+++ b/docs/advanced_topics/documents/overview.md
@@ -85,7 +85,7 @@ Here's an example template to access the document field and render it:
 
 ## Using documents within `RichTextFields`
 
-Links to documents can be made in pages using the [`RichTextField`](rich_text_docs). By default, Wagtail will include the features for adding links to documents see [](rich_text_features).
+Links to documents can be made in pages using the [`RichTextField`](rich_text_field). By default, Wagtail will include the features for adding links to documents see [](rich_text_features).
 
 
 You can either exclude or include these by passing the `features` to your `RichTextField`. In the example below we create a `RichTextField` with only documents and basic formatting.

--- a/docs/advanced_topics/documents/storing_and_serving.md
+++ b/docs/advanced_topics/documents/storing_and_serving.md
@@ -43,7 +43,7 @@ WAGTAILDOCS_INLINE_CONTENT_TYPES = ['application/pdf', 'text/plain']
 
 Wagtail allows you to specify the permitted file extensions for document uploads using the [WAGTAILDOCS_EXTENSIONS](wagtaildocs_extensions) setting.
 
-It also validates the extensions using Django's [FileExtensionValidator](django:ref/validators#fileextensionvalidator). For example:
+It also validates the extensions using Django's [FileExtensionValidator](https://docs.djangoproject.com/en/stable/ref/validators/#fileextensionvalidator). For example:
 
 ```python
 WAGTAILDOCS_EXTENSIONS = ['pdf', 'docx']

--- a/docs/extending/extending_client_side.md
+++ b/docs/extending/extending_client_side.md
@@ -25,7 +25,7 @@ The simplest way is to add global JavaScript files via hooks, see [](insert_edit
 
 For JavaScript added when a specific Widget is used you can add an inner `Media` class to ensure that the file is loaded when the widget is used, see [Django's docs on their form `Media` class](https://docs.djangoproject.com/en/stable/topics/forms/media/#assets-as-a-static-definition).
 
-In a similar way, Wagtail's [template components](template_components) provide a `media` property or `Media` class to add scripts when rendered.
+In a similar way, Wagtail's [](./template_components) provide a `media` property or `Media` class to add scripts when rendered.
 
 These will ensure the added files are used in the admin after the core JavaScript admin files are already loaded.
 

--- a/docs/extending/rich_text_internals.md
+++ b/docs/extending/rich_text_internals.md
@@ -15,7 +15,7 @@ The components involved in Wagtail's rich text handling are described below.
 
 ## Data format
 
-Rich text data (as handled by [RichTextField](rich_text), and `RichTextBlock` within [StreamField](../topics/streamfield.rst)) is stored in the database in a format that is similar, but not identical, to HTML. For example, a link to a page might be stored as:
+Rich text data (as handled by [RichTextField](rich_text_field), and `RichTextBlock` within [StreamField](../topics/streamfield.rst)) is stored in the database in a format that is similar, but not identical, to HTML. For example, a link to a page might be stored as:
 
 ```html
 <p><a linktype="page" id="3">Contact us</a> for more information.</p>

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -236,7 +236,7 @@ As a result, the following features are now deprecated:
 - {meth}`wagtail.models.Revision.approve_moderation`
 - {meth}`wagtail.models.Revision.reject_moderation`
 - The `submitted_for_moderation` argument in {meth}`wagtail.models.RevisionMixin.save_revision`
-- [`WAGTAIL_MODERATION_ENABLED`](wagtail_moderation_enabled)
+- `WAGTAIL_MODERATION_ENABLED`
 - `wagtail.admin.userbar.ModeratePageItem`
 - `wagtail.admin.userbar.ApproveModerationEditPageItem`
 - `wagtail.admin.userbar.RejectModerationEditPageItem`

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -386,7 +386,7 @@ And to use the `<amp-img>` tag (based on the [Mountains example](https://amp.dev
 
 ## Images embedded in rich text
 
-The information above relates to images defined via image-specific fields in your model. However, images can also be embedded arbitrarily in Rich Text fields by the page editor (see [](rich_text)).
+The information above relates to images defined via image-specific fields in your model. However, images can also be embedded arbitrarily in Rich Text fields by the page editor (see [](rich_text_field).
 
 Images embedded in Rich Text fields can't be controlled by the template developer as easily. There are no image objects to work with, so the `{% image %}` template tag can't be used. Instead, editors can choose from one of a number of image "Formats" at the point of inserting images into their text.
 

--- a/docs/tutorial/create_portfolio_page.md
+++ b/docs/tutorial/create_portfolio_page.md
@@ -350,7 +350,7 @@ To add your resume to your portfolio site, follow these steps:
     c. Click **Paragraph block**.   
     d. Copy and paste the following text in your new **Paragraph block**:  
 
-    ```txt
+    ```text
     I'm a Wagtail Developer with a proven track record of developing and maintaining complex web applications. I have experience writing custom code to extend Wagtail applications, collaborating with other developers, and integrating third-party services and APIs.
     ```  
 
@@ -366,7 +366,7 @@ To add your resume to your portfolio site, follow these steps:
 
     j. Type the following after your Heading 3:
 
-    ```txt
+    ```text
     January 2022 to November 2023
 
     - Developed and maintained a complex web application using Wagtail, resulting in a 25% increase in user engagement and a 20% increase in revenue within the first year.

--- a/docs/tutorial/deployment.md
+++ b/docs/tutorial/deployment.md
@@ -55,7 +55,7 @@ After setting up your Backblaze B2 Cloud Storage, you must link it to your portf
 
 Start by creating a `.env.production` file at the root of your project directory. At this stage, your project directory should look like this:
 
-```txt
+```text
 mysite/
 ├── base
 ├── blog
@@ -130,7 +130,7 @@ Now, use your `keyID` as the value of `AWS_S3_ACCESS_KEY_ID` and `applicationKey
 
 At this stage, the content of your `.env.production` file looks like this:
 
-```txt
+```text
 AWS_STORAGE_BUCKET_NAME=yourname-wagtail-portfolio
 AWS_S3_ENDPOINT_URL=https://s3.us-east-005.backblazeb2.com
 AWS_S3_REGION_NAME=us-east-005
@@ -162,7 +162,7 @@ To set up your Fly.io account, follow these steps:
 3. Sign up using your GitHub account, Google account, or the email option.
 4. Check your email inbox for the verification link to verify your email.
 
-```note
+```{note}
 If your email verification fails, go to your Fly.io [Dashboard](https://fly.io/dashboard) and try again.
 ```
 
@@ -306,7 +306,7 @@ console_command = "/code/manage.py shell"
 
 Now add your production dependencies by replacing the content of your `requirements.txt` file with the following:
 
-```txt
+```text
 Django>=4.2,<4.3
 wagtail==5.1.1
 gunicorn>=21.2.0,<22.0.0
@@ -416,7 +416,7 @@ Now, complete the configuration of your environment variables by modifying your 
 
 The content of your `.env.production` file should now look like this:
 
-```txt
+```text
 AWS_STORAGE_BUCKET_NAME=yourname-wagtail-portfolio
 AWS_S3_ENDPOINT_URL=https://s3.us-east-005.backblazeb2.com
 AWS_S3_REGION_NAME=us-east-005

--- a/docs/tutorial/style_your_site.md
+++ b/docs/tutorial/style_your_site.md
@@ -178,7 +178,7 @@ To add a skip-link, add the following styles to your `mysite/static/css/mysite.c
 
 After adding the styles, go to your `mysite/templates/base.html` file and add a unique identifier:
 
-```html+python
+```html+django
 {% include "includes/header.html" %}
 
 {# Add a unique identifier: #}


### PR DESCRIPTION
I noticed a handful of warnings while building our docs locally with `make html` so I thought I would do some tidying. I managed to get rid of all but one: 

`/Code/wagtail-dev/wagtail/docs/releases/5.2.md:502: WARNING: Could not lex literal_block as "html+django". Highlighting skipped.`

I fooled around with it and the html+django parser doesn't like the div inside this code block:
```html+django
{% load wagtailadmin_tags %}
<script type="text/django-form-template" id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
    {% escapescript %}
        <div>Widget template content</div>
        <script src="/js/my-widget.js"></script>
    {% endescapescript %}
</script>
```
If I remove that line or move the `<div>` out of the `<script>` tag, the warning disappears and the remaining code gets its syntax highlighting. @lb- this is from an example you added. I assume the example needs to be as it is and we just live with the lack of highlighting, yes?

<img width="834" alt="Screenshot 2023-12-30 at 9 06 18 PM" src="https://github.com/wagtail/wagtail/assets/5952/b06569dc-99a0-47d0-ab3f-f54f17986030">

