### PR TITLE
Universal listings: Add 'pills' to show active filters

### DIFF
--- a/client/src/entrypoints/admin/date-time-chooser.js
+++ b/client/src/entrypoints/admin/date-time-chooser.js
@@ -44,7 +44,7 @@ function initDateChooser(id, opts) {
           format: 'Y-m-d',
           onGenerate: hideCurrent,
           onChangeDateTime(_, $el) {
-            $el.get(0).dispatchEvent(new Event('change'));
+            $el.get(0).dispatchEvent(new Event('change', { bubbles: true }));
           },
         },
         opts || {},
@@ -59,7 +59,7 @@ function initDateChooser(id, opts) {
           format: 'Y-m-d',
           onGenerate: hideCurrent,
           onChangeDateTime(_, $el) {
-            $el.get(0).dispatchEvent(new Event('change'));
+            $el.get(0).dispatchEvent(new Event('change', { bubbles: true }));
           },
         },
         opts || {},

--- a/wagtail/admin/templates/wagtailadmin/generic/index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index_results.html
@@ -2,6 +2,10 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block before_results %}
+    {% if view.active_filters %}
+        {% include "wagtailadmin/shared/active_filters.html" with active_filters=view.active_filters %}
+    {% endif %}
+
     <div class="nice-padding">
         {% if is_searching or is_filtering %}
             <h2 role="alert">

--- a/wagtail/admin/templates/wagtailadmin/pages/index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index_results.html
@@ -1,5 +1,9 @@
 {% load wagtailadmin_tags i18n %}
 
+{% if view.active_filters %}
+    {% include "wagtailadmin/shared/active_filters.html" with active_filters=view.active_filters %}
+{% endif %}
+
 <form id="page-reorder-form">
     {% csrf_token %}
 

--- a/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
@@ -1,7 +1,12 @@
+{% load i18n %}
 <ul class="active-filters">
     {% for filter in active_filters %}
         <li>
             {{ filter.field_label }}: <b>{{ filter.value }}</b>
+            <a href="{{ filter.removed_filter_url }}"
+               aria-label="{% blocktranslate trimmed with field_label=filter.field_label value=filter.value %}Remove filter on {{ field_label }}: {{ value }}{% endblocktranslate %}">
+                [x]
+            </a>
         </li>
     {% endfor %}
 </ul>

--- a/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
@@ -1,0 +1,7 @@
+<ul class="active-filters">
+    {% for filter in active_filters %}
+        <li>
+            {{ filter.field_label }}: <b>{{ filter.value }}</b>
+        </li>
+    {% endfor %}
+</ul>

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -563,6 +563,12 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertEqual(
             page_ids, {self.child_page.id, self.new_page.id, new_page_child.id}
         )
