### PR TITLE
Reduce memory when rebuilding indexes

### DIFF
--- a/wagtail/management/commands/rebuild_references_index.py
+++ b/wagtail/management/commands/rebuild_references_index.py
@@ -38,7 +38,9 @@ class Command(BaseCommand):
 
         with transaction.atomic():
             with disable_reference_index_auto_update():
-                ReferenceIndex.objects.all().delete()
+                # Use `_raw_delete` to avoid loading instances into memory
+                all_references = ReferenceIndex.objects.all()
+                all_references._raw_delete(using=all_references.db)
 
             for model in apps.get_models():
                 if not ReferenceIndex.is_indexed(model):

--- a/wagtail/search/backends/database/mysql/mysql.py
+++ b/wagtail/search/backends/database/mysql/mysql.py
@@ -276,7 +276,7 @@ class Index:
             update_method(content_type_pk, indexers)
 
     def delete_item(self, item):
-        item.index_entries.using(self.db_alias).delete()
+        item.index_entries.all()._raw_delete(using=self.db_alias)
 
     def __str__(self):
         return self.nam
@@ -662,7 +662,7 @@ class MySQLSearchBackend(BaseSearchBackend):
             for connection in connections.all()
             if connection.vendor == "mysql"
         ]:
-            IndexEntry._default_manager.using(connection.alias).delete()
+            IndexEntry._default_manager.all()._raw_delete(using=connection.alias)
 
     def add_type(self, model):
         pass  # Not needed.

--- a/wagtail/search/backends/database/postgres/postgres.py
+++ b/wagtail/search/backends/database/postgres/postgres.py
@@ -353,7 +353,7 @@ class Index:
             update_method(content_type_pk, indexers)
 
     def delete_item(self, item):
-        item.index_entries.using(self.db_alias).delete()
+        item.index_entries.all()._raw_delete(using=self.db_alias)
 
     def __str__(self):
         return self.name
@@ -762,7 +762,7 @@ class PostgresSearchBackend(BaseSearchBackend):
             for connection in connections.all()
             if connection.vendor == "postgresql"
         ]:
-            IndexEntry._default_manager.using(connection.alias).delete()
+            IndexEntry._default_manager.all()._raw_delete(using=connection.alias)
 
     def add_type(self, model):
         pass  # Not needed.

--- a/wagtail/search/backends/database/sqlite/sqlite.py
+++ b/wagtail/search/backends/database/sqlite/sqlite.py
@@ -270,7 +270,7 @@ class Index:
             update_method(content_type_pk, indexers)
 
     def delete_item(self, item):
-        item.index_entries.using(self.db_alias).delete()
+        item.index_entries.all()._raw_delete(using=self.db_alias)
 
     def __str__(self):
         return self.name
@@ -685,7 +685,7 @@ class SQLiteSearchBackend(BaseSearchBackend):
             for connection in connections.all()
             if connection.vendor == "sqlite"
         ]:
-            IndexEntry._default_manager.using(connection.alias).delete()
+            IndexEntry._default_manager.all()._raw_delete(using=connection.alias)
 
     def add_type(self, model):
         pass  # Not needed.


### PR DESCRIPTION
Reduce the memory usage and increase performance when rebuilding indexes.

`_raw_delete` doesn't run signals or other referential integrity checks, but also doesn't use Django's mechanisms which load deleting models into memory. In most cases, we don't want this when rebuilding the index, so use `_raw_delete` to streamline the process.

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
