### PR TITLE
Fix pagination links on history and usage views

### DIFF
--- a/wagtail/admin/views/generic/history.py
+++ b/wagtail/admin/views/generic/history.py
@@ -63,6 +63,7 @@ class HistoryView(PermissionCheckedMixin, BaseListingView):
     any_permission_required = ["add", "change", "delete"]
     page_title = gettext_lazy("History")
     results_template_name = "wagtailadmin/generic/history_results.html"
+    history_url_name = None
     history_results_url_name = None
     header_icon = "history"
     is_searchable = False
@@ -121,9 +122,16 @@ class HistoryView(PermissionCheckedMixin, BaseListingView):
         if self.edit_url_name:
             return reverse(self.edit_url_name, args=(quote(instance.pk),))
 
+    def get_history_url(self, instance):
+        if self.history_url_name:
+            return reverse(self.history_url_name, args=(quote(instance.pk),))
+
     def get_history_results_url(self, instance):
         if self.history_results_url_name:
             return reverse(self.history_results_url_name, args=(quote(instance.pk),))
+
+    def get_index_url(self):  # used for pagination links
+        return self.get_history_url(self.object)
 
     def get_index_results_url(self):
         return self.get_history_results_url(self.object)

--- a/wagtail/admin/views/generic/usage.py
+++ b/wagtail/admin/views/generic/usage.py
@@ -25,6 +25,7 @@ class UsageView(PermissionCheckedMixin, BaseObjectMixin, BaseListingView):
     page_title = gettext_lazy("Usage")
     index_url_name = None
     edit_url_name = None
+    usage_url_name = None
     permission_required = "change"
 
     @cached_property
@@ -39,6 +40,13 @@ class UsageView(PermissionCheckedMixin, BaseObjectMixin, BaseListingView):
 
     def get_edit_url(self):
         return reverse(self.edit_url_name, args=(quote(self.object.pk),))
+
+    def get_usage_url(self, instance):
+        if self.usage_url_name:
+            return reverse(self.usage_url_name, args=(quote(instance.pk),))
+
+    def get_index_url(self):  # used for pagination links
+        return self.get_usage_url(self.object)
 
     def get_page_subtitle(self):
         return get_latest_str(self.object)


### PR DESCRIPTION
Fixes #11569

Override `get_index_url` to point to the listing's own URL, so that BaseListingView uses this to generate pagination links.
