### PR TITLE
add docs section to customize or remove settings panels

### DIFF
--- a/docs/advanced_topics/customisation/admin_templates.md
+++ b/docs/advanced_topics/customisation/admin_templates.md
@@ -206,6 +206,28 @@ To completely customize the login form, override the `login_form` block. This bl
 {% endblock %}
 ```
 
+## Customizing or removing settings panels
+
+Some panels on the admin menu may want to be modified or even completely removed. For example, you may wish to disable modification of user accounts in the wagtail CMS interface. To modify the built-in panels, you can override their properties during django [app startup](https://docs.djangoproject.com/en/stable/ref/applications/#django.apps.AppConfig.ready). As an example, in your `apps.py`:
+
+```python
+from django.apps import AppConfig
+
+from .forms import MyCustomForm
+
+class MyApp(AppConfig):
+    def ready(self) -> None:
+        from wagtail.admin.views.account import NameEmailSettingsPanel
+
+        # customize the form class
+        NameEmailSettingsPanel.form_class = MyCustomForm
+
+        # or disable the panel entirely
+        NameEmailSettingsPanel.is_active = lambda self: False
+
+        return super().ready()
+```
+
 ## Extending the password reset request form
 
 To add extra controls to the password reset form, create a template file `dashboard/templates/wagtailadmin/account/password_reset/form.html`.

--- a/docs/advanced_topics/customisation/admin_templates.md
+++ b/docs/advanced_topics/customisation/admin_templates.md
@@ -208,7 +208,7 @@ To completely customize the login form, override the `login_form` block. This bl
 
 ## Customizing or removing settings panels
 
-Some panels on the admin menu may want to be modified or even completely removed. For example, you may wish to disable modification of user accounts in the wagtail CMS interface. To modify the built-in panels, you can override their properties during django [app startup](https://docs.djangoproject.com/en/stable/ref/applications/#django.apps.AppConfig.ready). As an example, in your `apps.py`:
+Some panels on the admin menu may want to be modified or even completely removed. For example, you may wish to modfiy the form a user can edit regarding fields on their user account, or even disable modification of user accounts in the wagtail CMS interface entirely. To modify the built-in panels, you can override their properties during django [app startup](https://docs.djangoproject.com/en/stable/ref/applications/#django.apps.AppConfig.ready). As an example, in your `apps.py`:
 
 ```python
 from django.apps import AppConfig


### PR DESCRIPTION
Update documentation to include details on how to customize or remove settings panels in the Wagtail CMS. This was originally discussed and requested in #7410