### PR TITLE
Raise meaningful error when no site for SiteSetting

### DIFF
--- a/wagtail/contrib/settings/models.py
+++ b/wagtail/contrib/settings/models.py
@@ -142,6 +142,8 @@ class BaseSiteSetting(AbstractSetting):
         """
         Get or create an instance of this setting for the site.
         """
+        if site is None:
+            raise cls.DoesNotExist("%s does not exist for site None." % cls)
         queryset = cls.base_queryset()
         instance, created = queryset.get_or_create(site=site)
         return instance

--- a/wagtail/contrib/settings/tests/site_specific/test_model.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_model.py
@@ -1,6 +1,6 @@
 import pickle
 
-from django.test import TestCase, override_settings
+from django.test import RequestFactory, TestCase, override_settings
 
 from wagtail.models import Site
 from wagtail.test.testapp.models import ImportantPagesSiteSetting, TestSiteSetting
@@ -17,6 +17,19 @@ class SettingModelTestCase(SiteSettingsTestMixin, TestCase):
         ):
             with self.subTest(site=site):
                 self.assertEqual(TestSiteSetting.for_site(site), expected_settings)
+
+    @override_settings(ALLOWED_HOSTS=["no-site-match.example"])
+    def test_for_request_raises_does_not_exist_when_no_site_match(self):
+        Site.objects.update(is_default_site=False)
+        # Use RequestFactory directly, as self.get_request sets SERVER_NAME and site.
+        request = RequestFactory(SERVER_NAME="no-site-match.example").get("/")
+        with self.assertRaises(TestSiteSetting.DoesNotExist):
+            TestSiteSetting.for_request(request)
+
+    @override_settings(ALLOWED_HOSTS=["no-site-match.example"])
+    def test_for_site_raises_does_not_exist_when_site_is_none(self):
+        with self.assertRaises(TestSiteSetting.DoesNotExist):
+            TestSiteSetting.for_site(None)
 
     def test_for_request_returns_expected_settings(self):
         default_site_request = self.get_request()


### PR DESCRIPTION
This fixes the issue where confusing errors are raised if you try to use the methods `SiteSetting.for_site(None)` or `SiteSetting.for_request(request)` if there is no default site, and the request host name does not match any existing sites.

The traceback is roughly:

`contrib.settings.models.SiteSetting.for_request`:
```python
        site = Site.find_for_request(request)
        site_settings = cls.for_site(site)
```

`contrib.settings.models.SiteSetting.for_site`:
```python
        instance, created = queryset.get_or_create(site=site)
```

which causes IntegrityError for the required site_id field. This feels very easy to cause if all it takes is MySiteSetting.for_request(request) with the sites configured badly. This PR raises `SiteSetting.DoesNotExist` instead.