### PR TITLE
Bump dependencies to django-taggit>=4.0, django-modelcluster>=6.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ except ImportError:
 
 install_requires = [
     "Django>=4.2,<6.0",
-    "django-modelcluster>=6.1,<7.0",
+    "django-modelcluster>=6.2.1,<7.0",
     "django-permissionedforms>=0.1,<1.0",
-    "django-taggit>=2.0,<5.1",
+    "django-taggit>=4.0,<5.1",
     "django-treebeard>=4.5.1,<5.0",
     "djangorestframework>=3.11.1,<4.0",
     "django-filter>=23.3,<24",


### PR DESCRIPTION
Ref https://github.com/wagtail/django-modelcluster/issues/182 - recent django-taggit and django-modelcluster releases have bugfixes and performance enhancements relevant to Wagtail.

(Not to be backported to 5.2.x, since there's a remote possibility that people could be running a pinned django-taggit 2.x on their projects for the previous slug behaviour, so this is technically a breaking change, albeit not one worth noting in an upgrade consideration)