### PR TITLE
Ensure unit tests for preview links are more robust

### DIFF
--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -571,8 +571,11 @@ class TestEnablePreview(WagtailTestUtils, TestCase):
         )
 
         response = self.client.get(history_url)
-        self.assertContains(response, "Preview")
-        self.assertContains(response, preview_url)
+        soup = self.get_soup(response.content)
+
+        preview_link = soup.find("a", {"href": preview_url})
+        self.assertEqual(len(preview_link), 1)
+        self.assertEqual("Preview", preview_link.text)
 
 
 class TestDisablePreviewButton(WagtailTestUtils, TestCase):
@@ -635,5 +638,10 @@ class TestDisablePreviewButton(WagtailTestUtils, TestCase):
             "wagtailadmin_pages:revisions_view",
             args=(stream_page.id, latest_revision.id),
         )
-        self.assertNotContains(response, "Preview")
+
         self.assertNotContains(response, preview_url)
+
+        soup = self.get_soup(response.content)
+
+        preview_link = soup.find("a", {"href": preview_url})
+        self.assertIsNone(preview_link)


### PR DESCRIPTION
- Relates to #11717
- The word "Preview" can exist in multiple locations, especially for new code
- Instead of checking the word preview exists or does not exist, use Soup to check for the link specifically

