### PR TITLE
Upgrade sphinxcontrib-spelling to 7.x

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -90,6 +90,7 @@ Changelog
  * Maintenance: Simplify browserslist and browser support documentation (Thibaud Colas)
  * Maintenance: Relax django-taggit dependency to allow 5.0 (Sylvain Fankhauser)
  * Maintenance: Fix various warnings when building docs (Cynthia Kiser)
+ * Maintenance: Upgrade sphinxcontrib-spelling to 7.x for Python 3.12 compatibility (Matt Westcott)
 
 
 5.2.2 (06.12.2023)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -122,6 +122,7 @@ The admin interface now supports right-to-left languages, such as Persian, Arabi
  * Simplify browserslist and browser support documentation for maintainers (Thibaud Colas)
  * Relax django-taggit dependency to allow 5.0 (Sylvain Fankhauser)
  * Fix various warnings when building docs (Cynthia Kiser)
+ * Upgrade sphinxcontrib-spelling to 7.x for Python 3.12 compatibility (Matt Westcott)
 
 ## Upgrade considerations - removal of deprecated features from Wagtail 4.2 - 5.1
 

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ testing_extras = [
 # Documentation dependencies
 documentation_extras = [
     "pyenchant>=3.1.1,<4",
-    "sphinxcontrib-spelling>=5.4.0,<6",
+    "sphinxcontrib-spelling>=7,<8",
     "Sphinx>=1.5.2",
     "sphinx-autobuild>=0.6.0",
     "sphinx-wagtail-theme==6.1.1",


### PR DESCRIPTION
The old version fails on Python 3.12 with "Could not import extension sphinxcontrib.spelling (exception: No module named 'imp')".
