### PR TITLE
Universal listings: avoid error when ordering search results by latest_revision_created_at

### DIFF
--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -159,6 +159,28 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
             page_ids, [self.child_page.id, self.new_page.id, self.old_page.id]
         )
 
+    def test_ordering_search_results_by_created_at(self):
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=(self.root_page.id,)),
+            {"q": "page", "ordering": "latest_revision_created_at"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
+
+        # child pages should be ordered by updated_at, oldest first
+        page_ids = [page.id for page in response.context["pages"]]
+        self.assertEqual(page_ids, [self.old_page.id, self.new_page.id])
+
+    def test_ordering_search_results_by_content_type(self):
+        # Ordering search results by content_type is not currently supported,
+        # but should not cause an error
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=(self.root_page.id,)),
+            {"q": "page", "ordering": "content_type"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
+
     def test_change_default_child_page_ordering_attribute(self):
         # save old get_default_order to reset at end of test
         # overriding class methods does not reset at end of test case

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -285,15 +285,19 @@ class BaseIndexView(generic.IndexView):
         if self.ordering == "ord":
             # preserve the native ordering from get_children()
             pass
-        elif self.ordering == "latest_revision_created_at":
+        elif self.ordering == "latest_revision_created_at" and not self.is_searching:
             # order by oldest revision first.
             # Special case NULL entries - these should go at the top of the list.
+            # Skip this special case when searching (and fall through to plain field ordering
+            # instead) as search backends do not support F objects in order_by
             queryset = queryset.order_by(
                 F("latest_revision_created_at").asc(nulls_first=True)
             )
-        elif self.ordering == "-latest_revision_created_at":
+        elif self.ordering == "-latest_revision_created_at" and not self.is_searching:
             # order by oldest revision first.
             # Special case NULL entries - these should go at the end of the list.
+            # Skip this special case when searching (and fall through to plain field ordering
+            # instead) as search backends do not support F objects in order_by
             queryset = queryset.order_by(
                 F("latest_revision_created_at").desc(nulls_last=True)
             )

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.db.models import Count
+from django.db.models import F
 from django.forms import CheckboxSelectMultiple, RadioSelect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
@@ -288,17 +288,15 @@ class BaseIndexView(generic.IndexView):
         elif self.ordering == "latest_revision_created_at":
             # order by oldest revision first.
             # Special case NULL entries - these should go at the top of the list.
-            # Do this by annotating with Count('latest_revision_created_at'),
-            # which returns 0 for these
-            queryset = queryset.annotate(
-                null_position=Count("latest_revision_created_at")
-            ).order_by("null_position", "latest_revision_created_at")
+            queryset = queryset.order_by(
+                F("latest_revision_created_at").asc(nulls_first=True)
+            )
         elif self.ordering == "-latest_revision_created_at":
             # order by oldest revision first.
             # Special case NULL entries - these should go at the end of the list.
-            queryset = queryset.annotate(
-                null_position=Count("latest_revision_created_at")
-            ).order_by("-null_position", "-latest_revision_created_at")
+            queryset = queryset.order_by(
+                F("latest_revision_created_at").desc(nulls_last=True)
+            )
         else:
             queryset = super().order_queryset(queryset)
 

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -218,7 +218,7 @@ class BaseIndexView(generic.IndexView):
 
         return super().get(request)
 
-    def get_ordering(self):
+    def get_valid_orderings(self):
         valid_orderings = [
             "title",
             "-title",
@@ -228,11 +228,7 @@ class BaseIndexView(generic.IndexView):
             "-latest_revision_created_at",
         ]
 
-        if self.is_searching and not self.is_explicitly_ordered:
-            # default to ordering by relevance
-            default_ordering = None
-        else:
-            default_ordering = self.parent_page.get_admin_default_ordering()
+        if not self.is_searching:
             # ordering by page order is only available when not searching
             valid_orderings.append("ord")
 
@@ -241,8 +237,17 @@ class BaseIndexView(generic.IndexView):
             valid_orderings.append("content_type")
             valid_orderings.append("-content_type")
 
+        return valid_orderings
+
+    def get_ordering(self):
+        if self.is_searching and not self.is_explicitly_ordered:
+            # default to ordering by relevance
+            default_ordering = None
+        else:
+            default_ordering = self.parent_page.get_admin_default_ordering()
+
         ordering = self.request.GET.get("ordering", default_ordering)
-        if ordering not in valid_orderings:
+        if ordering not in self.get_valid_orderings():
             ordering = default_ordering
 
         return ordering


### PR DESCRIPTION
Ordering search results by `latest_revision_created_at` fails with the error `Cannot sort search results with field "null_position"`, because the annotation we use to put nulls first/last isn't supported by search backends.

Django has [a built-in way to specify the ordering of nulls](https://docs.djangoproject.com/en/5.0/ref/models/expressions/#using-f-to-sort-null-values), making this annotation unnecessary - but search backends don't support that either, so we fall back on the default order_by handling when searching.