### PR TITLE
Universal listings: use new designs (with breadcrumbs) for sites and locale views

### DIFF
--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -597,14 +597,16 @@ class CreateView(
         return context
 
     def get_side_panels(self):
-        side_panels = [
-            StatusSidePanel(
-                self.form.instance,
-                self.request,
-                locale=self.locale,
-                translations=self.translations,
+        side_panels = []
+        if self.locale:
+            side_panels.append(
+                StatusSidePanel(
+                    self.form.instance,
+                    self.request,
+                    locale=self.locale,
+                    translations=self.translations,
+                )
             )
-        ]
         return MediaContainer(side_panels)
 
     def get_translations(self):

--- a/wagtail/locales/tests.py
+++ b/wagtail/locales/tests.py
@@ -20,7 +20,10 @@ class TestLocaleIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/generic/index.html")
-        self.assertBreadcrumbsNotRendered(response.content)
+        self.assertBreadcrumbsItemsRendered(
+            [{"url": "", "label": "Locales"}],
+            response.content,
+        )
 
 
 class TestLocaleCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
@@ -43,7 +46,13 @@ class TestLocaleCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtaillocales/create.html")
-        self.assertBreadcrumbsNotRendered(response.content)
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {"label": "Locales", "url": "/admin/locales/"},
+                {"label": "New: Locale", "url": ""},
+            ],
+            response.content,
+        )
 
         self.assertEqual(
             response.context["form"].fields["language_code"].choices, [("fr", "French")]
@@ -116,7 +125,13 @@ class TestLocaleEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtaillocales/edit.html")
-        self.assertBreadcrumbsNotRendered(response.content)
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {"url": "/admin/locales/", "label": "Locales"},
+                {"url": "", "label": str(self.english)},
+            ],
+            response.content,
+        )
 
         self.assertEqual(
             response.context["form"].fields["language_code"].choices,

--- a/wagtail/locales/views.py
+++ b/wagtail/locales/views.py
@@ -98,7 +98,6 @@ class LocaleViewSet(ModelViewSet):
     model = Locale
     permission_policy = locale_permission_policy
     add_to_reference_index = False
-    _show_breadcrumbs = False
 
     index_view_class = IndexView
     add_view_class = CreateView

--- a/wagtail/sites/tests.py
+++ b/wagtail/sites/tests.py
@@ -28,7 +28,7 @@ class TestSiteIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def test_num_queries(self):
         # Warm up the cache
         self.get()
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             self.get()
 
         sites = [
@@ -37,7 +37,7 @@ class TestSiteIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         ]
         Site.objects.bulk_create(sites)
 
-        with self.assertNumQueries(20):
+        with self.assertNumQueries(9):
             self.get()
 
 

--- a/wagtail/sites/tests.py
+++ b/wagtail/sites/tests.py
@@ -20,7 +20,10 @@ class TestSiteIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/generic/index.html")
-        self.assertBreadcrumbsNotRendered(response.content)
+        self.assertBreadcrumbsItemsRendered(
+            [{"url": "", "label": "Sites"}],
+            response.content,
+        )
 
 
 class TestSiteCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
@@ -56,7 +59,13 @@ class TestSiteCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def test_simple(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertBreadcrumbsNotRendered(response.content)
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {"label": "Sites", "url": "/admin/sites/"},
+                {"label": "New: Site", "url": ""},
+            ],
+            response.content,
+        )
 
     def test_create(self):
         response = self.post(
@@ -200,7 +209,13 @@ class TestSiteEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def test_simple(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertBreadcrumbsNotRendered(response.content)
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {"url": "/admin/sites/", "label": "Sites"},
+                {"url": "", "label": str(self.localhost)},
+            ],
+            response.content,
+        )
 
         url_finder = AdminURLFinder(self.user)
         expected_url = "/admin/sites/edit/%d/" % self.localhost.id

--- a/wagtail/sites/tests.py
+++ b/wagtail/sites/tests.py
@@ -25,6 +25,21 @@ class TestSiteIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
             response.content,
         )
 
+    def test_num_queries(self):
+        # Warm up the cache
+        self.get()
+        with self.assertNumQueries(10):
+            self.get()
+
+        sites = [
+            Site(hostname=f"host {i}", port=f"800{i}", root_page_id=2)
+            for i in range(10)
+        ]
+        Site.objects.bulk_create(sites)
+
+        with self.assertNumQueries(20):
+            self.get()
+
 
 class TestSiteCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def setUp(self):

--- a/wagtail/sites/views.py
+++ b/wagtail/sites/views.py
@@ -53,7 +53,6 @@ class SiteViewSet(ModelViewSet):
     model = Site
     permission_policy = site_permission_policy
     add_to_reference_index = False
-    _show_breadcrumbs = False
 
     index_view_class = IndexView
     add_view_class = CreateView

--- a/wagtail/sites/views.py
+++ b/wagtail/sites/views.py
@@ -28,6 +28,9 @@ class IndexView(generic.IndexView):
         ),
     ]
 
+    def get_base_queryset(self):
+        return super().get_base_queryset().select_related("root_page")
+
 
 class CreateView(generic.CreateView):
     page_title = _("Add site")


### PR DESCRIPTION
Built on top of #11709.