### PR TITLE
Change groups in v6.0 release notes

### DIFF
--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -25,7 +25,15 @@ This tutorial series was created by Damilola Oladele as part of the Google Seaso
 
 Following design improvements to the page listing view, Wagtail now provides a unified search and filtering interface for all listings. This will improve navigation capabilities, particularly for sites with a large number of pages or where content tends to use a flat structure.
 
-In this release, the universal listing interface is available for Pages, Snippets, and Forms.
+In this release, the universal listing interface is available for Pages, Snippets, and Forms. For pages, the UI includes the following filters out of the box:
+
+ * Page type
+ * Date updated
+ * Owner
+ * Edited by
+ * Site
+ * Has child pages
+ * Locale
 
 This feature was developed by Ben Enright, Matt Westcott, Nick Lee, Thibaud Colas, and Sage Abdullah.
 
@@ -41,29 +49,50 @@ The [built-in accessibility checker](authoring_accessible_content) now displays 
 
 This feature was implemented by Nick Lee, Thibaud Colas, and Sage Abdullah.
 
+### Page types usage report
+
+The new Page types report provides a breakdown of the number of pages for each type. It helps answer questions such as:
+
+ * Which page types do we have on our CMS?
+ * How many pages of that page type do we have?
+ * When was a page of that type last edited? By whom? Which page was that?
+
+This feature was developed by Jhonatan Lopes, as part of a sponsorship by the Mozilla Foundation.
+
+### Accessibility improvements
+
+This release comes with a high number of accessibility improvements across the admin inteface.
+
+ * Improve layout and accessibility of the image URL generator page, reduce reliance on JavaScript (Temidayo Azeez)
+ * Remove overly verbose image captions in image listings for screen readers (Sage Abdullah)
+ * Ensure screen readers and dictation tools can more easily navigate bulk actions in images, documents and page listings by streamlining labels and descriptions (Sage Abdullah)
+ * Add optional caption field to `TypedTableBlock` (Tommaso Amici, Cynthia Kiser)
+ * Switch the `TableBlock` header controls to a field that requires user input (Bhuvnesh Sharma, Aman Pandey, Cynthia Kiser)
+ * Add support for `caption` on admin UI Table component (Aman Pandey)
+ * Replace legacy dropdown component with new Tippy dropdown-button (Thibaud Colas)
+ * Ensure the sidebar account toggle has no duplicate accessible labels (Nandini Arora)
+ * Ensure that page listing re-ordering messages and accessible labels can be translated (Aman Pandey, LB (Ben) Johnston)
+ * Resolve multiple issues with page listing re-ordering using keyboard and screen readers (Aman Pandey)
+ * When using an empty table header (`th`) for visual spacing, ensure this is ignored by accessibility tooling (V Rohitansh)
+ * Ensure that TableBlock cells are accessible when using keyboard control only (Elhussein Almasri)
+
 ### Other features
 
  * Added [`search_index` option to StreamField](streamfield_search) blocks to control whether the block is indexed for searching (Vedant Pandey)
  * Remember previous location on returning from page add/edit actions (Robert Rollins)
  * Update settings file in project settings to address Django 4.2 deprecations (Sage Abdullah)
- * Improve layout and accessibility of the image URL generator page, reduce reliance on JavaScript (Temidayo Azeez)
  * Allow `UniqueConstraint` in place of `unique_together` for {class}`~wagtail.models.TranslatableMixin`'s system check (Temidayo Azeez, Sage Abdullah)
  * Make use of `IndexView.get_add_url()` in snippets index view template (Christer Jensen, Sage Abdullah)
  * Allow `Page.permissions_for_user()` to be overridden by specific page types (Sébastien Corbin)
  * Improve visual alignment of explore icon in Page listings for longer content (Krzysztof Jeziorny)
  * Add `extra_actions` blocks to Snippets and generic index templates (Bhuvnesh Sharma)
- * Added page types usage report (Jhonatan Lopes)
  * Add support for defining `panels` / `edit_handler` on `ModelViewSet` (Sage Abdullah)
  * Use a single instance of `PagePermissionPolicy` in `wagtail.permissions` module (Sage Abdullah)
  * Add max tag length validation for multiple uploads (documents/images) (Temidayo Azeez)
  * Ensure expanded side panel does not overlap form content for most viewports (Chiemezuo Akujobi)
  * Add ability to [modify the default ordering](page_model_ref) for the page explorer view (Shlomo Markowitz)
- * Remove overly verbose image captions in image listings for screen readers (Sage Abdullah)
- * Ensure screen readers and dictation tools can more easily navigate bulk actions in images, documents and page listings by streamlining labels and descriptions (Sage Abdullah)
  * Remove support for Safari 14 (Thibaud Colas)
  * Add ability to click to copy the URL in the image URL generator page (Sai Srikar Dumpeti)
