### PR TITLE
Resolved the logo's hovering problem on the admin page.

### DIFF
--- a/client/src/components/Sidebar/modules/WagtailBranding.scss
+++ b/client/src/components/Sidebar/modules/WagtailBranding.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable declaration-no-important, selector-attribute-name-disallowed-list */
 
-$logo-size: 110px;
+$logo-size: 130px;
 
 // Wagging animation
 @keyframes tail-wag {
@@ -70,14 +70,15 @@ $logo-size: 110px;
   // Bird wrapper
   &__icon-wrapper {
     @apply w-bg-white-15 w-relative w-overflow-hidden hover:w-overflow-visible;
-    margin: auto;
+    margin: 0 -3%;
     width: $logo-size;
     height: $logo-size;
     border-radius: 50%;
 
     .sidebar--slim & {
-      width: 40px;
-      height: 40px;
+      width: 50px;
+      height: 50px;
+      margin: 0 -12%;
     }
 
     .page404__bg & {

--- a/client/src/components/Sidebar/modules/WagtailLogo.tsx
+++ b/client/src/components/Sidebar/modules/WagtailLogo.tsx
@@ -12,7 +12,7 @@ const WagtailLogo = ({ className, slim }: WagtailLogoProps) => {
   return (
     <svg
       style={{
-        left: slim ? '-1.125rem' : '-1.75rem',
+        left: slim ? '-0.6rem' : '-0.5rem',
       }}
       className={`
          sidebar-wagtail-branding__icon


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11634 

The SVG was extending beyond the boundaries of its wrapper div when hovering over it, so I increased the width and height of the wrapper div by 20px and added suitable margins. Additionally, I aligned the SVG inside the wrapper div by adjusting its margins.

### Technical details
• Python version: 3.11.4
• Django version: 5.0.2
• Wagtail version: 6.0
• Browser version: Edge 120