### PR TITLE
Universal listings - Update filters drilldown content in response to removing active filters

### DIFF
--- a/client/src/controllers/DrilldownController.ts
+++ b/client/src/controllers/DrilldownController.ts
@@ -58,6 +58,16 @@ export class DrilldownController extends Controller<HTMLElement> {
   }
 
   /**
+   * Delay closing the submenu to allow the top-level menu to fade out first.
+   * Useful for resetting the state when the user clicks outside the menu.
+   * This can be used as an action for the w-dropdown:hidden event of the menu,
+   * e.g. data-action="w-dropdown:hidden->w-drilldown#delayedClose".
+   */
+  delayedClose() {
+    setTimeout(() => this.close(), 200);
+  }
+
+  /**
    * Derive the component’s targets based on the state,
    * so the drilldown state can be controlled externally more easily.
    */

--- a/client/src/controllers/DrilldownController.ts
+++ b/client/src/controllers/DrilldownController.ts
@@ -32,7 +32,7 @@ export class DrilldownController extends Controller<HTMLElement> {
       );
       const filteredParams = new URLSearchParams();
       params.forEach((value, key) => {
-        if (value.trim() !== '') {
+        if (value.trim() !== '' && !key.startsWith('_w_')) {
           // Check if the value is not empty after trimming white space
           filteredParams.append(key, value);
         }

--- a/client/src/controllers/DropdownController.ts
+++ b/client/src/controllers/DropdownController.ts
@@ -164,6 +164,10 @@ export class DropdownController extends Controller<HTMLElement> {
       this.dispatch('shown');
     };
 
+    const onHide = () => {
+      this.dispatch('hide');
+    };
+
     return {
       ...(this.hasContentTarget
         ? { content: this.contentTarget as Content }
@@ -187,6 +191,7 @@ export class DropdownController extends Controller<HTMLElement> {
         if (hoverTooltipInstance) {
           hoverTooltipInstance.enable();
         }
+        onHide();
       },
     };
   }

--- a/client/src/controllers/DropdownController.ts
+++ b/client/src/controllers/DropdownController.ts
@@ -117,6 +117,8 @@ export class DropdownController extends Controller<HTMLElement> {
     theme: { default: 'dropdown' as TippyTheme, type: String },
   };
 
+  // Hide on click *inside* the dropdown. Differs from tippy's hideOnClick
+  // option for outside clicks that defaults to true and we don't yet expose it.
   declare hideOnClickValue: boolean;
   declare offsetValue: [number, number];
 
@@ -176,6 +178,7 @@ export class DropdownController extends Controller<HTMLElement> {
       trigger: 'click',
       interactive: true,
       ...(this.hasOffsetValue && { offset: this.offsetValue }),
+      hideOnClick: !this.useCustomHideOnClickAway,
       getReferenceClientRect: () => this.reference.getBoundingClientRect(),
       theme: this.themeValue,
       plugins: this.plugins,
@@ -196,12 +199,67 @@ export class DropdownController extends Controller<HTMLElement> {
     };
   }
 
+  get useCustomHideOnClickAway() {
+    // Tippy's default hideOnClick option for "hiding on click away" doesn't
+    // work well with our datetime libraries. Instead, we use a custom plugin
+    // to hide the tooltip when clicking outside the dropdown. It's unlikely
+    // we'll render a datetime picker for themes other than drilldown, so use
+    // the custom solution for this theme only.
+    return this.themeValue === 'drilldown';
+  }
+
+  /**
+   * Hides tooltip on click away from the reference element.
+   * A custom implementation to replace tippy's default hideOnClick option,
+   * which doesn't play well with our datetime libraries (or others that render
+   * elements outside of the dropdown's DOM).
+   */
+  get hideTooltipOnClickAway() {
+    // We can't use `this` to access the controller instance inside the plugin
+    // function, so we need to get these ahead in time.
+    const reference = this.reference;
+    const toggleTarget = this.toggleTarget;
+
+    return {
+      name: 'hideTooltipOnClickAway',
+      fn(instance: Instance) {
+        const onClick = (e: MouseEvent) => {
+          if (
+            instance.state.isShown &&
+            // Hide if the click is outside of the reference element,
+            // or if the click is on the toggle button itself.
+            (!reference.contains(e.target as Node) ||
+              toggleTarget.contains(e.target as Node))
+          ) {
+            instance.hide();
+          }
+        };
+
+        return {
+          onShow() {
+            document.addEventListener('click', onClick);
+          },
+          onHide() {
+            document.removeEventListener('click', onClick);
+          },
+        };
+      },
+    };
+  }
+
   get plugins() {
-    return [
+    const plugins = [
       hideTooltipOnBreadcrumbsChange,
       hideTooltipOnEsc,
       rotateToggleIcon,
-    ].concat(this.hideOnClickValue ? [hideTooltipOnClickInside] : []);
+    ];
+    if (this.hideOnClickValue) {
+      plugins.push(hideTooltipOnClickInside);
+    }
+    if (this.useCustomHideOnClickAway) {
+      plugins.push(this.hideTooltipOnClickAway);
+    }
+    return plugins;
   }
 
   /**

--- a/client/src/controllers/DropdownController.ts
+++ b/client/src/controllers/DropdownController.ts
@@ -176,7 +176,7 @@ export class DropdownController extends Controller<HTMLElement> {
       trigger: 'click',
       interactive: true,
       ...(this.hasOffsetValue && { offset: this.offsetValue }),
-      getReferenceClientRect: () => this.getReference().getBoundingClientRect(),
+      getReferenceClientRect: () => this.reference.getBoundingClientRect(),
       theme: this.themeValue,
       plugins: this.plugins,
       onShow() {
@@ -207,7 +207,7 @@ export class DropdownController extends Controller<HTMLElement> {
   /**
    * Use a different reference element depending on the theme.
    */
-  getReference() {
+  get reference() {
     const toggleParent = this.toggleTarget.parentElement as HTMLElement;
     return this.themeValue === 'dropdown-button'
       ? (toggleParent.parentElement as HTMLElement)

--- a/client/src/controllers/TeleportController.ts
+++ b/client/src/controllers/TeleportController.ts
@@ -98,6 +98,22 @@ export class TeleportController extends Controller<HTMLTemplateElement> {
       throw new Error('Invalid template content.');
     }
 
+    // HACK:
+    // cloneNode doesn't run scripts, so we need to create new script elements
+    // and copy the attributes and innerHTML over. This is necessary when we're
+    // teleporting a template that contains legacy init code, e.g. initDateChooser.
+    // Only do this for inline scripts, as that's what we're expecting.
+    templateElement
+      .querySelectorAll('script:not([src], [type])')
+      .forEach((script) => {
+        const newScript = document.createElement('script');
+        Array.from(script.attributes).forEach((key) =>
+          newScript.setAttribute(key.nodeName, key.nodeValue || ''),
+        );
+        newScript.innerHTML = script.innerHTML;
+        script.replaceWith(newScript);
+      });
+
     return templateElement;
   }
 }

--- a/client/src/controllers/TeleportController.ts
+++ b/client/src/controllers/TeleportController.ts
@@ -4,6 +4,8 @@ import { Controller } from '@hotwired/stimulus';
  * Allows the controlled element's content to be copied and appended
  * to another place in the DOM. Once copied, the original controlled
  * element will be removed from the DOM unless `keep` is true.
+ * If `reset` is true, the target element will be emptied before
+ * the controlled element is appended.
  * If a target selector isn't provided, a default target of
  * `document.body` or the Shadow Root's first DOM node will be used.
  * Depending on location of the controlled element.
@@ -22,11 +24,14 @@ import { Controller } from '@hotwired/stimulus';
 export class TeleportController extends Controller<HTMLTemplateElement> {
   static values = {
     keep: { default: false, type: Boolean },
+    reset: { default: false, type: Boolean },
     target: { default: '', type: String },
   };
 
   /** If true, keep the original DOM element intact, otherwise remove it when cloned. */
   declare keepValue: boolean;
+  /** If true, empty the target element's contents before appending the cloned element. */
+  declare resetValue: boolean;
   /** A selector to determine the target location to clone the element. */
   declare targetValue: string;
 
@@ -40,6 +45,7 @@ export class TeleportController extends Controller<HTMLTemplateElement> {
 
     const complete = () => {
       if (completed) return;
+      if (this.resetValue) target.innerHTML = '';
       target.append(this.templateElement);
       this.dispatch('appended', { cancelable: false, detail: { target } });
       completed = true;

--- a/wagtail/admin/templates/wagtailadmin/generic/index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index_results.html
@@ -6,6 +6,12 @@
         {% include "wagtailadmin/shared/active_filters.html" with active_filters=view.active_filters %}
     {% endif %}
 
+    {% if render_filters_fragment %}
+        <template data-controller="w-teleport" data-w-teleport-target-value="#filters-drilldown" data-w-teleport-reset-value="true">
+            {% include "wagtailadmin/shared/headers/_filters.html" with filters=filters %}
+        </template>
+    {% endif %}
+
     {% if is_searching and view.show_other_searches %}
         <div class="nice-padding">
             {% search_other %}

--- a/wagtail/admin/templates/wagtailadmin/pages/index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index_results.html
@@ -4,6 +4,12 @@
     {% include "wagtailadmin/shared/active_filters.html" with active_filters=view.active_filters %}
 {% endif %}
 
+{% if render_filters_fragment %}
+    <template data-controller="w-teleport" data-w-teleport-target-value="#filters-drilldown" data-w-teleport-reset-value="true">
+        {% include "wagtailadmin/shared/headers/_filters.html" with filters=filters %}
+    </template>
+{% endif %}
+
 <form id="page-reorder-form">
     {% csrf_token %}
 

--- a/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
@@ -1,7 +1,7 @@
 {% load i18n wagtailadmin_tags %}
 <ul class="w-active-filters">
     {% for filter in active_filters %}
-        <li class="w-pill" data-w-active-filter-name="{{ filter.field_name }}">
+        <li class="w-pill" data-w-active-filter-name="{{ filter.auto_id }}">
             <div class="w-pill__content">
                 <span class="w-text-14">{{ filter.field_label }}:</span>
                 <b class="w-ml-1">{{ filter.value }}</b>

--- a/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
@@ -1,7 +1,7 @@
 {% load i18n wagtailadmin_tags %}
 <ul class="w-active-filters">
     {% for filter in active_filters %}
-        <li class="w-pill">
+        <li class="w-pill" data-w-active-filter-name="{{ filter.field_name }}">
             <div class="w-pill__content">
                 <span class="w-text-14">{{ filter.field_label }}:</span>
                 <b class="w-ml-1">{{ filter.value }}</b>

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/_filters.html
@@ -12,6 +12,7 @@
                 <button class="w-drilldown__toggle" type="button" aria-expanded="false" aria-controls="drilldown-{{ field.auto_id }}" data-w-drilldown-target="toggle" data-action="click->w-drilldown#open">
                     {{ field.label }}
                     <div class="w-flex w-items-center w-gap-2">
+                        <span class="w-drilldown__count" data-w-drilldown-target="count" data-count-name="{{ field.name }}" hidden></span>
                         {% icon name="arrow-right" %}
                     </div>
                 </button>

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/_filters.html
@@ -1,0 +1,29 @@
+{% load wagtailadmin_tags i18n %}
+
+{% fragment as toggle_suffix %}
+    <span class="w-drilldown__count" data-w-drilldown-target="count" hidden></span>
+{% endfragment %}
+
+{% dropdown theme="drilldown" toggle_icon="sliders" toggle_classname="w-filter-button" toggle_aria_label=_("Show filters") toggle_suffix=toggle_suffix %}
+    <div class="w-drilldown__contents">
+        <div class="w-drilldown__menu" data-w-drilldown-target="menu">
+            <h2 class="w-help-text w-pl-5 w-py-2.5 w-my-0">{% trans "Filter by" %}</h2>
+            {% for field in filters.form %}
+                <button class="w-drilldown__toggle" type="button" aria-expanded="false" aria-controls="drilldown-{{ field.auto_id }}" data-w-drilldown-target="toggle" data-action="click->w-drilldown#open">
+                    {{ field.label }}
+                    <div class="w-flex w-items-center w-gap-2">
+                        {% icon name="arrow-right" %}
+                    </div>
+                </button>
+            {% endfor %}
+        </div>
+        {% for field in filters.form %}
+            <div class="w-drilldown__submenu" id="drilldown-{{ field.auto_id }}" hidden tabindex="-1">
+                <button class="w-drilldown__back" type="button" aria-label="{% trans 'Back' %}" data-action="click->w-drilldown#close">
+                    {% icon name="arrow-left" %}
+                </button>
+                {% formattedfield field %}
+            </div>
+        {% endfor %}
+    </div>
+{% enddropdown %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/_filters.html
@@ -12,7 +12,7 @@
                 <button class="w-drilldown__toggle" type="button" aria-expanded="false" aria-controls="drilldown-{{ field.auto_id }}" data-w-drilldown-target="toggle" data-action="click->w-drilldown#open">
                     {{ field.label }}
                     <div class="w-flex w-items-center w-gap-2">
-                        <span class="w-drilldown__count" data-w-drilldown-target="count" data-count-name="{{ field.name }}" hidden></span>
+                        <span class="w-drilldown__count" data-w-drilldown-target="count" data-count-name="{{ field.auto_id }}" hidden></span>
                         {% icon name="arrow-right" %}
                     </div>
                 </button>

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -79,7 +79,7 @@
                         {% endif %}
 
                         {% if filters %}
-                            <div id="filters-drilldown" class="w-drilldown" data-controller="w-drilldown" data-action="w-swap:success@document->w-drilldown#updateParamsCount">
+                            <div id="filters-drilldown" class="w-drilldown" data-controller="w-drilldown" data-action="w-swap:success@document->w-drilldown#updateParamsCount w-dropdown:hide->w-drilldown#delayedClose">
                                 {% include "wagtailadmin/shared/headers/_filters.html" with filters=filters only %}
                             </div>
                         {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -79,7 +79,7 @@
                         {% endif %}
 
                         {% if filters %}
-                            <div id="filters-drilldown" class="w-drilldown" data-controller="w-drilldown" data-action="w-swap:success@document->w-drilldown#updateParamsCount w-dropdown:hide->w-drilldown#delayedClose">
+                            <div id="filters-drilldown" class="w-drilldown" data-controller="w-drilldown" data-action="w-swap:success@document->w-drilldown#updateParams w-dropdown:hide->w-drilldown#delayedClose" data-w-drilldown-count-attr-value="data-w-active-filter-name">
                                 {% include "wagtailadmin/shared/headers/_filters.html" with filters=filters only %}
                             </div>
                         {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -79,33 +79,8 @@
                         {% endif %}
 
                         {% if filters %}
-                            <div class="w-drilldown" data-controller="w-drilldown" data-action="w-swap:success@document->w-drilldown#updateParamsCount">
-                                {% fragment as toggle_suffix %}
-                                    <span class="w-drilldown__count" data-w-drilldown-target="count" hidden></span>
-                                {% endfragment %}
-                                {% dropdown theme="drilldown" toggle_icon="sliders" toggle_classname="w-filter-button" toggle_aria_label=_("Show filters") toggle_suffix=toggle_suffix %}
-                                    <div class="w-drilldown__contents">
-                                        <div class="w-drilldown__menu" data-w-drilldown-target="menu">
-                                            <h2 class="w-help-text w-pl-5 w-py-2.5 w-my-0">{% trans "Filter by" %}</h2>
-                                            {% for field in filters.form %}
-                                                <button class="w-drilldown__toggle" type="button" aria-expanded="false" aria-controls="drilldown-{{field.auto_id}}" data-w-drilldown-target="toggle" data-action="click->w-drilldown#open">
-                                                    {{ field.label }}
-                                                    <div class="w-flex w-items-center w-gap-2">
-                                                        {% icon name="arrow-right" %}
-                                                    </div>
-                                                </button>
-                                            {% endfor %}
-                                        </div>
-                                        {% for field in filters.form %}
-                                            <div class="w-drilldown__submenu" id="drilldown-{{field.auto_id}}" hidden tabindex="-1">
-                                                <button class="w-drilldown__back" type="button" aria-label="{% trans 'Back' %}" data-action="click->w-drilldown#close">
-                                                    {% icon name="arrow-left" %}
-                                                </button>
-                                                {% formattedfield field %}
-                                            </div>
-                                        {% endfor %}
-                                    </div>
-                                {% enddropdown %}
+                            <div id="filters-drilldown" class="w-drilldown" data-controller="w-drilldown" data-action="w-swap:success@document->w-drilldown#updateParamsCount">
+                                {% include "wagtailadmin/shared/headers/_filters.html" with filters=filters only %}
                             </div>
                         {% endif %}
 

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -36,7 +36,7 @@ urlpatterns = [
     ),
     path(
         "pages/<int:parent_page_id>/results/",
-        listing.IndexResultsView.as_view(),
+        listing.IndexView.as_view(results_only=True),
         name="wagtailadmin_explore_results",
     ),
     # bulk actions

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -227,6 +227,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                 query_dict.pop(p, None)
         else:
             query_dict.pop(param, None)
+        query_dict["_w_filter_fragment"] = 1
         return base_url + "?" + query_dict.urlencode()
 
     def get_url_without_filter_param_value(self, param, value):
@@ -240,6 +241,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
         query_dict.setlist(
             param, [v for v in query_dict.getlist(param) if v != str(value)]
         )
+        query_dict["_w_filter_fragment"] = 1
         return base_url + "?" + query_dict.urlencode()
 
     @cached_property
@@ -263,8 +265,9 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                         ActiveFilter(
                             filter_def.label,
                             field.label_from_instance(item),
-                            self.get_url_without_filter_param_value(field_name, item.pk)
-                            + "&filter_fragment=1",
+                            self.get_url_without_filter_param_value(
+                                field_name, item.pk
+                            ),
                         )
                     )
             elif isinstance(filter_def, ModelChoiceFilter):
@@ -273,8 +276,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                     ActiveFilter(
                         filter_def.label,
                         field.label_from_instance(value),
-                        self.get_url_without_filter_param(field_name)
-                        + "&filter_fragment=1",
+                        self.get_url_without_filter_param(field_name),
                     )
                 )
             elif isinstance(filter_def, DateFromToRangeFilter):
@@ -286,8 +288,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                         "%s - %s" % (start_date_display, end_date_display),
                         self.get_url_without_filter_param(
                             [f"{field_name}_before", f"{field_name}_after"]
-                        )
-                        + "&filter_fragment=1",
+                        ),
                     )
                 )
             elif isinstance(filter_def, ChoiceFilter):
@@ -296,8 +297,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                     ActiveFilter(
                         filter_def.label,
                         choices.get(str(value), str(value)),
-                        self.get_url_without_filter_param(field_name)
-                        + "&filter_fragment=1",
+                        self.get_url_without_filter_param(field_name),
                     )
                 )
             else:
@@ -305,8 +305,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                     ActiveFilter(
                         filter_def.label,
                         str(value),
-                        self.get_url_without_filter_param(field_name)
-                        + "&filter_fragment=1",
+                        self.get_url_without_filter_param(field_name),
                     )
                 )
 
@@ -426,11 +425,11 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
             context["is_filtering"] = self.is_filtering
             context["media"] += self.filters.form.media
 
-        # If we're rendering the results as an HTML fragment, the caller can pass a filter_fragment=1
+        # If we're rendering the results as an HTML fragment, the caller can pass a _w_filter_fragment=1
         # URL parameter to indicate that the filters should be rendered as a <template> block so that
         # we can replace the existing filters.
         context["render_filters_fragment"] = (
-            self.request.GET.get("filter_fragment")
+            self.request.GET.get("_w_filter_fragment")
             and self.filters
             and self.results_only
         )

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -263,9 +263,8 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                         ActiveFilter(
                             filter_def.label,
                             field.label_from_instance(item),
-                            self.get_url_without_filter_param_value(
-                                field_name, item.pk
-                            ),
+                            self.get_url_without_filter_param_value(field_name, item.pk)
+                            + "&filter_fragment=1",
                         )
                     )
             elif isinstance(filter_def, ModelChoiceFilter):
@@ -274,7 +273,8 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                     ActiveFilter(
                         filter_def.label,
                         field.label_from_instance(value),
-                        self.get_url_without_filter_param(field_name),
+                        self.get_url_without_filter_param(field_name)
+                        + "&filter_fragment=1",
                     )
                 )
             elif isinstance(filter_def, DateFromToRangeFilter):
