### PR TITLE
Changed all British spellings to American spellings, in the releases section of the docs.

### DIFF
--- a/docs/releases/0.4.rst
+++ b/docs/releases/0.4.rst
@@ -82,7 +82,7 @@ Core
 * Added ``get_next_siblings`` and ``get_prev_siblings`` to ``Page``
 * Added ``page_published`` signal
 * Added ``copy`` method to ``Page`` to allow copying of pages
-* Added ``construct_whitelister_element_rules`` hook for customising the HTML whitelist used when saving ``RichText`` fields
+* Added ``construct_whitelister_element_rules`` hook for customizing the HTML whitelist used when saving ``RichText`` fields
 * Support for setting a ``subpage_types`` property on ``Page`` models, to define which page types are allowed as subpages
 
 
@@ -103,7 +103,7 @@ Search
 ------
 
 * Added a new way to configure searchable/filterable fields on models
-* Added ``get_indexed_objects`` allowing developers to customise which objects get added to the search index
+* Added ``get_indexed_objects`` allowing developers to customize which objects get added to the search index
 * Major refactor of Elasticsearch backend
 * Use ``match`` instead of ``query_string`` queries
 * Fields are now indexed in Elasticsearch with their correct type

--- a/docs/releases/0.5.rst
+++ b/docs/releases/0.5.rst
@@ -96,7 +96,7 @@ Upgrade considerations
 Urlconf entries for ``/admin/images/``, ``/admin/embeds/`` etc need to be removed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you created a Wagtail project prior to the release of Wagtail 0.3, it is likely to contain the following entries in its ``urls.py``:
+If you created a Wagtail project before the release of Wagtail 0.3, it is likely to contain the following entries in its ``urls.py``:
 
 .. code-block:: python
 
@@ -113,7 +113,7 @@ If you created a Wagtail project prior to the release of Wagtail 0.3, it is like
 
 These entries (and the corresponding ``from wagtail.wagtail* import ...`` lines) need to be removed from ``urls.py``. (The entry for ``/admin/`` should be left in, however.)
 
-Since Wagtail 0.3, the wagtailadmin module automatically takes care of registering these URL subpaths, so these entries are redundant, and these urlconf modules are not guaranteed to remain stable and backwards-compatible in future. Leaving these entries in place will now cause an ``ImproperlyConfigured`` exception to be thrown.
+Since Wagtail 0.3, the wagtailadmin module automatically takes care of registering these URL subpaths, so these entries are redundant, and these urlconf modules are not guaranteed to remain stable and backwards-compatible in the future. Leaving these entries in place will now cause an ``ImproperlyConfigured`` exception to be thrown.
 
 
 New fields on Image and Rendition models

--- a/docs/releases/0.7.rst
+++ b/docs/releases/0.7.rst
@@ -19,7 +19,7 @@ New interface for choosing image focal point
     :width: 332px
     :height: 353px
 
-When editing images, users can now specify a 'focal point' region that cropped versions of the image will be centred on. Previously the focal point could only be set automatically, through image feature detection.
+When editing images, users can now specify a 'focal point' region that cropped versions of the image will be centered on. Previously the focal point could only be set automatically, through image feature detection.
 
 
 Groups and Sites administration interfaces
@@ -28,7 +28,7 @@ Groups and Sites administration interfaces
 .. figure:: ../_static/images/releasenotes_0_7_editor-management.png
     :width: 696px
 
-The main navigation menu has been reorganised, placing site configuration options in a 'Settings' submenu. This includes two new items, which were previously only available through the Django admin backend: 'Groups', for setting up user groups with a specific set of permissions, and 'Sites', for managing the list of sites served by this Wagtail instance.
+The main navigation menu has been reorganized, placing site configuration options in a 'Settings' submenu. This includes two new items, which were previously only available through the Django admin backend: 'Groups', for setting up user groups with a specific set of permissions, and 'Sites', for managing the list of sites served by this Wagtail instance.
 
 
 Page locking
@@ -37,7 +37,7 @@ Page locking
 .. figure:: ../_static/images/releasenotes_0_7_page-locking.png
     :width: 696px
 
-Moderators and administrators now have the ability to lock a page, preventing further edits from being made to that page until it is unlocked again.
+Moderators and administrators now can lock a page, preventing further edits from being made to that page until it is unlocked again.
 
 
 Minor features
@@ -100,7 +100,7 @@ The page locking mechanism adds a ``locked`` field to wagtailcore.Page, defaulti
 Update to ``focal_point_key`` field on custom Rendition models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``focal_point_key`` field on wagtailimages.Rendition has been changed to ``null=False``, to fix an issue with duplicate renditions being created. If you have defined a custom Rendition model in your project (by extending the ``wagtailimages.AbstractRendition`` class), you will need to apply a migration to make the corresponding change on your custom model. Unfortunately neither South nor Django 1.7's migration system are able to generate this automatically - you will need to customise the migration produced by ``./manage.py schemamigration`` / ``./manage.py makemigrations``, using the wagtailimages migration as a guide:
+The ``focal_point_key`` field on wagtailimages.Rendition has been changed to ``null=False``, to fix an issue with duplicate renditions being created. If you have defined a custom Rendition model in your project (by extending the ``wagtailimages.AbstractRendition`` class), you will need to apply a migration to make the corresponding change on your custom model. Unfortunately, neither South nor Django 1.7's migration system can generate this automatically - you will need to customize the migration produced by ``./manage.py schemamigration`` / ``./manage.py makemigrations``, using the wagtailimages migration as a guide:
 
 - https://github.com/wagtail/wagtail/blob/stable/0.7.x/wagtail/wagtailimages/south_migrations/0004_auto__chg_field_rendition_focal_point_key.py (for South / Django 1.6)
 - https://github.com/wagtail/wagtail/blob/stable/0.7.x/wagtail/wagtailimages/migrations/0004_make_focal_point_key_not_nullable.py (for Django 1.7)

--- a/docs/releases/0.8.3.rst
+++ b/docs/releases/0.8.3.rst
@@ -19,10 +19,10 @@ Bug fixes
 * Added missing jQuery UI sprite files, causing collectstatic to throw errors (most reported on Heroku)
 * Page system check for on_delete actions of ForeignKeys was throwing false positives when page class descends from an abstract class (Alejandro Giacometti)
 * Page system check for on_delete actions of ForeignKeys now only raises warnings, not errors
-* Fixed a regression where form builder submissions containing a number field would fail with a JSON serialisation error
+* Fixed a regression where form builder submissions containing a number field would fail with a JSON serialization error
 * Resizing an image with a focal point equal to the image size would result in a divide-by-zero error
 * Focal point indicator would sometimes be positioned incorrectly for small or thin images
-* Fix: Focal point chooser background colour changed to grey to make working with transparent images easier
+* Fix: Focal point chooser background color changed to grey to make working with transparent images easier
 * Elasticsearch configuration now supports specifying HTTP authentication parameters as part of the URL, and defaults to ports 80 (HTTP) and 443 (HTTPS) if port number not specified
 * Fixed a TypeError when previewing pages that use RoutablePageMixin
 * Rendering image with missing file in rich text no longer crashes the entire page
