### PR TITLE
Fix filters from being removed when searching

### DIFF
--- a/client/src/controllers/DropdownController.ts
+++ b/client/src/controllers/DropdownController.ts
@@ -144,12 +144,21 @@ export class DropdownController extends Controller<HTMLElement> {
       });
     }
 
+    const onShow = () => {
+      if (hoverTooltipInstance) {
+        hoverTooltipInstance.disable();
+      }
+    };
+
     const onShown = () => {
       this.dispatch('shown');
     };
 
     const onHide = () => {
       this.dispatch('hide');
+      if (hoverTooltipInstance) {
+        hoverTooltipInstance.enable();
+      }
     };
 
     return {
@@ -162,20 +171,9 @@ export class DropdownController extends Controller<HTMLElement> {
       ...(this.hasOffsetValue && { offset: this.offsetValue }),
       getReferenceClientRect: () => this.reference.getBoundingClientRect(),
       theme: this.themeValue,
-      onShow() {
-        if (hoverTooltipInstance) {
-          hoverTooltipInstance.disable();
-        }
-      },
-      onShown() {
-        onShown();
-      },
-      onHide() {
-        if (hoverTooltipInstance) {
-          hoverTooltipInstance.enable();
-        }
-        onHide();
-      },
+      onShow,
+      onShown,
+      onHide,
     };
   }
 

--- a/client/src/controllers/DropdownController.ts
+++ b/client/src/controllers/DropdownController.ts
@@ -217,17 +217,11 @@ export class DropdownController extends Controller<HTMLElement> {
    * elements outside of the dropdown's DOM).
    */
   get hideTooltipOnClickAway() {
-    // We can't use `this` to access the controller instance inside the plugin
-    // function, so we need to get these ahead in time.
-    const reference = this.reference;
-    const toggleTarget = this.toggleTarget;
-    const dispatch = this.dispatch.bind(this);
-
     return {
       name: 'hideTooltipOnClickAway',
-      fn(instance: Instance) {
+      fn: (instance: Instance) => {
         const onClick = (e: MouseEvent) => {
-          const event = dispatch('clickaway', {
+          const event = this.dispatch('clickaway', {
             cancelable: true,
             detail: { target: e.target },
           });
@@ -238,8 +232,8 @@ export class DropdownController extends Controller<HTMLElement> {
             instance.state.isShown &&
             // Hide if the click is outside of the reference element,
             // or if the click is on the toggle button itself.
-            (!reference.contains(e.target as Node) ||
-              toggleTarget.contains(e.target as Node))
+            (!this.reference.contains(e.target as Node) ||
+              this.toggleTarget.contains(e.target as Node))
           ) {
             instance.hide();
           }

--- a/wagtail/admin/templates/wagtailadmin/shared/dropdown/dropdown.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/dropdown/dropdown.html
@@ -14,12 +14,21 @@
     - `toggle_classname` (string?) - additional toggle classes
     - `toggle_tooltip_offset` (string?) - Tooltip offset prop
     - `hide_on_click` (boolean?) - Whether or not the tooltip should hide when clicking inside
+    - `keep_mounted` (boolean?) - Whether or not the tooltip should keep its DOM node mounted when hidden
     - `children` - Dropdown contents (`a` and `button` elements only)
 {% endcomment %}
 
 {% fragment as class %}{% classnames 'w-dropdown' classname %}{% if theme %} w-dropdown--{{ theme }}{% endif %}{% endfragment %}
 
-<div data-controller="w-dropdown" {% if theme %}data-w-dropdown-theme-value="{{ theme }}"{% endif %} class="{{ class }}" {{ attrs }} {% if hide_on_click %}data-w-dropdown-hide-on-click-value="true"{% endif %}{% if toggle_tooltip_offset %} data-w-dropdown-offset-value="{{ toggle_tooltip_offset }}"{% endif %}>
+<div
+    data-controller="w-dropdown"
+    class="{{ class }}"
+    {{ attrs }}
+    {% if theme %}data-w-dropdown-theme-value="{{ theme }}"{% endif %}
+    {% if toggle_tooltip_offset %}data-w-dropdown-offset-value="{{ toggle_tooltip_offset }}"{% endif %}
+    {% if hide_on_click %}data-w-dropdown-hide-on-click-value="true"{% endif %}
+    {% if keep_mounted %}data-w-dropdown-keep-mounted-value="true"{% endif %}
+>
     <button type="button" class="{% classnames 'w-dropdown__toggle' toggle_label|yesno:',w-dropdown__toggle--icon' toggle_classname %}" data-w-dropdown-target="toggle"{% if toggle_aria_label %} aria-label="{{ toggle_aria_label }}"{% endif %}{% if toggle_describedby %} aria-describedby="{{ toggle_describedby }}"{% endif %}{% if toggle_tippy_offset %} data-tippy-offset="{{ toggle_tippy_offset }}"{% endif %}>
         {{ toggle_label }}
         {% if toggle_icon %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/_filters.html
@@ -4,7 +4,7 @@
     <span class="w-drilldown__count" data-w-drilldown-target="count" hidden></span>
 {% endfragment %}
 
-{% dropdown theme="drilldown" toggle_icon="sliders" toggle_classname="w-filter-button" toggle_aria_label=_("Show filters") toggle_suffix=toggle_suffix %}
+{% dropdown theme="drilldown" toggle_icon="sliders" toggle_classname="w-filter-button" toggle_aria_label=_("Show filters") toggle_suffix=toggle_suffix keep_mounted=True %}
     <div class="w-drilldown__contents">
         <div class="w-drilldown__menu" data-w-drilldown-target="menu">
             <h2 class="w-help-text w-pl-5 w-py-2.5 w-my-0">{% trans "Filter by" %}</h2>


### PR DESCRIPTION
Incorporates/closes #11523.

Tippy unmounts its popper element from the DOM on hide, which means that the filter fields get detached from the form. As a result, when performing a search (which means the filters popup is closed), any filters that have been applied will be lost. The issue does not occur the other way around (filtering after search) because the filter fields will still be in the DOM (as the popup is open while you're applying the filters).

Unfortunately, Tippy does not offer a built-in option to keep the popper mounted in the DOM when it's hidden. https://github.com/atomiks/tippyjs/issues/868#issuecomment-934141260

As a workaround, use Tippy's hooks to re-append the popper to the DOM.
- `onCreate`: ensure the popper element is mounted even when the tippy was just created (normally it's only mounted when shown). This is useful to keep the filters when searching after a full-page refresh (e.g. after navigating to the next page in pagination).
- `onHidden`: ensure the popper is still mounted, to solve the main issue
- `onShow`: remove the hidden attribute and let tippy move the popper element as necessary (though usually this isn't necessary, because we remount it in the same position (the controller's element).

The `hidden` attribute shouldn't cause any issues here as Tippy doesn't use it. Without it, the solution still works because Tippy uses CSS to make the element invisible. However, the complete CSS doesn't get applied until the tippy is shown at least once. This means on initial load with the `onCreate` hook, the tippy will take up the space while being invisible. Using the attribute fixes it (and `display: none` probably would too).

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 121, Firefox 121, Safari 17.2.1 on macOS 14.2.1
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

Two scenarios:
- Apply filters, then do a search.
- Apply filters, go to the next page (if you don't have enough pages, doing a full reload has the same effect), then do a search (without opening the filter popup)

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
