### PR TITLE
Fix/5919 nested inline panels ordering buttons

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Fix: Fix typo in `__str__` for MySQL search index (Jake Howard)
  * Fix: Ensure that unit tests correctly check for migrations in all core Wagtail apps (Matt Westcott)
  * Fix: Correctly handle `date` objects on `human_readable_date` template tag (Jhonatan Lopes)
+ * Fix: Ensure re-ordering buttons work correctly when using a nested InlinePanel (Adrien Hamraoui)
  * Docs: Add contributing development documentation on how to work with a fork of Wagtail (Nix Asteri, Dan Braghis)
  * Docs: Make sure the settings panel is listed in tabbed interface examples (Tibor Leupold)
  * Docs: Update multiple pages in the reference sections and multiple page names to their US spelling instead of UK spelling (Victoria Poromon)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -798,6 +798,7 @@
 * Hossein
 * Andre Delorme
 * arshyia3000
+* Adrien Hamraoui
 
 ## Translators
 

--- a/client/src/components/InlinePanel/index.js
+++ b/client/src/components/InlinePanel/index.js
@@ -52,8 +52,10 @@ export class InlinePanel extends ExpandingFormset {
     const childId = 'inline_child_' + prefix;
     const deleteInputId = 'id_' + prefix + '-DELETE';
     const currentChild = $('#' + childId);
-    const $up = currentChild.find('[data-inline-panel-child-move-up]');
-    const $down = currentChild.find('[data-inline-panel-child-move-down]');
+    const $up = currentChild.find('[data-inline-panel-child-move-up]:first ');
+    const $down = currentChild.find(
+      '[data-inline-panel-child-move-down]:first ',
+    );
 
     $('#' + deleteInputId + '-button').on('click', () => {
       /* set 'deleted' form field to true */
@@ -148,8 +150,14 @@ export class InlinePanel extends ExpandingFormset {
       forms.each(function updateButtonStates(i) {
         const isFirst = i === 0;
         const isLast = i === forms.length - 1;
-        $('[data-inline-panel-child-move-up]', this).prop('disabled', isFirst);
-        $('[data-inline-panel-child-move-down]', this).prop('disabled', isLast);
+        $('[data-inline-panel-child-move-up]:first', this).prop(
+          'disabled',
+          isFirst,
+        );
+        $('[data-inline-panel-child-move-down]:first', this).prop(
+          'disabled',
+          isLast,
+        );
       });
     }
   }

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -25,6 +25,7 @@ depth: 1
  * Fix typo in `__str__` for MySQL search index (Jake Howard)
  * Ensure that unit tests correctly check for migrations in all core Wagtail apps (Matt Westcott)
  * Correctly handle `date` objects on `human_readable_date` template tag (Jhonatan Lopes)
+ * Ensure re-ordering buttons work correctly when using a nested InlinePanel (Adrien Hamraoui)
 
 
 ### Documentation


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #5919







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**:
        - Firefox 115.7.0esr on Debian GNU/Linux 12 (bookworm)
        - Chromium 121.0.6167.85 on Debian GNU/Linux 12 (bookworm)
    -   [ ] **Please list which assistive technologies [^3] you tested**: None
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

This change can be tested on the admin interface, when there are nested inline panels.

Example is available on this repo https://github.com/hamadr/bakerydemo/tree/fix/5919-nested-inline-panels-ordering-buttons  (branch `fix/5919-nested-inline-panels-ordering-buttons`) based on https://github.com/wagtail/bakerydemo/

Steps to reproduce are :
- launch the bakery demo after running all of the migrations
- Go to the admin page to edit a country (http://127.0.0.1:8000/admin/snippets/breads/country/edit/24/ for example)
- Add a hierarchy of regions/cities and save
- Play with the up and down arrows

Without the fix : cities up/down arrows move also the regions + cities up/down arrows are in the same state as their parent's up/down arrow

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
