### PR TITLE
fix: MutationObserver in dirty form check only tests direct descendants

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Fix: Resolve issue local development of docs when running `make livehtml` (Sage Abdullah)
  * Fix: Resolve issue with unwanted padding in chooser modal listings (Sage Abdullah)
  * Fix: Ensure form builder emails that have date or datetime fields correctly localize dates based on the configured `LANGUAGE_CODE` (Mark Niehues)
+ * Fix: Ensure the Stimulus `UnsavedController` checks for nested removal/additions of inputs so that the unsaved warning shows in more valid cases when editing a page (Karthik Ayangar)
  * Docs: Add contributing development documentation on how to work with a fork of Wagtail (Nix Asteri, Dan Braghis)
  * Docs: Make sure the settings panel is listed in tabbed interface examples (Tibor Leupold)
  * Docs: Update content and page names to their US spelling instead of UK spelling (Victoria Poromon)

--- a/client/src/controllers/UnsavedController.ts
+++ b/client/src/controllers/UnsavedController.ts
@@ -198,6 +198,17 @@ export class UnsavedController extends Controller<HTMLFormElement> {
     if (current !== previous) this.notify();
   }
 
+  getIsValidNode(node: Node | null) {
+    if (!node || node.nodeType !== node.ELEMENT_NODE) return false;
+
+    const validElements = ['input', 'textarea', 'select'];
+
+    return (
+      validElements.includes((node as Element).localName) ||
+      (node as Element).querySelector(validElements.join(',')) !== null
+    );
+  }
+
   /**
    * Notify the user of changes to the form.
    * Dispatch events to update the footer message via dispatching events.
@@ -288,15 +299,11 @@ export class UnsavedController extends Controller<HTMLFormElement> {
         detail: { initialFormData },
       });
 
-      const isValidInputNode = (node) =>
-        node.nodeType === node.ELEMENT_NODE &&
-        ['INPUT', 'TEXTAREA', 'SELECT'].includes(node.tagName);
-
       const observer = new MutationObserver((mutationList) => {
         const hasMutationWithValidInputNode = mutationList.some(
           (mutation) =>
-            Array.from(mutation.addedNodes).some(isValidInputNode) ||
-            Array.from(mutation.removedNodes).some(isValidInputNode),
+            Array.from(mutation.addedNodes).some(this.getIsValidNode) ||
+            Array.from(mutation.removedNodes).some(this.getIsValidNode),
         );
 
         if (hasMutationWithValidInputNode) this.check();

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -35,6 +35,7 @@ depth: 1
  * Resolve issue local development of docs when running `make livehtml` (Sage Abdullah)
  * Resolve issue with unwanted padding in chooser modal listings (Sage Abdullah)
  * Ensure form builder emails that have date or datetime fields correctly localize dates based on the configured `LANGUAGE_CODE` (Mark Niehues)
+ * Ensure the Stimulus `UnsavedController` checks for nested removal/additions of inputs so that the unsaved warning shows in more valid cases when editing a page (Karthik Ayangar)
 
 
 ### Documentation


### PR DESCRIPTION


#11142 

I was working on this issue in which the function [isValidInputNode()](https://github.com/wagtail/wagtail/blob/main/client/src/controllers/UnsavedController.ts#L291) was checking only the current node and was failing if input is nested deep inside for e.g. if the node is <div><input/></div> this function fails.
To fix this, I added a querySelector check in addition to this to check whether any input node is present inside the current node (on which the isValidInputNode() is called)
`const isValidInputNode = (node) =>
        node.nodeType === node.ELEMENT_NODE &&
        (['INPUT', 'TEXTAREA', 'SELECT'].includes(node.tagName) ||
          node.querySelector('input, textarea, select') !== null);`
Also in the comments, @SebCorbin suggested to add some extra tests in `UnsavedController.test.js` . I have never written a jest test before this. I know my test might be wrong. Can you give me some resources so that I can understand about test and write correct required tests. 

Also, there is another way of improving this isValidInput function. By using traversing through all the childs of the node one by one to find the input element