### PR TITLE
Raise 404 with bulk actions for models which don't exist

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -76,6 +76,7 @@ Changelog
  * Fix: Ensure `MultipleChooserPanel` modal works correctly when `USE_THOUSAND_SEPARATOR` is `True` for pages with ids over 1,000 (Sankalp, Rohit Sharma)
  * Fix: When using an empty table header (`th`) for visual spacing, ensure this is ignored by accessibility tooling (V Rohitansh)
  * Fix: Ensure the panel anchor button sizes meet accessibility guidelines for minimum dimensions (Nandini Arora)
+ * Fix: Raise a 404 for bulk actions for models which don't exist instead of throwing a 500 error (Alex Tomkins)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)
  * Docs: Add section to testing docs about creating pages and working with page content (Mariana Bedran Lesche)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -109,6 +109,7 @@ Thank you to Thibaud Colas, Badr Fourane, and Sage Abdullah for their work on th
  * Ensure `MultipleChooserPanel` modal works correctly when `USE_THOUSAND_SEPARATOR` is `True` for pages with ids over 1,000 (Sankalp, Rohit Sharma)
  * When using an empty table header (`th`) for visual spacing, ensure this is ignored by accessibility tooling (V Rohitansh)
  * Ensure the panel anchor button sizes meet accessibility guidelines for minimum dimensions (Nandini Arora)
+ * Raise a 404 for bulk actions for models which don't exist instead of throwing a 500 error (Alex Tomkins)
 
 
 ### Documentation

--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_action.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_action.py
@@ -20,3 +20,15 @@ class TestBulkActionDispatcher(WagtailTestUtils, TestCase):
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
+
+    def test_bulk_action_invalid_model(self):
+        url = reverse(
+            "wagtail_bulk_action",
+            args=(
+                "doesnotexist",
+                "doesnotexist",
+                "doesnotexist",
+            ),
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)

--- a/wagtail/admin/views/bulk_action/dispatcher.py
+++ b/wagtail/admin/views/bulk_action/dispatcher.py
@@ -5,7 +5,10 @@ from wagtail.admin.views.bulk_action.registry import bulk_action_registry as reg
 
 
 def index(request, app_label, model_name, action):
-    model = apps.get_model(app_label, model_name)
+    try:
+        model = apps.get_model(app_label, model_name)
+    except LookupError:
+        raise Http404
     action_class = registry.get_bulk_action_class(app_label, model_name, action)
     if action_class is not None:
         return action_class(request, model).dispatch(request)


### PR DESCRIPTION
Fixes #11491

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

To test:

```
pip install -e git+https://github.com/tomkins/wagtail.git@bulk-action-500#egg=wagtail
wagtail start mysite
cd mysite
./manage.py makemigrations
./manage.py migrate
./manage.py createsuperuser
./manage.py runserver
```

Go to: http://127.0.0.1:8000/admin/bulk/test/test/test/

Should give a 404 instead of a 500.