@@ -36,4 +36,4 @@ Upgrade considerations
 Port number must be specified when running Elasticsearch on port 9200
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In previous versions, an Elasticsearch connection URL in ``WAGTAILSEARCH_BACKENDS`` without an explicit port number (e.g. ``http://localhost/``) would be treated as port 9200 (the Elasticsearch default) whereas the correct behaviour would be to use the default http/https port of 80/443. This behaviour has now been fixed, so sites running Elasticsearch on port 9200 must now specify this explicitly - e.g. ``http://localhost:9200``. (Projects using the default settings, or the settings given in the Wagtail documentation, are unaffected.)
+In previous versions, an Elasticsearch connection URL in ``WAGTAILSEARCH_BACKENDS`` without an explicit port number (e.g. ``http://localhost/``) would be treated as port 9200 (the Elasticsearch default) whereas the correct behavior would be to use the default http/https port of 80/443. This behavior has now been fixed, so sites running Elasticsearch on port 9200 must now specify this explicitly - e.g. ``http://localhost:9200``. (Projects using the default settings, or the settings given in the Wagtail documentation, are unaffected.)

--- a/docs/releases/0.8.6.rst
+++ b/docs/releases/0.8.6.rst
@@ -40,4 +40,4 @@ This release fixes a bug with page deletion introduced in 0.8, where deleting a 
 
 This will output a list of any orphaned pages found, and request confirmation before deleting them.
 
-Since this now makes ``fixtree`` an interactive command, a ``./manage.py fixtree --noinput`` option has been added to restore the previous non-interactive behaviour. With this option enabled, deleting orphaned pages is always skipped.
+Since this now makes ``fixtree`` an interactive command, a ``./manage.py fixtree --noinput`` option has been added to restore the previous non-interactive behavior. With this option enabled, deleting orphaned pages is always skipped.

--- a/docs/releases/1.0.rst
+++ b/docs/releases/1.0.rst
@@ -15,7 +15,7 @@ What's changed
 StreamField - a field type for freeform content
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-StreamField provides an editing model for freeform content such as blog posts and news stories, allowing diverse content types such as text, images, headings, video and more specialised types such as maps and charts to be mixed in any order. See :ref:`streamfield_topic`.
+StreamField provides an editing model for freeform content such as blog posts and news stories, allowing diverse content types such as text, images, headings, video and more specialized types such as maps and charts to be mixed in any order. See :ref:`streamfield_topic`.
 
 
 Wagtail API - A RESTful API for your Wagtail site
@@ -61,7 +61,7 @@ Core
 
 * The Page model now records the date/time that a page was first published, as the field ``first_published_at``
 * Increased the maximum length of a page slug from 50 to 255 characters
-* Added hooks ``register_rich_text_embed_handler`` and ``register_rich_text_link_handler`` for customising link / embed handling within rich text fields
+* Added hooks ``register_rich_text_embed_handler`` and ``register_rich_text_link_handler`` for customizing link / embed handling within rich text fields
 * Page URL paths can now be longer than 255 characters
 
 
@@ -106,7 +106,7 @@ Admin
 * Reversing ``django.contrib.auth.admin.login`` will no longer lead to Wagtails login view (making it easier to have frontend login views)
 * Added cache-control headers to all admin views. This allows Varnish/Squid/CDN to run on vanilla settings in front of a Wagtail site
 * Date / time pickers now consistently use times without seconds, to prevent JavaScript behaviour glitches when focusing / unfocusing fields
-* Added hook ``construct_homepage_summary_items`` for customising the site summary panel on the admin homepage
+* Added hook ``construct_homepage_summary_items`` for customizing the site summary panel on the admin homepage
 * Renamed the ``construct_wagtail_edit_bird`` hook to ``construct_wagtail_userbar``
 * 'static' template tags are now used throughout the admin templates, in place of ``STATIC_URL``
 
@@ -204,7 +204,7 @@ In previous versions of Wagtail, page types that used the :class:`~wagtail.contr
 
 Wagtail 1.0 introduces a new syntax where each view function is annotated with a ``@route`` decorator - see :ref:`routable_page_mixin`.
 
-The old ``subpage_urls`` convention will continue to work on Django versions prior to 1.8, but this is now deprecated; all existing ``RoutablePage`` definitions should be updated to the decorator-based convention.
+The old ``subpage_urls`` convention will continue to work on Django versions before 1.8, but this is now deprecated; all existing ``RoutablePage`` definitions should be updated to the decorator-based convention.
 
 Upgrading from the external ``wagtailapi`` module.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -276,7 +276,7 @@ Celery no longer automatically used for sending notification emails
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Previously, Wagtail would try to use Celery whenever the ``djcelery`` module was
-installed, even if Celery wasn't actually set up. This could cause a very hard
+installed, even if Celery wasn't set up. This could cause a very hard
 to track down problem where notification emails would not be sent so this
 functionality has now been removed.
 
@@ -299,7 +299,7 @@ To improve compatibility with third-party form widgets, pages within the Wagtail
 EditHandler internal API has changed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-While it is not an official Wagtail API, it has been possible for Wagtail site implementers to define their own ``EditHandler`` subclasses for use in panel definitions, to customise the behaviour of the page / snippet editing forms. If you have made use of this facility, you will need to update your custom EditHandlers, as this mechanism has been refactored (to allow EditHandler classes to keep a persistent reference to their corresponding model). If you have only used Wagtail's built-in panel types (``FieldPanel``, ``InlinePanel``, ``PageChooserPanel`` and so on), you are unaffected by this change.
+While it is not an official Wagtail API, it has been possible for Wagtail site implementers to define their own ``EditHandler`` subclasses for use in panel definitions, to customize the behavior of the page / snippet editing forms. If you have made use of this facility, you will need to update your custom EditHandlers, as this mechanism has been refactored (to allow EditHandler classes to keep a persistent reference to their corresponding model). If you have only used Wagtail's built-in panel types (``FieldPanel``, ``InlinePanel``, ``PageChooserPanel`` and so on), you are unaffected by this change.
 
 Previously, functions like ``FieldPanel`` acted as 'factory' functions, where a call such as ``FieldPanel('title')`` constructed and returned an ``EditHandler`` subclass tailored to work on a 'title' field. These functions now return an object with a ``bind_to_model`` method instead; the EditHandler subclass can be obtained by calling this with the model class as a parameter. As a guide to updating your custom EditHandler code, you may wish to refer to `the relevant change to the Wagtail codebase <https://github.com/wagtail/wagtail/commit/121c01c7f7db6087a985fa8dc9957bc78b9f6a6a>`_.
 
@@ -324,7 +324,7 @@ Previously, the ``document_served`` signal (which is fired whenever a user downl
 Custom image models must specify an ``admin_form_fields`` list
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Previously, the forms for creating and editing images followed Django's default behaviour of showing all fields defined on the model; this would include any custom fields specific to your project that you defined by subclassing ``AbstractImage`` and setting ``WAGTAILIMAGES_IMAGE_MODEL``. This behaviour is risky as it may lead to fields being unintentionally exposed to the user, and so Django has deprecated this, for removal in Django 1.8. Accordingly, if you create your own custom subclass of ``AbstractImage``, you must now provide an ``admin_form_fields`` property, listing the fields that should appear on the image creation / editing form - for example:
+Previously, the forms for creating and editing images followed Django's default behavior of showing all fields defined on the model; this would include any custom fields specific to your project that you defined by subclassing ``AbstractImage`` and setting ``WAGTAILIMAGES_IMAGE_MODEL``. This behavior is risky as it may lead to fields being unintentionally exposed to the user, and so Django has deprecated this, for removal in Django 1.8. Accordingly, if you create your own custom subclass of ``AbstractImage``, you must now provide an ``admin_form_fields`` property, listing the fields that should appear on the image creation / editing form - for example:
 
 .. code-block:: python
 

--- a/docs/releases/1.1.rst
+++ b/docs/releases/1.1.rst
@@ -38,7 +38,7 @@ We hope to support more REST framework features, such as a browsable API, in fut
 Permissions fixes in the admin interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A number of inconsistencies around permissions in the admin interface were fixed in this release:
+Several inconsistencies around permissions in the admin interface were fixed in this release:
 
 * Removed all permissions for "User profile" (not used)
 * Removed "delete" permission for Images and documents (not used)

--- a/docs/releases/1.10.rst
+++ b/docs/releases/1.10.rst
@@ -94,7 +94,7 @@ Bug fixes
 * The ModelAdmin module can now work without the wagtailimages and wagtaildocs apps installed (Andy Babic)
 * Cloudflare error handling now handles non-string error responses correctly (hdnpl)
 * Search indexing now uses a defined query ordering to prevent objects from being skipped (Christian Peters)
-* Ensure that number localisation is not applied to object IDs within admin templates (Tom Hendrikx)
+* Ensure that number localization is not applied to object IDs within admin templates (Tom Hendrikx)
 * Paginating with a search present was always returning the 1st page in Internet Explorer 10 & 11 (Ralph Jacobs)
 * RoutablePageMixin and wagtailforms previews now set the ``request.is_preview`` flag (Wietze Helmantel)
 * The save and preview buttons in the page editor are now mobile-friendly (Maarten Kling)
@@ -159,7 +159,7 @@ Projects using :ref:`custom image models <custom_image_model>` no longer need to
 Adding / editing users through Wagtail admin no longer sets ``is_staff`` flag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Previously, the ``is_staff`` flag (which grants access to the Django admin interface) was automatically set for superusers, and reset for other users, when creating and updating users through the Wagtail admin. This behaviour has now been removed, since Wagtail is designed to work independently of the Django admin. If you need to reinstate the old behaviour, you can set up a `pre_save signal handler <https://docs.djangoproject.com/en/stable/ref/signals/#django.db.models.signals.pre_save>`_ on the User model to set the flag appropriately.
+Previously, the ``is_staff`` flag (which grants access to the Django admin interface) was automatically set for superusers, and reset for other users, when creating and updating users through the Wagtail admin. This behaviour has now been removed, since Wagtail is designed to work independently of the Django admin. If you need to reinstate the old behavior, you can set up a `pre_save signal handler <https://docs.djangoproject.com/en/stable/ref/signals/#django.db.models.signals.pre_save>`_ on the User model to set the flag appropriately.
 
 
 Specifying the full file name in documents URL is mandatory
@@ -174,5 +174,5 @@ This feature was supposed to allow shorter URLs but was not used in Wagtail.
 For security reasons, we removed it, so only the full URL works:
 ``/documents/1/your-file-name.pdf``
 
-If any of your applications relied on the previous behaviour, you will have to
+If any of your applications relied on the previous behavior, you will have to
 rewrite it to take this into account.

--- a/docs/releases/1.12.rst
+++ b/docs/releases/1.12.rst
@@ -50,7 +50,7 @@ Bug fixes
 * Hide the userbar from printed page representation (Eugene Morozov)
 * Prevent the page editor footer content from collapsing into two lines unnecessarily (Jack Paine)
 * StructBlock values no longer render HTML templates as their ``str`` representation, to prevent infinite loops in debugging / logging tools (Matt Westcott)
-* Removed deprecated jQuery ``load`` call from TableBlock initialisation (Jack Paine)
+* Removed deprecated jQuery ``load`` call from TableBlock initialization (Jack Paine)
 * Position of options in mobile nav-menu (Jack Paine)
 * Center page editor footer regardless of screen width (Jack Paine)
 * Change the design of the navbar toggle icon so that it no longer obstructs page headers (Jack Paine)
@@ -62,7 +62,7 @@ Upgrade considerations
 StreamField now defaults to ``blank=False``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-StreamField now respects the ``blank`` field setting; when this is false, at least one block must be supplied for the field to pass validation. To match the behaviour of other model fields, ``blank`` defaults to ``False``; if you wish to allow a StreamField to be left empty, you must now add ``blank=True`` to the field.
+StreamField now respects the ``blank`` field setting; when this is false, at least one block must be supplied for the field to pass validation. To match the behavior of other model fields, ``blank`` defaults to ``False``; if you wish to allow a StreamField to be left empty, you must now add ``blank=True`` to the field.
 
 When passing an explicit ``StreamBlock`` as the top-level block of a StreamField definition, note that the StreamField's ``blank`` keyword argument always takes precedence over the block's ``required`` property, including when it is left as the default value of ``blank=False``. Consequently, setting ``required=False`` on a top-level ``StreamBlock`` has no effect.
 
@@ -70,19 +70,19 @@ When passing an explicit ``StreamBlock`` as the top-level block of a StreamField
 Old configuration settings for embeds are deprecated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The configuration settings ``WAGTAILEMBEDS_EMBED_FINDER`` and ``WAGTAILEMBEDS_EMBEDLY_KEY`` have been deprecated in favour of the new ``WAGTAILEMBEDS_FINDERS`` setting. Please see :ref:`configuring_embed_finders` for the new configuration to use.
+The configuration settings ``WAGTAILEMBEDS_EMBED_FINDER`` and ``WAGTAILEMBEDS_EMBEDLY_KEY`` have been deprecated in favor of the new ``WAGTAILEMBEDS_FINDERS`` setting. Please see :ref:`configuring_embed_finders` for the new configuration to use.
 
 
 Registering custom hallo.js plugins directly is deprecated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ability to enable / disable ``hallo.js`` plugins by calling ``registerHalloPlugin`` or modifying the ``halloPlugins`` list has been deprecated, and will be removed in Wagtail 1.14. The recommended way of customising the hallo.js editor is now through :ref:`rich text features <rich_text_features>`.
+The ability to enable / disable ``hallo.js`` plugins by calling ``registerHalloPlugin`` or modifying the ``halloPlugins`` list has been deprecated, and will be removed in Wagtail 1.14. The recommended way of customizing the hallo.js editor is now through :ref:`rich text features <rich_text_features>`.
 
 
 Custom ``get_admin_display_title`` methods should use ``draft_title``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This release introduces a new ``draft_title`` field on page models, so that page titles as used across the admin interface will correctly reflect any changes that exist in draft. If any of your page models override the ``get_admin_display_title`` method, to customise the display of page titles in the admin, it is recommended that you now update these to base their output on ``draft_title`` rather than ``title``. Alternatively, to preserve backwards compatibility, you can invoke ``super`` on the method, for example:
+This release introduces a new ``draft_title`` field on page models, so that page titles as used across the admin interface will correctly reflect any changes that exist in draft. If any of your page models override the ``get_admin_display_title`` method, to customize the display of page titles in the admin, it is recommended that you now update these to base their output on ``draft_title`` rather than ``title``. Alternatively, to preserve backwards compatibility, you can invoke ``super`` on the method, for example:
 
 .. code-block:: python
 

--- a/docs/releases/1.2.rst
+++ b/docs/releases/1.2.rst
@@ -50,7 +50,7 @@ See: :ref:`wagtailsearch_searching`
 ``max_num`` and ``min_num`` parameters on inline panels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Inline panels now accept the optional parameters ``max_num`` and ``min_num``, to specify the maximum / minimum number of child items that must exist in order for the page to be valid.
+Inline panels now accept the optional parameters ``max_num`` and ``min_num``, to specify the maximum / minimum number of child items that must exist for the page to be valid.
 
 See: :ref:`inline_panels`
 
@@ -76,21 +76,21 @@ Wagtail now supports Python 3.5 when run in conjunction with Django 1.8.6 or lat
 Minor features
 ~~~~~~~~~~~~~~
 
-* WagtailRedirectMiddleware can now ignore the query string if there is no redirect that exactly matches it
+* WagtailRedirectMiddleware can now ignore the query string if no redirect exactly matches it
 * Order of URL parameters now ignored by redirect middleware
 * Added SQL Server compatibility to image migration
 * Added ``class`` attributes to Wagtail rich text editor buttons to aid custom styling
 * Simplified body_class in default homepage template
 * page_published signal now called with the revision object that was published
-* Added a favicon to the admin interface, customisable by overriding the ``branding_favicon`` block (see :ref:`custom_branding`).
+* Added a favicon to the admin interface, customizable by overriding the ``branding_favicon`` block (see :ref:`custom_branding`).
 * Added spinner animations to long-running form submissions
 * The EMBEDLY_KEY setting has been renamed to WAGTAILEMBEDS_EMBEDLY_KEY
 * StreamField blocks are now added automatically, without showing the block types menu, if only one block type exists (Alex Gleason)
 * The ``first_published_at`` and ``latest_revision_created_at`` fields on page models are now available as filter fields on search queries
-* Wagtail admin now standardises on a single thumbnail image size, to reduce the overhead of creating multiple renditions
+* Wagtail admin now standardizes on a single thumbnail image size, to reduce the overhead of creating multiple renditions
 * Rich text fields now strip out HTML comments
 * Page editor form now sets ``enctype="multipart/form-data"`` as appropriate, allowing FileField to be used on page models (Petr Vacha)
-* Explorer navigation menu on a completely empty page tree now takes you to the root level, rather than doing nothing
+* Explorer navigation menu on an empty page tree now takes you to the root level, rather than doing nothing
 * Added animation and fixed display issues when focusing a rich text field (Alex Gleason)
 * Added a system check to warn if Pillow is compiled without JPEG / PNG support
 * Page chooser now prevents users from selecting the root node where this would be invalid
@@ -132,7 +132,7 @@ Previously, the manager methods behaved as *exclusive* by default; that is, they
 
     >>> event_1 = EventPage.objects.get(title='Event 1')
     >>> EventPage.objects.sibling_of(event_1)
-    [<EventPage: Event 2>]  # OLD behaviour: Event 1 is not considered a sibling of itself
+    [<EventPage: Event 2>]  # OLD behavior: Event 1 is not considered a sibling of itself
 
 
 This has now been changed to be *inclusive* by default; that is, the page is counted as a sibling of itself:
@@ -141,7 +141,7 @@ This has now been changed to be *inclusive* by default; that is, the page is cou
 
     >>> event_1 = EventPage.objects.get(title='Event 1')
     >>> EventPage.objects.sibling_of(event_1)
-    [<EventPage: Event 1>, <EventPage: Event 2>]  # NEW behaviour: Event 1 is considered a sibling of itself
+    [<EventPage: Event 1>, <EventPage: Event 2>]  # NEW behavior: Event 1 is considered a sibling of itself
 
 
 If the call to ``sibling_of`` or ``not_sibling_of`` is chained after another QuerySet method - such as ``all()``, ``filter()`` or ``live()`` - behaviour is unchanged; this behaves as *inclusive*, as it did in previous versions:
@@ -153,7 +153,7 @@ If the call to ``sibling_of`` or ``not_sibling_of`` is chained after another Que
     [<EventPage: Event 1>, <EventPage: Event 2>]  # OLD and NEW behaviour
 
 
-If your project includes queries that rely on the old (exclusive) behaviour, this behaviour can be restored by adding the keyword argument ``inclusive=False``:
+If your project includes queries that rely on the old (exclusive) behavior, this behavior can be restored by adding the keyword argument ``inclusive=False``:
 
 .. code-block:: python
 
@@ -165,7 +165,7 @@ If your project includes queries that rely on the old (exclusive) behaviour, thi
 ``Image.search`` and ``Document.search`` methods are deprecated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``Image.search`` and ``Document.search`` methods have been deprecated in favour of the new QuerySet-based search mechanism - see :ref:`wagtailsearch_images_documents_custom_models`. Code using the old ``search`` methods should be updated to search on QuerySets instead; for example:
+The ``Image.search`` and ``Document.search`` methods have been deprecated in favor of the new QuerySet-based search mechanism - see :ref:`wagtailsearch_images_documents_custom_models`. Code using the old ``search`` methods should be updated to search on QuerySets instead; for example:
 
 .. code-block:: python
 
@@ -189,6 +189,6 @@ If you have the Wagtail API (``wagtail.contrib.wagtailapi``) enabled, you must n
 
 If you have any application code that makes direct updates to page data, at the model or database level, be aware that the way these edits are reflected in the page editor has changed.
 
-Previously, the ``get_latest_revision_as_page`` method - used by the page editor to return the current page revision for editing - always retrieved data from the page's revision history. Now, it will only do so if the page has unpublished changes (i.e. the page is in ``live + draft`` state) - pages which have received no draft edits since being published will return the page's live data instead.
+Previously, the ``get_latest_revision_as_page`` method - used by the page editor to return the current page revision for editing - always retrieved data from the page's revision history. Now, it will only do so if the page has unpublished changes (i.e. the page is in ``live + draft`` state) - pages that have received no draft edits since being published will return the page's live data instead.
 
-As a result, any changes made directly to a live page object will be immediately reflected in the editor without needing to update the latest revision record (but note, the old behaviour is still used for pages in ``live + draft`` state).
+As a result, any changes made directly to a live page object will be immediately reflected in the editor without needing to update the latest revision record (but note, the old behavior is still used for pages in ``live + draft`` state).

--- a/docs/releases/1.3.rst
+++ b/docs/releases/1.3.rst
@@ -39,7 +39,7 @@ Fields on related objects can now be indexed in Elasticsearch using the new ``in
         ]
 
     # Search books where their author was born after 1950
-    # Both the book title and the authors name will be searched
+    # Both the book title and the author's name will be searched
     >>> Book.objects.filter(author__date_of_birth__gt=date(1950, 1, 1)).search("Hello")
 
 See: :ref:`wagtailsearch_index_relatedfields`
@@ -93,7 +93,7 @@ Bug fixes
 * ``MenuItem`` ``url`` parameter can now take a lazy URL (Adon Metcalfe, rayrayndwiga)
 * Added missing translation tag to InlinePanel 'Add' button (jnns)
 * Added missing translation tag to 'Signing in...' button text (Eugene MechanisM)
-* Restored correct highlighting behaviour of rich text toolbar buttons
+* Restored correct highlighting behavior of rich text toolbar buttons
 * Rendering a missing image through ImageChooserBlock no longer breaks the whole page (Christian Peters)
 * Filtering by popular tag in the image chooser now works when using the database search backend
 

--- a/docs/releases/1.4.5.rst
+++ b/docs/releases/1.4.5.rst
@@ -16,7 +16,7 @@ Bug fixes
 ~~~~~~~~~
 
 * Paste / drag operations done entirely with the mouse are now correctly picked up as edits within the rich text editor (Matt Fozard)
-* Logic for cancelling the "unsaved changes" check on form submission has been fixed to work cross-browser (Stephen Rice)
+* Logic for canceling the "unsaved changes" check on form submission has been fixed to work cross-browser (Stephen Rice)
 * The "unsaved changes" confirmation was erroneously shown on IE / Firefox when previewing a page with validation errors (Matt Westcott)
 * The up / down / delete controls on the "Promoted search results" form no longer trigger a form submission (Matt Westcott)
 * Opening preview window no longer performs user-agent sniffing, and now works correctly on IE11 (Matt Westcott)

--- a/docs/releases/1.4.rst
+++ b/docs/releases/1.4.rst
@@ -24,10 +24,10 @@ Page revision management
 From the page editing interface, editors can now access a list of previous revisions of the page, and preview or roll back to any earlier revision.
 
 
-Collections for image / document organisation
+Collections for image / document organization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Images and documents can now be organised into collections, set up by administrators through the Settings -> Collections menu item. User permissions can be set either globally (on the 'Root' collection) or on individual collections, allowing different user groups to keep their media items separated. Thank you to the University of South Wales for sponsoring this feature.
+Images and documents can now be organized into collections, set up by administrators through the Settings -> Collections menu item. User permissions can be set either globally (on the 'Root' collection) or on individual collections, allowing different user groups to keep their media items separated. Thank you to the University of South Wales for sponsoring this feature.
 
 
 Redesigned userbar
@@ -73,7 +73,7 @@ Minor features
 * Notification message on publish now indicates whether the page is being published now or scheduled for publication in future (Chris Rogers)
 * Server errors when uploading images / documents through the chooser modal are now reported back to the user (Nigel Fletton)
 * Added a hook :ref:`insert_global_admin_css` for inserting custom CSS throughout the admin backend (Tom Dyson)
-* Added a hook :ref:`construct_explorer_page_queryset` for customising the set of pages displayed in the page explorer
+* Added a hook :ref:`construct_explorer_page_queryset` for customizing the set of pages displayed in the page explorer
 * Page models now perform field validation, including testing slugs for uniqueness within a parent page, at the model level on saving
 * Page slugs are now auto-generated at the model level on page creation if one has not been specified explicitly
 * The ``Page`` model now has two new methods ``get_site()`` and ``get_url_parts()`` to aid with customising the page URL generation logic

--- a/docs/releases/1.5.rst
+++ b/docs/releases/1.5.rst
@@ -12,12 +12,12 @@ Wagtail 1.5 release notes
 What's new
 ==========
 
-Reorganised page explorer actions
+Reorganized page explorer actions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. image:: ../_static/images/releasenotes_1_5_explorermenu.png
 
-The action buttons on the page explorer have been reorganised to reduce clutter, and lesser-used actions have been moved to a "More" dropdown. A new hook :ref:`register_page_listing_buttons` has been added for adding custom action buttons to the page explorer.
+The action buttons on the page explorer have been reorganized to reduce clutter, and lesser-used actions have been moved to a "More" dropdown. A new hook :ref:`register_page_listing_buttons` has been added for adding custom action buttons to the page explorer.
 
 ModelAdmin
 ~~~~~~~~~~
@@ -88,7 +88,7 @@ Minor features
 * Spinner was added to Save button on site settings (Liam Brenner)
 * Added success message after logout from Admin (Liam Brenner)
 * Added ``get_upload_to`` method to ``AbstractRendition`` which, when overridden, allows control over where image renditions are stored (Rob Moggach and Matt Westcott)
-* Added a mechanism to customise the add / edit user forms for custom user models - see :doc:`/advanced_topics/customisation/custom_user_models` (Nigel Fletton)
+* Added a mechanism to customize the add / edit user forms for custom user models - see :doc:`/advanced_topics/customisation/custom_user_models` (Nigel Fletton)
 * Added internal provision for swapping in alternative rich text editors (Karl Hobley)
 
 Bug fixes
@@ -166,7 +166,7 @@ Previously, if you used the Elasticsearch backend, configured with the URLS prop
 
 Elasticsearch would not be configured to verify SSL certificates for HTTPS URLs. This has been changed so that SSL certificates are verified for HTTPS connections by default.
 
-If you need the old behaviour back, where SSL certificates are not verified for your HTTPS connection, you can configure the Elasticsearch backend with the ``HOSTS`` option, like so:
+If you need the old behavior back, where SSL certificates are not verified for your HTTPS connection, you can configure the Elasticsearch backend with the ``HOSTS`` option, like so:
 
 .. code-block:: python
 
@@ -189,4 +189,4 @@ Project template now imports ``settings.dev`` explicitly
 
 In previous releases, the project template's ``settings/__init__.py`` file was set up to import the development settings (``settings/dev.py``), so that these would be picked up as the default (i.e. whenever a settings module was not specified explicitly). However, in some setups this meant that the development settings were being inadvertently imported in production mode.
 
-For this reason, the import in ``settings/__init__.py`` has now been removed, and commands must now specify ``myproject.settings.dev`` or ``myproject.settings.production`` as appropriate; the supporting scripts (such as ``manage.py``) have been updated accordingly. As this is a change to the project template, existing projects are not affected; however, if you have any common scripts or configuration files that rely on importing ``myproject.settings`` as the settings module, these will need to be updated in order to work on projects created under Wagtail 1.5.
+For this reason, the import in ``settings/__init__.py`` has now been removed, and commands must now specify ``myproject.settings.dev`` or ``myproject.settings.production`` as appropriate; the supporting scripts (such as ``manage.py``) have been updated accordingly. As this is a change to the project template, existing projects are not affected; however, if you have any common scripts or configuration files that rely on importing ``myproject.settings`` as the settings module, these will need to be updated to work on projects created under Wagtail 1.5.

--- a/docs/releases/1.6.rst
+++ b/docs/releases/1.6.rst
@@ -22,7 +22,7 @@ Wagtail is now compatible with Django 1.10. Thanks to Mikalai Radchuk and Paul J
 ``{% include_block %}`` tag for improved StreamField template inclusion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In previous releases, the standard way of rendering the HTML content of a StreamField was through a simple variable template tag, such as ``{{ page.body }}``. This had the drawback that any templates used in the StreamField rendering would not inherit variables from the parent template's context, such as ``page`` and ``request``. To address this, a new template tag ``{% include_block page.body %}`` has been introduced as the new recommended way of outputting Streamfield content - this replicates the behaviour of Django's ``{% include %}`` tag, passing on the full template context by default. For full documentation, see :ref:`streamfield_template_rendering`. This feature was developed by Matt Westcott, and additionally ported to Jinja2 (see: :doc:`/reference/jinja2`) by Mikalai Radchuk.
+In previous releases, the standard way of rendering the HTML content of a StreamField was through a simple variable template tag, such as ``{{ page.body }}``. This had the drawback that any templates used in the StreamField rendering would not inherit variables from the parent template's context, such as ``page`` and ``request``. To address this, a new template tag ``{% include_block page.body %}`` has been introduced as the new recommended way of outputting Streamfield content - this replicates the behavior of Django's ``{% include %}`` tag, passing on the full template context by default. For full documentation, see :ref:`streamfield_template_rendering`. This feature was developed by Matt Westcott, and additionally ported to Jinja2 (see: :doc:`/reference/jinja2`) by Mikalai Radchuk.
 
 
 Unicode page slugs
@@ -51,7 +51,7 @@ Minor features
 * Added a new FloatBlock, DecimalBlock and a RegexBlock (Oktay Altay, Andy Babic)
 * Wagtail version number is now shown on the settings menu (Chris Rogers)
 * Added a system check to validate that fields listed in ``search_fields`` are defined on the model (Josh Schneier)
-* Added formal APIs for customising the display of StructBlock forms within the page editor - see :ref:`custom_editing_interfaces_for_structblock` (Matt Westcott)
+* Added formal APIs for customizing the display of StructBlock forms within the page editor - see :ref:`custom_editing_interfaces_for_structblock` (Matt Westcott)
 * ``wagtailforms.models.AbstractEmailForm`` now supports multiple email recipients (Serafeim Papastefanos)
 * Added ability to delete users through Settings -> Users (Vincent Audebert; thanks also to Ludolf Takens and Tobias Schmidt for alternative implementations)
 * Page previews now pass additional HTTP headers, to simulate the page being viewed by the logged-in user and avoid clashes with middleware (Robert Rollins)
@@ -67,7 +67,7 @@ Bug fixes
 * Email templates and document uploader now support custom ``STATICFILES_STORAGE`` (Jonny Scholes)
 * Removed alignment options (deprecated in HTML and not rendered by Wagtail) from ``TableBlock`` context menu (Moritz Pfeiffer)
 * Fixed incorrect CSS path on ModelAdmin's "choose a parent page" view
-* Prevent empty redirect by overnormalisation
+* Prevent empty redirect by overnormalization
 * "Remove link" button in rich text editor didn't trigger "edit" event, leading to the change to sometimes not be persisted (Matt Westcott)
 * ``RichText`` values can now be correctly evaluated as booleans (Mike Dingjan, Bertrand Bordage)
 * wagtailforms no longer assumes an .html extension when determining the landing page template filename (kakulukia)
@@ -95,7 +95,7 @@ There are some changes in the ``wagtailforms.models.AbstractFormField`` model:
 * The ``choices`` field has been changed from a ``CharField`` to a ``TextField``, to allow it to be of unlimited length;
 * The help text for the ``to_address`` field has been changed: it now gives more information on how to specify multiple addresses.
 
-These changes require migration. If you are using the ``wagtailforms`` module in your project, you will need to run ``python manage.py makemigrations`` and ``python manage.py migrate`` after upgrading, in order to apply changes to your form page models.
+These changes require migration. If you are using the ``wagtailforms`` module in your project, you will need to run ``python manage.py makemigrations`` and ``python manage.py migrate`` after upgrading, to apply changes to your form page models.
 
 ``TagSearchable`` needs removing from custom image / document model migrations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/1.7.rst
+++ b/docs/releases/1.7.rst
@@ -50,14 +50,14 @@ Minor features
 * The Wagtail version number can now be obtained as a tuple using ``from wagtail import VERSION`` (Tim Heap)
 * ``send_mail`` logic has been moved from ``AbstractEmailForm.process_form_submission`` into ``AbstractEmailForm.send_mail``. Now it's easier to override this logic (Tim Leguijt)
 * Added ``before_create_page``, ``before_edit_page``, ``before_delete_page`` hooks (Karl Hobley)
-* Updated font sizes and colours to improve legibility of admin menu and buttons (Stein Strindhaug)
+* Updated font sizes and colors to improve legibility of admin menu and buttons (Stein Strindhaug)
 * Added pagination to "choose destination" view when moving pages (Nick Smith, Žan Anderle)
 * Added ability to annotate search results with score - see :ref:`wagtailsearch_annotating_results_with_score` (Karl Hobley)
 * Added ability to limit access to form submissions - see :ref:`filter_form_submissions_for_user` (Mikalai Radchuk)
 * Added the ability to configure the number of days search logs are kept for, through the :ref:`WAGTAILSEARCH_HITS_MAX_AGE <wagtailsearch_hits_max_age>` setting (Stephen Rice)
 * ``SnippetChooserBlock`` now supports passing the model name as a string (Nick Smith)
 * Redesigned account settings / logout area in the sidebar for better clarity (Janneke Janssen)
-* Pillow's image optimisation is now applied when saving JPEG images (Karl Hobley)
+* Pillow's image optimization is now applied when saving JPEG images (Karl Hobley)
 
 
 Bug fixes
@@ -65,7 +65,7 @@ Bug fixes
 
 * Migrations for wagtailcore and project template are now reversible (Benjamin Bach)
 * Migrations no longer depend on wagtailcore and taggit's ``__latest__`` migration, logically preventing those apps from receiving new migrations (Matt Westcott)
-* The default image format label text ('Full width', 'Left-aligned', 'Right-aligned') is now localised (Mikalai Radchuk)
+* The default image format label text ('Full width', 'Left-aligned', 'Right-aligned') is now localized (Mikalai Radchuk)
 * Text on the front-end 'password required' form is now marked for translation (Janneke Janssen)
 * Text on the page view restriction form is now marked for translation (Luiz Boaretto)
 * Fixed toggle behaviour of userbar on mobile (Robert Rollins)
@@ -109,7 +109,7 @@ This may produce ``InconsistentMigrationHistory`` errors under Django 1.10 when 
 Custom image models require a data migration for the new ``filter_spec`` field
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The data model for image renditions will be changed in Wagtail 1.8 to eliminate ``Filter`` as a model. Wagtail sites using a custom image model (see :ref:`custom_image_model`) need to have a schema and data migration in place prior to upgrading to Wagtail 1.8. To create these migrations:
+The data model for image renditions will be changed in Wagtail 1.8 to eliminate ``Filter`` as a model. Wagtail sites using a custom image model (see :ref:`custom_image_model`) need to have a schema and data migration in place before upgrading to Wagtail 1.8. To create these migrations:
 
 * Run ``manage.py makemigrations`` to create the schema migration
 * Run ``manage.py makemigrations --empty myapp`` (replacing ``myapp`` with the name of the app containing the custom image model) to create an empty migration

--- a/docs/releases/1.8.rst
+++ b/docs/releases/1.8.rst
@@ -28,7 +28,7 @@ See: :ref:`private_pages`
 Restrictions on bulk-deletion of pages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Previously, any user with edit permission over a page and its descendants was able to delete them all as a single action, which led to the risk of accidental deletions. To guard against this, the permission rules have been revised so that a user with basic permissions can only delete pages that have no children; in order to delete a whole subtree, they must individually delete each child page first. A new "bulk delete" permission type has been added which allows a user to delete pages with children, as before; superusers receive this permission implicitly, and so there is no change of behaviour for them.
+Previously, any user with edit permission over a page and its descendants was able to delete them all as a single action, which led to the risk of accidental deletions. To guard against this, the permission rules have been revised so that a user with basic permissions can only delete pages that have no children; to delete a whole subtree, they must individually delete each child page first. A new "bulk delete" permission type has been added which allows a user to delete pages with children, as before; superusers receive this permission implicitly, and so there is no change of behavior for them.
 
 This feature was developed by Matt Westcott.
 
@@ -134,7 +134,7 @@ The ``get_image_model`` function should now be imported from ``wagtail.wagtailim
 Non-administrators now need 'bulk delete' permission to delete pages with children
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As a precaution against accidental data loss, this release introduces a new "bulk delete" permission on pages, which can be set through the Settings -> Groups area. Non-administrator users must have this permission in order to delete pages that have children; a user without this permission would have to delete each child individually before deleting the parent. By default, no groups are assigned this new permission. If you wish to restore the previous behaviour, and don't want to configure permissions manually through the admin interface, you can do so with a data migration. Create an empty migration using ``./manage.py makemigrations myapp --empty --name assign_bulk_delete_permission`` (replacing ``myapp`` with the name of one of your project's apps) and edit the migration file to contain the following:
+As a precaution against accidental data loss, this release introduces a new "bulk delete" permission on pages, which can be set through the Settings -> Groups area. Non-administrator users must have this permission to delete pages that have children; a user without this permission would have to delete each child individually before deleting the parent. By default, no groups are assigned this new permission. If you wish to restore the previous behavior and don't want to configure permissions manually through the admin interface, you can do so with a data migration. Create an empty migration using ``./manage.py makemigrations myapp --empty --name assign_bulk_delete_permission`` (replacing ``myapp`` with the name of one of your project's apps) and edit the migration file to contain the following:
 
 .. code-block:: python
 
@@ -191,7 +191,7 @@ For details of how to obtain the zone identifier, see `the Cloudflare API docume
 Extra options for the Elasticsearch constructor should be now defined with the new key ``OPTIONS`` of the ``WAGTAILSEARCH_BACKENDS`` setting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For the Elasticsearch backend, all extra keys defined in ``WAGTAILSEARCH_BACKENDS`` are passed directly to the Elasticsearch constructor. All these keys now should be moved inside the new ``OPTIONS`` dictionary. The old behaviour is still supported, but deprecated.
+For the Elasticsearch backend, all extra keys defined in ``WAGTAILSEARCH_BACKENDS`` are passed directly to the Elasticsearch constructor. All these keys now should be moved inside the new ``OPTIONS`` dictionary. The old behavior is still supported but deprecated.
 
 For example, the following configuration changes the connection class that the Elasticsearch connector_ uses:
 

--- a/docs/releases/1.9.rst
+++ b/docs/releases/1.9.rst
@@ -40,10 +40,10 @@ Accessing parent context from StreamField block ``get_context`` methods
 The ``get_context`` method on StreamField blocks now receives a ``parent_context`` keyword argument, consisting of the dict of variables passed in from the calling template. For example, this makes it possible to perform pagination logic within ``get_context``, retrieving the current page number from ``parent_context['request'].GET``. See :ref:`get_context on StreamField blocks <streamfield_get_context>`. This feature was developed by Mikael Svensson and Peter Baumgartner.
 
 
-Welcome message customisation for multi-tenanted installations
+Welcome message customization for multi-tenanted installations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The welcome message on the admin dashboard has been updated to be more suitable for multi-tenanted installations. Users whose page permissions lie within a single site will now see that site name in the welcome message, rather than the installation-wide ``WAGTAIL_SITE_NAME``. As before, this message can be customised, and additional template variables have been provided for this purpose - see :ref:`custom_branding`. This feature was developed by Jeffrey Chau.
+The welcome message on the admin dashboard has been updated to be more suitable for multi-tenanted installations. Users whose page permissions lie within a single site will now see that site name in the welcome message, rather than the installation-wide ``WAGTAIL_SITE_NAME``. As before, this message can be customized, and additional template variables have been provided for this purpose - see :ref:`custom_branding`. This feature was developed by Jeffrey Chau.
 
 
 Other features

--- a/docs/releases/2.0.1.rst
+++ b/docs/releases/2.0.1.rst
@@ -19,7 +19,7 @@ Bug fixes
 ~~~~~~~~~
 
 * Draftail now supports features specified via the ``WAGTAILADMIN_RICH_TEXT_EDITORS`` setting (Todd Dembrey)
-* Password reset form no longer indicates whether the email is recognised, as per standard Django behaviour (Bertrand Bordage)
+* Password reset form no longer indicates whether the email is recognized, as per standard Django behavior (Bertrand Bordage)
 * ``UserAttributeSimilarityValidator`` is now correctly enforced on user creation / editing forms (Tim Heap)
 * Editing setting object with no site configured no longer crashes (Harm Zeinstra)
 * Creating a new object with inlines while mandatory fields are empty no longer crashes (Bertrand Bordage)

--- a/docs/releases/2.0.rst
+++ b/docs/releases/2.0.rst
@@ -24,16 +24,16 @@ New rich text editor
 Wagtail's rich text editor has now been replaced with `Draftail <https://github.com/springload/draftail>`_, a new editor based on `Draft.js <https://draftjs.org/>`_, fixing numerous bugs and providing an improved editing experience, better support for current browsers, and more consistent HTML output. This feature was developed by Thibaud Colas, Loïc Teixeira and Matt Westcott.
 
 
-Reorganised modules
+Reorganized modules
 ~~~~~~~~~~~~~~~~~~~
 
-The modules that make up Wagtail have been renamed and reorganised, to avoid the repetition in names like ``wagtail.wagtailcore.models`` (originally an artefact of app naming limitations in Django 1.6) and to improve consistency. While this will require some up-front work to upgrade existing Wagtail sites, we believe that this will be a long-term improvement to the developer experience, improving readability of code and reducing errors. This change was implemented by Karl Hobley and Matt Westcott.
+The modules that make up Wagtail have been renamed and reorganized, to avoid the repetition in names like ``wagtail.wagtailcore.models`` (originally an artifact of app naming limitations in Django 1.6) and to improve consistency. While this will require some up-front work to upgrade existing Wagtail sites, we believe that this will be a long-term improvement to the developer experience, improving readability of code and reducing errors. This change was implemented by Karl Hobley and Matt Westcott.
 
 
 Scheduled page revisions
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The behaviour of scheduled publishing has been revised so that pages are no longer unpublished at the point of setting a future go-live date, making it possible to schedule updates to an existing published page. This feature was developed by Patrick Woods.
+The behavior of scheduled publishing has been revised so that pages are no longer unpublished at the point of setting a future go-live date, making it possible to schedule updates to an existing published page. This feature was developed by Patrick Woods.
 
 
 Other features
@@ -47,7 +47,7 @@ Other features
 * Usage count now shows on delete confirmation page when WAGTAIL_USAGE_COUNT_ENABLED is active (Kees Hink)
 * Added usage count to snippets (Kees Hink)
 * Moved usage count to the sidebar on the edit page (Kees Hink)
-* Explorer menu now reflects customisations to the page listing made via the `construct_explorer_page_queryset` hook and `ModelAdmin.exclude_from_explorer` property (Tim Heap)
+* Explorer menu now reflects customizations to the page listing made via the `construct_explorer_page_queryset` hook and `ModelAdmin.exclude_from_explorer` property (Tim Heap)
 * "Choose another image" button changed to "Change image" to avoid ambiguity (Edd Baldry)
 * Added hooks ``before_create_user``, ``after_create_user``, ``before_delete_user``, ``after_delete_user``, ``before_edit_user``, ``after_edit_user`` (Jon Carmack)
 * Added ``exclude_fields_in_copy`` property to Page to define fields that should not be included on page copy (LB (Ben Johnston))
