### PR TITLE
References to Laces

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
  * Docs: Update content and page names to their US spelling instead of UK spelling (Victoria Poromon)
  * Docs: Update broken and incorrect links throughout the documentation (EK303)
  * Docs: Fix formatting of `--purge-only` in `wagtail_update_image_renditions` management command section (Pranith)
+ * Docs: Update template components documentation to better explain the usage of the Laces library (Tibor Leupold)
  * Maintenance: Move RichText HTML whitelist parser to use the faster, built in `html.parser` (Jake Howard)
  * Maintenance: Remove duplicate 'path' in default_exclude_fields_in_copy (Ramchandra Shahi Thakuri)
  * Maintenance: Update unit tests to always use the faster, built in `html.parser` & remove `html5lib` dependency (Jake Howard)

--- a/docs/extending/template_components.md
+++ b/docs/extending/template_components.md
@@ -20,6 +20,18 @@ A (possibly empty) :doc:`form media <django:topics/forms/media>` object defining
    Any object implementing this API can be considered a valid component; it does not necessarily have to inherit from the `Component` class described below, and user code that works with components should not assume this (for example, it must not use `isinstance` to check whether a given value is a component).
 ```
 
+```{note}
+   Starting with version 6.0, Wagtail uses the [Laces](https://pypi.org/project/laces/) library to provide all the component related implementations.
+
+   The Laces library was extracted from Wagtail to make the concept of "template components" available to the wider Django ecosystem.
+
+   All import paths shown below continue to work, but they are only references to the implementations in Laces.
+
+   "Template components" are not restricted to extensions of the Wagtail admin. You can use the concepts and tools below in your user-facing code as well.
+
+   You can find more information on the use of components in the [Laces documentation](https://github.com/tbrlpld/laces/blob/main/README.md).
+```
+
 (creating_template_components)=
 
 ## Creating components

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -205,7 +205,7 @@ As part of ongoing refactorings, we have migrated several views to use generic c
  * Upgrade `ruff` and replace `black` with `ruff format` (John-Scott Atlakson)
  * Update Willow upper bound to 2.x (Dan Braghis)
  * Removed support for Django < 4.2 (Dan Braghis)
- * Replace template components implementation with standalone `laces` library (Tibor Leupold)
+ * Replace template components implementation with [standalone `laces` library](https://pypi.org/project/laces/) (Tibor Leupold)
  * Introduce an internal `{% formattedfield %}` tag to replace direct use of `wagtailadmin/shared/field.html` (Matt Westcott)
  * Update Telepath dependency to 0.3.1 (Matt Westcott)
  * Allow `ActionController` to have a `noop` method to more easily leverage standalone Stimulus action options (Nandini Arora)

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -40,6 +40,7 @@ depth: 1
  * Update content and page names to their US spelling instead of UK spelling (Victoria Poromon)
  * Update broken and incorrect links throughout the documentation (EK303)
  * Fix formatting of `--purge-only` in [`wagtail_update_image_renditions`](wagtail_update_image_renditions) management command section (Pranith)
+ * Update [template components](creating_template_components) documentation to better explain the usage of the Laces library (Tibor Leupold)
 
 
 ### Maintenance


### PR DESCRIPTION
Adds a link to the mention of Laces in the 6.0 release notes. 

Adds a notes about the extraction of the "template components" into a standalone library to the respective docs section. 

Also, adds a note about "template components" not being a concept exclusive to the Wagtail admin to the docs. 

---

The purpose of these changes is to make it easier people interested in the topic of "template components" to find more information about it in the Laces docs. 