### PR TITLE
wagtail_update_image_renditions(Fixed typo)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Docs: Make sure the settings panel is listed in tabbed interface examples (Tibor Leupold)
  * Docs: Update content and page names to their US spelling instead of UK spelling (Victoria Poromon)
  * Docs: Update broken and incorrect links throughout the documentation (EK303)
+ * Docs: Fix formatting of `--purge-only` in `wagtail_update_image_renditions` management command section (Pranith)
  * Maintenance: Move RichText HTML whitelist parser to use the faster, built in `html.parser` (Jake Howard)
  * Maintenance: Remove duplicate 'path' in default_exclude_fields_in_copy (Ramchandra Shahi Thakuri)
  * Maintenance: Update unit tests to always use the faster, built in `html.parser` & remove `html5lib` dependency (Jake Howard)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -803,6 +803,7 @@
 * EK303
 * Damian Borneman
 * Viktor Szépe
+* Pranith
 
 ## Translators
 

--- a/docs/reference/management_commands.md
+++ b/docs/reference/management_commands.md
@@ -162,5 +162,5 @@ This does not remove unused rendition images, this can be done by clearing the f
 
 Options:
 
--   **--purge-only** :
+-  `--purge-only` :
     This argument will purge all image renditions without regenerating them. They will be regenerated when next requested.

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -39,6 +39,7 @@ depth: 1
  * Make sure the settings panel is listed in tabbed interface examples (Tibor Leupold)
  * Update content and page names to their US spelling instead of UK spelling (Victoria Poromon)
  * Update broken and incorrect links throughout the documentation (EK303)
+ * Fix formatting of `--purge-only` in [`wagtail_update_image_renditions`](wagtail_update_image_renditions) management command section (Pranith)
 
 
 ### Maintenance


### PR DESCRIPTION
fixes #11646 
As the issue details said, changing `-purge-only`  to `--purge-only` would resolve problem `error: unrecognized arguments: -purge-only`
I changed `-purge-only` to `--purge-only` in documentation.

<img width="944" alt="image" src="https://github.com/wagtail/wagtail/assets/116240849/b334c9a3-6346-47d9-8c42-e52ce4d721b9">


