### PR TITLE
Universal listings - table styles tweaks

### DIFF
--- a/client/scss/components/_footer.scss
+++ b/client/scss/components/_footer.scss
@@ -81,7 +81,7 @@
 }
 
 // Footer control bar for performing actions on the page
-.actions {
+.footer .actions {
   width: 100%;
 
   @include media-breakpoint-up(sm) {
@@ -93,18 +93,18 @@
       width: 310px;
     }
   }
+}
 
-  .button {
-    @apply w-leading-none w-inline-flex w-items-center;
-    font-weight: 600;
-    padding: 0 theme('spacing.3');
-    white-space: initial;
+.actions .button {
+  @apply w-leading-none w-inline-flex w-items-center;
+  font-weight: 600;
+  padding: 0 theme('spacing.3');
+  white-space: initial;
 
-    .icon {
-      width: theme('spacing.4');
-      margin-inline-end: theme('spacing.2');
-      flex-shrink: 0;
-    }
+  .icon {
+    width: theme('spacing.4');
+    margin-inline-end: theme('spacing.2');
+    flex-shrink: 0;
   }
 }
 

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -27,7 +27,11 @@ ul.listing {
 
   td,
   th {
-    padding: 1.2em 1em;
+    padding: 1.2em 0.3em;
+
+    @include media-breakpoint-up(sm) {
+      padding: 1.2em 1em;
+    }
 
     &.no-padding {
       padding: 0;
@@ -36,7 +40,11 @@ ul.listing {
 
   &.small td,
   th {
-    padding: 0.6em 1em;
+    padding: 0.6em 0.3em;
+
+    @include media-breakpoint-up(sm) {
+      padding: 0.6em 1em;
+    }
   }
 
   td {
@@ -44,8 +52,12 @@ ul.listing {
   }
 
   td.title {
-    padding: 1em;
     line-height: 2em;
+    padding: 1em 0.3em;
+
+    @include media-breakpoint-up(sm) {
+      padding: 1em;
+    }
   }
 
   thead {

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -678,3 +678,20 @@ table.listing {
     color: theme('colors.text-link-default');
   }
 }
+
+.w-title-ellipsis {
+  display: inline-block;
+  vertical-align: middle;
+  max-width: 20ch;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  @include media-breakpoint-up(sm) {
+    max-width: 30ch;
+  }
+
+  @include media-breakpoint-up(md) {
+    max-width: none;
+  }
+}

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -72,6 +72,10 @@ ul.listing {
       white-space: nowrap;
     }
 
+    th.title {
+      white-space: normal;
+    }
+
     th.children {
       border: 0;
     }

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
@@ -15,16 +15,16 @@
                     {% endblocktranslate %}
                 {% endif %}
                 <a href="{{ table.base_url }}{% querystring p=None search_all=None %}">
-                    {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}Search within '{{ title }}'{% endblocktranslate %}
+                    {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}Search in '<span class="w-title-ellipsis">{{ title }}</span>'{% endblocktranslate %}
                 </a>
             {% else %}
                 {% if result_count %}
                     {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}
-                        {{ start_index }}-{{ end_index }} of {{ result_count }} within '{{ title }}'.
+                        {{ start_index }}-{{ end_index }} of {{ result_count }} in '<span class="w-title-ellipsis">{{ title }}</span>'.
                     {% endblocktranslate %}
                 {% else %}
                     {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}
-                        No results within '{{ title }}'.
+                        No results in '<span class="w-title-ellipsis">{{ title }}</span>'.
                     {% endblocktranslate %}
                 {% endif %}
                 <a href="{{ table.base_url }}{% querystring p=None search_all=1 %}">

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -559,7 +559,10 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
         page_ids = [page.id for page in response.context["pages"]]
         self.assertEqual(page_ids, [self.old_page.id])
-        self.assertContains(response, "Search within 'New page (simple page)'")
+        self.assertContains(
+            response,
+            "Search in '<span class=\"w-title-ellipsis\">New page (simple page)</span>'",
+        )
 
     def test_filter_by_page_type(self):
         new_page_child = SimplePage(


### PR DESCRIPTION
Includes changes to listing table styles to make them work better at small widths, and a fix to footer actions styles getting applied within listings.

- Switches the wording from "within" to "in"
- Reduces horizontal spacing on small viewports
- Allows the Title header cell to wrap
- Forces the title header cell’s results meta text to partly hide its content with an ellipsis when space would be tight.

Demo of the text wrapping:

![text-wrap](https://github.com/wagtail/wagtail/assets/877585/f3ce36dd-4a4c-417d-8d8e-7ccb208ac64a)

I didn’t make it as aggressive as it could be, on the assumption that displaying the header cell contents spread over 2-3 lines would be acceptable enough.

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 121
    -   [x] **Please list which assistive technologies [^3] you tested**: None
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

