### PR TITLE
Fix pre-commit versions for prettier and eslint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,13 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.3
+    rev: v3.1.0
     hooks:
       - id: prettier
         types_or: [css, scss, javascript, ts, tsx, json, yaml]
         additional_dependencies:
           # Keep in sync with package.json
-          - prettier@3.2.5
+          - prettier@3.1.0
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v8.56.0
     hooks:
@@ -27,8 +27,8 @@ repos:
         additional_dependencies:
           # Keep in sync with package.json
           - eslint@8.56.0
-          - '@typescript-eslint/eslint-plugin@6.21.0'
-          - '@typescript-eslint/parser@6.21.0'
+          - '@typescript-eslint/eslint-plugin@6.2.1'
+          - '@typescript-eslint/parser@6.2.1'
           - '@wagtail/eslint-config-wagtail@0.4.0'
   - repo: https://github.com/thibaudcolas/pre-commit-stylelint
     rev: v15.11.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "mini-css-extract-plugin": "^2.4.5",
         "postcss": "^8.4.31",
         "postcss-loader": "^6.2.1",
-        "prettier": "^3.2.5",
+        "prettier": "^3.1.0",
         "react-test-renderer": "^16.14.0",
         "redux-mock-store": "^1.3.0",
         "sass": "^1.69.5",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "mini-css-extract-plugin": "^2.4.5",
     "postcss": "^8.4.31",
     "postcss-loader": "^6.2.1",
-    "prettier": "^3.2.5",
+    "prettier": "^3.1.0",
     "react-test-renderer": "^16.14.0",
     "redux-mock-store": "^1.3.0",
     "sass": "^1.69.5",


### PR DESCRIPTION
Ensure that versions are consistent between 1) what we specify in package.json; 2) the tag specified on the pre-commit mirror; 3) the package dependency line in the pre-commit config.

This fixes errors on running pre-commit hooks such as "prettier requires at least version 14 of Node, please upgrade" and "AssertionError: assert prefix.exists('package.json')". Tested by deleting and recreating the Python virtualenv, `node_modules`, and `~/.cache/pre-commit`.