### PR TITLE
SCSS variables and mixins cleanup

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -127,6 +127,7 @@ Changelog
  * Maintenance: Migrate the unsaved form checks & confirmation trigger to Stimulus `UnsavedController` (Sai Srikar Dumpeti, LB (Ben) Johnston)
  * Maintenance: Reduce gap between snippets and generic views/templates (Sage Abdullah)
  * Maintenance: Migrate page listing menu re-ordering (drag & drop) from jQuery inline scripts to `OrderableController` (Aman Pandey, LB (Ben) Johnston)
+ * Maintenance: Clean up scss variable usage, remove unused variables and mixins, adopt more core token variables (Jai Vignesh J, Nandini Arora, LB (Ben) Johnston)
 
 
 5.2.3 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -784,6 +784,7 @@
 * Aditya
 * Tommaso Amici
 * Curtis Maloney
+* Jai Vignesh J
 
 ## Translators
 

--- a/client/scss/components/_bulk_actions.scss
+++ b/client/scss/components/_bulk_actions.scss
@@ -66,7 +66,7 @@
       color: theme('colors.text-link-default');
       background-color: transparent;
       border: 0;
-      font-family: $font-sans;
+      font-family: theme('fontFamily.sans');
       padding: 0;
     }
 

--- a/client/scss/components/_footer.scss
+++ b/client/scss/components/_footer.scss
@@ -1,5 +1,4 @@
 @use 'sass:math';
