### PR TITLE
Don't hide breadcrumb root page for users with limited tree visibility (without breadcrumbs toggle)

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
@@ -3,7 +3,7 @@
 
 {% block breadcrumbs %}
     {# breadcrumbs #}
-    {% page_breadcrumbs parent_page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' is_expanded=parent_page.is_root %}
+    {% page_breadcrumbs parent_page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' %}
 {% endblock %}
 
 {% block actions %}

--- a/wagtail/admin/templates/wagtailadmin/shared/page_breadcrumbs.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/page_breadcrumbs.html
@@ -32,18 +32,6 @@
                 </a>
                 {% icon name="arrow-right" classname=icon_classes %}
             </li>
-        {% elif forloop.first %}
-            {# For limited-permission users whose breadcrumb starts further down from the root #}
-            <li
-                class="{{ breadcrumb_item_classes }} {% if not is_expanded %}w-max-w-0{% endif %}"
-                {% if not is_expanded %}hidden{% endif %}
-                data-w-breadcrumbs-target="content"
-            >
-                <a class="{{ breadcrumb_link_classes }}" href="{{ breadcrumb_url }}{{ querystring_value }}">
-                    {% trans "Root" %}
-                </a>
-                {% icon name="arrow-right" classname=icon_classes %}
-            </li>
         {% elif forloop.last %}
             <li
                 class="{{ breadcrumb_item_classes }} w-font-bold"

--- a/wagtail/admin/templates/wagtailadmin/shared/page_breadcrumbs.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/page_breadcrumbs.html
@@ -18,21 +18,7 @@
         {% else %}
             {% url url_name page.id as breadcrumb_url %}
         {% endif %}
-        {% if page.is_root %}
-            <li
-                class="{{ breadcrumb_item_classes }} {% if forloop.last %}w-font-bold{% endif %} {% if not is_expanded %}w-max-w-0{% endif %}"
-                {% if not is_expanded %}hidden{% endif %}
-                data-w-breadcrumbs-target="content"
-            >
-                <a
-                    class="{{ breadcrumb_link_classes }}"
-                    href="{{ breadcrumb_url }}{{ querystring_value }}"
-                >
-                    {% trans "Root" %}
-                </a>
-                {% icon name="arrow-right" classname=icon_classes %}
-            </li>
-        {% elif forloop.last %}
+        {% if forloop.last %}
             <li
                 class="{{ breadcrumb_item_classes }} w-font-bold"
                 {% if trailing_breadcrumb_title and not is_expanded %}hidden{% endif %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -92,10 +92,17 @@ def page_breadcrumbs(
     if not cca:
         return {"items": Page.objects.none()}
 
-    return {
-        "items": page.get_ancestors(inclusive=include_self)
+    items = (
+        page.get_ancestors(inclusive=include_self)
         .descendant_of(cca, inclusive=True)
-        .specific(),
+        .specific()
+    )
+
+    if len(items) == 1:
+        is_expanded = True
+
+    return {
+        "items": items,
         "current_page": page,
         "is_expanded": is_expanded,
         "page_perms": page_perms,

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -1140,7 +1140,7 @@ class TestExplorablePageVisibility(WagtailTestUtils, TestCase):
         expected = """
             <li class="w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-max-w-0" data-w-breadcrumbs-target="content" hidden>
                 <a class="w-flex w-items-center w-text-text-label w-pr-0.5 w-text-14 w-no-underline w-outline-offset-inside w-border-b w-border-b-2 w-border-transparent w-box-content hover:w-border-current hover:w-text-text-label" href="/admin/pages/4/">
-                    Root
+                    Welcome to example.com!
                 </a>
                 <svg class="icon icon-arrow-right w-w-4 w-h-4 w-ml-3" aria-hidden="true">
                     <use href="#icon-arrow-right"></use>
@@ -1159,8 +1159,22 @@ class TestExplorablePageVisibility(WagtailTestUtils, TestCase):
             </li>
         """
         self.assertContains(response, expected, html=True)
-        # The page title shouldn't appear because it's the "home" breadcrumb.
-        self.assertNotContains(response, "Welcome to example.com!")
+
+    def test_nonadmin_sees_non_hidden_root(self):
+        self.login(username="josh", password="password")
+        response = self.client.get(reverse("wagtailadmin_explore", args=[4]))
+        self.assertEqual(response.status_code, 200)
+        # When Josh is viewing his visible root page, he should the page title as a non-hidden, single-item breadcrumb.
+        expected = """
+            <li
+                class="w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-font-bold">
+                <a class="w-flex w-items-center w-text-text-label w-pr-0.5 w-text-14 w-no-underline w-outline-offset-inside w-border-b w-border-b-2 w-border-transparent w-box-content hover:w-border-current hover:w-text-text-label"
+                   href="/admin/pages/4/">
+                    Welcome to example.com!
+                </a>
+            </li>
+        """
+        self.assertContains(response, expected, html=True)
 
     def test_admin_home_page_changes_with_permissions(self):
         self.login(username="bob", password="password")

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -1167,7 +1167,7 @@ class TestExplorablePageVisibility(WagtailTestUtils, TestCase):
         # When Josh is viewing his visible root page, he should the page title as a non-hidden, single-item breadcrumb.
         expected = """
             <li
-                class="w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-font-bold">
+                class="w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-font-bold" data-w-breadcrumbs-target="content">
                 <a class="w-flex w-items-center w-text-text-label w-pr-0.5 w-text-14 w-no-underline w-outline-offset-inside w-border-b w-border-b-2 w-border-transparent w-box-content hover:w-border-current hover:w-text-text-label"
                    href="/admin/pages/4/">
                     Welcome to example.com!


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11451, closes #11520.

The previous PR results in different behaviour as per https://github.com/wagtail/wagtail/pull/11520#pullrequestreview-1846363456.

This PR takes the original approach further by eliminating the root page distinction completely, and instead enforcing the breadcrumbs to be expanded when there is only one item. This ensures the styling is consistent:

<img width="472" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/56fd63ff-de5b-48ce-b7b2-0323c2db0e7f">

<img width="472" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/a5274fc5-b75c-4f59-ba3d-113bd57a7606">

It also removes the extraneous right arrow when exploring the root page.

In the future, we might want to add left padding to make sure the title still aligns with the title column. For now I decided to not add the padding just yet, as that's how it has always looked for the Root page.

That said, it'd be nice to just get rid of `page_breadcrumbs` in the future and reuse the simpler pattern of the new generic `breadcrumbs` template tag that accepts a list of `[{"url": str, "label": str}]` objects.

I had a WIP PR here: #10876


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

See testing details in #11520.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
