### PR TITLE
Various spacing fixes for universal listings

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -623,7 +623,12 @@ table.listing {
         // so the checkbox align with the breadcrumbs toggle.
         padding-inline-start: theme('spacing.5');
       }
+    }
 
+    // Remove left padding from the second column if either bulk action or
+    // custom ordering is active, as the padding to match the breadcrumbs is
+    // already handled by the first column.
+    &:has(.bulk-actions-filter-checkbox, .ord) {
       th:nth-child(2),
       td:nth-child(2) {
         padding-inline-start: 0;
@@ -632,7 +637,9 @@ table.listing {
 
     // If no bulk actions are present, and nice padding is not applied,
     // apply the same 80px padding via the first column's left padding.
-    &:not(.nice-padding &, .report &):not(:has(.bulk-actions-filter-checkbox)) {
+    &:not(.nice-padding &, .report &):not(
+        :has(.bulk-actions-filter-checkbox, .ord)
+      ) {
       th:first-child,
       td:first-child {
         padding-inline-start: theme('spacing.20');

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -91,7 +91,7 @@ ul.listing {
     }
   }
 
-  &:has(.bulk-action-checkbox) {
+  &:has(.bulk-actions-filter-checkbox) {
     td:first-child,
     th:first-child {
       // Bulk actions, use smaller width (48px) for smaller screens
@@ -609,7 +609,7 @@ table.listing {
       padding-inline-start: 50px;
     }
 
-    &:has(.bulk-action-checkbox) {
+    &:has(.bulk-actions-filter-checkbox) {
       // Bulk actions, match the width of the header spacing up until
       // the page title (final breadcrumb item):
       // Breadcrumbs left padding: 20px
@@ -632,7 +632,7 @@ table.listing {
 
     // If no bulk actions are present, and nice padding is not applied,
     // apply the same 80px padding via the first column's left padding.
-    &:not(.nice-padding &, .report &):not(:has(.bulk-action-checkbox)) {
+    &:not(.nice-padding &, .report &):not(:has(.bulk-actions-filter-checkbox)) {
       th:first-child,
       td:first-child {
         padding-inline-start: theme('spacing.20');

--- a/wagtail/admin/templates/wagtailadmin/generic/listing_results.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/listing_results.html
@@ -7,7 +7,9 @@
     {% endblock %}
     {% block pagination %}
         {% if is_paginated %}
-            {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj linkurl=index_url %}
+            <div class="nice-padding">
+                {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj linkurl=index_url %}
+            </div>
         {% endif %}
     {% endblock %}
 {% else %}

--- a/wagtail/images/templates/wagtailimages/images/index.html
+++ b/wagtail/images/templates/wagtailimages/images/index.html
@@ -10,8 +10,8 @@
 {% endblock %}
 
 {% block listing %}
-    <div class="nice-padding">
-        <form class="image-search" action="{{ index_url }}" method="GET" novalidate>
+    <div>
+        <form class="image-search nice-padding" action="{{ index_url }}" method="GET" novalidate>
             {% if current_tag %}
                 <input type="hidden" name="tag" value="{{ current_tag }}" />
             {% endif %}

--- a/wagtail/images/templates/wagtailimages/images/index_results.html
+++ b/wagtail/images/templates/wagtailimages/images/index_results.html
@@ -3,22 +3,24 @@
 {% load i18n l10n %}
 
 {% block results %}
-    <ul class="listing horiz images">
-        {% for image in object_list %}
-            <li>
-                {% fragment as title_id %}image_{{ image.pk|unlocalize|admin_urlquote }}_title{% endfragment %}
-                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="image" instance=image aria_describedby=title_id only %}
-                <a class="image-choice" title="{% if collections %}{{ image.collection.name }} » {% endif %}{{ image.title }}" href="{% url view.edit_url_name image.id %}{% if next %}?next={{ next|urlencode }}{% endif %}">
-                    <figure>
-                        {% include "wagtailimages/images/results_image.html" %}
-                        <figcaption id="{{ title_id }}">
-                            {{ image.title|ellipsistrim:60 }}
-                        </figcaption>
-                    </figure>
-                </a>
-            </li>
-        {% endfor %}
-    </ul>
+    <div class="nice-padding">
+        <ul class="listing horiz images">
+            {% for image in object_list %}
+                <li>
+                    {% fragment as title_id %}image_{{ image.pk|unlocalize|admin_urlquote }}_title{% endfragment %}
+                    {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="image" instance=image aria_describedby=title_id only %}
+                    <a class="image-choice" title="{% if collections %}{{ image.collection.name }} » {% endif %}{{ image.title }}" href="{% url view.edit_url_name image.id %}{% if next %}?next={{ next|urlencode }}{% endif %}">
+                        <figure>
+                            {% include "wagtailimages/images/results_image.html" %}
+                            <figcaption id="{{ title_id }}">
+                                {{ image.title|ellipsistrim:60 }}
+                            </figcaption>
+                        </figure>
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
 {% endblock %}
 
 {% block no_results_message %}


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Various fixes around nice-padding, see each commit message for more details.



_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 120
    -   [x] **Please list which assistive technologies [^3] you tested**: None

**Please describe additional details for testing this change**.

I recommend testing the following views:
- Page listing (lots of customisations from the generic views)
- Image listing (uses its own grid style layout)
- Documents listing (has bulk actions, mostly follows generic index view/template but has its own filtering section)
- Users listing (has bulk actions, mostly reuses generic index view/template, but doesn't use the tables UI framework)
- Snippets listing (basically generic index view with bulk actions added)
- Usage view (generic BaseListingView, not the more feature-complete IndexView)

Ideas for scenarios to test:
- Search, with results and not
- For page listing, activate custom ordering ("Sort menu order") and not
- For image, documents, and users, look at the padding for the "search other:" bar as well
- Pagination (if you don't have enough items, e.g. in usage view, you can change `paginate_by` in `wagtail.admin.views.generic.usage.UsageView` to 1)

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
