### PR TITLE
Document MIT licensing terms for handsontable 6.2.2

### DIFF
--- a/docs/reference/contrib/table_block.md
+++ b/docs/reference/contrib/table_block.md
@@ -1,6 +1,6 @@
 # TableBlock
 
-The TableBlock module provides an HTML table block type for StreamField. This module uses [handsontable 6.2.2](https://handsontable.com/) to provide users with the ability to create and edit HTML tables in Wagtail. Table blocks provides a caption field for accessibility.
+The TableBlock module provides an HTML table block type for StreamField. This module uses [handsontable 6.2.2](https://github.com/handsontable/handsontable/tree/6.2.2) (distributed under the MIT license) to provide users with the ability to create and edit HTML tables in Wagtail. Table blocks provides a caption field for accessibility.
 
 ![The TableBlock component in StreamField, with row header, column header, caption fields - and then the editable table](../../_static/images/screen40_table_block.png)
 


### PR DESCRIPTION
Ref: #11497
People regularly raise concerns about handsontable as a commercial product being incompatible with Wagtail's licence. Clarify that we are using the last version available under the MIT licence, and link to the relevant git tag to allow people to verify this (since the handsontable website no longer mentions the open-source version, and is probably a vastly different product at this point).
