### PR TITLE
Fix broken checkboxes in MultipleChooserPanel

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -73,6 +73,7 @@ Changelog
  * Fix: Resolve multiple issues with page listing re-ordering using keyboard and screen readers (Aman Pandey)
  * Fix: Remove 'Page' from page types filter on aging pages report (Matt Westcott)
  * Fix: Prevent page types filter from showing other non-Page models that match by name (Matt Westcott)
+ * Fix: Ensure `MultipleChooserPanel` modal works correctly when `USE_THOUSAND_SEPARATOR` is `True` for pages with ids over 1,000 (Sankalp, Rohit Sharma)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)
  * Docs: Add section to testing docs about creating pages and working with page content (Mariana Bedran Lesche)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -785,6 +785,7 @@
 * Tommaso Amici
 * Curtis Maloney
 * Jai Vignesh J
+* Sankalp
 
 ## Translators
 

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -106,6 +106,7 @@ Thank you to Thibaud Colas, Badr Fourane, and Sage Abdullah for their work on th
  * Resolve multiple issues with page listing re-ordering using keyboard and screen readers (Aman Pandey)
  * Remove 'Page' from page types filter on aging pages report (Matt Westcott)
  * Prevent page types filter from showing other non-Page models that match by name (Matt Westcott)
+ * Ensure `MultipleChooserPanel` modal works correctly when `USE_THOUSAND_SEPARATOR` is `True` for pages with ids over 1,000 (Sankalp, Rohit Sharma)
 
 
 ### Documentation

--- a/wagtail/admin/templates/wagtailadmin/chooser/tables/page_checkbox_select_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/tables/page_checkbox_select_cell.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n l10n %}
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
-    <input type="checkbox" id="chooser-modal-select-{{ value }}" data-multiple-choice-select name="id" value="{{ value }}" {% if not instance.can_choose %}disabled{% endif %} title="{% blocktrans trimmed with title=instance %}Select {{ title }}{% endblocktrans %}">
+    <input type="checkbox" id="chooser-modal-select-{{ value|unlocalize }}" data-multiple-choice-select name="id" value="{{ value|unlocalize }}" {% if not instance.can_choose %}disabled{% endif %} title="{% blocktrans trimmed with title=instance %}Select {{ title }}{% endblocktrans %}">
 </td>

--- a/wagtail/admin/templates/wagtailadmin/generic/chooser/checkbox_select_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/chooser/checkbox_select_cell.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n l10n %}
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
-    <input type="checkbox" id="chooser-modal-select-{{ value }}" data-multiple-choice-select name="id" value="{{ value }}" title="{% blocktrans trimmed with title=instance %}Select {{ title }}{% endblocktrans %}">
+    <input type="checkbox" id="chooser-modal-select-{{ value|unlocalize }}" data-multiple-choice-select name="id" value="{{ value|unlocalize }}" title="{% blocktrans trimmed with title=instance %}Select {{ title }}{% endblocktrans %}">
 </td>

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -51,6 +51,44 @@ class TestChooserBrowse(WagtailTestUtils, TestCase):
         self.assertEqual(len(response.context["table"].data), 2)
         self.assertEqual(response.context["table"].data[1].specific, page)
 
+    @override_settings(USE_THOUSAND_SEPARATOR=True)
+    def test_multiple_chooser_view(self):
+        self.page = Page.objects.get(id=1)
+
+        self.child_page = SimplePage(
+            title="test_child_page", content="test content", pk=10022
+        )
+        self.page.add_child(instance=self.child_page)
+
+        response = self.get({"multiple": "1"})
+
+        checkbox_value = str(self.child_page.id)
+        decoded_content = response.content.decode()
+
+        self.assertIn(f'value=\\"{checkbox_value}\\"', decoded_content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/chooser/browse.html")
+
+    @override_settings(USE_THOUSAND_SEPARATOR=False)
+    def test_multiple_chooser_view_without_thousand_separator(self):
+        self.page = Page.objects.get(id=1)
+
+        self.child_page = SimplePage(
+            title="test_child_page", content="test content", pk=10050
+        )
+        self.page.add_child(instance=self.child_page)
+
+        response = self.get({"multiple": "1"})
+
+        checkbox_value = str(self.child_page.id)
+        decoded_content = response.content.decode()
+
+        self.assertIn(f'value=\\"{checkbox_value}\\"', decoded_content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/chooser/browse.html")
+
 
 class TestCanChooseRootFlag(WagtailTestUtils, TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11134 Added the `|unlocalize` filter to the occurrences of values in MultipleChooserPanel.







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
