### PR TITLE
Fix preview and workflow initialisation scripts in the editor

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -16,7 +16,7 @@
 
 {% block main_content %}
     {% block before_form %}{% endblock %}
-    <form action="{{ action_url }}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form action="{{ action_url }}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %} data-edit-form>
         {% csrf_token %}
 
         {% if panel %}

--- a/wagtail/admin/templates/wagtailadmin/shared/_workflow_init.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/_workflow_init.html
@@ -1,36 +1,44 @@
 <script>
     $(function() {
-        ActivateWorkflowActionsForEditView('[data-edit-form]');
+        document.querySelectorAll('footer [data-controller="w-dropdown"]').forEach((e) => {
+            e.addEventListener(
+                'w-dropdown:shown',
+                () => {
+                    ActivateWorkflowActionsForEditView('[data-edit-form]');
 
-        {% if publishing_will_cancel_workflow %}
-            /* Make user confirm before publishing the object if it will cancel an ongoing workflow */
-            let cancellationConfirmed = false;
-            $('[name=action-publish]').click((e) => {
-                if (!cancellationConfirmed) {
-                    e.stopImmediatePropagation();
-                    e.preventDefault();
-                    ModalWorkflow({
-                        'url': "{{ confirm_workflow_cancellation_url }}",
-                        'onload': {
-                            'confirm': function(modal, jsonData) {
-                                $('[data-confirm-cancellation]', modal.body).click((event) => {
-                                    cancellationConfirmed = true;
-                                    modal.close();
-                                    e.currentTarget.click();
-                                })
-                                $('[data-cancel-dialog]', modal.body).click((event) => {
-                                    modal.close();
-                                })
-                            },
-                            'no_confirmation_needed': function(modal, jsonData) {
-                                modal.close();
-                                cancellationConfirmed = true;
-                                e.currentTarget.click();
+                    {% if publishing_will_cancel_workflow %}
+                        /* Make user confirm before publishing the object if it will cancel an ongoing workflow */
+                        let cancellationConfirmed = false;
+                        $('[name=action-publish]').click((e) => {
+                            if (!cancellationConfirmed) {
+                                e.stopImmediatePropagation();
+                                e.preventDefault();
+                                ModalWorkflow({
+                                    'url': "{{ confirm_workflow_cancellation_url }}",
+                                    'onload': {
+                                        'confirm': function(modal, jsonData) {
+                                            $('[data-confirm-cancellation]', modal.body).click((event) => {
+                                                cancellationConfirmed = true;
+                                                modal.close();
+                                                e.currentTarget.click();
+                                            })
+                                            $('[data-cancel-dialog]', modal.body).click((event) => {
+                                                modal.close();
+                                            })
+                                        },
+                                        'no_confirmation_needed': function(modal, jsonData) {
+                                            modal.close();
+                                            cancellationConfirmed = true;
+                                            e.currentTarget.click();
+                                        }
+                                    },
+                                });
                             }
-                        },
-                    });
-                }
-            });
-        {% endif %}
+                        });
+                    {% endif %}
+                },
+                { once: true }
+            )
+        });
     });
 </script>

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -117,6 +117,36 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         # Login
         self.user = self.login()
 
+    def assertSchedulingDialogRendered(self, response, edit_url):
+        # Should show the "Edit schedule" button
+        html = response.content.decode()
+        self.assertTagInHTML(
+            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+        # Should show the dialog template pointing to the [data-edit-form] selector as the root
+        self.assertTagInHTML(
+            '<template data-controller="w-teleport" data-w-teleport-target-value="[data-edit-form]">',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+        # Should render the main form with data-edit-form attribute
+        self.assertTagInHTML(
+            f'<form action="{edit_url}" method="POST" data-edit-form>',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+        self.assertTagInHTML(
+            '<div id="schedule-publishing-dialog" class="w-dialog w-dialog--message publishing" data-controller="w-dialog">',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+
     def test_page_edit(self):
         # Tests that the edit page loads
         response = self.client.get(
@@ -452,28 +482,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             count=1,
         )
 
-        # Should show the "Edit schedule" button
-        html = response.content.decode()
-        self.assertTagInHTML(
-            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-
-        # Should show the dialog template pointing to the [data-edit-form] selector as the root
-        self.assertTagInHTML(
-            '<template data-controller="w-teleport" data-w-teleport-target-value="[data-edit-form]">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-        self.assertTagInHTML(
-            '<div id="schedule-publishing-dialog" class="w-dialog w-dialog--message publishing" data-controller="w-dialog">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
+        self.assertSchedulingDialogRendered(response, edit_url)
 
         self.assertContains(
             response,
@@ -545,27 +554,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             count=1,
         )
 
-        # Should show the "Edit schedule" button
-        self.assertTagInHTML(
-            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-
-        # Should show the dialog template pointing to the [data-edit-form] selector as the root
-        self.assertTagInHTML(
-            '<template data-controller="w-teleport" data-w-teleport-target-value="[data-edit-form]">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-        self.assertTagInHTML(
-            '<div id="schedule-publishing-dialog" class="w-dialog w-dialog--message publishing" data-controller="w-dialog">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
+        self.assertSchedulingDialogRendered(response, edit_url)
 
         # Should show the input with the correct value in the user's timezone
         self.assertTagInHTML(
@@ -1261,29 +1250,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             html=True,
             count=1,
         )
-
-        # Should show the "Edit schedule" button
-        html = response.content.decode()
-        self.assertTagInHTML(
-            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-
-        # Should show the dialog template pointing to the [data-edit-form] selector as the root
-        self.assertTagInHTML(
-            '<template data-controller="w-teleport" data-w-teleport-target-value="[data-edit-form]">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-        self.assertTagInHTML(
-            '<div id="schedule-publishing-dialog" class="w-dialog w-dialog--message publishing" data-controller="w-dialog">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
+        self.assertSchedulingDialogRendered(response, edit_url)
 
     def test_edit_post_publish_schedule_before_a_scheduled_expire_page(self):
         # First let's publish a page with *just* an expire_at in the future

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -1031,6 +1031,7 @@ class TestCreateDraftStateSnippet(WagtailTestUtils, TestCase):
         )
 
     def test_get(self):
+        add_url = reverse("wagtailsnippets_tests_draftstatemodel:add")
         response = self.get()
 
         self.assertEqual(response.status_code, 200)
@@ -1059,6 +1060,26 @@ class TestCreateDraftStateSnippet(WagtailTestUtils, TestCase):
         html = response.content.decode()
         self.assertTagInHTML(
             '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Set schedule</button>',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+        # Should show the dialog template pointing to the [data-edit-form] selector as the root
+        self.assertTagInHTML(
+            '<template data-controller="w-teleport" data-w-teleport-target-value="[data-edit-form]">',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+        # Should render the main form with data-edit-form attribute
+        self.assertTagInHTML(
+            f'<form action="{add_url}" method="POST" data-edit-form>',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+        self.assertTagInHTML(
+            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-controller="w-dialog">',
             html,
             count=1,
             allow_extra_attrs=True,
@@ -1433,6 +1454,36 @@ class BaseTestSnippetEditView(WagtailTestUtils, TestCase):
 
     def setUp(self):
         self.user = self.login()
+
+    def assertSchedulingDialogRendered(self, response, label="Edit schedule"):
+        # Should show the "Edit schedule" button
+        html = response.content.decode()
+        self.assertTagInHTML(
+            f'<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">{label}</button>',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+        # Should show the dialog template pointing to the [data-edit-form] selector as the root
+        self.assertTagInHTML(
+            '<template data-controller="w-teleport" data-w-teleport-target-value="[data-edit-form]">',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+        # Should render the main form with data-edit-form attribute
+        self.assertTagInHTML(
+            f'<form action="{self.get_edit_url()}" method="POST" data-edit-form>',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+        self.assertTagInHTML(
+            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-controller="w-dialog">',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
 
 
 class TestSnippetEditView(BaseTestSnippetEditView):
@@ -1811,13 +1862,7 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         self.assertContains(response, "No publishing schedule set")
 
         # Should show the "Set schedule" button
-        html = response.content.decode()
-        self.assertTagInHTML(
-            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Set schedule</button>',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
+        self.assertSchedulingDialogRendered(response, label="Set schedule")
 
         # Should show the correct subtitle in the dialog
         self.assertContains(
@@ -2399,29 +2444,7 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
             html=True,
             count=1,
         )
-
-        # Should show the "Edit schedule" button
-        html = response.content.decode()
-        self.assertTagInHTML(
-            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-
-        # Should show the dialog template pointing to the [data-edit-form] selector as the root
-        self.assertTagInHTML(
-            '<template data-controller="w-teleport" data-w-teleport-target-value="[data-edit-form]">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-        self.assertTagInHTML(
-            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-controller="w-dialog">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
+        self.assertSchedulingDialogRendered(response)
 
     def test_edit_scheduled_go_live_before_expiry(self):
         response = self.post(
@@ -2643,29 +2666,7 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
             html=True,
             count=1,
         )
-
-        # Should still show the "Edit schedule" button
-        html = response.content.decode()
-        self.assertTagInHTML(
-            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-
-        # Should show the dialog template pointing to the [data-edit-form] selector as the root
-        self.assertTagInHTML(
-            '<template data-controller="w-teleport" data-w-teleport-target-value="[data-edit-form]">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-        self.assertTagInHTML(
-            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-controller="w-dialog">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
+        self.assertSchedulingDialogRendered(response)
 
     def test_edit_post_publish_now_an_already_scheduled_unpublished(self):
         # First let's publish an object with a go_live_at in the future
@@ -2728,29 +2729,7 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         )
 
         response = self.get()
-
-        # Should show the "Edit schedule" button
-        html = response.content.decode()
-        self.assertTagInHTML(
-            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-
-        # Should show the dialog template pointing to the [data-edit-form] selector as the root
-        self.assertTagInHTML(
-            '<template data-controller="w-teleport" data-w-teleport-target-value="[data-edit-form]">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-        self.assertTagInHTML(
-            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-controller="w-dialog">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
+        self.assertSchedulingDialogRendered(response)
 
     def test_edit_post_publish_scheduled_published(self):
         self.test_snippet.save_revision().publish()
@@ -2830,29 +2809,7 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
             html=True,
             count=1,
         )
-
-        # Should still show the "Edit schedule" button
-        html = response.content.decode()
-        self.assertTagInHTML(
-            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-
-        # Should show the dialog template pointing to the [data-edit-form] selector as the root
-        self.assertTagInHTML(
-            '<template data-controller="w-teleport" data-w-teleport-target-value="[data-edit-form]">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-        self.assertTagInHTML(
-            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-controller="w-dialog">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
+        self.assertSchedulingDialogRendered(response)
 
     def test_edit_post_publish_now_an_already_scheduled_published(self):
         self.test_snippet.save_revision().publish()
@@ -3027,29 +2984,7 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
             html=True,
             count=1,
         )
-
-        # Should still show the "Edit schedule" button
-        html = response.content.decode()
-        self.assertTagInHTML(
-            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-
-        # Should show the dialog template pointing to the [data-edit-form] selector as the root
-        self.assertTagInHTML(
-            '<template data-controller="w-teleport" data-w-teleport-target-value="[data-edit-form]">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-        self.assertTagInHTML(
-            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-controller="w-dialog">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
+        self.assertSchedulingDialogRendered(response)
 
     def test_edit_post_publish_schedule_before_a_scheduled_expire(self):
         # First let's publish an object with *just* an expire_at in the future
@@ -3145,29 +3080,7 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
             html=True,
             count=1,
         )
-
-        # Should still show the "Edit schedule" button
-        html = response.content.decode()
-        self.assertTagInHTML(
-            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-
-        # Should show the dialog template pointing to the [data-edit-form] selector as the root
-        self.assertTagInHTML(
-            '<template data-controller="w-teleport" data-w-teleport-target-value="[data-edit-form]">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-        self.assertTagInHTML(
-            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-controller="w-dialog">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
+        self.assertSchedulingDialogRendered(response)
 
     def test_edit_post_publish_schedule_after_a_scheduled_expire(self):
         # First let's publish an object with *just* an expire_at in the future
@@ -3266,29 +3179,7 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
             html=True,
             count=1,
         )
-
-        # Should still show the "Edit schedule" button
-        html = response.content.decode()
-        self.assertTagInHTML(
-            '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-
-        # Should show the dialog template pointing to the [data-edit-form] selector as the root
-        self.assertTagInHTML(
-            '<template data-controller="w-teleport" data-w-teleport-target-value="[data-edit-form]">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
-        self.assertTagInHTML(
-            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-controller="w-dialog">',
-            html,
-            count=1,
-            allow_extra_attrs=True,
-        )
+        self.assertSchedulingDialogRendered(response)
 
 
 class TestScheduledForPublishLock(BaseTestSnippetEditView):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes a few regressions from previous PRs, see each commit for more details. Hide whitespace when reviewing.







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

## Testing

**Please describe additional details for testing this change**.

To test the `data-edit-form` fix, edit a person snippet in bakerydemo and notice that the preview panel and the scheduled publishing dialog are broken on latest `main` and fixed in this PR.

To test the workflow fixes, submit a page/snippet to a workflow and then choose "Request changes" afterwards. Instead of opening the modal to input your comment, it will save and reload instead. With this PR, it works as expected. In addition, the issue in #11420 can now be replicated again.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
