### PR TITLE
fix: enum eslint error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,6 +55,14 @@ module.exports = {
     'import/resolver': { node: { extensions: ['.js', '.ts', '.tsx'] } },
   },
   overrides: [
+    // Rules that needs to be adjusted for TypeScript only files
+    {
+      files: ['*.ts'],
+      rules: {
+        '@typescript-eslint/no-shadow': 'error',
+        'no-shadow': 'off',
+      },
+    },
     // Rules that we are ignoring currently due to legacy code in React components only
     {
       files: ['client/src/components/**'],

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ Changelog
  * Maintenance: Move RichText HTML whitelist parser to use the faster, built in `html.parser` (Jake Howard)
  * Maintenance: Remove duplicate 'path' in default_exclude_fields_in_copy (Ramchandra Shahi Thakuri)
  * Maintenance: Update unit tests to always use the faster, built in `html.parser` & remove `html5lib` dependency (Jake Howard)
+ * Maintenance: Adjust Eslint rules for TypeScript files (Karthik Ayangar)
 
 
 6.0 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -791,6 +791,7 @@
 * Osaf AliSayed
 * Ramchandra Shahi Thakuri
 * Nix Asteri
+* Karthik Ayangar
 
 ## Translators
 

--- a/client/src/controllers/OrderableController.ts
+++ b/client/src/controllers/OrderableController.ts
@@ -1,7 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
 import Sortable from 'sortablejs';
 
-// eslint-disable-next-line no-shadow
 enum Direction {
   Up = 'UP',
   Down = 'DOWN',

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -34,6 +34,7 @@ depth: 1
  * Move RichText HTML whitelist parser to use the faster, built in `html.parser` (Jake Howard)
  * Remove duplicate 'path' in default_exclude_fields_in_copy (Ramchandra Shahi Thakuri)
  * Update unit tests to always use the faster, built in `html.parser` & remove `html5lib` dependency (Jake Howard)
+ * Adjust Eslint rules for TypeScript files (Karthik Ayangar)
 
 
 ## Upgrade considerations


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #...







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

Overrides the default `no-shadow` rule with `@typescript-eslint/no-shadow` for all the .ts files. So that enum can be used anywhere across all the ts files without linting errors.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
