### PR TITLE
docs: Update admin_templates.md . Fixed spelling from British English… Resolves #11539

### DIFF
--- a/docs/advanced_topics/customisation/admin_templates.md
+++ b/docs/advanced_topics/customisation/admin_templates.md
@@ -1,4 +1,4 @@
-# Customising admin templates
+# Customizing admin templates
 
 In your projects with Wagtail, you may wish to replace elements such as the Wagtail logo within the admin interface with your own branding. This can be done through Django's template inheritance mechanism.
 
@@ -21,7 +21,7 @@ INSTALLED_APPS = (
 
 ## Custom branding
 
-The template blocks that are available to customise the branding in the admin interface are as follows:
+The template blocks that are available to customize the branding in the admin interface are as follows:
 
 ### `branding_logo`
 
@@ -36,7 +36,7 @@ To replace the default logo, create a template file `dashboard/templates/wagtail
 {% endblock %}
 ```
 
-The logo also appears in the following pages and can be replaced with its template file:
+The logo also appears on the following pages and can be replaced with its template file:
 
 -   **login page** - create a template file `dashboard/templates/wagtailadmin/login.html` that overwrites the `branding_logo` block.
 -   **404 error page** - create a template file `dashboard/templates/wagtailadmin/404.html` that overrides the `branding_logo` block.
@@ -89,7 +89,7 @@ To replace the welcome message on the dashboard, create a template file `dashboa
 
 ## Custom user interface fonts
 
-To customise the font families used in the admin user interface, inject a CSS file using the hook [](insert_global_admin_css) and override the variables within the `:root` selector:
+To customize the font families used in the admin user interface, inject a CSS file using the hook [](insert_global_admin_css) and override the variables within the `:root` selector:
 
 ```css
 :root {
@@ -100,25 +100,25 @@ To customise the font families used in the admin user interface, inject a CSS fi
 
 (custom_user_interface_colours)=
 
-## Custom user interface colours
+## Custom user interface colors
 
 ```{warning}
-The default Wagtail colours conform to the WCAG2.1 AA level colour contrast requirements. When customising the admin colours you should test the contrast using tools like [Axe](https://www.deque.com/axe/browser-extensions/).
+The default Wagtail colors conform to the WCAG2.1 AA level color contrast requirements. When customizing the admin colors you should test the contrast using tools like [Axe](https://www.deque.com/axe/browser-extensions/).
 ```
 
-To customise the colours used in the admin user interface, inject a CSS file using the hook [](insert_global_admin_css) and set the desired variables within the `:root` selector. Colour variables are reused across both the light and dark themes of the admin interface. To change the colours of a specific theme, use:
+To customize the colors used in the admin user interface, inject a CSS file using the hook [](insert_global_admin_css) and set the desired variables within the `:root` selector. Color variables are reused across both the light and dark themes of the admin interface. To change the colors of a specific theme, use:
 
 -   `:root, .w-theme-light` for the light theme.
 -   `.w-theme-dark` for the dark theme.
 -   `@media (prefers-color-scheme: light) { .w-theme-system { […] }}` for the light theme via system settings.
 -   `@media (prefers-color-scheme: dark) { .w-theme-system { […] }}` for the dark theme via system settings.
 
-There are two ways to customise Wagtail’s colour scheme:
+There are two ways to customize Wagtail’s color scheme:
 
--   Set static colour variables, which are then reused in both light and dark themes across a wide number of UI components.
--   Set semantic colours, which are more numerous but allow customising specific UI components.
+-   Set static color variables, which are then reused in both light and dark themes across a wide number of UI components.
+-   Set semantic colors, which are more numerous but allow customizing specific UI components.
 
-For static colours, either set each colour separately (for example `--w-color-primary: #2E1F5E;`); or separately set [HSL](https://en.wikipedia.org/wiki/HSL_and_HSV) (`--w-color-primary-hue`, `--w-color-primary-saturation`, `--w-color-primary-lightness`) variables so all shades are customised at once. For example, setting `--w-color-secondary-hue: 180;` will customise all of the secondary shades at once.
+For static colors, either set each color separately (for example `--w-color-primary: #2E1F5E;`); or separately set [HSL](https://en.wikipedia.org/wiki/HSL_and_HSV) (`--w-color-primary-hue`, `--w-color-primary-saturation`, `--w-color-primary-lightness`) variables so all shades are customized at once. For example, setting `--w-color-secondary-hue: 180;` will customize all of the secondary shades at once.
 
 ```{include} ../../_static/wagtail_colors_tables.txt
 
@@ -126,7 +126,7 @@ For static colours, either set each colour separately (for example `--w-color-pr
 
 ## Specifying a site or page in the branding
 
-The admin interface has a number of variables available to the renderer context that can be used to customise the branding in the admin page. These can be useful for customising the dashboard on a multitenanted Wagtail installation:
+The admin interface has a number of variables available to the renderer context that can be used to customize the branding on the admin page. These can be useful for customizing the dashboard on a multitenanted Wagtail installation:
 
 ### `root_page`
 
@@ -195,7 +195,7 @@ To add extra buttons to the login form, override the `submit_buttons` block. You
 
 ### `login_form`
 
-To completely customise the login form, override the `login_form` block. This block wraps the whole contents of the `<form>` element:
+To completely customize the login form, override the `login_form` block. This block wraps the whole contents of the `<form>` element:
 
 ```html+django
 {% extends "wagtailadmin/login.html" %}


### PR DESCRIPTION
… to American English in many areas. Resolves #11539

This pull request resolves #11539 with context to #10608 , focusing on the transition from British English to American English spelling in the documentation. The changes specifically target the "customising admin templates" section. I've also resolved some grammatical issues in places where 'in' preposition was used instead of 'on'.

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #...







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
