### PR TITLE
Use fullpageurl instead of pageurl template tag throughout wagtail admin

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/chooser/tables/page_title_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/tables/page_title_cell.html
@@ -6,7 +6,7 @@
             {% if column.is_multiple_choice %}
                 <label for="chooser-modal-select-{{ page.id|unlocalize }}">{{ value }}</label>
             {% else %}
-                <a class="choose-page" href="#{{ page.id|unlocalize }}" data-id="{{ page.id|unlocalize }}" data-title="{{ page.title }}" data-admin-title="{{ page.get_admin_display_title }}" data-url="{% pageurl page %}" data-parent-id="{{ page.get_parent.id|unlocalize }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ value }}</a>
+                <a class="choose-page" href="#{{ page.id|unlocalize }}" data-id="{{ page.id|unlocalize }}" data-title="{{ page.title }}" data-admin-title="{{ page.get_admin_display_title }}" data-url="{% fullpageurl page %}" data-parent-id="{{ page.get_parent.id|unlocalize }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ value }}</a>
             {% endif %}
         {% else %}
             {{ value }}

--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -47,7 +47,7 @@
                                             <a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" target="_blank" rel="noreferrer">{% trans 'Draft' %}</a>
                                         {% endif %}
                                         {% if page.live %}
-                                            {% pageurl page as page_url %}
+                                            {% fullpageurl page as page_url %}
                                             {% if page_url is not None %}
                                                 <a href="{{ page_url }}" target="_blank" rel="noreferrer">{% trans 'Live' %}</a>
                                             {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
@@ -37,7 +37,7 @@
                                             <a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" target="_blank" rel="noreferrer">{% trans 'Draft' %}</a>
                                         {% endif %}
                                         {% if page.live %}
-                                            {% pageurl page as page_url %}
+                                            {% fullpageurl page as page_url %}
                                             {% if page_url is not None %}
                                                 <a href="{{ page_url }}" target="_blank" rel="noreferrer">{% trans 'Live' %}</a>
                                             {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/page_status_tag.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/page_status_tag.html
@@ -2,7 +2,7 @@
 {% load i18n wagtailadmin_tags %}
 {% trans "Current page status:" as status_hidden_label %}
 {% if page.live %}
-    {% pageurl page as page_url %}
+    {% fullpageurl page as page_url %}
     {% if page_url is not None %}
         {% status page.status_string url=page_url title=_("Visit the live page") hidden_label=status_hidden_label classname="w-status--primary" attrs='target="_blank" rel="noreferrer"' %}
     {% else %}

--- a/wagtail/admin/templates/wagtailadmin/shared/page_status_tag_new.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/page_status_tag_new.html
@@ -1,3 +1,4 @@
+{% load wagtailcore_tags %}
 {% load i18n wagtailadmin_tags %}
 {% comment %}
 
@@ -8,44 +9,47 @@
 {% endcomment %}
 
 {% comment %} Unable to use pageurl template tag here due to issues in unit tests where request is not yet available - see #10157 {% endcomment %}
-{% if page.live and page.url is not None %}
-    {% test_page_is_public page as is_public %}
+{% if page.live %}
+    {% fullpageurl page as page_url %}
+    {% if page_url is not None %}
+        {% test_page_is_public page as is_public %}
 
-    <a href="{{ page.url }}" target="_blank" rel="noreferrer"
-       class="
-              page-status-tag
-              u-text-uppercase
-              w-inline-flex
-              w-items-center
-              w-justify-center
-              w-whitespace-nowrap
-              w-px-1
-              w-ml-3
-              w-text-[0.6875rem]
-              w-rounded-sm
-              w-bg-transparent
-              w-text-text-meta
-              w-border
-              w-border-border-furniture
-              w-no-underline
-              w-font-semibold
-              hover:w-border-surface-menus
-              hover:w-text-text-label
-              w-transition"
-       aria-label="{% if is_public %}{% trans 'Visible to all. Visit the live page' %}{% else %}{% trans 'Private. Visit the live page' %}{% endif %}"
-       data-controller="w-tooltip"
-       data-w-tooltip-content-value="{% if is_public %}{% trans 'Visible to all' %}{% else %}{% trans 'Private' %}{% endif %}"
-       data-w-tooltip-offset-value="[0, 13]"
-    >
+        <a href="{{ page_url }}" target="_blank" rel="noreferrer"
+           class="
+                  page-status-tag
+                  u-text-uppercase
+                  w-inline-flex
+                  w-items-center
+                  w-justify-center
+                  w-whitespace-nowrap
+                  w-px-1
+                  w-ml-3
+                  w-text-[0.6875rem]
+                  w-rounded-sm
+                  w-bg-transparent
+                  w-text-text-meta
+                  w-border
+                  w-border-border-furniture
+                  w-no-underline
+                  w-font-semibold
+                  hover:w-border-surface-menus
+                  hover:w-text-text-label
+                  w-transition"
+           aria-label="{% if is_public %}{% trans 'Visible to all. Visit the live page' %}{% else %}{% trans 'Private. Visit the live page' %}{% endif %}"
+           data-controller="w-tooltip"
+           data-w-tooltip-content-value="{% if is_public %}{% trans 'Visible to all' %}{% else %}{% trans 'Private' %}{% endif %}"
+           data-w-tooltip-offset-value="[0, 13]"
+        >
 
-        {% with icon_classes='privacy-indicator-icon w-w-4 w-h-4 w-mr-1' %}
-            {% if is_public %}
-                {% icon name="view" classname=icon_classes %}
-            {% else %}
-                {% icon name="no-view" classname=icon_classes %}
-            {% endif %}
-        {% endwith %}
+            {% with icon_classes='privacy-indicator-icon w-w-4 w-h-4 w-mr-1' %}
+                {% if is_public %}
+                    {% icon name="view" classname=icon_classes %}
+                {% else %}
+                    {% icon name="no-view" classname=icon_classes %}
+                {% endif %}
+            {% endwith %}
 
-        {% trans 'Live' %}
-    </a>
+            {% trans 'Live' %}
+        </a>
+    {% endif %}
 {% endif %}

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -2035,7 +2035,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         # as when running it within the full test suite
         self.client.get(reverse("wagtailadmin_pages:edit", args=(self.event_page.id,)))
 
-        with self.assertNumQueries(35):
+        with self.assertNumQueries(36):
             self.client.get(
                 reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
             )
@@ -2048,7 +2048,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         # Warm up the cache as above.
         self.client.get(reverse("wagtailadmin_pages:edit", args=(self.event_page.id,)))
 
-        with self.assertNumQueries(39):
+        with self.assertNumQueries(40):
             self.client.get(
                 reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
             )

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -1092,7 +1092,7 @@ class TestInWorkflowStatus(WagtailTestUtils, TestCase):
         soup = self.get_soup(response.content)
 
         for page in [self.christmas, self.saint_patrick]:
-            status = soup.select_one(f'a.w-status[href="{page.url}"]')
+            status = soup.select_one(f'a.w-status[href="{page.full_url}"]')
             self.assertIsNotNone(status)
             self.assertEqual(
                 status.text.strip(), "Current page status: live + in moderation"


### PR DESCRIPTION
Fixes #10775

Changes all usages of `pageurl` in the wagtail admin (added by [#10157](https://github.com/wagtail/wagtail/pull/10157)) to `fullpageurl` to accommodate sites with a seperate admin domain.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
