### PR TITLE
Corrected spelling of loaded tag 'wagtailimages_tags'

### DIFF
--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -667,7 +667,7 @@ class BlogPage(Page):
     ]
 ```
 
-This method is now available from your templates. Update `blog_index_page.html` to load the `wagtailimages_tags` and include the main image as a thumbnail alongside each post:
+This method is now available from your templates. Update `blog_index_page.html` to load the `wagtailimages_tags` library and include the main image as a thumbnail alongside each post:
 
 ```html+django
 <!-- Load wagtailimages_tags: -->

--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -667,7 +667,7 @@ class BlogPage(Page):
     ]
 ```
 
-This method is now available from your templates. Update `blog_index_page.html` to load the `wagtailimages_tag` and include the main image as a thumbnail alongside each post:
+This method is now available from your templates. Update `blog_index_page.html` to load the `wagtailimages_tags` and include the main image as a thumbnail alongside each post:
 
 ```html+django
 <!-- Load wagtailimages_tags: -->


### PR DESCRIPTION
Corrected spelling in getting started documentation. From 'wagtailimages_tag' to 'wagtailimages_tags'

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #...
Just corrected spelling of loaded tags in the getting started documentation.







_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
