### PR TITLE
Update hooks.md

### DIFF
--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -792,8 +792,8 @@ class GuacamoleMenuItem(ActionMenuItem):
 
 
 @hooks.register('register_page_action_menu_item')
-def register_guacamole_menu_item():
-    return GuacamoleMenuItem(order=10)
+def register_guacamole_menu_item(order=10):
+    return GuacamoleMenuItem()
 ```
 
 (construct_page_action_menu)=

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -792,8 +792,8 @@ class GuacamoleMenuItem(ActionMenuItem):
 
 
 @hooks.register('register_page_action_menu_item')
-def register_guacamole_menu_item(order=10):
-    return GuacamoleMenuItem()
+def register_guacamole_menu_item(order=None):
+    return GuacamoleMenuItem(order=10)
 ```
 
 (construct_page_action_menu)=

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -792,7 +792,7 @@ class GuacamoleMenuItem(ActionMenuItem):
 
 
 @hooks.register('register_page_action_menu_item')
-def register_guacamole_menu_item(order=None):
+def register_guacamole_menu_item():
     return GuacamoleMenuItem(order=10)
 ```
 
@@ -1244,7 +1244,7 @@ class GuacamoleMenuItem(ActionMenuItem):
 
 
 @hooks.register('register_snippet_action_menu_item')
-def register_guacamole_menu_item():
+def register_guacamole_menu_item(model):
     return GuacamoleMenuItem(order=10)
 ```
 


### PR DESCRIPTION
order=10 should be in function argument, not class attribute.

@hooks.register('register_snippet_action_menu_item') def register_guacamole_menu_item(order=10):
    return GuacamoleMenuItem()

<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #...







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
