### PR TITLE
Workflow model to get inherited from AbstractWorkflow model (#11538)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Changelog
  * Maintenance: Update unit tests to always use the faster, built in `html.parser` & remove `html5lib` dependency (Jake Howard)
  * Maintenance: Adjust Eslint rules for TypeScript files (Karthik Ayangar)
  * Maintenance: Rename the React `Button` that only renders links (a element) to `Link` and remove unused prop & behavior that was non-compliant for aria role usage (Advik Kabra)
+ * Maintenance: Set up an `wagtail.models.AbstractWorkflow` model to support future customisations around workflows (Hossein)
 
 
 6.0 (07.02.2024)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -795,6 +795,7 @@
 * mirusu400
 * Advik Kabra
 * Ankur Raiyani
+* Hossein
 
 ## Translators
 

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -38,6 +38,7 @@ depth: 1
  * Update unit tests to always use the faster, built in `html.parser` & remove `html5lib` dependency (Jake Howard)
  * Adjust Eslint rules for TypeScript files (Karthik Ayangar)
  * Rename the React `Button` that only renders links (a element) to `Link` and remove unused prop & behavior that was non-compliant for aria role usage (Advik Kabra)
+ * Set up an `wagtail.models.AbstractWorkflow` model to support future customisations around workflows (Hossein)
 
 
 ## Upgrade considerations

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -3519,7 +3519,7 @@ class WorkflowManager(models.Manager):
         return self.filter(active=True)
 
 
-class Workflow(ClusterableModel):
+class AbstractWorkflow(ClusterableModel):
     name = models.CharField(max_length=255, verbose_name=_("name"))
     active = models.BooleanField(
         verbose_name=_("active"),
@@ -3608,6 +3608,11 @@ class Workflow(ClusterableModel):
     class Meta:
         verbose_name = _("workflow")
         verbose_name_plural = _("workflows")
+        abstract = True
+
+
+class Workflow(AbstractWorkflow):
+    pass
 
 
 class GroupApprovalTask(Task):


### PR DESCRIPTION


<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Per issue #11538 of my colleague, changed Workflow model, so that it get inherited from AbstractWorkflow. No migration is needed. 

This would help developers, to inherit from AbstractWorkflow and make their own CustomWorkflow model in order to add fields and methods to Workflow model, especially helpful for Snippets. For Page model, further development, similar to custom Document and Image models are needed. 






_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
