### PR TITLE
Fix crash when accessing workflow reports with a deleted snippet

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -109,6 +109,7 @@ Changelog
  * Fix: Ensure that TableBlock cells are accessible when using keyboard control only (Elhussein Almasri)
  * Fix: Resolve issue where clicking Publish for a Page that was in workflow in Safari would block publishing and not trigger the workflow confirmation modal (Alex Morega)
  * Fix: Fix pagination links on model history and usage views (Matt Westcott)
+ * Fix: Fix crash when accessing workflow reports with a deleted snippet (Sage Abdullah)
  * Docs: New developer tutorial (Damilola Oladele, Meagen Voss, Thibaud Colas)
  * Docs: Document, for contributors, the use of translate string literals passed as arguments to tags and filters using `_()` within templates (Chiemezuo Akujobi)
  * Docs: Document all features for the Documents app in one location (Neeraj Yetheendran)

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -148,6 +148,7 @@ This release comes with a high number of accessibility improvements across the a
  * Ensure that `default_ordering` set on IndexView is preserved if ModelViewSet does not specify an explicit ordering (Cynthia Kiser)
  * Resolve issue where clicking Publish for a Page that was in workflow in Safari would block publishing and not trigger the workflow confirmation modal (Alex Morega)
  * Fix pagination links on model history and usage views (Matt Westcott)
+ * Fix crash when accessing workflow reports with a deleted snippet (Sage Abdullah)
 
 
 ### Documentation

--- a/wagtail/admin/views/reports/workflows.py
+++ b/wagtail/admin/views/reports/workflows.py
@@ -188,8 +188,11 @@ class WorkflowView(ReportView):
             content_type_id__in=get_editable_content_type_ids(self.request)
         )
 
-        return WorkflowState.objects.filter(editable_pages | editable_objects).order_by(
-            "-created_at"
+        return (
+            WorkflowState.objects.filter(editable_pages | editable_objects)
+            .select_related("workflow", "requested_by")
+            .prefetch_related("content_object", "content_object__latest_revision")
+            .order_by("-created_at")
         )
 
     def dispatch(self, request, *args, **kwargs):
@@ -256,6 +259,12 @@ class WorkflowTasksView(ReportView):
                 self.request
             )
         )
-        return TaskState.objects.filter(editable_pages | editable_objects).order_by(
-            "-started_at"
+        return (
+            TaskState.objects.filter(editable_pages | editable_objects)
+            .select_related("workflow_state", "task")
+            .prefetch_related(
+                "workflow_state__content_object",
+                "workflow_state__content_object__latest_revision",
+            )
+            .order_by("-started_at")
         )

--- a/wagtail/admin/views/reports/workflows.py
+++ b/wagtail/admin/views/reports/workflows.py
@@ -195,6 +195,9 @@ class WorkflowView(ReportView):
             .order_by("-created_at")
         )
 
+    def decorate_paginated_queryset(self, object_list):
+        return [obj for obj in object_list if obj.content_object]
+
     def dispatch(self, request, *args, **kwargs):
         if not page_permission_policy.user_has_any_permission(
             request.user, ["add", "change", "publish"]
@@ -268,3 +271,6 @@ class WorkflowTasksView(ReportView):
             )
             .order_by("-started_at")
         )
+
+    def decorate_paginated_queryset(self, object_list):
+        return [obj for obj in object_list if obj.workflow_state.content_object]

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -304,7 +304,9 @@ class FullFeaturedSnippetViewSet(SnippetViewSet):
 
     class IndexView(SnippetViewSet.index_view_class):
         def get_add_url(self):
-            return set_query_params(super().get_add_url(), {"customised": "param"})
+            if not (add_url := super().get_add_url()):
+                return None
+            return set_query_params(add_url, {"customised": "param"})
 
     index_view_class = IndexView
 


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes an issue similar to #11300.

If a snippet model with `WorkflowMixin` does not define a `GenericRelation` to the `WorkflowState` model, the corresponding `WorkflowState`s won't be deleted when the snippet is deleted. As a result, deleting such a snippet that previously was in workflow (finished or not) will result in the workflow reports crashing when working with `WorkflowState.content_object`.

I also found quite a lot of duplicated queries as the view does not apply `select_related`/`prefetch_related` for the related objects that are accessed in the templates, so I took the time to add them.

---

I think we should add a system check for `RevisionMixin` and `WorkflowMixin` to ensure that the model defines the correct `GenericRelation`s, but that seems out of scope for 6.0 during feature freeze so I'll do it later for 6.1.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

Submit a Person snippet in bakerydemo to a workflow, then delete the snippet (doesn't matter the workflow was completed or not). Opening the workflow reports will result in `AttributeError: 'NoneType' object has not attribute 'snippet_viewset'`.

Corresponding fix in bakerydemo: https://github.com/wagtail/bakerydemo/pull/477

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
