### PR TITLE
Enable the option to disable shared passwords

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
  * Add RelatedObjectsColumn to the table UI framework (Matt Westcott)
  * Reduce memory usage when rebuilding search indexes (Jake Howard)
  * Support creating images in .ico format (Jake Howard)
+ * Add the ability to disable the usage of a shared password for enhanced security for the private pages and collections (documents) feature (Salvo Polizzi, Jake Howard)
  * Fix: Fix typo in `__str__` for MySQL search index (Jake Howard)
  * Fix: Ensure that unit tests correctly check for migrations in all core Wagtail apps (Matt Westcott)
  * Fix: Correctly handle `date` objects on `human_readable_date` template tag (Jhonatan Lopes)

--- a/docs/advanced_topics/privacy.md
+++ b/docs/advanced_topics/privacy.md
@@ -8,13 +8,53 @@ Users with publish permission on a page can set it to be private by clicking the
 -   **Accessible with a shared password:** The user must enter the given shared password to view the page. This is appropriate for situations where you want to share a page with a trusted group of people, but giving them individual user accounts would be overkill. The same password is shared between all users, and this works independently of any user accounts that exist on the site.
 -   **Accessible to users in specific groups:** The user must be logged in, and a member of one or more of the specified groups, in order to view the page.
 
+```{warning}
+Shared passwords should not be used to protect sensitive content, as the password is shared between all users, and stored in plain text in the database. Where possible, it's recommended to require users log in to access private page content.
+```
+
+You can disable shared password for pages using `WAGTAIL_ALLOW_SHARED_PASSWORD_PAGE`.
+
+```python
+WAGTAIL_ALLOW_SHARED_PASSWORD_PAGE = False
+```
+
+Any existing shared password usage will remain active but will not be viewable by the user within the admin, these can be removed in the Django shell as follows.
+
+```py
+from wagtail.models import Page
+
+for page in Page.objects.private():
+   page.get_view_restrictions().filter(restriction_type='password').delete()
+```
+
+(private_collections)=
+
+## Private collections (restricting documents)
+
 Similarly, documents can be made private by placing them in a collection with appropriate privacy settings (see: [](image_document_permissions)).
 
-Private pages and documents work on Wagtail out of the box - the site implementer does not need to do anything to set them up. However, the default "login" and "password required" forms are only bare-bones HTML pages, and site implementers may wish to replace them with a page customized to their site design.
+You can also disable shared password for collections (which will impact document links) using `WAGTAIL_ALLOW_SHARED_PASSWORD_COLLECTION`.
+
+```python
+WAGTAIL_ALLOW_SHARED_PASSWORD_COLLECTION = False
+```
+
+Any existing shared password usage will remain active but will not be viewable within the admin, these can be removed in the Django shell as follows.
+
+```py
+from wagtail.models import Collection
+
+for collection in Collection.objects.all():
+    collection.get_view_restrictions().filter(restriction_type='password').delete()
+```
 
 (login_page)=
 
 ## Setting up a login page
+
+Private pages and collections (restricting documents) work on Wagtail out of the box - the site implementer does not need to do anything to set them up.
+
+However, the default "login" and "password required" forms are only bare-bones HTML pages, and site implementers may wish to replace them with a page customized to their site design.
 
 The basic login page can be customized by setting `WAGTAIL_FRONTEND_LOGIN_TEMPLATE` to the path of a template you wish to use:
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -668,6 +668,26 @@ WAGTAIL_FRONTEND_LOGIN_URL = '/accounts/login/'
 
 For more details, see the [](login_page) documentation.
 
