### PR TITLE
Reduce queries in group create/edit view

### DIFF
--- a/wagtail/users/forms.py
+++ b/wagtail/users/forms.py
@@ -297,7 +297,9 @@ class PagePermissionsForm(forms.Form):
             content_type__app_label="wagtailcore",
             content_type__model="page",
             codename__in=PAGE_PERMISSION_CODENAMES,
-        ).order_by("codename"),
+        )
+        .select_related("content_type")
+        .order_by("codename"),
         # Use codename as the field to use for the option values rather than pk,
         # to minimise the changes needed since we moved to the Permission model
         # and to ease testing.

--- a/wagtail/users/templatetags/wagtailusers_tags.py
+++ b/wagtail/users/templatetags/wagtailusers_tags.py
@@ -1,4 +1,5 @@
 import itertools
+from collections import defaultdict
 
 from django import template
 
@@ -68,9 +69,16 @@ def format_permissions(permission_bound_field):
         "unlock": False,
         "custom": False,
     }
+    # Batch the permission query for all content types, then group by content type
+    # (instead of querying permissions for each content type separately)
+    content_perms_by_ct_id = defaultdict(list)
+    permissions = permissions.filter(content_type_id__in=content_type_ids)
+    for permission in permissions:
+        content_perms_by_ct_id[permission.content_type_id].append(permission)
 
-    for content_type_id in content_type_ids:
-        content_perms = permissions.filter(content_type_id=content_type_id)
+    # Iterate using the sorted content_type_ids
+    for ct_id in content_type_ids:
+        content_perms = content_perms_by_ct_id[ct_id]
         content_perms_dict = {}
         custom_perms = []
 

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -1418,7 +1418,7 @@ class TestGroupCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def test_num_queries(self):
         # Warm up the cache
         self.get()
-        with self.assertNumQueries(113):
+        with self.assertNumQueries(20):
             self.get()
 
     def test_create_group(self):
@@ -1699,7 +1699,7 @@ class TestGroupEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def test_num_queries(self):
         # Warm up the cache
         self.get()
-        with self.assertNumQueries(130):
+        with self.assertNumQueries(31):
             self.get()
 
     def test_nonexistant_group_redirect(self):

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -1415,6 +1415,12 @@ class TestGroupCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailusers/groups/create.html")
         self.assertBreadcrumbsNotRendered(response.content)
 
+    def test_num_queries(self):
+        # Warm up the cache
+        self.get()
+        with self.assertNumQueries(113):
+            self.get()
+
     def test_create_group(self):
         response = self.post({"name": "test group"})
 
@@ -1689,6 +1695,12 @@ class TestGroupEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         url_finder = AdminURLFinder(self.user)
         expected_url = "/admin/groups/edit/%d/" % self.test_group.id
         self.assertEqual(url_finder.get_edit_url(self.test_group), expected_url)
+
+    def test_num_queries(self):
+        # Warm up the cache
+        self.get()
+        with self.assertNumQueries(130):
+            self.get()
 
     def test_nonexistant_group_redirect(self):
         self.assertEqual(self.get(group_id=100000).status_code, 404)


### PR DESCRIPTION
Add missing `select_related` for `content_type` and batch the permission queries for all content types instead of doing one query per model, which can be a lot.

There are still duplicated queries due to the use of formsets, but there isn't much we can do about it without some nasty hacks:

https://stackoverflow.com/questions/32082945