### PR TITLE
Tab components in Django with template

### DIFF
--- a/client/src/controllers/TabsController.ts
+++ b/client/src/controllers/TabsController.ts
@@ -35,7 +35,6 @@ export class TabsController extends Controller<HTMLDivElement> {
   declare tabPanelTargets: HTMLElement[];
 
   declare disableURLValue: boolean;
-  declare initialPageLoadValue: boolean;
   declare activeTabIdValue: string;
   declare transitionValue: number;
   declare animateValue: boolean;
@@ -65,6 +64,10 @@ export class TabsController extends Controller<HTMLDivElement> {
   }
 
   connect() {
+    setTimeout(() => {
+      window.scrollTo(0, 0);
+    }, this.transitionValue * 2);
+
     if (this.tabLabelTargets) {
       this.setAriaControlByHref(this.tabLabelTargets);
       const tabActive = [...this.tabLabelTargets].find(
@@ -123,13 +126,6 @@ export class TabsController extends Controller<HTMLDivElement> {
       this.animateIn(tabContent);
     } else {
       tabContent.hidden = false;
-    }
-
-    if (this.initialPageLoadValue) {
-      // On first load set the scroll to top to avoid scrolling to active section and header covering up tabs
-      setTimeout(() => {
-        window.scrollTo(0, 0);
-      }, this.transitionValue * 2);
     }
 
     const href = tab.getAttribute('href') as string;
@@ -212,14 +208,10 @@ export class TabsController extends Controller<HTMLDivElement> {
   }
 
   setURLHash(tabId: string) {
-    if (
-      !this.initialPageLoadValue &&
-      (!window.history.state || window.history.state.tabContent !== tabId)
-    ) {
+    if (!window.history.state || window.history.state.tabContent !== tabId) {
       // Add a new history item to the stack
       window.history.pushState({ tabContent: tabId }, '', `#${tabId}`);
     }
-    this.initialPageLoadValue = false;
   }
 
   selectTabByURLHash() {

--- a/client/src/controllers/TabsController.ts
+++ b/client/src/controllers/TabsController.ts
@@ -51,12 +51,12 @@ export class TabsController extends Controller<HTMLElement> {
     this.tabsPanel = this.element.querySelectorAll('[role=tabpanel]');
     this.tabTriggerLinks = this.element.querySelectorAll('[data-tab-trigger]');
     this.tabList = this.element.querySelector('[role=tablist]') as HTMLElement;
-    
+
     if (this.tabTriggerLinks) {
       this.tabTriggerLinks.forEach((trigger) => {
         trigger.addEventListener('click', (e) => {
           e.preventDefault();
-          const href = trigger.getAttribute("href") as string
+          const href = trigger.getAttribute('href') as string;
           const tab = this.getTabElementByHref(href) as HTMLElement;
           if (tab) {
             this.selectTab(tab);

--- a/client/src/controllers/TabsController.ts
+++ b/client/src/controllers/TabsController.ts
@@ -1,0 +1,298 @@
+import { Controller } from '@hotwired/stimulus';
+
+export class TabsController extends Controller<HTMLElement> {
+  static targets = ['tablist', 'tabcontent'];
+
+  static values = {
+    transition: { default: 150, type: Number },
+    activeTabId: { default: '', type: String },
+    disableURL: { default: false, type: Boolean },
+    initialPageLoad: { default: true, type: Boolean },
+    animate: { default: true, type: Boolean },
+  };
+
+  declare disableURLValue: boolean;
+  declare initialPageLoadValue: boolean;
+  declare activeTabIdValue: string;
+  declare transitionValue: number;
+  declare animateValue: boolean;
+
+  declare tablist: HTMLDivElement;
+  declare tabcontent: HTMLDivElement;
+
+  declare tabsConstant;
+  declare tabsButtons: NodeListOf<HTMLAnchorElement>;
+  declare tabsPanel: NodeListOf<HTMLElement>;
+  declare tabTriggerLinks: NodeListOf<HTMLElement>;
+  declare tabList: HTMLElement;
+
+  initialize() {
+    this.tabsConstant = {
+      // CSS Classes
+      css: {
+        animate: 'animate-in',
+      },
+      // Keyboard Keys
+      keys: {
+        end: 'End',
+        home: 'Home',
+        left: 'ArrowLeft',
+        up: 'ArrowUp',
+        right: 'ArrowRight',
+        down: 'ArrowDown',
+      },
+      direction: {
+        ArrowLeft: -1,
+        ArrowRight: 1,
+      },
+    };
+
+    this.tabsButtons = this.element.querySelectorAll('[role=tab]');
+    this.tabsPanel = this.element.querySelectorAll('[role=tabpanel]');
+    this.tabTriggerLinks = this.element.querySelectorAll('[data-tab-trigger]');
+    this.tabList = this.element.querySelector('[role=tablist]') as HTMLElement;
+    
+    if (this.tabTriggerLinks) {
+      this.tabTriggerLinks.forEach((trigger) => {
+        trigger.addEventListener('click', (e) => {
+          e.preventDefault();
+          const href = trigger.getAttribute("href") as string
+          const tab = this.getTabElementByHref(href) as HTMLElement;
+          if (tab) {
+            this.selectTab(tab);
+            tab.focus();
+          }
+        });
+      });
+    }
+  }
+
+  // Populate a list of links aria-controls attributes with their href value
+  setAriaControlByHref(tabLinks: NodeListOf<HTMLAnchorElement | HTMLElement>) {
+    tabLinks.forEach((tabLink) => {
+      const href = tabLink.getAttribute('href') as string;
+      tabLink.setAttribute('aria-controls', href.replace('#', ''));
+    });
+  }
+
+  connect() {
+    if (this.tabsButtons) {
+      this.setAriaControlByHref(this.tabsButtons);
+      const tabActive = [...this.tabsButtons].find(
+        (button) => button.getAttribute('aria-selected') === 'true',
+      );
+
+      if (window.location.hash && !this.disableURLValue) {
+        this.selectTabByURLHash();
+      } else if (tabActive) {
+        this.tabsPanel.forEach((tab) => {
+          // eslint-disable-next-line no-param-reassign
+          tab.hidden = true;
+        });
+        this.selectTab(tabActive);
+      } else {
+        this.selectFirstTab();
+      }
+    }
+    if (this.tabTriggerLinks) {
+      this.setAriaControlByHref(this.tabTriggerLinks);
+    }
+  }
+
+  selectTab(tab: HTMLElement) {
+    if (!tab) {
+      return;
+    }
+    const tabContentId = tab.getAttribute('aria-controls') as string;
+    if (tabContentId) {
+      this.unSelectActiveTab(tabContentId);
+    }
+
+    this.activeTabIdValue = tabContentId;
+
+    const linkedTab = this.element.querySelector(
+      `a[href="${tab.getAttribute('href')}"][role="tab"]`,
+    );
+    if (linkedTab) {
+      linkedTab.setAttribute('aria-selected', 'true');
+      linkedTab.removeAttribute('tabindex');
+    }
+
+    tab.setAttribute('aria-selected', 'true');
+    tab.removeAttribute('tabindex');
+
+    const tabContent = this.element.querySelector(
+      `#${tabContentId}`,
+    ) as HTMLElement;
+
+    if (!tabContent) {
+      return;
+    }
+
+    if (this.animateValue) {
+      this.animateIn(tabContent);
+    } else {
+      tabContent.hidden = false;
+    }
+
+    if (this.initialPageLoadValue) {
+      // On first load set the scroll to top to avoid scrolling to active section and header covering up tabs
+      setTimeout(() => {
+        window.scrollTo(0, 0);
+      }, this.transitionValue * 2);
+    }
+
+    const href = tab.getAttribute('href') as string;
+    this.tabList.dispatchEvent(
+      new CustomEvent('switch', {
+        detail: { tab: href.replace('#', '') },
+      }),
+    );
+    // Dispatch tab-changed event on the document
+    document.dispatchEvent(new CustomEvent('wagtail:tab-changed'));
+
+    // Set URL hash and browser history
+    if (!this.disableURLValue) {
+      this.setURLHash(tabContentId);
+    }
+  }
+
+  unSelectActiveTab(newTabId) {
+    if (newTabId === this.activeTabIdValue || !this.activeTabIdValue) {
+      return;
+    }
+
+    // Tab Content to deactivate
+    const tabContent = this.element.querySelector(
+      `#${this.activeTabIdValue}`,
+    ) as HTMLElement;
+
+    if (!tabContent) {
+      return;
+    }
+
+    if (this.animateValue) {
+      this.animateOut(tabContent);
+    } else {
+      tabContent.hidden = true;
+    }
+
+    const tab = this.element.querySelector(
+      `a[href='#${this.activeTabIdValue}']`,
+    ) as HTMLElement;
+
+    tab.setAttribute('aria-selected', 'false');
+    tab.setAttribute('tabindex', '-1');
+  }
+
+  getTabElementByHref(href: string) {
+    return this.element.querySelector(`a[href="${href}"][role="tab"]`);
+  }
+
+  loadTabsFromHistory(event: PopStateEvent) {
+    if (event.state && event.state.tabContent) {
+      const tab = this.getTabElementByHref(
+        `#${event.state.tabContent}`,
+      ) as HTMLElement;
+      if (tab) {
+        this.selectTab(tab);
+        tab.focus();
+      }
+    }
+  }
+
+  animateIn(tabContent: HTMLElement) {
+    setTimeout(() => {
+      // eslint-disable-next-line no-param-reassign
+      tabContent.hidden = false;
+      // Wait for hidden attribute to be applied then fade in
+      setTimeout(() => {
+        tabContent.classList.add(this.tabsConstant.css.animate);
+      }, this.transitionValue);
+    }, this.transitionValue);
+  }
+
+  animateOut(tabContent: HTMLElement) {
+    // Wait element to transition out and then hide with hidden
+    tabContent.classList.remove(this.tabsConstant.css.animate);
+    setTimeout(() => {
+      // eslint-disable-next-line no-param-reassign
+      tabContent.hidden = true;
+    }, this.transitionValue);
+  }
+
+  setURLHash(tabId: string) {
+    if (
+      !this.initialPageLoadValue &&
+      (!window.history.state || window.history.state.tabContent !== tabId)
+    ) {
+      // Add a new history item to the stack
+      window.history.pushState({ tabContent: tabId }, '', `#${tabId}`);
+    }
+    this.initialPageLoadValue = false;
+  }
+
+  selectTabByURLHash() {
+    if (window.location.hash) {
+      const cleanedHash = window.location.hash.replace(/[^\w\-#]/g, '');
+      // Support linking straight to a tab, or to an element within a tab.
+      const tabID = document
+        .querySelector(cleanedHash)
+        ?.closest('[role="tabpanel"]')
+        ?.getAttribute('aria-labelledby') as string;
+      const tab = document.getElementById(tabID);
+      if (tab) {
+        this.selectTab(tab);
+      } else {
+        // The hash doesn't match a tab on the page then select first tab
+        this.selectFirstTab();
+      }
+    }
+  }
+
+  selectFirstTab() {
+    this.selectTab(this.tabsButtons[0]);
+    this.activeTabIdValue = this.tabsButtons[0].getAttribute(
+      'aria-controls',
+    ) as string;
+  }
+
+  // func bindEvents listening for click events
+  // on tab title
+  changeTab(event: MouseEvent) {
+    event.preventDefault();
+    const targetElement = event.target as HTMLElement;
+    this.selectTab(targetElement);
+  }
+
+  switchTabOnArrowPress(event: KeyboardEvent) {
+    const keyPressed = event.key;
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const index = event.target.index;
+    const { direction, keys } = this.tabsConstant;
+
+    if (direction[keyPressed]) {
+      if (index !== undefined) {
+        if (this.tabsButtons[index + direction[keyPressed]]) {
+          const tab = this.tabsButtons[
+            index + direction[keyPressed]
+          ] as HTMLAnchorElement;
+          tab.focus();
+          this.selectTab(tab);
+        } else if (keyPressed === keys.left) {
+          const lastTab = this.tabsButtons[this.tabsButtons.length - 1];
+          this.focusTab(lastTab);
+        } else if (keyPressed === keys.right) {
+          const firstTab = this.tabsButtons[0];
+          this.focusTab(firstTab);
+        }
+      }
+    }
+  }
+
+  focusTab(tab: HTMLAnchorElement) {
+    tab.focus();
+    this.selectTab(tab);
+  }
+}

--- a/client/src/controllers/index.ts
+++ b/client/src/controllers/index.ts
@@ -22,6 +22,7 @@ import { TagController } from './TagController';
 import { TeleportController } from './TeleportController';
 import { TooltipController } from './TooltipController';
 import { UpgradeController } from './UpgradeController';
+import { TabsController } from './TabsController';
 
 /**
  * Important: Only add default core controllers that should load with the base admin JS bundle.
@@ -47,6 +48,7 @@ export const coreControllerDefinitions: Definition[] = [
   { controllerConstructor: SubmitController, identifier: 'w-submit' },
   { controllerConstructor: SwapController, identifier: 'w-swap' },
   { controllerConstructor: SyncController, identifier: 'w-sync' },
+  { controllerConstructor: TabsController, identifier: 'w-tabs' },
   { controllerConstructor: TagController, identifier: 'w-tag' },
   { controllerConstructor: TeleportController, identifier: 'w-teleport' },
   { controllerConstructor: TooltipController, identifier: 'w-tooltip' },

--- a/client/src/includes/tabs.js
+++ b/client/src/includes/tabs.js
@@ -363,13 +363,13 @@ class Tabs {
 
 export default Tabs;
 
-export const initTabs = (tabs = document.querySelectorAll('[data-tabs]')) => {
-  tabs.forEach((tabSet) => new Tabs(tabSet));
+// export const initTabs = (tabs = document.querySelectorAll('[data-tabs]')) => {
+//   tabs.forEach((tabSet) => new Tabs(tabSet));
 
-  // Dispatch tab-changed on window load
-  if (tabs) {
-    document.addEventListener('DOMContentLoaded', () => {
-      document.dispatchEvent(new CustomEvent('wagtail:tab-changed'));
-    });
-  }
-};
+//   // Dispatch tab-changed on window load
+//   if (tabs) {
+//     document.addEventListener('DOMContentLoaded', () => {
+//       document.dispatchEvent(new CustomEvent('wagtail:tab-changed'));
+//     });
+//   }
+// };

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -2,12 +2,29 @@
 {% load wagtailadmin_tags %}
 {% load i18n %}
 {% load l10n %}
+{% load tabs %}
 {% block bodyclass %}editor-view {% if page.live %}page-is-live{% endif %} {% if page_locked %}content-locked{% endif %}{% endblock %}
 
 {% block content %}
     {% page_permissions page as page_perms %}
 
     {% include 'wagtailadmin/shared/headers/page_edit_header.html' with title=header_title %}
+
+    {% tabs %}
+        {% tab tab_id="tab-label-content" title="Content" %}
+            <h1>
+                Here are tab 1's contents.
+            </h1>
+        {% endtab %}
+        {% tab tab_id="tab-label-promote" title="Promote" %}
+            <h1>
+                Here are tab 2's contents.
+            </h1>
+            <h1>
+                Here are tab 2's contents.
+            </h1>
+        {% endtab %}
+    {% endtabs %}
 
     {% block form %}
 

--- a/wagtail/admin/templatetags/tabs.py
+++ b/wagtail/admin/templatetags/tabs.py
@@ -1,0 +1,85 @@
+from django import template
+
+register = template.Library()
+
+
+@register.tag
+def tabs(parser, token):
+    # Parse tabs and content
+    tabs = parser.parse(("endtabs",))
+    args = token.split_contents()
+    kwargs = {arg.split("=")[0]: arg.split("=")[1] for arg in args[1:]}
+    parser.delete_first_token()
+    return TabsNode(tabs, token, kwargs)
+
+
+class TabsNode(template.Node):
+    def __init__(self, tabs, token, kwargs):
+        self.tabs = tabs
+        self.token = token
+        self.kwargs = kwargs
+
+    def render(self, context):
+        output = f"""
+          <div class="tabs" data-controller="w-tabs" data-action="popstate@window->w-tabs#loadTabsFromHistory" data-w-tabs-active-tab-id-value={self.kwargs.get("active_tab_id")}> 
+          <div class="w-tabs__wrapper"> 
+          <div class="w-tabs__list" role="tablist">
+        """
+        for node in self.tabs:
+            if isinstance(node, TabNode):
+                output += node.render(
+                    context, active_tab_id=self.kwargs.get("active_tab_id")
+                )  # Render each tab's content
+        output += """
+          </div>
+          </div>
+        """
+        output += """
+          <div class="tab-content tab-content--comments-enabled" >
+        """
+        for node in self.tabs:
+            if isinstance(node, TabNode):
+                tab_label = node.kwargs.get("tab_id")
+                tab_panel_id = tab_label.replace("-label", "")
+
+                is_hidden = (
+                    'hidden="true"'
+                    if self.kwargs.get("active_tab_id") != tab_label
+                    else ""
+                )
+
+                output += f"""<section id={tab_panel_id} class="w-tabs__panel " role="tabpanel" aria-labelledby={tab_label} {is_hidden}>"""
+                output += node.content.render(context)  # Render each tab's content
+                output += "</section>"
+
+        output += """
+          </div>
+          </div>
+        """
+        return output
+
+
+@register.tag
+def tab(parser, token):
+    # Parse tab attributes and content
+    args = token.split_contents()
+    kwargs = {arg.split("=")[0]: arg.split("=")[1] for arg in args[1:]}
+    content = parser.parse(("endtab",))
+    parser.delete_first_token()
+    return TabNode(kwargs, content)
+
+
+class TabNode(template.Node):
+    def __init__(self, kwargs, content):
+        self.kwargs = kwargs
+        self.content = content
+
+    def render(self, context, active_tab_id):
+        tab_id = self.kwargs.get("tab_id")
+        tab_id_panel = self.kwargs.get("tab_id").replace("-label", "").strip('"')
+        tab_title = self.kwargs.get("title").strip('"')
+        tab_selected = (
+            'aria-selected="true"' if active_tab_id == self.kwargs.get("tab_id") else ""
+        )
+        output = f"""<a id={tab_id} href="#{tab_id_panel}" class="w-tabs__tab" role="tab" data-action="click->w-tabs#changeTab keydown->w-tabs#switchTabOnArrowPress keydown->w-tabs#switchTabOnArrowPress" {tab_selected} aria-controls={tab_id}>{tab_title}</a>"""
+        return output


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #8408 

now we can use like this

```python
{% tabs %}
        {% tab tab_id="tab-label-content" title="Content" %}
            <h1>
                Here are tab 1's contents.
            </h1>
        {% endtab %}
        {% tab tab_id="tab-label-promote" title="Promote" %}
            <h1>
                Here are tab 2's contents.
            </h1>
            <h1>
                Here are tab 2's contents.
            </h1>
        {% endtab %}
{% endtabs %}
```





_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
