### PR TITLE
Move locale selector in generic IndexView to a filter

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ Changelog
  * Standardise search form placeholder to 'Search…' (Sage Abdullah)
  * Use SlugInput on all SlugFields by default (LB (Ben) Johnston)
  * Show character counts on RichTextBlock with `max_length` (Elhussein Almasri)
+ * Move locale selector in generic IndexView to a filter (Sage Abdullah)
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -58,6 +58,7 @@ Thank you to Thibaud Colas and Badr Fourane for their work on this feature.
  * Standardise search form placeholder to 'Search…' (Sage Abdullah)
  * Use SlugInput on all SlugFields by default (LB (Ben) Johnston)
  * Show character counts on RichTextBlock with `max_length` (Elhussein Almasri)
+ * Move locale selector in generic IndexView to a filter (Sage Abdullah)
 
 
 ### Bug fixes

--- a/wagtail/admin/templates/wagtailadmin/generic/index.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index.html
@@ -2,13 +2,6 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block main_header %}
-    {% fragment as base_actions %}
-        {% block base_actions %}
-            {% if locale %}
-                {% include 'wagtailadmin/shared/locale_selector.html' with theme="large" %}
-            {% endif %}
-        {% endblock %}
-    {% endfragment %}
     {% fragment as extra_actions %}
         {% block extra_actions %}
             {% if view.list_export %}
@@ -17,6 +10,6 @@
         {% endblock %}
     {% endfragment %}
     {% if not breadcrumbs_items %}
