### PR TITLE
PR for issue #11459

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -74,6 +74,7 @@ Changelog
  * Fix: Remove 'Page' from page types filter on aging pages report (Matt Westcott)
  * Fix: Prevent page types filter from showing other non-Page models that match by name (Matt Westcott)
  * Fix: Ensure `MultipleChooserPanel` modal works correctly when `USE_THOUSAND_SEPARATOR` is `True` for pages with ids over 1,000 (Sankalp, Rohit Sharma)
+ * Fix: When using an empty table header (`th`) for visual spacing, ensure this is ignored by accessibility tooling (V Rohitansh)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)
  * Docs: Add section to testing docs about creating pages and working with page content (Mariana Bedran Lesche)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -786,6 +786,7 @@
 * Curtis Maloney
 * Jai Vignesh J
 * Sankalp
+* V Rohitansh
 
 ## Translators
 

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -107,6 +107,7 @@ Thank you to Thibaud Colas, Badr Fourane, and Sage Abdullah for their work on th
  * Remove 'Page' from page types filter on aging pages report (Matt Westcott)
  * Prevent page types filter from showing other non-Page models that match by name (Matt Westcott)
  * Ensure `MultipleChooserPanel` modal works correctly when `USE_THOUSAND_SEPARATOR` is `True` for pages with ids over 1,000 (Sankalp, Rohit Sharma)
+ * When using an empty table header (`th`) for visual spacing, ensure this is ignored by accessibility tooling (V Rohitansh)
 
 
 ### Documentation

--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -10,7 +10,7 @@
             <thead>
                 <tr>
                     <th class="title">{% trans "Title" %}</th>
-                    <th></th>
+                    <th aria-hidden="true">{% comment %} added for visual alignment only {% endcomment %}</th>
                     <th>{% trans "Locked at" %}</th>
                 </tr>
             </thead>


### PR DESCRIPTION
… #11459

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->
This pull request is done for solving issue #11459 "Empty table header found in the 'Your locked pages' dashboard section…"

Fixes #...
Adding "aria-hidden=true" attribute to <th></th>, so that it is not accessed by screen reader.





_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
