### PR TITLE
Add more tests to new Stimulus controller behaviours

### DIFF
--- a/client/src/controllers/DropdownController.test.js
+++ b/client/src/controllers/DropdownController.test.js
@@ -6,8 +6,8 @@ jest.useFakeTimers();
 describe('DropdownController', () => {
   let application;
 
-  beforeEach(async () => {
-    document.body.innerHTML = `
+  const setup = async (
+    html = `
 <section>
   <div data-controller="w-dropdown" data-w-dropdown-theme-value="dropdown" data-action="custom:show->w-dropdown#show custom:hide->w-dropdown#hide">
     <button id="toggle" type="button" data-w-dropdown-target="toggle" aria-label="Actions"></button>
@@ -15,7 +15,9 @@ describe('DropdownController', () => {
       <a href="/">Option</a>
     </div>
   </div>
-</section>`;
+</section>`,
+  ) => {
+    document.body.innerHTML = html;
 
     application = Application.start();
     application.register('w-dropdown', DropdownController);
@@ -33,6 +35,10 @@ describe('DropdownController', () => {
           .getControllerForElementAndIdentifier(element, 'w-dropdown')
           .tippy.setProps({ duration: 0 }); // tippy will merge props with whatever has already been set
       });
+  };
+
+  beforeEach(async () => {
+    await setup();
   });
 
   afterEach(() => {
@@ -131,7 +137,6 @@ describe('DropdownController', () => {
       .setAttribute('data-w-dropdown-offset-value', '[12,24]');
 
     application = Application.start();
-    application = Application.start();
     application.register('w-dropdown', DropdownController);
 
     await Promise.resolve();
@@ -142,5 +147,66 @@ describe('DropdownController', () => {
     ).tippy;
 
     expect(tippy.props).toHaveProperty('offset', [12, 24]);
+  });
+
+  describe('with keep-mounted-value set to true', () => {
+    beforeEach(async () => {
+      application?.stop();
+      await setup(`
+        <section>
+          <div data-controller="w-dropdown" data-w-dropdown-theme-value="dropdown" data-w-dropdown-keep-mounted-value="true" data-action="custom:show->w-dropdown#show custom:hide->w-dropdown#hide">
+            <button id="toggle" type="button" data-w-dropdown-target="toggle" aria-label="Actions"></button>
+            <div data-w-dropdown-target="content">
+              <a href="/">Option</a>
+            </div>
+          </div>
+        </section>`);
+    });
+
+    it('initialises Tippy.js on connect and keeps the content mounted in the DOM', async () => {
+      expect(document.querySelectorAll('[role="tooltip"]')).toHaveLength(1);
+      const toggle = document.querySelector(
+        '[data-w-dropdown-target="toggle"]',
+      );
+      await Promise.resolve();
+      expect(toggle.getAttribute('aria-expanded')).toBe('false');
+
+      const content = document.querySelector(
+        '[data-controller="w-dropdown"] [data-w-dropdown-target="content"]',
+      );
+      expect(content.innerHTML).toContain('<a href="/">Option</a>');
+
+      toggle.dispatchEvent(new Event('click'));
+
+      const expandedContent = document.querySelectorAll('[role="tooltip"]');
+      expect(expandedContent).toHaveLength(1);
+
+      expect(expandedContent[0].innerHTML).toContain('<a href="/">Option</a>');
+    });
+
+    it('should support methods to show and hide the dropdown while keeping the content in the DOM', async () => {
+      expect(document.querySelectorAll('[role="tooltip"]')).toHaveLength(1);
+
+      const dropdownElement = document.querySelector(
+        '[data-controller="w-dropdown"]',
+      );
+
+      dropdownElement.dispatchEvent(new CustomEvent('custom:show'));
+
+      expect(document.querySelectorAll('[role="tooltip"]')).toHaveLength(1);
+
+      dropdownElement.dispatchEvent(new CustomEvent('custom:hide'));
+
+      expect(document.querySelectorAll('[role="tooltip"]')).toHaveLength(1);
+
+      const toggle = document.querySelector(
+        '[data-w-dropdown-target="toggle"]',
+      );
+      const content = document.querySelector(
+        '[data-controller="w-dropdown"] [data-w-dropdown-target="content"]',
+      );
+      expect(toggle.getAttribute('aria-expanded')).toBe('false');
+      expect(content.innerHTML).toContain('<a href="/">Option</a>');
+    });
   });
 });

--- a/client/src/controllers/LinkController.test.js
+++ b/client/src/controllers/LinkController.test.js
@@ -1,0 +1,429 @@
+import { Application } from '@hotwired/stimulus';
+import { LinkController } from './LinkController';
+
+describe('LinkController', () => {
+  let app;
+  const oldWindowLocation = window.location;
+
+  const setWindowLocation = (url) => {
+    delete window.location;
+    window.location = new URL(url);
+  };
+
+  beforeEach(() => {
+    app = Application.start();
+    app.register('w-link', LinkController);
+  });
+
+  afterEach(() => {
+    app?.stop();
+    jest.clearAllMocks();
+    window.location = oldWindowLocation;
+  });
+
+  describe('basic behaviour on connect', () => {
+    it('should reflect all params by default', async () => {
+      setWindowLocation(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok',
+      );
+      expect(window.location.href).toEqual(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok',
+      );
+
+      document.body.innerHTML = `
+        <a
+          id="link"
+          href="/admin/something/"
+          data-controller="w-link"
+        >
+          Reflective link
+        </a>
+      `;
+
+      // Trigger next browser render cycle
+      await Promise.resolve();
+
+      // All params are reflected as-is, including multi-value and empty params
+      // and the relative URL is resolved against the current URL
+      expect(document.getElementById('link').href).toEqual(
+        'http://localhost:8000/admin/something/?foo=bar&foo=baz&hello=&world=ok',
+      );
+      // The current URL is not changed
+      expect(window.location.href).toEqual(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok',
+      );
+    });
+
+    it('should only apply params in reflect-keys-value', async () => {
+      setWindowLocation(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok',
+      );
+      expect(window.location.href).toEqual(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok',
+      );
+
+      document.body.innerHTML = `
+        <a
+          id="link"
+          href="/admin/something/"
+          data-controller="w-link"
+          data-w-link-reflect-keys-value='["foo", "hello"]'
+        >
+          Selectively reflective link
+        </a>
+      `;
+
+      // Trigger next browser render cycle
+      await Promise.resolve();
+
+      // Only the specified params are reflected
+      expect(document.getElementById('link').href).toEqual(
+        'http://localhost:8000/admin/something/?foo=bar&foo=baz&hello=',
+      );
+      // The current URL is not changed
+      expect(window.location.href).toEqual(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok',
+      );
+    });
+
+    it('should preserve params in preserve-keys-value', async () => {
+      setWindowLocation(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok&a=z',
+      );
+      expect(window.location.href).toEqual(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok&a=z',
+      );
+
+      document.body.innerHTML = `
+        <a
+          id="link"
+          href="/admin/something/?export=xlsx&export=csv&foo=fii&number=1&a=b"
+          data-controller="w-link"
+          data-w-link-preserve-keys-value='["export", "foo"]'
+        >
+          Reflective link with preserve-keys-value
+        </a>
+      `;
+
+      // Trigger next browser render cycle
+      await Promise.resolve();
+
+      // Behaviour:
+      // - `export` param preserved (multi-value, not in new URL)
+      // - `foo` param preserved (single value, available in new URL)
+      // - `number` param not preserved (single value, not in new URL)
+      // - `hello` param reflected (empty value, only available in new URL)
+      // - `world` param reflected (single value, only available in new URL)
+      // - `a` param reflected (single value, available in both, taken from new URL)
+      expect(document.getElementById('link').href).toEqual(
+        'http://localhost:8000/admin/something/?hello=&world=ok&a=z&export=xlsx&export=csv&foo=fii',
+      );
+      // The current URL is not changed
+      expect(window.location.href).toEqual(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok&a=z',
+      );
+    });
+
+    it('should reflect only the keys in reflect-keys-value and keep keys in preserve-keys-value', async () => {
+      setWindowLocation(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok&a=z',
+      );
+      expect(window.location.href).toEqual(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok&a=z',
+      );
+
+      document.body.innerHTML = `
+        <a
+          id="link"
+          href="/admin/something/?export=xlsx&export=csv&foo=fii&number=1&a=b"
+          data-controller="w-link"
+          data-w-link-reflect-keys-value='["hello", "a"]'
+          data-w-link-preserve-keys-value='["export", "foo"]'
+        >
+          Reflective link with reflect-keys-value and preserve-keys-value
+        </a>
+      `;
+
+      // Trigger next browser render cycle
+      await Promise.resolve();
+
+      // Behaviour:
+      // - `export` param preserved (multi-value, not in new URL)
+      // - `foo` param preserved (single value, available in new URL)
+      // - `number` param not preserved (single value, not in new URL)
+      // - `hello` param reflected (empty value, only available in new URL)
+      // - `world` param not reflected (single value, only available in new URL)
+      // - `a` param reflected (single value, available in both, taken from new URL)
+      expect(document.getElementById('link').href).toEqual(
+        'http://localhost:8000/admin/something/?hello=&a=z&export=xlsx&export=csv&foo=fii',
+      );
+      // The current URL is not changed
+      expect(window.location.href).toEqual(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok&a=z',
+      );
+    });
+  });
+
+  describe('handling an event with requestUrl in the detail', () => {
+    it('should reflect all params by default', async () => {
+      expect(window.location.href).toEqual('http://localhost/');
+
+      document.body.innerHTML = `
+        <a
+          id="link"
+          href="/admin/something/"
+          data-controller="w-link"
+          data-action="w-swap:reflect@document->w-link#setParams"
+        >
+          Reflective link
+        </a>
+      `;
+
+      // Trigger next browser render cycle
+      await Promise.resolve();
+
+      document.dispatchEvent(
+        new CustomEvent('w-swap:reflect', {
+          detail: {
+            requestUrl:
+              'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok',
+          },
+        }),
+      );
+
+      // All params are reflected as-is, including multi-value and empty params
+      // and the relative URL is resolved against the current URL
+      expect(document.getElementById('link').href).toEqual(
+        'http://localhost/admin/something/?foo=bar&foo=baz&hello=&world=ok',
+      );
+    });
+
+    it('should only apply params in reflect-keys-value', async () => {
+      expect(window.location.href).toEqual('http://localhost/');
+
+      document.body.innerHTML = `
+        <a
+          id="link"
+          href="/admin/something/"
+          data-controller="w-link"
+          data-w-link-reflect-keys-value='["foo", "hello"]'
+          data-action="w-swap:reflect@document->w-link#setParams"
+        >
+          Selectively reflective link
+        </a>
+      `;
+
+      // Trigger next browser render cycle
+      await Promise.resolve();
+
+      document.dispatchEvent(
+        new CustomEvent('w-swap:reflect', {
+          detail: {
+            requestUrl:
+              'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok',
+          },
+        }),
+      );
+
+      // Only the specified params are reflected
+      expect(document.getElementById('link').href).toEqual(
+        'http://localhost/admin/something/?foo=bar&foo=baz&hello=',
+      );
+    });
+
+    it('should preserve params in preserve-keys-value', async () => {
+      expect(window.location.href).toEqual('http://localhost/');
+
+      document.body.innerHTML = `
+        <a
+          id="link"
+          href="/admin/something/?export=xlsx&export=csv&foo=fii&number=1&a=b"
+          data-controller="w-link"
+          data-w-link-preserve-keys-value='["export", "foo"]'
+          data-action="w-swap:reflect@document->w-link#setParams"
+        >
+          Reflective link with preserve-keys-value
+        </a>
+      `;
+
+      // Trigger next browser render cycle
+      await Promise.resolve();
+
+      document.dispatchEvent(
+        new CustomEvent('w-swap:reflect', {
+          detail: {
+            requestUrl:
+              'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok&a=z',
+          },
+        }),
+      );
+
+      // Behaviour:
+      // - `export` param preserved (multi-value, not in new URL)
+      // - `foo` param preserved (single value, available in new URL)
+      // - `number` param not preserved (single value, not in new URL)
+      // - `hello` param reflected (empty value, only available in new URL)
+      // - `world` param reflected (single value, only available in new URL)
+      // - `a` param reflected (single value, available in both, taken from new URL)
+      expect(document.getElementById('link').href).toEqual(
+        'http://localhost/admin/something/?hello=&world=ok&a=z&export=xlsx&export=csv&foo=fii',
+      );
+    });
+
+    it('should reflect only the keys in reflect-keys-value and keep keys in preserve-keys-value', async () => {
+      expect(window.location.href).toEqual('http://localhost/');
+
+      document.body.innerHTML = `
+        <a
+          id="link"
+          href="/admin/something/?export=xlsx&export=csv&foo=fii&number=1&a=b"
+          data-controller="w-link"
+          data-w-link-reflect-keys-value='["hello", "a"]'
+          data-w-link-preserve-keys-value='["export", "foo"]'
+          data-action="w-swap:reflect@document->w-link#setParams"
+        >
+          Reflective link with reflect-keys-value and preserve-keys-value
+        </a>
+      `;
+
+      // Trigger next browser render cycle
+      await Promise.resolve();
+
+      document.dispatchEvent(
+        new CustomEvent('w-swap:reflect', {
+          detail: {
+            requestUrl:
+              'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok&a=z',
+          },
+        }),
+      );
+
+      // Behaviour:
+      // - `export` param preserved (multi-value, not in new URL)
+      // - `foo` param preserved (single value, available in new URL)
+      // - `number` param not preserved (single value, not in new URL)
+      // - `hello` param reflected (empty value, only available in new URL)
+      // - `world` param not reflected (single value, only available in new URL)
+      // - `a` param reflected (single value, available in both, taken from new URL)
+      expect(document.getElementById('link').href).toEqual(
+        'http://localhost/admin/something/?hello=&a=z&export=xlsx&export=csv&foo=fii',
+      );
+    });
+  });
+
+  describe('handling an event without requestUrl in the detail', () => {
+    it('should not reflect any params', async () => {
+      expect(window.location.href).toEqual('http://localhost/');
+
+      document.body.innerHTML = `
+        <a
+          id="link"
+          href="/admin/something/"
+          data-controller="w-link"
+          data-action="custom:event@document->w-link#setParams"
+        >
+          Reflective link
+        </a>
+      `;
+
+      // Trigger next browser render cycle
+      await Promise.resolve();
+
+      document.dispatchEvent(
+        new CustomEvent('custom:event', {
+          detail: {
+            something: 'else',
+          },
+        }),
+      );
+
+      // Should not change the href
+      expect(document.getElementById('link').href).toEqual(
+        'http://localhost/admin/something/',
+      );
+    });
+  });
+
+  describe('using a custom attr-name-value for the link', () => {
+    it('should reflect the params from the current URL to the link in the specified attribute', async () => {
+      setWindowLocation(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok&a=z',
+      );
+      expect(window.location.href).toEqual(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok&a=z',
+      );
+
+      document.body.innerHTML = `
+        <button
+          id="button"
+          data-target-url="/admin/something/?export=xlsx&export=csv&foo=fii&number=1&a=b"
+          data-controller="w-link"
+          data-w-link-attr-name-value="data-target-url"
+          data-w-link-reflect-keys-value='["hello", "a"]'
+          data-w-link-preserve-keys-value='["export", "foo"]'
+        >
+          Reflective link with attr-name-value, reflect-keys-value, and preserve-keys-value
+        </button>
+      `;
+
+      // Trigger next browser render cycle
+      await Promise.resolve();
+
+      // Behaviour:
+      // - `export` param preserved (multi-value, not in new URL)
+      // - `foo` param preserved (single value, available in new URL)
+      // - `number` param not preserved (single value, not in new URL)
+      // - `hello` param reflected (empty value, only available in new URL)
+      // - `world` param not reflected (single value, only available in new URL)
+      // - `a` param reflected (single value, available in both, taken from new URL)
+      expect(document.getElementById('button').dataset.targetUrl).toEqual(
+        'http://localhost:8000/admin/something/?hello=&a=z&export=xlsx&export=csv&foo=fii',
+      );
+      // The current URL is not changed
+      expect(window.location.href).toEqual(
+        'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok&a=z',
+      );
+    });
+
+    it("should reflect the params from the event's requestUrl to the link in the specified attribute", async () => {
+      expect(window.location.href).toEqual('http://localhost/');
+
+      document.body.innerHTML = `
+        <button
+          id="button"
+          data-target-url="/admin/something/?export=xlsx&export=csv&foo=fii&number=1&a=b"
+          data-controller="w-link"
+          data-w-link-attr-name-value="data-target-url"
+          data-w-link-reflect-keys-value='["hello", "a"]'
+          data-w-link-preserve-keys-value='["export", "foo"]'
+          data-action="w-swap:reflect@document->w-link#setParams"
+        >
+          Reflective link with attr-name-value, reflect-keys-value, and preserve-keys-value
+        </button>
+      `;
+
+      // Trigger next browser render cycle
+      await Promise.resolve();
+
+      document.dispatchEvent(
+        new CustomEvent('w-swap:reflect', {
+          detail: {
+            requestUrl:
+              'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok&a=z',
+          },
+        }),
+      );
+
+      // Behaviour:
+      // - `export` param preserved (multi-value, not in new URL)
+      // - `foo` param preserved (single value, available in new URL)
+      // - `number` param not preserved (single value, not in new URL)
+      // - `hello` param reflected (empty value, only available in new URL)
+      // - `world` param not reflected (single value, only available in new URL)
+      // - `a` param reflected (single value, available in both, taken from new URL)
+      expect(document.getElementById('button').dataset.targetUrl).toEqual(
+        'http://localhost/admin/something/?hello=&a=z&export=xlsx&export=csv&foo=fii',
+      );
+    });
+  });
+});

--- a/client/src/controllers/TeleportController.test.js
+++ b/client/src/controllers/TeleportController.test.js
@@ -116,6 +116,55 @@ describe('TeleportController', () => {
       );
     });
 
+    it('should clear the target container if the reset value is set to true', async () => {
+      document.body.innerHTML += `
+        <div id="target-container"><p>I should not be here</p></div>
+        `;
+
+      const template = document.querySelector('template');
+      template.setAttribute(
+        'data-w-teleport-target-value',
+        '#target-container',
+      );
+      template.setAttribute('data-w-teleport-reset-value', 'true');
+
+      expect(document.getElementById('target-container').innerHTML).toEqual(
+        '<p>I should not be here</p>',
+      );
+
+      application.start();
+
+      await Promise.resolve();
+
+      expect(document.getElementById('target-container').innerHTML).toEqual(
+        '<div id="content">Some content</div>',
+      );
+    });
+
+    it('should not clear the target container if the reset value is unset (false)', async () => {
+      document.body.innerHTML += `
+        <div id="target-container"><p>I should still be here</p></div>
+        `;
+
+      const template = document.querySelector('template');
+      template.setAttribute(
+        'data-w-teleport-target-value',
+        '#target-container',
+      );
+
+      expect(document.getElementById('target-container').innerHTML).toEqual(
+        '<p>I should still be here</p>',
+      );
+
+      application.start();
+
+      await Promise.resolve();
+
+      expect(document.getElementById('target-container').innerHTML).toEqual(
+        '<p>I should still be here</p><div id="content">Some content</div>',
+      );
+    });
+
     it('should throw an error if the template content is empty', async () => {
       const errors = [];
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Incorporates #11559, adds tests for:

- `w-teleport-reset-value`
- `w-link`
- `w-dropdown-keep-mounted-value`

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
