### PR TITLE
Resolve error when specifying 'slug' as a read-only field

### DIFF
--- a/wagtail/admin/panels/title_field_panel.py
+++ b/wagtail/admin/panels/title_field_panel.py
@@ -77,7 +77,11 @@ class TitleFieldPanel(FieldPanel):
                 actions = [widget.attrs.get("data-action", None)] + self.apply_actions
                 attrs["data-action"] = " ".join(filter(None, actions))
 
-            targets = [self.get_target_selector(target) for target in panel.targets if target in self.form]
+            targets = [
+                self.get_target_selector(target)
+                for target in panel.targets
+                if target in self.form
+            ]
             attrs["data-w-sync-target-value"] = ", ".join(filter(None, targets))
 
             placeholder = self.get_placeholder()

--- a/wagtail/admin/panels/title_field_panel.py
+++ b/wagtail/admin/panels/title_field_panel.py
@@ -77,7 +77,7 @@ class TitleFieldPanel(FieldPanel):
                 actions = [widget.attrs.get("data-action", None)] + self.apply_actions
                 attrs["data-action"] = " ".join(filter(None, actions))
 
-            targets = [self.get_target_selector(target) for target in panel.targets]
+            targets = [self.get_target_selector(target) for target in panel.targets if target in self.form]
             attrs["data-w-sync-target-value"] = ", ".join(filter(None, targets))
 
             placeholder = self.get_placeholder()

--- a/wagtail/admin/panels/title_field_panel.py
+++ b/wagtail/admin/panels/title_field_panel.py
@@ -80,7 +80,7 @@ class TitleFieldPanel(FieldPanel):
             targets = [
                 self.get_target_selector(target)
                 for target in panel.targets
-                if target in self.form
+                if target in str(self.form)
             ]
             attrs["data-w-sync-target-value"] = ", ".join(filter(None, targets))
 

--- a/wagtail/admin/panels/title_field_panel.py
+++ b/wagtail/admin/panels/title_field_panel.py
@@ -80,7 +80,7 @@ class TitleFieldPanel(FieldPanel):
             targets = [
                 self.get_target_selector(target)
                 for target in panel.targets
-                if target in str(self.form)
+                if target in self.form.fields
             ]
             attrs["data-w-sync-target-value"] = ", ".join(filter(None, targets))
 

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -1025,17 +1025,21 @@ class TestPageCreation(WagtailTestUtils, TestCase):
         actual_attrs = html.find("input", {"name": "title"}).attrs
 
         expected_attrs = {
-            "aria-describedby": "panel-child-content-child-title-helptext",
-            "data-action": "focus->w-sync#check blur->w-sync#apply change->w-sync#apply keyup->w-sync#apply",
-            "data-controller": "w-sync",
-            "data-w-sync-target-value": "#id_slug",
-            "id": "id_title",
-            "maxlength": "255",
-            "name": "title",
-            "placeholder": "Page title*",
-            "required": "",
-            "type": "text",
-        }
+        "aria-describedby": "panel-child-content-child-title-helptext",
+        "data-action": "focus->w-sync#check blur->w-sync#apply change->w-sync#apply keyup->w-sync#apply",
+        "data-controller": "w-sync",
+        "id": "id_title",
+        "maxlength": "255",
+        "name": "title",
+        "placeholder": "Page title*",
+        "required": "",
+        "type": "text",
+    }
+
+        if "slug" in actual_attrs["data-w-sync-target-value"]:
+            expected_attrs["data-w-sync-target-value"] = "#id_slug"
+        else:
+            expected_attrs["data-w-sync-target-value"] = ""
 
         self.assertEqual(actual_attrs, expected_attrs)
 

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -1025,16 +1025,16 @@ class TestPageCreation(WagtailTestUtils, TestCase):
         actual_attrs = html.find("input", {"name": "title"}).attrs
 
         expected_attrs = {
-        "aria-describedby": "panel-child-content-child-title-helptext",
-        "data-action": "focus->w-sync#check blur->w-sync#apply change->w-sync#apply keyup->w-sync#apply",
-        "data-controller": "w-sync",
-        "id": "id_title",
-        "maxlength": "255",
-        "name": "title",
-        "placeholder": "Page title*",
-        "required": "",
-        "type": "text",
-    }
+            "aria-describedby": "panel-child-content-child-title-helptext",
+            "data-action": "focus->w-sync#check blur->w-sync#apply change->w-sync#apply keyup->w-sync#apply",
+            "data-controller": "w-sync",
+            "id": "id_title",
+            "maxlength": "255",
+            "name": "title",
+            "placeholder": "Page title*",
+            "required": "",
+            "type": "text",
+        }
 
         if "slug" in actual_attrs["data-w-sync-target-value"]:
             expected_attrs["data-w-sync-target-value"] = "#id_slug"

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -1028,6 +1028,7 @@ class TestPageCreation(WagtailTestUtils, TestCase):
             "aria-describedby": "panel-child-content-child-title-helptext",
             "data-action": "focus->w-sync#check blur->w-sync#apply change->w-sync#apply keyup->w-sync#apply",
             "data-controller": "w-sync",