@@ -55,18 +55,18 @@ Other features
 * Optimised preview data storage (Bertrand Bordage)
 * Added ``render_landing_page`` method to ``AbstractForm`` to be easily overridden and pass ``form_submission`` to landing page context (Stein Strindhaug)
 * Added ``heading`` kwarg to ``InlinePanel`` to allow heading to be set independently of button label (Adrian Turjak)
-* The value type returned from a ``StructBlock`` can now be customised. See :ref:`custom_value_class_for_structblock` (LB (Ben Johnston))
+* The value type returned from a ``StructBlock`` can now be customized. See :ref:`custom_value_class_for_structblock` (LB (Ben Johnston))
 * Added ``bgcolor`` image operation (Karl Hobley)
 * Added ``WAGTAILADMIN_USER_LOGIN_FORM`` setting for overriding the admin login form (Mike Dingjan)
 * Snippets now support custom primary keys (Sævar Öfjörð Magnússon)
 * Upgraded jQuery to version 3.2.1 (Janneke Janssen)
 * Update autoprefixer configuration to better match browser support targets (Janneke Janssen)
 * Update React and related dependencies to latest versions (Janneke Janssen, Hugo van den Berg)
-* Remove Hallo editor ``.richtext`` CSS class in favour of more explicit extension points (Thibaud Colas)
+* Remove Hallo editor ``.richtext`` CSS class in favor of more explicit extension points (Thibaud Colas)
 * Updated documentation styling (LB (Ben Johnston))
 * Rich text fields now take feature lists into account when whitelisting HTML elements (Matt Westcott)
 * FormPage lists and Form submission lists in admin now use class based views for easy overriding (Johan Arensman)
-* Form submission csv exports now have the export date in the filename and can be customised (Johan Arensman)
+* Form submission csv exports now have the export date in the filename and can be customized (Johan Arensman)
 * FormBuilder class now uses bound methods for field generation, adding custom fields is now easier and documented (LB (Ben Johnston))
 * Added ``WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS`` setting to determine whether superusers are included in moderation email notifications (Bruno Alla)
 * Added a basic Dockerfile to the project template (Tom Dyson)
@@ -91,7 +91,7 @@ Bug fixes
 * Fixed incorrect z-index on userbar causing it to appear behind page content (Stein Strindhaug)
 * Form submissions pagination no longer looses date filter when changing page (Bertrand Bordage)
 * PostgreSQL search backend now removes duplicate page instances from the database (Bertrand Bordage)
-* ``FormSubmissionsPanel`` now recognises custom form submission classes (LB (Ben Johnston))
+* ``FormSubmissionsPanel`` now recognizes custom form submission classes (LB (Ben Johnston))
 * Prevent the footer and revisions link from unnecessarily collapsing on mobile (Jack Paine)
 * Empty searches were activated when paginating through images and documents (LB (Ben Johnston))
 * Summary numbers of pages, images and documents were not responsive when greater than 4 digits (Michael Palmer)
@@ -131,7 +131,7 @@ Before upgrading to Django 2.0, you are advised to review the `release notes <ht
 Wagtail module path updates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Many of the module paths within Wagtail have been reorganised to reduce duplication - for example, ``wagtail.wagtailcore.models`` is now ``wagtail.core.models``. As a result, ``import`` lines and other references to Wagtail modules will need to be updated when you upgrade to Wagtail 2.0. A new command has been added to assist with this - from the root of your project's code base:
+Many of the module paths within Wagtail have been reorganized to reduce duplication - for example, ``wagtail.wagtailcore.models`` is now ``wagtail.core.models``. As a result, ``import`` lines and other references to Wagtail modules will need to be updated when you upgrade to Wagtail 2.0. A new command has been added to assist with this - from the root of your project's code base:
 
 .. code-block:: console
 
@@ -205,10 +205,10 @@ However, note that this only applies to dotted module paths beginning with ``wag
 * Template tag library names, e.g. ``{% load wagtailcore_tags %}``
 
 
-Hallo.js customisations are unavailable on the Draftail rich text editor
+Hallo.js customizations are unavailable on the Draftail rich text editor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Draftail rich text editor has a substantially different API from Hallo.js, including the use of a non-HTML format for its internal data representation; as a result, functionality added through Hallo.js plugins will be unavailable. If your project is dependent on Hallo.js-specific behaviour, you can revert to the original Hallo-based editor by adding the following to your settings:
+The Draftail rich text editor has a substantially different API from Hallo.js, including the use of a non-HTML format for its internal data representation; as a result, functionality added through Hallo.js plugins will be unavailable. If your project is dependent on Hallo.js-specific behavior, you can revert to the original Hallo-based editor by adding the following to your settings:
 
 .. code-block:: python
 
@@ -313,7 +313,7 @@ The ``generate_signature`` function in ``wagtail.images.views.serve``, used to b
 Deprecated search view
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Wagtail has always included a bundled view for frontend search. However, this view isn't easy to customise so
+Wagtail has always included a bundled view for frontend search. However, this view isn't easy to customize so
 defining this view per project is usually preferred. If you have used this bundled view (check for an import
 from  ``wagtail.wagtailsearch.urls`` in your project's ``urls.py``), you will need to replace this with your
 own implementation.

--- a/docs/releases/2.1.rst
+++ b/docs/releases/2.1.rst
@@ -15,7 +15,7 @@ What's new
 New ``HelpPanel``
 ~~~~~~~~~~~~~~~~~
 
-A new panel type ``HelpPanel`` allows to easily add HTML within an edit form.
+A new panel type ``HelpPanel`` allows you to easily add HTML within an edit form.
 This new feature was developed by Kevin Chung.
 
 
@@ -65,7 +65,7 @@ Other features
 * Set `ALLOWED_HOSTS` in the project template to allow any host in development (Tom Dyson)
 * Expose reusable client-side code to build Draftail extensions (Thibaud Colas)
 * Added ``WAGTAILFRONTENDCACHE_LANGUAGES`` setting to specify the languages whose URLs are to be purged when using ``i18n_patterns`` (PyMan Claudio Marinozzi)
-* Added ``extra_footer_actions`` template blocks for customising the add/edit page views (Arthur Holzner)
+* Added ``extra_footer_actions`` template blocks for customizing the add/edit page views (Arthur Holzner)
 
 Bug fixes
 ~~~~~~~~~
@@ -75,7 +75,7 @@ Bug fixes
 * Move image editor action buttons to the bottom of the form on mobile (Julian Gallo)
 * StreamField icons are now correctly sorted into groups on the 'append' menu (Tim Heap)
 * Draftail now supports features specified via the ``WAGTAILADMIN_RICH_TEXT_EDITORS`` setting (Todd Dembrey)
-* Password reset form no longer indicates whether the email is recognised, as per standard Django behaviour (Bertrand Bordage)
+* Password reset form no longer indicates whether the email is recognized, as per standard Django behavior (Bertrand Bordage)
 * ``UserAttributeSimilarityValidator`` is now correctly enforced on user creation / editing forms (Tim Heap)
 * Focal area removal not working in IE11 and MS Edge (Thibaud Colas)
 * Rewrite password change feedback message to be more user-friendly (Casper Timmers)
@@ -88,12 +88,12 @@ Bug fixes
 * Localization of image and apps verbose names
 * Draftail editor no longer crashes after deleting image/embed using DEL key (Thibaud Colas)
 * Breadcrumb navigation now respects custom ``get_admin_display_title`` methods (Arthur Holzner, Wietze Helmantel, Matt Westcott)
-* Inconsistent order of heading features when adding h1, h5 or h6 as default feature for Hallo RichText editor (Loic Teixeira)
+* Inconsistent order of heading features when adding h1, h5, or h6 as default feature for Hallo RichText editor (Loic Teixeira)
 * Add invalid password reset link error message (Coen van der Kamp)
 * Bypass select/prefetch related optimisation on ``update_index`` for ``ParentalManyToManyField`` to fix crash (Tim Kamanin)
 * 'Add user' is now rendered as a button due to the use of quotes within translations (Benoît Vogel)
 * Menu icon no longer overlaps with title in Modeladmin on mobile (Coen van der Kamp)
-* Background colour overflow within the Wagtail documentation (Sergey Fedoseev)
+* Background color overflow within the Wagtail documentation (Sergey Fedoseev)
 * Page count on homepage summary panel now takes account of user permissions (Andy Chosak)
 * Explorer view now prevents navigating outside of the common ancestor of the user's permissions (Andy Chosak)
 * Generate URL for the current site when multiple sites share the same root page (Codie Roelf)

--- a/docs/releases/2.10.rst
+++ b/docs/releases/2.10.rst
@@ -45,7 +45,7 @@ Accessibility and usability
 This release contains a number of improvements to the accessibility and general usability of the Wagtail admin, fixing long-standing issues. Some of the changes come from our January 2020 sprint in Bristol, and some from our brand new `accessibility team <https://github.com/wagtail/wagtail/wiki/Accessibility-team>`_:
 
 * Remove sticky footer on small devices, so that content is not blocked and more easily editable (Saeed Tahmasebi)
-* Add SVG icons to resolve accessibility and customisation issues and start using them in a subset of Wagtail's admin (Coen van der Kamp, Scott Cranfill, Thibaud Colas, Dan Braghis)
+* Add SVG icons to resolve accessibility and customization issues and start using them in a subset of Wagtail's admin (Coen van der Kamp, Scott Cranfill, Thibaud Colas, Dan Braghis)
 * Switch userbar and header H1s to use SVG icons (Coen van der Kamp)
 * Add skip link for keyboard users to bypass Wagtail navigation in the admin (Martin Coote)
 * Add missing dropdown icons to image upload, document upload, and site settings screens (Andreas Bernacca)
@@ -83,7 +83,7 @@ Other features
 * Add ``after_edit_snippet``, ``after_create_snippet`` and ``after_delete_snippet`` hooks and documentation (Kalob Taulien)
 * Improve performance of empty search results by avoiding downloading the entire search index in these scenarios (Lars van de Kerkhof, Coen van der Kamp)
 * Replace ``gulp-sass`` with ``gulp-dart-sass`` to improve core development across different platforms (Thibaud Colas)
-* Remove markup around rich text rendering by default, provide a way to use old behaviour via ``wagtail.contrib.legacy.richtext``. See :doc:`/reference/contrib/legacy_richtext`. (Coen van der Kamp, Dan Braghis)
+* Remove markup around rich text rendering by default, provide a way to use old behavior via ``wagtail.contrib.legacy.richtext``. See :doc:`/reference/contrib/legacy_richtext`. (Coen van der Kamp, Dan Braghis)
 * Add ``WAGTAIL_TIME_FORMAT`` setting (Jacob Topp-Mugglestone)
 * Apply title length normalisation to improve ranking on PostgreSQL search (Karl Hobley)
 * Allow omitting the default editor from ``WAGTAILADMIN_RICH_TEXT_EDITORS`` (Gassan Gousseinov)

--- a/docs/releases/2.11.8.rst
+++ b/docs/releases/2.11.8.rst
@@ -17,6 +17,6 @@ CVE-2021-32681: Improper escaping of HTML ('Cross-site Scripting') in Wagtail St
 
 This release addresses a cross-site scripting (XSS) vulnerability in StreamField. When the ``{% include_block %}`` template tag is used to output the value of a plain-text StreamField block (``CharBlock``, ``TextBlock`` or a similar user-defined block derived from ``FieldBlock``), and that block does not specify a template for rendering, the tag output is not properly escaped as HTML. This could allow users to insert arbitrary HTML or scripting. This vulnerability is only exploitable by users with the ability to author StreamField content (i.e. users with 'editor' access to the Wagtail admin).
 
-Site implementers who wish to retain the existing behaviour of allowing editors to insert HTML content in these blocks (and are willing to accept the risk of untrusted editors inserting arbitrary code) may disable the escaping by surrounding the relevant ``{% include_block %}`` tag in ``{% autoescape off %}...{% endautoescape %}``.
+Site implementers who wish to retain the existing behavior of allowing editors to insert HTML content in these blocks (and are willing to accept the risk of untrusted editors inserting arbitrary code) may disable the escaping by surrounding the relevant ``{% include_block %}`` tag in ``{% autoescape off %}...{% endautoescape %}``.
 
 Many thanks to Karen Tracey for reporting this issue. For further details, please see `the CVE-2021-32681 security advisory <https://github.com/wagtail/wagtail/security/advisories/GHSA-xfrw-hxr5-ghqf>`_.

--- a/docs/releases/2.13.2.rst
+++ b/docs/releases/2.13.2.rst
@@ -17,6 +17,6 @@ CVE-2021-32681: Improper escaping of HTML ('Cross-site Scripting') in Wagtail St
 
 This release addresses a cross-site scripting (XSS) vulnerability in StreamField. When the ``{% include_block %}`` template tag is used to output the value of a plain-text StreamField block (``CharBlock``, ``TextBlock`` or a similar user-defined block derived from ``FieldBlock``), and that block does not specify a template for rendering, the tag output is not properly escaped as HTML. This could allow users to insert arbitrary HTML or scripting. This vulnerability is only exploitable by users with the ability to author StreamField content (i.e. users with 'editor' access to the Wagtail admin).
 
-Site implementers who wish to retain the existing behaviour of allowing editors to insert HTML content in these blocks (and are willing to accept the risk of untrusted editors inserting arbitrary code) may disable the escaping by surrounding the relevant ``{% include_block %}`` tag in ``{% autoescape off %}...{% endautoescape %}``.
+Site implementers who wish to retain the existing behavior of allowing editors to insert HTML content in these blocks (and are willing to accept the risk of untrusted editors inserting arbitrary code) may disable the escaping by surrounding the relevant ``{% include_block %}`` tag in ``{% autoescape off %}...{% endautoescape %}``.
 
 Many thanks to Karen Tracey for reporting this issue. For further details, please see `the CVE-2021-32681 security advisory <https://github.com/wagtail/wagtail/security/advisories/GHSA-xfrw-hxr5-ghqf>`_.

--- a/docs/releases/2.13.3.rst
+++ b/docs/releases/2.13.3.rst
@@ -18,5 +18,5 @@ Bug fixes
  * Prevent error when using rich text on views where commenting is unavailable (Jacob Topp-Mugglestone)
  * Include form media on account settings page (Matt Westcott)
  * Avoid error when rendering validation error messages on ListBlock children (Matt Westcott)
- * Prevent comments CSS from overriding admin UI colour customisations (Matt Westcott)
+ * Prevent comments CSS from overriding admin UI color customisations (Matt Westcott)
  * Avoid validation error when editing rich text content preceding a comment (Jacob Topp-Mugglestone)

--- a/docs/releases/2.13.5.rst
+++ b/docs/releases/2.13.5.rst
@@ -22,13 +22,13 @@ Bug fixes
 Upgrade considerations
 ======================
 
-Customising relation name for admin comments
+Customizing relation name for admin comments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The admin commenting feature introduced in Wagtail 2.13 added a relation named ``comments`` to the Page and User
 models. This can cause conflicts with third-party apps that implement commenting functionality, and so this will be
 renamed to ``wagtail_admin_comments`` in Wagtail 2.15. Developers who are affected by this issue, and have thus been
-unable to upgrade to Wagtail 2.13 or above, can now "opt in" to the Wagtail 2.15 behaviour by adding the following
+unable to upgrade to Wagtail 2.13 or above, can now "opt in" to the Wagtail 2.15 behavior by adding the following
 line to their project settings:
 
 .. code-block:: python

--- a/docs/releases/2.14.2.rst
+++ b/docs/releases/2.14.2.rst
@@ -22,13 +22,13 @@ Bug fixes
 Upgrade considerations
 ======================
 
-Customising relation name for admin comments
+Customizing relation name for admin comments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The admin commenting feature introduced in Wagtail 2.13 added a relation named ``comments`` to the Page and User
 models. This can cause conflicts with third-party apps that implement commenting functionality, and so this will be
 renamed to ``wagtail_admin_comments`` in Wagtail 2.15. Developers who are affected by this issue, and have thus been
-unable to upgrade to Wagtail 2.13 or above, can now "opt in" to the Wagtail 2.15 behaviour by adding the following
+unable to upgrade to Wagtail 2.13 or above, can now "opt in" to the Wagtail 2.15 behavior by adding the following
 line to their project settings:
 
 .. code-block:: python

--- a/docs/releases/2.14.rst
+++ b/docs/releases/2.14.rst
@@ -27,7 +27,7 @@ New features
  * Add Google Data Studio to the list of oEmbed providers (Petr Dlouhý)
  * Allow ListBlock to raise validation errors that are not attached to an individual child block (Matt Westcott)
  * Use ``DATETIME_FORMAT`` for localization in templates (Andrew Stone)
- * Added documentation on multi-site, multi instance and multi tenancy setups (Coen Van Der Kamp)
+ * Added documentation on multi-site, multi-instance and multi-tenancy setups (Coen Van Der Kamp)
  * Updated Facebook / Instagram oEmbed endpoints to v11.0 (Thomas Kremmel)
  * Performance improvements for admin listing pages (Jake Howard, Dan Braghis, Tom Usher)
 

--- a/docs/releases/2.15.2.rst
+++ b/docs/releases/2.15.2.rst
@@ -47,4 +47,4 @@ If SQLite is subsequently upgraded to a version with ``fts5`` support, existing 
   ./manage.py migrate
   ./manage.py update_index
 
-Additionally, since the database search backend now needs to run a query on initialisation to check for the presence of this table, calling ``wagtail.search.backends.get_search_backend`` during application startup may now fail with a "Models aren't loaded yet" error. Code that does this should be updated to only call ``get_search_backend`` at the point when a search query is to be performed.
+Additionally, since the database search backend now needs to run a query on initialization to check for the presence of this table, calling ``wagtail.search.backends.get_search_backend`` during application startup may now fail with a "Models aren't loaded yet" error. Code that does this should be updated to only call ``get_search_backend`` at the point when a search query is to be performed.

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -29,7 +29,7 @@ This feature was developed by Aldán Creo as part of Google Summer of Code.
 Bulk actions
 ~~~~~~~~~~~~
 
-Bulk actions are now available for Page, User, Image and Document models in the Wagtail Admin, allowing users to perform actions like publication or deletion on groups of objects at once.
+Bulk actions are now available for Page, User, Image, and Document models in the Wagtail Admin, allowing users to perform actions like publication or deletion on groups of objects at once.
 
 This feature was developed by Shohan Dutta Roy, mentored by Dan Braghis, Jacob Topp-Mugglestone, and Storm Heg.
 
@@ -37,13 +37,13 @@ This feature was developed by Shohan Dutta Roy, mentored by Dan Braghis, Jacob T
 Audit logging for all models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Audit logging has been extended so that all models (not just pages) can have actions logged against them. The Site History report now includes logs from all object types, and snippets and ModelAdmin provide a history view showing previous edits to an object. This feature was developed by Matt Westcott, and sponsored by `The Motley Fool <https://www.fool.com/>`_.
+Audit logging has been extended so that all models (not just pages) can have actions logged against them. The Site History report now includes logs from all object types and snippets and ModelAdmin provide a history view showing previous edits to an object. This feature was developed by Matt Westcott, and sponsored by `The Motley Fool <https://www.fool.com/>`_.
 
 
 Collection management permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Permission for managing collections can now be assigned to individual subtrees of the collection hierarchy, allowing sub-teams within a site to control how their images and documents are organised. For more information, see :ref:`collection_management_permissions`. This feature was developed by Cynthia Kiser.
+Permission for managing collections can now be assigned to individual subtrees of the collection hierarchy, allowing sub-teams within a site to control how their images and documents are organized. For more information, see :ref:`collection_management_permissions`. This feature was developed by Cynthia Kiser.
 
 
 Typed table block
@@ -58,9 +58,9 @@ As part of a broad push to improve the accessibility of the administration inter
 
 Individual fixes were implemented by a large number of first-time and seasoned contributors:
 
- * Comments icon now matches link colour (Dmitrii Faiazov, LB (Ben Johnston))
+ * Comments icon now matches link color (Dmitrii Faiazov, LB (Ben Johnston))
  * Sidebar logo is now visible in high contrast mode (Dmitrii Faiazov, LB (Ben Johnston))
- * Icons in links and buttons now use the appropriate “active control” colour (Dmitrii Faiazov, LB (Ben Johnston))
+ * Icons in links and buttons now use the appropriate “active control” color (Dmitrii Faiazov, LB (Ben Johnston))
  * Comments dropdown now has a border (Shariq Jamil, LB (Ben Johnston))
  * Make StreamField block chooser menu buttons appear as buttons (Dmitrii Faiazov, LB (Ben Johnston))
  * Add a separator to identify the search forms (Dmitrii Faiazov, LB (Ben Johnston))
@@ -99,17 +99,17 @@ Other features
  * Open Preview and Live page links in the same tab, except where it would interrupt editing a Page (Sagar Agarwal)
  * Added ``ExcelDateFormatter`` to ``wagtail.admin.views.mixins`` so that dates in Excel exports will appear in the locale's ``SHORT_DATETIME_FORMAT`` (Andrew Stone)
  * Add TIDAL support to the list of oEmbed providers (Wout De Puysseleir)
- * Add ``label_format`` attribute to customise the label shown for a collapsed StructBlock (Matt Westcott)
+ * Add ``label_format`` attribute to customize the label shown for a collapsed StructBlock (Matt Westcott)
  * User Group permissions editing in the admin will now show all custom object permissions in one row instead of a separate table (Kamil Marut)
  * Create ``ImageFileMixin`` to extract shared file handling methods from ``AbstractImage`` and ``AbstractRendition`` (Fabien Le Frapper)
  * Add ``before_delete_page`` and ``register_permissions`` examples to Hooks documentation (Jane Liu, Daniel Fairhead)
- * Add clarity to modeladmin template override behaviour in the documentation (Joe Howard, Dan Swain)
+ * Add clarity to modeladmin template override behavior in the documentation (Joe Howard, Dan Swain)
  * Add section about CSV exports to security documentation (Matt Westcott)
  * Add initial support for Django 4.0 deprecations (Matt Westcott, Jochen Wersdörfer)
  * Translations in ``nl_NL`` are moved to the ``nl`` po files. ``nl_NL`` translation files are deleted. Projects that use ``LANGUAGE_CODE = 'nl-nl'`` will automatically fallback to ``nl``. (Loïc Teixeira, Coen van der Kamp)
  * Add documentation for how to redirect to a separate page on Form builder submissions using ``RoutablePageMixin`` (Nick Smith)
  * Refactored index listing views and made column sort-by headings more consistent (Matt Westcott)
- * The title field on Image and Document uploads will now default to the filename without the file extension and this behaviour can be customised (LB Johnston)
+ * The title field on Image and Document uploads will now default to the filename without the file extension and this behavior can be customized (LB Johnston)
  * Add support for Python 3.10 (Matt Westcott)
  * Introduce, ``autocomplete``, a separate method which performs partial matching on specific autocomplete fields. This is useful for suggesting pages to the user in real-time as they type their query. (Karl Hobley, Matt Westcott)
  * Use SVG icons in modeladmin headers and StreamField buttons/headers (Jérôme Lebleu)
@@ -263,7 +263,7 @@ should now be rewritten as:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Audit logging is now supported on all model types, not just pages, and so the ``PageLogEntry.objects.log_action``
-method for logging actions performed on pages is deprecated in favour of the general-purpose ``log`` function. Code that
+method for logging actions performed on pages is deprecated in favor of the general-purpose ``log`` function. Code that
 calls ``PageLogEntry.objects.log_action`` should now import the ``log`` function from ``wagtail.core.log_actions`` and
 call this instead (all arguments are unchanged).
 
@@ -273,7 +273,7 @@ Additionally, for logging actions on non-Page models, it is generally no longer 
 Removed support for Internet Explorer (IE11)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If this affects you or your organisation, consider which alternative browsers you may be able to use.
+If this affects you or your organization, consider which alternative browsers you may be able to use.
 Wagtail is fully compatible with Microsoft Edge, Microsoft’s replacement for Internet Explorer. You may consider using its `IE mode <https://learn.microsoft.com/en-us/deployedge/edge-ie-mode>`_ to keep access to IE11-only sites, while other sites and apps like Wagtail can leverage modern browser capabilities.
 
 
@@ -281,9 +281,9 @@ Wagtail is fully compatible with Microsoft Edge, Microsoft’s replacement for I
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Before the ``autocomplete()`` method was introduced, the search method also did partial matching.
-This behaviour is will be deprecated in a future release and you should either switch to the new
+This behavior is will be deprecated in a future release and you should either switch to the new
 ``autocomplete()`` method or pass ``partial_match=False`` into the search method to opt-in to the
-new behaviour. The partial matching in ``search()`` will be completely removed in a future release.
+new behavior. The partial matching in ``search()`` will be completely removed in a future release.
 See: :ref:`wagtailsearch_searching_pages`
 
 
@@ -294,7 +294,7 @@ The ``related_name`` of the relation linking the Page and User models to admin c
 changed from ``comments`` to ``wagtail_admin_comments``, to avoid conflicts with third-party apps
 that implement commenting. If you have any code that references the ``comments`` relation
 (including fixture files), this should be updated to refer to ``wagtail_admin_comments`` instead.
-If this is not feasible, the previous behaviour can be restored by adding
+If this is not feasible, the previous behavior can be restored by adding
 ``WAGTAIL_COMMENTS_RELATION_NAME = 'comments'`` to your project's settings.
 
 Reusable library code that needs to preserve backwards compatibility with previous Wagtail versions

