### PR TITLE
Ensure BooleanRadioSelect uses the same styles as RadioSelect

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,12 @@ Changelog
  * Maintenance: Merge `UploadedDocument` and `UploadedImage` into new `UploadedFile` model for easier shared code usage (Advik Kabra, Karl Hobley)
 
 
+6.0.1 (xx.xx.xxxx) - IN DEVELOPMENT
+~~~~~~~~~~~~~~~~
+
+ * Ensure `BooleanRadioSelect` uses the same styles as `RadioSelect` (Thibaud Colas)
+
+
 6.0 (07.02.2024)
 ~~~~~~~~~~~~~~~~
 

--- a/client/scss/components/forms/_radio-checkbox-multiple.scss
+++ b/client/scss/components/forms/_radio-checkbox-multiple.scss
@@ -5,6 +5,7 @@
 
 .w-field--checkbox_select_multiple,
 .w-field--checkbox_select_multiple_with_disabled_options,
+.w-field--boolean_radio_select,
 .w-field--radio_select {
   ul {
     list-style: none;

--- a/client/scss/overrides/_vendor.tippy.scss
+++ b/client/scss/overrides/_vendor.tippy.scss
@@ -32,7 +32,7 @@
 }
 
 .tippy-box[data-theme='drilldown'] {
-  @apply w-rounded w-bg-surface-page w-shadow-md;
+  @apply w-rounded w-bg-surface-page w-text-inherit w-shadow-md;
   width: 300px;
 
   .tippy-content {

--- a/docs/releases/6.0.1.md
+++ b/docs/releases/6.0.1.md
@@ -1,0 +1,16 @@
+# Wagtail 6.0.1 release notes
+
+_Unreleased_
+
+```{contents}
+---
+local:
+depth: 1
+---
+```
+
+## What's new
+
+### Bug fixes
+
+ * Ensure `BooleanRadioSelect` uses the same styles as `RadioSelect` (Thibaud Colas)


### PR DESCRIPTION
Fixes #11615. This is the simpler fix, where we make sure the widget is rendered the same as `RadioSelect`. 

I’ve also tweaked the "drilldown" Tippy theme styles to make sure if custom widgets are in use in the filters, they’ll have a usable text color if they don’t set one directly.