### PR TITLE
Document the vary_fields property for custom image filters

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -49,6 +49,7 @@ Changelog
  * Docs: Add note about `prefers-reduced-motion` to the accessibility documentation (Roel Koper)
  * Docs: Update deployment instructions for Fly.io (Jeroen de Vries)
  * Docs: Add better docs for generating URLs on creating admin views (Shlomo Markowitz)
+ * Docs: Document the `vary_fields` property for custom image filters (Daniel Kirkham)
  * Maintenance: Use `DjangoJSONEncoder` instead of custom `LazyStringEncoder` to serialize Draftail config (Sage Abdullah)
  * Maintenance: Refactor image chooser pagination to check `WAGTAILIMAGES_CHOOSER_PAGE_SIZE` at runtime (Matt Westcott)
  * Maintenance: Exclude the `client/scss` directory in Tailwind content config to speed up CSS compilation (Sage Abdullah)

--- a/docs/extending/custom_image_filters.md
+++ b/docs/extending/custom_image_filters.md
@@ -36,3 +36,16 @@ Use the filter in a template, like so:
 
 {% image page.photo width-400 blur-7 %}
 ```
+
+If your custom image filter depends on fields within the `Image`, for instance those defining the focal point, add a `vary_fields` property listing those field names to the subclassed `FilterOperation`. This ensures that a new rendition is created whenever the focal point is changed:
+
+```python
+class BlurOutsideFocusPointOperation(FilterOperation):
+    vary_fields = (
+        "focal_point_width",
+        "focal_point_height",
+        "focal_point_x",
+        "focal_point_y",
+    )
+    # ...
+```

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -70,6 +70,7 @@ This feature was implemented by Albina Starykova, with support from the Wagtail 
  * Add note about `prefers-reduced-motion` to the accessibility documentation (Roel Koper)
  * Update deployment instructions for Fly.io (Jeroen de Vries)
  * Add better docs for generating URLs on [creating admin views](../extending/admin_views.md) (Shlomo Markowitz)
+ * Document the `vary_fields` property for [custom image filters](custom_image_filters) (Daniel Kirkham)
 
 ### Maintenance
 


### PR DESCRIPTION
As I [commented](https://wagtailcms.slack.com/archives/C81FGJR2S/p1707913525649869?thread_ts=1707637158.622399&cid=C81FGJR2S) in Slack #support, the mechanism that ensures image renditions are recreated when ``Image`` properties such as the focal point are changed has not been documented.

In part, the Slack comment says:
> It appears that the undocumented ``vary_fields`` property in image operations activates the creation of a new rendition when the named fields are changed. See the code at [wagtail/images/models.py#L1045-L1048](https://github.com/wagtail/wagtail/blob/c4f953e90fa2949bb399dbaeb0dc6d4dd5cd8d7a/wagtail/images/models.py#L1045-L1048) and a typical property value for vary_fields at [wagtail/images/image_operations.py#L140-L146](https://github.com/wagtail/wagtail/blob/c4f953e90fa2949bb399dbaeb0dc6d4dd5cd8d7a/wagtail/images/image_operations.py#L140-L146).
>
> This feels like a missing bit of documentation in https://docs.wagtail.org/en/stable/extending/custom_image_filters.html – do others agree, and is it worth preparing a PR to add it?

This PR adds that documentation.