### PR TITLE
Fix: Remove blur action from orderable controller

### DIFF
--- a/client/src/controllers/OrderableController.test.js
+++ b/client/src/controllers/OrderableController.test.js
@@ -32,15 +32,15 @@ describe('OrderableController', () => {
       data-w-orderable-message-value="'__label__' has been updated!"
     >
       <li data-w-orderable-target="item" data-w-orderable-item-id="73" data-w-orderable-item-label="Beef">
-        <button class="handle" type="button" data-w-orderable-target="handle" data-action="keyup.up->w-orderable#up:prevent keyup.down->w-orderable#down:prevent keydown.enter->w-orderable#apply blur->w-orderable#apply">--</button>
+        <button class="handle" type="button" data-w-orderable-target="handle" data-action="keyup.up->w-orderable#up:prevent keyup.down->w-orderable#down:prevent keydown.enter->w-orderable#apply">--</button>
         Item 73
       </li>
       <li data-w-orderable-target="item" data-w-orderable-item-id="75" data-w-orderable-item-label="Cheese">
-        <button class="handle" type="button" data-w-orderable-target="handle" data-action="keyup.up->w-orderable#up:prevent keyup.down->w-orderable#down:prevent keydown.enter->w-orderable#apply blur->w-orderable#apply">--</button>
+        <button class="handle" type="button" data-w-orderable-target="handle" data-action="keyup.up->w-orderable#up:prevent keyup.down->w-orderable#down:prevent keydown.enter->w-orderable#apply">--</button>
         Item 75
       </li>
       <li data-w-orderable-target="item" data-w-orderable-item-id="93" data-w-orderable-item-label="Santa">
-        <button class="handle" type="button" data-w-orderable-target="handle" data-action="keyup.up->w-orderable#up:prevent keyup.down->w-orderable#down:prevent keydown.enter->w-orderable#apply blur->w-orderable#apply">--</button>
+        <button class="handle" type="button" data-w-orderable-target="handle" data-action="keyup.up->w-orderable#up:prevent keyup.down->w-orderable#down:prevent keydown.enter->w-orderable#apply">--</button>
         Item 93
       </li>
     </ul>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_ordering_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_ordering_cell.html
@@ -5,7 +5,7 @@
         type="button"
         aria-live="polite"
         data-w-orderable-target="handle"
-        data-action="keydown.up->w-orderable#up:prevent keydown.down->w-orderable#down:prevent keydown.enter->w-orderable#apply blur->w-orderable#apply"
+        data-action="keydown.up->w-orderable#up:prevent keydown.down->w-orderable#down:prevent keydown.enter->w-orderable#apply"
     >
         {% icon name="grip" classname="default" %}
         <span class="w-sr-only">

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -322,7 +322,7 @@ class BaseIndexView(generic.IndexView):
         if self.show_ordering_column:
             kwargs["attrs"] = {
                 "aria-description": _(
-                    "Press enter to select an item, use up and down arrows to move the item. Pressing enter or moving to a different item will complete the move."
+                    "Focus on the drag button and press up or down arrows to move the item, then press enter to submit the change."
                 ),
                 "data-controller": "w-orderable",
                 "data-w-orderable-active-class": "w-orderable--active",


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #https://github.com/wagtail/wagtail/pull/11250

Issue: https://github.com/wagtail/wagtail/issues/10909

CC: @lb- 

Removed `blur` action from from `_ordering_cell.html` and blur action support from orderable stimulus controller.



-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [x] Run `make lint` from the Wagtail root.

