### PR TITLE
Fix number of results info when custom ordering is active in page listings

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
@@ -2,39 +2,37 @@
 {% load wagtailadmin_tags i18n %}
 
 {% block after_label %}
-    {% with result_count=items_count %}
-        {% if is_searching or is_filtering %}
-            {% if is_searching_whole_tree %}
-                {% if result_count %}
-                    {% blocktranslate trimmed %}
-                        {{ start_index }}-{{ end_index }} of {{ result_count }} across entire site.
-                    {% endblocktranslate %}
-                {% else %}
-                    {% blocktranslate trimmed %}
-                        No results across entire site.
-                    {% endblocktranslate %}
-                {% endif %}
-                <a href="{{ table.base_url }}{% querystring p=None search_all=None %}">
-                    {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}Search in '<span class="w-title-ellipsis">{{ title }}</span>'{% endblocktranslate %}
-                </a>
+    {% if is_searching or is_filtering %}
+        {% if is_searching_whole_tree %}
+            {% if items_count %}
+                {% blocktranslate trimmed %}
+                    {{ start_index }}-{{ end_index }} of {{ items_count }} across entire site.
+                {% endblocktranslate %}
             {% else %}
-                {% if result_count %}
-                    {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}
-                        {{ start_index }}-{{ end_index }} of {{ result_count }} in '<span class="w-title-ellipsis">{{ title }}</span>'.
-                    {% endblocktranslate %}
-                {% else %}
-                    {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}
-                        No results in '<span class="w-title-ellipsis">{{ title }}</span>'.
-                    {% endblocktranslate %}
-                {% endif %}
-                <a href="{{ table.base_url }}{% querystring p=None search_all=1 %}">
-                    {% translate "Search the whole site" %}
-                </a>
+                {% blocktranslate trimmed %}
+                    No results across entire site.
+                {% endblocktranslate %}
             {% endif %}
+            <a href="{{ table.base_url }}{% querystring p=None search_all=None %}">
+                {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}Search in '<span class="w-title-ellipsis">{{ title }}</span>'{% endblocktranslate %}
+            </a>
         {% else %}
-            {% blocktranslate trimmed %}
-                {{ start_index }}-{{ end_index }} of {{ result_count }}
-            {% endblocktranslate %}
+            {% if items_count %}
+                {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}
+                    {{ start_index }}-{{ end_index }} of {{ items_count }} in '<span class="w-title-ellipsis">{{ title }}</span>'.
+                {% endblocktranslate %}
+            {% else %}
+                {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}
+                    No results in '<span class="w-title-ellipsis">{{ title }}</span>'.
+                {% endblocktranslate %}
+            {% endif %}
+            <a href="{{ table.base_url }}{% querystring p=None search_all=1 %}">
+                {% translate "Search the whole site" %}
+            </a>
         {% endif %}
-    {% endwith %}
+    {% else %}
+        {% blocktranslate trimmed %}
+            {{ start_index }}-{{ end_index }} of {{ items_count }}
+        {% endblocktranslate %}
+    {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
@@ -2,7 +2,7 @@
 {% load wagtailadmin_tags i18n %}
 
 {% block after_label %}
-    {% with start_index=page_obj.start_index end_index=page_obj.end_index result_count=page_obj.paginator.count %}
+    {% with result_count=items_count %}
         {% if is_searching or is_filtering %}
             {% if is_searching_whole_tree %}
                 {% if result_count %}

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -387,6 +387,25 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         # Check response
         self.assertEqual(response.status_code, 404)
 
+    def test_no_pagination_with_custom_ordering(self):
+        self.make_pages()
+
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=(self.root_page.id,)),
+            {"ordering": "ord"},
+        )
+
+        # Check response
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
+
+        # Check that we don't have a paginator page object
+        self.assertIsNone(response.context["page_obj"])
+
+        # Check that all pages are shown
+        self.assertContains(response, "1-153 of 153")
+        self.assertEqual(len(response.context["pages"]), 153)
+
     @override_settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True)
     def test_no_thousand_separators_in_bulk_action_checkbox(self):
         """

--- a/wagtail/admin/ui/tables/pages.py
+++ b/wagtail/admin/ui/tables/pages.py
@@ -11,6 +11,7 @@ class PageTitleColumn(BaseColumn):
 
     def get_header_context_data(self, parent_context):
         context = super().get_header_context_data(parent_context)
+        context["items_count"] = parent_context.get("items_count")
         context["page_obj"] = parent_context.get("page_obj")
         context["parent_page"] = parent_context.get("parent_page")
         context["is_searching"] = parent_context.get("is_searching")
@@ -18,6 +19,14 @@ class PageTitleColumn(BaseColumn):
         context["is_searching_whole_tree"] = parent_context.get(
             "is_searching_whole_tree"
         )
+
+        # If results are not paginated e.g. when using the OrderingColumn,
+        # all items are displayed on the page
+        context["start_index"] = 1
+        context["end_index"] = context["items_count"]
+        if context["page_obj"]:
+            context["start_index"] = context["page_obj"].start_index()
+            context["end_index"] = context["page_obj"].end_index()
         return context
 
     def get_cell_context_data(self, instance, parent_context):
@@ -140,6 +149,7 @@ class PageTable(Table):
         context = super().get_context_data(parent_context)
         context["show_locale_labels"] = self.show_locale_labels
         context["perms"] = parent_context.get("perms")
+        context["items_count"] = parent_context.get("items_count")
         context["page_obj"] = parent_context.get("page_obj")
         context["parent_page"] = parent_context.get("parent_page")
         context["is_searching"] = parent_context.get("is_searching")


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fix an issue where the number of pages is not shown correctly when custom ordering is active in the page listings. Hide whitespace when reviewing.

## Before

<img width="255" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/34213968-9e93-4cf0-9ddc-568a41b02d9f">


## After

<img width="255" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/89316842-b4ef-4583-8600-1c9661ad23b4">








_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
