### PR TITLE
docs: documented get_children in Page model reference

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -90,6 +90,7 @@ Changelog
  * Docs: Update contributing guide documentation and GitHub templates to better support new contributors (Thibaud Colas)
  * Docs: Update MyST documentation parser library to v 2.0.0 (Neeraj Yetheendran)
  * Docs: Add documentation writing guidelines for intersphinx / external links (LB (Ben) Johnston)
+ * Docs: Add `Page` model reference `get_children` documentation (Salvo Polizzi)
  * Maintenance: Update BeautifulSoup upper bound to 4.12.x (scott-8)
  * Maintenance: Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)
  * Maintenance: Adopt the usage of of translate string literals using `arg=_('...')` in all `wagtailadmin` module templates (Chiemezuo Akujobi)

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -202,6 +202,8 @@ See also [django-treebeard](https://django-treebeard.readthedocs.io/en/latest/in
 
     .. automethod:: get_parent
 
+    .. automethod:: get_children
+
     .. automethod:: get_ancestors
 
     .. automethod:: get_descendants

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -128,6 +128,7 @@ Thank you to Thibaud Colas, Badr Fourane, and Sage Abdullah for their work on th
  * Add more CSS authoring guidelines (Thibaud Colas)
  * Update MyST documentation parser library to v 2.0.0 (Neeraj Yetheendran)
  * Add documentation writing guidelines for intersphinx / external links (LB (Ben) Johnston)
+ * Add `Page` model reference `get_children` documentation (Salvo Polizzi)
 
 ### Maintenance
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11499: documented get_children in Page model reference







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
