### PR TITLE
Add a custom style block to adjust text baseline

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
@@ -1,16 +1,23 @@
 {% extends "wagtailadmin/tables/column_header.html" %}
 {% load wagtailadmin_tags i18n %}
 
+<style>
+    /* Add a custom style block to adjust text baseline */
+    .baseline-adjust {
+        vertical-align: baseline;
+    }
+</style>
+
 {% block after_label %}
     {% if is_searching or is_filtering %}
         {% if is_searching_whole_tree %}
             {% if items_count %}
                 {% blocktranslate trimmed %}
-                    {{ start_index }}-{{ end_index }} of {{ items_count }} across entire site.
+                    <span class="baseline-adjust">{{ start_index }}-{{ end_index }} of {{ items_count }} across entire site.</span>
                 {% endblocktranslate %}
             {% else %}
                 {% blocktranslate trimmed %}
-                    No results across entire site.
+                    <span class="baseline-adjust">No results across entire site.</span>
                 {% endblocktranslate %}
             {% endif %}
             <a href="{{ table.base_url }}{% querystring p=None search_all=None %}">
@@ -19,11 +26,11 @@
         {% else %}
             {% if items_count %}
                 {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}
-                    {{ start_index }}-{{ end_index }} of {{ items_count }} in '<span class="w-title-ellipsis">{{ title }}</span>'.
+                    <span class="baseline-adjust">{{ start_index }}-{{ end_index }} of {{ items_count }} in '<span class="w-title-ellipsis">{{ title }}</span>'.</span>
                 {% endblocktranslate %}
             {% else %}
                 {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}
-                    No results in '<span class="w-title-ellipsis">{{ title }}</span>'.
+                    <span class="baseline-adjust">No results in '<span class="w-title-ellipsis">{{ title }}</span>'.</span>
                 {% endblocktranslate %}
             {% endif %}
             <a href="{{ table.base_url }}{% querystring p=None search_all=1 %}">
@@ -32,7 +39,7 @@
         {% endif %}
     {% else %}
         {% blocktranslate trimmed %}
-            {{ start_index }}-{{ end_index }} of {{ items_count }}
+            <span class="baseline-adjust">{{ start_index }}-{{ end_index }} of {{ items_count }}</span>
         {% endblocktranslate %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11534
Uneven Text Baseline in Zero-Results Search Query Message:

Adjusted the HTML and added a custom style block to address the uneven text baseline issue in the zero-results search query message.
Introduced a class named baseline-adjust with the vertical-align: baseline; property to ensure consistent baseline alignment.



_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