--- a/docs/releases/2.16.1.rst
+++ b/docs/releases/2.16.1.rst
@@ -20,4 +20,4 @@ Bug fixes
  * Fix issue where bulk actions would not work for object IDs greater than 999 when ``USE_THOUSAND_SEPARATOR`` (Dennis McGregor)
  * Set cookie for sidebar collapsed state to "SameSite: lax" (LB (Ben Johnston))
  * Prevent error on creating automatic redirects for sites with non-standard ports (Matt Westcott)
- * Restore ability to customise admin UI colours via CSS (LB (Ben Johnston))
+ * Restore ability to customize admin UI colors via CSS (LB (Ben Johnston))

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -73,7 +73,7 @@ Thank you to [The National Archives](https://www.nationalarchives.gov.uk) for ki
 
 ### Bug fixes
 
- * Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast, help/error/warning blocks for fields and general content, side comment buttons within the page editor, dropdown buttons (Sakshi Uppoor, Shariq Jamil, LB (Ben Johnston), Jason Attwood)
+ * Accessibility fixes for Windows high contrast mode; Dashboard icons color and contrast, help/error/warning blocks for fields and general content, side comment buttons within the page editor, dropdown buttons (Sakshi Uppoor, Shariq Jamil, LB (Ben Johnston), Jason Attwood)
  * Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
  * Pages are refreshed from database on create before passing to hooks. Page aliases get correct `first_published_date` and `last_published_date` (Dan Braghis)
  * Additional login form fields from `WAGTAILADMIN_USER_LOGIN_FORM` are now rendered correctly (Michael Karamuth)
@@ -120,14 +120,14 @@ The internal (undocumented) class-based view `wagtail.admin.views.generic.Delete
 
 ### Renamed admin/expanding-formset.js
 
-`admin/expanding_formset.js` has been renamed to `admin/expanding-formset.js` as part of frontend code clean up work. Check for any customised admin views that are extending expanding formsets, or have overridden template and copied the previous file name used in an import as these may need updating.
+`admin/expanding_formset.js` has been renamed to `admin/expanding-formset.js` as part of frontend code clean up work. Check for any customized admin views that are extending expanding formsets, or have overridden template and copied the previous file name used in an import as these may need updating.
 
 ### Deprecated sidebar capabilities
 
-The new sidebar largely supports the same customisations as its predecessor, with a few exceptions:
+The new sidebar largely supports the same customizations as its predecessor, with a few exceptions:
 
 - Top-level menu items should now always provide an `icon_name`, so they can be visually distinguished when the sidebar is collapsed.
-- `MenuItem` and its sub-classes no longer supports customising arbitrary HTML attributes.
-- `MenuItem` can no longer be sub-classed to customise its HTML output or load additional JavaScript
+- `MenuItem` and its sub-classes no longer supports customizing arbitrary HTML attributes.
+- `MenuItem` can no longer be sub-classed to customize its HTML output or load additional JavaScript
 
 For sites relying on those capabilities, we provide a `WAGTAIL_SLIM_SIDEBAR = False` setting to switch back to the legacy sidebar. The legacy sidebar and this setting will be removed in Wagtail 2.18.

--- a/docs/releases/2.2.rst
+++ b/docs/releases/2.2.rst
@@ -29,7 +29,7 @@ Other features
 
 * Added another valid AudioBoom oEmbed pattern (Bertrand Bordage)
 * Added ``annotate_score`` support to PostgreSQL search backend (Bertrand Bordage)
-* Pillow's image optimisation is now applied when saving PNG images (Dmitry Vasilev)
+* Pillow's image optimization is now applied when saving PNG images (Dmitry Vasilev)
 * JS / CSS media files can now be associated with Draftail feature definitions (Matt Westcott)
 * The ``{% slugurl %}`` template tag is now site-aware (Samir Shah)
 * Added ``file_size`` field to documents (Karl Hobley)
@@ -39,7 +39,7 @@ Other features
 * Snippets can now be deleted from the listing view (LB (Ben Johnston))
 * Increased max length of redirect URL field to 255 (Michael Harrison)
 * Added documentation for new JS/CSS media files association with Draftail feature definitions (Ed Henderson)
-* Added accessible colour contrast guidelines to the style guide (Catherine Farman)
+* Added accessible color contrast guidelines to the style guide (Catherine Farman)
 * Admin modal views no longer rely on JavaScript ``eval()``, for better CSP compliance (Matt Westcott)
 * Update editor guide for embeds and documents in rich text (Kevin Howbrook)
 * Improved performance of sitemap generation (Michael van Tellingen, Bertrand Bordage)

--- a/docs/releases/2.3.rst
+++ b/docs/releases/2.3.rst
@@ -23,7 +23,7 @@ Added Django 2.1 support
 Wagtail is now compatible with Django 2.1.  Compatibility fixes were contributed by Ryan Verner and Matt Westcott.
 
 
-Improved colour contrast
+Improved color contrast
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Colour contrast within the admin interface has been improved, and now complies with WCAG 2 level AA. This was completed by Coen van der Kamp and Naomi Morduch Toubman based on earlier work from Edd Baldry, Naa Marteki Reed and Ben Enright.
@@ -34,7 +34,7 @@ Other features
 
 * Added 'scale' image filter (Oliver Wilkerson)
 * Added meta tag to prevent search engines from indexing admin pages (Karl Hobley)
-* EmbedBlock now validates against recognised embed providers on save (Bertrand Bordage)
+* EmbedBlock now validates against recognized embed providers on save (Bertrand Bordage)
 * Made cache control headers on Wagtail admin consistent with Django admin (Tomasz Knapik)
 * Notification emails now include an "Auto-Submitted: auto-generated" header (Dan Braghis)
 * Image chooser panels now show alt text as title (Samir Shah)
@@ -50,7 +50,7 @@ Bug fixes
 * before_delete_page / after_delete_page hooks now run within the same database transaction as the page deletion (Tomasz Knapik)
 * Seek to the beginning of image files when uploading, to restore compatibility with django-storages Google Cloud and Azure backends (Mikalai Radchuk)
 * Snippet chooser modal no longer fails on snippet models with UUID primary keys (Sævar Öfjörð Magnússon)
-* Restored localisation in date/time pickers (David Moore, Thibaud Colas)
+* Restored localization in date/time pickers (David Moore, Thibaud Colas)
 * Tag input field no longer treats 'б' on Russian keyboards as a comma (Michael Borisov)
 * Disabled autocomplete dropdowns on date/time chooser fields (Janneke Janssen)
 * Split up ``wagtail.admin.forms`` to make it less prone to circular imports (Matt Westcott)
@@ -63,7 +63,7 @@ Bug fixes
 Upgrade considerations
 ======================
 
-``wagtail.admin.forms`` reorganised
+``wagtail.admin.forms`` reorganized
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``wagtail.admin.forms`` module has been split up into submodules to make it less prone to producing circular imports, particularly when a custom user model is in use. The following (undocumented) definitions have now been moved to new locations:

--- a/docs/releases/2.4.rst
+++ b/docs/releases/2.4.rst
@@ -37,7 +37,7 @@ Other features
 * Make documentation links on welcome page work for prereleases (Matt Westcott)
 * Allow overridden ``copy()`` methods in ``Page`` subclasses to be called from the page copy view (Robert Rollins)
 * Users without a preferred language set on their profile now use language selected by Django's ``LocaleMiddleware`` (Benjamin Bach)
-* Added hooks to customise the actions menu on the page create/edit views (Matt Westcott)
+* Added hooks to customize the actions menu on the page create/edit views (Matt Westcott)
 * Cleanup: Use ``functools.partial()`` instead of ``django.utils.functional.curry()`` (Sergey Fedoseev)
 * Added ``before_move_page`` and ``after_move_page`` hooks (Maylon Pedroso)
 * Bulk deletion button for snippets is now hidden until items are selected (Karl Hobley)

--- a/docs/releases/2.5.rst
+++ b/docs/releases/2.5.rst
@@ -34,13 +34,13 @@ To learn other shortcuts, have a look at the `keyboard shortcuts <https://www.dr
 Other features
 ~~~~~~~~~~~~~~
 
-* Added support for customising EditHandler-based forms on a per-request basis (Bertrand Bordage)
+* Added support for customizing EditHandler-based forms on a per-request basis (Bertrand Bordage)
 * Added more informative error message when ``|richtext`` filter is applied to a non-string value (mukesh5)
 * Automatic search indexing can now be disabled on a per-model basis via the ``search_auto_update`` attribute (Karl Hobley)
 * Improved diffing of StreamFields when comparing page revisions (Karl Hobley)
 * Highlight broken links to pages and missing documents in rich text (Brady Moe)
 * Preserve links when copy-pasting rich text content from Wagtail to other tools (Thibaud Colas)
-* Rich text to contentstate conversion now prioritises more specific rules, to accommodate ``<p>`` and ``<br>`` elements with attributes (Matt Westcott)
+* Rich text to contentstate conversion now prioritizes more specific rules, to accommodate ``<p>`` and ``<br>`` elements with attributes (Matt Westcott)
 * Added limit image upload size by number of pixels (Thomas Elliott)
 * Added ``manage.py wagtail_update_index`` alias to avoid clashes with ``update_index`` commands from other packages (Matt Westcott)
 * Renamed ``target_model`` argument on ``PageChooserBlock`` to ``page_type`` (Loic Teixeira)
@@ -78,7 +78,7 @@ Bug fixes
 * ``send_mail`` now correctly uses the ``html_message`` kwarg for HTML messages (Tiago Requeijo)
 * Page copying no longer allowed if page model has reached its ``max_count`` (Andy Babic)
 * Don't show page type on page chooser button when multiple types are allowed (Thijs Kramer)
-* Make sure page chooser search results correspond to the latest search by cancelling previous requests (Esper Kuijs)
+* Make sure page chooser search results correspond to the latest search by canceling previous requests (Esper Kuijs)
 * Inform user when moving a page from one parent to another where there is an already existing page with the same slug (Casper Timmers)
 * User add/edit forms now support form widgets with JS/CSS media (Damian Grinwis)
 * Rich text processing now preserves non-breaking spaces instead of converting them to normal spaces (Wesley van Lee)
@@ -98,13 +98,13 @@ Upgrade considerations
 ``EditHandler.bind_to_model`` and ``EditHandler.bind_to_instance`` deprecated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The internal ``EditHandler`` methods ``bind_to_model`` and ``bind_to_instance`` have been deprecated, in favour of a new combined ``bind_to`` method which accepts ``model``, ``instance``, ``request`` and ``form`` as optional keyword arguments. Any user code which calls ``EditHandler.bind_to_model(model)`` should be updated to use ``EditHandler.bind_to(model=model)`` instead; any user code which calls ``EditHandler.bind_to_instance(instance, request, form)`` should be updated to use ``EditHandler.bind_to(instance=instance, request=request, form=form)``.
+The internal ``EditHandler`` methods ``bind_to_model`` and ``bind_to_instance`` have been deprecated, in favor of a new combined ``bind_to`` method which accepts ``model``, ``instance``, ``request`` and ``form`` as optional keyword arguments. Any user code which calls ``EditHandler.bind_to_model(model)`` should be updated to use ``EditHandler.bind_to(model=model)`` instead; any user code which calls ``EditHandler.bind_to_instance(instance, request, form)`` should be updated to use ``EditHandler.bind_to(instance=instance, request=request, form=form)``.
 
 
 Changes to admin pagination helpers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A number of changes have been made to pagination handling within the Wagtail admin; these are internal API changes, but may affect applications and third-party packages that add new paginated object listings, including chooser modals, to the admin. The ``paginate`` function in ``wagtail.utils.pagination`` has been deprecated in favour of the ``django.core.paginator.Paginator.get_page`` method introduced in Django 2.0 - a call such as:
+Several changes have been made to pagination handling within the Wagtail admin; these are internal API changes, but may affect applications and third-party packages that add new paginated object listings, including chooser modals, to the admin. The ``paginate`` function in ``wagtail.utils.pagination`` has been deprecated in favor of the ``django.core.paginator.Paginator.get_page`` method introduced in Django 2.0 - a call such as:
 
 .. code-block:: python
 
@@ -145,7 +145,7 @@ Wagtail now has built-in support for new rich text formats, disabled by default:
 * ``strikethrough``, using the ``STRIKETHROUGH`` Draft.js inline style, saved as a ``<s>`` tag.
 * ``code``, using the ``CODE`` Draft.js inline style, saved as a ``<code>`` tag.
 
-Projects already using those exact Draft.js type and HTML tag combinations can safely replace their feature definitions with the new built-ins. Projects that use the same feature identifier can keep their existing feature definitions as overrides. Finally, if the Draft.js types / HTML tags are used but with a different combination, do not enable the new feature definitions to avoid conflicts in storage or editor behaviour.
+Projects already using those exact Draft.js type and HTML tag combinations can safely replace their feature definitions with the new built-ins. Projects that use the same feature identifier can keep their existing feature definitions as overrides. Finally, if the Draft.js types / HTML tags are used but with a different combination, do not enable the new feature definitions to avoid conflicts in storage or editor behavior.
 
 
 ``register_link_type`` and ``register_embed_type`` methods for rich text tag rewriting have changed

--- a/docs/releases/2.6.rst
+++ b/docs/releases/2.6.rst
@@ -15,14 +15,14 @@ What's new
 Accessibility targets and improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Wagtail now has official accessibility support targets: we are aiming for compliance with `WCAG2.1 <https://www.w3.org/TR/WCAG21/>`_, AA level. WCAG 2.1 is the international standard which underpins many national accessibility laws.
+Wagtail now has official accessibility support targets: we are aiming for compliance with `WCAG2.1 <https://www.w3.org/TR/WCAG21/>`_, AA level. WCAG 2.1 is the international standard that underpins many national accessibility laws.
 
 Wagtail isn't fully compliant just yet, but we have made many changes to the admin interface to get there. We thank the UK Government (in particular the CMS team at the Department for International Trade), who commissioned many of these improvements.
 
-Here are changes which should make Wagtail more usable for all users regardless of abilities:
+Here are changes that should make Wagtail more usable for all users regardless of abilities:
 
 * Increase font-size across the whole admin (Beth Menzies, Katie Locke)
-* Improved text colour contrast across the whole admin (Beth Menzies, Katie Locke)
+* Improved text color contrast across the whole admin (Beth Menzies, Katie Locke)
 * Added consistent focus outline styles across the whole admin (Thibaud Colas)
 * Ensured the 'add child page' button displays when focused (Helen Chapman, Katie Locke)
 
@@ -31,13 +31,13 @@ This release also contains many big improvements for screen reader users:
 * Added more ARIA landmarks across the admin interface and welcome page for screen reader users to navigate the CMS more easily (Beth Menzies)
 * Improved heading structure for screen reader users navigating the CMS admin (Beth Menzies, Helen Chapman)
 * Make icon font implementation more screen-reader-friendly (Thibaud Colas)
-* Removed buggy tab order customisations in the CMS admin (Jordan Bauer)
+* Removed buggy tab order customizations in the CMS admin (Jordan Bauer)
 * Screen readers now treat page-level action dropdowns as navigation instead of menus (Helen Chapman)
 * Fixed occurrences of invalid HTML across the CMS admin (Thibaud Colas)
 * Add empty alt attributes to all images in the CMS admin (Andreas Bernacca)
 * Fixed focus not moving to the pages explorer menu when open (Helen Chapman)
 
-We’ve also had a look at how controls are labelled across the UI for screen reader users:
+We’ve also had a look at how controls are labeled across the UI for screen reader users:
 
 * Add image dimensions in image gallery and image choosers for screen reader users (Helen Chapman)
 * Add more contextual information for screen readers in the explorer menu's links (Helen Chapman)
@@ -52,7 +52,7 @@ We’ve also had a look at how controls are labelled across the UI for screen re
 * Add screen-reader labels for dashboard summary cards (Helen Chapman, Katie Locke)
 * Add screen-reader labels for privacy toggle of collections (Helen Chapman, Katie Locke)
 
-Again, this is still a work in progress – if you are aware of other existing accessibility issues, please do `open an issue <https://github.com/wagtail/wagtail/issues?q=is%3Aopen+is%3Aissue+label%3AAccessibility>`_ if there isn't one already.
+Again, this is still a work in progress – if you are aware of other existing accessibility issues, please do `open an issue <https://github.com/wagtail/wagtail/issues?q=is%3Aopen+is%3Aissue+label%3AAccessibility>`_ if there isn't one already.
 
 
 Other features
@@ -63,9 +63,9 @@ Other features
 * Added support for specifying cell alignment on TableBlock (Samuel Mendes)
 * Added more informative error when a non-image object is passed to the ``image`` template tag (Deniz Dogan)
 * Added ButtonHelper examples in the modelAdmin primer page within documentation (Kalob Taulien)
-* Multiple clarifications, grammar and typo fixes throughout documentation (Dan Swain)
+* Multiple clarifications, grammar, and typo fixes throughout documentation (Dan Swain)
 * Use correct URL in API example in documentation (Michael Bunsen)
-* Move datetime widget initialiser JS into the widget's form media instead of page editor media (Matt Westcott)
+* Move datetime widget initializer JS into the widget's form media instead of page editor media (Matt Westcott)
 * Add form field prefixes for input forms in chooser modals (Matt Westcott)
 * Removed version number from the logo link's title. The version can now be found under the Settings menu (Thibaud Colas)
 * Added "don't delete" option to confirmation screen when deleting images, documents and modeladmin models (Kevin Howbrook)
@@ -73,8 +73,8 @@ Other features
 * Added support for custom search handler classes to modeladmin's IndexView, and added a class that uses the default Wagtail search backend for searching (Seb Brown, Andy Babic)
 * Update group edit view to expose the ``Permission`` object for each checkbox (George Hickman)
 * Improve performance of Pages for Moderation panel (Fidel Ramos)
-* Added ``process_child_object`` and ``exclude_fields`` arguments to ``Page.copy()`` to make it easier for third-party apps to customise copy behaviour (Karl Hobley)
-* Added ``Page.with_content_json()``, allowing revision content loading behaviour to be customised on a per-model basis (Karl Hobley)
+* Added ``process_child_object`` and ``exclude_fields`` arguments to ``Page.copy()`` to make it easier for third-party apps to customize copy behavior (Karl Hobley)
+* Added ``Page.with_content_json()``, allowing revision content loading behavior to be customized on a per-model basis (Karl Hobley)
 * Added ``construct_settings_menu`` hook (Jordan Bauer, Quadric)
 * Fixed compatibility of date / time choosers with wagtail-react-streamfield (Mike Hearn)
 * Performance optimization of several admin functions, including breadcrumbs, home and index pages (Fidel Ramos)
@@ -99,7 +99,7 @@ Bug fixes
 * ``Page.copy()`` no longer copies child objects when the accessor name is included in ``exclude_fields_in_copy`` (Karl Hobley)
 * Clicking the privacy toggle while the page is still loading no longer loads the wrong data in the page (Helen Chapman)
 * Added missing ``is_stored_locally`` method to ``AbstractDocument`` (jonny5532)
-* Query model no longer removes punctuation as part of string normalisation (William Blackie)
+* Query model no longer removes punctuation as part of string normalization (William Blackie)
 * Make login test helper work with user models with non-default username fields (Andrew Miller)
 * Delay dirty form check to prevent "unsaved changes" warning from being wrongly triggered (Thibaud Colas)
 

--- a/docs/releases/2.7.rst
+++ b/docs/releases/2.7.rst
@@ -47,7 +47,7 @@ Other features
 * Recognise Soundcloud artist URLs as embeddable (Kiril Staikov)
 * Add ``WAGTAILDOCS_SERVE_METHOD`` setting to determine how document downloads will be linked to and served (Tobias McNulty, Matt Westcott)
 * Add ``WAGTAIL_MODERATION_ENABLED`` setting to enable / disable the 'Submit for Moderation' option (Jacob Topp-Mugglestone) - thanks to `The Motley Fool <https://www.fool.com/>`_ for sponsoring this feature
-* Added settings to customise pagination page size for the Images admin area (Brian Whitton)
+* Added settings to customize pagination page size for the Images admin area (Brian Whitton)
 * Added ARIA role to TableBlock output (Matt Westcott)
 * Added cache-busting query parameters to static files within the Wagtail admin (Matt Westcott)
 * Allow ``register_page_action_menu_item`` and ``construct_page_action_menu`` hooks to override the default menu action (Rahmi Pruitt, Matt Westcott) - thanks to `The Motley Fool <https://www.fool.com/>`_ for sponsoring review of this feature
@@ -59,7 +59,7 @@ Bug fixes
 
 * Added line breaks to long filenames on multiple image / document uploader (Kevin Howbrook)
 * Added https support for Scribd oEmbed provider (Rodrigo)
-* Changed StreamField group label colour so labels are visible (Catherine Farman)
+* Changed StreamField group label color so labels are visible (Catherine Farman)
 * Prevented images with a very wide aspect ratio from being displayed distorted in the rich text editor (Iman Syed)
 * Prevent exception when deleting a model with a protected One-to-one relationship (Neal Todd)
 * Added labels to snippet bulk edit checkboxes for screen reader users (Martey Dodoo)
@@ -103,13 +103,13 @@ Changes to document serving on remote storage backends (Amazon S3 etc)
 
 This release introduces a new setting :ref:`WAGTAILDOCS_SERVE_METHOD <wagtaildocs_serve_method>` to control how document downloads are served. On previous versions of Wagtail, document files would always be served through a Django view, to allow permission checks to be applied. When using a remote storage backend such as Amazon S3, this meant that the document would be downloaded to the Django server on every download request.
 
-In Wagtail 2.7, the default behaviour on remote storage backends is to redirect to the storage's underlying URL after performing the permission check. If this is unsuitable for your project (for example, your storage provider is configured to block public access, or revealing its URL would be a security risk) you can revert to the previous behaviour by setting ``WAGTAILDOCS_SERVE_METHOD`` to ``'serve_view'``.
+In Wagtail 2.7, the default behavior on remote storage backends is to redirect to the storage's underlying URL after performing the permission check. If this is unsuitable for your project (for example, your storage provider is configured to block public access, or revealing its URL would be a security risk) you can revert to the previous behavior by setting ``WAGTAILDOCS_SERVE_METHOD`` to ``'serve_view'``.
 
 
 Template change for page action menu hooks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When customising the action menu on the page edit view through the :ref:`register_page_action_menu_item <register_page_action_menu_item>` or :ref:`construct_page_action_menu <construct_page_action_menu>` hook, the ``ActionMenuItem`` object's ``template`` attribute or ``render_html`` method can be overridden to customise the menu item's HTML. As of Wagtail 2.7, the HTML returned from these should *not* include the enclosing ``<li>`` element.
+When customizing the action menu on the page edit view through the :ref:`register_page_action_menu_item <register_page_action_menu_item>` or :ref:`construct_page_action_menu <construct_page_action_menu>` hook, the ``ActionMenuItem`` object's ``template`` attribute or ``render_html`` method can be overridden to customize the menu item's HTML. As of Wagtail 2.7, the HTML returned from these should *not* include the enclosing ``<li>`` element.
 
 Any add-on library that uses this feature and needs to preserve backward compatibility with previous Wagtail versions can conditionally reinsert the ``<li>`` wrapper through its ``render_html`` method - for example:
 

--- a/docs/releases/2.8.rst
+++ b/docs/releases/2.8.rst
@@ -31,7 +31,7 @@ Other features
 
 * Removed leftover Python 2.x compatibility code (Sergey Fedoseev)
 * Combine flake8 configurations (Sergey Fedoseev)
-* Improve diffing behaviour for text fields (Aliosha Padovani)
+* Improve diffing behavior for text fields (Aliosha Padovani)
 * Improve contrast of disabled inputs (Nick Smith)
 * Added ``get_document_model_string`` function (Andrey Smirnov)
 * Added support for Cloudflare API tokens for frontend cache invalidation (Tom Usher)
@@ -40,7 +40,7 @@ Other features
 * Removed Django admin management of ``Page`` & ``Site`` models (Andreas Bernacca)
 * Cleaned up Django docs URLs in documentation (Pete Andrew)
 * Add StreamFieldPanel to available panel types in documentation (Dan Swain)
-* Add ``{{ block.super }}`` example to ModelAdmin customisation in documentation (Dan Swain)
+* Add ``{{ block.super }}`` example to ModelAdmin customization in documentation (Dan Swain)
 * Add ability to filter image index by a tag (Benedikt Willi)
 * Add partial experimental support for nested InlinePanels (Matt Westcott, Sam Costigan, Andy Chosak, Scott Cranfill)
 * Added cache control headers when serving documents (Johannes Vogel)
@@ -62,8 +62,8 @@ Bug fixes
 * Fixed order of URLs in project template so that static / media URLs are not blocked (Nick Smith)
 * Added ``verbose_name_plural`` to form submission model (Janneke Janssen)
 * Prevent ``update_index`` failures and incorrect front-end rendering on blank ``TableBlock`` (Carlo Ascani)
-* Dropdown initialisation on the search page after AJAX call (Eric Sherman)
-* Make sure all modal chooser search results correspond to the latest search by cancelling previous requests (Esper Kuijs)
+* Dropdown initialization on the search page after AJAX call (Eric Sherman)
+* Make sure all modal chooser search results correspond to the latest search by canceling previous requests (Esper Kuijs)
 
 
 Upgrade considerations
@@ -78,14 +78,14 @@ Django 2.0 is no longer supported as of this release; please upgrade to Django 2
 Edit locking behaviour changed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The behaviour of the page locking feature in the admin interface has been changed.
+The behavior of the page locking feature in the admin interface has been changed.
 In past versions, the page lock would apply to all users including the user who
 locked the page. Now, the user who locked the page can still edit it but all other
 users cannot.
 
 Pages that were locked before this release will continue to be locked in the same
 way as before, so this only applies to newly locked pages. If you would like to
-restore the previous behaviour, you can set the
+restore the previous behavior, you can set the
 ``WAGTAILADMIN_GLOBAL_PAGE_EDIT_LOCK`` setting to ``True``.
 
 
@@ -95,7 +95,7 @@ Responsive HTML for embeds no longer added by default
 In previous versions of Wagtail, embedded media elements were given
 a class name of ``responsive-object`` and an inline ``padding-bottom`` style to assist
 in styling them responsively. These are no longer added by default. To restore the previous
-behaviour, add ``WAGTAILEMBEDS_RESPONSIVE_HTML = True`` to your project settings.
+behavior, add ``WAGTAILEMBEDS_RESPONSIVE_HTML = True`` to your project settings.
 
 
 API endpoint classes have moved

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -112,7 +112,7 @@ When using a queryset to render a list of items with images, you can now make us
  * Make sure the focus outline of checkboxes is fully around the outer border (Steven Steinwand)
  * Consistently set `aria-haspopup="menu"` for all sidebar menu items that have sub-menus (LB (Ben Johnston))
  * Make sure `aria-expanded` is always explicitly set as a string in sidebar (LB (Ben Johnston))
- * Use a button element instead of a link for page explorer menu item, for the correct semantics and behaviour (LB (Ben Johnston))
+ * Use a button element instead of a link for page explorer menu item, for the correct semantics and behavior (LB (Ben Johnston))
  * Make sure the “Title” column label can be translated in the page chooser and page move UI (Stephanie Cheng Smith)
  * Remove redundant `role="main"` attributes on `<main>` elements causing HTML validation issues (Luis Espinoza)
  * Allow bulk publishing of pages without revisions (Andy Chosak)
@@ -134,7 +134,7 @@ When using a queryset to render a list of items with images, you can now make us
 
 ### Changes to module paths
 
-Various modules of Wagtail have been reorganised, and imports should be updated as follows:
+Various modules of Wagtail have been reorganized, and imports should be updated as follows:
 
 * The `wagtail.core.utils` module is renamed to `wagtail.coreutils`
 * All other modules under `wagtail.core` can now be found under `wagtail` - for example, `from wagtail.core.models import Page` should be changed to `from wagtail.models import Page`
@@ -185,7 +185,7 @@ If you are upgrading a pre-2.10 project that uses the [Wagtail form builder](for
 
 Jinja2 2.x is no longer supported as of this release; if you are using Jinja2 templating on your project, please upgrade to Jinja2 3.0 or above.
 
-## Upgrade considerations - changes affecting Wagtail customisations
+## Upgrade considerations - changes affecting Wagtail customizations
 
 ### API changes to panels (EditHandlers)
 
@@ -201,15 +201,15 @@ Where possible, third-party packages that implement their own field panel types 
  * If the panel provides a `widget_overrides` method, your code should instead call [`register_form_field_override`](/extending/forms) so that the desired widget is always selected for the relevant model field type.
  * If the panel provides a `get_comparison_class` method, your code should instead call `wagtail.admin.compare.register_comparison_class` to register the comparison class against the relevant model field type.
 
-Within the `Panel` class, the methods `widget_overrides`, `required_fields` and `required_formsets` have been deprecated in favour of a new `get_form_options` method that returns a dict of configuration options to be passed on to the generated form class:
+Within the `Panel` class, the methods `widget_overrides`, `required_fields` and `required_formsets` have been deprecated in favor of a new `get_form_options` method that returns a dict of configuration options to be passed on to the generated form class:
 
  * Panels that define `required_fields` should instead return this value as a `fields` item in the dict returned from `get_form_options`
  * Panels that define `required_formsets` should instead return this value as a `formsets` item in the dict returned from `get_form_options`
  * Panels that define `widget_overrides` should instead return this value as a `widgets` item in the dict returned from `get_form_options`
 
-The methods `on_request_bound`, `on_instance_bound` and `on_form_bound` are no longer used. In previous versions, over the course of serving a request an edit handler would have the attributes `request`, `model`, `instance` and `form` attached to it, with the corresponding `on_*_bound` method being called at that point. In the new implementation, only the `model` attribute and `on_model_bound` method are still available. This means it is no longer possible to vary or patch the form class in response to per-request information such as the user object. For permission checks, you should use the new `permission` option on `FieldPanel`; for other per-request customisations to the form object, use [a custom form class](custom_edit_handler_forms) with an overridden `__init__` method. (The current user object is available from the form as `self.for_user`.)
+The methods `on_request_bound`, `on_instance_bound` and `on_form_bound` are no longer used. In previous versions, over the course of serving a request an edit handler would have the attributes `request`, `model`, `instance` and `form` attached to it, with the corresponding `on_*_bound` method being called at that point. In the new implementation, only the `model` attribute and `on_model_bound` method are still available. This means it is no longer possible to vary or patch the form class in response to per-request information such as the user object. For permission checks, you should use the new `permission` option on `FieldPanel`; for other per-request customizations to the form object, use [a custom form class](custom_edit_handler_forms) with an overridden `__init__` method. (The current user object is available from the form as `self.for_user`.)
 
-Binding to a request, instance and form object is now handled by a new class `Panel.BoundPanel`. Any initialisation logic previously performed in `on_request_bound`, `on_instance_bound` or `on_form_bound` can instead be moved to the constructor method of a subclass of `BoundPanel`:
+Binding to a request, instance and form object is now handled by a new class `Panel.BoundPanel`. Any initialization logic previously performed in `on_request_bound`, `on_instance_bound` or `on_form_bound` can instead be moved to the constructor method of a subclass of `BoundPanel`:
 
 ```python
 class CustomPanel(Panel):
@@ -224,7 +224,7 @@ The template context for panels derived from `BaseChooserPanel` has changed. `Ba
 
 ### API changes to ModelAdmin
 
-Some changes of behaviour have been made to ModelAdmin as a result of the panel API changes:
+Some changes of behavior have been made to ModelAdmin as a result of the panel API changes:
 
 * When overriding the `get_form_class` method of a ModelAdmin `CreateView` or `EditView` to pass a custom form class, that form class must now inherit from `wagtail.admin.forms.models.WagtailAdminModelForm`. Passing a plain Django ModelForm subclass is no longer valid.
 * The `ModelAdmin.get_form_fields_exclude` method is no longer passed a `request` argument. Subclasses that override this method should remove this from the method signature. If the request object is being used to vary the set of fields based on the user's permission, this can be replaced with the new `permission` option on `FieldPanel`.
@@ -273,7 +273,7 @@ operations = [
 
 ### Replaced `form_data` `TextField` with `JSONField` in `AbstractFormSubmission`
 
-The `form_data` field in the `AbstractFormSubmission` model (and its subclasses `FormSubmission`) has been converted to `JSONField` instead of `TextField`. If you have customisations that programmatically add form submissions you will need to ensure that the `form_data` that is output is no longer a JSON string but instead a serialisable Python object. When interacting with the `form_data` you will now receive a Python object and not a string.
+The `form_data` field in the `AbstractFormSubmission` model (and its subclasses `FormSubmission`) has been converted to `JSONField` instead of `TextField`. If you have customizations that programmatically add form submissions you will need to ensure that the `form_data` that is output is no longer a JSON string but instead a serializable Python object. When interacting with the `form_data` you will now receive a Python object and not a string.
 
 Example change
 

--- a/docs/releases/4.0.2.md
+++ b/docs/releases/4.0.2.md
@@ -19,7 +19,7 @@ depth: 1
  * Ensure tag autocompletion dropdown has a solid background (LB (Ben) Johnston)
  * Allow inline panels to be ordered (LB (Ben) Johnston)
  * Only show draft / live status tags on snippets that have `DraftStateMixin` applied (Sage Abdullah)
- * Prevent JS error when initialising chooser modals with no tabs (LB (Ben) Johnston)
+ * Prevent JS error when initializing chooser modals with no tabs (LB (Ben) Johnston)
  * Add missing vertical spacing between chooser modal header and body when there are no tabs (LB (Ben) Johnston)
  * Reinstate specific labels for chooser buttons (for example 'Choose another page', 'Edit this page' not 'Change', 'Edit') so that it is clearer for users and non-English translations (Matt Westcott)
  * Resolve issue where searches with a tag and a query param in the image listing would result in an `FilterFieldError` (Stefan Hammer)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -41,7 +41,7 @@ Further updates to the page editor are expected in the next release. Those chang
 
 ### Rich text improvements
 
-As part of the page editor redesign project sponsored by Google, we have made a number of improvements to our rich text editor:
+As part of the page editor redesign project sponsored by Google, we have made several improvements to our rich text editor:
 
 * Inline toolbar: The toolbar now shows inline, to avoid clashing with the page’s header.
 * Command palette: Start a block with a slash ‘/’ to open the palette and change the text format.
@@ -57,15 +57,15 @@ As part of the page editor redesign project sponsored by Google, we have made a 
 
 Wagtail’s page preview is now available in a side panel within the page editor. This preview auto-updates as users type, and can display the page in three different viewports: mobile, tablet, desktop. The existing preview functionality is still present, moved inside the preview panel rather than at the bottom of the page editor. The auto-update delay can be configured with the `WAGTAIL_AUTO_UPDATE_PREVIEW_INTERVAL` setting. This feature was developed by Sage Abdullah.
 
-### Admin colour themes
+### Admin color themes
 
-In Wagtail 2.12, we introduced theming support for Wagtail’s primary brand colour. This has now been extended to almost all of Wagtail’s colour palette. View our [](custom_user_interface_colours) documentation for more information, an overview of Wagtail’s customisable colour palette, and a live demo of the supported customisations. This was implemented by Thibaud Colas, under the page editor redesign project sponsored by Google.
+In Wagtail 2.12, we introduced theming support for Wagtail’s primary brand color. This has now been extended to almost all of Wagtail’s color palette. View our [](custom_user_interface_colours) documentation for more information, an overview of Wagtail’s customizable color palette, and a live demo of the supported customizations. This was implemented by Thibaud Colas, under the page editor redesign project sponsored by Google.
 
 ### Windows High Contrast mode support improvements
 
 In Wagtail 2.16, we introduced support for Windows High Contrast mode (WHCM). This release sees a lot of improvements to our support, thanks to our new contributor Anuja Verma, who has been working on this as part of the [Contrast Themes](https://github.com/wagtail/wagtail/discussions/8193) Google Summer of Code project, with support from Jane Hughes, Scott Cranfill, and Thibaud Colas.
 
-* Improve help block styles with less reliance on communication via colour alone in forced colors mode
+* Improve help block styles with less reliance on communication via color alone in forced colors mode
 * Add a bottom border to top messages so they stand out from the header in forced colors mode
 * Make progress bars’ progress visible in forced colors mode
 * Make checkboxes visible in forced colors mode
@@ -73,7 +73,7 @@ In Wagtail 2.16, we introduced support for Windows High Contrast mode (WHCM). Th
 * Add a border around modal dialogs so they can be identified in forced colors mode
 * Ensure disabled buttons are distinguishable from active buttons in forced colors mode
 * Ensure that the fields on login and password reset forms are visible in forced colors mode
-* Missing a outline on dropdown content and malformed tooltip arrow in forced colors mode
+* Missing an outline on dropdown content and malformed tooltip arrow in forced colors mode
 
 ### UX unification and consistency improvements
 
@@ -82,7 +82,7 @@ The bulk of these enhancements have been from Paarth Agarwal, who has been doing
 
 * **Login and password reset**
   * Refreshed design for login and password reset pages to better suit a wider range of device sizes
-  * Better accessibility and screen reader support for the sign in form due to a more appropriate DOM structure and skip link improvements
+  * Better accessibility and screen reader support for the sign-in form due to a more appropriate DOM structure and skip link improvements
   * Remove usage of inline script to focus on username field and instead use `autofocus`
   * Wagtail logo added with the ability to override this logo via [](custom_branding)
 * **Breadcrumbs**
@@ -101,9 +101,9 @@ The bulk of these enhancements have been from Paarth Agarwal, who has been doing
   * Adopt new Tabs component in the workflow history report page, removing the bespoke implementation there
 * **Dashboard (home) view**
   * Migrate the dashboard (home) view header to the shared header template and update designs
-  * Refresh designs for Home (Dashboard) site summary panels, use theme spacing and colours
+  * Refresh designs for Home (Dashboard) site summary panels, use theme spacing and colors
   * Add support for RTL layouts and better support for small devices
-  * Add CSS support for more than three summary items if added via customisations
+  * Add CSS support for more than three summary items if added via customizations
 * **Page Listing view**
   * Adopt the slim header in page listing views, with buttons moved under the "Actions" dropdown
   * Add convenient access to the translate page button in the parent "more" button
@@ -120,15 +120,15 @@ These features were developed by Sage Abdullah.
 
 ### Documentation improvements
 
-The documentation now has dark mode which will be turned on by default if set in your browser or OS preferences, it can also be toggled on and off manually. The colours and fonts of the documentation now align with the design updates introduced in Wagtail 3.0. These features were developed by Vince Salvino.
+The documentation now has dark mode which will be turned on by default if set in your browser or OS preferences, it can also be toggled on and off manually. The colors and fonts of the documentation now align with the design updates introduced in Wagtail 3.0. These features were developed by Vince Salvino.
 
 There are also many improvements to the documentation both under the hood and in the layout;
 
  * Convert the rest of the documentation to Markdown, in place of RST, which will make it much easier for others to contribute to better documentation (Khanh Hoang, Vu Pham, Daniel Kirkham, LB (Ben) Johnston, Thiago Costa de Souza, Benedict Faw, Noble Mittal, Sævar Öfjörð Magnússon, Sandeep M A, Stefano Silvestri)
  * Replace latin abbreviations (i.e. / e.g.) with common English phrases so that documentation is easier to understand (Dominik Lech)
- * Improve organisation of the settings reference page with logical grouping and better internal linking (Akash Kumar Sen)
- * Improve the accessibility of the documentation with higher contrast colours, consistent focus outline, better keyboard only navigation through the sidebar (LB (Ben) Johnston, Vince Salvino)
- * Better sidebar scrolling behaviour, it is now sticky on larger devices and scrollable on its own (Paarth Agarwal, LB (Ben) Johnston)
+ * Improve the organization of the settings reference page with logical grouping and better internal linking (Akash Kumar Sen)
+ * Improve the accessibility of the documentation with higher contrast colors, consistent focus outline, better keyboard only navigation through the sidebar (LB (Ben) Johnston, Vince Salvino)
+ * Better sidebar scrolling behavior, it is now sticky on larger devices and scrollable on its own (Paarth Agarwal, LB (Ben) Johnston)
  * Fix links showing incorrectly in Safari (Tibor Leupold)
  * See other features below for new feature specific documentation added.
 
@@ -138,10 +138,10 @@ There are also many improvements to the documentation both under the hood and in
  * Add `base_url_path` to `ModelAdmin` so that the default URL structure of app_label/model_name can be overridden (Vu Pham, Khanh Hoang)
  * Add `full_url` to the API output of `ImageRenditionField` (Paarth Agarwal)
  * Use `InlinePanel`'s label when available for field comparison label (Sandil Ranasinghe)
- * Drop support for Safari 13 by removing left/right positioning in favour of CSS logical properties (Thibaud Colas)
+ * Drop support for Safari 13 by removing left/right positioning in favor of CSS logical properties (Thibaud Colas)
  * Use `FormData` instead of jQuery's `form.serialize` when editing documents or images just added so that additional fields can be better supported (Stefan Hammer)
  * Add informational Codecov status checks for GitHub CI pipelines (Tom Hu)
- * Make it possible to reuse and customise Wagtail’s fonts with CSS variables (LB (Ben) Johnston)
+ * Make it possible to reuse and customize Wagtail’s fonts with CSS variables (LB (Ben) Johnston)
  * Add better handling and informative developer errors for cross linking URLS (e.g. success after add) in generic views `wagtail.admin.views.generic` (Matt Westcott)
  * Introduce `wagtail.admin.widgets.chooser.BaseChooser` to make it easier to build custom chooser inputs (Matt Westcott)
  * Introduce JavaScript chooser module, including a SearchController class which encapsulates the standard pattern of re-rendering the results panel in response to search queries and pagination (Matt Westcott)
@@ -152,7 +152,7 @@ There are also many improvements to the documentation both under the hood and in
  * Implement redesign of the Workflow Status dialog, fixing accessibility issues (Steven Steinwand)
  * Add the ability to change the number of images displayed per page in the image library (Tidiane Dia, with sponsorship from YouGov)
  * Allow users to sort by different fields in the image library (Tidiane Dia, with sponsorship from YouGov)
- * Add `prefetch_renditions` method to `ImageQueryset` for performance optimisation on image listings (Tidiane Dia, Karl Hobley)
+ * Add `prefetch_renditions` method to `ImageQueryset` for performance optimization on image listings (Tidiane Dia, Karl Hobley)
  * Add ability to define a custom `get_field_clean_name` method when defining `FormField` models that extend `AbstractFormField` (LB (Ben) Johnston)
  * Migrate Home (Dashboard) view to use generic Wagtail class based view (LB (Ben) Johnston)
  * Combine most of Wagtail’s stylesheets into the global `core.css` file (Thibaud Colas)
@@ -188,7 +188,7 @@ There are also many improvements to the documentation both under the hood and in
  * Improve security of redirect imports by adding a file hash (signature) check for so that any tampering of file contents between requests will throw a `BadSignature` error (Jaap Roes)
  * Allow generic chooser viewsets to support non-model data such as an API endpoint (Matt Westcott)
  * Added `path` and `re_path` decorators to the `RoutablePageMixin` module which emulate their Django URL utils equivalent, redirect `re_path` to the original `route` decorator (Tidiane Dia)
- * `BaseChooser` widget now provides a Telepath adapter that's directly usable for any subclasses that use the chooser widget and modal JS as-is with no customisations (Matt Westcott)
+ * `BaseChooser` widget now provides a Telepath adapter that's directly usable for any subclasses that use the chooser widget and modal JS as-is with no customizations (Matt Westcott)
  * Introduce new template fragment and block level enclosure tags for easier template composition (Thibaud Colas)
  * Implement the new chooser widget styles as part of the page editor redesign (Thibaud Colas)
  * Update base Draftail/TextField form designs as part of the page editor redesign (Thibaud Colas)
@@ -203,7 +203,7 @@ There are also many improvements to the documentation both under the hood and in
 
  * Fix issue where `ModelAdmin` index listings with export list enabled would show buttons with an incorrect layout (Josh Woodcock)
  * Fix typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
- * Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
+ * Throw a meaningful error when saving an image to an unrecognized image format (Christian Franke)
  * Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)
  * Replace `PageRevision` with generic `Revision` model (Sage Abdullah)
  * Ensure that custom document or image models support custom tag models (Matt Westcott)
@@ -218,16 +218,16 @@ There are also many improvements to the documentation both under the hood and in
  * Show alternative message when no page types are available to be created (Jaspreet Singh)
  * Prevent error on sending notifications for the legacy moderation process when no user was specified (Yves Serrano)
  * Ensure `aria-label` is not set on locale selection dropdown within page chooser modal as it was a duplicate of the button contents (LB (Ben Johnston))
- * Revise the `ModelAdmin` title column behaviour to only link to 'edit' if the user has the correct permissions, fallback to the 'inspect' view or a non-clickable title if needed (Stefan Hammer)
+ * Revise the `ModelAdmin` title column behavior to only link to 'edit' if the user has the correct permissions, fallback to the 'inspect' view or a non-clickable title if needed (Stefan Hammer)
  * Ensure that `DecimalBlock` preserves the `Decimal` type when retrieving from the database (Yves Serrano)
- * When no snippets are added, ensure the snippet chooser modal would have the correct URL for creating a new snippet (Matt Westcott)
+ * When no snippets are added, ensure the snippet chooser modal has the correct URL for creating a new snippet (Matt Westcott)
  * `ngettext` in Wagtail's internal JavaScript internationalisation utilities now works (LB (Ben) Johnston)
  * Ensure the linting/formatting npm scripts work on Windows (Anuja Verma)
  * Fix display of dates in exported xlsx files on macOS Preview and Numbers (Jaap Roes)
  * Remove outdated reference to 30-character limit on usernames in help text (minusf)
  * Resolve multiple form submissions index listing page layout issues including title not being visible on mobile and interaction with large tables (Paarth Agarwal)
  * Ensure `ModelAdmin` single selection lists show correctly with Django 4.0 form template changes (Coen van der Kamp)
- * Ensure icons within help blocks have accessible contrasting colours, and links have a darker colour plus underline to indicate they are links (Paarth Agarwal)
+ * Ensure icons within help blocks have accessible contrasting colors, and links have a darker color plus underline to indicate they are links (Paarth Agarwal)
  * Ensure consistent sidebar icon position whether expanded or collapsed (Scott Cranfill)
  * Avoid redirects import error if the file had lots of columns (Jaap Roes)
  * Resolve accessibility and styling issues with the expanding status panel (Sage Abdullah)
@@ -264,7 +264,7 @@ There are also many improvements to the documentation both under the hood and in
  * Ensure that the live preview panel correctly clears the cache when a new page is created (Sage Abdullah)
  * Ensure that there is a larger hoverable area for add block (+) within the Draftail editor (Steven Steinwand)
  * Resolve multiple header styling issues for modal, alignment on small devices, outside click handling target on medium devices, close button target size and hover styles (Paarth Agarwal)
- * Fix issue where comments could not be added in StreamField that were already already saved (Jacob Topp-Mugglestone)
+ * Fix issue where comments could not be added in StreamField that were already saved (Jacob Topp-Mugglestone)
  * Remove outdated reference to Image.LoaderError (Matt Westcott)
 
 
@@ -276,7 +276,7 @@ As part of making previews available to non-page models, the `serve_preview()` m
 
 ### Opening links within the live preview panel
 
-The live preview panel utilises an iframe to display the preview in the editor page, which requires the page in the iframe to have the `X-Frame-Options` header set to `SAMEORIGIN` (or unset). If you click a link within the preview panel, you may notice that the iframe stops working. This is because the link is loaded within the iframe and the linked page may have the `X-Frame-Options` header set to `DENY`. To work around this problem, add the following `<base>` tag within your `<head>` element in your `base.html` template, before any `<link>` elements:
+The live preview panel utilizes an iframe to display the preview in the editor page, which requires the page in the iframe to have the `X-Frame-Options` header set to `SAMEORIGIN` (or unset). If you click a link within the preview panel, you may notice that the iframe stops working. This is because the link is loaded within the iframe and the linked page may have the `X-Frame-Options` header set to `DENY`. To work around this problem, add the following `<base>` tag within your `<head>` element in your `base.html` template, before any `<link>` elements:
 
 ```html+django
 {% if request.in_preview_panel %}
@@ -347,9 +347,9 @@ The `move_breadcrumb` template tag is no longer used and has been removed.
 
 The `wagtail.contrib.modeladmin.menus.SubMenu` class should no longer be used for constructing submenus of the admin sidebar menu. Instead, import `wagtail.admin.menu.Menu` and pass the list of menu items as the `items` keyword argument.
 
-### Chooser widget JavaScript initialisers replaced with classes
+### Chooser widget JavaScript initializers replaced with classes
 
-The internal JavaScript functions `createPageChooser`, `createSnippetChooser`, `createDocumentChooser` and `createImageChooser` used for initialising chooser widgets have been replaced by classes, and user code that calls them needs to be updated accordingly:
+The internal JavaScript functions `createPageChooser`, `createSnippetChooser`, `createDocumentChooser` and `createImageChooser` used for initializing chooser widgets have been replaced by classes, and user code that calls them needs to be updated accordingly:
 
 * `createPageChooser(id)` should be replaced with `new PageChooser(id)`
 * `createSnippetChooser(id)` should be replaced with `new SnippetChooser(id)`
@@ -380,16 +380,16 @@ As part of the introduction of the new live preview panel, we have changed the `
 
 The page explorer listings now use Wagtail’s new slim header, replacing the previous large teal header. The parent page’s metadata and related actions are now available within the “Info” side panel, while the majority of buttons are now available under the Actions dropdown in the header, identically to the page create/edit forms.
 
-Customising which actions are available and adding extra actions is still possible, but has to be done with the [`register_page_header_buttons`](register_page_header_buttons) hook, rather than [`register_page_listing_buttons`](register_page_listing_buttons) and [`register_page_listing_more_buttons`](register_page_listing_more_buttons). Those hooks still work as-is to define actions for each page within the listings.
+Customizing which actions are available and adding extra actions is still possible, but has to be done with the [`register_page_header_buttons`](register_page_header_buttons) hook, rather than [`register_page_listing_buttons`](register_page_listing_buttons) and [`register_page_listing_more_buttons`](register_page_listing_more_buttons). Those hooks still work as-is to define actions for each page within the listings.
 
 ### `is_parent` removed from page button hooks
 
 * The following hooks `construct_page_listing_buttons`, `register_page_listing_buttons`, `register_page_listing_more_buttons` no longer accept the `is_parent` keyword argument and this should be removed.
 * `is_parent` was the previous approach for determining whether the buttons would show in the listing rows or the page's more button, this can be now achieved with discrete hooks instead.
 
-### Changed CSS variables for admin colour themes
+### Changed CSS variables for admin color themes
 
-As part of our support for theming across all colors, we’ve had to rename or remove some of the pre-existing CSS variables. Wagtail’s indigo is now customisable with `--w-color-primary`, and the teal is customisable as `--w-color-secondary`. See [](custom_user_interface_colours) for an overview of all customisable colours. Here are replaced variables:
+As part of our support for theming across all colors, we’ve had to rename or remove some of the pre-existing CSS variables. Wagtail’s indigo is now customizable with `--w-color-primary`, and the teal is customizable as `--w-color-secondary`. See [](custom_user_interface_colours) for an overview of all customizable colors. Here are replaced variables:
 
 -   `--color-primary` is now `--w-color-secondary`
 -   `--color-primary-hue` is now `--w-color-secondary-hue`
@@ -412,21 +412,21 @@ As part of our support for theming across all colors, we’ve had to rename or r
 -   `--color-primary-light-saturation` is now `--w-color-secondary-50-saturation`
 -   `--color-primary-light-lightness` is now `--w-color-secondary-50-lightness`
 
-We’ve additionally removed all `--color-input-focus` and `--color-input-focus-border` variables, as Wagtail’s form fields no longer have a different colour on focus.
+We’ve additionally removed all `--color-input-focus` and `--color-input-focus-border` variables, as Wagtail’s form fields no longer have a different color on focus.
 
 ### `WAGTAILDOCS_DOCUMENT_FORM_BASE` and `WAGTAILIMAGES_IMAGE_FORM_BASE` must inherit from `BaseDocumentForm` / `BaseImageForm`
 
 Previously, it was valid to specify an arbitrary model form as the `WAGTAILDOCS_DOCUMENT_FORM_BASE` / `WAGTAILIMAGES_IMAGE_FORM_BASE` settings. This is no longer supported; these forms must now inherit from `wagtail.documents.forms.BaseDocumentForm` and `wagtail.images.forms.BaseImageForm` respectively.
 
-### Panel customisations
+### Panel customizations
 
-As part of the page editor redesign, we have removed support for the `classname="full"` customisation to panels. Existing `title` and `collapsed` customisations remain unchanged.
+As part of the page editor redesign, we have removed support for the `classname="full"` customization to panels. Existing `title` and `collapsed` customizations remain unchanged.
 
 ### Optional replacement for regex only `route` decorator for `RoutablePageMixin`
 
 -   This is an optional replacement, there are no immediate plans to remove the `route` decorator at this time.
 -   The `RoutablePageMixin` contrib module now provides a `path` decorator that behaves the same way as Django's [`django.urls.path`](https://docs.djangoproject.com/en/stable/ref/urls/#django.urls.path) function.
--   `RoutablePageMixin`'s `route` decorator will now redirect to a new `re_path` decorator that emulates the behaviour of [`django.urls.re_path`](https://docs.djangoproject.com/en/stable/ref/urls/#django.urls.re_path).
+-   `RoutablePageMixin`'s `route` decorator will now redirect to a new `re_path` decorator that emulates the behavior of [`django.urls.re_path`](https://docs.djangoproject.com/en/stable/ref/urls/#django.urls.re_path).
 
 ### `BaseSetting` model replaced by `BaseSiteSetting`
 

--- a/docs/releases/4.1.2.md
+++ b/docs/releases/4.1.2.md
@@ -24,7 +24,7 @@ depth: 1
  * Close the userbar when clicking its toggle (Albina Starykova)
  * Do not show bulk actions checkbox in page type usage view (Sage Abdullah)
  * Prevent account name from overflowing the sidebar (Aman Pandey)
- * Ensure edit form is displayed as unlocked immediately after cancelling a workflow (Sage Abdullah)
+ * Ensure edit form is displayed as unlocked immediately after canceling a workflow (Sage Abdullah)
  * Prevent `latest_revision` pointer from being copied over when copying translatable snippets for translation (Sage Abdullah)
 
 ### Documentation

--- a/docs/releases/4.1.3.md
+++ b/docs/releases/4.1.3.md
@@ -15,7 +15,7 @@ depth: 1
 
  * Add right-to-left (RTL) support for the following form components: Switch, Minimap, live preview (Thibaud Colas)
  * Improve right-to-left (RTL) positioning for the following components: Page explorer, Sidebar sub-menu, rich text tooltips, rich text toolbar trigger, editor section headers (Thibaud Colas)
- * Ensure links within help blocks meet colour contrast guidelines for accessibility (Theresa Okoro)
+ * Ensure links within help blocks meet color contrast guidelines for accessibility (Theresa Okoro)
  * Support creating `StructValue` copies (Tidiane Dia)
  * Fix "Edit this page" missing from userbar (Satvik Vashisht)
  * Prevent audit log report from failing on missing models (Andy Chosak)

--- a/docs/releases/4.1.4.md
+++ b/docs/releases/4.1.4.md
@@ -32,7 +32,7 @@ Many thanks to Jake Howard for reporting this issue. For further details, please
 * Fix radio and checkbox elements shrinking when using a long label (Sage Abdullah)
 * Fix select elements expanding beyond their container when using a long option label (Sage Abdullah)
 * Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
-* Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
+* Ensure TableBlock initialization correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
 * Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
 * Fix server-side caching of the icons sprite (Thibaud Colas)
 * Always show Add buttons, guide lines, Move up/down, Duplicate, Delete; in StreamField and Inline Panel (Thibaud Colas)

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -19,11 +19,11 @@ To help with onboarding new users, Wagtail now displays a banner on the dashboar
 
 Users can dismiss the new banner and the sidebar items’ indicators by interacting with the corresponding UI element. We store the state in the user’s profile so we only call attention to the content once.
 
-To turn off the new banner, set [`WAGTAIL_ENABLE_WHATS_NEW_BANNER`](wagtail_enable_whats_new_banner) to `False` in your settings. The new menu items can be removed and customised with the following hooks:
+To turn off the new banner, set [`WAGTAIL_ENABLE_WHATS_NEW_BANNER`](wagtail_enable_whats_new_banner) to `False` in your settings. The new menu items can be removed and customized with the following hooks:
 
 - [`register_help_menu_item`](register_help_menu_item) – to add new items to the "Help" menu
-- [`construct_help_menu`](construct_help_menu) – to change or remove existing items from the "Help" menu
-- [`construct_main_menu`](construct_main_menu) – to remove the new "Help" menu altogether
+- [`construct_help_menu`](construct_help_menu) – to change or remove existing items from the "Help" menu
+- [`construct_main_menu`](construct_main_menu) – to remove the new "Help" menu altogether
 
 ### Page editor minimap
 
@@ -31,11 +31,11 @@ When navigating long page editing interfaces, it can be tedious to pinpoint a sp
 
 ### New UI for scheduled publishing
 
-Scheduled publishing settings can now be found within the Status side panel of the page editing view. This change aims to improve clarity over who is able to set schedules, and when they take effect. This feature was developed by Sage Abdullah.
+Scheduled publishing settings can now be found within the Status side panel of the page editing view. This change aims to improve clarity over who can set schedules, and when they take effect. This feature was developed by Sage Abdullah.
 
 ### Customisable snippet admin views
 
-The `register_snippet` function now accepts a `SnippetViewSet` class, allowing various aspects of the snippet's admin views to be customised. See [](wagtailsnippets_custom_admin_views). This feature was developed by Sage Abdullah.
+The `register_snippet` function now accepts a `SnippetViewSet` class, allowing various aspects of the snippet's admin views to be customized. See [](wagtailsnippets_custom_admin_views). This feature was developed by Sage Abdullah.
 
 ### Scheduled publishing for snippets
 
@@ -68,7 +68,7 @@ There are multiple improvements to the documentation theme this release, here ar
  * Remove legacy styling classes for buttons and refactor button styles to be more maintainable (Paarth Agarwal, LB (Ben Johnston))
  * Add button variations to the pattern library (Paarth Agarwal)
  * Provide a more accessible page title where the unique information is shown first and the CMS name is shown last (Mehrdad Moradizadeh)
- * Pull out behaviour from `AbstractFormField` to `FormMixin` and `AbstractEmailForm` to `EmailFormMixin` to allow use with subclasses of `Page` [](form_builder_mixins) (Mehrdad Moradizadeh, Kurt Wall)
+ * Pull out behavior from `AbstractFormField` to `FormMixin` and `AbstractEmailForm` to `EmailFormMixin` to allow use with subclasses of `Page` [](form_builder_mixins) (Mehrdad Moradizadeh, Kurt Wall)
  * Add a `docs.wagtail.org/.well-known/security.txt` so that the security policy is available as per the specification on [https://securitytxt.org/](https://securitytxt.org/) (Jake Howard)
  * Add unit tests for the `classnames` Wagtail admin template tag (Mehrdad Moradizadeh)
  * Show an inverse locked indicator when the page has been locked by the current user in reports and dashboard listings (Vaibhav Shukla, LB (Ben Johnston))
@@ -107,7 +107,7 @@ There are multiple improvements to the documentation theme this release, here ar
 
  * Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
- * Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))
+ * Revise color usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))
  * Ensure that disabled buttons have a consistent presentation on hover to indicate no interaction is available (Paarth Agarwal)
  * Update the 'Locked pages' report menu title so that it is consistent with other pages reports and its own title on viewing (Nicholas Johnson)
  * Support `formfield_callback` handling on `ModelForm.Meta` for future Django 4.2 release (Matt Westcott)