-        {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=header_action_url action_text=header_action_label action_icon=header_action_icon base_actions=base_actions extra_actions=extra_actions icon=header_icon search_url=search_url search_form=search_form search_results_url=index_results_url only %}
+        {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=header_action_url action_text=header_action_label action_icon=header_action_icon extra_actions=extra_actions icon=header_icon search_url=search_url search_form=search_form search_results_url=index_results_url only %}
     {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/generic/index.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index.html
@@ -20,10 +20,3 @@
         {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=header_action_url action_text=header_action_label action_icon=header_action_icon base_actions=base_actions extra_actions=extra_actions icon=header_icon search_url=search_url search_form=search_form search_results_url=index_results_url only %}
     {% endif %}
 {% endblock %}
-
-{% block above_listing %}
-    {% if breadcrumbs_items and locale %}
-        {# TODO: temporarily put the locale selector here since we no longer use the legacy header #}
-        {% include 'wagtailadmin/shared/locale_selector.html' with theme="large" %}
-    {% endif %}
-{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/generic/listing.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/listing.html
@@ -14,7 +14,6 @@
 
     {% block listing %}
         <div class="{% if filters and not breadcrumbs_items %}filterable{% endif %}">
-            {% block above_listing %}{% endblock %}
             <div id="listing-results">
                 {% comment %}
                     This div will be replaced on AJAX refreshes.

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -164,16 +164,10 @@ class IndexView(
     def get_filterset_class(self):
         # Allow filterset_class to be dynamically constructed from list_filter.
 
-        # If the model is translatable and we're using the slim header
-        # (breadcrumbs), ensure a ``WagtailFilterSet`` subclass is returned
-        # anyway (even if list_filter is undefined), so the locale filter is
-        # always included.
-        if self.locale and self._show_breadcrumbs:
-            pass
-        # However, if the slim header is not used, the locale selector uses
-        # plain links instead of using a filterset. Thus, only add filters if
-        # list_filter is defined.
-        elif not self.list_filter or not self.model:
+        # If the model is translatable, ensure a ``WagtailFilterSet`` subclass
+        # is returned anyway (even if list_filter is undefined), so the locale
+        # filter is always included.
+        if not self.model or (not self.list_filter and not self.locale):
             return None
 
         class Meta:
@@ -235,9 +229,6 @@ class IndexView(
         queryset = self.get_base_queryset()
 
         queryset = self.filter_queryset(queryset)
-
-        if self.locale and not self.filters:
-            queryset = queryset.filter(locale=self.locale)
 
         has_updated_at_column = any(
             getattr(column, "accessor", None) == "_updated_at"
@@ -419,18 +410,6 @@ class IndexView(
             )
 
         return buttons
-
-    def get_translations(self):
-        index_url = self.get_index_url()
-        if not index_url:
-            return []
-        return [
-            {
-                "locale": locale,
-                "url": self._set_locale_query_param(index_url, locale),
-            }
-            for locale in Locale.objects.all().exclude(id=self.locale.id)
-        ]
 
     def get_list_more_buttons(self, instance):
         buttons = []

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -383,13 +383,15 @@ class IndexView(
     @cached_property
     def header_buttons(self):
         buttons = []
-        if not self.permission_policy or self.permission_policy.user_has_permission(
-            self.request.user, "add"
+        add_url = self.get_add_url()
+        if add_url and (
+            not self.permission_policy
+            or self.permission_policy.user_has_permission(self.request.user, "add")
         ):
             buttons.append(
                 HeaderButton(
                     self.add_item_label,
-                    url=self.get_add_url(),
+                    url=add_url,
                     icon_name="plus",
                 )
             )

--- a/wagtail/contrib/forms/templates/wagtailforms/index_results.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_results.html
@@ -1,5 +1,1 @@
-{% extends "wagtailadmin/generic/listing_results.html" %}
-{% load i18n %}
-{% block no_results_message %}
-    <p>{% trans "No form pages have been created." %}</p>
-{% endblock %}
+{% extends "wagtailadmin/generic/index_results.html" %}

--- a/wagtail/contrib/forms/urls.py
+++ b/wagtail/contrib/forms/urls.py
@@ -10,6 +10,9 @@ app_name = "wagtailforms"
 urlpatterns = [
     path("", FormPagesListView.as_view(), name="index"),
     path(
+        "results/", FormPagesListView.as_view(results_only=True), name="index_results"
+    ),
+    path(
         "submissions/<int:page_id>/", get_submissions_list_view, name="list_submissions"
     ),
     path(

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -5,7 +5,7 @@ from django.contrib.admin.utils import quote
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.utils.translation import gettext_lazy, ngettext
+from django.utils.translation import gettext, gettext_lazy, ngettext
 from django.views.generic import ListView, TemplateView
 
 from wagtail.admin import messages
@@ -46,9 +46,10 @@ class FormPagesListView(generic.IndexView):
     paginate_by = 20
     page_kwarg = "p"
     index_url_name = "wagtailforms:index"
-    page_title = "Forms"
-    page_subtitle = "Pages"
+    index_results_url_name = "wagtailforms:index_results"
+    page_title = gettext_lazy("Forms")
     header_icon = "form"
+    _show_breadcrumbs = True
     columns = [
         TitleColumn(
             "title",
@@ -67,6 +68,13 @@ class FormPagesListView(generic.IndexView):
     ]
     model = Page
     is_searchable = False
+
+    def get_breadcrumbs_items(self):
+        if not self.model:
+            return self.breadcrumbs_items
+        return self.breadcrumbs_items + [
+            {"url": "", "label": self.page_title, "sublabel": gettext("Pages")},
+        ]
 
     def get_base_queryset(self):
         """Return the queryset of form pages for this view"""

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -337,22 +337,16 @@ class TestLocaleSelectorOnList(WagtailTestUtils, TestCase):
         response = self.client.get(
             reverse("wagtailsnippets_snippetstests_translatablesnippet:list")
         )
+        soup = self.get_soup(response.content)
 
-        switch_to_french_url = (
-            reverse("wagtailsnippets_snippetstests_translatablesnippet:list")
-            + "?locale=fr"
-        )
-        self.assertContains(
-            response,
-            f'<a href="{switch_to_french_url}" data-locale-selector-link>',
-        )
+        french_input = soup.select_one('input[name="locale"][value="fr"]')
+        self.assertIsNotNone(french_input)
 
         # Check that the add URLs include the locale
         add_url = (
             reverse("wagtailsnippets_snippetstests_translatablesnippet:add")
             + "?locale=en"
         )
-        soup = self.get_soup(response.content)
         add_button = soup.select_one(f'a[href="{add_url}"]')
         self.assertIsNotNone(add_button)
         self.assertContains(
@@ -365,8 +359,10 @@ class TestLocaleSelectorOnList(WagtailTestUtils, TestCase):
         response = self.client.get(
             reverse("wagtailsnippets_snippetstests_translatablesnippet:list")
         )
+        soup = self.get_soup(response.content)
 
-        self.assertNotContains(response, "data-locale-selector")
+        input_element = soup.select_one('input[name="locale"]')
+        self.assertIsNone(input_element)
 
         # Check that the add URLs don't include the locale
         add_url = reverse("wagtailsnippets_snippetstests_translatablesnippet:add")
@@ -380,8 +376,10 @@ class TestLocaleSelectorOnList(WagtailTestUtils, TestCase):
 
     def test_locale_selector_not_present_on_non_translatable_snippet(self):
         response = self.client.get(reverse("wagtailsnippets_tests_advert:list"))
+        soup = self.get_soup(response.content)
 
-        self.assertNotContains(response, "data-locale-selector")
+        input_element = soup.select_one('input[name="locale"]')
+        self.assertIsNone(input_element)
 
         # Check that the add URLs don't include the locale
         add_url = reverse("wagtailsnippets_tests_advert:add")

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -1514,7 +1514,5 @@ class TestCustomMethods(BaseSnippetViewSetTests):
         response = self.client.get(self.get_url("list") + "?locale=fr")
         add_url = self.get_url("add") + "?locale=fr&customised=param"
         soup = self.get_soup(response.content)
-        # Should contain the customised add URL in two places:
-        # The main action button, and the "Why not add one?" suggestion
         links = soup.find_all("a", attrs={"href": add_url})
-        self.assertEqual(len(links), 2)
+        self.assertEqual(len(links), 1)


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

This proved quite difficult to get the balance right...

I think ideally we do want the locale to be processed as part of the filterset to make things consistent. However, we don't want to force developers to have to explicitly add a locale filter to their viewset definitions, especially since they didn't have to do that before. This means the locale filter needs to be added when the model is translatable and:

- Neither `list_filter` nor `filterset_class` is defined
- `list_filter` is defined without a filter for `locale__language_code`
- `filterset_class` is defined without a `locale` filter

This effectively removes the use of the locale selector dropdown from the index view. Locale selection is instead done via the filters popup, which means that the results are updated without a reload (using AJAX). This also changes the behaviour of index views to _not_ filter by the default locale by default, and show results for all locales instead.

One caveat with this is that the "add" button no longer reacts to your selected locale filter, because they aren't rerendered when the results are updated via AJAX. The code that appends the query param is still there, so if you manually enter e.g. `?locale=de` to the index view URL, the add button will include the query param. I think we should handle this more generally later, either by including the buttons (or the header?) as part of the results response, or via Stimulus controllers to automatically update such links with the right query params. Another instance of this pattern is the collection filter in the documents index view. Or more generically, passing the current URL (and filters) as a `next` parameter for the add view (and other actions), as mentioned in https://github.com/wagtail/wagtail/discussions/10446#discussioncomment-7559438.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

Using bakerydemo, the footer text snippet should now have a filter for the locale.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
