### PR TITLE
Spool image data before passing to `willow` during upload

### DIFF
--- a/wagtail/images/fields.py
+++ b/wagtail/images/fields.py
@@ -149,15 +149,12 @@ class WagtailImageField(ImageField):
             return None
 
         # Get the file content ready for Willow
-        if hasattr(data, "temporary_file_path"):
-            # Django's `TemporaryUploadedFile` is enough of a file to satisfy Willow
+        if hasattr(data, "read"):
+            # Django's `UploadedFile` is enough of a file to satisfy Willow
             # Willow doesn't support opening images by path https://github.com/wagtail/Willow/issues/108
             file = data
         else:
-            if hasattr(data, "read"):
-                file = BytesIO(data.read())
-            else:
-                file = BytesIO(data["content"])
+            file = BytesIO(data["content"])
 
         try:
             # Annotate the python representation of the FileField with the image


### PR DESCRIPTION
This should reduce memory usage quite a bit, as `willow` will only need to read a very small portion of the file during validation.

The `.read` attribute seems to be enough for `willow` to be happy using the file directly, so we let it. Whilst `TemporaryUploadedFile` is on disk, files smaller than that are still loaded into memory. This fix changes that, so all are kept on their original object if possible, which reduces duplication.