@@ -116,7 +116,7 @@ There are multiple improvements to the documentation theme this release, here ar
  * Remove `capitalize()` calls to avoid issues with other languages or incorrectly presented model names for reporting and parts of site settings (Stefan Hammer)
  * Add back rendering of `help_text` for InlinePanel (Matt Westcott)
  * Ensure `for_user` argument is passed to the form class when previewing pages (Matt Westcott)
- * Ensure the capitalisation of the `timesince_simple` tag is consistently added in the template based on usage in context (Stefan Hammer)
+ * Ensure the capitalization of the `timesince_simple` tag is consistently added in the template based on usage in context (Stefan Hammer)
  * Add missing translation usage for the `timesince_last_update` and ensure the translated labels can be easier to work with in Transifex (Stefan Hammer)
  * Add additional checks for duplicate form field `clean_name` values in the Form Builder validation and increase performance of checks (Dan Bentley)
  * Use correct color for labels of radio and checkbox fields (Steven Steinwand)
@@ -137,13 +137,13 @@ There are multiple improvements to the documentation theme this release, here ar
  * Update latest version message on Dashboard to accept dev build version format used on nlightly builds (Sam Moran)
  * Ensure `ChooserBlock.extract_references` uses the model class, not the model string (Alex Tomkins)
  * Regression in field width for authentication pages (log in / password reset) (Chisom Okeoma)
