### PR TITLE
Add table caption property in table class component

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -49,6 +49,7 @@ Changelog
  * Keep database state of pages and snippets updated while in draft state (Stefan Hammer)
  * Add the accessibility checker within the page and snippets editor (Thibaud Colas)
  * Add `DrilldownController` and `w-drilldown` component to support drilldown menus (Thibaud Colas)
+ * Add support for `caption` on admin UI Table component (Aman Pandey)
  * Fix: Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Fix: Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Fix: Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions wide viewports (CheesyPhoenix, Christer Jensen)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -141,7 +141,7 @@ Changelog
  * Maintenance: Remove non-functional and inaccessible auto-focus on first field in page create forms (LB (Ben) Johnston)
  * Maintenance: Migrate the unsaved form checks & confirmation trigger to Stimulus `UnsavedController` (Sai Srikar Dumpeti, LB (Ben) Johnston)
  * Maintenance: Reduce gap between snippets and generic views/templates (Sage Abdullah)
- * Maintenance: Migrate page listing menu re-ordering (drag & drop) from jQuery inline scripts to `OrderableController` (Aman Pandey, LB (Ben) Johnston)
+ * Maintenance: Migrate page listing menu re-ordering (drag & drop) from jQuery inline scripts to `OrderableController` with a more accessible solution (Aman Pandey, LB (Ben) Johnston)
  * Maintenance: Clean up scss variable usage, remove unused variables and mixins, adopt more core token variables (Jai Vignesh J, Nandini Arora, LB (Ben) Johnston)
  * Maintenance: Migrate Image URL generator views to class based views (Rohit Sharma)
  * Maintenance: Use Django's `FileResponse` when serving files such as Images or Documents (Jake Howard)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -190,7 +190,7 @@ This feature was implemented by Nick Lee, Thibaud Colas, and Sage Abdullah.
  * Remove non-functional and inaccessible auto-focus on first field in page create forms (LB (Ben) Johnston)
  * Migrate the unsaved form checks & confirmation trigger to Stimulus `UnsavedController` (Sai Srikar Dumpeti, LB (Ben) Johnston)
  * Reduce gap between snippets and generic views/templates (Sage Abdullah)
- * Migrate page listing menu re-ordering (drag & drop) from jQuery inline scripts to `OrderableController` (Aman Pandey, LB (Ben) Johnston)
+ * Migrate page listing menu re-ordering (drag & drop) from jQuery inline scripts to `OrderableController` with a more accessible solution (Aman Pandey, LB (Ben) Johnston)
  * Clean up scss variable usage, remove unused variables and mixins, adopt more core token variables (Jai Vignesh J, Nandini Arora, LB (Ben) Johnston)
  * Migrate Image URL generator views to class based views (Rohit Sharma)
  * Use Django's `FileResponse` when serving files such as Images or Documents (Jake Howard)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -81,6 +81,7 @@ This feature was implemented by Nick Lee, Thibaud Colas, and Sage Abdullah.
  * Polish dark theme styles and update color tokens (Thibaud Colas, Rohit Sharma)
  * Keep database state of pages and snippets updated while in draft state (Stefan Hammer)
  * Add `DrilldownController` and `w-drilldown` component to support drilldown menus (Thibaud Colas)
+ * Add support for `caption` on admin UI Table component (Aman Pandey)
 
 
 ### Bug fixes

--- a/wagtail/admin/templates/wagtailadmin/tables/table.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/table.html
@@ -1,6 +1,11 @@
 {% load wagtailadmin_tags %}
 
 <table{% include "wagtailadmin/shared/attrs.html" with attrs=table.attrs %}>
+    {% with caption=table.get_caption %}
+        {% if caption %}
+            <caption class="w-sr-only">{{ caption }}</caption>
+        {% endif %}
+    {% endwith %}
     {% if table.has_column_widths %}
         {% for column in table.columns.values %}
             <col {% if column.width %}width="{{ column.width }}"{% endif %} />

--- a/wagtail/admin/tests/ui/test_tables.py
+++ b/wagtail/admin/tests/ui/test_tables.py
@@ -47,6 +47,40 @@ class TestTable(TestCase):
         """,
         )
 
+    def test_table_render_with_caption(self):
+        data = [
+            {"first_name": "Paul", "last_name": "Simon"},
+            {"first_name": "Art", "last_name": "Garfunkel"},
+        ]
+
+        caption = "Test table"
+
+        table = Table(
+            columns=[
+                Column("first_name"),
+                Column("last_name"),
+            ],
+            data=data,
+            caption=caption,
+        )
+
+        html = self.render_component(table)
+        self.assertHTMLEqual(
+            html,
+            """
+            <table class="listing">
+                <caption class="w-sr-only">Test table</caption>
+                <thead>
+                    <tr><th>First name</th><th>Last name</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>Paul</td><td>Simon</td></tr>
+                    <tr><td>Art</td><td>Garfunkel</td></tr>
+                </tbody>
+            </table>
+        """,
+        )
+
     def test_table_render_with_width(self):
         data = [
             {"first_name": "Paul", "last_name": "Simon"},

--- a/wagtail/admin/ui/tables/__init__.py
+++ b/wagtail/admin/ui/tables/__init__.py
@@ -413,8 +413,10 @@ class Table(Component):
         ordering=None,
         classname=None,
         attrs=None,
+        caption=None,
     ):
         self.columns = OrderedDict([(column.name, column) for column in columns])
+        self.caption = caption
         self.data = data
         if template_name:
             self.template_name = template_name
@@ -423,6 +425,9 @@ class Table(Component):
         if classname is not None:
             self.classname = classname
         self.base_attrs = attrs or {}
+
+    def get_caption(self):
+        return self.caption
 
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -347,10 +347,10 @@ class BaseIndexView(generic.IndexView):
         kwargs["actions_next_url"] = self.index_url
 
         if self.show_ordering_column:
+            kwargs["caption"] = _(
+                "Focus on the drag button and press up or down arrows to move the item, then press enter to submit the change."
+            )
             kwargs["attrs"] = {
-                "aria-description": _(
-                    "Focus on the drag button and press up or down arrows to move the item, then press enter to submit the change."
-                ),
                 "data-controller": "w-orderable",
                 "data-w-orderable-active-class": "w-orderable--active",
                 "data-w-orderable-chosen-class": "w-orderable__item--active",


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/11493

1.  To add support for `caption` on `Table` component.
2.  To addapt the caption support in sortable mode page listing table.

CC: @lb- 

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

