### PR TITLE
Update checkbox_select_cell.html

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/generic/chooser/checkbox_select_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/chooser/checkbox_select_cell.html
@@ -1,4 +1,5 @@
 {% load i18n %}
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
-    <input type="checkbox" id="chooser-modal-select-{{ value }}" data-multiple-choice-select name="id" value="{{ value }}" title="{% blocktrans trimmed with title=instance %}Select {{ title }}{% endblocktrans %}">
+    <input type="checkbox" id="chooser-modal-select-{{ value|unlocalize }}" data-multiple-choice-select name="id" value="{{ value|unlocalize }}" title="{% blocktrans trimmed with title=instance %}Select {{ title }}{% endblocktrans %}">
 </td>
+


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11134

As in this issue USE_THOUSAND_SEPARATOR has value already set to true so as the values are printed with thousand seperator I set the values with unlocalize which fixes this issue







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
