### PR TITLE
Remove extraneous padding in chooser modal listings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changelog
  * Fix: Ensure re-ordering buttons work correctly when using a nested InlinePanel (Adrien Hamraoui)
  * Fix: Consistently remove model's `verbose_name` in group edit view when listing custom permissions (Sage Abdullah, Neeraj Yetheendran, Omkar Jadhav)
  * Fix: Resolve issue local development of docs when running `make livehtml` (Sage Abdullah)
+ * Fix: Resolve issue with unwanted padding in chooser modal listings (Sage Abdullah)
  * Docs: Add contributing development documentation on how to work with a fork of Wagtail (Nix Asteri, Dan Braghis)
  * Docs: Make sure the settings panel is listed in tabbed interface examples (Tibor Leupold)
  * Docs: Update content and page names to their US spelling instead of UK spelling (Victoria Poromon)

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -635,9 +635,15 @@ table.listing {
       }
     }
 
-    // If no bulk actions are present, and nice padding is not applied,
-    // apply the same 80px padding via the first column's left padding.
-    &:not(.nice-padding &, .report &):not(
+    // If either:
+    // - no nice padding is applied,
+    // - we're not in a report listing,
+    // - we're not in the editor view,
+    // and:
+    // - no bulk actions are present,
+    // - we're not in the "custom ordering" mode,
+    // then apply the same 80px padding via the first column's left padding.
+    &:not(.nice-padding &, .report &, .editor-view &):not(
         :has(.bulk-actions-filter-checkbox, .ord)
       ) {
       th:first-child,

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -33,6 +33,7 @@ depth: 1
  * Ensure re-ordering buttons work correctly when using a nested InlinePanel (Adrien Hamraoui)
  * Consistently remove model's `verbose_name` in group edit view when listing custom permissions (Sage Abdullah, Neeraj Yetheendran, Omkar Jadhav)
  * Resolve issue local development of docs when running `make livehtml` (Sage Abdullah)
+ * Resolve issue with unwanted padding in chooser modal listings (Sage Abdullah)
 
 
 ### Documentation


### PR DESCRIPTION
Fixes #11704

<img width="985" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/c686f388-22a0-4a99-9c9a-55ea736818f6">

The selectors in here is quite nasty and very complex I know, but currently we have to consider different scenarios:
- universal listing with bulk actions
- universal listing with custom ordering active
- universal listing without bulk actions
- old listing with bulk actions
- old listing without bulk actions
- old listing that hasn't been migrated to use full-width styles (still inside `nice-padding`)
- report listing (technically similar to the ones inside `nice-padding`, but for some reason the report views use margin with the same value as `nice-padding` instead of the actual `nice-padding`)

We should be able to remove these complex selectors once we can safely assume that all listings have been migrated to use universal listings. But, until then...