### PR TITLE
Universal listings: Implement clickable active filters to open drilldown component with specific filter

### DIFF
--- a/client/scss/components/_pill.scss
+++ b/client/scss/components/_pill.scss
@@ -7,6 +7,10 @@
   }
 
   &__remove {
-    @apply w-pr-3 w-py-1 w-rounded-r-xl w-border w-border-info-100 w-bg-info-100 hover:w-bg-info-125 w-text-white hover:w-text-white w-p-0 w-pl-2 w-flex w-items-center w-justify-center w-h-full;
+    @apply w-pr-3 w-py-1 w-rounded-r-xl w-border w-border-info-100 w-bg-info-100 w-text-white w-p-0 w-pl-2 w-flex w-items-center w-justify-center w-h-full;
+  }
+
+  button {
+    @apply hover:w-bg-info-125;
   }
 }

--- a/client/src/controllers/DropdownController.ts
+++ b/client/src/controllers/DropdownController.ts
@@ -219,11 +219,19 @@ export class DropdownController extends Controller<HTMLElement> {
     // function, so we need to get these ahead in time.
     const reference = this.reference;
     const toggleTarget = this.toggleTarget;
+    const dispatch = this.dispatch.bind(this);
 
     return {
       name: 'hideTooltipOnClickAway',
       fn(instance: Instance) {
         const onClick = (e: MouseEvent) => {
+          const event = dispatch('clickaway', {
+            cancelable: true,
+            detail: { target: e.target },
+          });
+          if (event.defaultPrevented) {
+            return;
+          }
           if (
             instance.state.isShown &&
             // Hide if the click is outside of the reference element,

--- a/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
@@ -1,11 +1,11 @@
 {% load i18n wagtailadmin_tags %}
 <ul class="w-active-filters">
     {% for filter in active_filters %}
-        <li class="w-pill" data-w-active-filter-name="{{ filter.auto_id }}">
-            <div class="w-pill__content">
+        <li class="w-pill">
+            <button class="w-pill__content" data-controller="w-action" data-w-active-filter-name="{{ filter.auto_id }}" aria-controls="drilldown-{{ filter.auto_id }}">
                 <span class="w-text-14">{{ filter.field_label }}:</span>
                 <b class="w-ml-1">{{ filter.value }}</b>
-            </div>
+            </button>
             <button
                 data-controller="w-swap"
                 data-action="click->w-swap#replaceLazy"

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -79,7 +79,15 @@
                         {% endif %}
 
                         {% if filters %}
-                            <div id="filters-drilldown" class="w-drilldown" data-controller="w-drilldown" data-action="w-swap:success@document->w-drilldown#updateParams w-dropdown:hide->w-drilldown#delayedClose" data-w-drilldown-count-attr-value="data-w-active-filter-name">
+                            <div
+                                id="filters-drilldown"
+                                class="w-drilldown"
+                                data-controller="w-drilldown"
+                                data-action="w-swap:success@document->w-drilldown#updateParams w-dropdown:hide->w-drilldown#delayedClose w-dropdown:clickaway->w-drilldown#preventOutletClickaway"
+                                data-w-drilldown-count-attr-value="data-w-active-filter-name"
+                                data-w-drilldown-w-action-outlet="[data-w-active-filter-name][data-controller='w-action']"
+                                data-w-drilldown-w-dropdown-outlet="#filters-drilldown [data-controller='w-dropdown']"
+                            >
                                 {% include "wagtailadmin/shared/headers/_filters.html" with filters=filters only %}
                             </div>
                         {% endif %}


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Incorporates #11516 







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
