### PR TITLE
Update issue templates and contribution guidelines to clarify who can work on what

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,23 +5,38 @@ Thank you for considering to help Wagtail.
 We welcome all support, whether on bug reports, code, design, reviews, tests,
 documentation, translations or just feature requests.
 
-## Using the issue tracker
+## Working on an issue
 
-The [issue tracker](https://github.com/wagtail/wagtail/issues) is
-the preferred channel for [bug reports](#bugs), [features requests](#features)
-and [submitting pull requests](#pull-requests). Please don't use the issue tracker
-for support - use [the 'wagtail' tag on Stack Overflow](https://stackoverflow.com/questions/tagged/wagtail) (preferred) or the [#support channel on the Wagtail Slack](https://github.com/wagtail/wagtail/wiki/Slack).
+👉 If an issue isn’t being worked on by anyone, go for it! **No need to ask "please assign me this issue".** Add a comment to claim the issue once you’re ready to start.
 
-## New code
+Please review the [contributing guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
+You might like to start by checking issues with the [good first issue](https://github.com/wagtail/wagtail/labels/good%20first%20issue) label.
 
-Please review the
-[contributing guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-You might like to start by checking issues with the
-[good first issue](https://github.com/wagtail/wagtail/labels/good%20first%20issue) label.
+## Reporting bugs
+
+To report bugs, use our [issue tracker](https://github.com/wagtail/wagtail/issues).
+
+## Feature requests
+
+Use our [issue tracker](https://github.com/wagtail/wagtail/issues) for feature requests, or go the [Wagtail Slack](https://github.com/wagtail/wagtail/wiki/Slack) or [Discussions](https://github.com/wagtail/wagtail/discussions) if you want to discuss an idea before requesting it.
+
+## Support
+
+Please don't use the issue tracker for support - use [the 'wagtail' tag on Stack Overflow](https://stackoverflow.com/questions/tagged/wagtail) (preferred) or the [#support channel](https://github.com/wagtail/wagtail/wiki/Slack#support) on the [Wagtail Slack](https://github.com/wagtail/wagtail/wiki/Slack).
 
 ## Code reviews
 
-We welcome code reviews from everyone. There's always a list of pull requests tagged ['Needs review'](https://github.com/wagtail/wagtail/pulls?q=is%3Apr+is%3Aopen+label%3A%22Needs+review%22).
+We welcome code reviews from everyone. There's always a list of pull requests tagged [status:Needs Review](https://github.com/wagtail/wagtail/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc+label%3A%22status%3ANeeds+Review%22).
+
+## Triaging issues
+
+We welcome help with triaging issues and pull requests. You can help by:
+
+- Adding more details or your own perspective to bug reports or feature requests.
+- Attempting to reproduce issues tagged [status:Unconfirmed](https://github.com/wagtail/wagtail/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Astatus%3AUnconfirmed) and sharing your findings.
+- Reviewing or otherwise offering your feedback on pull requests.
+
+View our [issue tracking guidelines](https://docs.wagtail.org/en/latest/contributing/issue_tracking.html) for more information.
 
 ## Translations
 

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -32,3 +32,13 @@ Any other relevant information. For example, why do you consider this a bug and 
 -   Django version: Look in your requirements.txt, or run `pip show django | grep Version`.
 -   Wagtail version: Look at the bottom of the Settings menu in the Wagtail admin, or run `pip show wagtail | grep Version:`.
 -   Browser version: You can use https://www.whatsmybrowser.org/ to find this out.
+
+### Working on this
+
+<!--
+  Do you have thoughts on skills needed?
+  Are you keen to work on this yourself once the issue has been accepted?
+  Please let us know here.
+-->
+
+Anyone can contribute to this. View our [contributing guidelines](https://docs.wagtail.org/en/latest/contributing/index.html), add a comment to the issue once you’re ready to start.

--- a/.github/ISSUE_TEMPLATE/DOCUMENTATION.md
+++ b/.github/ISSUE_TEMPLATE/DOCUMENTATION.md
@@ -29,3 +29,13 @@ assignees: ''
 <!--
   If you're suggesting a very specific change to the documentation, feel free to directly submit a pull request.
 -->
+
+### Working on this
+
+<!--
+  Do you have thoughts on skills needed?
+  Are you keen to work on this yourself once the issue has been accepted?
+  Please let us know here.
+-->
+
+Anyone can contribute to this. View our [contributing guidelines](https://docs.wagtail.org/en/latest/contributing/index.html), add a comment to the issue once you’re ready to start.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -39,3 +39,13 @@ assignees: ''
 -->
 
 (Write your answer here.)
+
+### Working on this
+
+<!--
+  Do you have thoughts on skills needed?
+  Are you keen to work on this yourself once the issue has been accepted?
+  Please let us know here.
+-->
+
+Anyone can contribute to this. View our [contributing guidelines](https://docs.wagtail.org/en/latest/contributing/index.html), add a comment to the issue once you’re ready to start.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -62,6 +62,7 @@ Changelog
  * Docs: Add clarity that MultipleChooserPanel may require a chooser viewset and how the functionality is expected to work (Andy Chosak)
  * Docs: Clarify where documentation build commands should be run (Nikhil S Kalburgi)
  * Docs: Add missing import to tutorial BlogPage example (Salvo Polizzi)
+ * Docs: Update contributing guide documentation and GitHub templates to better support new contributors (Thibaud Colas)
  * Maintenance: Update BeautifulSoup upper bound to 4.12.x (scott-8)
  * Maintenance: Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)
  * Maintenance: Adopt the usage of of translate string literals using `arg=_('...')` in all `wagtailadmin` module templates (Chiemezuo Akujobi)

--- a/docs/contributing/first_contribution_guide.md
+++ b/docs/contributing/first_contribution_guide.md
@@ -156,7 +156,7 @@ Finally, before 'claiming' check you can do the following;
 
 ### 6. Contributing a solution
 
-**Important:** We only use GitHub's issue assignment feature to members of the Wagtail core team. If an issue is not assigned to anyone, feel free to work on it, **no need to ask "please assign me this issue"**.
+**Important:** If an issue is not assigned to anyone and doesn’t already have a pull request, feel free to work on it, **no need to ask "please assign me this issue"**. We only use GitHub's issue assignment feature to assign certain issues to members of the Wagtail core team.
 
 If you feel ready to contribute a solution, now is a good time to add a comment to the issue describing your intention to do so, to prevent duplicating efforts. Instead of asking "please assign me this issue", write something similar to the following:
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,5 +1,13 @@
 # Contributing to Wagtail
 
+Thank you for your interest in improving Wagtail!
+
+## First-time contributors
+
+1. Read this document first.
+2. We don’t assign tasks. Feel free to pick any issue/task that isn’t already being worked on by someone else.
+3. Read the [Your first contribution guide](first_contribution_guide).
+
 ## Issues
 
 The easiest way to contribute to Wagtail is to tell us how to improve it! First, check to see if your bug or feature request has already been submitted at [github.com/wagtail/wagtail/issues](https://github.com/wagtail/wagtail/issues). If it has, and you have some supporting information which may help us deal with it, comment on the existing issue. If not, please [create a new one](https://github.com/wagtail/wagtail/issues/new), providing as much relevant context as possible. For example, if you're experiencing problems with installation, detail your environment and the steps you've already taken. If something isn't displaying correctly, tell us what browser you're using, and include a screenshot if possible.

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -93,6 +93,7 @@ Thank you to Thibaud Colas and Badr Fourane for their work on this feature.
  * Add clarity that [`MultipleChooserPanel`](multiple_chooser_panel) may require a chooser viewset and how the functionality is expected to work (Andy Chosak)
  * Clarify where documentation build commands should be run (Nikhil S Kalburgi)
  * Add missing import to tutorial BlogPage example (Salvo Polizzi)
+ * Update contributing guide documentation and GitHub templates to better support new contributors (Thibaud Colas)
 
 ### Maintenance
 


### PR DESCRIPTION
This is a follow-up to #10071 / this week’s core team meeting. We discussed how to better sign-post information in the project so people pick up tasks without feeling like they have to ask "Can I work on this?" comments.

The proposed changes here are to:

1. Add a very concise "first-time contributors" at the top of our [contribution guidelines](https://docs.wagtail.org/en/latest/contributing/index.html)
2. Reword / re-order the CONTRIBUTING.md so it’s hopefully easier for contributors to skim
3. Add a new "Working on this" section to our issue templates

All three changes are pretty much separate, but they’re related so I only made one PR.

## New section: Working on this

I would expect this will be the most effective change here. There is no guarantee that contributors read the full issue description, but if they do and are interested in contributing, there will be very clear and concise instructions:

> Anyone can work on this. View our [contributing guidelines](https://docs.wagtail.org/en/latest/contributing/index.html), claim the issue once you’re ready to start.

I’ve also added a comment above to encourage people who file issues to use this as an opportunity to define in broad terms "who can work on this":

1. Some indication of skills needed – backend, frontend, a design task. We use labels for this to some extent, but people who file issues don’t necessarily have the permissions to add those labels.
2. Some indication of effort involved – "seasoned contributor", "good first issue", "weeks of work".

For example, if a task was only doable by someone with "core team" permissions, we could file it as:

```markdown
### Working on this

This can only be worked on by a core team member.
```

This kind of information would generally be present in the description anyway, but having more structured content should help people who review issues looking for a good fit. And in the future, I could foresee this helping with automation if we wanted a place to auto-update the issue with a link to the latest PR, "last updated" time, etc.