### PR TITLE
Added `AbstractGroupApprovalTask` to simplify customizing behavior

### DIFF
--- a/docs/extending/custom_tasks.md
+++ b/docs/extending/custom_tasks.md
@@ -4,11 +4,16 @@ The Workflow system allows users to create tasks, which represent stages of mode
 
 Wagtail provides one built-in task type: `GroupApprovalTask`, which allows any user in specific groups to approve or reject moderation.
 
-However, it is possible to implement your own task types. Instances of your custom task can then be created in the `Tasks` section of the Wagtail Admin.
+However, it is possible to implement your own task types. Instances of your custom task can then be created in the `Workflow tasks` section of the Wagtail Admin.
 
 ## Task models
 
-All custom tasks must be models inheriting from `wagtailcore.Task`. In this set of examples, we'll set up a task that can be approved by only one specific user.
+All custom tasks must be models inheriting from `wagtailcore.Task`. 
+
+If you need to customize the behavior of the built-in `GroupApprovalTask`, create a custom task which inherits from `AbstractGroupApprovalTask` and add your customizations there.
+See below for more details on how to customize behavior.
+
+In this set of examples, we'll set up a task that can be approved by only one specific user.
 
 ```python
 # <project>/models.py

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -3616,7 +3616,7 @@ class Workflow(AbstractWorkflow):
     pass
 
 
-class GroupApprovalTask(Task):
+class AbstractGroupApprovalTask(Task):
     groups = models.ManyToManyField(
         Group,
         verbose_name=_("groups"),
@@ -3687,8 +3687,13 @@ class GroupApprovalTask(Task):
         return _("Members of the chosen Wagtail Groups can approve this task")
 
     class Meta:
+        abstract = True
         verbose_name = _("Group approval task")
         verbose_name_plural = _("Group approval tasks")
+
+
+class GroupApprovalTask(AbstractGroupApprovalTask):
+    pass
 
 
 class WorkflowStateQuerySet(models.QuerySet):


### PR DESCRIPTION
Moved the internals of `GroupApprovalTask` into an abstract base class. Currently, if one wishes to use a `GroupApprovalTask` but merely wants to modify the behavior of e.g., `get_actions()`, they are required to completely duplicate the existing model definition which poses a maintenance burden should other behaviors change upstream in future releases.