### PR TITLE
Prevent test failures due to inconsistent queryset ordering on test_bulk_delete

### DIFF
--- a/wagtail/snippets/tests/test_bulk_actions/test_bulk_delete.py
+++ b/wagtail/snippets/tests/test_bulk_actions/test_bulk_delete.py
@@ -123,7 +123,7 @@ class TestSnippetDeleteView(WagtailTestUtils, TestCase):
         self.assertNotEqual(response.content, b"Overridden!")
 
         # The instances were not deleted
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.snippet_model.objects.filter(
                 pk__in=[snippet.pk for snippet in self.test_snippets]
             ),
@@ -135,7 +135,7 @@ class TestSnippetDeleteView(WagtailTestUtils, TestCase):
         def hook_func(request, action_type, instances, action_class_instance):
             self.assertIsInstance(request, HttpRequest)
             self.assertEqual(action_type, "delete")
-            self.assertQuerysetEqual(instances, self.test_snippets)
+            self.assertEqual(set(instances), set(self.test_snippets))
             self.assertIsInstance(action_class_instance, DeleteBulkAction)
             return HttpResponse("Overridden!")
 
@@ -146,7 +146,7 @@ class TestSnippetDeleteView(WagtailTestUtils, TestCase):
         self.assertEqual(response.content, b"Overridden!")
 
         # Request intercepted before the snippets were deleted
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.snippet_model.objects.filter(
                 pk__in=[snippet.pk for snippet in self.test_snippets]
             ),
@@ -158,7 +158,7 @@ class TestSnippetDeleteView(WagtailTestUtils, TestCase):
         def hook_func(request, action_type, instances, action_class_instance):
             self.assertIsInstance(request, HttpRequest)
             self.assertEqual(action_type, "delete")
-            self.assertQuerysetEqual(instances, self.test_snippets)
+            self.assertEqual(set(instances), set(self.test_snippets))
             self.assertIsInstance(action_class_instance, DeleteBulkAction)
             return HttpResponse("Overridden!")
 
@@ -182,7 +182,7 @@ class TestSnippetDeleteView(WagtailTestUtils, TestCase):
     def test_before_delete_snippet_hook_get(self):
         def hook_func(request, instances):
             self.assertIsInstance(request, HttpRequest)
-            self.assertQuerysetEqual(instances, self.test_snippets)
+            self.assertEqual(set(instances), set(self.test_snippets))
             return HttpResponse("Overridden!")
 
         with self.register_hook("before_delete_snippet", hook_func):
@@ -192,7 +192,7 @@ class TestSnippetDeleteView(WagtailTestUtils, TestCase):
         self.assertEqual(response.content, b"Overridden!")
 
         # Request intercepted before the snippets were deleted
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.snippet_model.objects.filter(
                 pk__in=[snippet.pk for snippet in self.test_snippets]
             ),
@@ -203,7 +203,7 @@ class TestSnippetDeleteView(WagtailTestUtils, TestCase):
     def test_before_delete_snippet_hook_post(self):
         def hook_func(request, instances):
             self.assertIsInstance(request, HttpRequest)
-            self.assertQuerysetEqual(instances, self.test_snippets)
+            self.assertEqual(set(instances), set(self.test_snippets))
             return HttpResponse("Overridden!")
 
         with self.register_hook("before_delete_snippet", hook_func):
@@ -213,7 +213,7 @@ class TestSnippetDeleteView(WagtailTestUtils, TestCase):
         self.assertEqual(response.content, b"Overridden!")
 
         # Request intercepted before the snippets were deleted
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.snippet_model.objects.filter(
                 pk__in=[snippet.pk for snippet in self.test_snippets]
             ),
@@ -224,7 +224,7 @@ class TestSnippetDeleteView(WagtailTestUtils, TestCase):
     def test_after_delete_snippet_hook(self):
         def hook_func(request, instances):
             self.assertIsInstance(request, HttpRequest)
-            self.assertQuerysetEqual(instances, self.test_snippets)
+            self.assertEqual(set(instances), set(self.test_snippets))
             return HttpResponse("Overridden!")
 
         with self.register_hook("after_delete_snippet", hook_func):


### PR DESCRIPTION
Following c51baf6d429a7b4dddf35278397e09c7a281377b we have started seeing intermittent test failures on `wagtail.snippets.tests.test_bulk_actions.test_bulk_delete.TestSnippetDeleteView.test_after_bulk_action_hook` under Postgres: https://github.com/wagtail/wagtail/actions/runs/7624525647/job/20766838203

These failures seem to be because we were using `assertQuerysetEqual` to check the result of a database query that does not guarantee ordering. This result is in fact passed as a list rather than a queryset, so assertQuerysetEqual is not valid here. Instead, we compare the two lists as sets.

Additionally, this method is now named `assertQuerySetEqual` as of Django 4.2 (see https://docs.djangoproject.com/en/5.0/topics/testing/tools/#django.test.TransactionTestCase.assertQuerySetEqual) - update the valid uses of this elsewhere in the file.

It's unclear why this surfaced due to #10104 (if indeed it did - it could have been due to an earlier commit, given that it's intermittent). #10104 is introducing an update operation on the snippet model's database table that wasn't there previously, so it's plausible that this mixes up Postgres's internal state enough that it's no longer just returning them in creation order - however, it doesn't look like we're making any draft edits to the snippet in this particular test.