### PR TITLE
Remove the usage of global chooserUrls

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Add system checks to ensure that `WAGTAIL_DATE_FORMAT`, `WAGTAIL_DATETIME_FORMAT`, `WAGTAIL_TIME_FORMAT` are correctly configured (Rohit Sharma, Coen van der Kamp)
  * Allow custom permissions with the same prefix as built-in permissions (Sage Abdullah)
  * Allow displaying permissions linked to the Admin model's content type (Sage Abdullah)
+ * Add support for Draftail's JavaScript to use chooserUrls provided by entity options & for the Draftail widget to encode lazy URLs/ translations (Elhussein Almasri)
  * Fix: Fix typo in `__str__` for MySQL search index (Jake Howard)
  * Fix: Ensure that unit tests correctly check for migrations in all core Wagtail apps (Matt Westcott)
  * Fix: Correctly handle `date` objects on `human_readable_date` template tag (Jhonatan Lopes)
@@ -32,6 +33,7 @@ Changelog
  * Maintenance: Optimize queries in dashboard panels (Sage Abdullah)
  * Maintenance: Optimize queries in group create/edit view (Sage Abdullah)
  * Maintenance: Move modal-workflow.js script usage to base admin template instead of ad-hoc imports (Elhussein Almasri)
+ * Maintenance: Update all Draftail chooserUrls to be passed in via the Entity options instead of using `window.chooserUrls` globals, removing the need for inline scripts (Elhussein Almasri)
 
 
 6.0.1 (15.02.2024)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Changelog
  * Maintenance: Merge `UploadedDocument` and `UploadedImage` into new `UploadedFile` model for easier shared code usage (Advik Kabra, Karl Hobley)
  * Maintenance: Optimize queries in dashboard panels (Sage Abdullah)
  * Maintenance: Optimize queries in group create/edit view (Sage Abdullah)
