### PR TITLE
Update universal listings & UI table unit tests to be more robust

### DIFF
--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -994,7 +994,7 @@ class TestHistoryView(WagtailTestUtils, TestCase):
         )
         response = self.client.get(self.url)
         soup = self.get_soup(response.content)
-        rows = soup.select("tbody tr")
+        rows = soup.select("#listing-results tbody tr")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(rows), 2)
 
@@ -1084,7 +1084,7 @@ class TestUsageView(WagtailTestUtils, TestCase):
         h1 = soup.select_one("h1")
         self.assertEqual(h1.text.strip(), f"Usage: {self.object}")
 
-        tds = soup.select("tbody tr td")
+        tds = soup.select("#listing-results tbody tr td")
         self.assertEqual(len(tds), 3)
         self.assertEqual(tds[0].text.strip(), str(self.tbx))
         self.assertEqual(tds[1].text.strip(), "Various on delete model")
@@ -1132,7 +1132,7 @@ class TestUsageView(WagtailTestUtils, TestCase):
         h1 = soup.select_one("h1")
         self.assertEqual(h1.text.strip(), f"Usage: {self.object}")
 
-        tds = soup.select("tbody tr td")
+        tds = soup.select("#listing-results tbody tr td")
         self.assertEqual(len(tds), 3)
         self.assertEqual(tds[0].text.strip(), "(Private various on delete model)")
         self.assertEqual(tds[1].text.strip(), "Various on delete model")
@@ -1154,7 +1154,7 @@ class TestUsageView(WagtailTestUtils, TestCase):
         h1 = soup.select_one("h1")
         self.assertEqual(h1.text.strip(), f"Usage: {self.object}")
 
-        tds = soup.select("tbody tr td")
+        tds = soup.select("#listing-results tbody tr td")
         self.assertEqual(len(tds), 3)
         self.assertEqual(tds[0].text.strip(), str(self.tbx))
         self.assertEqual(tds[1].text.strip(), "Various on delete model")

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -715,10 +715,12 @@ class TestListViewWithCustomColumns(BaseSnippetViewSetTests):
         # One from the country code column, another from the custom foo column
         self.assertContains(response, sort_country_code_url, count=2)
 
-        html = response.content.decode()
+        soup = self.get_soup(response.content)
+
+        headings = soup.select("#listing-results table th")
 
         # The bulk actions column plus 6 columns defined in FullFeaturedSnippetViewSet
-        self.assertTagInHTML("<th>", html, count=7, allow_extra_attrs=True)
+        self.assertEqual(len(headings), 7)
 
     def test_falsy_value(self):
         # https://github.com/wagtail/wagtail/issues/10765


### PR DESCRIPTION
Relates to #11717 - Ensure that tests checking for th/td scope the checks to specific tables

We have a few unit tests that are counting `th`/`td` but currently these are not scoped to specific tables in the HTML. This means that any shared addition of tables will break these tests.

I have scoped the selectors to the elements that are intended to be tested, also making these tests more robust with mapping to the `id` so we know where these elements should be contained.