### PR TITLE
Universal listings - refactor listing views to share more queryset ordering logic

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/generic/index.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index.html
@@ -2,13 +2,6 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block main_header %}
-    {% fragment as base_actions %}
-        {% block base_actions %}
-            {% if locale %}
-                {% include 'wagtailadmin/shared/locale_selector.html' with theme="large" %}
-            {% endif %}
-        {% endblock %}
-    {% endfragment %}
     {% fragment as extra_actions %}
         {% block extra_actions %}
             {% if view.list_export %}
@@ -17,6 +10,6 @@
         {% endblock %}
     {% endfragment %}
     {% if not breadcrumbs_items %}
-        {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=header_action_url action_text=header_action_label action_icon=header_action_icon base_actions=base_actions extra_actions=extra_actions icon=header_icon search_url=search_url search_form=search_form search_results_url=index_results_url only %}
+        {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=header_action_url action_text=header_action_label action_icon=header_action_icon extra_actions=extra_actions icon=header_icon search_url=search_url search_form=search_form search_results_url=index_results_url only %}
     {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/generic/index.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index.html
@@ -20,10 +20,3 @@
         {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=header_action_url action_text=header_action_label action_icon=header_action_icon base_actions=base_actions extra_actions=extra_actions icon=header_icon search_url=search_url search_form=search_form search_results_url=index_results_url only %}
     {% endif %}
 {% endblock %}
-
-{% block above_listing %}
-    {% if breadcrumbs_items and locale %}
-        {# TODO: temporarily put the locale selector here since we no longer use the legacy header #}
-        {% include 'wagtailadmin/shared/locale_selector.html' with theme="large" %}
-    {% endif %}
-{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/generic/listing.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/listing.html
@@ -14,7 +14,6 @@
 
     {% block listing %}
         <div class="{% if filters and not breadcrumbs_items %}filterable{% endif %}">
-            {% block above_listing %}{% endblock %}
             <div id="listing-results">
                 {% comment %}
                     This div will be replaced on AJAX refreshes.

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -206,6 +206,10 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                 orderings.append("-%s" % col.sort_key)
         return orderings
 
+    @cached_property
+    def is_explicitly_ordered(self):
+        return "ordering" in self.request.GET
+
     def get_ordering(self):
         ordering = self.request.GET.get("ordering", self.default_ordering)
         if ordering not in self.get_valid_orderings():

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -217,6 +217,10 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
             ordering = self.default_ordering
         return ordering
 
+    @cached_property
+    def ordering(self):
+        return self.get_ordering()
+
     def order_queryset(self, queryset):
         if not self.ordering:
             return queryset
@@ -244,12 +248,12 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
     def get_queryset(self):
         # Instead of calling super().get_queryset(), we copy the initial logic from Django's
         # MultipleObjectMixin into get_base_queryset(). This allows us to perform additional steps
-        # before the ordering step (such as annotations), and retain the result of get_ordering()
-        # in self.ordering for use in get_table_kwargs() and elsewhere.
+        # before the ordering step (such as annotations), and funnel the call to get_ordering()
+        # through the cached property self.ordering so that we don't have to worry about calling
+        # get_ordering() multiple times.
         # https://github.com/django/django/blob/stable/4.1.x/django/views/generic/list.py#L22-L47
 
         queryset = self.get_base_queryset()
-        self.ordering = self.get_ordering()
         queryset = self.order_queryset(queryset)
         queryset = self.filter_queryset(queryset)
         return queryset

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -218,12 +218,16 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
 
     def get_queryset(self):
         queryset = super().get_queryset()
+        self.ordering = self.get_ordering()
+        # FIXME: get_ordering is also called from super().get_queryset (but it doesn't keep the result),
+        # so we are calling it twice here.
+
         queryset = self.filter_queryset(queryset)
         return queryset
 
     def get_table_kwargs(self):
         return {
-            "ordering": self.get_ordering(),
+            "ordering": self.ordering,
             "classname": self.table_classname,
             "base_url": self.index_url,
         }

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -217,10 +217,11 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
             ordering = self.default_ordering
         return ordering
 
-    def order_queryset(self, queryset, ordering):
-        if not ordering:
+    def order_queryset(self, queryset):
+        if not self.ordering:
             return queryset
 
+        ordering = self.ordering
         if not isinstance(ordering, (list, tuple)):
             ordering = (ordering,)
         return queryset.order_by(*ordering)
@@ -249,7 +250,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
 
         queryset = self.get_base_queryset()
         self.ordering = self.get_ordering()
-        queryset = self.order_queryset(queryset, self.ordering)
+        queryset = self.order_queryset(queryset)
         queryset = self.filter_queryset(queryset)
         return queryset
 

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -248,10 +248,8 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
         # https://github.com/django/django/blob/stable/4.1.x/django/views/generic/list.py#L22-L47
 
         queryset = self.get_base_queryset()
-
         self.ordering = self.get_ordering()
         queryset = self.order_queryset(queryset, self.ordering)
-
         queryset = self.filter_queryset(queryset)
         return queryset
 

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -259,6 +259,7 @@ class IndexView(
             else:
                 queryset = queryset.order_by("-pk")
 
+        queryset = self.search_queryset(queryset)
         return queryset
 
     def search_queryset(self, queryset):
@@ -484,11 +485,8 @@ class IndexView(
             )
         return _("Add")
 
-    def get_context_data(self, *args, object_list=None, **kwargs):
-        queryset = object_list if object_list is not None else self.object_list
-        queryset = self.search_queryset(queryset)
-
-        context = super().get_context_data(*args, object_list=queryset, **kwargs)
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
 
         context["can_add"] = (
             self.permission_policy is None

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -248,9 +248,9 @@ class IndexView(
         if has_updated_at_column:
             queryset = self._annotate_queryset_updated_at(queryset)
 
-        ordering = self.get_ordering()
-        if ordering:
-            queryset = self.order_queryset(queryset, ordering)
+        self.ordering = self.get_ordering()
+        if self.ordering:
+            queryset = self.order_queryset(queryset, self.ordering)
 
         # Preserve the model-level ordering if specified, but fall back on
         # updated_at and PK if not (to ensure pagination is consistent)

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -266,7 +266,7 @@ class IndexView(
         return queryset
 
     def search_queryset(self, queryset):
-        if not self.search_query:
+        if not self.is_searching:
             return queryset
 
         if class_is_indexed(queryset.model) and self.search_backend_name:

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -273,7 +273,10 @@ class IndexView(
             search_backend = get_search_backend(self.search_backend_name)
             if queryset.model.get_autocomplete_search_fields():
                 return search_backend.autocomplete(
-                    self.search_query, queryset, fields=self.search_fields
+                    self.search_query,
+                    queryset,
+                    fields=self.search_fields,
+                    order_by_relevance=(not self.is_explicitly_ordered),
                 )
             else:
                 # fall back on non-autocompleting search
@@ -284,7 +287,10 @@ class IndexView(
                     category=RuntimeWarning,
                 )
                 return search_backend.search(
-                    self.search_query, queryset, fields=self.search_fields
+                    self.search_query,
+                    queryset,
+                    fields=self.search_fields,
+                    order_by_relevance=(not self.is_explicitly_ordered),
                 )
         query = Q()
         for field in self.search_fields or []:

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -205,7 +205,7 @@ class IndexView(
         )
         return queryset.annotate(_updated_at=models.Subquery(latest_log))
 
-    def order_queryset(self, queryset, ordering):
+    def order_queryset(self, queryset):
         has_updated_at_column = any(
             getattr(column, "accessor", None) == "_updated_at"
             for column in self.columns
@@ -215,12 +215,12 @@ class IndexView(
 
         # Explicitly handle null values for the updated at column to ensure consistency
         # across database backends and match the behaviour in page explorer
-        if ordering == "_updated_at":
+        if self.ordering == "_updated_at":
             return queryset.order_by(models.F("_updated_at").asc(nulls_first=True))
-        elif ordering == "-_updated_at":
+        elif self.ordering == "-_updated_at":
             return queryset.order_by(models.F("_updated_at").desc(nulls_last=True))
         else:
-            queryset = super().order_queryset(queryset, ordering)
+            queryset = super().order_queryset(queryset)
 
             # Preserve the model-level ordering if specified, but fall back on
             # updated_at and PK if not (to ensure pagination is consistent)

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -164,16 +164,10 @@ class IndexView(
     def get_filterset_class(self):
         # Allow filterset_class to be dynamically constructed from list_filter.
 
-        # If the model is translatable and we're using the slim header
-        # (breadcrumbs), ensure a ``WagtailFilterSet`` subclass is returned
-        # anyway (even if list_filter is undefined), so the locale filter is
-        # always included.
-        if self.locale and self._show_breadcrumbs:
-            pass
-        # However, if the slim header is not used, the locale selector uses
-        # plain links instead of using a filterset. Thus, only add filters if
-        # list_filter is defined.
-        elif not self.list_filter or not self.model:
+        # If the model is translatable, ensure a ``WagtailFilterSet`` subclass
+        # is returned anyway (even if list_filter is undefined), so the locale
+        # filter is always included.
+        if not self.model or (not self.list_filter and not self.locale):
             return None
 
         class Meta:
@@ -235,9 +229,6 @@ class IndexView(
         queryset = self.get_base_queryset()
 
         queryset = self.filter_queryset(queryset)
-
-        if self.locale and not self.filters:
-            queryset = queryset.filter(locale=self.locale)
 
         has_updated_at_column = any(
             getattr(column, "accessor", None) == "_updated_at"
@@ -419,18 +410,6 @@ class IndexView(
             )
 
         return buttons
-
-    def get_translations(self):
-        index_url = self.get_index_url()
-        if not index_url:
-            return []
-        return [
-            {
-                "locale": locale,
-                "url": self._set_locale_query_param(index_url, locale),
-            }
-            for locale in Locale.objects.all().exclude(id=self.locale.id)
-        ]
 
     def get_list_more_buttons(self, instance):
         buttons = []

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -383,13 +383,15 @@ class IndexView(
     @cached_property
     def header_buttons(self):
         buttons = []
-        if not self.permission_policy or self.permission_policy.user_has_permission(
-            self.request.user, "add"
+        add_url = self.get_add_url()
+        if add_url and (
+            not self.permission_policy
+            or self.permission_policy.user_has_permission(self.request.user, "add")
         ):
             buttons.append(
                 HeaderButton(
                     self.add_item_label,
-                    url=self.get_add_url(),
+                    url=add_url,
                     icon_name="plus",
                 )
             )

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -229,16 +229,16 @@ class BaseIndexView(generic.IndexView):
 
         return pages
 
-    def order_queryset(self, queryset, ordering):
+    def order_queryset(self, queryset):
         if self.is_searching and not self.is_explicitly_ordered:
             # search backend will order by relevance in this case, so don't bother to
             # apply an ordering on the queryset
             return queryset
 
-        if ordering == "ord":
+        if self.ordering == "ord":
             # preserve the native ordering from get_children()
             pass
-        elif ordering == "latest_revision_created_at":
+        elif self.ordering == "latest_revision_created_at":
             # order by oldest revision first.
             # Special case NULL entries - these should go at the top of the list.
             # Do this by annotating with Count('latest_revision_created_at'),
@@ -246,14 +246,14 @@ class BaseIndexView(generic.IndexView):
             queryset = queryset.annotate(
                 null_position=Count("latest_revision_created_at")
             ).order_by("null_position", "latest_revision_created_at")
-        elif ordering == "-latest_revision_created_at":
+        elif self.ordering == "-latest_revision_created_at":
             # order by oldest revision first.
             # Special case NULL entries - these should go at the end of the list.
             queryset = queryset.annotate(
                 null_position=Count("latest_revision_created_at")
             ).order_by("-null_position", "-latest_revision_created_at")
         else:
-            queryset = super().order_queryset(queryset, ordering)
+            queryset = super().order_queryset(queryset)
 
         return queryset
 

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -205,15 +205,17 @@ class BaseIndexView(generic.IndexView):
 
         return ordering
 
-    def get_queryset(self):
+    def get_base_queryset(self):
         if self.is_searching or self.is_filtering:
             if self.is_searching_whole_tree:
-                pages = Page.objects.all()
+                return Page.objects.all()
             else:
-                pages = self.parent_page.get_descendants()
+                return self.parent_page.get_descendants()
         else:
-            pages = self.parent_page.get_children()
+            return self.parent_page.get_children()
 
+    def get_queryset(self):
+        pages = self.get_base_queryset()
         pages = pages.prefetch_related(
             "content_type", "sites_rooted_here"
         ) & self.permission_policy.explorable_instances(self.request.user)

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -257,19 +257,6 @@ class BaseIndexView(generic.IndexView):
 
         return queryset
 
-    def get_queryset(self):
-        pages = self.get_base_queryset()
-
-        pages = self.filter_queryset(pages)
-
-        self.ordering = self.get_ordering()
-        if self.ordering:
-            pages = self.order_queryset(pages, self.ordering)
-
-        pages = self.search_queryset(pages)
-
-        return pages
-
     def search_queryset(self, queryset):
         # allow hooks to modify queryset. This should happen as close as possible to the
         # final queryset, but (for backward compatibility) needs to be passed an actual queryset

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -270,15 +270,17 @@ class BaseIndexView(generic.IndexView):
         for hook in hooks.get_hooks("construct_explorer_page_queryset"):
             pages = hook(self.parent_page, pages, self.request)
 
-        if self.is_searching:
-            if self.is_explicitly_ordered:
-                pages = pages.order_by(self.ordering).autocomplete(
-                    self.query_string, order_by_relevance=False
-                )
-            else:
-                pages = pages.autocomplete(self.query_string)
+        pages = self.search_queryset(pages)
 
         return pages
+
+    def search_queryset(self, queryset):
+        if not self.is_searching:
+            return queryset
+
+        return queryset.autocomplete(
+            self.query_string, order_by_relevance=(not self.is_explicitly_ordered)
+        )
 
     def get_paginate_by(self, queryset):
         if self.ordering == "ord":

--- a/wagtail/contrib/forms/templates/wagtailforms/index_results.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_results.html
@@ -1,5 +1,1 @@
-{% extends "wagtailadmin/generic/listing_results.html" %}
-{% load i18n %}
-{% block no_results_message %}
-    <p>{% trans "No form pages have been created." %}</p>
-{% endblock %}
+{% extends "wagtailadmin/generic/index_results.html" %}

--- a/wagtail/contrib/forms/urls.py
+++ b/wagtail/contrib/forms/urls.py
@@ -10,6 +10,9 @@ app_name = "wagtailforms"
 urlpatterns = [
     path("", FormPagesListView.as_view(), name="index"),
     path(
+        "results/", FormPagesListView.as_view(results_only=True), name="index_results"
+    ),
+    path(
         "submissions/<int:page_id>/", get_submissions_list_view, name="list_submissions"
     ),
     path(

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -5,7 +5,7 @@ from django.contrib.admin.utils import quote
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.utils.translation import gettext_lazy, ngettext
+from django.utils.translation import gettext, gettext_lazy, ngettext
 from django.views.generic import ListView, TemplateView
 
 from wagtail.admin import messages
@@ -46,9 +46,10 @@ class FormPagesListView(generic.IndexView):
     paginate_by = 20
     page_kwarg = "p"
     index_url_name = "wagtailforms:index"
-    page_title = "Forms"
-    page_subtitle = "Pages"
+    index_results_url_name = "wagtailforms:index_results"
+    page_title = gettext_lazy("Forms")
     header_icon = "form"
+    _show_breadcrumbs = True
     columns = [
         TitleColumn(
             "title",
@@ -67,6 +68,13 @@ class FormPagesListView(generic.IndexView):
     ]
     model = Page
     is_searchable = False
+
+    def get_breadcrumbs_items(self):
+        if not self.model:
+            return self.breadcrumbs_items
+        return self.breadcrumbs_items + [
+            {"url": "", "label": self.page_title, "sublabel": gettext("Pages")},
+        ]
 
     def get_base_queryset(self):
         """Return the queryset of form pages for this view"""

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -73,14 +73,11 @@ class IndexView(generic.IndexView):
         return self.ORDERING_OPTIONS
 
     def get_base_queryset(self):
-        # Get ordering
-        self.ordering = self.get_ordering()
-        # Get images (filtered by user permission and ordered by `ordering`)
+        # Get images (filtered by user permission)
         images = (
             permission_policy.instances_user_has_any_permission_for(
                 self.request.user, ["change", "delete"]
             )
-            .order_by(self.ordering)
             .select_related("collection")
             .prefetch_renditions("max-165x165")
         )

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -337,22 +337,16 @@ class TestLocaleSelectorOnList(WagtailTestUtils, TestCase):
         response = self.client.get(
             reverse("wagtailsnippets_snippetstests_translatablesnippet:list")
         )
+        soup = self.get_soup(response.content)
 
-        switch_to_french_url = (
-            reverse("wagtailsnippets_snippetstests_translatablesnippet:list")
-            + "?locale=fr"
-        )
-        self.assertContains(
-            response,
-            f'<a href="{switch_to_french_url}" data-locale-selector-link>',
-        )
+        french_input = soup.select_one('input[name="locale"][value="fr"]')
+        self.assertIsNotNone(french_input)
 
         # Check that the add URLs include the locale
         add_url = (
             reverse("wagtailsnippets_snippetstests_translatablesnippet:add")
             + "?locale=en"
         )
-        soup = self.get_soup(response.content)
         add_button = soup.select_one(f'a[href="{add_url}"]')
         self.assertIsNotNone(add_button)
         self.assertContains(
@@ -365,8 +359,10 @@ class TestLocaleSelectorOnList(WagtailTestUtils, TestCase):
         response = self.client.get(
             reverse("wagtailsnippets_snippetstests_translatablesnippet:list")
         )
+        soup = self.get_soup(response.content)
 
-        self.assertNotContains(response, "data-locale-selector")
+        input_element = soup.select_one('input[name="locale"]')
+        self.assertIsNone(input_element)
 
         # Check that the add URLs don't include the locale
         add_url = reverse("wagtailsnippets_snippetstests_translatablesnippet:add")
@@ -380,8 +376,10 @@ class TestLocaleSelectorOnList(WagtailTestUtils, TestCase):
 
     def test_locale_selector_not_present_on_non_translatable_snippet(self):
         response = self.client.get(reverse("wagtailsnippets_tests_advert:list"))
+        soup = self.get_soup(response.content)
 
-        self.assertNotContains(response, "data-locale-selector")
+        input_element = soup.select_one('input[name="locale"]')
+        self.assertIsNone(input_element)
 
         # Check that the add URLs don't include the locale
         add_url = reverse("wagtailsnippets_tests_advert:add")

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -1514,7 +1514,5 @@ class TestCustomMethods(BaseSnippetViewSetTests):
         response = self.client.get(self.get_url("list") + "?locale=fr")
         add_url = self.get_url("add") + "?locale=fr&customised=param"
         soup = self.get_soup(response.content)
-        # Should contain the customised add URL in two places:
-        # The main action button, and the "Why not add one?" suggestion
         links = soup.find_all("a", attrs={"href": add_url})
-        self.assertEqual(len(links), 2)
+        self.assertEqual(len(links), 1)

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -126,10 +126,9 @@ class ModelIndexView(generic.IndexView):
         ]
 
     def get_context_data(self, **kwargs):
-        ordering = self.get_ordering()
-        reverse = ordering[0] == "-"
+        reverse = self.ordering[0] == "-"
 
-        if ordering in ["count", "-count"]:
+        if self.ordering in ["count", "-count"]:
             snippet_types = sorted(
                 self.snippet_types,
                 key=lambda type: type["count"],

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -118,7 +118,7 @@ class Index(IndexView):
         if "last_name" in model_fields and "first_name" in model_fields:
             users = users.order_by("last_name", "first_name")
 
-        if self.get_ordering() == "username":
+        if self.ordering == "username":
             users = users.order_by(User.USERNAME_FIELD)
 
         return users
@@ -127,7 +127,7 @@ class Index(IndexView):
         context_data = super().get_context_data(
             *args, object_list=object_list, **kwargs
         )
-        context_data["ordering"] = self.get_ordering()
+        context_data["ordering"] = self.ordering
         context_data["group"] = self.group
 
         context_data.update(


### PR DESCRIPTION
Incorporates #11432 (wanted to hold off on merging that one in case @zerolab had further feedback).

Move various bits of ordering logic from `wagtail.admin.views.pages.listing.BaseIndexView`, `wagtail.admin.views.generic.models.IndexView` and `wagtail.admin.view.generic.base.BaseListingView` up the inheritance chain so that they share more code and don't have to do as much overriding. In particular:

* BaseListingView now implements the `get_base_queryset` / `get_queryset` split that was previously in IndexView
* The selected ordering (taking `default_ordering` and the `ordering` URL variable into account) is always available as the cached property `self.ordering`
* Queryset ordering is handled by a new method `BaseListingView.order_queryset` to align with BaseListingView's `filter_queryset` and IndexView's `search_queryset`
* A new `is_explicitly_ordered` property indicates whether an ordering has been explicitly chosen by the user - this is used when searching to decide when field-based ordering should take precedence over order by relevance.