-$grid-gutter-width: 3%;
 
 .footer {
   @include transition(bottom 0.5s ease 1s);

--- a/client/scss/components/_footer.scss
+++ b/client/scss/components/_footer.scss
@@ -1,4 +1,5 @@
 @use 'sass:math';
+$grid-gutter-width: 3%;
 
 .footer {
   @include transition(bottom 0.5s ease 1s);

--- a/client/scss/components/_messages.scss
+++ b/client/scss/components/_messages.scss
@@ -17,7 +17,6 @@
   }
 
   > ul > li {
-    // @include nice-padding;
     padding: 1.6em 3em 1.6em 1.6em;
     color: theme('colors.text-button');
     border-bottom: 1px solid transparent;

--- a/client/scss/components/_panel.scss
+++ b/client/scss/components/_panel.scss
@@ -24,7 +24,7 @@ $header-button-size: theme('spacing.6');
   display: flex;
   align-items: center;
   margin-bottom: theme('spacing.[0.5]');
-  margin-inline-start: -1 * $mobile-nice-padding;
+  margin-inline-start: calc(-1 * #{$mobile-nice-padding});
 
   @include media-breakpoint-up(sm) {
     margin-inline-start: calc(

--- a/client/scss/components/_userbar.scss
+++ b/client/scss/components/_userbar.scss
@@ -114,7 +114,7 @@ $positions: (
   margin: 0;
   min-width: 210px;
   visibility: hidden;
-  font-family: $font-sans;
+  font-family: theme('fontFamily.sans');
   font-size: 0.875rem;
   padding-inline-start: 0;
   text-decoration: none;
@@ -142,7 +142,7 @@ $positions: (
   overflow: hidden;
   transition-duration: 0.125s;
   transition-timing-function: cubic-bezier(0.55, 0, 0.1, 1);
-  font-family: $font-sans;
+  font-family: theme('fontFamily.sans');
   font-size: 1rem;
   text-decoration: none;
 
@@ -216,7 +216,7 @@ $positions: (
 .w-dialog--userbar {
   // Display off to the side of the page rather than in the middle.
   inset-inline-start: auto;
-  font-family: $font-sans;
+  font-family: theme('fontFamily.sans');
   padding-inline-end: 2rem;
   z-index: $userbar-z-index;
 

--- a/client/scss/components/forms/_field-comment-control.scss
+++ b/client/scss/components/forms/_field-comment-control.scss
@@ -1,7 +1,6 @@
 // Comments
 $icon-size: theme('spacing.4');
 $button-padding: theme('spacing.2');
-$button-space: theme('spacing.1');
 
 .w-field__comment-button {
   $root: &;

--- a/client/scss/components/forms/_nested-panel.scss
+++ b/client/scss/components/forms/_nested-panel.scss
@@ -1,7 +1,5 @@
 $header-icon-size: theme('spacing.4');
-$header-button-size-sm: theme('spacing.6');
 $icon-center-offset: 2px;
-$panel-bottom-margin: $form-field-spacing;
 $guide-line-bottom-margin: calc($form-field-spacing / 3);
 
 /**

--- a/client/scss/elements/_typography.scss
+++ b/client/scss/elements/_typography.scss
@@ -1,6 +1,6 @@
 body {
   -webkit-font-smoothing: antialiased; // Do not remove!
-  font-family: $font-sans;
+  font-family: theme('fontFamily.sans');
   font-size: 85%;
   line-height: 1.5em;
   color: theme('colors.text-context');
@@ -44,13 +44,13 @@ code {
   box-shadow: inset 0 0 4px 0 theme('colors.black-20');
   background-color: theme('colors.surface-page');
   color: theme('colors.text-context');
-  font-family: $font-mono;
+  font-family: theme('fontFamily.mono');
   padding: 2px 5px;
 }
 
 kbd {
   border-radius: 3px;
-  font-family: $font-sans;
+  font-family: theme('fontFamily.sans');
   border: 1px solid currentColor;
   border-color: theme('colors.black-20');
   color: theme('colors.text-meta');
@@ -58,7 +58,7 @@ kbd {
 }
 
 pre {
-  font-family: $font-mono;
+  font-family: theme('fontFamily.mono');
 }
 
 dl,

--- a/client/scss/layouts/_404.scss
+++ b/client/scss/layouts/_404.scss
@@ -5,7 +5,7 @@
   width: 100vw;
   height: 100vh;
   background-color: theme('colors.secondary.400');
-  font-family: $font-sans;
+  font-family: theme('fontFamily.sans');
   color: theme('colors.white.DEFAULT');
 }
 

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -1,21 +1,18 @@
 @use 'sass:color';
-// paths
 
+// Paths
 // We can't use absolute paths here, because those are dependent on Django's
 // STATIC_URL setting. Instead, relative paths from the final location of the
 // compiled CSS files are used.
-// */
 
 $images-root: '../images/';
 
-// grid settings
-
-$mobile-nice-padding: 20px;
-$desktop-nice-padding: 80px;
+$mobile-nice-padding: theme('spacing.5');
+$desktop-nice-padding: theme('spacing.20');
 
 // All text inputs have a 42px set height to simplify alignment.
 $text-input-height: 2.625rem;
-// Forms should be constrainted to a maximum width for legibility.
+// Forms should be constrained to a maximum width for legibility.
 $max-form-width: 840px;
 // Consistent spacing between form fields.
 $form-field-spacing: theme('spacing.[7.5]');
@@ -41,10 +38,8 @@ $breakpoints: (
 // that the most 'up-to-date' and available system font is used and rendered consistently as possible across browsers.
 
 // misc sizing
-$menu-width: 200px;
 $menu-width-slim: 60px;
-$side-panel-width: 500px;
-
+$menu-width: 200px;
 $mobile-nav-indent: 50px;
 
 // transitions

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -9,10 +9,6 @@
 $images-root: '../images/';
 
 // grid settings
-$grid-columns: 12;
-$grid-gutter-width: 3%;
-$grid-max-width: 1200px;
-$grid-content-indent: 0.7;
 
 $mobile-nice-padding: 20px;
 $desktop-nice-padding: 80px;
@@ -44,9 +40,6 @@ $breakpoints: (
 // Our fonts are based off of a list of system fallbacks to ensure
 // that the most 'up-to-date' and available system font is used and rendered consistently as possible across browsers.
 
-$font-sans: theme('fontFamily.sans');
-$font-mono: theme('fontFamily.mono');
-
 // misc sizing
 $menu-width: 200px;
 $menu-width-slim: 60px;
@@ -54,13 +47,8 @@ $side-panel-width: 500px;
 
 $mobile-nav-indent: 50px;
 
-$sidebar-toggle-spacing: 12px;
-$sidebar-toggle-size: 35px;
-
 // transitions
 // Please keep in sync with SIDEBAR_TRANSITION_DURATION variable in `client/src/components/Sidebar/Sidebar.tsx`
 $menu-transition-duration: 150ms;
 
 $focus-outline-width: 3px;
-
-$object-title-height: 40px;

--- a/client/scss/tools/_mixins.grid.scss
+++ b/client/scss/tools/_mixins.grid.scss
@@ -1,5 +1,9 @@
 @use 'sass:math';
 
+// grid settings
+$grid-columns: 12;
+$grid-gutter-width: 3%;
+
 // Utility variable - you should never need to modify this
 $padding: math.div($grid-gutter-width, 2);
 

--- a/client/scss/tools/_mixins.grid.scss
+++ b/client/scss/tools/_mixins.grid.scss
@@ -31,28 +31,6 @@ $padding: math.div($grid-gutter-width, 2);
   padding-inline-start: $padding;
 }
 
-@mixin table-column($x, $padding: $padding, $grid-columns: $grid-columns) {
-  width: 100% * math.div($x, $grid-columns);
-}
-
-// Push adds left padding
-@mixin push($offset: 1, $grid-columns: $grid-columns) {
-  margin-inline-start: 100% * math.div($offset, $grid-columns);
-}
-
-@mixin push-padding($offset: 1, $grid-columns: $grid-columns) {
-  padding-inline-start: 100% * math.div($offset, $grid-columns);
-}
-
-// Pull adds right padding
-@mixin pull($offset: 1, $grid-columns: $grid-columns) {
-  margin-inline-end: 100% * math.div($offset, $grid-columns);
-}
-
-@mixin pull-padding($offset: 1, $grid-columns: $grid-columns) {
-  padding-inline-end: 100% * math.div($offset, $grid-columns);
-}
-
 // only used in places where padding not applied to same elements as row or row-flush
 // most of the time this class should be applied directly to the html elements
 @mixin nice-padding {

--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -23,7 +23,7 @@ $draftail-toolbar-icon-size: 1em;
 $draftail-trigger-additional-size: 30px;
 $draftail-block-hoverable-area-offset: 40px;
 
-$draftail-editor-font-family: $font-sans;
+$draftail-editor-font-family: theme('fontFamily.sans');
 
 @import '../../../../node_modules/draft-js/dist/Draft';
 @import '../../../../node_modules/draftail/src/index';

--- a/client/src/components/PageExplorer/PageExplorer.scss
+++ b/client/src/components/PageExplorer/PageExplorer.scss
@@ -1,5 +1,4 @@
 $c-page-explorer-bg-active: theme('colors.black-50');
-$c-page-explorer-easing: cubic-bezier(0.075, 0.82, 0.165, 1);
 $menu-footer-height: 50px;
 
 @use 'sass:map';

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -1,3 +1,6 @@
+$sidebar-toggle-spacing: 12px;
+$sidebar-toggle-size: 35px;
+
 @mixin sidebar-toggle() {
   @include transition(background-color $menu-transition-duration ease);
 

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -171,6 +171,7 @@ Thank you to Thibaud Colas, Badr Fourane, and Sage Abdullah for their work on th
  * Migrate the unsaved form checks & confirmation trigger to Stimulus `UnsavedController` (Sai Srikar Dumpeti, LB (Ben) Johnston)
  * Reduce gap between snippets and generic views/templates (Sage Abdullah)
  * Migrate page listing menu re-ordering (drag & drop) from jQuery inline scripts to `OrderableController` (Aman Pandey, LB (Ben) Johnston)
+ * Clean up scss variable usage, remove unused variables and mixins, adopt more core token variables (Jai Vignesh J, Nandini Arora, LB (Ben) Johnston)
 
 ## Upgrade considerations - removal of deprecated features from Wagtail 4.2 - 5.1
 


### PR DESCRIPTION
Fixes #11458 

Not a duplicate of #11468
Check comments in the issue #11458

1.Removed unused $grid-content-indent,$grid-max-width and $object-title-height.
2.Replaced $font-sans with direct usage of theme('fontFamily.sans') and $font-mono with direct usage of theme('fontFamily.mono').
3.Moved $grid-columns,$grid-gutter-width,$sidebar-toggle-size and $sidebar-toggle-spacing to the file that they are used in.
4.Removed all unused mixins.

_Please check the following:_

-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [X] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
