### PR TITLE
Reinstate icons in views that use breadcrumbs

### DIFF
--- a/client/scss/components/_breadcrumbs.scss
+++ b/client/scss/components/_breadcrumbs.scss
@@ -12,8 +12,15 @@
       }
     }
 
-    .w-breadcrumbs__sublabel {
+    .w-breadcrumbs__sublabel,
+    .w-breadcrumbs__icon {
       display: inline-block;
+    }
+
+    .w-breadcrumbs__icon {
+      width: theme('spacing.5');
+      height: theme('spacing.5');
+      margin-inline-end: theme('spacing[2.5]');
     }
   }
 }

--- a/wagtail/admin/templates/wagtailadmin/generic/base.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/base.html
@@ -17,7 +17,7 @@
                 {% endfragment %}
 
                 {# Ensure all necessary variables are passed explicitly here #}
-                {% include "wagtailadmin/shared/headers/slim_header.html" with breadcrumbs_items=breadcrumbs_items side_panels=side_panels history_url=history_url title=header_title search_url=index_results_url search_form=search_form filters=filters actions=actions only %}
+                {% include "wagtailadmin/shared/headers/slim_header.html" with breadcrumbs_items=breadcrumbs_items side_panels=side_panels history_url=history_url title=header_title search_url=index_results_url search_form=search_form filters=filters actions=actions icon_name=header_icon only %}
             {% endif %}
         {% endblock %}
         {% block main_header %}

--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -4,9 +4,9 @@
 
 {% block main_header %}
     {% if breadcrumbs_items %}
-        <div class="w-header nice-padding w-mt-8">
-            <h2 class="w-header__title" id="header-title">
-                {% icon classname="w-header__glyph" name=header_icon %}
+        <div class="nice-padding w-mt-8">
+            <h2 class="w-relative w-h1" id="header-title">
+                {% icon classname="w-absolute w-top-1 -w-left-11 w-max-w-[1em] w-max-h-[1em]" name=header_icon %}
                 {{ page_subtitle }}
             </h2>
         </div>

--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -6,6 +6,7 @@
     {% if breadcrumbs_items %}
         <div class="w-header nice-padding w-mt-8">
             <h2 class="w-header__title" id="header-title">
+                {% icon classname="w-header__glyph" name=header_icon %}
                 {{ page_subtitle }}
             </h2>
         </div>

--- a/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
@@ -11,6 +11,7 @@
                 data-action="click->w-swap#replaceLazy"
                 data-w-swap-src-value="{{ filter.removed_filter_url }}"
                 data-w-swap-target-value="#listing-results"
+                data-w-swap-reflect-value="true"
                 class="w-pill__remove"
                 aria-label="{% trans 'Clear' %}">
                 {% icon name="cross" classname="w-h-4 w-w-4" %}

--- a/wagtail/admin/templates/wagtailadmin/shared/breadcrumbs.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/breadcrumbs.html
@@ -6,6 +6,7 @@
     `items` - A list of {"url": Union[str, None], "label": str, "sublabel": Union[str, None]} dicts
     `classname` - Modifier classes
     `is_expanded` - Whether the breadcrumbs are always expanded or not, if True the breadcrumbs will not be collapsible
+    `icon_name` - The name of the icon to display before the final item when the breadcrumbs are collapsed
 {% endcomment %}
 {% with breadcrumb_link_classes='w-flex w-items-center w-text-text-label w-pr-0.5 w-text-14 w-no-underline w-outline-offset-inside w-border-b w-border-b-2 w-border-transparent w-box-content hover:w-border-current hover:w-text-text-label' breadcrumb_item_classes='w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0' icon_classes='w-w-4 w-h-4 w-ml-3' %}
     {# Breadcrumbs are visible on mobile by default but hidden on desktop #}
@@ -48,6 +49,11 @@
                                     data-w-breadcrumbs-target="content"
                                 {% endif %}
                             >
+                                {% fragment as icon %}
+                                    {% if icon_name and forloop.last %}
+                                        {% icon name=icon_name classname="w-breadcrumbs__icon w-hidden" %}
+                                    {% endif %}
+                                {% endfragment %}
                                 {% fragment as sublabel %}
                                     {% if item.sublabel %}
                                         <span class="w-sr-only">: </span>
@@ -58,11 +64,13 @@
                                 {% endfragment %}
                                 {% if item.url is not None %}
                                     <a class="{{ breadcrumb_link_classes }}" href="{{ item.url }}">
+                                        {{ icon }}
                                         {{ item.label }}
                                         {{ sublabel }}
                                     </a>
                                 {% else %}
                                     <div class="w-flex w-justify-start w-items-center">
+                                        {{ icon }}
                                         {{ item.label }}
                                         {{ sublabel }}
                                     </div>

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -11,6 +11,7 @@
     - `search_url` - URL to the search view, should respond with a partial template for the results
     - `search_form` - form to be rendered for search
     - `filters` - filters to be rendered
+    - `icon_name` - name of the icon to be used in the header
 
     When including this template, use the `only` parameter whenever possible to
     ensure that the above variables are indeed the only ones needed for this
@@ -40,7 +41,7 @@
 
                         {% block breadcrumbs %}
                             {% if breadcrumbs_items %}
-                                {% breadcrumbs breadcrumbs_items %}
+                                {% breadcrumbs breadcrumbs_items icon_name=icon_name %}
                             {% endif %}
                         {% endblock %}
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -67,8 +67,13 @@ register.filter("naturaltime", naturaltime)
 
 
 @register.inclusion_tag("wagtailadmin/shared/breadcrumbs.html")
-def breadcrumbs(items, is_expanded=False, classname=None):
-    return {"items": items, "is_expanded": is_expanded, "classname": classname}
+def breadcrumbs(items, is_expanded=False, classname=None, icon_name=None):
+    return {
+        "items": items,
+        "is_expanded": is_expanded,
+        "classname": classname,
+        "icon_name": icon_name,
+    }
 
 
 @register.inclusion_tag("wagtailadmin/shared/page_breadcrumbs.html", takes_context=True)

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -59,6 +59,7 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertEqual(active_filter.get_text(separator=" ", strip=True), text)
         self.assertIsNotNone(clear_button)
         self.assertNotIn(param, clear_button.attrs.get("data-w-swap-src-value"))
+        self.assertEqual(clear_button.attrs.get("data-w-swap-reflect-value"), "true")
 
     def test_explore(self):
         explore_url = reverse("wagtailadmin_explore", args=(self.root_page.id,))

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -2410,7 +2410,14 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         # Should use the latest draft content for the title
         self.assertContains(
             response,
-            '<h2 class="w-header__title" id="header-title">Draft-enabled Bar, In Draft</h2>',
+            """
+            <h2 class="w-header__title" id="header-title">
+                <svg class="icon icon-snippet w-header__glyph" aria-hidden="true">
+                    <use href="#icon-snippet"></use>
+                </svg>
+                Draft-enabled Bar, In Draft
+            </h2>
+            """,
             html=True,
         )
 

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -2407,19 +2407,13 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         )
         self.assertContains(response, "Unpublish")
 
-        # Should use the latest draft content for the title
-        self.assertContains(
-            response,
-            """
-            <h2 class="w-header__title" id="header-title">
-                <svg class="icon icon-snippet w-header__glyph" aria-hidden="true">
-                    <use href="#icon-snippet"></use>
-                </svg>
-                Draft-enabled Bar, In Draft
-            </h2>
-            """,
-            html=True,
-        )
+        soup = self.get_soup(response.content)
+        h2 = soup.select_one("#header-title")
+        self.assertIsNotNone(h2)
+        icon = h2.select_one("svg use")
+        self.assertIsNotNone(icon)
+        self.assertEqual(icon["href"], "#icon-snippet")
+        self.assertEqual(h2.text.strip(), "Draft-enabled Bar, In Draft")
 
         # Should use the latest draft content for the form
         self.assertTagInHTML(


### PR DESCRIPTION
Previously removed in 8a7dd1f5a1272f3701cde369c3ea314baec1f2ca and 663f9603cad34915d49789aec2aa7ac1b1b377df.

<img width="296" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/add143f9-d0d9-4803-b9a3-4749e0be9a55">

<img width="296" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/8c6d30a8-e526-42ca-8959-c9b432652d5d">
