### PR TITLE
Fix - Ensure that modal tabs width are not impacted by side panel opening

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,12 @@ Changelog
  * Maintenance: Remove usage of inline scripts and instead use event dispatching to instantiate standalone Draftail editor instances (Chiemezuo Akujobi)
 
 
+6.0.2 (xx.xx.xxxx) - IN DEVELOPMENT
+~~~~~~~~~~~~~~~~~~
+
+ * Fix: Ensure that modal tabs width are not impacted by side panel opening (LB (Ben) Johnston)
+
+
 6.0.1 (15.02.2024)
 ~~~~~~~~~~~~~~~~~~
 

--- a/client/scss/components/forms/_form-width.scss
+++ b/client/scss/components/forms/_form-width.scss
@@ -4,22 +4,25 @@
 
 @include media-breakpoint-up(md) {
   .minimap-open {
-    .tab-content {
-      width: theme('width.[4/5]');
+    .w-form-width {
+      max-width: theme('width.[4/5]');
     }
   }
 
   .side-panel-open {
-    .tab-content {
+    .w-form-width {
       // Account for dynamic width of the side panel when open.
-      width: max(theme('width.[1/3]'), calc(100% - var(--side-panel-width)));
+      max-width: max(
+        theme('width.[1/3]'),
+        calc(100% - var(--side-panel-width))
+      );
     }
   }
 
   .side-panel-open.minimap-open {
-    .tab-content {
+    .w-form-width {
       // Account for additional space taken up by the minimap.
-      width: max(
+      max-width: max(
         theme('width.[2/5]'),
         calc(100% - var(--side-panel-width) - 15rem)
       );

--- a/docs/releases/6.0.2.md
+++ b/docs/releases/6.0.2.md
@@ -1,0 +1,16 @@
+# Wagtail 6.0.2 release notes - IN DEVELOPMENT
+
+_Unreleased_
+
+```{contents}
+---
+local:
+depth: 1
+---
+```
+
+## What's new
+
+### Bug fixes
+
+ * Ensure that modal tabs width are not impacted by side panel opening (LB (Ben) Johnston)

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -6,6 +6,7 @@ Release notes
 
    upgrading
    6.1
+   6.0.2
    6.0.1
    6.0
    5.2.3


### PR DESCRIPTION
This bug was reported in Slack, it appears that https://github.com/wagtail/wagtail/pull/11150 introduced a regression where the side panel opening would cause the tab-content within modals to also be impacted.

https://wagtailcms.slack.com/archives/C81FGJR2S/p1708033342014629
<img width="965" alt="Screenshot 2024-02-28 at 8 34 54 pm" src="https://github.com/wagtail/wagtail/assets/1396140/1356e4aa-c277-4199-b69a-9e6d59ec3853">


Ideally we would better isolate these classes but for now here's a simple fix to this problem.

Note: The extra padding on the table columns is unrelated, probably needs to be fixed also but I will flag that in a different thread.

## To reproduce the bug

1. Open any page editing view
2. Open a wide side panel (e.g. the preview panel)
3. Open a chooser modal, one with tabs in it such as the links chooser
4. Observe the content is not the full width of the modal
5. Close the chooser, close the side panel and then re-open the chooser
6. Observe the content is now the full width of the modal

## Screenshots

### Before

<img width="1652" alt="Screenshot 2024-02-28 at 8 25 56 pm" src="https://github.com/wagtail/wagtail/assets/1396140/fc6db5b1-01e6-46ba-a1b5-fb856fdbad4e">


### After

<img width="1650" alt="Screenshot 2024-02-28 at 8 29 21 pm" src="https://github.com/wagtail/wagtail/assets/1396140/000dba0d-3844-4eb6-b305-024f48b07a14">
