### PR TITLE
Allow displaying permissions linked to the `Admin` model's content type

### DIFF
--- a/docs/topics/permissions.md
+++ b/docs/topics/permissions.md
@@ -67,9 +67,29 @@ See Django's documentation on [custom permissions](https://docs.djangoproject.co
 The ability to have custom permissions with codenames starting with `add_`, `change_`, or `delete_` was added.
 ```
 
-## Displaying custom permissions in the admin
+Permissions for models registered with Wagtail will automatically show up in the Wagtail admin Group edit form. For other models, you can also add the permissions using the `register_permissions` hook (see [](register_permissions)).
 
-Most permissions will automatically show up in the Wagtail admin Group edit form, however, you can also add them using the `register_permissions` hook (see [](register_permissions)).
+To add a custom permission to be used in the Wagtail admin without relating to a specific model, you can create it using the content type of the `wagtail.admin.models.Admin` model. For example:
+
+```python
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from wagtail.admin.models import Admin
+
+
+content_type = ContentType.objects.get_for_model(Admin)
+permission = Permission.objects.create(
+    content_type=content_type,
+    codename="can_do_something",
+    name="Can do something",
+)
+```
+
+After registering the permission using the `register_permissions` hook, it will be displayed in the Wagtail admin Group edit form under the 'Other permissions' section, alongside the 'Can access Wagtail admin' permission.
+
+```{versionadded} 6.1
+The ability to register custom permissions in the "Other permissions" section was added.
+```
 
 ## `FieldPanel` and `PanelGroup` permissions
 


### PR DESCRIPTION
Built on top of #11667, fixes #8086.

To test, run in shell:

```py
from django.contrib.contenttypes.models import ContentType
from django.contrib.auth.models import Permission

content_type = ContentType.objects.get(app_label="wagtailadmin", model="admin")
Permission.objects.create(
    content_type=content_type, codename="branch_import", name="Branch-Import"
)
Permission.objects.create(
    content_type=content_type, codename="hansalog_import", name="Hansalog-Import"
)
```

Then add this hook:

```py
@hooks.register("register_permissions")
def register_permissions():
    app = "wagtailadmin"

    return Permission.objects.filter(
        content_type__app_label=app,
        codename__in=["hansalog_import", "branch_import"],
    )
```

Then the permissions will be displayed in the group create/edit view.