### PR TITLE
Hide empty headers across admin using aria-hidden

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ Changelog
  * Fix: Prevent generic model edit view from unquoting non-integer primary keys multiple times (Matt Westcott)
  * Fix: Ensure comments are functional when editing Page models with `read_only` `Fieldpanel`s in use (Strapchay)
  * Fix: Ensure the accessible labels and tooltips reflect the correct private/public status on the live link button within pages after changing the privacy (Ayaan Qadri)
+ * Fix: Fix empty `th` (table heading) elements that are not compliant with accessibility standards (Jai Vignesh J)
  * Docs: Move the model reference page from reference/pages to the references section as it covers all Wagtail core models (Srishti Jaiswal)
  * Docs: Move the panels reference page from references/pages to the references section as panels are available for any model editing, merge panels API into this page (Srishti Jaiswal)
  * Docs: Move the tags documentation to standalone advanced topic, instead of being inside the reference/pages section (Srishti Jaiswal)

--- a/client/src/entrypoints/contrib/typed_table_block/__snapshots__/typed_table_block.test.js.snap
+++ b/client/src/entrypoints/contrib/typed_table_block/__snapshots__/typed_table_block.test.js.snap
@@ -24,7 +24,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock it renders cor
         <div class="typed-table-block__wrapper">
           <table>
             <thead>
-              <tr><th></th><th><input type="hidden" name="mytable-column-0-type" value="test_block_a"><input type="hidden" name="mytable-column-0-order" value="0"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" title="Insert column">
+              <tr><th aria-hidden="true"></th><th><input type="hidden" name="mytable-column-0-type" value="test_block_a"><input type="hidden" name="mytable-column-0-order" value="0"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" title="Insert column">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
       </button><input type="text" name="mytable-column-0-heading" class="column-heading" placeholder="Column heading"><button type="button" class="button button-secondary button-small button--icon text-replace no delete-column" aria-label="Delete column" title="Delete column">
         <svg class="icon icon-bin icon" aria-hidden="true"><use href="#icon-bin"></use></svg>
@@ -130,7 +130,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError passe
         <div class="typed-table-block__wrapper">
           <table>
             <thead>
-              <tr><th></th><th><input type="hidden" name="mytable-column-0-type" value="test_block_a"><input type="hidden" name="mytable-column-0-order" value="0"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" title="Insert column">
+              <tr><th aria-hidden="true"></th><th><input type="hidden" name="mytable-column-0-type" value="test_block_a"><input type="hidden" name="mytable-column-0-order" value="0"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" title="Insert column">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
       </button><input type="text" name="mytable-column-0-heading" class="column-heading" placeholder="Column heading"><button type="button" class="button button-secondary button-small button--icon text-replace no delete-column" aria-label="Delete column" title="Delete column">
         <svg class="icon icon-bin icon" aria-hidden="true"><use href="#icon-bin"></use></svg>
@@ -236,7 +236,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError shows
         <div class="typed-table-block__wrapper">
           <table>
             <thead>
-              <tr><th></th><th><input type="hidden" name="mytable-column-0-type" value="test_block_a"><input type="hidden" name="mytable-column-0-order" value="0"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" title="Insert column">
+              <tr><th aria-hidden="true"></th><th><input type="hidden" name="mytable-column-0-type" value="test_block_a"><input type="hidden" name="mytable-column-0-order" value="0"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" title="Insert column">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
       </button><input type="text" name="mytable-column-0-heading" class="column-heading" placeholder="Column heading"><button type="button" class="button button-secondary button-small button--icon text-replace no delete-column" aria-label="Delete column" title="Delete column">
         <svg class="icon icon-bin icon" aria-hidden="true"><use href="#icon-bin"></use></svg>

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
@@ -76,7 +76,7 @@ export class TypedTableBlock {
           <table>
             <thead>
               <tr>
-                <th></th>
+                <th aria-hidden="true"></th>
                 <th class="control-cell">
                   <button type="button" class="button button-small button-secondary append-column" data-append-column>
                     ${h(strings.ADD_COLUMN)}

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -39,6 +39,7 @@ depth: 1
  * Prevent generic model edit view from unquoting non-integer primary keys multiple times (Matt Westcott)
  * Ensure comments are functional when editing Page models with `read_only` `Fieldpanel`s in use (Strapchay)
  * Ensure the accessible labels and tooltips reflect the correct private/public status on the live link button within pages after changing the privacy (Ayaan Qadri)
+ * Fix empty `th` (table heading) elements that are not compliant with accessibility standards (Jai Vignesh J)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_pages_formset.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_pages_formset.html
@@ -17,7 +17,7 @@
     <thead>
         <tr>
             <th>{% trans "Page" %}</th>
-            <th></th>
+            <th aria-label="{% trans 'Action' %}"></th>
         </tr>
     </thead>
     <tbody id="id_{{ formset.prefix }}-FORMS">


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11596 

Added aria-hidden="true" to empty headers across admin as mentioned in https://github.com/wagtail/wagtail/issues/11596#issue-2119724365

Updated Jest snapshots for js files
Added django template comments for html files

OS:Ubuntu
Browser : Brave
_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