- * Ensure the new minimap correctly pluralises error counts for `aria-label`s (Matt Westcott)
+ * Ensure the new minimap correctly pluralizes error counts for `aria-label`s (Matt Westcott)
 
 ## Upgrade considerations
 
 ### `rebuild_references_index` management command
 
-After upgrading, you will need to run `./manage.py rebuild_references_index` in order to populate the references table and ensure that usage counts for images, documents and snippets are displayed accurately. By default, references are tracked for all models in the project, including ones not managed through Wagtail - to disable this for specific models, see [](managing_the_reference_index).
+After upgrading, you will need to run `./manage.py rebuild_references_index` to populate the references table and ensure that usage counts for images, documents and snippets are displayed accurately. By default, references are tracked for all models in the project, including ones not managed through Wagtail - to disable this for specific models, see [](managing_the_reference_index).
 
 ### Recommend `WagtailPageTestCase` in place of `WagtailPageTests`
 

--- a/docs/releases/4.2.2.md
+++ b/docs/releases/4.2.2.md
@@ -32,7 +32,7 @@ Many thanks to Jake Howard for reporting this issue. For further details, please
 * Fix radio and checkbox elements shrinking when using a long label (Sage Abdullah)
 * Fix select elements expanding beyond their container when using a long option label (Sage Abdullah)
 * Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
-* Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
+* Ensure TableBlock initialization correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
 * Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
 * Fix server-side caching of the icons sprite (Thibaud Colas)
 * Avoid showing scrollbars in the block picker unless necessary (Babitha Kumari)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -48,7 +48,7 @@ Those changes improve the maintainability of the code, and help us move towards 
 
 ### Accessibility checker integration
 