@@ -286,7 +286,8 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                         "%s - %s" % (start_date_display, end_date_display),
                         self.get_url_without_filter_param(
                             [f"{field_name}_before", f"{field_name}_after"]
-                        ),
+                        )
+                        + "&filter_fragment=1",
                     )
                 )
             elif isinstance(filter_def, ChoiceFilter):
@@ -295,7 +296,8 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                     ActiveFilter(
                         filter_def.label,
                         choices.get(str(value), str(value)),
-                        self.get_url_without_filter_param(field_name),
+                        self.get_url_without_filter_param(field_name)
+                        + "&filter_fragment=1",
                     )
                 )
             else:
@@ -303,7 +305,8 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                     ActiveFilter(
                         filter_def.label,
                         str(value),
-                        self.get_url_without_filter_param(field_name),
+                        self.get_url_without_filter_param(field_name)
+                        + "&filter_fragment=1",
                     )
                 )
 
@@ -422,5 +425,14 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
             context["filters"] = self.filters
             context["is_filtering"] = self.is_filtering
             context["media"] += self.filters.form.media
+
+        # If we're rendering the results as an HTML fragment, the caller can pass a filter_fragment=1
+        # URL parameter to indicate that the filters should be rendered as a <template> block so that
+        # we can replace the existing filters.
+        context["render_filters_fragment"] = (
+            self.request.GET.get("filter_fragment")
+            and self.filters
+            and self.results_only
+        )
 
         return context

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -173,7 +173,7 @@ class BaseOperationView(BaseObjectMixin, View):
 
 # Represents a django-filters filter that is currently in force on a listing queryset
 ActiveFilter = namedtuple(
-    "ActiveFilter", ["field_name", "field_label", "value", "removed_filter_url"]
+    "ActiveFilter", ["auto_id", "field_label", "value", "removed_filter_url"]
 )
 
 
