### PR TITLE
Don't hide breadcrumb root page for users with limited tree visibility

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/page_breadcrumbs.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/page_breadcrumbs.html
@@ -32,18 +32,6 @@
                 </a>
                 {% icon name="arrow-right" classname=icon_classes %}
             </li>
-        {% elif forloop.first %}
-            {# For limited-permission users whose breadcrumb starts further down from the root #}
-            <li
-                class="{{ breadcrumb_item_classes }} {% if not is_expanded %}w-max-w-0{% endif %}"
-                {% if not is_expanded %}hidden{% endif %}
-                data-w-breadcrumbs-target="content"
-            >
-                <a class="{{ breadcrumb_link_classes }}" href="{{ breadcrumb_url }}{{ querystring_value }}">
-                    {% trans "Root" %}
-                </a>
-                {% icon name="arrow-right" classname=icon_classes %}
-            </li>
         {% elif forloop.last %}
             <li
                 class="{{ breadcrumb_item_classes }} w-font-bold"

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -1140,7 +1140,7 @@ class TestExplorablePageVisibility(WagtailTestUtils, TestCase):
         expected = """
             <li class="w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-max-w-0" data-w-breadcrumbs-target="content" hidden>
                 <a class="w-flex w-items-center w-text-text-label w-pr-0.5 w-text-14 w-no-underline w-outline-offset-inside w-border-b w-border-b-2 w-border-transparent w-box-content hover:w-border-current hover:w-text-text-label" href="/admin/pages/4/">
-                    Root
+                    Welcome to example.com!
                 </a>
                 <svg class="icon icon-arrow-right w-w-4 w-h-4 w-ml-3" aria-hidden="true">
                     <use href="#icon-arrow-right"></use>
@@ -1159,8 +1159,22 @@ class TestExplorablePageVisibility(WagtailTestUtils, TestCase):
             </li>
         """
         self.assertContains(response, expected, html=True)
-        # The page title shouldn't appear because it's the "home" breadcrumb.
-        self.assertNotContains(response, "Welcome to example.com!")
+
+    def test_nonadmin_sees_non_hidden_root(self):
+        self.login(username="josh", password="password")
+        response = self.client.get(reverse("wagtailadmin_explore", args=[4]))
+        self.assertEqual(response.status_code, 200)
+        # When Josh is viewing his visible root page, he should the page title as a non-hidden, single-item breadcrumb.
+        expected = """
+            <li
+                class="w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-font-bold">
+                <a class="w-flex w-items-center w-text-text-label w-pr-0.5 w-text-14 w-no-underline w-outline-offset-inside w-border-b w-border-b-2 w-border-transparent w-box-content hover:w-border-current hover:w-text-text-label"
+                   href="/admin/pages/4/">
+                    Welcome to example.com!
+                </a>
+            </li>
+        """
+        self.assertContains(response, expected, html=True)
 
     def test_admin_home_page_changes_with_permissions(self):
         self.login(username="bob", password="password")


### PR DESCRIPTION
Fixes #11451

Remove the special case for when the first item in the breadcrumb is something other than the site root. This special-casing had two effects, neither of which was actually desirable:

* It replaced the displayed page title with 'Root' (which is undesirable because the page in question is often one that the user can edit, and therefore they ought to be able to see what it is
* It took precedence over the styling for the _last_ item in the breadcrumb, which should be always visible rather than on-hover

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

To test on Bakerydemo: create a Breaditors group with: Access to Wagtail admin, Add and Edit permission over the Breads page, and no other permissions. Create a user account in the Breaditors group and log in as that user. Go to Pages -> Breads.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
