### PR TITLE
Flag Warnings as Errors during Documentation Build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,3 +9,5 @@ python:
       path: .
       extra_requirements:
         - docs
+sphinx:
+  fail_on_warning: True

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W --keep-going -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/extending/extending_client_side.md
+++ b/docs/extending/extending_client_side.md
@@ -213,7 +213,7 @@ For more complex widgets we can now integrate additional libraries whenever the 
 
 In this example we will build a color picker widget using the [Coloris](https://coloris.js.org/) JavaScript library with support for custom widget options.
 
-First, let's start with the HTML, building on the [Django widgets](django:ref/forms/widgets) system that Wagtail supports for `FieldPanel` and `FieldBlock`. Using the `build_attrs` method, we build up the appropriate Stimulus data attributes to support common data structures being passed into the controller.
+First, let's start with the HTML, building on the [Django widgets](inv:django#ref/forms/widgets) system that Wagtail supports for `FieldPanel` and `FieldBlock`. Using the `build_attrs` method, we build up the appropriate Stimulus data attributes to support common data structures being passed into the controller.
 
 Observe that we are using `json.dumps` for complex values (a list of strings in this case), Django will automatically escape these values when rendered to avoid common causes of insecure client-side code.
 

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -499,7 +499,7 @@ The current approach will trigger a deprecation warning and will be removed in a
 
 #### Old
 
-```html+django
+```text
 {% load wagtailadmin_tags %}
 <script type="text/django-form-template" id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
     {% escapescript %}

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -317,7 +317,7 @@ window.enableDirtyFormCheck('.my-form', { alwaysDirty: true, confirmationMessage
 
 The new approach will be data attribute driven as follows.
 
-```javascript
+```text
 <form
   method="POST"
   data-controller="w-unsaved"


### PR DESCRIPTION
Fixes #9778 warnings during documentation build will now be errors and build will not be completed until they are resolved.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For new features: Has the documentation been updated accordingly?