+ * Maintenance: Move modal-workflow.js script usage to base admin template instead of ad-hoc imports (Elhussein Almasri)
 
 
 6.0.1 (15.02.2024)

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.js
@@ -173,16 +173,21 @@ class ImageModalWorkflowSource extends ModalWorkflowSource {
   getChooserConfig(entity) {
     let url;
     let urlParams;
+    const { imageChooser } = {
+      ...this.props.entityType?.chooserUrls,
+      /** @deprecated RemovedInWagtail70 - Remove global.chooserUrls usage  */
+      ...global.chooserUrls,
+    };
 
     if (entity) {
       const data = entity.getData();
-      url = `${global.chooserUrls.imageChooser}${data.id}/select_format/`;
+      url = `${imageChooser}${data.id}/select_format/`;
       urlParams = {
         format: data.format,
         alt_text: data.alt,
       };
     } else {
-      url = `${global.chooserUrls.imageChooser}?select_format=true`;
+      url = `${imageChooser}?select_format=true`;
       urlParams = {};
     }
     return {
@@ -207,13 +212,18 @@ class ImageModalWorkflowSource extends ModalWorkflowSource {
 
 class EmbedModalWorkflowSource extends ModalWorkflowSource {
   getChooserConfig(entity) {
+    const { embedsChooser } = {
+      ...this.props.entityType?.chooserUrls,
+      /** @deprecated RemovedInWagtail70 - Remove global.chooserUrls usage  */
+      ...global.chooserUrls,
+    };
     const urlParams = {};
 
     if (entity) {
       urlParams.url = entity.getData().url;
     }
     return {
-      url: global.chooserUrls.embedsChooser,
+      url: embedsChooser,
       urlParams,
       onload: global.EMBED_CHOOSER_MODAL_ONLOAD_HANDLERS,
       responses: {
@@ -237,7 +247,13 @@ class EmbedModalWorkflowSource extends ModalWorkflowSource {
 
 class LinkModalWorkflowSource extends ModalWorkflowSource {
   getChooserConfig(entity, selectedText) {
-    let url = global.chooserUrls.pageChooser;
+    const chooserUrls = {
+      ...this.props.entityType?.chooserUrls,
+      /** @deprecated RemovedInWagtail70 - Remove global.chooserUrls usage  */
+      ...global.chooserUrls,
+    };
+    let url = chooserUrls.pageChooser;
+
     const urlParams = {
       page_type: 'wagtailcore.page',
       allow_external_link: true,
@@ -252,21 +268,21 @@ class LinkModalWorkflowSource extends ModalWorkflowSource {
 
       if (data.id) {
         if (data.parentId !== null) {
-          url = `${global.chooserUrls.pageChooser}${data.parentId}/`;
+          url = `${chooserUrls.pageChooser}${data.parentId}/`;
         } else {
-          url = global.chooserUrls.pageChooser;
+          url = chooserUrls.pageChooser;
         }
       } else if (data.url.startsWith('mailto:')) {
-        url = global.chooserUrls.emailLinkChooser;
+        url = chooserUrls.emailLinkChooser;
         urlParams.link_url = data.url.replace('mailto:', '');
       } else if (data.url.startsWith('tel:')) {
-        url = global.chooserUrls.phoneLinkChooser;
+        url = chooserUrls.phoneLinkChooser;
         urlParams.link_url = data.url.replace('tel:', '');
       } else if (data.url.startsWith('#')) {
-        url = global.chooserUrls.anchorLinkChooser;
+        url = chooserUrls.anchorLinkChooser;
         urlParams.link_url = data.url.replace('#', '');
       } else {
-        url = global.chooserUrls.externalLinkChooser;
+        url = chooserUrls.externalLinkChooser;
         urlParams.link_url = data.url;
       }
     }
@@ -298,8 +314,14 @@ class LinkModalWorkflowSource extends ModalWorkflowSource {
 
 class DocumentModalWorkflowSource extends ModalWorkflowSource {
   getChooserConfig() {
+    const { documentChooser } = {
+      ...this.props.entityType?.chooserUrls,
+      /** @deprecated RemovedInWagtail70 - Remove global.chooserUrls usage  */
+      ...global.chooserUrls,
+    };
+
     return {
-      url: global.chooserUrls.documentChooser,
+      url: documentChooser,
       urlParams: {},
       onload: global.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS,
       responses: {

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
@@ -44,7 +44,13 @@ describe('ModalWorkflowSource', () => {
   });
 
   describe('#getChooserConfig', () => {
-    const imageSource = new ImageModalWorkflowSource();
+    const imageSource = new ImageModalWorkflowSource({
+      entityType: {
+        chooserUrls: {
+          imageChooser: '/admin/images/chooser/',
+        },
+      },
+    });
     it('IMAGE without entity', () => {
       expect(imageSource.getChooserConfig(null, '')).toEqual({
         url: '/admin/images/chooser/?select_format=true',
@@ -67,7 +73,13 @@ describe('ModalWorkflowSource', () => {
       });
     });
 
-    const embedSource = new EmbedModalWorkflowSource();
+    const embedSource = new EmbedModalWorkflowSource({
+      entityType: {
+        chooserUrls: {
+          embedsChooser: '/admin/embeds/chooser/',
+        },
+      },
+    });
     it('EMBED without entity', () => {
       expect(embedSource.getChooserConfig(null, '')).toMatchObject({
         url: '/admin/embeds/chooser/',
@@ -85,7 +97,13 @@ describe('ModalWorkflowSource', () => {
       });
     });
 
-    const documentSource = new DocumentModalWorkflowSource();
+    const documentSource = new DocumentModalWorkflowSource({
+      entityType: {
+        chooserUrls: {
+          documentChooser: '/admin/documents/chooser/',
+        },
+      },
+    });
     it('DOCUMENT', () => {
       expect(documentSource.getChooserConfig(null, '')).toEqual({
         url: '/admin/documents/chooser/',
@@ -95,7 +113,17 @@ describe('ModalWorkflowSource', () => {
       });
     });
 
-    const linkSource = new LinkModalWorkflowSource();
+    const linkSource = new LinkModalWorkflowSource({
+      entityType: {
+        chooserUrls: {
+          pageChooser: '/admin/choose-page/',
+          emailLinkChooser: '/admin/choose-email-link/',
+          externalLinkChooser: '/admin/choose-external-link/',
+          anchorLinkChooser: '/admin/choose-anchor-link/',
+          phoneLinkChooser: 'admin/choose-phone-link/',
+        },
+      },
+    });
     describe('LINK', () => {
       it('no entity', () => {
         expect(linkSource.getChooserConfig(null, '')).toMatchSnapshot();

--- a/client/src/entrypoints/admin/draftail.js
+++ b/client/src/entrypoints/admin/draftail.js
@@ -16,6 +16,9 @@ window.Draftail = Draftail;
 // Expose module as a global.
 window.draftail = draftail;
 
+/** @deprecated RemovedInWagtail70 - Ensure that any third party packages that use global.chooserUrls can still append to this global object until support is removed. */
+window.chooserUrls = global.chooserUrls || {};
+
 // Plugins for the built-in entities.
 const entityTypes = [
   {

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -46,16 +46,6 @@ global.wagtailVersion = '1.6a1';
 
 global.wagtail = {};
 
-global.chooserUrls = {
-  documentChooser: '/admin/documents/chooser/',
-  emailLinkChooser: '/admin/choose-email-link/',
-  anchorLinkChooser: '/admin/choose-anchor-link',
-  embedsChooser: '/admin/embeds/chooser/',
-  externalLinkChooser: '/admin/choose-external-link/',
-  imageChooser: '/admin/images/chooser/',
-  pageChooser: '/admin/choose-page/',
-};
-
 /* use dummy content for onload handlers just so that we can verify that we've chosen the right one */
 global.IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = { type: 'image' };
 global.PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = { type: 'page' };

--- a/docs/extending/extending_draftail.md
+++ b/docs/extending/extending_draftail.md
@@ -122,6 +122,8 @@ Optionally, we can also define styles for the blocks with the `Draftail-block--h
 
 That’s it! The extra complexity is that you may need to write CSS to style the blocks in the editor.
 
+(creating_new_draftail_editor_entities)=
+
 ### Creating new entities
 
 ```{warning}

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -52,6 +52,7 @@ depth: 1
  * Merge `UploadedDocument` and `UploadedImage` into new `UploadedFile` model for easier shared code usage (Advik Kabra, Karl Hobley)
  * Optimize queries in dashboard panels (Sage Abdullah)
  * Optimize queries in group create/edit view (Sage Abdullah)
+ * Move modal-workflow.js script usage to base admin template instead of ad-hoc imports (Elhussein Almasri)
 
 
 ## Upgrade considerations

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -21,6 +21,7 @@ depth: 1
  * Add system checks to ensure that `WAGTAIL_DATE_FORMAT`, `WAGTAIL_DATETIME_FORMAT`, `WAGTAIL_TIME_FORMAT` are [correctly configured](wagtail_date_time_formats) (Rohit Sharma, Coen van der Kamp)
  * Allow custom permissions with the same prefix as built-in permissions (Sage Abdullah)
  * Allow displaying permissions linked to the Admin model's content type (Sage Abdullah)
+ * Add support for Draftail's JavaScript to use chooserUrls provided by entity options & for the Draftail widget to encode lazy URLs/ translations (Elhussein Almasri)
 
 
 ### Bug fixes
@@ -53,6 +54,95 @@ depth: 1
  * Optimize queries in dashboard panels (Sage Abdullah)
  * Optimize queries in group create/edit view (Sage Abdullah)
  * Move modal-workflow.js script usage to base admin template instead of ad-hoc imports (Elhussein Almasri)
+ * Update all Draftail chooserUrls to be passed in via the Entity options instead of using `window.chooserUrls` globals, removing the need for inline scripts (Elhussein Almasri)
 
 
 ## Upgrade considerations
+
+## Upgrade considerations - changes to undocumented internals
+
+### Deprecation of `window.chooserUrls` within Draftail choosers
+
+The undocumented usage of the JavaScript `window.chooserUrls` within Draftail choosers will be removed in a future release.
+
+The following `chooserUrl` object values will be impacted.
+
+-   `anchorLinkChooser`
+-   `documentChooser`
+-   `emailLinkChooser`
+-   `embedsChooser`
+-   `externalLinkChooser`
+-   `imageChooser`
+-   `pageChooser`
+
+Overriding these inner values on the global `window.chooserUrls` object will still override their usage in the Draftail choosers for now but this capability will be removed in a future release.
+
+#### Example
+
+It's recommended that usage of this global is removed in any customisations or third party packages and instead a custom Draftail Entity be used instead. See example below.
+
+##### Old
+
+```python
+# .../wagtail_hooks.py
+
+@hooks.register("insert_editor_js")
+def editor_js():
+    return format_html(
+        """
+        <script>
+            window.chooserUrls.myCustomChooser = '{0}';
+        </script>
+        """,
+        reverse("myapp_chooser:choose"),
+    )
+```
+
+##### New
+
+Remove the `insert_editor_js` hook usage and instead pass the data needed via the Entity's data.
+
+```python
+# .../wagtail_hooks.py
+
+from django.urls import reverse_lazy
+
+@hooks.register("register_rich_text_features")
+def register_my_custom_feature(features):
+    # features.register_link_type...
+
+    features.register_editor_plugin(
+        "draftail",
+        "custom-link",
+        draftail_features.EntityFeature(
+            {
+                "type": "CUSTOM_ITEM",
+                "icon": "doc-full-inverse",
+                "description": gettext_lazy("Item"),
+                "chooserUrls": {
+                    # Important: `reverse_lazy` must be used unless the URL path is hard-coded
+                    "myChooser": reverse_lazy("myapp_chooser:choose")
+                },
+            },
+            js=["..."],
+        ),
+    )
+
+```
+
+#### Overriding existing `chooserUrls` values
+
+To override existing chooser Entities' `chooserUrls` values, here is an example of an unsupported monkey patch can achieve a similar goal.
+
+However, it's recommended that a [custom Entity be created](creating_new_draftail_editor_entities) to be registered as a replacement feature for Draftail customisations as per the documentation.
+
+```py
+# .../wagtail_hooks.py
+from django.urls import reverse_lazy
+
+from wagtail import hooks
+
+@hooks.register("register_rich_text_features")
+def override_embed_feature_url(features):
+    features.plugins_by_editor["draftail"]["embed"].data["chooserUrls"]["embedsChooser"] = reverse_lazy("my_embeds:chooser")
+```

--- a/wagtail/admin/rich_text/editors/draftail/__init__.py
+++ b/wagtail/admin/rich_text/editors/draftail/__init__.py
@@ -2,13 +2,30 @@ import json
 import warnings
 
 from django.forms import Media, widgets
+from django.urls import reverse_lazy
 from django.utils.functional import cached_property
+from django.utils.translation import gettext_lazy
 
 from wagtail.admin.rich_text.converters.contentstate import ContentstateConverter
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.rich_text import features as feature_registry
 from wagtail.telepath import register
 from wagtail.widget_adapters import WidgetAdapter
+
+
+class LazyStringEncoder(json.JSONEncoder):
+    """
+    Add support for lazy strings to the JSON encoder so that URLs and
+    translations can be resolved when rendering the widget only.
+    """
+
+    lazy_string_types = [type(reverse_lazy("")), type(gettext_lazy(""))]
+
+    def default(self, obj):
+        if type(obj) in self.lazy_string_types:
+            return str(obj)
+
+        return json.JSONEncoder.default(self, obj)
 
 
 class DraftailRichTextArea(widgets.HiddenInput):
@@ -65,7 +82,9 @@ class DraftailRichTextArea(widgets.HiddenInput):
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
-        context["widget"]["options_json"] = json.dumps(self.options)
+        context["widget"]["options_json"] = json.dumps(
+            self.options, cls=LazyStringEncoder
+        )
         return context
 
     def value_from_datadict(self, data, files, name):

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -56,6 +56,7 @@
     <script src="{% versioned_static 'wagtailadmin/js/wagtailadmin.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/telepath/telepath.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/sidebar.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 
     {% hook_output 'insert_global_admin_js' %}
 

--- a/wagtail/admin/templates/wagtailadmin/collections/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/collections/edit.html
@@ -7,6 +7,5 @@
 
 {% block extra_js %}
     {{ block.super }}
-    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/privacy-switch.js' %}"></script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -89,7 +89,6 @@
         </table>
     {% endpanel %}
 
-    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/workflow-action.js' %}"></script>
     <script>
         document.querySelectorAll('[data-controller="w-dropdown"]').forEach((e) => {

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
@@ -18,7 +18,6 @@
 <script src="{% versioned_static 'wagtailadmin/js/vendor/rangy-core.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/vendor/mousetrap.min.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/expanding-formset.js' %}"></script>
-<script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/page-editor.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/preview-panel.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/privacy-switch.js' %}"></script>

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
@@ -4,16 +4,6 @@
     JavaScript declarations to be included on the 'create page' and 'edit page' views
 {% endcomment %}
 
-<script>
-    window.chooserUrls = {
-        'pageChooser': '{% url "wagtailadmin_choose_page" %}',
-        'externalLinkChooser': '{% url "wagtailadmin_choose_page_external_link" %}',
-        'emailLinkChooser': '{% url "wagtailadmin_choose_page_email_link" %}',
-        'phoneLinkChooser': '{% url "wagtailadmin_choose_page_phone_link" %}',
-        'anchorLinkChooser': '{% url "wagtailadmin_choose_page_anchor_link" %}',
-    };
-</script>
-
 <script src="{% versioned_static 'wagtailadmin/js/comments.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/vendor/rangy-core.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/vendor/mousetrap.min.js' %}"></script>

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -23,8 +23,6 @@
 {% block extra_js %}
     {{ block.super }}
 
-    {% comment %} modal-workflow is required by the view restrictions interface {% endcomment %}
-    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/privacy-switch.js' %}"></script>
 
     {% comment %}

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib.auth.models import Permission
-from django.urls import reverse
+from django.urls import reverse, reverse_lazy
 from django.utils.functional import cached_property
 from django.utils.http import urlencode
 from django.utils.translation import gettext
@@ -742,6 +742,21 @@ def register_core_features(features):
                 "allowlist": {
                     # Keep pasted links with http/https protocol, and not-pasted links (href = undefined).
                     "href": "^(http:|https:|undefined$)",
+                },
+                "chooserUrls": {
+                    "pageChooser": reverse_lazy("wagtailadmin_choose_page"),
+                    "externalLinkChooser": reverse_lazy(
+                        "wagtailadmin_choose_page_external_link"
+                    ),
+                    "emailLinkChooser": reverse_lazy(
+                        "wagtailadmin_choose_page_email_link"
+                    ),
+                    "phoneLinkChooser": reverse_lazy(
+                        "wagtailadmin_choose_page_phone_link"
+                    ),
+                    "anchorLinkChooser": reverse_lazy(
+                        "wagtailadmin_choose_page_anchor_link"
+                    ),
                 },
             },
             js=[

--- a/wagtail/documents/tests/test_rich_text.py
+++ b/wagtail/documents/tests/test_rich_text.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.urls import reverse_lazy
 
 from wagtail.documents import get_document_model
 from wagtail.documents.rich_text import (
@@ -8,6 +9,7 @@ from wagtail.documents.rich_text.editor_html import (
     DocumentLinkHandler as EditorHtmlDocumentLinkHandler,
 )
 from wagtail.fields import RichTextField
+from wagtail.rich_text.feature_registry import FeatureRegistry
 from wagtail.test.utils import WagtailTestUtils
 
 
@@ -59,4 +61,16 @@ class TestFrontendDocumentLinkHandler(TestCase):
                 )
             ),
             [(get_document_model(), "1", "", "")],
+        )
+
+
+class TestEntityFeatureChooserUrls(TestCase):
+    def test_chooser_urls_exist(self):
+        features = FeatureRegistry()
+        document = features.get_editor_plugin("draftail", "document-link")
+
+        self.assertIsNotNone(document.data.get("chooserUrls"))
+        self.assertEqual(
+            document.data["chooserUrls"]["documentChooser"],
+            reverse_lazy("wagtaildocs_chooser:choose"),
         )

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.template.response import TemplateResponse
-from django.urls import include, path, reverse
-from django.utils.html import format_html
+from django.urls import include, path, reverse, reverse_lazy
 from django.utils.translation import gettext, ngettext
 from django.utils.translation import gettext_lazy as _
 
@@ -64,18 +63,6 @@ def register_documents_menu_item():
     )
 
 
-@hooks.register("insert_editor_js")
-def editor_js():
-    return format_html(
-        """
-        <script>
-            window.chooserUrls.documentChooser = '{0}';
-        </script>
-        """,
-        reverse("wagtaildocs_chooser:choose"),
-    )
-
-
 @hooks.register("register_rich_text_features")
 def register_document_feature(features):
     features.register_link_type(DocumentLinkHandler)
@@ -88,6 +75,9 @@ def register_document_feature(features):
                 "type": "DOCUMENT",
                 "icon": "doc-full-inverse",
                 "description": gettext("Document"),
+                "chooserUrls": {
+                    "documentChooser": reverse_lazy("wagtaildocs_chooser:choose")
+                },
             },
             js=["wagtaildocs/js/document-chooser-modal.js"],
         ),

--- a/wagtail/embeds/tests/test_rich_text.py
+++ b/wagtail/embeds/tests/test_rich_text.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.test import TestCase, override_settings
+from django.urls import reverse_lazy
 
 from wagtail.embeds.exceptions import EmbedNotFoundException
 from wagtail.embeds.models import Embed
@@ -9,6 +10,7 @@ from wagtail.embeds.rich_text.editor_html import (
     MediaEmbedHandler as EditorHtmlMediaEmbedHandler,
 )
 from wagtail.rich_text import expand_db_html
+from wagtail.rich_text.feature_registry import FeatureRegistry
 from wagtail.test.utils import WagtailTestUtils
 
 
@@ -142,4 +144,16 @@ class TestFrontendMediaEmbedHandler(TestCase):
         self.assertIn("test html", result)
         get_embed.assert_called_with(
             "https://www.youtube.com/watch?v=O7D-1RG-VRk&t=25", None, None
+        )
+
+
+class TestEntityFeatureChooserUrls(TestCase):
+    def test_chooser_urls_exist(self):
+        features = FeatureRegistry()
+        embed = features.get_editor_plugin("draftail", "embed")
+
+        self.assertIsNotNone(embed.data.get("chooserUrls"))
+        self.assertEqual(
+            embed.data["chooserUrls"]["embedsChooser"],
+            reverse_lazy("wagtailembeds:chooser"),
         )

--- a/wagtail/embeds/wagtail_hooks.py
+++ b/wagtail/embeds/wagtail_hooks.py
@@ -1,5 +1,4 @@
-from django.urls import include, path, reverse
-from django.utils.html import format_html
+from django.urls import include, path, reverse_lazy
 from django.utils.translation import gettext as _
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
@@ -15,18 +14,6 @@ def register_admin_urls():
     return [
         path("embeds/", include(urls, namespace="wagtailembeds")),
     ]
-
-
-@hooks.register("insert_editor_js")
-def editor_js():
-    return format_html(
-        """
-            <script>
-                window.chooserUrls.embedsChooser = '{0}';
-            </script>
-        """,
-        reverse("wagtailembeds:chooser"),
-    )
 
 
 @hooks.register("register_rich_text_features")
@@ -49,6 +36,9 @@ def register_embed_feature(features):
                 "type": "EMBED",
                 "icon": "media",
                 "description": _("Embed"),
+                "chooserUrls": {
+                    "embedsChooser": reverse_lazy("wagtailembeds:chooser"),
+                },
             },
             js=["wagtailembeds/js/embed-chooser-modal.js"],
         ),

--- a/wagtail/images/tests/test_rich_text.py
+++ b/wagtail/images/tests/test_rich_text.py
@@ -1,10 +1,12 @@
 from django.test import TestCase
+from django.urls import reverse_lazy
 
 from wagtail.fields import RichTextField
 from wagtail.images.rich_text import ImageEmbedHandler as FrontendImageEmbedHandler
 from wagtail.images.rich_text.editor_html import (
     ImageEmbedHandler as EditorHtmlImageEmbedHandler,
 )
+from wagtail.rich_text.feature_registry import FeatureRegistry
 from wagtail.test.utils import WagtailTestUtils
 
 from .utils import Image, get_test_image_file
@@ -139,4 +141,16 @@ class TestExtractReferencesWithImage(WagtailTestUtils, TestCase):
                 )
             ),
             [(Image, "52", "", "")],
+        )
+
+
+class TestEntityFeatureChooserUrls(TestCase):
+    def test_chooser_urls_exist(self):
+        features = FeatureRegistry()
+        image = features.get_editor_plugin("draftail", "image")
+
+        self.assertIsNotNone(image.data.get("chooserUrls"))
+        self.assertEqual(
+            image.data["chooserUrls"]["imageChooser"],
+            reverse_lazy("wagtailimages_chooser:choose"),
         )

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -1,5 +1,4 @@
-from django.urls import include, path, reverse
-from django.utils.html import format_html
+from django.urls import include, path, reverse, reverse_lazy
 from django.utils.translation import gettext, ngettext
 from django.utils.translation import gettext_lazy as _
 
@@ -58,18 +57,6 @@ def register_images_menu_item():
     )
 
 
-@hooks.register("insert_editor_js")
-def editor_js():
-    return format_html(
-        """
-        <script>
-            window.chooserUrls.imageChooser = '{0}';
-        </script>
-        """,
-        reverse("wagtailimages_chooser:choose"),
-    )
-
-
 @hooks.register("register_rich_text_features")
 def register_image_feature(features):
     # define a handler for converting <embed embedtype="image"> tags into frontend HTML
@@ -96,6 +83,9 @@ def register_image_feature(features):
                 # Keep only images which are from Wagtail.
                 "allowlist": {
                     "id": True,
+                },
+                "chooserUrls": {
+                    "imageChooser": reverse_lazy("wagtailimages_chooser:choose")
                 },
             },
             js=[

--- a/wagtail/sites/templates/wagtailsites/create.html
+++ b/wagtail/sites/templates/wagtailsites/create.html
@@ -1,7 +1,0 @@
-{% extends "wagtailadmin/generic/create.html" %}
-{% load wagtailadmin_tags %}
-
-{% block extra_js %}
-    {{ block.super }}
-    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
-{% endblock %}

--- a/wagtail/sites/templates/wagtailsites/edit.html
+++ b/wagtail/sites/templates/wagtailsites/edit.html
@@ -1,7 +1,0 @@
-{% extends "wagtailadmin/generic/edit.html" %}
-{% load wagtailadmin_tags %}
-
-{% block extra_js %}
-    {{ block.super }}
-    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
-{% endblock %}

--- a/wagtail/sites/tests.py
+++ b/wagtail/sites/tests.py
@@ -56,7 +56,6 @@ class TestSiteCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def test_simple(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailsites/create.html")
         self.assertBreadcrumbsNotRendered(response.content)
 
     def test_create(self):
@@ -201,7 +200,6 @@ class TestSiteEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def test_simple(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailsites/edit.html")
         self.assertBreadcrumbsNotRendered(response.content)
 
         url_finder = AdminURLFinder(self.user)
@@ -396,7 +394,6 @@ class TestLimitedPermissions(WagtailTestUtils, TestCase):
     def test_get_create_view(self):
         response = self.client.get(reverse("wagtailsites:add"))
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailsites/create.html")
 
     def test_create(self):
         response = self.client.post(
@@ -418,7 +415,6 @@ class TestLimitedPermissions(WagtailTestUtils, TestCase):
         edit_url = reverse("wagtailsites:edit", args=(self.localhost.id,))
         response = self.client.get(edit_url)
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailsites/edit.html")
 
     def test_edit(self):
         edit_url = reverse("wagtailsites:edit", args=(self.localhost.id,))

--- a/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
@@ -1,6 +1,5 @@
 {% load wagtailadmin_tags %}
 <script src="{% versioned_static 'wagtailadmin/js/expanding-formset.js' %}"></script>
-<script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 <script src="{% versioned_static 'wagtailusers/js/group-form.js' %}"></script>
 
 {{ form_media.js }}


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11586
Fixes https://github.com/wagtail/wagtail/issues/11421 , Fixes https://github.com/wagtail/wagtail/issues/10377

Removing the usage of   global.chooserUrls  will resolve some CSP issues and make
 draftail available in more places , and more.

now this solution only work for `RichTextField` as shown below :

![Screenshot ](https://github.com/wagtail/wagtail/assets/90080237/e7cc75d0-5f15-4075-9b59-b31063007601)

 but  unfortunately not only `RichTextField` use `window.chooserUrls`  but also  other components or 
Blocks like `RichTextBlock`  and this make it fail , and I think this fail not because Frontend ,
but because Backend and I think same solution or approach will be to the other failed blocks so to solve this issue :
  - Determine all components that use `window.chooserUrls` in `ModalWorkflowSource`
  - Implement same solution or similar approach,I think the problem in this components or blocks may be in  Backend, I think 
      the problem just pass `chooserUrls` from Backend to Frontend for the failed blocks like this solution,
       I think the frontend already fixed .

Another solution for this problem but I think this is not intended to be done,
just for example use
` const url = this.props.entityType.chooserUrls.pageChooser || global.chooserUrls.pageChooser `

This will make `RichTextField`  use `local chooserUrls` and other failed blocks  
will use `window.chooserUrls` , but I think this is not intended to do.

but for `RichTextField` as I said Backend and Frontend work perfect , 
and now `RichTextField`  not rely on the `global.chooserUrls` but rely on `local chooserUrls`.


_Please check the following:_

-   ✅ Do the tests still pass?[^1]
-   ✅ Does the code comply with the style guide?
    -  ✅ Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
