### PR TITLE
Universal listings - POC of updating filters dialog in response to removing active filters

### DIFF
--- a/client/src/controllers/SwapController.ts
+++ b/client/src/controllers/SwapController.ts
@@ -259,6 +259,21 @@ export class SwapController extends Controller<
       })
       .then((results) => {
         target.innerHTML = results;
+
+        /* HACK: if target now contains a `<template id="filters-dialog-fragment">` element,
+        replace the contents of the filters dialog with it */
+        const filtersDialogFragment = target.querySelector(
+          '#filters-dialog-fragment',
+        );
+        if (filtersDialogFragment) {
+          const filtersDialog = document.querySelector(
+            '#filters-dialog [data-w-dialog-target="body"]',
+          );
+          if (filtersDialog) {
+            filtersDialog.innerHTML = filtersDialogFragment.innerHTML;
+          }
+        }
+
         this.dispatch('success', {
           cancelable: false,
           detail: { requestUrl, results },

--- a/wagtail/admin/templates/wagtailadmin/generic/index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index_results.html
@@ -6,6 +6,12 @@
         {% include "wagtailadmin/shared/active_filters.html" with active_filters=view.active_filters %}
     {% endif %}
 
+    {% if render_filters_fragment %}
+        <template id="filters-dialog-fragment">
+            {% include "wagtailadmin/shared/headers/_filters.html" with filters=filters %}
+        </template>
+    {% endif %}
+
     {% if is_searching and view.show_other_searches %}
         <div class="nice-padding">
             {% search_other %}

--- a/wagtail/admin/templates/wagtailadmin/pages/index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index_results.html
@@ -4,6 +4,12 @@
     {% include "wagtailadmin/shared/active_filters.html" with active_filters=view.active_filters %}
 {% endif %}
 
+{% if render_filters_fragment %}
+    <template id="filters-dialog-fragment">
+        {% include "wagtailadmin/shared/headers/_filters.html" with filters=filters %}
+    </template>
+{% endif %}
+
 <form id="page-reorder-form">
     {% csrf_token %}
 

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/_filters.html
@@ -1,0 +1,5 @@
+{% load wagtailadmin_tags %}
+
+{% for field in filters.form %}
+    {% formattedfield field %}
+{% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -83,9 +83,7 @@
                             {% dialog_toggle classname="w-filter-button" dialog_id="filters-dialog" text=filters_icon %}
 
                             {% dialog theme="floating" id="filters-dialog" title=_("Filters") dialog_root_selector="[data-search-form]" %}
-                                {% for field in filters.form %}
-                                    {% formattedfield field %}
-                                {% endfor %}
+                                {% include "wagtailadmin/shared/headers/_filters.html" with filters=filters %}
                             {% enddialog %}
                         {% endif %}
 

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -36,7 +36,7 @@ urlpatterns = [
     ),
     path(
         "pages/<int:parent_page_id>/results/",
-        listing.IndexResultsView.as_view(),
+        listing.IndexView.as_view(results_only=True),
         name="wagtailadmin_explore_results",
     ),
     # bulk actions

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -263,9 +263,8 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                         ActiveFilter(
                             filter_def.label,
                             field.label_from_instance(item),
-                            self.get_url_without_filter_param_value(
-                                field_name, item.pk
-                            ),
+                            self.get_url_without_filter_param_value(field_name, item.pk)
+                            + "&filter_fragment=1",
                         )
                     )
             elif isinstance(filter_def, ModelChoiceFilter):
@@ -274,7 +273,8 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                     ActiveFilter(
                         filter_def.label,
                         field.label_from_instance(value),
-                        self.get_url_without_filter_param(field_name),
+                        self.get_url_without_filter_param(field_name)
+                        + "&filter_fragment=1",
                     )
                 )
             elif isinstance(filter_def, DateFromToRangeFilter):
@@ -286,7 +286,8 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                         "%s - %s" % (start_date_display, end_date_display),
                         self.get_url_without_filter_param(
                             [f"{field_name}_before", f"{field_name}_after"]
-                        ),
+                        )
+                        + "&filter_fragment=1",
                     )
                 )
             elif isinstance(filter_def, ChoiceFilter):
@@ -295,7 +296,8 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                     ActiveFilter(
                         filter_def.label,
                         choices.get(str(value), str(value)),
-                        self.get_url_without_filter_param(field_name),
+                        self.get_url_without_filter_param(field_name)
+                        + "&filter_fragment=1",
                     )
                 )
             else:
@@ -303,7 +305,8 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                     ActiveFilter(
                         filter_def.label,
                         str(value),
-                        self.get_url_without_filter_param(field_name),
+                        self.get_url_without_filter_param(field_name)
+                        + "&filter_fragment=1",
                     )
                 )
 
@@ -422,5 +425,14 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
             context["filters"] = self.filters
             context["is_filtering"] = self.is_filtering
             context["media"] += self.filters.form.media
+
+        # If we're rendering the results as an HTML fragment, the caller can pass a filter_fragment=1
+        # URL parameter to indicate that the filters should be rendered as a <template> block so that
+        # we can replace the existing filters.
+        context["render_filters_fragment"] = (
+            self.request.GET.get("filter_fragment")
+            and self.filters
+            and self.results_only
+        )
 
         return context

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -119,7 +119,9 @@ class PageFilterSet(WagtailFilterSet):
         fields = []  # only needed for filters being generated automatically
 
 
-class BaseIndexView(generic.IndexView):
+class IndexView(generic.IndexView):
+    template_name = "wagtailadmin/pages/index.html"
+    results_template_name = "wagtailadmin/pages/index_results.html"
     permission_policy = page_permission_policy
     any_permission_required = {
         "add",
@@ -403,6 +405,11 @@ class BaseIndexView(generic.IndexView):
             }
         )
 
+        if not self.results_only:
+            side_panels = self.get_side_panels()
+            context["side_panels"] = side_panels
+            context["media"] += side_panels.media
+
         return context
 
     def get_translations(self):
@@ -415,10 +422,6 @@ class BaseIndexView(generic.IndexView):
             .only("id", "locale")
             .select_related("locale")
         ]
-
-
-class IndexView(BaseIndexView):
-    template_name = "wagtailadmin/pages/index.html"
 
     def get_side_panels(self):
         # Don't show side panels on the root page
@@ -437,14 +440,3 @@ class IndexView(BaseIndexView):
             ),
         ]
         return MediaContainer(side_panels)
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        side_panels = self.get_side_panels()
-        context["side_panels"] = side_panels
-        context["media"] += side_panels.media
-        return context
-
-
-class IndexResultsView(BaseIndexView):
-    template_name = "wagtailadmin/pages/index_results.html"


### PR DESCRIPTION
A proposed approach for updating the filter dialog state in response to removing an active filter (cc @thibaudcolas @laymonage):

* Move the filter dialog content to its own include
* Update the index_results endpoint to accept a `filter_fragment=1` URL variable - if this is present, insert a `<template id="filters-dialog-fragment">` element containing the re-rendered filter HTML
* Pass `filter_fragment=1` as part of the 'remove filter' URLs
* Update SwapController to check for the presence of the `<template>`, and update the dialog body with it if found

Obviously for the final version we'll want to do something smarter and more Stimulus-y than hard-coding the element replacement code, and apply this on top of #11477 when that's ready. Also, as this stands the date pickers stop working after the replacement - because they still rely on inline scripts within the fragment, and setting `innerHTML` does not execute these. (Do we have a non-jQuery solution for this yet...?)