### PR TITLE
Fix exclude_fields_in_copy

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -80,6 +80,7 @@ Changelog
  * Fix: Ensure the panel anchor button sizes meet accessibility guidelines for minimum dimensions (Nandini Arora)
  * Fix: Raise a 404 for bulk actions for models which don't exist instead of throwing a 500 error (Alex Tomkins)
  * Fix: Raise a `SiteSetting.DoesNotExist` error when retrieving settings for an unrecognised site (Nick Smith)
+ * Fix: Ensure that defaulted or unique values declared in `exclude_fields_in_copy` are correctly excluded in new copies, resolving to the default value (Elhussein Almasri)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)
  * Docs: Add section to testing docs about creating pages and working with page content (Mariana Bedran Lesche)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -113,6 +113,7 @@ Thank you to Thibaud Colas, Badr Fourane, and Sage Abdullah for their work on th
  * Ensure the panel anchor button sizes meet accessibility guidelines for minimum dimensions (Nandini Arora)
  * Raise a 404 for bulk actions for models which don't exist instead of throwing a 500 error (Alex Tomkins)
  * Raise a `SiteSetting.DoesNotExist` error when retrieving settings for an unrecognised site (Nick Smith)
+ * Ensure that defaulted or unique values declared in `exclude_fields_in_copy` are correctly excluded in new copies, resolving to the default value (Elhussein Almasri)
 
 
 ### Documentation

--- a/wagtail/actions/copy_page.py
+++ b/wagtail/actions/copy_page.py
@@ -221,6 +221,14 @@ class CopyPageAction:
                                 child_object["translation_key"]
                             )
 
+                for exclude_field in specific_page.exclude_fields_in_copy:
+                    if exclude_field in revision_content and hasattr(
+                        page_copy, exclude_field
+                    ):
+                        revision_content[exclude_field] = getattr(
+                            page_copy, exclude_field, None
+                        )
+
                 revision.content = revision_content
 
                 # Save

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -1909,13 +1909,16 @@ class TestCopyPage(TestCase):
                 special_field="Context is for Kings",
             )
         )
+        page.save_revision()
         new_page = page.copy(to=homepage, update_attrs={"slug": "disco-2"})
+        exclude_field = new_page.latest_revision.content["special_field"]
 
         self.assertEqual(page.title, new_page.title)
         self.assertNotEqual(page.id, new_page.id)
         self.assertNotEqual(page.path, new_page.path)
         # special_field is in the list to be excluded
         self.assertNotEqual(page.special_field, new_page.special_field)
+        self.assertEqual(new_page.special_field, exclude_field)
 
     def test_page_with_generic_relation(self):
         """Test that a page with a GenericRelation will have that relation ignored when


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11428  , Fixes #10922

 the reason for these two issues is the same ,these two issues may like this issue #11323    and the reason of these issues
already mentioned or may be similar to this #11448 . 
in brief : the fields excluded in the `copied page`  must also be excluded in the `revision` of this page as well.

for this issue #11428

 original page 
![Screenshot](https://github.com/wagtail/wagtail/assets/90080237/59e9e124-c1c6-4385-9980-f4d77ee36dab)

the excluded fields must appear in the copied page with default values or null if don ,t have default value, as shown below 
in the Screenshot:

![Screenshot2](https://github.com/wagtail/wagtail/assets/90080237/d0af3bd0-3357-410a-b947-27efe1318e11)


for this issue #10922 

 I follow the steps mentioned in the issue's description , and same error occurred as well.
After : the error disappear and the copied page could be `published` or be live with `uuid` . as shown below in the Screenshot:

![Screenshot3](https://github.com/wagtail/wagtail/assets/90080237/1ae70827-d1cc-4650-9f15-0d2661e7d26f)


_Please check the following:_

-   ✅ Do the tests still pass?[^1]
-   ✅ Does the code comply with the style guide?
    -   ✅ Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
