### PR TITLE
Fix TestForMigrations to catch missing migrations on core app

### DIFF
--- a/wagtail/tests/test_migrations.py
+++ b/wagtail/tests/test_migrations.py
@@ -16,7 +16,7 @@ class TestForMigrations(TestCase):
         app_labels = {
             app.label
             for app in apps.get_app_configs()
-            if app.name.startswith("wagtail.")
+            if app.name.split(".")[0] == "wagtail"
         }
         for app_label in app_labels:
             apps.get_app_config(app_label.split(".")[-1])


### PR DESCRIPTION
See #11572

The core app is now named `wagtail`, which means that the old test of `app.name.startswith("wagtail.")` causes it to be left off the list.

(To test, make an arbitrary change to a model definition in `wagtail/models` without a corresponding migration, run `./runtests.py wagtail.tests.test_migrations` and confirm that the test fails.)