### PR TITLE
Fix Links of RichTextField in CustomImage

### DIFF
--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -9,7 +9,7 @@
 
 {% block extra_js %}
     {{ block.super }}
-
+    {% include "wagtailadmin/pages/_editor_js.html" %}
     {{ form.media.js }}
 
     <!-- Focal point chooser -->


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11421 , Fixes #10377
these two issues  are  same ,
these issues just because draftail `RichTextField ` not have access to ` chooserUrls` and other scripts inside` _editor_js.html`  to complete its initialization(this issue not only for Links but also for others widget chooser like Documents  ), so this error occur
Before:

![Before](https://github.com/wagtail/wagtail/assets/90080237/f1ad0c92-ec22-4bc5-ae13-2e2fda5449f0)

now `RichTextField` simply have access to ` _editor_js.html`  and could have `Links` and other choosers like `Documents`  and `Images ` as show below
After:  

![After](https://github.com/wagtail/wagtail/assets/90080237/8c4d22a8-3063-475d-aaac-9819ecb0b623)


_Please check the following:_

-   ✅ Do the tests still pass?[^1]
-   ✅ Does the code comply with the style guide?
    -   ✅ Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
