### PR TITLE
Refine approach for reflecting query params of AJAX search and add more tests

### DIFF
--- a/client/src/api/client.test.js
+++ b/client/src/api/client.test.js
@@ -3,7 +3,7 @@ import client from './client';
 describe('client API', () => {
   it('should succeed fetching', (done) => {
     const response = '{"meta":{"total_count":1},"items":[]}';
-    fetch.mockResponseSuccess(response);
+    fetch.mockResponseSuccessJSON(response);
 
     client.get('/example/url').then((result) => {
       expect(result).toMatchSnapshot();

--- a/client/src/controllers/DrilldownController.ts
+++ b/client/src/controllers/DrilldownController.ts
@@ -76,25 +76,6 @@ export class DrilldownController extends Controller<HTMLElement> {
     });
   }
 
-  updateParams(e: Event) {
-    const swapEvent = e as CustomEvent<{ requestUrl: string }>;
-    if ((e.target as HTMLElement)?.id === 'listing-results') {
-      const params = new URLSearchParams(
-        swapEvent.detail?.requestUrl.split('?')[1],
-      );
-      const filteredParams = new URLSearchParams();
-      params.forEach((value, key) => {
-        if (value.trim() !== '' && !key.startsWith('_w_')) {
-          // Check if the value is not empty after trimming white space
-          filteredParams.append(key, value);
-        }
-      });
-      const queryString = `?${filteredParams.toString()}`;
-      window.history.replaceState(null, '', queryString);
-    }
-    this.updateCount();
-  }
-
   open(e: MouseEvent) {
     const toggle = (e.target as HTMLElement)?.closest(
       'button',

--- a/client/src/controllers/LinkController.ts
+++ b/client/src/controllers/LinkController.ts
@@ -1,5 +1,13 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * Adds the ability for the controlled element to reflect the URL's query parameters
+ * from an event or the current URL into the window.location so that dynamic updates
+ * to listings can be available on refreshing or other internal links.
+ *
+ * @example - Reflecting the URL's query parameters
+ * <a href="/?q=1" data-controller="w-link" data-w-link-reflect-keys-value="['q']"></a>
+ */
 export class LinkController extends Controller<HTMLElement> {
   static values = {
     attrName: { default: 'href', type: String },
@@ -7,8 +15,11 @@ export class LinkController extends Controller<HTMLElement> {
     reflectKeys: { default: ['__all__'], type: Array },
   };
 
+  /** Attribute on the controlled element containing the URL string. */
   declare attrNameValue: string;
+  /** URL param keys that will be kept in the current location's URL. */
   declare preserveKeysValue: string[];
+  /** URL param keys to be added to the location URL from the source URL. */
   declare reflectKeysValue: string[];
 
   get url() {
@@ -59,14 +70,16 @@ export class LinkController extends Controller<HTMLElement> {
     this.element.setAttribute(this.attrNameValue, currentUrl.toString());
   }
 
-  setParams(e?: CustomEvent<{ requestUrl?: string }>) {
-    if (!e) {
+  setParams(event?: CustomEvent<{ requestUrl?: string }>) {
+    if (!event) {
       this.setParamsFromURL(new URL(window.location.href));
       return;
     }
 
-    if (!e.detail?.requestUrl) return;
+    if (!event.detail?.requestUrl) return;
 
-    this.setParamsFromURL(new URL(e.detail.requestUrl, window.location.href));
+    this.setParamsFromURL(
+      new URL(event.detail.requestUrl, window.location.href),
+    );
   }
 }

--- a/client/src/controllers/LinkController.ts
+++ b/client/src/controllers/LinkController.ts
@@ -19,7 +19,7 @@ export class LinkController extends Controller<HTMLElement> {
   }
 
   connect() {
-    this.setParamsFromLocation();
+    this.setParams();
   }
 
   get reflectAll() {
@@ -33,11 +33,13 @@ export class LinkController extends Controller<HTMLElement> {
 
     const sourceParams = url.searchParams;
     sourceParams.forEach((value, key) => {
+      // Skip the key if
       if (
-        key.startsWith('_w_') || // Wagtail internal
-        // Delete the key if we want to preserve it from the current URL, or
-        // if we don't want to reflect it to the new URL
+        // it's a Wagtail internal param, or
+        key.startsWith('_w_') ||
+        // we want to preserve it from the current URL, or
         this.preserveKeysValue.includes(key) ||
+        // we don't want to reflect it to the new URL
         (!reflectAll && !this.reflectKeysValue.includes(key))
       ) {
         return;
@@ -57,12 +59,14 @@ export class LinkController extends Controller<HTMLElement> {
     this.element.setAttribute(this.attrNameValue, currentUrl.toString());
   }
 
-  setParamsFromSwapRequest(e: CustomEvent<{ requestUrl?: string }>) {
-    if (!e.detail?.requestUrl) return;
-    this.setParamsFromURL(new URL(e.detail.requestUrl, window.location.href));
-  }
+  setParams(e?: CustomEvent<{ requestUrl?: string }>) {
+    if (!e) {
+      this.setParamsFromURL(new URL(window.location.href));
+      return;
+    }
 
-  setParamsFromLocation() {
-    this.setParamsFromURL(new URL(window.location.href));
+    if (!e.detail?.requestUrl) return;
+
+    this.setParamsFromURL(new URL(e.detail.requestUrl, window.location.href));
   }
 }

--- a/client/src/controllers/OrderableController.test.js
+++ b/client/src/controllers/OrderableController.test.js
@@ -142,7 +142,7 @@ describe('OrderableController', () => {
         'orderable',
       ]);
 
-      fetch.mockResponseSuccess('');
+      fetch.mockResponseSuccessJSON('');
 
       // emulate a drag end (with change)
 
@@ -250,7 +250,7 @@ describe('OrderableController', () => {
 
       expect(global.fetch).not.toHaveBeenCalled();
 
-      fetch.mockResponseSuccess('');
+      fetch.mockResponseSuccessJSON('');
 
       await Promise.resolve(handle.dispatchEvent(new KeyboardEvent(...ENTER)));
 

--- a/client/src/controllers/SwapController.test.js
+++ b/client/src/controllers/SwapController.test.js
@@ -183,13 +183,7 @@ describe('SwapController', () => {
         document.addEventListener('w-swap:success', resolve);
       });
 
-      fetch.mockImplementationOnce(() =>
-        Promise.resolve({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(results),
-        }),
-      );
+      fetch.mockResponseSuccessText(results);
 
       expect(window.location.search).toEqual('');
       expect(handleError).not.toHaveBeenCalled();
@@ -390,12 +384,7 @@ describe('SwapController', () => {
       const onErrorEvent = jest.fn();
       document.addEventListener('w-swap:error', onErrorEvent);
 
-      fetch.mockImplementationOnce(() =>
-        Promise.resolve({
-          ok: false,
-          status: 500,
-        }),
-      );
+      fetch.mockResponseFailure();
 
       expect(window.location.search).toEqual('');
       expect(handleError).not.toHaveBeenCalled();
@@ -478,13 +467,7 @@ describe('SwapController', () => {
         document.addEventListener('w-swap:success', resolve);
       });
 
-      fetch.mockImplementationOnce(() =>
-        Promise.resolve({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(results),
-        }),
-      );
+      fetch.mockResponseSuccessText(results);
 
       expect(window.location.search).toEqual('');
       expect(handleError).not.toHaveBeenCalled();
@@ -543,13 +526,7 @@ describe('SwapController', () => {
 
       document.addEventListener('w-swap:begin', beginEventHandler);
 
-      fetch.mockImplementationOnce(() =>
-        Promise.resolve({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(results),
-        }),
-      );
+      fetch.mockResponseSuccessText(results);
 
       expect(window.location.search).toEqual('');
       expect(handleError).not.toHaveBeenCalled();
@@ -609,13 +586,7 @@ describe('SwapController', () => {
       beginEventHandler = jest.fn();
       document.addEventListener('w-swap:begin', beginEventHandler);
 
-      fetch.mockImplementationOnce(() =>
-        Promise.resolve({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(results),
-        }),
-      );
+      fetch.mockResponseSuccessText(results);
     });
 
     it('should allow for actions to call the replace method directly, defaulting to the form action url', async () => {
@@ -994,13 +965,7 @@ describe('SwapController', () => {
       const beginEventHandler = jest.fn();
       document.addEventListener('w-swap:begin', beginEventHandler);
 
-      fetch.mockImplementationOnce(() =>
-        Promise.resolve({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(results),
-        }),
-      );
+      fetch.mockResponseSuccessText(results);
 
       expect(window.location.search).toEqual('');
       expect(handleError).not.toHaveBeenCalled();
@@ -1066,13 +1031,7 @@ describe('SwapController', () => {
       const beginEventHandler = jest.fn();
       document.addEventListener('w-swap:begin', beginEventHandler);
 
-      fetch.mockImplementationOnce(() =>
-        Promise.resolve({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(results),
-        }),
-      );
+      fetch.mockResponseSuccessText(results);
 
       expect(window.location.search).toEqual('');
       expect(handleError).not.toHaveBeenCalled();
@@ -1148,13 +1107,7 @@ describe('SwapController', () => {
       const beginEventHandler = jest.fn();
       document.addEventListener('w-swap:begin', beginEventHandler);
 
-      fetch.mockImplementationOnce(() =>
-        Promise.resolve({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(results),
-        }),
-      );
+      fetch.mockResponseSuccessText(results);
 
       expect(window.location.search).toEqual('');
       expect(handleError).not.toHaveBeenCalled();
@@ -1226,13 +1179,7 @@ describe('SwapController', () => {
 
       document.addEventListener('w-swap:begin', beginEventHandler);
 
-      fetch.mockImplementationOnce(() =>
-        Promise.resolve({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(results),
-        }),
-      );
+      fetch.mockResponseSuccessText(results);
 
       expect(window.location.search).toEqual('');
       expect(handleError).not.toHaveBeenCalled();

--- a/client/src/controllers/SwapController.test.js
+++ b/client/src/controllers/SwapController.test.js
@@ -718,6 +718,138 @@ describe('SwapController', () => {
       expect(window.location.search).toEqual('');
     });
 
+    it('should reflect the query params of the request URL if reflect-value is true', async () => {
+      const expectedRequestUrl = '/path/to-src-value/?foo=bar&abc=&xyz=123';
+
+      expect(window.location.search).toEqual('');
+      expect(handleError).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      const reflectEventHandler = new Promise((resolve) => {
+        document.addEventListener('w-swap:reflect', resolve);
+      });
+
+      formElement.setAttribute('data-w-swap-src-value', expectedRequestUrl);
+      formElement.setAttribute('data-w-swap-reflect-value', 'true');
+
+      formElement.dispatchEvent(
+        new CustomEvent('custom:event', { bubbles: false }),
+      );
+
+      expect(beginEventHandler).not.toHaveBeenCalled();
+
+      jest.runAllTimers(); // search is debounced
+
+      // should fire a begin event before the request is made
+      expect(beginEventHandler).toHaveBeenCalledTimes(1);
+      expect(beginEventHandler.mock.calls[0][0].detail).toEqual({
+        requestUrl: expectedRequestUrl,
+      });
+
+      // visual loading state should be active
+      await Promise.resolve(); // trigger next rendering
+
+      expect(handleError).not.toHaveBeenCalled();
+      expect(global.fetch).toHaveBeenCalledWith(
+        expectedRequestUrl,
+        expect.any(Object),
+      );
+
+      const reflectEvent = await reflectEventHandler;
+
+      // should dispatch reflect event
+      expect(reflectEvent.detail).toEqual({
+        requestUrl: expectedRequestUrl,
+      });
+
+      const successEvent = await onSuccess;
+
+      // should dispatch success event
+      expect(successEvent.detail).toEqual({
+        requestUrl: expectedRequestUrl,
+        results: expect.any(String),
+      });
+
+      // should update HTML
+      expect(
+        document.getElementById('content').querySelectorAll('li'),
+      ).toHaveLength(2);
+
+      await flushPromises();
+
+      // should update the current URL to have the query params from requestUrl
+      // (except for those that are empty)
+      // as the reflect-value attribute is set to true
+      expect(window.location.search).toEqual('?foo=bar&xyz=123');
+    });
+
+    it('should allow for blocking the reflection of query params with event handlers', async () => {
+      const expectedRequestUrl = '/path/to-src-value/?foo=bar&abc=&xyz=123';
+
+      expect(window.location.search).toEqual('');
+      expect(handleError).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      const reflectEventHandler = jest.fn((event) => {
+        event.preventDefault();
+      });
+
+      document.addEventListener('w-swap:reflect', reflectEventHandler);
+
+      formElement.setAttribute('data-w-swap-src-value', expectedRequestUrl);
+      formElement.setAttribute('data-w-swap-reflect-value', 'true');
+
+      formElement.dispatchEvent(
+        new CustomEvent('custom:event', { bubbles: false }),
+      );
+
+      expect(beginEventHandler).not.toHaveBeenCalled();
+
+      jest.runAllTimers(); // search is debounced
+
+      // should fire a begin event before the request is made
+      expect(beginEventHandler).toHaveBeenCalledTimes(1);
+      expect(beginEventHandler.mock.calls[0][0].detail).toEqual({
+        requestUrl: expectedRequestUrl,
+      });
+
+      // visual loading state should be active
+      await Promise.resolve(); // trigger next rendering
+
+      expect(handleError).not.toHaveBeenCalled();
+      expect(global.fetch).toHaveBeenCalledWith(
+        expectedRequestUrl,
+        expect.any(Object),
+      );
+
+      const successEvent = await onSuccess;
+
+      // should dispatch reflect event
+      expect(reflectEventHandler).toHaveBeenCalledTimes(1);
+      expect(reflectEventHandler.mock.calls[0][0].detail).toEqual({
+        requestUrl: expectedRequestUrl,
+      });
+
+      // should dispatch success event
+      expect(successEvent.detail).toEqual({
+        requestUrl: expectedRequestUrl,
+        results: expect.any(String),
+      });
+
+      // should update HTML
+      expect(
+        document.getElementById('content').querySelectorAll('li'),
+      ).toHaveLength(2);
+
+      await flushPromises();
+
+      // should NOT update the current URL
+      // as the reflect-value attribute is set to false
+      expect(window.location.search).toEqual('');
+
+      document.removeEventListener('w-swap:reflect', reflectEventHandler);
+    });
+
     it('should support replace with a url value provided via the Custom event detail', async () => {
       const expectedRequestUrl = '/path/to/url-in-event-detail/?q=alpha';
 
@@ -767,6 +899,7 @@ describe('SwapController', () => {
       await flushPromises();
 
       // should NOT update the current URL
+      // as the reflect-value attribute is not set
       expect(window.location.search).toEqual('');
     });
 
@@ -914,7 +1047,172 @@ describe('SwapController', () => {
       await flushPromises();
 
       // should NOT update the current URL
+      // as the reflect-value attribute is not set
       expect(window.location.search).toEqual('');
+    });
+
+    it('should reflect the query params of the request URL if reflect-value is true', async () => {
+      const formElement = document.querySelector('form');
+      formElement.setAttribute('data-w-swap-reflect-value', 'true');
+
+      const input = document.getElementById('search');
+
+      const results = getMockResults({ total: 5 });
+
+      const onSuccess = new Promise((resolve) => {
+        document.addEventListener('w-swap:success', resolve);
+      });
+
+      const beginEventHandler = jest.fn();
+      document.addEventListener('w-swap:begin', beginEventHandler);
+
+      fetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(results),
+        }),
+      );
+
+      expect(window.location.search).toEqual('');
+      expect(handleError).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      input.value = 'alpha';
+      document.querySelector('[name="other"]').value = 'something on other';
+      document.querySelector('[name="type"]').value = '';
+      input.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+
+      expect(beginEventHandler).not.toHaveBeenCalled();
+
+      jest.runAllTimers(); // search is debounced
+
+      // should fire a begin event before the request is made
+      expect(beginEventHandler).toHaveBeenCalledTimes(1);
+      expect(beginEventHandler.mock.calls[0][0].detail).toEqual({
+        requestUrl:
+          '/path/to/form/action/?q=alpha&type=&other=something+on+other',
+      });
+
+      // visual loading state should be active
+      await Promise.resolve(); // trigger next rendering
+
+      expect(handleError).not.toHaveBeenCalled();
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/path/to/form/action/?q=alpha&type=&other=something+on+other',
+        expect.any(Object),
+      );
+
+      const successEvent = await onSuccess;
+
+      // should dispatch success event
+      expect(successEvent.detail).toEqual({
+        requestUrl:
+          '/path/to/form/action/?q=alpha&type=&other=something+on+other',
+        results: expect.any(String),
+      });
+
+      // should update HTML
+      expect(
+        document.getElementById('task-results').querySelectorAll('li').length,
+      ).toBeTruthy();
+
+      await flushPromises();
+
+      // should update the current URL to have the query params from requestUrl
+      // (except for those that are empty)
+      // as the reflect-value attribute is set to true
+      expect(window.location.search).toEqual(
+        '?q=alpha&other=something+on+other',
+      );
+    });
+
+    it('should allow for blocking the reflection of query params with event handlers', async () => {
+      const formElement = document.querySelector('form');
+      formElement.setAttribute('data-w-swap-reflect-value', 'true');
+
+      const reflectEventHandler = jest.fn((event) => {
+        event.preventDefault();
+      });
+
+      document.addEventListener('w-swap:reflect', reflectEventHandler);
+
+      const input = document.getElementById('search');
+
+      const results = getMockResults({ total: 5 });
+
+      const onSuccess = new Promise((resolve) => {
+        document.addEventListener('w-swap:success', resolve);
+      });
+
+      const beginEventHandler = jest.fn();
+      document.addEventListener('w-swap:begin', beginEventHandler);
+
+      fetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(results),
+        }),
+      );
+
+      expect(window.location.search).toEqual('');
+      expect(handleError).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      input.value = 'alpha';
+      document.querySelector('[name="other"]').value = 'something on other';
+      document.querySelector('[name="type"]').value = '';
+      input.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+
+      expect(beginEventHandler).not.toHaveBeenCalled();
+
+      jest.runAllTimers(); // search is debounced
+
+      // should fire a begin event before the request is made
+      expect(beginEventHandler).toHaveBeenCalledTimes(1);
+      expect(beginEventHandler.mock.calls[0][0].detail).toEqual({
+        requestUrl:
+          '/path/to/form/action/?q=alpha&type=&other=something+on+other',
+      });
+
+      // visual loading state should be active
+      await Promise.resolve(); // trigger next rendering
+
+      expect(handleError).not.toHaveBeenCalled();
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/path/to/form/action/?q=alpha&type=&other=something+on+other',
+        expect.any(Object),
+      );
+
+      const successEvent = await onSuccess;
+
+      // should dispatch reflect event
+      expect(reflectEventHandler).toHaveBeenCalledTimes(1);
+      expect(reflectEventHandler.mock.calls[0][0].detail).toEqual({
+        requestUrl:
+          '/path/to/form/action/?q=alpha&type=&other=something+on+other',
+      });
+
+      // should dispatch success event
+      expect(successEvent.detail).toEqual({
+        requestUrl:
+          '/path/to/form/action/?q=alpha&type=&other=something+on+other',
+        results: expect.any(String),
+      });
+
+      // should update HTML
+      expect(
+        document.getElementById('task-results').querySelectorAll('li').length,
+      ).toBeTruthy();
+
+      await flushPromises();
+
+      // should NOT update the current URL
+      // as the reflect-value attribute is set to false
+      expect(window.location.search).toEqual('');
+
+      document.removeEventListener('w-swap:reflect', reflectEventHandler);
     });
 
     it('should allow for blocking the request with custom events', async () => {

--- a/client/src/controllers/SwapController.ts
+++ b/client/src/controllers/SwapController.ts
@@ -45,8 +45,8 @@ export class SwapController extends Controller<
   static values = {
     icon: { default: '', type: String },
     loading: { default: false, type: Boolean },
-    src: { default: '', type: String },
     reflect: { default: false, type: Boolean },
+    src: { default: '', type: String },
     target: { default: '#listing-results', type: String },
     wait: { default: 200, type: Number },
   };
@@ -58,8 +58,8 @@ export class SwapController extends Controller<
 
   declare iconValue: string;
   declare loadingValue: boolean;
-  declare srcValue: string;
   declare reflectValue: boolean;
+  declare srcValue: string;
   declare targetValue: string;
   declare waitValue: number;
 

--- a/client/src/controllers/UpgradeController.test.js
+++ b/client/src/controllers/UpgradeController.test.js
@@ -44,7 +44,7 @@ describe('UpgradeController', () => {
 
     expect(global.fetch).not.toHaveBeenCalled();
 
-    fetch.mockResponseSuccess(JSON.stringify(data));
+    fetch.mockResponseSuccessJSON(JSON.stringify(data));
 
     // start application
     application = Application.start();
@@ -92,7 +92,7 @@ describe('UpgradeController', () => {
       },
     };
 
-    fetch.mockResponseSuccess(JSON.stringify(data));
+    fetch.mockResponseSuccessJSON(JSON.stringify(data));
 
     expect(global.fetch).not.toHaveBeenCalled();
 

--- a/client/tests/mock-fetch.js
+++ b/client/tests/mock-fetch.js
@@ -2,11 +2,23 @@
 global.fetch = jest.fn();
 global.Headers = jest.fn();
 
-// Helper to mock a success response.
-fetch.mockResponseSuccess = (body) => {
+// Helper to mock a success JSON response.
+fetch.mockResponseSuccessJSON = (body) => {
   fetch.mockImplementationOnce(() =>
     Promise.resolve({
       json: () => Promise.resolve(JSON.parse(body)),
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+    }),
+  );
+};
+
+// Helper to mock a success text response.
+fetch.mockResponseSuccessText = (body) => {
+  fetch.mockImplementationOnce(() =>
+    Promise.resolve({
+      text: () => Promise.resolve(body),
       ok: true,
       status: 200,
       statusText: 'OK',

--- a/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
@@ -2,7 +2,7 @@
 <ul class="w-active-filters">
     {% for filter in active_filters %}
         <li class="w-pill">
-            <button class="w-pill__content" data-controller="w-action" data-w-active-filter-name="{{ filter.auto_id }}" aria-controls="drilldown-{{ filter.auto_id }}">
+            <button class="w-pill__content" data-controller="w-action" data-w-active-filter-id="{{ filter.auto_id }}" aria-controls="drilldown-{{ filter.auto_id }}">
                 <span class="w-text-14">{{ filter.field_label }}:</span>
                 <b class="w-ml-1">{{ filter.value }}</b>
             </button>

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -71,6 +71,7 @@
                         data-action="change->w-swap#submitLazy input->w-swap#submitLazy"
                         data-w-swap-src-value="{{ search_url }}"
                         data-w-swap-target-value="#listing-results"
+                        data-w-swap-reflect-value="true"
                     >
                         {% if search_form %}
                             {% for field in search_form %}
@@ -83,7 +84,7 @@
                                 id="filters-drilldown"
                                 class="w-drilldown"
                                 data-controller="w-drilldown"
-                                data-action="w-swap:success@document->w-drilldown#updateParams w-dropdown:hide->w-drilldown#delayedClose w-dropdown:clickaway->w-drilldown#preventOutletClickaway"
+                                data-action="w-swap:success@document->w-drilldown#updateCount w-dropdown:hide->w-drilldown#delayedClose w-dropdown:clickaway->w-drilldown#preventOutletClickaway"
                                 data-w-drilldown-count-attr-value="data-w-active-filter-name"
                                 data-w-drilldown-w-action-outlet="[data-w-active-filter-name][data-controller='w-action']"
                                 data-w-drilldown-w-dropdown-outlet="#filters-drilldown [data-controller='w-dropdown']"

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -85,8 +85,8 @@
                                 class="w-drilldown"
                                 data-controller="w-drilldown"
                                 data-action="w-swap:success@document->w-drilldown#updateCount w-dropdown:hide->w-drilldown#delayedClose w-dropdown:clickaway->w-drilldown#preventOutletClickaway"
-                                data-w-drilldown-count-attr-value="data-w-active-filter-name"
-                                data-w-drilldown-w-action-outlet="[data-w-active-filter-name][data-controller='w-action']"
+                                data-w-drilldown-count-attr-value="data-w-active-filter-id"
+                                data-w-drilldown-w-action-outlet="[data-w-active-filter-id][data-controller='w-action']"
                                 data-w-drilldown-w-dropdown-outlet="#filters-drilldown [data-controller='w-dropdown']"
                             >
                                 {% include "wagtailadmin/shared/headers/_filters.html" with filters=filters only %}

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -111,7 +111,7 @@ class HeaderButton(Button):
             {
                 "data-controller": "w-tooltip w-link",
                 "data-w-tooltip-content-value": label,
-                "data-action": "w-swap:success@document->w-link#setParamsFromSwapRequest",
+                "data-action": "w-swap:reflect@document->w-link#setParams",
                 "aria-label": label,
             }
         )


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Instead of having `DrilldownController.updateParams` handle the reflection of the URLs to the address bar by detecting when the `w-swap:success` event's target is the (hardcoded) `#listing-results`, move the reflection logic to `SwapController` that can be enabled by setting the `reflect-value` to `true`.

This effectively makes the `SwapController.search` method redundant. The `search` method works by reading the current params, picking out the input element and its value, then manually removing any params that don't belong (e.g. `p`), which is quite brittle. This method is currently only used in the legacy `header.html`.

With the new slim header, we put the search field and the filter fields together in a single `<form>` element, and leverage the `SwapController`'s `submit` mechanism to serialize the form and submit it to the server, much like how a traditional non-AJAX form is submitted. This means other unrelated params e.g. `p` won't be included and will be correctly reset, which saves us from having to handle them separately.

Once all index views have been migrated to use the slim header, we can deprecate the `SwapController.search` method and remove it in a future major release.

---

Also rename `data-w-active-filter-name` to `data-w-active-filter-id` for correctness, since the value is for the `id` not the `name` attribute of the active filter.


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
