### PR TITLE
Universal listings - Exclude 'Page' from the page types filter

### DIFF
--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -582,6 +582,15 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
             f"content_type={page_type_pk}",
         )
 
+        # "Page" should not be listed as a content type
+        soup = self.get_soup(response.content)
+        page_type_labels = {
+            list(label.children)[-1].strip()
+            for label in soup.select("#filters-dialog #id_content_type label")
+        }
+        self.assertIn("Simple page", page_type_labels)
+        self.assertNotIn("Page", page_type_labels)
+
     def test_filter_by_date_updated(self):
         new_page_child = SimplePage(
             title="New page child",

--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -759,12 +759,12 @@ class TestFilteredAgingPagesView(WagtailTestUtils, TestCase):
 
     def test_filter_by_content_type(self):
         response = self.get(
-            params={"content_type": self.home_page.specific.content_type.pk}
+            params={"content_type": self.aboutus_page.specific.content_type.pk}
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, self.home_page.title)
-        self.assertNotContains(response, self.aboutus_page.title)
+        self.assertContains(response, self.aboutus_page.title)
+        self.assertNotContains(response, self.home_page.title)
 
     def test_filter_by_last_published_at(self):
         self.home_page.last_published_at = timezone.now()

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count
 from django.forms import CheckboxSelectMultiple, RadioSelect
 from django.shortcuts import get_object_or_404, redirect
@@ -35,13 +34,8 @@ from wagtail.admin.ui.tables.pages import (
     PageTitleColumn,
 )
 from wagtail.admin.views import generic
-from wagtail.models import Page, Site, get_page_models
+from wagtail.models import Page, Site, get_page_content_types
 from wagtail.permissions import page_permission_policy
-
-
-def get_content_types_for_filter():
-    models = [model.__name__.lower() for model in get_page_models()]
-    return ContentType.objects.filter(model__in=models).order_by("model")
 
 
 class SiteFilter(ModelMultipleChoiceFilter):
@@ -62,7 +56,7 @@ class HasChildPagesFilter(ChoiceFilter):
 class PageFilterSet(WagtailFilterSet):
     content_type = MultipleContentTypeFilter(
         label=_("Page type"),
-        queryset=lambda request: get_content_types_for_filter(),
+        queryset=lambda request: get_page_content_types(include_base_page_type=False),
         widget=CheckboxSelectMultiple,
     )
     latest_revision_created_at = DateFromToRangeFilter(

--- a/wagtail/admin/views/reports/aging_pages.py
+++ b/wagtail/admin/views/reports/aging_pages.py
@@ -1,6 +1,5 @@
 import django_filters
 from django.contrib.auth import get_user_model
-from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import OuterRef, Subquery
 from django.utils.translation import gettext_lazy as _
@@ -8,16 +7,11 @@ from django.utils.translation import gettext_lazy as _
 from wagtail.admin.filters import ContentTypeFilter, WagtailFilterSet
 from wagtail.admin.widgets import AdminDateInput
 from wagtail.coreutils import get_content_type_label
-from wagtail.models import Page, PageLogEntry, get_page_models
+from wagtail.models import Page, PageLogEntry, get_page_content_types
 from wagtail.permissions import page_permission_policy
 from wagtail.users.utils import get_deleted_user_display_name
 
 from .base import PageReportView
-
-
-def get_content_types_for_filter():
-    models = [model.__name__.lower() for model in get_page_models()]
-    return ContentType.objects.filter(model__in=models).order_by("model")
 
 
 class AgingPagesReportFilterSet(WagtailFilterSet):
@@ -25,7 +19,8 @@ class AgingPagesReportFilterSet(WagtailFilterSet):
         label=_("Last published before"), lookup_expr="lte", widget=AdminDateInput
     )
     content_type = ContentTypeFilter(
-        label=_("Type"), queryset=lambda request: get_content_types_for_filter()
+        label=_("Type"),
+        queryset=lambda request: get_page_content_types(include_base_page_type=False),
     )
 
     class Meta:

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -159,7 +159,7 @@ def get_page_models():
     """
     Returns a list of all non-abstract Page model classes defined in this project.
     """
-    return PAGE_MODEL_CLASSES
+    return PAGE_MODEL_CLASSES.copy()
 
 
 def get_page_content_types(include_base_page_type=True):

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -162,6 +162,20 @@ def get_page_models():
     return PAGE_MODEL_CLASSES
 
 
+def get_page_content_types(include_base_page_type=True):
+    """
+    Returns a queryset of all ContentType objects corresponding to Page model classes.
+    """
+    models = get_page_models()
+    if not include_base_page_type:
+        models.remove(Page)
+
+    content_type_ids = [
+        ct.pk for ct in ContentType.objects.get_for_models(*models).values()
+    ]
+    return ContentType.objects.filter(pk__in=content_type_ids).order_by("model")
+
+
 def get_default_page_content_type():
     """
     Returns the content type to use as a default for pages whose content type


### PR DESCRIPTION
Add a new get_page_content_types helper function to wagtail.models that's more robust than the old version used here and on the aging_pages report - querying ContentType on the 'model' field (i.e. the model name) may return models from other apps that just happen to share the same name.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
