### PR TITLE
Universal listings drilldown component

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -48,6 +48,7 @@ Changelog
  * Polish dark theme styles and update color tokens (Thibaud Colas, Rohit Sharma)
  * Keep database state of pages and snippets updated while in draft state (Stefan Hammer)
  * Add the accessibility checker within the page and snippets editor (Thibaud Colas)
+ * Add `DrilldownController` and `w-drilldown` component to support drilldown menus (Thibaud Colas)
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)

--- a/client/scss/components/_drilldown.scss
+++ b/client/scss/components/_drilldown.scss
@@ -1,0 +1,86 @@
+.w-drilldown__contents {
+  max-height: min(480px, 70vh);
+  overflow-y: auto;
+}
+
+.w-drilldown .w-drilldown__toggle {
+  @apply w-label-1;
+  display: flex;
+  justify-content: space-between;
+  padding-inline-start: theme('spacing.5');
+  padding-inline-end: theme('spacing.5');
+  border: 1px solid transparent;
+
+  &:hover {
+    background-color: transparent;
+    border-color: theme('colors.border-button-outline-hover');
+    color: theme('colors.text-link-hover');
+    cursor: pointer;
+
+    @media (forced-colors: active) {
+      border-color: Highlight;
+    }
+  }
+
+  .icon {
+    pointer-events: none;
+    width: theme('spacing.5');
+    height: theme('spacing.5');
+    opacity: 1;
+    margin-inline-end: 0;
+  }
+}
+
+.w-drilldown__submenu {
+  display: grid;
+  grid-template-columns: min-content 1fr;
+  padding-inline-end: theme('spacing.[2.5]');
+}
+
+.w-drilldown .w-drilldown__back {
+  @apply w-label-1;
+  position: relative;
+  padding: theme('spacing.[2.5]');
+  align-self: flex-start;
+
+  .icon {
+    pointer-events: none;
+    margin-inline-end: 0;
+  }
+
+  &:hover {
+    background-color: transparent;
+    border-color: theme('colors.border-button-outline-hover');
+    color: theme('colors.text-link-hover');
+    cursor: pointer;
+
+    @media (forced-colors: active) {
+      border-color: Highlight;
+    }
+  }
+}
+
+.w-drilldown__submenu .w-field__label {
+  @apply w-label-1;
+  margin-top: theme('spacing.2');
+  margin-bottom: theme('spacing.3');
+}
+
+.w-drilldown__count {
+  $badge-size: theme('spacing.4');
+  width: $badge-size;
+  height: $badge-size;
+  line-height: $badge-size;
+  text-align: center;
+  font-size: 0.5625rem;
+  font-weight: theme('fontWeight.bold');
+  border-radius: theme('borderRadius.full');
+  background-color: theme('colors.info.100');
+  color: theme('colors.white.DEFAULT');
+
+  .w-filter-button & {
+    position: absolute;
+    top: calc(-0.5 * #{$badge-size});
+    inset-inline-end: calc(-0.5 * #{$badge-size});
+  }
+}

--- a/client/scss/components/_drilldown.scss
+++ b/client/scss/components/_drilldown.scss
@@ -62,6 +62,7 @@
 
 .w-drilldown__submenu .w-field__label {
   @apply w-label-1;
+  // Align with the submenu’s back button.
   margin-top: theme('spacing.2');
   margin-bottom: theme('spacing.3');
 }
@@ -76,8 +77,10 @@
   font-weight: theme('fontWeight.bold');
   border-radius: theme('borderRadius.full');
   background-color: theme('colors.info.100');
+  border: 1px solid theme('colors.info.100');
   color: theme('colors.white.DEFAULT');
 
+  // Reuse the same count component as a button badge.
   .w-filter-button & {
     position: absolute;
     top: calc(-0.5 * #{$badge-size});

--- a/client/scss/components/_drilldown.scss
+++ b/client/scss/components/_drilldown.scss
@@ -60,10 +60,15 @@
   }
 }
 
+.w-drilldown__submenu .w-field__wrapper {
+  // Align the margin-top with the submenu’s back button
+  // and reduce the default margin-bottom.
+  margin-top: theme('spacing.2');
+  margin-bottom: theme('spacing.2');
+}
+
 .w-drilldown__submenu .w-field__label {
   @apply w-label-1;
-  // Align with the submenu’s back button.
-  margin-top: theme('spacing.2');
   margin-bottom: theme('spacing.3');
 }
 

--- a/client/scss/components/_filters.scss
+++ b/client/scss/components/_filters.scss
@@ -25,6 +25,7 @@
 }
 
 .w-filter-button {
+  position: relative;
   width: theme('spacing.10');
   height: theme('spacing.10');
   padding: 0;

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -180,7 +180,7 @@
     .w-field__input {
       @apply w-mt-0;
 
-      input {
+      > input {
         @apply w-text-16;
         min-height: theme('spacing.10');
       }

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -174,7 +174,7 @@
     @apply w-mx-2 w-flex w-items-center w-gap-2;
   }
 
-  .w-field__wrapper:not(.w-dialog .w-field__wrapper) {
+  .w-field__wrapper:not(.w-drilldown .w-field__wrapper) {
     @apply w-mb-0;
 
     .w-field__input {

--- a/client/scss/components/_pill.scss
+++ b/client/scss/components/_pill.scss
@@ -3,10 +3,10 @@
   min-height: theme('spacing[6.5]');
 
   &__content {
-    @apply w-pl-3 w-py-1 w-rounded-l-xl w-bg-info-100 hover:w-bg-info-125 w-p-0 w-text-white hover:w-text-white w-pr-2 w-text-14 w-flex w-items-center w-border-r w-border-white-15 w-h-full;
+    @apply w-pl-3 w-py-1 w-rounded-l-xl w-bg-info-100 w-p-0 w-text-white w-pr-2 w-text-14 w-flex w-items-center w-border w-border-info-100 w-border-r-white-15 w-h-full;
   }
 
   &__remove {
-    @apply w-pr-3 w-py-1 w-rounded-r-xl w-bg-info-100 hover:w-bg-info-125 w-text-white hover:w-text-white w-p-0 w-pl-2 w-flex w-items-center w-justify-center w-h-full;
+    @apply w-pr-3 w-py-1 w-rounded-r-xl w-border w-border-info-100 w-bg-info-100 hover:w-bg-info-125 w-text-white hover:w-text-white w-p-0 w-pl-2 w-flex w-items-center w-justify-center w-h-full;
   }
 }

--- a/client/scss/core.scss
+++ b/client/scss/core.scss
@@ -110,6 +110,7 @@ These are classes for components.
 @import 'components/panel';
 @import 'components/dialog';
 @import 'components/dismissible';
+@import 'components/drilldown';
 @import 'components/dropdown';
 @import 'components/dropdown-button';
 @import 'components/help-block';

--- a/client/scss/overrides/_vendor.tippy.scss
+++ b/client/scss/overrides/_vendor.tippy.scss
@@ -31,6 +31,15 @@
   }
 }
 
+.tippy-box[data-theme='drilldown'] {
+  @apply w-rounded w-bg-surface-page w-shadow-md;
+  width: 300px;
+
+  .tippy-content {
+    @apply w-p-0;
+  }
+}
+
 .tippy-box[data-theme='dropdown-button'] {
   @apply w-rounded-none w-w-full w-bg-transparent;
 

--- a/client/src/controllers/DrilldownController.ts
+++ b/client/src/controllers/DrilldownController.ts
@@ -8,38 +8,31 @@ export class DrilldownController extends Controller<HTMLElement> {
   };
 
   declare activeSubmenuValue: string;
-  declare swapSuccessListener: (e: Event) => void;
 
   declare readonly menuTarget: HTMLElement;
   declare readonly toggleTargets: HTMLButtonElement[];
 
   connect() {
     this.updateToggleCounts();
-
-    this.swapSuccessListener = (e: Event) => {
-      const swapEvent = e as CustomEvent<{ requestUrl: string }>;
-      if ((e.target as HTMLElement)?.id === 'listing-results') {
-        const params = new URLSearchParams(
-          swapEvent.detail?.requestUrl.split('?')[1],
-        );
-        const filteredParams = new URLSearchParams();
-        params.forEach((value, key) => {
-          if (value.trim() !== '') {
-            // Check if the value is not empty after trimming white space
-            filteredParams.append(key, value);
-          }
-        });
-        const queryString = '?' + filteredParams.toString();
-        this.updateToggleCounts();
-        window.history.replaceState(null, '', queryString);
-      }
-    };
-
-    document.addEventListener('w-swap:success', this.swapSuccessListener);
   }
 
-  disconnect() {
-    document.removeEventListener('w-swap:success', this.swapSuccessListener);
+  updateParamsCount(e: Event) {
+    const swapEvent = e as CustomEvent<{ requestUrl: string }>;
+    if ((e.target as HTMLElement)?.id === 'listing-results') {
+      const params = new URLSearchParams(
+        swapEvent.detail?.requestUrl.split('?')[1],
+      );
+      const filteredParams = new URLSearchParams();
+      params.forEach((value, key) => {
+        if (value.trim() !== '') {
+          // Check if the value is not empty after trimming white space
+          filteredParams.append(key, value);
+        }
+      });
+      const queryString = '?' + filteredParams.toString();
+      this.updateToggleCounts();
+      window.history.replaceState(null, '', queryString);
+    }
   }
 
   open(e: MouseEvent) {

--- a/client/src/controllers/DrilldownController.ts
+++ b/client/src/controllers/DrilldownController.ts
@@ -1,0 +1,123 @@
+import { Controller } from '@hotwired/stimulus';
+
+export class DrilldownController extends Controller<HTMLElement> {
+  static targets = ['menu', 'toggle'];
+
+  static values = {
+    activeSubmenu: { default: '', type: String },
+  };
+
+  declare activeSubmenuValue: string;
+  declare swapSuccessListener: (e: Event) => void;
+
+  declare readonly menuTarget: HTMLElement;
+  declare readonly toggleTargets: HTMLButtonElement[];
+
+  connect() {
+    this.updateToggleCounts();
+
+    this.swapSuccessListener = (e: Event) => {
+      const swapEvent = e as CustomEvent<{ requestUrl: string }>;
+      if ((e.target as HTMLElement)?.id === 'listing-results') {
+        const params = new URLSearchParams(
+          swapEvent.detail?.requestUrl.split('?')[1],
+        );
+        const filteredParams = new URLSearchParams();
+        params.forEach((value, key) => {
+          if (value.trim() !== '') {
+            // Check if the value is not empty after trimming white space
+            filteredParams.append(key, value);
+          }
+        });
+        const queryString = '?' + filteredParams.toString();
+        this.updateToggleCounts();
+        window.history.replaceState(null, '', queryString);
+      }
+    };
+
+    document.addEventListener('w-swap:success', this.swapSuccessListener);
+  }
+
+  disconnect() {
+    document.removeEventListener('w-swap:success', this.swapSuccessListener);
+  }
+
+  open(e: MouseEvent) {
+    const toggle = (e.target as HTMLElement)?.closest(
+      'button',
+    ) as HTMLButtonElement;
+    this.activeSubmenuValue = toggle.getAttribute('aria-controls') || '';
+  }
+
+  close() {
+    this.activeSubmenuValue = '';
+    this.updateToggleCounts();
+  }
+
+  activeSubmenuValueChanged(activeSubmenu: string, prevActiveSubmenu?: string) {
+    if (prevActiveSubmenu) {
+      const toggle = document.querySelector(
+        `[aria-controls="${prevActiveSubmenu}"]`,
+      ) as HTMLButtonElement;
+      this.toggle(false, toggle);
+    }
+
+    if (activeSubmenu) {
+      const toggle = document.querySelector(
+        `[aria-controls="${activeSubmenu}"]`,
+      ) as HTMLButtonElement;
+      this.toggle(true, toggle);
+    }
+  }
+
+  toggle(expanded: boolean, toggle: HTMLButtonElement) {
+    const controls = toggle.getAttribute('aria-controls');
+    const content = this.element.querySelector<HTMLElement>(`#${controls}`);
+    if (!content) {
+      return;
+    }
+    toggle.setAttribute('aria-expanded', expanded.toString());
+    content.hidden = !expanded;
+    this.menuTarget.hidden = expanded;
+    this.element.classList.toggle('w-drilldown--active', expanded);
+
+    if (expanded) {
+      content.focus();
+    } else {
+      toggle.focus();
+    }
+  }
+
+  /**
+   * Placeholder function until this is more correctly set up with the backend.
+   */
+  updateToggleCounts() {
+    let sum = 0;
+
+    this.toggleTargets.forEach((toggle) => {
+      const content = this.element.querySelector<HTMLElement>(
+        `#${toggle.getAttribute('aria-controls')}`,
+      );
+      const counter = toggle.querySelector<HTMLElement>('.w-drilldown__count');
+      if (!content || !counter) {
+        return;
+      }
+      // Hack to detect fields with a non-default value.
+      const nbActiveFields = content.querySelectorAll(
+        '[type="checkbox"]:checked, [type="radio"]:checked:not([id$="_0"]), option:checked:not(:first-child), input:not([type="checkbox"], [type="radio"]):not(:placeholder-shown)',
+      ).length;
+      counter.hidden = nbActiveFields === 0;
+      counter.textContent = nbActiveFields.toString();
+      sum += nbActiveFields;
+    });
+
+    const sumCounter = this.element.querySelector<HTMLElement>(
+      '.w-drilldown__count',
+    );
+    if (!sumCounter) {
+      return;
+    }
+    sumCounter.hidden = sum === 0;
+    sumCounter.textContent = sum.toString();
+  }
+}

--- a/client/src/controllers/DropdownController.ts
+++ b/client/src/controllers/DropdownController.ts
@@ -86,6 +86,11 @@ const themeOptions = {
     maxWidth: 350,
     placement: 'bottom',
   },
+  'drilldown': {
+    arrow: false,
+    maxWidth: 'none',
+    placement: 'bottom-end',
+  },
   'dropdown-button': {
     arrow: false,
     maxWidth: 'none',

--- a/client/src/controllers/index.ts
+++ b/client/src/controllers/index.ts
@@ -9,6 +9,7 @@ import { CloneController } from './CloneController';
 import { CountController } from './CountController';
 import { DialogController } from './DialogController';
 import { DismissibleController } from './DismissibleController';
+import { DrilldownController } from './DrilldownController';
 import { DropdownController } from './DropdownController';
 import { InitController } from './InitController';
 import { OrderableController } from './OrderableController';
@@ -39,6 +40,7 @@ export const coreControllerDefinitions: Definition[] = [
   { controllerConstructor: CountController, identifier: 'w-count' },
   { controllerConstructor: DialogController, identifier: 'w-dialog' },
   { controllerConstructor: DismissibleController, identifier: 'w-dismissible' },
+  { controllerConstructor: DrilldownController, identifier: 'w-drilldown' },
   { controllerConstructor: DropdownController, identifier: 'w-dropdown' },
   { controllerConstructor: InitController, identifier: 'w-init' },
   { controllerConstructor: OrderableController, identifier: 'w-orderable' },

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -80,6 +80,7 @@ This feature was implemented by Nick Lee, Thibaud Colas, and Sage Abdullah.
  * Add ability to filter by existence of child pages in the page listing view (Matt Westcott)
  * Polish dark theme styles and update color tokens (Thibaud Colas, Rohit Sharma)
  * Keep database state of pages and snippets updated while in draft state (Stefan Hammer)
+ * Add `DrilldownController` and `w-drilldown` component to support drilldown menus (Thibaud Colas)
 
 
 ### Bug fixes

--- a/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
@@ -2,10 +2,10 @@
 <ul class="w-active-filters">
     {% for filter in active_filters %}
         <li class="w-pill">
-            <button data-a11y-dialog-show="filters-dialog" class="w-pill__content">
+            <div class="w-pill__content">
                 <span class="w-text-14">{{ filter.field_label }}:</span>
                 <b class="w-ml-1">{{ filter.value }}</b>
-            </button>
+            </div>
             <button
                 data-controller="w-swap"
                 data-action="click->w-swap#replaceLazy"

--- a/wagtail/admin/templates/wagtailadmin/shared/dropdown/dropdown.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/dropdown/dropdown.html
@@ -8,6 +8,7 @@
     - `attrs` (string?) - more attributes for parent element
     - `toggle_icon` (string?) - toggle icon identifier
     - `toggle_label` (string?) - Visible label for the toggle button
+    - `toggle_suffix` (string?) - Visible content for the toggle button after the icon
     - `toggle_aria_label` (string?) - aria-label for the toggle button
     - `toggle_describedby` (string?) - aria-describedby for the toggle button
     - `toggle_classname` (string?) - additional toggle classes
@@ -24,6 +25,7 @@
         {% if toggle_icon %}
             {% icon name=toggle_icon classname="w-dropdown__toggle-icon" %}
         {% endif %}
+        {{ toggle_suffix }}
     </button>
 
     <div data-w-dropdown-target="content" class="w-dropdown__content" hidden>

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -79,14 +79,35 @@
                         {% endif %}
 
                         {% if filters %}
-                            {% fragment as filters_icon %}{% icon name="sliders" title=_("Show filters") %}{% endfragment %}
-                            {% dialog_toggle classname="w-filter-button" dialog_id="filters-dialog" text=filters_icon %}
-
-                            {% dialog theme="floating" id="filters-dialog" title=_("Filters") dialog_root_selector="[data-search-form]" %}
-                                {% for field in filters.form %}
-                                    {% formattedfield field %}
-                                {% endfor %}
-                            {% enddialog %}
+                            <div class="w-drilldown" data-controller="w-drilldown">
+                                {% fragment as toggle_suffix %}
+                                    <span class="w-drilldown__count" hidden></span>
+                                {% endfragment %}
+                                {% dropdown theme="drilldown" toggle_icon="sliders" toggle_classname="w-filter-button" toggle_aria_label=_("Show filters") toggle_suffix=toggle_suffix %}
+                                    <div class="w-drilldown__contents">
+                                        <div class="w-drilldown__menu" data-w-drilldown-target="menu">
+                                            <h2 class="w-help-text w-pl-5 w-py-2.5 w-my-0">{% trans "Filter by" %}</h2>
+                                            {% for field in filters.form %}
+                                                <button class="w-drilldown__toggle" data-w-drilldown-target="toggle" data-action="click->w-drilldown#open" type="button" class="w-flex w-justify-between" aria-expanded="false" aria-controls="drilldown-{{field.auto_id}}">
+                                                    {{ field.label }}
+                                                    <div class="w-flex w-items-center w-gap-2">
+                                                        <span class="w-drilldown__count" hidden></span>
+                                                        {% icon name="arrow-right" %}
+                                                    </div>
+                                                </button>
+                                            {% endfor %}
+                                        </div>
+                                        {% for field in filters.form %}
+                                            <div class="w-drilldown__submenu" id="drilldown-{{field.auto_id}}" hidden tabindex="-1">
+                                                <button class="w-drilldown__back" type="button" data-action="click->w-drilldown#close" aria-label="{% trans 'Back' %}">
+                                                    {% icon name="arrow-left" %}
+                                                </button>
+                                                {% formattedfield field %}
+                                            </div>
+                                        {% endfor %}
+                                    </div>
+                                {% enddropdown %}
+                            </div>
                         {% endif %}
 
                         {% comment %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -79,7 +79,7 @@
                         {% endif %}
 
                         {% if filters %}
-                            <div class="w-drilldown" data-controller="w-drilldown">
+                            <div class="w-drilldown" data-controller="w-drilldown" data-action="w-swap:success@document->w-drilldown#updateParamsCount">
                                 {% fragment as toggle_suffix %}
                                     <span class="w-drilldown__count" hidden></span>
                                 {% endfragment %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -81,17 +81,16 @@
                         {% if filters %}
                             <div class="w-drilldown" data-controller="w-drilldown" data-action="w-swap:success@document->w-drilldown#updateParamsCount">
                                 {% fragment as toggle_suffix %}
-                                    <span class="w-drilldown__count" hidden></span>
+                                    <span class="w-drilldown__count" data-w-drilldown-target="count" hidden></span>
                                 {% endfragment %}
                                 {% dropdown theme="drilldown" toggle_icon="sliders" toggle_classname="w-filter-button" toggle_aria_label=_("Show filters") toggle_suffix=toggle_suffix %}
                                     <div class="w-drilldown__contents">
                                         <div class="w-drilldown__menu" data-w-drilldown-target="menu">
                                             <h2 class="w-help-text w-pl-5 w-py-2.5 w-my-0">{% trans "Filter by" %}</h2>
                                             {% for field in filters.form %}
-                                                <button class="w-drilldown__toggle" data-w-drilldown-target="toggle" data-action="click->w-drilldown#open" type="button" class="w-flex w-justify-between" aria-expanded="false" aria-controls="drilldown-{{field.auto_id}}">
+                                                <button class="w-drilldown__toggle" type="button" aria-expanded="false" aria-controls="drilldown-{{field.auto_id}}" data-w-drilldown-target="toggle" data-action="click->w-drilldown#open">
                                                     {{ field.label }}
                                                     <div class="w-flex w-items-center w-gap-2">
-                                                        <span class="w-drilldown__count" hidden></span>
                                                         {% icon name="arrow-right" %}
                                                     </div>
                                                 </button>
@@ -99,7 +98,7 @@
                                         </div>
                                         {% for field in filters.form %}
                                             <div class="w-drilldown__submenu" id="drilldown-{{field.auto_id}}" hidden tabindex="-1">
-                                                <button class="w-drilldown__back" type="button" data-action="click->w-drilldown#close" aria-label="{% trans 'Back' %}">
+                                                <button class="w-drilldown__back" type="button" aria-label="{% trans 'Back' %}" data-action="click->w-drilldown#close">
                                                     {% icon name="arrow-left" %}
                                                 </button>
                                                 {% formattedfield field %}

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -630,7 +630,7 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         soup = self.get_soup(response.content)
         page_type_labels = {
             list(label.children)[-1].strip()
-            for label in soup.select("#filters-dialog #id_content_type label")
+            for label in soup.select("#id_content_type label")
         }
         self.assertIn("Simple page", page_type_labels)
         self.assertNotIn("Page", page_type_labels)

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -57,10 +57,6 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         clear_button = soup.select_one(".w-active-filters .w-pill__remove")
         self.assertIsNotNone(active_filter)
         self.assertEqual(active_filter.get_text(separator=" ", strip=True), text)
-        self.assertEqual(
-            active_filter.attrs.get("data-a11y-dialog-show"),
-            "filters-dialog",
-        )
         self.assertIsNotNone(clear_button)
         self.assertNotIn(param, clear_button.attrs.get("data-w-swap-src-value"))
 

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -967,7 +967,7 @@ class TestHistoryView(WagtailTestUtils, TestCase):
         response = self.client.get(self.url, {"action": "wagtail.create"})
         soup = self.get_soup(response.content)
         rows = soup.select("tbody tr")
-        heading = soup.select_one("h2:not(.w-dialog h2)")
+        heading = soup.select_one('h2[role="alert"]')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(heading.string.strip(), "There is 1 match")
         self.assertEqual(len(rows), 1)


### PR DESCRIPTION
Moves the universal listings to a new "dropdown + drilldown" component. The component combines the generic "dropdown" with a custom theme (#11456), with a new bespoke "drilldown" component. That component could be made more generic (separate the drilldown menu interface from the filters logic as two controllers), but for now it’s just the one.

Aside from the drilldown UI, this component also manages the browser URL based on events from SwapController instances.

There are a few things that are missing from the component and will hopefully make it into the next release:

- Better integration with SwapController to have:
  - Error handling
  - Loading state (currently the search form shows one but that’s not appropriate)
  - Resetting the form fields based on external active filters interactions
- Integration with dropdown to:
  - Allow clicking of active filters to go straight to a specific panel within the drilldown
  - Resetting the drilldown when it’s "click outside" or "escape key" closed
- UI
  - Left/right animation when switching panels
  - Counts within the filtering panel rather than top toggle only
- Code quality
  - Unit tests for controller
  - Extract markup to separate template

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 122, Safari 17, Firefox 121 macOS 14
    -   [x] **Please list which assistive technologies [^3] you tested**: forced colors mode, VoiceOver macOS
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

To test this,

- Go to the listings UI with and without filters predefined in the URL
- Use keyboard navigation to interact with the component
- Observe the interaction with active filters