### PR TITLE
Avoid calling versioned_static from styleguide on application startup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
           pip install "${{ matrix.django }}"
       - name: Test
         run: |
+          WAGTAIL_FAIL_ON_VERSIONED_STATIC=1 DJANGO_SETTINGS_MODULE=wagtail.test.settings django-admin check
           coverage run --parallel-mode --source wagtail runtests.py
         env:
           DATABASE_ENGINE: django.db.backends.sqlite3
@@ -132,6 +133,7 @@ jobs:
           ${{ matrix.install_extras }}
       - name: Test
         run: |
+          WAGTAIL_FAIL_ON_VERSIONED_STATIC=1 DJANGO_SETTINGS_MODULE=wagtail.test.settings django-admin check
           coverage run --parallel-mode --source wagtail runtests.py ${{ matrix.parallel }}
         env:
           DATABASE_ENGINE: django.db.backends.postgresql
@@ -185,6 +187,7 @@ jobs:
           pip install "${{ matrix.django }}"
       - name: Test
         run: |
+          WAGTAIL_FAIL_ON_VERSIONED_STATIC=1 DJANGO_SETTINGS_MODULE=wagtail.test.settings django-admin check
           coverage run --parallel-mode --source wagtail runtests.py ${{ matrix.parallel }}
         env:
           DATABASE_ENGINE: django.db.backends.mysql

--- a/wagtail/contrib/styleguide/views.py
+++ b/wagtail/contrib/styleguide/views.py
@@ -92,8 +92,13 @@ class ExampleForm(forms.Form):
     document_chooser = forms.BooleanField(required=True)
     snippet_chooser = forms.BooleanField(required=True)
 
-    class Media:
-        css = {"all": [versioned_static("wagtailstyleguide/css/animate-progress.css")]}
+    @property
+    def media(self):
+        return forms.Media(
+            css={
+                "all": [versioned_static("wagtailstyleguide/css/animate-progress.css")]
+            }
+        )
 
 
 icon_id_pattern = re.compile(r"id=\"icon-([a-z0-9-]+)\"")


### PR DESCRIPTION
Fixes #11643. Change `class Media` into a `media` property to prevent it from being called on application startup, and add a check to our CI to fail loudly if this happens in future.