### PR TITLE
Update 5.0.md to include installed apps for Query change

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -804,6 +804,7 @@
 * Damian Borneman
 * Viktor Szépe
 * Pranith Beeram
+* Maranda Provance
 
 ## Translators
 

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -279,7 +279,7 @@ The undocumented `Page.get_static_site_paths` method (which returns a generator 
 The `wagtailsearch.Query` model has been moved from the `search` application to the contrib application `wagtail.contrib.search_promotions`.
 All imports will need to be updated and migrations will need to be run via a management command, some imports will still work with a warning until a future version.
 
-To continue using the `Query` model, you must also add the `wagtail.contrib.search_promotes` application to your project's `INSTALLED_APPS` setting.
+To continue using the `Query` model, you must also add the `wagtail.contrib.search_promotions` application to your project's `INSTALLED_APPS` setting.
 
 #### Migration command
 

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -279,6 +279,8 @@ The undocumented `Page.get_static_site_paths` method (which returns a generator 
 The `wagtailsearch.Query` model has been moved from the `search` application to the contrib application `wagtail.contrib.search_promotions`.
 All imports will need to be updated and migrations will need to be run via a management command, some imports will still work with a warning until a future version.
 
+To continue using the `Query` model, you must also add the `wagtail.contrib.search_promotes` application to your project's `INSTALLED_APPS` setting.
+
 #### Migration command
 
 If you have daily hits records in the `wagtailsearch.Query` you can run the management command to move these records to the new location.


### PR DESCRIPTION
I was upgrading to Wagtail 5 and got stuck temporarily because I was not able to run the migration command. I figured it out that I needed to add the new app, but this may help future people, especially beginners, not waste time trying to figure out the missing piece.