+        soup = self.get_soup(response.content)
+        active_filters = soup.find("ul", class_="active-filters")
+        self.assertEqual(
+            active_filters.find("li").text.strip(),
+            "Page type: Simple page",
+        )
 
     def test_filter_by_date_updated(self):
         new_page_child = SimplePage(
@@ -580,6 +586,12 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
         page_ids = {page.id for page in response.context["pages"]}
         self.assertEqual(page_ids, {self.new_page.id, new_page_child.id})
+        soup = self.get_soup(response.content)
+        active_filters = soup.find("ul", class_="active-filters")
+        self.assertEqual(
+            active_filters.find("li").text.strip(),
+            "Date updated: Jan. 1, 2015 -",
+        )
 
     def test_filter_by_owner(self):
         barry = self.create_user(
@@ -613,6 +625,13 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         page_ids = {page.id for page in response.context["pages"]}
         self.assertEqual(page_ids, {new_page_child.id})
 
+        soup = self.get_soup(response.content)
+        active_filters = soup.find("ul", class_="active-filters")
+        self.assertEqual(
+            active_filters.find("li").text.strip(),
+            "Owner: Barry Manilow",
+        )
+
     def test_filter_by_site(self):
         new_site = Site.objects.create(
             hostname="new.example.com", root_page=self.new_page
@@ -631,6 +650,13 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
         page_ids = {page.id for page in response.context["pages"]}
         self.assertEqual(page_ids, {self.new_page.id, new_page_child.id})
+
+        soup = self.get_soup(response.content)
+        active_filters = soup.find("ul", class_="active-filters")
+        self.assertEqual(
+            active_filters.find("li").text.strip(),
+            "Site: new.example.com",
+        )
 
     def test_explore_custom_permissions(self):
         page = CustomPermissionPage(title="Page with custom perms", slug="custom-perms")

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -325,6 +325,10 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
             **self.get_table_kwargs(),
         )
 
+    @cached_property
+    def index_url(self):
+        return self.get_index_url()
+
     def get_index_url(self):
         if self.index_url_name:
             return reverse(self.index_url_name)
@@ -332,7 +336,6 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
 
-        self.index_url = self.get_index_url()
         table = self.get_table(context["object_list"])
 
         context["index_url"] = self.index_url

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -295,7 +295,7 @@ class BaseIndexView(generic.IndexView):
         kwargs["use_row_ordering_attributes"] = self.show_ordering_column
         kwargs["parent_page"] = self.parent_page
         kwargs["show_locale_labels"] = self.i18n_enabled and self.parent_page.is_root()
-        kwargs["actions_next_url"] = self.get_index_url()
+        kwargs["actions_next_url"] = self.index_url
 
         if self.show_ordering_column:
             kwargs["attrs"] = {
@@ -336,7 +336,6 @@ class BaseIndexView(generic.IndexView):
             {
                 "parent_page": self.parent_page,
                 "ordering": self.ordering,
-                "index_url": self.get_index_url(),
                 "search_url": self.get_index_results_url(),
                 "history_url": self.get_history_url(),
                 "search_form": self.search_form,

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -52,7 +52,7 @@ class PageFilterSet(WagtailFilterSet):
         widget=CheckboxSelectMultiple,
     )
     latest_revision_created_at = DateFromToRangeFilter(
-        label=_("Date Updated"),
+        label=_("Date updated"),
         widget=DateRangePickerWidget,
     )
     owner = MultipleUserFilter(

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.query import QuerySet
 from django.http import Http404
-from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.forms.search import SearchForm
@@ -64,6 +63,7 @@ class BaseSearchView(PermissionCheckedMixin, BaseListingView):
     page_kwarg = "p"
     context_object_name = "pages"
     table_class = PageTable
+    index_url_name = "wagtailadmin_pages:search"
 
     columns = [
         BulkActionsColumn("bulk_actions"),
@@ -159,9 +159,6 @@ class BaseSearchView(PermissionCheckedMixin, BaseListingView):
 
         return pages
 
-    def get_index_url(self):
-        return reverse("wagtailadmin_pages:search")
-
     def get_table_kwargs(self):
         kwargs = super().get_table_kwargs()
         kwargs["show_locale_labels"] = self.show_locale_labels
@@ -176,7 +173,6 @@ class BaseSearchView(PermissionCheckedMixin, BaseListingView):
                 "content_types": self.content_types,
                 "selected_content_type": self.selected_content_type,
                 "ordering": self.ordering,
-                "index_url": self.get_index_url(),
             }
         )
         return context

--- a/wagtail/admin/views/pages/usage.py
+++ b/wagtail/admin/views/pages/usage.py
@@ -67,12 +67,7 @@ class ContentTypeUseView(BaseListingView):
 
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
         context = super().get_context_data(**kwargs)
-        context.update(
-            {
-                "index_url": self.get_index_url(),
-                "page_class": self.page_class,
-            }
-        )
+        context["page_class"] = self.page_class
         return context
 
 

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -123,7 +123,7 @@ class IndexView(generic.IndexView):
         return collections
 
     def get_next_url(self):
-        next_url = self.get_index_url()
+        next_url = self.index_url
         request_query_string = self.request.META.get("QUERY_STRING")
         if request_query_string:
             next_url += "?" + request_query_string

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -114,7 +114,7 @@ class IndexView(generic.IndexView):
         )
 
     def get_next_url(self):
-        next_url = self.get_index_url()
+        next_url = self.index_url
         request_query_string = self.request.META.get("QUERY_STRING")
         if request_query_string:
             next_url += "?" + request_query_string


### PR DESCRIPTION
Display the currently active filters, along with links to remove them individually.

![Screenshot 2024-01-11 at 17 14 06](https://github.com/wagtail/wagtail/assets/85097/00c6883a-b30a-469b-8553-7f97f9d23f88)

Marking as draft for now, since we probably don't want to merge this until we have the 'pill' styling in place.