- * Add ability to filter by page type and date updated in the page listing view (Matt Westcott)
- * Add ability to filter by owner and site in the page listing view (Matt Westcott)
  * Show edit as a main action in generic history and usage views (Sage Abdullah)
  * Make styles for header buttons consistent (Sage Abdullah)
  * Improve styles of slim header's search and filters (Sage Abdullah)
@@ -74,15 +103,10 @@ This feature was implemented by Nick Lee, Thibaud Colas, and Sage Abdullah.
  * Show character counts on RichTextBlock with `max_length` (Elhussein Almasri)
  * Move locale selector in generic IndexView to a filter (Sage Abdullah)
  * Add ability to [customise a page's copy form](custom_page_copy_form) including an auto-incrementing slug example (Neeraj Yetheendran)
- * Add optional caption field to `TypedTableBlock` (Tommaso Amici, Cynthia Kiser)
- * Switch the `TableBlock` header controls to a field that requires user input (Bhuvnesh Sharma, Aman Pandey, Cynthia Kiser)
  * Add [`WAGTAILADMIN_LOGIN_URL` setting](wagtailadmin_login_url) to allow customising the login URL (Neeraj Yetheendran)
- * Replace legacy dropdown component with new Tippy dropdown-button (Thibaud Colas)
- * Add ability to filter by existence of child pages in the page listing view (Matt Westcott)
  * Polish dark theme styles and update color tokens (Thibaud Colas, Rohit Sharma)
  * Keep database state of pages and snippets updated while in draft state (Stefan Hammer)
  * Add `DrilldownController` and `w-drilldown` component to support drilldown menus (Thibaud Colas)
- * Add support for `caption` on admin UI Table component (Aman Pandey)
  * Add API support for a [redirects (contrib)](redirects_api_endpoint) endpoint (Rohit Sharma, Jaap Roes, Andreas Donig)
  * Add the default ability for all `SnippetViewSet` & `ModelViewSet` to support [being copied](modelviewset_copy), this can be disabled by `copy_view_enabled = False` (Shlomo Markowitz)
  * Support dynamic Wagtail guide links in the admin that are based on the running version of Wagtail (Tidiane Dia)
@@ -113,20 +137,15 @@ This feature was implemented by Nick Lee, Thibaud Colas, and Sage Abdullah.
  * Avoid duplicate entries in "Recent edits" panel when copying pages (Matt Westcott)
  * Prevent TitleFieldPanel from raising an error when the slug field is missing or read-only (Rohit Sharma)
  * Ensure that the close button on the new dialog designs is visible in the non-message variant (Nandini Arora)
- * Ensure the sidebar account toggle has no duplicate accessible labels (Nandini Arora)
  * Avoid text overflow issues in comment replies and scroll position issues for long comments (Rohit Sharma)
- * Ensure that page listing re-ordering messages and accessible labels can be translated (Aman Pandey, LB (Ben) Johnston)
- * Resolve multiple issues with page listing re-ordering using keyboard and screen readers (Aman Pandey)
  * Remove 'Page' from page types filter on aging pages report (Matt Westcott)
  * Prevent page types filter from showing other non-Page models that match by name (Matt Westcott)
  * Ensure `MultipleChooserPanel` modal works correctly when `USE_THOUSAND_SEPARATOR` is `True` for pages with ids over 1,000 (Sankalp, Rohit Sharma)
- * When using an empty table header (`th`) for visual spacing, ensure this is ignored by accessibility tooling (V Rohitansh)
  * Ensure the panel anchor button sizes meet accessibility guidelines for minimum dimensions (Nandini Arora)
  * Raise a 404 for bulk actions for models which don't exist instead of throwing a 500 error (Alex Tomkins)
  * Raise a `SiteSetting.DoesNotExist` error when retrieving settings for an unrecognised site (Nick Smith)
  * Ensure that defaulted or unique values declared in `exclude_fields_in_copy` are correctly excluded in new copies, resolving to the default value (Elhussein Almasri)
  * Ensure that `default_ordering` set on IndexView is preserved if ModelViewSet does not specify an explicit ordering (Cynthia Kiser)
- * Ensure that TableBlock cells are accessible when using keyboard control only (Elhussein Almasri)
  * Resolve issue where clicking Publish for a Page that was in workflow in Safari would block publishing and not trigger the workflow confirmation modal (Alex Morega)
 
 
@@ -152,12 +171,26 @@ This feature was implemented by Nick Lee, Thibaud Colas, and Sage Abdullah.
 
 ### Maintenance
 
+#### Generic class-based views adoption
+
+As part of ongoing refactorings, we have migrated a number of views to use generic class-based views. This allows for easier extensibility and better code reuse.
+
+ * Migrate the contrib styleguide index view to a class-based view (Chiemezuo Akujobi)
+ * Migrate the contrib settings edit view to a class-based view (Chiemezuo Akujobi, Sage Abdullah)
+ * Migrate account editing view to a class-based view (Kehinde Bobade)
+ * Refactor page explorer index template to extend generic index template (Sage Abdullah)
+ * Refactor snippets index view and template to make better use of generic IndexView (Sage Abdullah)
+ * Refactor documents listing view to use generic IndexView (Sage Abdullah)
+ * Refactor images listing view to use generic IndexView (Sage Abdullah)
+ * Refactor form pages listing view to use generic IndexView (Sage Abdullah)
+ * Reduce gap between snippets and generic views/templates (Sage Abdullah)
+
+#### Other maintenance
+
  * Update BeautifulSoup upper bound to 4.12.x (scott-8)
  * Migrate initialization of classes (such as `body.ready`) from multiple JavaScript implementations to one Stimulus controller `w-init` (Chiemezuo Akujobi)
  * Adopt the usage of translate string literals using `arg=_('...')` in all `wagtailadmin` module templates (Chiemezuo Akujobi)
- * Migrate the contrib styleguide index view to a class-based view (Chiemezuo Akujobi)
  * Update djhtml to 3.0.6 (Matt Westcott)
- * Migrate the contrib settings edit view to a class-based view (Chiemezuo Akujobi, Sage Abdullah)
  * Remove django-pattern-library upper bound in testing dependencies (Sage Abdullah)
  * Split up functions in Elasticsearch backend for easier extensibility (Marcel Kornblum, Cameron Lamb, Sam Dudley)
  * Relax draftjs_exporter dependency to allow using version 5.x (Sylvain Fankhauser)
@@ -165,23 +198,17 @@ This feature was implemented by Nick Lee, Thibaud Colas, and Sage Abdullah.
  * Remove icon font support (Matt Westcott)
  * Remove deprecated SVG icons (Matt Westcott)
  * Remove icon font styles (Thibaud Colas)
- * Migrate account editing view to a class-based view (Kehinde Bobade)
  * Upgrade frontend tooling to use Node 20 (LB (Ben) Johnston)
  * Upgrade `ruff` and replace `black` with `ruff format` (John-Scott Atlakson)
  * Update Willow upper bound to 2.x (Dan Braghis)
  * Removed support for Django < 4.2 (Dan Braghis)
- * Refactor page explorer index template to extend generic index template (Sage Abdullah)
  * Replace template components implementation with standalone `laces` library (Tibor Leupold)
- * Refactor snippets index view and template to make better use of generic IndexView (Sage Abdullah)
  * Introduce an internal `{% formattedfield %}` tag to replace direct use of `wagtailadmin/shared/field.html` (Matt Westcott)
  * Update Telepath dependency to 0.3.1 (Matt Westcott)
  * Allow `ActionController` to have a `noop` method to more easily leverage standalone Stimulus action options (Nandini Arora)
  * Upgrade to latest TypeScript and Storybook (Thibaud Colas, Sage Abdullah)
  * Turn on `skipLibCheck` for TypeScript (LB (Ben) Johnston)
- * Refactor documents listing view to use generic IndexView (Sage Abdullah)
  * Support for the Stimulus `CloneController` to auto clear the added content after a set duration (LB (Ben) Johnston)
- * Refactor images listing view to use generic IndexView (Sage Abdullah)
- * Refactor form pages listing view to use generic IndexView (Sage Abdullah)
  * Update Stylelint, our linting configuration, Sass, and related code changes (LB (Ben) Johnston)
  * Simplify browserslist and browser support documentation for maintainers (Thibaud Colas)
  * Relax django-taggit dependency to allow 5.0 (Sylvain Fankhauser)
@@ -200,7 +227,6 @@ This feature was implemented by Nick Lee, Thibaud Colas, and Sage Abdullah.
  * Update Jest version - frontend tooling (Nandini Arora)
  * Remove non-functional and inaccessible auto-focus on first field in page create forms (LB (Ben) Johnston)
  * Migrate the unsaved form checks & confirmation trigger to Stimulus `UnsavedController` (Sai Srikar Dumpeti, LB (Ben) Johnston)
- * Reduce gap between snippets and generic views/templates (Sage Abdullah)
  * Migrate page listing menu re-ordering (drag & drop) from jQuery inline scripts to `OrderableController` with a more accessible solution (Aman Pandey, LB (Ben) Johnston)
  * Clean up scss variable usage, remove unused variables and mixins, adopt more core token variables (Jai Vignesh J, Nandini Arora, LB (Ben) Johnston)
  * Migrate Image URL generator views to class-based views (Rohit Sharma)


### PR DESCRIPTION
Reorders the release line items in the Markdown release notes, to better highlight specific group efforts.

- Universal listings filters now in the universal listings sections.
- The Page types usage report is a sponsored feature, and a cool one at that, so warrants its own section.
- There’s been loads of accessibility improvements so this warrants its own section.
- Same for Generic class-based views adoption, which is also on our roadmap.