### PR TITLE
Fix #11573 PageChoosers locale filter

### DIFF
--- a/client/src/components/ChooserWidget/PageChooserWidget.js
+++ b/client/src/components/ChooserWidget/PageChooserWidget.js
@@ -34,7 +34,7 @@ export class PageChooser extends Chooser {
       matchSubclass: this.opts.matchSubclass,
       canChooseRoot: this.opts.canChooseRoot,
       userPerms: this.opts.userPerms,
-      parentId: this.opts.parentId,
+      instanceId: this.opts.instanceId
     };
     if (this.state && this.state.parentId) {
       opts.parentId = this.state.parentId;

--- a/client/src/components/ChooserWidget/PageChooserWidget.js
+++ b/client/src/components/ChooserWidget/PageChooserWidget.js
@@ -34,7 +34,7 @@ export class PageChooser extends Chooser {
       matchSubclass: this.opts.matchSubclass,
       canChooseRoot: this.opts.canChooseRoot,
       userPerms: this.opts.userPerms,
-      instanceId: this.opts.instanceId
+      instanceId: this.opts.instanceId,
     };
     if (this.state && this.state.parentId) {
       opts.parentId = this.state.parentId;

--- a/client/src/components/ChooserWidget/PageChooserWidget.js
+++ b/client/src/components/ChooserWidget/PageChooserWidget.js
@@ -34,6 +34,7 @@ export class PageChooser extends Chooser {
       matchSubclass: this.opts.matchSubclass,
       canChooseRoot: this.opts.canChooseRoot,
       userPerms: this.opts.userPerms,
+      parentId: this.opts.parentId,
     };
     if (this.state && this.state.parentId) {
       opts.parentId = this.state.parentId;

--- a/client/src/entrypoints/admin/page-chooser-modal.js
+++ b/client/src/entrypoints/admin/page-chooser-modal.js
@@ -251,6 +251,9 @@ class PageChooserModal extends ChooserModal {
     if (opts.userPerms) {
       urlParams.user_perms = opts.userPerms;
     }
+    if (opts.instanceId) {
+      urlParams.instance_id = opts.instanceId;
+    }
     return urlParams;
   }
 }

--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -158,7 +158,11 @@ class WagtailAdminPageForm(WagtailAdminModelForm):
         for obj in self.fields.values():
             if isinstance(obj, models.ModelChoiceField):
                 try:
-                    obj.widget.form_instance = self
+                    obj.widget.page_instance = (
+                        self.instance
+                        if self.instance.id is not None
+                        else self.parent_page
+                    )
                 except AttributeError:
                     # Then propably it isn't a page chooser
                     pass

--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.conf import settings
+from django.forms import models
 from django.utils.translation import gettext as _
 from django.utils.translation import ngettext
 
@@ -152,6 +153,15 @@ class WagtailAdminPageForm(WagtailAdminModelForm):
         super().__init__(data, files, *args, initial=initial, **kwargs)
 
         self.parent_page = parent_page
+
+        # bind the parent page of this forms page to the PageChooser widget
+        for obj in self.fields.values():
+            if isinstance(obj, models.ModelChoiceField):
+                try:
+                    obj.widget.form_instance = self
+                except AttributeError:
+                    # Then propably it isn't a page chooser
+                    pass
 
         if not self.show_comments_toggle:
             del self.fields["comment_notifications"]

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -295,9 +295,6 @@ class BrowseView(View):
                     active_locale_id = selected_locale.pk
                 else:
                     active_locale_id = Locale.get_active().pk
-                    selected_locale = get_object_or_404(
-                        Locale, language_code=active_locale_id
-                    )
 
                 # we are at the Root level, so get the locales from the current pages
                 choose_url = reverse("wagtailadmin_choose_page")

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -295,6 +295,9 @@ class BrowseView(View):
                     active_locale_id = selected_locale.pk
                 else:
                     active_locale_id = Locale.get_active().pk
+                    selected_locale = get_object_or_404(
+                        Locale, language_code=active_locale_id
+                    )
 
                 # we are at the Root level, so get the locales from the current pages
                 choose_url = reverse("wagtailadmin_choose_page")

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -295,6 +295,7 @@ class BrowseView(View):
                     active_locale_id = selected_locale.pk
                 else:
                     active_locale_id = Locale.get_active().pk
+                    selected_locale = get_object_or_404(Locale, id=active_locale_id)
 
                 # we are at the Root level, so get the locales from the current pages
                 choose_url = reverse("wagtailadmin_choose_page")

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -292,10 +292,12 @@ class BrowseView(View):
                     selected_locale = get_object_or_404(
                         Locale, language_code=request.GET["locale"]
                     )
-                    active_locale_id = selected_locale.pk
+                elif request.GET.get("instance_id"):
+                    page_instance = Page.objects.get(id=request.GET["instance_id"])
+                    selected_locale = page_instance.locale
                 else:
-                    active_locale_id = Locale.get_active().pk
-                    selected_locale = get_object_or_404(Locale, id=active_locale_id)
+                    selected_locale = Locale.get_active()
+                active_locale_id = selected_locale.pk
 
                 # we are at the Root level, so get the locales from the current pages
                 choose_url = reverse("wagtailadmin_choose_page")

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -302,7 +302,7 @@ class AdminPageChooser(BaseChooser):
         parent_id = value_data.get("parent_id")
         if parent_id is not None:
             opts["parentId"] = parent_id
-            
+
         if self.page_instance is not None:
             opts["instanceId"] = self.page_instance.id
         return opts

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -224,7 +224,7 @@ class AdminPageChooser(BaseChooser):
     icon = "doc-empty-inverse"
     classname = "page-chooser"
     js_constructor = "PageChooser"
-    form_instance = None
+    page_instance = None
 
     def __init__(
         self, target_models=None, can_choose_root=False, user_perms=None, **kwargs
@@ -299,20 +299,9 @@ class AdminPageChooser(BaseChooser):
     def get_js_init_options(self, id_, name, value_data):
         opts = super().get_js_init_options(id_, name, value_data)
         value_data = value_data or {}
-        page_id = None
-
-        if self.form_instance:
-            # the parentId is set to the current instances id, if the current page instance
-            # exists i.e. EditView, else set to the parent page id since the current
-            # instance doesn't exist yet. i.e CreateView, and to None if no parent page
-            if self.form_instance.instance.id is not None:
-                page_id = self.form_instance.instance.id
-            elif self.form_instance.parent_page is not None:
-                page_id = self.form_instance.parent_page.id
-
         parent_id = value_data.get("parent_id")
-        if parent_id is not None or page_id is not None:
-            opts["parentId"] = parent_id or page_id
+        if parent_id is not None or self.page_instance is not None:
+            opts["parentId"] = parent_id or self.page_instance.id
         return opts
 
     @property

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -299,14 +299,19 @@ class AdminPageChooser(BaseChooser):
     def get_js_init_options(self, id_, name, value_data):
         opts = super().get_js_init_options(id_, name, value_data)
         value_data = value_data or {}
+        page_id = None
 
-        # the parentId is set to the current instances id, if the current page instance
-        # exists i.e. EditView, else set to the parent page id since the current
-        # instance doesn't exist yet. i.e CreateView
-        page_id = self.form_instance.instance.id or self.form_instance.parent_page.id
+        if self.form_instance:
+            # the parentId is set to the current instances id, if the current page instance
+            # exists i.e. EditView, else set to the parent page id since the current
+            # instance doesn't exist yet. i.e CreateView, and to None if no parent page
+            if self.form_instance.instance.id is not None:
+                page_id = self.form_instance.instance.id
+            elif self.form_instance.parent_page is not None:
+                page_id = self.form_instance.parent_page.id
 
         parent_id = value_data.get("parent_id")
-        if parent_id is not None:
+        if parent_id is not None or page_id is not None:
             opts["parentId"] = parent_id or page_id
         return opts
 

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -224,6 +224,7 @@ class AdminPageChooser(BaseChooser):
     icon = "doc-empty-inverse"
     classname = "page-chooser"
     js_constructor = "PageChooser"
+    form_instance = None
 
     def __init__(
         self, target_models=None, can_choose_root=False, user_perms=None, **kwargs
@@ -298,9 +299,15 @@ class AdminPageChooser(BaseChooser):
     def get_js_init_options(self, id_, name, value_data):
         opts = super().get_js_init_options(id_, name, value_data)
         value_data = value_data or {}
+
+        # the parentId is set to the current instances id, if the current page instance
+        # exists i.e. EditView, else set to the parent page id since the current
+        # instance doesn't exist yet. i.e CreateView
+        page_id = self.form_instance.instance.id or self.form_instance.parent_page.id
+
         parent_id = value_data.get("parent_id")
         if parent_id is not None:
-            opts["parentId"] = parent_id
+            opts["parentId"] = parent_id or page_id
         return opts
 
     @property

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -300,8 +300,11 @@ class AdminPageChooser(BaseChooser):
         opts = super().get_js_init_options(id_, name, value_data)
         value_data = value_data or {}
         parent_id = value_data.get("parent_id")
-        if parent_id is not None or self.page_instance is not None:
-            opts["parentId"] = parent_id or self.page_instance.id
+        if parent_id is not None:
+            opts["parentId"] = parent_id
+            
+        if self.page_instance is not None:
+            opts["instanceId"] = self.page_instance.id
         return opts
 
     @property


### PR DESCRIPTION
<!-- Thanks for contributing to Wagtail! 🎉  Please add a description below, explaining the purpose of this pull request - including the issue number of the issue you're fixing (if applicable). -->

Fixes #11573 

Now the page choosers locale filter is working correctly, but still I am not sure if this is the correct the approach. I bind the widget and the form so the widget can access the instance or parent id. When I pass the instance id (during `EditView`), it behaves as the parents id and the chooser can only choose child pages. Should I only pass the parent id and never pass the instances id. Any feedback is appreciated for the way to approach this.

Tests are not added yet.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
