### PR TITLE
Updated a circle border on the brand logo

### DIFF
--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -15,8 +15,6 @@
     align-items: center;
     width: 100%;
     white-space: nowrap;
-    border-inline-start: 3px solid transparent;
-    border-inline-end: 3px solid transparent;
     -webkit-font-smoothing: auto;
     border: 0;
     background: transparent;

--- a/client/src/components/Sidebar/modules/WagtailBranding.scss
+++ b/client/src/components/Sidebar/modules/WagtailBranding.scss
@@ -106,3 +106,7 @@ $logo-size: 110px;
     padding: 40px 0;
   }
 }
+
+.sidebar-wagtail-branding__icon-wrapper{
+  border:1px solid theme('colors.border-field-default');
+}


### PR DESCRIPTION
Fixes #11449 

I have made some improvements to the design for Menu and Menu-Items. 
The border was added to the brand logo and extra 3px margins were removed from both left and right.