-The CMS now includes an accessibility checker in the [user bar](wagtailuserbar_tag), in order to assist users in building more accessible websites and follow [ATAG 2.0 guidelines](https://www.w3.org/TR/ATAG20/). The checker, which is based on the Axe testing engine, is designed for content authors to identify and fix accessibility issues on their own. It scans the loaded page for errors and displays the results, with three rules turned on in this release. It’s configurable with the [`construct_wagtail_userbar`](construct_wagtail_userbar) hook.
+The CMS now includes an accessibility checker in the [user bar](wagtailuserbar_tag), to assist users in building more accessible websites and follow [ATAG 2.0 guidelines](https://www.w3.org/TR/ATAG20/). The checker, which is based on the Axe testing engine, is designed for content authors to identify and fix accessibility issues on their own. It scans the loaded page for errors and displays the results, with three rules turned on in this release. It’s configurable with the [`construct_wagtail_userbar`](construct_wagtail_userbar) hook.
 
 This new feature was implemented by Albina Starykova as part of an [Outreachy internship](https://wagtail.org/blog/our-very-first-outreachy-interns/), with support from mentors Thibaud Colas, Sage Abdullah, and Joshua Munn.
 
@@ -102,8 +102,8 @@ This feature was developed by Matt Westcott, and sponsored by [YouGov](https://y
  * Incorrectly formatted link in the documentation for Wagtail community support (Bolarinwa Comfort Ajayi)
  * Ensure logo shows correctly on log in page in Windows high-contrast mode (Loveth Omokaro)
  * Comments notice background overflows its container (Yekasumah)
- * Ensure links within help blocks meet colour contrast guidelines for accessibility (Theresa Okoro)
- * Ensure the skip link (used for keyboard control) meets colour contrast guidelines for accessibility (Dauda Yusuf)
+ * Ensure links within help blocks meet color contrast guidelines for accessibility (Theresa Okoro)
+ * Ensure the skip link (used for keyboard control) meets color contrast guidelines for accessibility (Dauda Yusuf)
  * Ensure tag fields correctly show in both dark and light Windows high-contrast modes (Albina Starykova)
  * Ensure new tooltips & tooltip menus have visible borders and tip triangle in Windows high-contrast mode (Juliet Adeboye)
  * Ensure there is a visual difference of 'active/current link' vs normal links in Windows high-contrast mode (Mohammad Areeb)
@@ -117,7 +117,7 @@ This feature was developed by Matt Westcott, and sponsored by [YouGov](https://y
  * Support text resizing in workflow steps cards (Ivy Jeptoo)
  * Ignore images added via fixtures when using `WAGTAILIMAGES_FEATURE_DETECTION_ENABLED` to avoid errors for images that do not exist (Aman Pandey)
  * Restore ability to perform JSONField query operations against StreamField when running against the Django 4.2 development branch (Sage Abdullah)
- * Ensure there is correct grammar and pluralisation for Tab error counts shown to screen readers (Aman Pandey)
+ * Ensure there is correct grammar and pluralization for Tab error counts shown to screen readers (Aman Pandey)
  * Pass through expected expected `cc`, `bcc` and `reply_to` to the Django mail helper from `wagtail.admin.mail.send_mail` (Ben Gosney)
  * Allow reviewing or reverting to a Page's initial revision (Andy Chosak)
  * Use the correct padding for autocomplete block picker (Umar Farouk Yunusa)
@@ -144,7 +144,7 @@ This feature was developed by Matt Westcott, and sponsored by [YouGov](https://y
  * Server-side document filenames are preserved when replacing a document file (Suyash Singh, Matt Westcott)
  * Do not show bulk actions checkbox in page type usage view (Sage Abdullah)
  * Prevent account name from overflowing the sidebar (Aman Pandey)
- * Ensure edit form is displayed as unlocked immediately after cancelling a workflow (Sage Abdullah)
+ * Ensure edit form is displayed as unlocked immediately after canceling a workflow (Sage Abdullah)
  * Prevent `latest_revision` pointer from being copied over when copying translatable snippets for translation (Sage Abdullah)
 
 ### Documentation
@@ -189,13 +189,13 @@ This feature was developed by Matt Westcott, and sponsored by [YouGov](https://y
  * Migrated `initTagField` from core.js to own TypeScript file and add unit tests (Chisom Okeoma)
  * Added unit tests & JSDoc to `initDissmisibles` (Yekasumah)
  * Standardise on `classname` for passing HTML class attributes (LB (Ben Johnston))
- * Clean up expanding formset and `InlinePanel` JavaScript initialisation code and adopt a class approach (Matt Westcott)
+ * Clean up expanding formset and `InlinePanel` JavaScript initialization code and adopt a class approach (Matt Westcott)
  * Extracted revision and draft state logic from generic views into mixins (Sage Abdullah)
  * Extracted generic lock / unlock views from page lock / unlock views (Sage Abdullah)
  * Move `identity` JavaScript util into shared utils folder (LB (Ben Johnston))
  * Remove unnecessary declaration of function to determine URL query params, instead use `URLSearchParams` (Loveth Omokaro)
  * Update `tsconfig` to better support modern TypeScript development and clean up some code quality issues via Eslint (Loveth Omokaro)
- * Switch userbar to initialise a Web Component to avoid styling clashes (Albina Starykova)
+ * Switch userbar to initialize a Web Component to avoid styling clashes (Albina Starykova)
  * Refactor userbar stylesheets to use the same CSS loading as the rest of the admin (Albina Starykova)
  * Remove unused search-bar and button-filter styles (Thibaud Colas)
  * Use util method to construct dummy requests in tests (Jake Howard)
@@ -227,7 +227,7 @@ See https://github.com/wagtail/wagtail/issues/9685 for tracking of adding this b
 
 Some undocumented Wagtail admin template tags and includes have been refactored to adopt a more consistent naming of `classname`.
 
-If these are used within packages or customisations they will need to be updated to the new variable naming convention.
+If these are used within packages or customizations they will need to be updated to the new variable naming convention.
 
 | Name                | New (`classname`)                                                                                      | Old (various)                                                                                        |
 | ------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
@@ -241,7 +241,7 @@ Note that the `icon` template tag will still support `class_name` with a depreca
 
 ### `InlinePanel` JavaScript function is now a class
 
-The (internal, undocumented) `InlinePanel` JavaScript function, used to initialise client-side behaviour for inline panels, has been converted to a class. Any user code that calls this function should now replace `InlinePanel(...)` calls with `new InlinePanel(...)`. Additionally, child form controls are now initialised automatically, and so it is no longer necessary to call `initChildControls`, `updateChildCount`, `updateMoveButtonDisabledStates` or `updateAddButtonState`.
+The (internal, undocumented) `InlinePanel` JavaScript function, used to initialize client-side behavior for inline panels, has been converted to a class. Any user code that calls this function should now replace `InlinePanel(...)` calls with `new InlinePanel(...)`. Additionally, child form controls are now initialized automatically, and so it is no longer necessary to call `initChildControls`, `updateChildCount`, `updateMoveButtonDisabledStates` or `updateAddButtonState`.
 
 Python code that uses the `InlinePanel` panel type is not affected by this change.
 
@@ -251,9 +251,9 @@ The `WAGTAILADMIN_GLOBAL_PAGE_EDIT_LOCK` setting has been renamed to [`WAGTAILAD
 
 ### Wagtail userbar as a web component
 
-The [`wagtailuserbar`](wagtailuserbar_tag) template tag now initialises the userbar as a [Web Component](https://developer.mozilla.org/en-US/docs/Web/Web_Components), with a `wagtail-userbar` custom element using shadow DOM to apply styles without any collisions with the host page.
+The [`wagtailuserbar`](wagtailuserbar_tag) template tag now initializes the userbar as a [Web Component](https://developer.mozilla.org/en-US/docs/Web/Web_Components), with a `wagtail-userbar` custom element using shadow DOM to apply styles without any collisions with the host page.
 
-For any site customising the position of the userbar, target the styles to `wagtail-userbar::part(userbar)` instead of `.wagtail-userbar`. For example:
+For any site customizing the position of the userbar, target the styles to `wagtail-userbar::part(userbar)` instead of `.wagtail-userbar`. For example:
 
 ```css
 wagtail-userbar::part(userbar) {

--- a/docs/releases/5.0.1.md
+++ b/docs/releases/5.0.1.md
@@ -22,7 +22,7 @@ depth: 1
  * Remove comment button on InlinePanel fields (Sage Abdullah)
  * Fix missing link to `UsageView` from `EditView` for snippets (Christer Jensen)
  * Prevent lowercase conversions of IndexView column headers (Virag Jain)
- * Fix various colour issues in dark mode (Thibaud Colas)
+ * Fix various color issues in dark mode (Thibaud Colas)
 
 ### Documentation
 

--- a/docs/releases/5.0.2.md
+++ b/docs/releases/5.0.2.md
@@ -13,7 +13,7 @@ depth: 1
 
 ### New features
 
- * Added [](title_field_panel) to support title / slug field synchronisation (LB (Ben) Johnston)
+ * Added [](title_field_panel) to support title / slug field synchronization (LB (Ben) Johnston)
 
 ### Bug fixes
 
@@ -28,9 +28,9 @@ depth: 1
 
 ### Use of `TitleFieldPanel` for the page title field
 
-This release introduces a new [](title_field_panel) class, which is used by default for the page title field and provides the mechanism for synchronising the slug field with the title. Prior to Wagtail 5.0, this happened automatically on any field named 'title'.
+This release introduces a new [](title_field_panel) class, which is used by default for the page title field and provides the mechanism for synchronizing the slug field with the title. Before Wagtail 5.0, this happened automatically on any field named 'title'.
 
-If you have used `FieldPanel("title")` directly in a panel definition (rather than extending `Page.content_panels` as standard), and wish to restore the previous behaviour of auto-populating the slug, you will need to change this to `TitleFieldPanel("title")`. For example:
+If you have used `FieldPanel("title")` directly in a panel definition (rather than extending `Page.content_panels` as standard), and wish to restore the previous behavior of auto-populating the slug, you will need to change this to `TitleFieldPanel("title")`. For example:
 
 ```python
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -25,17 +25,17 @@ The image library can now be configured to allow uploading SVG images. These are
 
 ### Custom validation support for StreamField
 
-Support for adding custom validation logic to StreamField blocks has been formalised and simplified. For most purposes, raising a `ValidationError` from the block's `clean` method is now sufficient; more complex behaviours (such as attaching errors to a specific child block) are possible through block-specific subclasses of `ValidationError`. For more details, see [](streamfield_validation). This feature was developed by Matt Westcott.
+Support for adding custom validation logic to StreamField blocks has been formalized and simplified. For most purposes, raising a `ValidationError` from the block's `clean` method is now sufficient; more complex behaviors (such as attaching errors to a specific child block) are possible through block-specific subclasses of `ValidationError`. For more details, see [](streamfield_validation). This feature was developed by Matt Westcott.
 
-### Customisable SVG icons
+### Customizable SVG icons
 
-Wagtail’s icon set is now fully updated, customisable, and extendable. Built-in icons are now based on the latest [FontAwesome](https://fontawesome.com/) visuals, with capabilities to both customise existing icons as well as add new ones. In particular, this includes:
+Wagtail’s icon set is now fully updated, customizable, and extendable. Built-in icons are now based on the latest [FontAwesome](https://fontawesome.com/) visuals, with capabilities to both customize existing icons as well as add new ones. In particular, this includes:
 
  * A new `{% icon %}` icon template tag to reuse icons in custom templates.
  * A `register_icons` hook to register new icons and override existing ones.
  * Live documentation of all available icons in the styleguide, showcasing the icons available on the current site.
  * A list of [all built-in icons](icons) within our developer documentation.
- * Support for customising icons for snippets via `SnippetViewSet.icon`.
+ * Support for customizing icons for snippets via `SnippetViewSet.icon`.
  * Support for custom panel icons, with defaults, displayed for top-level editor panels.
  * New icons for StreamField blocks
 
@@ -50,13 +50,13 @@ The [built-in accessibility checker](authoring_accessible_content) has been upda
  * 5 more Axe rules enabled by default.
  * Sorting of checker results according to their position on the page.
  * Highlight styles to more easily identify elements with errors.
- * Configuration APIs in {class}`~wagtail.admin.userbar.AccessibilityItem` for simpler customisation of the checks performed.
+ * Configuration APIs in {class}`~wagtail.admin.userbar.AccessibilityItem` for simpler customization of the checks performed.
 
 Those improvements were implemented by Albina Starykova as part of an [Outreachy internship](https://wagtail.org/blog/introducing-wagtails-new-accessibility-checker/), with support from mentors Thibaud Colas, Sage Abdullah, and Joshua Munn.
 
 ### Always-on minimap
 
-Following its introduction in Wagtail 4.1, we have made a number of improvements to the page editor minimap:
+Following its introduction in Wagtail 4.1, we have made several improvements to the page editor minimap:
 
  * It now stays opened until dismissed, so users can keep it expanded if desired.
  * Its "expanded" state is preserved when navigating between different views of the CMS.
@@ -74,16 +74,16 @@ We hope this new theme will bring accessibility improvements for users who prefe
 
 ### Snippets parity with ModelAdmin
 
-Continuing on recent improvements to snippets, we have made the following additions to how snippets can be customised in the admin interface:
+Continuing on recent improvements to snippets, we have made the following additions to how snippets can be customized in the admin interface:
 
- * Allow customising the base URL and URL namespace for snippet views.
- * Allow customising the default ordering and number of items per page for snippet listing views.
+ * Allow customizing the base URL and URL namespace for snippet views.
+ * Allow customizing the default ordering and number of items per page for snippet listing views.
  * Allow admin templates for snippets to be overridden on a per-model or per-app basis.
  * Allow overriding the base queryset to be used in snippet `IndexView`.
- * Allow customising the `search_fields` and search backend via SnippetViewSet.
- * Allow filters on snippet index views to be customised through the `list_filter` attribute.
+ * Allow customizing the `search_fields` and search backend via SnippetViewSet.
+ * Allow filters on snippet index views to be customized through the `list_filter` attribute.
  * Allow `panels` / `edit_handler` to be specified via `SnippetViewSet`.
- * Support for customising icons for snippets via `SnippetViewSet.icon`.
+ * Support for customizing icons for snippets via `SnippetViewSet.icon`.
  * Allow snippets to be registered into arbitrary admin menu items.
 
 For more details, see [](wagtailsnippets_custom_admin_views).
@@ -94,7 +94,7 @@ Developed by Sage Abdullah, these features were implemented as part of [RFC 85: 
 
  * Add `WAGTAILIMAGES_EXTENSIONS` setting to restrict image uploads to specific file types (Aman Pandey, Ananjan-R)
  * Update user list column level to `Access level` to be easier to understand (Vallabh Tiwari)
- * Migrate `.button-longrunning` behaviour to a Stimulus controller with support for custom label element & duration (Loveth Omokaro)
+ * Migrate `.button-longrunning` behavior to a Stimulus controller with support for custom label element & duration (Loveth Omokaro)
  * Implement new simplified userbar designs (Albina Starykova)
  * Add usage view for pages (Sage Abdullah)
  * Copy page form now updates the slug field dynamically with a slugified value on blur (Loveth Omokaro)
@@ -126,7 +126,7 @@ Developed by Sage Abdullah, these features were implemented as part of [RFC 85: 
  * Fix image uploads on storage backends that require file pointer to be at the start of the file (Matt Westcott)
  * Fix "Edit this page" missing from userbar (Satvik Vashisht)
  * No longer allow invalid duplicate site hostname creation as hostnames and domain names are a case insensitive (Coen van der Kamp)
- * Image and Document multiple upload update forms now correctly use the progress button (longrunning) behaviour when clicked (Loveth Omokaro)
+ * Image and Document multiple upload update forms now correctly use the progress button (longrunning) behavior when clicked (Loveth Omokaro)
  * Prevent audit log report from failing on missing models (Andy Chosak)
  * Ensure that the privacy collection privacy edit button is styled as a button (Jatin Kumar)
  * Fix page/snippet cannot proceed a `GroupApprovalTask` if it's locked by someone outside of the group (Sage Abdullah)
@@ -143,18 +143,18 @@ Developed by Sage Abdullah, these features were implemented as part of [RFC 85: 
  * Fix radio and checkbox elements shrinking when using a long label (Sage Abdullah)
  * Fix select elements expanding beyond their container when using a long option label (Sage Abdullah)
  * Fix timezone handling of `TemplateResponse`s for users with a custom timezone (Stefan Hammer, Sage Abdullah)
- * Ensure TableBlock initialisation correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
+ * Ensure TableBlock initialization correctly runs after load and its width is aligned with the parent panel (Dan Braghis)
  * Ensure that the JavaScript media files are loaded by default in Snippet index listings for date fields (Sage Abdullah)
  * Fix server-side caching of the icons sprite (Thibaud Colas)
  * Avoid showing scrollbars in the block picker unless necessary (Babitha Kumari)
  * Always show Add buttons, guide lines, Move up/down, Duplicate, Delete; in StreamField and Inline Panel (Thibaud Colas)
  * Make admin JS i18n endpoint accessible to non-authenticated users (Matt Westcott)
  * Autosize text area field will now correctly resize when switching between comments toggle states (Suyash Srivastava)
- * Fix incorrect API serialisation for document `download_url` when `WAGTAILDOCS_SERVE_METHOD` is `direct` (Swojak-A)
+ * Fix incorrect API serialization for document `download_url` when `WAGTAILDOCS_SERVE_METHOD` is `direct` (Swojak-A)
  * Fix template configuration of snippets index results view (fidoriel, Sage Abdullah)
  * Prevent long preview mode names from making the select element overflow the side panel (Sage Abdullah)
  * When i18n is not enabled, avoid making a Locale query on every page view (Dan Braghis)
- * Fix initialisation of commenting widgets within StreamField (Thibaud Colas)
+ * Fix initialization of commenting widgets within StreamField (Thibaud Colas)
  * Fix various regressions in the commenting UI (Thibaud Colas)
  * Prevent TableBlock from becoming uneditable after save (Sage Abdullah)
  * Correctly show the "new item" badge within menu sections previously dismissed (Sage Abdullah)
@@ -188,24 +188,24 @@ Developed by Sage Abdullah, these features were implemented as part of [RFC 85: 
  * Replace `script` tags with `template` tag for image/document bulk uploads (Rishabh Kumar Bahukhandi)
  * Remove unneeded float styles on 404 page (Fabien Le Frapper)
  * Convert userbar implementation to TypeScript (Albina Starykova)
- * Migrate slug field behaviour to a Stimulus controller and create new `SlugInput` widget (Loveth Omokaro)
+ * Migrate slug field behavior to a Stimulus controller and create new `SlugInput` widget (Loveth Omokaro)
  * Refactor `status` HTML usage to shared template tag (Aman Pandey, LB (Ben) Johnston, Himanshu Garg)
  * Add curlylint and update djhtml, semgrep versions in pre-commit config (Himanshu Garg)
  * Use shared header template for `ModelAdmin` and Snippets type index header (Aman Pandey)
  * Move models and forms for `wagtailsearch.Query` to `wagtail.contrib.search_promotions` (Karl Hobley)
  * Migrate `initErrorDetection` (tabs error counts) to a Stimulus Controller `w-count` (Aman Pandey)
- * Migrate `window.addMessage` behaviour to a global event listener & Stimulus Controller approach with `w-messages` (Aman Pandey)
+ * Migrate `window.addMessage` behavior to a global event listener & Stimulus Controller approach with `w-messages` (Aman Pandey)
  * Update Algolia DocSearch to use new application and correct versioning setup (Thibaud Colas)
  * Move snippet choosers and model check registration to `SnippetViewSet.on_register()` (Sage Abdullah)
  * Remove unused snippets delete-multiple view (Sage Abdullah)
  * Improve performance of determining live page URLs across the admin interface using [`pageurl` template tag](performance_page_urls) (Satvik Vashisht)
- * Migrate `window.initSlugAutoPopulate` behaviour to a Stimulus Controller `w-sync` (Loveth Omokaro)
+ * Migrate `window.initSlugAutoPopulate` behavior to a Stimulus Controller `w-sync` (Loveth Omokaro)
  * Rename `status` classes to `w-status` to align with preferred CSS class naming conventions (Mansi Gundre)
  * Include wagtail-factories in `wagtail.test.utils` to avoid cross-dependency issues (Matt Westcott)
- * Fix search tests to correctly reflect behaviour of search backends other than the fallback backend (Matt Westcott)
+ * Fix search tests to correctly reflect behavior of search backends other than the fallback backend (Matt Westcott)
  * Migrate select all checkbox in simple translation's submit translation page to Stimulus controller `w-bulk`, remove inline script usage (Hanoon)
  * Refactor `SnippetViewSet` to extend `ModelViewSet` (Sage Abdullah)
- * Migrate initDismissibles behaviour to a Stimulus controller `w-disimissible` (Loveth Omokaro)
+ * Migrate initDismissibles behavior to a Stimulus controller `w-disimissible` (Loveth Omokaro)
  * Replace jQuery autosize v3 with Stimulus `w-autosize` controller using autosize npm package v6 (Suyash Srivastava)
  * Update `w-action` controller to support a click method (Suyash Srivastava)
  * Migrate the site settings switcher select from jQuery to a refined version of the `w-action` controller usage (Aadi jindal, LB (Ben) Johnston)
@@ -221,8 +221,8 @@ The following features deprecated in Wagtail 3.0 have been fully removed. See [W
 
 * The modules `wagtail.core`, `wagtail.tests`, `wagtail.admin.edit_handlers` and `wagtail.contrib.forms.edit_handlers` are removed.
 * The field panel classes `StreamFieldPanel`, `RichTextFieldPanel`, `ImageChooserPanel`, `DocumentChooserPanel` and `SnippetChooserPanel` are removed.
-* StreamField definitions must include `use_json_field=True` (with the exception of migrations created prior to Wagtail 5.0).
-* The `BASE_URL` setting is no longer recognised.
+* StreamField definitions must include `use_json_field=True` (except migrations created before Wagtail 5.0).
+* The `BASE_URL` setting is no longer recognized.
 * The `ModelAdmin.get_form_fields_exclude` method is no longer passed a `request` argument.
 * The `ModelAdmin.get_edit_handler` method is no longer passed a `request` or `instance` argument.
 * The `widget_overrides`, `required_fields`, `required_formsets`, `bind_to`, `render_as_object` and `render_as_field` methods on `Panel` (previously `EditHandler`) are removed.
@@ -246,7 +246,7 @@ Django 4.0 reached end of life on 1st April 2023 and is no longer supported by W
 
 The `search` method on pages, images and documents, and on the backend object returned by `wagtail.search.backends.get_search_backend()`, no longer performs partial word matching when the Elasticsearch backend is in use. Previously, a search query such as `Page.objects.search("cat")` would return results containing the word "caterpillar", while `Page.objects.search("cat", partial_match=False)` would only return results for the exact word "cat". The `search` method now always performs exact word matches, and the `partial_match` argument has no effect. This change makes the Elasticsearch backend consistent with the database-backed full-text search backends.
 
-To revert to the previous partial word matching behaviour, use the `autocomplete` method instead - for example, `Page.objects.autocomplete("cat")`. It may also be necessary to add an [](wagtailsearch_index_autocompletefield) entry for the relevant fields on the model's `search_fields` definition, as the old `SearchField("some_field", partial_match=True)` format is no longer supported.
+To revert to the previous partial word matching behavior, use the `autocomplete` method instead - for example, `Page.objects.autocomplete("cat")`. It may also be necessary to add an [](wagtailsearch_index_autocompletefield) entry for the relevant fields on the model's `search_fields` definition, as the old `SearchField("some_field", partial_match=True)` format is no longer supported.
 
 The `partial_match` argument on `search` and `SearchField` is now deprecated, and should be removed from your code; it will be dropped entirely in Wagtail 6.
 
@@ -309,7 +309,7 @@ If there are custom styles in place for the `ModelAdmin`'s header content or mor
 
 ### Slug field auto-cleaning now relies on data attributes
 
-The slug field JavaScript behaviour was previously attached to any field with an ID of `id_slug`, this has now changed to be any field with the appropriate Stimulus data attributes.
+The slug field JavaScript behavior was previously attached to any field with an ID of `id_slug`, this has now changed to be any field with the appropriate Stimulus data attributes.
 
 If using a custom edit handler or set of panels for page models, the correct widget will now need to be used for these data attributes to be included. This widget will use the `WAGTAIL_ALLOW_UNICODE_SLUGS` Django setting.
 
@@ -324,7 +324,7 @@ class MyPage(Page):
     ]
 ```
 
-Additionally, the slug behaviour can be attached to any field easily by including the following attributes in HTML or via Django's widget `attrs`.
+Additionally, the slug behavior can be attached to any field easily by including the following attributes in HTML or via Django's widget `attrs`.
 
 ```html
 <input
@@ -347,9 +347,9 @@ To allow unicode values, add the data attribute value;
 />
 ```
 
-### Changes to title / slug field synchronisation
+### Changes to title / slug field synchronization
 
-The mechanism for synchronising the slug field with the page title has changed, and is no longer hard-coded to activate on fields named 'title'. Notably, this change affects page panel definitions that use `FieldPanel("title")` directly (rather than the convention of extending `Page.content_panels`), as well as non-page models such as snippets.
+The mechanism for synchronizing the slug field with the page title has changed, and is no longer hard-coded to activate on fields named 'title'. Notably, this change affects page panel definitions that use `FieldPanel("title")` directly (rather than the convention of extending `Page.content_panels`), as well as non-page models such as snippets.
 
 To assist in upgrading these definitions, Wagtail 5.0.2 provides a new [](title_field_panel) class to be used in place of `FieldPanel("title")`. For example:
 
@@ -379,13 +379,13 @@ from wagtail.admin.panels import FieldPanel, MultiFieldPanel, TitleFieldPanel
     ]
 ```
 
-If you have made deeper customisations to this behaviour, or are unable to upgrade to Wagtail 5.0.2 or above, please read on as you may need to make some changes to adopt the new approach.
+If you have made deeper customizations to this behavior, or are unable to upgrade to Wagtail 5.0.2 or above, please read on as you may need to make some changes to adopt the new approach.
 
-The title field will sync its value with the slug field on Pages if the Page is not published and the slug has not been manually changed. This JavaScript behaviour previously attached to any field with an ID of `id_title`; this has now changed to be any field with the appropriate Stimulus data attributes.
+The title field will sync its value with the slug field on Pages if the Page is not published and the slug has not been manually changed. This JavaScript behavior previously attached to any field with an ID of `id_title`; this has now changed to be any field with the appropriate Stimulus data attributes.
 
 There is a new Stimulus controller `w-sync` which allows any field to change one or more other fields when its value changes, the other field in this case will be the slug field (`w-slug`) with the id `id_slug`.
 
-If you need to hook into this behaviour, the new approach will now correctly dispatch `change` events on the slug field. Alternatively, you can modify the data attributes on the fields to adjust this behaviour.
+If you need to hook into this behavior, the new approach will now correctly dispatch `change` events on the slug field. Alternatively, you can modify the data attributes on the fields to adjust this behavior.
 
 To adjust the target field (the one to be updated), you cam modify `"data-w-sync-target-value"`, the default being `"body:not(.page-is-live) [data-edit-form] #id_slug"` (find the field with id `id_slug` when the page is not live).
 
@@ -453,12 +453,12 @@ Minimum required attributes are `data-controller` and a `data-action`.
 
 #### Examples of additional capabilities
 
-Stimulus [targets](https://stimulus.hotwired.dev/reference/targets) and [actions](https://stimulus.hotwired.dev/reference/actions) can be leveraged to revise the behaviour via data attributes.
+Stimulus [targets](https://stimulus.hotwired.dev/reference/targets) and [actions](https://stimulus.hotwired.dev/reference/actions) can be leveraged to revise the behavior via data attributes.
 
 * `<button ... data-w-progress-duration-value="500" ...>` - custom duration can be declared on the element
 * `<button ... class="custom-button" data-w-progress-active-class="custom-button--busy" ...>` - custom 'active' class to replace the default `button-longrunning-active` (must be a single string without spaces)
 * `<button ... ><strong data-w-progress-target="label">{% trans 'Create' %}</strong></button>` - any element can be the button label (not just `em`)
-* `<button ... data-action="w-progress#activate focus->w-progress#activate" ...>` - any event can be used to trigger the in progress behaviour
+* `<button ... data-action="w-progress#activate focus->w-progress#activate" ...>` - any event can be used to trigger the in progress behavior
 * `<button ... data-action="w-progress#activate:once" ...>` - only trigger the progress behaviour once
 * `<button ... data-action="readystatechange@document->w-progress#activate:once" data-w-progress-duration-value="5000" disabled ...>` - disabled on load (once JS starts) and becomes enabled after 5s duration
 
@@ -496,7 +496,7 @@ Note that this event name may change in the future and this functionality is sti
 
 ### Changes to StreamField `ValidationError` classes
 
-The client-side handling of StreamField validation errors has been updated. The JavaScript classes `StreamBlockValidationError`, `ListBlockValidationError`, `StructBlockValidationError` and `TypedTableBlockValidationError` have been removed, and the corresponding Python classes can no longer be serialised using Telepath. Instead, the `setError` methods on client-side block objects now accept a plain JSON representation of the error, obtained from the `as_json_data` method on the Python class. Custom JavaScript code that works with these objects must be updated accordingly.
+The client-side handling of StreamField validation errors has been updated. The JavaScript classes `StreamBlockValidationError`, `ListBlockValidationError`, `StructBlockValidationError` and `TypedTableBlockValidationError` have been removed, and the corresponding Python classes can no longer be serialized using Telepath. Instead, the `setError` methods on client-side block objects now accept a plain JSON representation of the error, obtained from the `as_json_data` method on the Python class. Custom JavaScript code that works with these objects must be updated accordingly.
 
 Additionally, the Python `StreamBlockValidationError`, `ListBlockValidationError`, `StructBlockValidationError` and `TypedTableBlockValidationError` classes no longer provide a `params` dict with `block_errors` and `non_block_errors` items; these are now available as the attributes `block_errors` and `non_block_errors` on the exception itself (or `cell_errors` and `non_block_errors` in the case of `TypedTableBlockValidationError`).
 
@@ -506,11 +506,11 @@ The ability to remove multiple snippet instances from the `DeleteView` and the u
 
 The delete bulk action view now also calls the `{before,after}_delete_snippet` hooks, in addition to the `{before,after}_bulk_action` hooks.
 
-If you have customised the `IndexView` and/or `DeleteView` views in a `SnippetViewSet` subclass, make sure that the `delete_multiple_url_name` attribute is renamed to `delete_url_name`.
+If you have customized the `IndexView` and/or `DeleteView` views in a `SnippetViewSet` subclass, make sure that the `delete_multiple_url_name` attribute is renamed to `delete_url_name`.
 
 ### Snippets index views template name changed
 
-The template name for the index view of a snippet model has changed from `wagtailsnippets/snippets/type_index.html` and `wagtailsnippets/snippets/results.html` to `wagtailsnippets/snippets/index.html` and `wagtailsnippets/snippets/index_results.html`. In addition, the model index view that lists the snippet types now looks for the template `wagtailsnippets/snippets/model_index.html` before resorting to the generic index template. If you have customised these templates, make sure to update them accordingly.
+The template name for the index view of a snippet model has changed from `wagtailsnippets/snippets/type_index.html` and `wagtailsnippets/snippets/results.html` to `wagtailsnippets/snippets/index.html` and `wagtailsnippets/snippets/index_results.html`. In addition, the model index view that lists the snippet types now looks for the template `wagtailsnippets/snippets/model_index.html` before resorting to the generic index template. If you have customized these templates, make sure to update them accordingly.
 
 ### `status` classes are now `w-status`
 

--- a/docs/releases/5.1.2.md
+++ b/docs/releases/5.1.2.md
@@ -26,9 +26,9 @@ depth: 1
 
 ### Search within chooser interfaces requires `AutocompleteField` for full functionality
 
-In Wagtail 4.2, the search bar within snippet chooser interfaces (and custom choosers created via `ChooserViewSet`) returned results for partial word matches - for example, a search for "wagt" would return results containing "Wagtail" - if this was supported by the search backend in use, and at least one `AutocompleteField` was present in the model's `search_fields` definition. Otherwise, it would fall back to only matching on complete words. In Wagtail 5.0, this fallback behaviour was removed, and consequently a model with no `AutocompleteField`s in place would return no results.
+In Wagtail 4.2, the search bar within snippet chooser interfaces (and custom choosers created via `ChooserViewSet`) returned results for partial word matches - for example, a search for "wagt" would return results containing "Wagtail" - if this was supported by the search backend in use, and at least one `AutocompleteField` was present in the model's `search_fields` definition. Otherwise, it would fall back to only matching on complete words. In Wagtail 5.0, this fallback behavior was removed, and consequently a model with no `AutocompleteField`s in place would return no results.
 
-As of Wagtail 5.1.2, the fallback behaviour has been restored. Nevertheless, it is strongly recommended that you add `AutocompleteField` to your models' `search_fields` definitions, to ensure that users can receive search results continuously as they type. For example:
+As of Wagtail 5.1.2, the fallback behavior has been restored. Nevertheless, it is strongly recommended that you add `AutocompleteField` to your models' `search_fields` definitions, to ensure that users can receive search results continuously as they type. For example:
 
 ```python
 from wagtail.search import index

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -28,7 +28,7 @@ Thank you to Damilola for his work, and to Google for sponsoring this project.
 
 ### Custom template support for `wagtail start`
 
-The `wagtail start` command now supports an optional `--template` argument that allows you to specify a custom project template to use. This is useful if you want to use a custom template that includes additional features or customisations. For more details, see [the project template reference](/reference/project_template). This feature was developed by Thibaud Colas.
+The `wagtail start` command now supports an optional `--template` argument that allows you to specify a custom project template to use. This is useful if you want to use a custom template that includes additional features or customizations. For more details, see [the project template reference](/reference/project_template). This feature was developed by Thibaud Colas.
 
 ### Search query boosting on Elasticsearch 6 and above
 
@@ -43,7 +43,7 @@ This release adds support for Elasticsearch 8. This can be set up by installing 
 As part of tackling Wagtail’s technical debt and improving [CSP compatibility](https://github.com/wagtail/wagtail/issues/1288), we have continued extending our usage of Stimulus, based on the plans laid out in [RFC 78: Adopt Stimulus](https://github.com/wagtail/rfcs/pull/78).
 
 * Add support for `attrs` on `FieldPanel` and other panels to aid in custom Stimulus usage (Aman Pandey, Antoni Martyniuk, LB (Ben) Johnston)
-* Migrate Tagit initialisation to a Stimulus Controller (LB (Ben) Johnston)
+* Migrate Tagit initialization to a Stimulus Controller (LB (Ben) Johnston)
 * Migrate legacy dropdown implementation to a Stimulus controller (Thibaud Colas)
 * Migrate async header search and search with the Task chooser modal to `w-swap`, a Stimulus controller (LB (Ben) Johnston)
 * Replace Bootstrap tooltips with a new `w-tooltip` Stimulus controller (LB (Ben) Johnston)
@@ -58,7 +58,7 @@ This feature was developed by Aman Pandey as part of the Google Summer of Code p
 
 ### Permissions consolidation
 
-This release includes a number of changes to permissions, to make them easier to use and maintain, as well as to improve performance.
+This release includes several changes to permissions, to make them easier to use and maintain, as well as to improve performance.
 
 * Add initial implementation of `PagePermissionPolicy` (Sage Abdullah)
 * Refactor `UserPagePermissionsProxy` and `PagePermissionTester` to use `PagePermissionPolicy` (Sage Abdullah, Tidiane Dia)
@@ -70,11 +70,11 @@ This release includes a number of changes to permissions, to make them easier to
 
 ### Snippet enhancements
 
-We have made a number of improvements to snippets as part of [RFC 85: Snippets parity with ModelAdmin](https://github.com/wagtail/rfcs/pull/85), ahead of the deprecation of ModelAdmin contrib app.
+We have made several improvements to snippets as part of [RFC 85: Snippets parity with ModelAdmin](https://github.com/wagtail/rfcs/pull/85), ahead of the deprecation of ModelAdmin contrib app.
 
 * Add the ability to export snippets listing via `SnippetViewSet.list_export` (Sage Abdullah)
 * Add Inspect view to snippets (Sage Abdullah)
-* Reorganise snippets documentation to cover customisations and optional features (Sage Abdullah)
+* Reorganise snippets documentation to cover customizations and optional features (Sage Abdullah)
 * Add docs for migrating from ModelAdmin to Snippets (Sage Abdullah)
 * Purge revisions of non-page models in `purge_revisions` command (Sage Abdullah)
 
@@ -84,23 +84,23 @@ We have made a number of improvements to snippets as part of [RFC 85: Snippets p
  * Return filters from `parse_query_string` as a `QueryDict` to support multiple values (Aman Pandey)
  * Explicitly specify `MenuItem.name` for all admin menu and submenu items (Justin Koestinger)
  * Add oEmbed provider patterns for YouTube Shorts (e.g. [https://www.youtube.com/shorts/nX84KctJtG0](https://www.youtube.com/shorts/nX84KctJtG0)) and YouTube Live URLs (valnuro, Fabien Le Frapper)
- * Add a predictable default ordering of the "Object/Other permissions" in the Group Editing view, allow this [ordering to be customised](customizing_group_views_permissions_order) (Daniel Kirkham)
+ * Add a predictable default ordering of the "Object/Other permissions" in the Group Editing view, allow this [ordering to be customized](customizing_group_views_permissions_order) (Daniel Kirkham)
  * Implement a new design for chooser buttons with better accessibility (Thibaud Colas)
  * Add [`AbstractImage.get_renditions()`](image_renditions_multiple) for efficient generation of multiple renditions (Andy Babic)
  * Phone numbers entered via a link chooser will now have any spaces stripped out, ensuring a valid `href="tel:..."` attribute (Sahil Jangra)
  * Auto-select the `StreamField` block when only one block type is declared (Sébastien Corbin)
- * Add support for more [advanced Draftail customisation APIs](extending_the_draftail_editor_advanced) (Thibaud Colas)
+ * Add support for more [advanced Draftail customization APIs](extending_the_draftail_editor_advanced) (Thibaud Colas)
  * Add support for adding [HTML `attrs`](panels_attrs) on `FieldPanel`, `FieldRowPanel`, `MultiFieldPanel`, and others (Aman Pandey, Antoni Martyniuk, LB (Ben) Johnston)
  * Change to always cache renditions (Jake Howard)
  * Update link/document rich text tooltips for consistency with the inline toolbar (Albina Starykova)
  * Increase the contrast between the rich text / StreamField block picker and the page in dark mode (Albina Starykova)
  * Change the default WebP quality to 80 to match AVIF (Aman Pandey)
- * Adopt optimised Wagtail logo in the admin interface (Albina Starykova)
+ * Adopt optimized Wagtail logo in the admin interface (Albina Starykova)
  * Add support for presenting the userbar (Wagtail button) in dark mode (Albina Starykova)
 
 ### Bug fixes
 
- * Prevent choosers from failing when initial value is an unrecognised ID such as when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
+ * Prevent choosers from failing when initial value is an unrecognized ID such as when moving a page from a location where `parent_page_types` would disallow it (Dan Braghis)
  * Move comment notifications toggle to the comments side panel (Sage Abdullah)
  * Remove comment button on InlinePanel fields (Sage Abdullah)
  * Fix missing link to `UsageView` from `EditView` for snippets (Christer Jensen)
@@ -112,7 +112,7 @@ We have made a number of improvements to snippets as part of [RFC 85: Snippets p
  * Ensure that title and slug continue syncing after entering non-URL-safe characters (LB (Ben) Johnston)
  * Ensure that title and slug are synced on keypress, not just on blur (LB (Ben) Johnston)
  * Add a more visible active state for side panel toggle buttons (Thibaud Colas)
- * Debounce and optimise live preview panel to prevent excessive requests (Sage Abdullah)
+ * Debounce and optimize live preview panel to prevent excessive requests (Sage Abdullah)
  * Page listings actions under the "More" dropdown are now accessible for screen reader and keyboard users (Thibaud Colas)
  * Bulk actions under the "More" dropdown are now accessible for screen reader and keyboard users (Thibaud Colas)
  * Navigation to translations via the locale dropdown is now accessible for screen reader and keyboard users (Thibaud Colas)
@@ -129,7 +129,7 @@ We have made a number of improvements to snippets as part of [RFC 85: Snippets p
  * Prevent memory exhaustion when updating a large number of image renditions (Jake Howard)
  * Add missing Time Zone conversions and date formatting throughout the admin (Stefan Hammer)
  * Ensure that audit logs and revisions consistently use UTC and add migration for existing entries (Stefan Hammer)
- * Make sure "critical" buttons have enough colour contrast in dark mode (Albina Starykova)
+ * Make sure "critical" buttons have enough color contrast in dark mode (Albina Starykova)
  * Improve visibility of scheduled publishing errors in status side panel (Sage Abdullah)
  * Avoid N+1 queries in users index view (Tidiane Dia)
  * Use a theme-agnostic color token for read-only panels support in dark mode (Thibaud Colas)
@@ -147,7 +147,7 @@ We have made a number of improvements to snippets as part of [RFC 85: Snippets p
  * Document how to add StructBlock data to a StreamField (Ramon Wenger)
  * Update ReadTheDocs settings to v2 to resolve urllib3 issue in linkcheck extension (Thibaud Colas)
  * Update documentation for `log_action` parameter on `RevisionMixin.save_revision` (Christer Jensen)
- * Update color customisations guidance to include theme-agnostic options (Thibaud Colas)
+ * Update color customization guidance to include theme-agnostic options (Thibaud Colas)
  * Mark LTS releases in release note page titles (Thiago C. S. Tioma)
  * Revise main Getting started tutorial for clarity (Kevin Chung (kev-odin))
  * Update the [deployment documentation](deployment_guide) page and remove outdated information (Jake Howard)
@@ -186,9 +186,9 @@ We have made a number of improvements to snippets as part of [RFC 85: Snippets p
 
 ### Search within chooser interfaces requires `AutocompleteField` for full functionality
 
-In Wagtail 4.2, the search bar within snippet chooser interfaces (and custom choosers created via `ChooserViewSet`) returned results for partial word matches - for example, a search for "wagt" would return results containing "Wagtail" - if this was supported by the search backend in use, and at least one `AutocompleteField` was present in the model's `search_fields` definition. Otherwise, it would fall back to only matching on complete words. In Wagtail 5.0, this fallback behaviour was removed, and consequently a model with no `AutocompleteField`s in place would return no results.
+In Wagtail 4.2, the search bar within snippet chooser interfaces (and custom choosers created via `ChooserViewSet`) returned results for partial word matches - for example, a search for "wagt" would return results containing "Wagtail" - if this was supported by the search backend in use, and at least one `AutocompleteField` was present in the model's `search_fields` definition. Otherwise, it would fall back to only matching on complete words. In Wagtail 5.0, this fallback behavior was removed, and consequently a model with no `AutocompleteField`s in place would return no results.
 
-As of Wagtail 5.1.2, the fallback behaviour has been restored. Nevertheless, it is strongly recommended that you add `AutocompleteField` to your models' `search_fields` definitions, to ensure that users can receive search results continuously as they type. For example:
+As of Wagtail 5.1.2, the fallback behavior has been restored. Nevertheless, it is strongly recommended that you add `AutocompleteField` to your models' `search_fields` definitions, to ensure that users can receive search results continuously as they type. For example:
 
 ```python
 from wagtail.search import index
@@ -266,7 +266,7 @@ During the deprecation period, the `permission_type` field will still be availab
 The ordering for "Object permissions" and "Other permissions" now follows a predictable order equivalent to Django's default `Model` ordering.
 This will be different to the previous indeterminate ordering.
 
-The default ordering is now `["content_type__app_label", "content_type__model"]`. See [](customizing_group_views_permissions_order) for details on how to customise this order.
+The default ordering is now `["content_type__app_label", "content_type__model"]`. See [](customizing_group_views_permissions_order) for details on how to customize this order.
 
 ### JSON-timestamps stored in `ModelLogEntry` and `PageLogEntry` are now ISO-formatted and UTC
 
@@ -398,7 +398,7 @@ The documented include `"wagtailadmin/shared/field_as_li.html"` will be removed 
 </li>
 ```
 
-## Upgrade considerations - changes affecting Wagtail customisations
+## Upgrade considerations - changes affecting Wagtail customizations
 
 ### Tag (Tagit) field usage now relies on data attributes
 
@@ -431,7 +431,7 @@ The global util will be removed in a future release. It is recommended that the 
 />
 ```
 
-Note: The `data-w-tag-options-value` is a JSON object serialised into string. Django's HTML escaping will handle it automatically when you use the `AdminTagWidget`, but if you are manually writing the attributes, be sure to use quotation marks correctly.
+Note: The `data-w-tag-options-value` is a JSON object serialized into string. Django's HTML escaping will handle it automatically when you use the `AdminTagWidget`, but if you are manually writing the attributes, be sure to use quotation marks correctly.
 
 ### Header searching now relies on data attributes
 
@@ -476,7 +476,7 @@ Note: No need for `extra_js` usage at all.
 {% endblock %}
 ```
 
-Alternatively, if you have customisations that manually declare or override `window.headerSearch`, here's how to adopt the new approach.
+Alternatively, if you have customizations that manually declare or override `window.headerSearch`, here's how to adopt the new approach.
 
 #### Manual usage before
 

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -52,7 +52,7 @@ This feature was developed by Paarth Agarwal and Thibaud Colas as part of the Go
 
 ### Support extending Wagtail client-side with Stimulus
 
-Wagtail now officially supports client-side admin customisations with [Stimulus](https://stimulus.hotwired.dev/). The developer documentation has a dedicated page about [](extending_client_side). This covers fundamental topics of client-side extensibility, such as:
+Wagtail now officially supports client-side admin customizations with [Stimulus](https://stimulus.hotwired.dev/). The developer documentation has a dedicated page about [](extending_client_side). This covers fundamental topics of client-side extensibility, such as:
 
  * Adding custom JavaScript
  * Extending with DOM events and Wagtail's custom DOM events
@@ -63,7 +63,7 @@ Thank you to core contributor LB (Ben) Johnston for writing this documentation.
 
 ### `ModelViewSet` improvements
 
-A number of features from {class}`~wagtail.snippets.views.snippets.SnippetViewSet` have been implemented in {class}`~wagtail.admin.viewsets.model.ModelViewSet`, allowing you to use them without registering your models as snippets. For more details on using `ModelViewSet`, refer to [](generic_views).
+Several features from {class}`~wagtail.snippets.views.snippets.SnippetViewSet` have been implemented in {class}`~wagtail.admin.viewsets.model.ModelViewSet`, allowing you to use them without registering your models as snippets. For more details on using `ModelViewSet`, refer to [](generic_views).
 
  * Move `SnippetViewSet` menu registration mechanism to base `ViewSet` class (Sage Abdullah)
  * Move `SnippetViewSet` template override mechanism to `ModelViewSet` (Sage Abdullah)
@@ -138,7 +138,7 @@ Promoted search result entries can now use an external URL along with custom lin
  * Ensure 'mark as active' label in workflow bulk action set active form can be translated (Rohit Sharma)
  * Ensure the panel title for a user's settings correctly reflects the `WAGTAIL_EMAIL_MANAGEMENT_ENABLED` setting by not showing 'email' if disabled (Omkar Jadhav)
  * Update Spotify oEmbed provider URL parsing to resolve correctly (Dhrűv)
- * Update link colours within help blocks to meet accessible contrast requirements (Rohit Sharma)
+ * Update link colors within help blocks to meet accessible contrast requirements (Rohit Sharma)
  * Ensure the search promotions popular search terms picker correctly refers to the correct model (LB (Ben) Johnston)
  * Correctly quote non-numeric primary keys on snippet inspect view (Sage Abdullah)
  * Prevent crash on snippet inspect view when displaying a null foreign key to an image (Sage Abdullah)
@@ -172,7 +172,7 @@ Promoted search result entries can now use an external URL along with custom lin
 
 #### Stimulus adoption
 
-As part of our [adoption of Stimulus](https://github.com/wagtail/rfcs/blob/main/text/078-adopt-stimulus-js.md), in addition to the new documentation, we have migrated a number of existing components to the framework. Thank you to our core contributor LB who oversees this project, and to all contributors who refactored specific components.
+As part of our [adoption of Stimulus](https://github.com/wagtail/rfcs/blob/main/text/078-adopt-stimulus-js.md), in addition to the new documentation, we have migrated several existing components to the framework. Thank you to our core contributor LB who oversees this project, and to all contributors who refactored specific components.
 
  * Migrate form submission listing checkbox toggling to the shared `w-bulk` Stimulus implementation (LB (Ben) Johnston)
  * Migrate the editor unsaved messages popup to be driven by Stimulus using the shared `w-message` controller (LB (Ben) Johnston, Hussain Saherwala)
@@ -246,7 +246,7 @@ As a result, the following features are now deprecated:
 
 If you use any of the above features, remove them or replace them with the equivalent features from the new workflow system. The above features will be removed in a future release.
 
-## Upgrade considerations - changes affecting Wagtail customisations
+## Upgrade considerations - changes affecting Wagtail customizations
 
 ### Adoption of `classname` convention for `MenuItem` related classes and hooks
 
@@ -306,11 +306,11 @@ Models that are registered with a `ModelViewSet` now have reference index tracki
 
 ### Groups `IndexView.results_template_name` renamed from `results.html` to `index_results.html`
 
-The `IndexView`'s `results_template_name` attribute in the `GroupViewSet` has been renamed from `wagtailusers/groups/results.html` to `wagtailusers/groups/index_results.html` for consistency with the other viewsets. If you have customised or extended the template, e.g. for [](customizing_group_views), you will need to rename it to match the new name.
+The `IndexView`'s `results_template_name` attribute in the `GroupViewSet` has been renamed from `wagtailusers/groups/results.html` to `wagtailusers/groups/index_results.html` for consistency with the other viewsets. If you have customized or extended the template, e.g. for [](customizing_group_views), you will need to rename it to match the new name.
 
 ### `construct_snippet_listing_buttons` hook no longer accepts a `context` argument
 
-The [`construct_snippet_listing_buttons`](construct_snippet_listing_buttons) hook no longer accepts a `context` argument. If you have implemented this hook, you will need to remove the `context` argument from your implementation. If you need to access values computed by the view, you'll need to override the {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.index_view_class` with a custom `IndexView` subclass. The `get_list_buttons` and `get_list_more_buttons` methods in particular may be overridden to customise the buttons on the listing.
+The [`construct_snippet_listing_buttons`](construct_snippet_listing_buttons) hook no longer accepts a `context` argument. If you have implemented this hook, you will need to remove the `context` argument from your implementation. If you need to access values computed by the view, you'll need to override the {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.index_view_class` with a custom `IndexView` subclass. The `get_list_buttons` and `get_list_more_buttons` methods in particular may be overridden to customize the buttons on the listing.
 
 Defining a function for this hook that accepts the `context` argument will raise a warning, and the function will receive an empty dictionary (`{}`) as the `context`. Support for defining the `context` argument will be completely removed in a future Wagtail release.
 
@@ -341,7 +341,7 @@ If using custom styling for the breadcrumbs, this class has changed from singula
 
 ### Snippets templates refactored to reuse the shared `slim_header.html` template
 
-The templates for the snippets views have been refactored to reuse the shared `slim_header.html` template. If you have customised or extended the templates, e.g. for [](wagtailsnippets_custom_admin_views), you will need to update them to match the new structure. As a result, the following templates have been removed:
+The templates for the snippets views have been refactored to reuse the shared `slim_header.html` template. If you have customized or extended the templates, e.g. for [](wagtailsnippets_custom_admin_views), you will need to update them to match the new structure. As a result, the following templates have been removed:
 
 - `wagtailsnippets/snippets/headers/_base_header.html`
 - `wagtailsnippets/snippets/headers/create_header.html`
@@ -428,7 +428,7 @@ def my_view(request):
 
 The undocumented JavaScript implementation for the header breadcrumbs component has been migrated to a Stimulus controller and now uses different data attributes.
 
-This may impact custom header implementations that relied on the previous approach, custom breadcrumbs that did not use `breadcrumbs` and require the expand/collapse behaviour may be impacted.
+This may impact custom header implementations that relied on the previous approach, custom breadcrumbs that did not use `breadcrumbs` and require the expand/collapse behavior may be impacted.
 
 #### Events
 
@@ -459,8 +459,8 @@ data-w-breadcrumbs-peek-target-value="header"
 
 ### `window.updateFooterSaveWarning` global util removed
 
-The undocumented global util `window.updateFooterSaveWarning` has been removed, this is part of the footer 'unsaved' messages toggling behaviour on page forms.
-This behaviour has now moved to a Stimulus controller and leverages DOM events instead. Calling this function will do nothing and in a future release will throw an error.
+The undocumented global util `window.updateFooterSaveWarning` has been removed, this is part of the footer 'unsaved' messages toggling behavior on page forms.
+This behavior has now moved to a Stimulus controller and leverages DOM events instead. Calling this function will do nothing and in a future release will throw an error.
 
 You can implement roughly the equivalent functionality with this JavaScript function, however, this will not be guaranteed to work in future releases.
 

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -114,7 +114,7 @@ This release comes with a high number of accessibility improvements across the a
 
 ### Bug fixes
 
- * Update system check for overwriting storage backends to recognise the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
+ * Update system check for overwriting storage backends to recognize the `STORAGES` setting introduced in Django 4.2 (phijma-leukeleu)
  * Prevent password change form from raising a validation error when browser autocomplete fills in the "Old password" field (Chiemezuo Akujobi)
  * Ensure that the legacy dropdown options, when closed, do not get accidentally clicked by other interactions on wide viewports (CheesyPhoenix, Christer Jensen)
  * Add a fallback background for the editing preview iframe for sites without a background (Ian Price)
@@ -143,7 +143,7 @@ This release comes with a high number of accessibility improvements across the a
  * Ensure `MultipleChooserPanel` modal works correctly when `USE_THOUSAND_SEPARATOR` is `True` for pages with ids over 1,000 (Sankalp, Rohit Sharma)
  * Ensure the panel anchor button sizes meet accessibility guidelines for minimum dimensions (Nandini Arora)
  * Raise a 404 for bulk actions for models which don't exist instead of throwing a 500 error (Alex Tomkins)
- * Raise a `SiteSetting.DoesNotExist` error when retrieving settings for an unrecognised site (Nick Smith)
+ * Raise a `SiteSetting.DoesNotExist` error when retrieving settings for an unrecognized site (Nick Smith)
  * Ensure that defaulted or unique values declared in `exclude_fields_in_copy` are correctly excluded in new copies, resolving to the default value (Elhussein Almasri)
  * Ensure that `default_ordering` set on IndexView is preserved if ModelViewSet does not specify an explicit ordering (Cynthia Kiser)
  * Resolve issue where clicking Publish for a Page that was in workflow in Safari would block publishing and not trigger the workflow confirmation modal (Alex Morega)
@@ -176,7 +176,7 @@ This release comes with a high number of accessibility improvements across the a
 
 #### Generic class-based views adoption
 
-As part of ongoing refactorings, we have migrated a number of views to use generic class-based views. This allows for easier extensibility and better code reuse.
+As part of ongoing refactorings, we have migrated several views to use generic class-based views. This allows for easier extensibility and better code reuse.
 
  * Migrate the contrib styleguide index view to a class-based view (Chiemezuo Akujobi)
  * Migrate the contrib settings edit view to a class-based view (Chiemezuo Akujobi, Sage Abdullah)
@@ -223,7 +223,7 @@ As part of ongoing refactorings, we have migrated a number of views to use gener
  * Rewrite styles using legacy `c-`, `o-`, `u-`, `t-`, `is-` prefixes (Thibaud Colas)
  * Remove invalid CSS styles / Sass selector concatenation (Thibaud Colas)
  * Refactor listing views to share more queryset ordering logic (Matt Westcott)
- * Remove `initTooltips` in favour of Stimulus controller (LB (Ben) Johnston)
+ * Remove `initTooltips` in favor of Stimulus controller (LB (Ben) Johnston)
  * Enhance the Stimulus `InitController` to allow for custom event dispatching when ready (Aditya, LB (Ben) Johnston)
  * Remove inline script usage for comment initialization and adopt an event listener/dispatch approach for better CSP compliance (Aditya, LB (Ben) Johnston)
  * Migrate styleguide ad-hoc JavaScript to use styles only to avoid CSP issues (LB (Ben) Johnston)
@@ -261,11 +261,11 @@ The `use_json_field` argument to `StreamField` is no longer required, and can be
 
 ### Other removals
 
- * The `WAGTAILADMIN_GLOBAL_PAGE_EDIT_LOCK` setting is no longer recognised and should be replaced with `WAGTAILADMIN_GLOBAL_EDIT_LOCK`.
+ * The `WAGTAILADMIN_GLOBAL_PAGE_EDIT_LOCK` setting is no longer recognized and should be replaced with `WAGTAILADMIN_GLOBAL_EDIT_LOCK`.
  * The `Query` model is no longer part of the `wagtail.search` module; it can now be found in the optional `wagtail.contrib.search_promotions` app.
  * The `wagtail.models.UserPagePermissionsProxy` class and `get_pages_with_direct_explore_permission`, `get_explorable_root_page` and `users_with_page_permission` functions have been removed; equivalent functionality exists in the `wagtail.permission_policies.pages.PagePermissionPolicy` class.
  * The `permission_type` field of the `GroupPagePermission` model has been removed; the `permission` field (a foreign key to Django's `Permission` model) should be used instead.
- * The legacy moderation system used prior to the introduction of workflows in Wagtail 2.10 has been removed. Any moderation requests still in the queue from before this time will be lost.
+ * The legacy moderation system used before the introduction of workflows in Wagtail 2.10 has been removed. Any moderation requests still in the queue from before this time will be lost.
  * The Wagtail icon font has been removed; any direct usage of this needs to be converted to SVG icons.
  * Various unused icons deprecated in Wagtail 5.0 have been removed.
  * The `partial_match` argument on `SearchField` and on `search` methods has been removed. `AutocompleteField` and the `autocomplete` method should be used instead.
@@ -304,13 +304,13 @@ See [](modelviewset_copy) for additional details about this feature.
 
 ### Removed support for Django < 4.2
 
-Django versions prior to 4.2 are no longer supported as of this release; please upgrade to Django 4.2 or above before upgrading Wagtail.
+Django versions before 4.2 are no longer supported as of this release; please upgrade to Django 4.2 or above before upgrading Wagtail.
 
-## Upgrade considerations - changes affecting Wagtail customisations
+## Upgrade considerations - changes affecting Wagtail customizations
 
 ### `SlugInput` widget is now the default for `SlugField` fields
 
-In Wagtail 5.0 a new `SlugInput` admin widget was added to support slug behavior in Page and Page copy forms. This widget was included by default if the `promote_panels` fields layout was customised, causing confusion.
+In Wagtail 5.0 a new `SlugInput` admin widget was added to support slug behavior in Page and Page copy forms. This widget was included by default if the `promote_panels` fields layout was customized, causing confusion.
 
 As of this release, any forms that inherit from `WagtailAdminModelForm` (includes page and snippet model editing) will now use the `SlugInput` by default on all models with `SlugField` fields.
 
@@ -354,7 +354,7 @@ class MyPage(Page):
 
 ### Changed handling of database updates of non-live `Page` objects or subclasses of `DraftStateMixin`
 
-Prior to this release, the database record of a `Page` or any subclass of `DraftStateMixin` either contained the live data (if published), the state of the last published version (if unpublished), or the state of the first revision (if never published). Subsequent draft edits would create new `Revision` records, but the main database record would not be updated. As a result, the database record could lag substantially behind the current state of the object, causing unexpected behaviour particularly when unique constraints are in use.
+Before this release, the database record of a `Page` or any subclass of `DraftStateMixin` either contained the live data (if published), the state of the last published version (if unpublished), or the state of the first revision (if never published). Subsequent draft edits would create new `Revision` records, but the main database record would not be updated. As a result, the database record could lag substantially behind the current state of the object, causing unexpected behavior particularly when unique constraints are in use.
 
 As of this release, the database record of a non-live object will be updated to reflect the draft state of the object. This is unlikely to have a visible effect on existing sites, since the admin backend works with the `Revision` records while the site front-end typically filters out non-live objects. However, any code that relies on the database record being untouched by draft edits (for example, using it to store a specific approved / archived state of the page) may need to be updated.
 

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -44,7 +44,7 @@ depth: 1
  * Remove duplicate 'path' in default_exclude_fields_in_copy (Ramchandra Shahi Thakuri)
  * Update unit tests to always use the faster, built in `html.parser` & remove `html5lib` dependency (Jake Howard)
  * Adjust Eslint rules for TypeScript files (Karthik Ayangar)
- * Rename the React `Button` that only renders links (a element) to `Link` and remove unused prop & behavior that was non-compliant for aria role usage (Advik Kabra)
+ * Rename the React `Button` that only renders links (a element) to `Link` and remove unused prop & behaviors that was non-compliant for aria role usage (Advik Kabra)
  * Set up an `wagtail.models.AbstractWorkflow` model to support future customisations around workflows (Hossein)
  * Improve `classnames` template tag to handle nested lists of strings, use template tag for admin `body` element (LB (Ben) Johnston)
  * Merge `UploadedDocument` and `UploadedImage` into new `UploadedFile` model for easier shared code usage (Advik Kabra, Karl Hobley)

--- a/docs/releases/upgrading.md
+++ b/docs/releases/upgrading.md
@@ -47,7 +47,7 @@ To upgrade:
 -   Make any necessary code changes as directed in the "Upgrade considerations" section of the release notes.
 -   Test that your project is working as expected.
 
-Remember that the JavaScript and CSS files used in the Wagtail admin may have changed between releases - if you encounter erratic behaviour on upgrading, ensure that you have cleared your browser cache. When deploying the upgrade to a production server, be sure to run `./manage.py collectstatic` to make the updated static files available to the web server. In production, we recommend enabling [ManifestStaticFilesStorage](https://docs.djangoproject.com/en/stable/ref/contrib/staticfiles/#manifeststaticfilesstorage) in the `STORAGES["staticfiles"]` setting - this ensures that different versions of files are assigned distinct URLs.
+Remember that the JavaScript and CSS files used in the Wagtail admin may have changed between releases - if you encounter erratic behavior on upgrading, ensure that you have cleared your browser cache. When deploying the upgrade to a production server, be sure to run `./manage.py collectstatic` to make the updated static files available to the web server. In production, we recommend enabling [ManifestStaticFilesStorage](https://docs.djangoproject.com/en/stable/ref/contrib/staticfiles/#manifeststaticfilesstorage) in the `STORAGES["staticfiles"]` setting - this ensures that different versions of files are assigned distinct URLs.
 
 (compatible_django_python_versions)=
 


### PR DESCRIPTION
_Please describe the problem you're fixing here. Include the issue number, if applicable._

Documentation: This pull request resolves #10608
I have changed all the British Spellings to American spellings in the Releases section of the documentation. I have also fixed some minor grammatical errors in this section of the docs.