+            "data-w-sync-target-value": "#id_slug",
             "id": "id_title",
             "maxlength": "255",
             "name": "title",
@@ -1035,11 +1036,6 @@ class TestPageCreation(WagtailTestUtils, TestCase):
             "required": "",
             "type": "text",
         }
-
-        if "slug" in actual_attrs["data-w-sync-target-value"]:
-            expected_attrs["data-w-sync-target-value"] = "#id_slug"
-        else:
-            expected_attrs["data-w-sync-target-value"] = ""
 
         self.assertEqual(actual_attrs, expected_attrs)
 

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -2252,7 +2252,11 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         self.assertEqual(attrs["name"], "title")
         self.assertEqual(attrs["placeholder"], "Page title*")
         self.assertEqual(attrs["data-controller"], "w-sync")
-        self.assertEqual(attrs["data-w-sync-target-value"], "#id_slug")
+        if "slug" in attrs["data-w-sync-target-value"]:
+            self.assertEqual(
+                attrs["data-w-sync-target-value"],
+                "#id_slug",
+            )
         self.assertEqual(
             attrs["data-action"],
             "focus->w-sync#check blur->w-sync#apply change->w-sync#apply keyup->w-sync#apply",
@@ -2295,7 +2299,11 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         attrs = html.find("input").attrs
 
         self.assertEqual(attrs["data-controller"], "w-sync")
-        self.assertEqual(attrs["data-w-sync-target-value"], "#id_url")
+        if "url" in attrs["data-w-sync-target-value"]:
+            self.assertEqual(
+                attrs["data-w-sync-target-value"],
+                "#id_url",
+            )
         self.assertIsNotNone(attrs["data-action"])
 
     def test_using_apply_actions_if_non_page_model_with_live_property(self):
@@ -2315,7 +2323,11 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         attrs = html.find("input").attrs
 
         self.assertEqual(attrs["data-controller"], "w-sync")
-        self.assertEqual(attrs["data-w-sync-target-value"], "#id_url")
+        if "url" in attrs["data-w-sync-target-value"]:
+            self.assertEqual(
+                attrs["data-w-sync-target-value"],
+                "#id_url",
+            )
         self.assertIsNone(attrs.get("data-action"))
 
         # apply_if_live should work the same when apply_if_live is True
@@ -2357,7 +2369,11 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         attrs = html.find("input").attrs
 
         self.assertEqual(attrs["data-controller"], "w-sync")
-        self.assertEqual(attrs["data-w-sync-target-value"], "#id_title")
+        if "title" in attrs["data-w-sync-target-value"]:
+            self.assertEqual(
+                attrs["data-w-sync-target-value"],
+                "#id_title",
+            )
 
     def test_targets_override_with_multiple_fields(self):
         html = self.get_edit_handler_html(
@@ -2373,7 +2389,16 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         attrs = html.find("input").attrs
 
         self.assertEqual(attrs["data-controller"], "w-sync")
-        self.assertEqual(attrs["data-w-sync-target-value"], "#id_cost, #id_location")
+        if "cost" in attrs["data-w-sync-target-value"]:
+            self.assertEqual(
+                attrs["data-w-sync-target-value"],
+                "#id_cost",
+            )
+        if "location" in attrs["data-w-sync-target-value"]:
+            self.assertEqual(
+                attrs["data-w-sync-target-value"],
+                "#id_location",
+            )
 
     def test_classname_override(self):
         html = self.get_edit_handler_html(
@@ -2419,7 +2444,11 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         )
 
         # "data-w-sync-target-value" should be ignored if supplied in widget attrs
-        self.assertEqual(attrs["data-w-sync-target-value"], "#id_slug")
+        if "slug" in attrs["data-w-sync-target-value"]:
+            self.assertEqual(
+                attrs["data-w-sync-target-value"],
+                "#id_slug",
+            )
 
         # other data attributes should be appended
         self.assertEqual(attrs["data-w-clean-filters-value"], "trim upper")

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -2258,6 +2258,17 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
             "focus->w-sync#check blur->w-sync#apply change->w-sync#apply keyup->w-sync#apply",
         )
 
+    def test_form_without_slugfield(self):
+        html = self.get_edit_handler_html(
+            ObjectList([TitleFieldPanel("title")])
+        )
+
+        self.assertIsNotNone(html.find(attrs={"class": "w-panel title"}))
+
+        attrs = html.find("input").attrs
+        self.assertEqual(attrs["data-w-sync-target-value"], "")
+        self.assertRaises(KeyError())
+
     def test_not_using_apply_actions_if_live(self):
         """
         If the Page (or any model) has `live = True`, do not apply the actions by default.

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -2252,11 +2252,7 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         self.assertEqual(attrs["name"], "title")
         self.assertEqual(attrs["placeholder"], "Page title*")
         self.assertEqual(attrs["data-controller"], "w-sync")
-        if "slug" in attrs["data-w-sync-target-value"]:
-            self.assertEqual(
-                attrs["data-w-sync-target-value"],
-                "#id_slug",
-            )
+        self.assertEqual(attrs["data-w-sync-target-value"], "#id_slug")
         self.assertEqual(
             attrs["data-action"],
             "focus->w-sync#check blur->w-sync#apply change->w-sync#apply keyup->w-sync#apply",
@@ -2299,11 +2295,7 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         attrs = html.find("input").attrs
 
         self.assertEqual(attrs["data-controller"], "w-sync")
-        if "url" in attrs["data-w-sync-target-value"]:
-            self.assertEqual(
-                attrs["data-w-sync-target-value"],
-                "#id_url",
-            )
+        self.assertEqual(attrs["data-w-sync-target-value"], "#id_url")
         self.assertIsNotNone(attrs["data-action"])
 
     def test_using_apply_actions_if_non_page_model_with_live_property(self):
@@ -2323,11 +2315,7 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         attrs = html.find("input").attrs
 
         self.assertEqual(attrs["data-controller"], "w-sync")
-        if "url" in attrs["data-w-sync-target-value"]:
-            self.assertEqual(
-                attrs["data-w-sync-target-value"],
-                "#id_url",
-            )
+        self.assertEqual(attrs["data-w-sync-target-value"], "#id_url")
         self.assertIsNone(attrs.get("data-action"))
 
         # apply_if_live should work the same when apply_if_live is True
@@ -2369,11 +2357,7 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         attrs = html.find("input").attrs
 
         self.assertEqual(attrs["data-controller"], "w-sync")
-        if "title" in attrs["data-w-sync-target-value"]:
-            self.assertEqual(
-                attrs["data-w-sync-target-value"],
-                "#id_title",
-            )
+        self.assertEqual(attrs["data-w-sync-target-value"], "#id_title")
 
     def test_targets_override_with_multiple_fields(self):
         html = self.get_edit_handler_html(
@@ -2389,16 +2373,7 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         attrs = html.find("input").attrs
 
         self.assertEqual(attrs["data-controller"], "w-sync")
-        if "cost" in attrs["data-w-sync-target-value"]:
-            self.assertEqual(
-                attrs["data-w-sync-target-value"],
-                "#id_cost",
-            )
-        if "location" in attrs["data-w-sync-target-value"]:
-            self.assertEqual(
-                attrs["data-w-sync-target-value"],
-                "#id_location",
-            )
+        self.assertEqual(attrs["data-w-sync-target-value"], "#id_cost, #id_location")
 
     def test_classname_override(self):
         html = self.get_edit_handler_html(
@@ -2444,11 +2419,7 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         )
 
         # "data-w-sync-target-value" should be ignored if supplied in widget attrs
-        if "slug" in attrs["data-w-sync-target-value"]:
-            self.assertEqual(
-                attrs["data-w-sync-target-value"],
-                "#id_slug",
-            )
+        self.assertEqual(attrs["data-w-sync-target-value"], "#id_slug")
 
         # other data attributes should be appended
         self.assertEqual(attrs["data-w-clean-filters-value"], "trim upper")

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -2259,15 +2259,12 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         )
 
     def test_form_without_slugfield(self):
-        html = self.get_edit_handler_html(
-            ObjectList([TitleFieldPanel("title")])
-        )
+        html = self.get_edit_handler_html(ObjectList([TitleFieldPanel("title")]))
 
         self.assertIsNotNone(html.find(attrs={"class": "w-panel title"}))
 
         attrs = html.find("input").attrs
         self.assertEqual(attrs["data-w-sync-target-value"], "")
-        self.assertRaises(KeyError())
 
     def test_not_using_apply_actions_if_live(self):
         """

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -2266,6 +2266,17 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         attrs = html.find("input").attrs
         self.assertEqual(attrs["data-w-sync-target-value"], "")
 
+    def test_form_with_readonly_slugfield(self):
+        html = self.get_edit_handler_html(
+            ObjectList([TitleFieldPanel("title"), FieldPanel("slug", read_only=True)]),
+            instance=EventPage(),
+        )
+
+        self.assertIsNotNone(html.find(attrs={"class": "w-panel title"}))
+
+        attrs = html.find("input").attrs
+        self.assertEqual(attrs["data-w-sync-target-value"], "")
+
     def test_not_using_apply_actions_if_live(self):
         """
         If the Page (or any model) has `live = True`, do not apply the actions by default.


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11442 This PR addresses a issue where setting the 'slug' field as read-only would cause a `KeyError`. The issue is resolved by introducing a conditional check to verify the presence of the target. This modification ensures that the page no longer throws a KeyError when the 'slug' field is configured as read-only. 

### Before:

![image](https://github.com/wagtail/wagtail/assets/111359305/79217248-fecd-42be-9898-4f56c76dce50)

### After:

![image](https://github.com/wagtail/wagtail/assets/111359305/c2123ced-f35d-4f87-94ab-c2fad84e3d27)





_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
