### PR TITLE
Allow admin backend login URL to be customised

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -528,6 +528,14 @@ WAGTAILADMIN_USER_LOGIN_FORM = 'users.forms.LoginForm'
 
 Allows the default `LoginForm` to be extended with extra fields.
 
+### `WAGTAILADMIN_LOGIN_URL`
+
+```python
+WAGTAILADMIN_LOGIN_URL = 'http://example.com/login/'
+```
+
+This specifies the URL to redirect to when a user attempts to access a Wagtail admin page without being logged in. If omitted, Wagtail will fall back to using `wagtailadmin_login`.
+
 ## User preferences
 
 (wagtail_gravatar_provider_url)=

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -120,9 +120,11 @@ def reject_request(request):
     # wagtail.admin.auth, specifically where custom user models are involved
     from django.contrib.auth.views import redirect_to_login as auth_redirect_to_login
 
-    return auth_redirect_to_login(
-        request.get_full_path(), login_url=reverse("wagtailadmin_login")
+    login_url = getattr(
+        settings, "WAGTAILADMIN_USER_LOGIN_URL", reverse("wagtailadmin_login")
     )
+
+    return auth_redirect_to_login(request.get_full_path(), login_url=login_url)
 
 
 def require_admin_access(view_func):

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -121,7 +121,7 @@ def reject_request(request):
     from django.contrib.auth.views import redirect_to_login as auth_redirect_to_login
 
     login_url = getattr(
-        settings, "WAGTAILADMIN_USER_LOGIN_URL", reverse("wagtailadmin_login")
+        settings, "WAGTAILADMIN_LOGIN_URL", reverse("wagtailadmin_login")
     )
 
     return auth_redirect_to_login(request.get_full_path(), login_url=login_url)

--- a/wagtail/admin/tests/test_views.py
+++ b/wagtail/admin/tests/test_views.py
@@ -67,7 +67,7 @@ class TestLoginView(WagtailTestUtils, TestCase):
         response = self.client.get(login_url)
         self.assertRedirects(response, homepage_admin_url)
 
-    @override_settings(WAGTAILADMIN_USER_LOGIN_URL="http://example.com/login/")
+    @override_settings(WAGTAILADMIN_LOGIN_URL="http://example.com/login/")
     def test_unauthenticated_redirect_to_custom_login_url(self):
         response = self.client.get(reverse("wagtailadmin_home"))
         self.assertRedirects(

--- a/wagtail/admin/tests/test_views.py
+++ b/wagtail/admin/tests/test_views.py
@@ -67,6 +67,15 @@ class TestLoginView(WagtailTestUtils, TestCase):
         response = self.client.get(login_url)
         self.assertRedirects(response, homepage_admin_url)
 
+    @override_settings(WAGTAILADMIN_USER_LOGIN_URL="http://example.com/login/")
+    def test_unauthenticated_redirect_to_custom_login_url(self):
+        response = self.client.get(reverse("wagtailadmin_home"))
+        self.assertRedirects(
+            response,
+            "http://example.com/login/?next=/admin/",
+            fetch_redirect_response=False,
+        )
+
     @override_settings(LANGUAGE_CODE="de")
     def test_language_code(self):
         response = self.client.get(reverse("wagtailadmin_login"))


### PR DESCRIPTION
Resolves #10882 Allows admin backend login URL to be customised

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For new features: Has the documentation been updated accordingly?

