### PR TITLE
6853 allow search user with custom fields

### DIFF
--- a/wagtail/test/customuser/models.py
+++ b/wagtail/test/customuser/models.py
@@ -13,6 +13,7 @@ from django.db import models
 from wagtail.admin.auth import permission_denied  # noqa: F401
 from wagtail.admin.panels import FieldPanel
 from wagtail.admin.views.generic import chooser as chooser_views  # noqa: F401
+from wagtail.search import index
 
 from .fields import ConvertedValueField
 
@@ -55,7 +56,7 @@ class CustomUserManager(BaseUserManager):
         return self._create_user(username, email, password, True, True, **extra_fields)
 
 
-class CustomUser(AbstractBaseUser, PermissionsMixin):
+class CustomUser(index.Indexed, AbstractBaseUser, PermissionsMixin):
     identifier = ConvertedValueField(primary_key=True)
     username = models.CharField(max_length=100, unique=True)
     email = models.EmailField(max_length=255, blank=True)
@@ -80,4 +81,10 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
     panels = [
         FieldPanel("first_name"),
         FieldPanel("last_name"),
+    ]
+
+    search_fields = [
+        index.SearchField("country", partial_match=True),
+        index.SearchField("first_name"),
+        index.SearchField("last_name"),
     ]

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -239,6 +239,50 @@ class TestUserIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         results = response.context["users"]
         self.assertIn(self.test_user, results)
 
+    @unittest.skipUnless(
+        settings.AUTH_USER_MODEL == "customuser.CustomUser",
+        "Only applicable to CustomUser",
+    )
+    @override_settings(
+        WAGTAIL_USER_CREATION_FORM="wagtail.users.tests.CustomUserCreationForm",
+        WAGTAIL_USER_CUSTOM_FIELDS=["country", "document"],
+    )
+    def test_search_query_one_searchable_field(self):
+        custom_user_with_country = self.create_user(
+            username="testjoe",
+            email="testjoe@email.com",
+            password="password",
+            first_name="Joe",
+            last_name="Doe",
+            country="testcountry",
+        )
+        response = self.get({"q": "country"})
+        self.assertEqual(response.status_code, 200)
+        results = response.context["users"]
+        self.assertIn(custom_user_with_country, results)
+
+    @unittest.skipUnless(
+        settings.AUTH_USER_MODEL == "customuser.CustomUser",
+        "Only applicable to CustomUser",
+    )
+    @override_settings(
+        WAGTAIL_USER_CREATION_FORM="wagtail.users.tests.CustomUserCreationForm",
+        WAGTAIL_USER_CUSTOM_FIELDS=["country", "document"],
+    )
+    def test_search_query_searchable_multiple_fields(self):
+        custom_user_with_country = self.create_user(
+            username="testjoe",
+            email="testjoe@email.com",
+            password="password",
+            first_name="Joe",
+            last_name="Doe",
+            country="testcountry",
+        )
+        response = self.get({"q": "country joe doe"})
+        self.assertEqual(response.status_code, 200)
+        results = response.context["users"]
+        self.assertIn(custom_user_with_country, results)
+
     def test_search_query_multiple_fields(self):
         response = self.get({"q": "first name last name"})
         self.assertEqual(response.status_code, 200)

--- a/wagtail/users/views/bulk_actions/user_bulk_action.py
+++ b/wagtail/users/views/bulk_actions/user_bulk_action.py
@@ -3,6 +3,8 @@ from django.contrib.auth import get_user_model
 from wagtail.admin.views.bulk_action import BulkAction
 from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
 from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.search.backends import get_search_backend
+from wagtail.search.index import class_is_indexed
 from wagtail.users.views.users import get_users_filter_query
 
 User = get_user_model()
@@ -17,9 +19,15 @@ class UserBulkAction(PermissionCheckedMixin, BulkAction):
         listing_objects = self.model.objects.all().values_list("pk", flat=True)
         if "q" in self.request.GET:
             q = self.request.GET.get("q")
-            model_fields = {f.name for f in self.model._meta.get_fields()}
-            conditions = get_users_filter_query(q, model_fields)
+            if class_is_indexed(self.model):
+                search_backend = get_search_backend()
+                listing_objects = search_backend.search(
+                    q, User.objects.filter(self.group_filter)
+                )
+            else:
+                model_fields = {f.name for f in self.model._meta.get_fields()}
+                conditions = get_users_filter_query(q, model_fields)
 
-            listing_objects = listing_objects.filter(conditions)
+                listing_objects = listing_objects.filter(conditions)
 
         return listing_objects

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -1,3 +1,5 @@
+import operator
+from functools import reduce
 from warnings import warn
 
 import django_filters
@@ -36,6 +38,8 @@ from wagtail.admin.widgets.button import (
 )
 from wagtail.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 from wagtail.coreutils import accepts_kwarg
+from wagtail.search.backends import get_search_backend
+from wagtail.search.index import class_is_indexed
 from wagtail.users.forms import UserCreationForm, UserEditForm
 from wagtail.users.utils import user_can_delete_user
 from wagtail.utils.deprecation import RemovedInWagtail70Warning
@@ -84,6 +88,13 @@ def get_user_edit_form():
 
 def get_users_filter_query(q, model_fields):
     conditions = Q()
+    custom_fields_lookups = {}
+
+    if hasattr(User, "search_fields"):
+        custom_fields_lookups = [
+            "%s__icontains" % str(search_field.field_name)
+            for search_field in User.search_fields
+        ]
 
     for term in q.split():
         if "username" in model_fields:
@@ -98,6 +109,11 @@ def get_users_filter_query(q, model_fields):
         if "email" in model_fields:
             conditions |= Q(email__icontains=term)
 
+        if len(custom_fields_lookups) > 0:
+            or_queries = [
+                Q(**{custom_field: term}) for custom_field in custom_fields_lookups
+            ]
+            conditions |= reduce(operator.or_, or_queries)
     return conditions
 
 
@@ -269,6 +285,14 @@ class IndexView(generic.IndexView):
 
     def search_queryset(self, queryset):
         if self.is_searching:
+            # Filtering by related fields is not supported in search backend yet
+            # https://docs.wagtail.org/en/stable/topics/search/indexing.html#filtering-on-index-relatedfields
+            if class_is_indexed(User) and not self.filters.form.cleaned_data.get(
+                "group"
+            ):
+                search_backend = get_search_backend(self.search_backend_name)
+                return search_backend.search(self.search_query, User.objects.filter())
+
             conditions = get_users_filter_query(self.search_query, self.model_fields)
             return queryset.filter(conditions)
         return queryset


### PR DESCRIPTION
Resolves: #6853

Follow-up from  #6915.

With this PR, you can search users by custom fields using `search_fields`.

* Add the `search_fields` to the custom user for use in the tests.
* Add the tests to verify the functionality.
* Add the code to search using `search_fields`