+### `WAGTAIL_ALLOW_SHARED_PASSWORD_PAGE`
+
+If you'd rather users not have the ability to use a shared password to make pages private, you can disable it with this setting:
+
+```python
+WAGTAIL_ALLOW_SHARED_PASSWORD_PAGE = False
+```
+
+See [](private_pages) for more details.
+
+### `WAGTAIL_ALLOW_SHARED_PASSWORD_COLLECTION`
+
+If you'd rather users not have the ability to use a shared password to make collections (used for documents) private, you can disable it with this setting:
+
+```python
+WAGTAIL_ALLOW_SHARED_PASSWORD_COLLECTION = False
+```
+
+See [](private_pages) for more details.
+
 ## Tags
 
 ### `TAGGIT_CASE_INSENSITIVE`

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -17,6 +17,7 @@ depth: 1
  * Add RelatedObjectsColumn to the table UI framework (Matt Westcott)
  * Reduce memory usage when rebuilding search indexes (Jake Howard)
  * Support creating images in .ico format (Jake Howard)
+ * Add the ability to disable the usage of a shared password for enhanced security for the [private pages](private_pages) and [collections (documents)](private_collections) feature (Salvo Polizzi, Jake Howard)
 
 
 ### Bug fixes

--- a/wagtail/admin/forms/collections.py
+++ b/wagtail/admin/forms/collections.py
@@ -1,6 +1,7 @@
 from itertools import groupby
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -19,6 +20,17 @@ from .view_restrictions import BaseViewRestrictionForm
 
 
 class CollectionViewRestrictionForm(BaseViewRestrictionForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not getattr(settings, "WAGTAIL_ALLOW_SHARED_PASSWORD_COLLECTION", True):
+            self.fields["restriction_type"].choices = [
+                choice
+                for choice in CollectionViewRestriction.RESTRICTION_CHOICES
+                if choice[0] != CollectionViewRestriction.PASSWORD
+            ]
+            del self.fields["password"]
+
     class Meta:
         model = CollectionViewRestriction
         fields = ("restriction_type", "password", "groups")

--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -124,6 +124,17 @@ class CopyForm(forms.Form):
 
 
 class PageViewRestrictionForm(BaseViewRestrictionForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not getattr(settings, "WAGTAIL_ALLOW_SHARED_PASSWORD_PAGE", True):
+            self.fields["restriction_type"].choices = [
+                choice
+                for choice in PageViewRestriction.RESTRICTION_CHOICES
+                if choice[0] != PageViewRestriction.PASSWORD
+            ]
+            del self.fields["password"]
+
     class Meta:
         model = PageViewRestriction
         fields = ("restriction_type", "password", "groups")

--- a/wagtail/admin/templates/wagtailadmin/collection_privacy/set_privacy.html
+++ b/wagtail/admin/templates/wagtailadmin/collection_privacy/set_privacy.html
@@ -3,7 +3,9 @@
 <form action="{% url 'wagtailadmin_collections:set_privacy' collection.id %}" method="POST" novalidate>
     {% csrf_token %}
     {% formattedfield field=form.restriction_type show_label=False %}
-    {% formattedfield form.password %}
+    {% if form.password is not None %}
+        {% formattedfield form.password %}
+    {% endif %}
     <div id="groups-fields">
         {% formattedfield form.groups %}
     </div>

--- a/wagtail/admin/templates/wagtailadmin/page_privacy/set_privacy.html
+++ b/wagtail/admin/templates/wagtailadmin/page_privacy/set_privacy.html
@@ -3,7 +3,9 @@
 <form action="{% url 'wagtailadmin_pages:set_privacy' page.id %}" method="POST" novalidate>
     {% csrf_token %}
     {% formattedfield field=form.restriction_type show_label=False %}
-    {% formattedfield form.password %}
+    {% if form.password is not None %}
+        {% formattedfield form.password %}
+    {% endif %}
     <div id="groups-fields">
         {% formattedfield form.groups %}
     </div>


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11536 -- Allow ability to disable shared password in pages or collections







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.
Added `WAGTAIL_ALLOW_SHARED_PASSWORD_PAGE` and `WAGTAIL_ALLOW_SHARED_PASSWORD_COLLECTION` settings in order to make the user able to disable shared password if not needed. 


[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
