### PR TITLE
Fix closing button tag for promotion banner

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -107,7 +107,7 @@
                     <br>June 2024 in Philadelphia, USA
                 </div>
             </a>
-            <button class="close" aria-label="Hide banner" aria-expanded="true" type="button" data-clear>&#x2715;</span>
+            <button class="close" aria-label="Hide banner" aria-expanded="true" type="button" data-clear>&#x2715;</button>
         </div>
     </template>
 {% endblock %}


### PR DESCRIPTION
See #11554

Browsers will 'clean this up' automatically but would be good to fix in our DOM.