### PR TITLE
More detailed release note about move of Query model

### DIFF
--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -251,6 +251,10 @@ The most significant changes are highlighted below.
 
 The `wagtail.contrib.modeladmin` app has been removed. If you wish to continue using it, it is available as the external package [`wagtail-modeladmin`](https://github.com/wagtail-nest/wagtail-modeladmin).
 
+### `Query` model moved to `wagtail.contrib.search_promotions`
+
+The `Query` model (used to log search queries performed by users, to identify commonly searched terms) is no longer part of the `wagtail.search` module; it can now be found in the optional `wagtail.contrib.search_promotions` app. When updating code to import the model from the new location, ensure that you have added `wagtail.contrib.search_promotions` to your `INSTALLED_APPS` setting - failing to do this may result in a spurious migration being created within the core `wagtail` app.
+
 ### Support for Elasticsearch 5 and 6 dropped
 
 The Elasticsearch 5 and 6 backends have been removed. If you are using one of these backends, you will need to upgrade to Elasticsearch 7 or 8 before upgrading to Wagtail 6.0.
@@ -262,7 +266,6 @@ The `use_json_field` argument to `StreamField` is no longer required, and can be
 ### Other removals
 
  * The `WAGTAILADMIN_GLOBAL_PAGE_EDIT_LOCK` setting is no longer recognized and should be replaced with `WAGTAILADMIN_GLOBAL_EDIT_LOCK`.
- * The `Query` model is no longer part of the `wagtail.search` module; it can now be found in the optional `wagtail.contrib.search_promotions` app.
  * The `wagtail.models.UserPagePermissionsProxy` class and `get_pages_with_direct_explore_permission`, `get_explorable_root_page` and `users_with_page_permission` functions have been removed; equivalent functionality exists in the `wagtail.permission_policies.pages.PagePermissionPolicy` class.
  * The `permission_type` field of the `GroupPagePermission` model has been removed; the `permission` field (a foreign key to Django's `Permission` model) should be used instead.
  * The legacy moderation system used before the introduction of workflows in Wagtail 2.10 has been removed. Any moderation requests still in the queue from before this time will be lost.


### PR DESCRIPTION
As per https://github.com/wagtail/wagtail/issues/11690#issuecomment-1972969215 - many developers have overlooked the requirement to add `wagtail.contrib.search_promotions` to INSTALLED_APPS.
