### PR TITLE
Limit locale filter to only show the available locales

### DIFF
--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -201,7 +201,10 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
     @cached_property
     def filters(self):
         if self.filterset_class:
-            return self.filterset_class(self.request.GET, request=self.request)
+            filterset = self.filterset_class(self.request.GET, request=self.request)
+            # Don't use the filterset if it has no fields
+            if filterset.form.fields:
+                return filterset
 
     @cached_property
     def is_filtering(self):


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

The locale filter in `WagtailAdminFilterSet` consults the `get_content_languages` util which only gets the languages from the `WAGTAIL_CONTENT_LANGUAGES` setting, without checking whether each language has a corresponding `Locale` object or not.

As a result, if you have languages in `WAGTAIL_CONTENT_LANGUAGES` that don't yet have the `Locale`s created (as is the case with the current bakerydemo), these languages will still be shown on snippets. This shouldn't be a big deal, as the filter should just return no results. However, in the `LocaleMixin` (which is used in the generic `IndexView`), the locale specified in the `locale` parameter will also be fetched to be set as `self.locale` in the view. This results in the listing view throwing a 404, making the AJAX update of the results non-functional when selecting such locales.

This PR limits the locale options to only show the ones where the `Locale` objects exist. To match the pre-6.0 behaviour of deactivating the locale selector, skip the addition of the locale filter if there is only one `Locale`.

In addition, change the `filters` cached property of the `BaseListingView` class to disable the filters when the filter form has no fields (to prevent rendering an empty drilldown component).

(This does not prevent the listing from 404-ing if you provide a URL with a `locale` param value that does not have a corresponding `Locale` object, but that has been the case for a while.)





_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

With a fresh bakerydemo (which as of this writing still does not have `Locale` objects for Arabic/Deutsch), try filtering the footer text snippet by the Deutsch/Arabic locale. The AJAX refresh will fail (see browser console). If you have already created the Deutsch/Arabic locale, either delete one of them for testing or add another language to `WAGTAIL_CONTENT_LANGUAGES`.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
