### PR TITLE
Remove Duplicate Field In Additional Field Names List

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~~~~~
 
  * Refine wording of page & collection privacy using password is a shared password and should not be used for secure content (Rohit Sharma, Jake Howard)
+ * Maintenance: Remove duplicate 'path' in default_exclude_fields_in_copy (ramchandra-st)
 
 
 6.0 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -789,6 +789,7 @@
 * V Rohitansh
 * Andreas Donig
 * Osaf AliSayed
+* ramchandra-st
 
 ## Translators
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -1266,7 +1266,6 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
     exclude_fields_in_copy = []
     default_exclude_fields_in_copy = [
         "id",
-        "path",
         "depth",
         "numchild",
         "url_path",


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes:
- There were 2 `paths` field names in the list in the `Page` model's `default_exclude_fields_in_copy` list. So removed one of them.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
