### PR TITLE
Fix minor typo (6.0 release notes) in WidgetWithScript deprecation note

### DIFF
--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -456,5 +456,5 @@ class CustomEditorController extends window.StimulusModule.Controller {
     }
 }
 
-window.wagtail.app.register('color', CustomEditorController);
+window.wagtail.app.register('custom-editor', CustomEditorController);
 ```


### PR DESCRIPTION
Small typo fix for 6.0 release notes.