@@ -253,6 +253,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
 
         for field_name in self.filters.form.changed_data:
             filter_def = self.filters.filters[field_name]
+            bound_field = self.filters.form[field_name]
             try:
                 value = self.filters.form.cleaned_data[field_name]
             except KeyError:
@@ -263,7 +264,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                 for item in value:
                     filters.append(
                         ActiveFilter(
-                            field_name,
+                            bound_field.auto_id,
                             filter_def.label,
                             field.label_from_instance(item),
                             self.get_url_without_filter_param_value(
@@ -275,7 +276,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                 field = filter_def.field
                 filters.append(
                     ActiveFilter(
-                        field_name,
+                        bound_field.auto_id,
                         filter_def.label,
                         field.label_from_instance(value),
                         self.get_url_without_filter_param(field_name),
@@ -286,7 +287,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                 end_date_display = date_format(value.stop) if value.stop else ""
                 filters.append(
                     ActiveFilter(
-                        field_name,
+                        bound_field.auto_id,
                         filter_def.label,
                         "%s - %s" % (start_date_display, end_date_display),
                         self.get_url_without_filter_param(
@@ -298,7 +299,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                 choices = {str(id): label for id, label in filter_def.field.choices}
                 filters.append(
                     ActiveFilter(
-                        field_name,
+                        bound_field.auto_id,
                         filter_def.label,
                         choices.get(str(value), str(value)),
                         self.get_url_without_filter_param(field_name),
@@ -307,7 +308,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
             else:
                 filters.append(
                     ActiveFilter(
-                        field_name,
+                        bound_field.auto_id,
                         filter_def.label,
                         str(value),
                         self.get_url_without_filter_param(field_name),

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -173,7 +173,7 @@ class BaseOperationView(BaseObjectMixin, View):
 
 # Represents a django-filters filter that is currently in force on a listing queryset
 ActiveFilter = namedtuple(
-    "ActiveFilter", ["field_label", "value", "removed_filter_url"]
+    "ActiveFilter", ["field_name", "field_label", "value", "removed_filter_url"]
 )
 
 
@@ -263,6 +263,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                 for item in value:
                     filters.append(
                         ActiveFilter(
+                            field_name,
                             filter_def.label,
                             field.label_from_instance(item),
                             self.get_url_without_filter_param_value(
@@ -274,6 +275,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                 field = filter_def.field
                 filters.append(
                     ActiveFilter(
+                        field_name,
                         filter_def.label,
                         field.label_from_instance(value),
                         self.get_url_without_filter_param(field_name),
@@ -284,6 +286,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                 end_date_display = date_format(value.stop) if value.stop else ""
                 filters.append(
                     ActiveFilter(
+                        field_name,
                         filter_def.label,
                         "%s - %s" % (start_date_display, end_date_display),
                         self.get_url_without_filter_param(
@@ -295,6 +298,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                 choices = {str(id): label for id, label in filter_def.field.choices}
                 filters.append(
                     ActiveFilter(
+                        field_name,
                         filter_def.label,
                         choices.get(str(value), str(value)),
                         self.get_url_without_filter_param(field_name),
@@ -303,6 +307,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
             else:
                 filters.append(
                     ActiveFilter(
+                        field_name,
                         filter_def.label,
                         str(value),
                         self.get_url_without_filter_param(field_name),

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -119,7 +119,9 @@ class PageFilterSet(WagtailFilterSet):
         fields = []  # only needed for filters being generated automatically
 
 
-class BaseIndexView(generic.IndexView):
+class IndexView(generic.IndexView):
+    template_name = "wagtailadmin/pages/index.html"
+    results_template_name = "wagtailadmin/pages/index_results.html"
     permission_policy = page_permission_policy
     any_permission_required = {
         "add",
@@ -403,6 +405,11 @@ class BaseIndexView(generic.IndexView):
             }
         )
 
+        if not self.results_only:
+            side_panels = self.get_side_panels()
+            context["side_panels"] = side_panels
+            context["media"] += side_panels.media
+
         return context
 
     def get_translations(self):
@@ -415,10 +422,6 @@ class BaseIndexView(generic.IndexView):
             .only("id", "locale")
             .select_related("locale")
         ]
-
-
-class IndexView(BaseIndexView):
-    template_name = "wagtailadmin/pages/index.html"
 
     def get_side_panels(self):
         # Don't show side panels on the root page
@@ -437,14 +440,3 @@ class IndexView(BaseIndexView):
             ),
         ]
         return MediaContainer(side_panels)
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        side_panels = self.get_side_panels()
-        context["side_panels"] = side_panels
-        context["media"] += side_panels.media
-        return context
-
-
-class IndexResultsView(BaseIndexView):
-    template_name = "wagtailadmin/pages/index_results.html"


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Rebase of #11515 now that #11477 is in. Replace the SwapController hack in favour of reusing `TeleportController` with a new `reset` value to allow clearing the target element before appending the controlled element.

There's still a few issues:
- Date pickers don't work after refresh, as mentioned in #11477
- If you close the drilldown without going back to the top-level, then clear a filter, opening the drilldown and selecting the last selected filter doesn't work. You need to select a different filter and go back for it to work.
  - Likely because the `DrilldownController` isn't aware of its elements being replaced, and still remembers that the filter was still open.
- Not really an issue but the `filters_fragment` query param is now also reflected to the address bar

Out-of-scope for this PR, but we also still need to update e.g. export links in the header buttons with the filter params. I made a POC in https://github.com/laymonage/wagtail/commit/b0a2a0729dc0136871f3f752426d85bea3773f75





_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
