### PR TITLE
Change the default for `LinkController.reflectKeysValue` to use the current URL's parameters

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,6 +53,7 @@ Changelog
  * Fix: Ensure that modal tabs width are not impacted by side panel opening (LB (Ben) Johnston)
  * Fix: Resolve issue local development of docs when running `make livehtml` (Sage Abdullah)
  * Fix: Resolve issue with unwanted padding in chooser modal listings (Sage Abdullah)
+ * Fix: Ensure filter query parameters added in `IndexView.get_add_url()` is reflected in the "add" button URL when updating the listing (Sage Abdullah)
  * Docs: Update Sphinx theme to `6.3.0` with a fix for the missing favicon (Sage Abdullah)
 
 

--- a/client/src/controllers/LinkController.test.js
+++ b/client/src/controllers/LinkController.test.js
@@ -22,7 +22,7 @@ describe('LinkController', () => {
   });
 
   describe('basic behaviour on connect', () => {
-    it('should reflect all params by default', async () => {
+    it('should be able to reflect all params', async () => {
       setWindowLocation(
         'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok',
       );
@@ -35,6 +35,7 @@ describe('LinkController', () => {
           id="link"
           href="/admin/something/"
           data-controller="w-link"
+          data-w-link-reflect-keys-value='["__all__"]'
         >
           Reflective link
         </a>
@@ -100,6 +101,7 @@ describe('LinkController', () => {
           href="/admin/something/?export=xlsx&export=csv&foo=fii&number=1&a=b"
           data-controller="w-link"
           data-w-link-preserve-keys-value='["export", "foo"]'
+          data-w-link-reflect-keys-value='["__all__"]'
         >
           Reflective link with preserve-keys-value
         </a>
@@ -165,7 +167,7 @@ describe('LinkController', () => {
   });
 
   describe('handling an event with requestUrl in the detail', () => {
-    it('should reflect all params by default', async () => {
+    it('should be able to reflect all params', async () => {
       expect(window.location.href).toEqual('http://localhost/');
 
       document.body.innerHTML = `
@@ -174,6 +176,7 @@ describe('LinkController', () => {
           href="/admin/something/"
           data-controller="w-link"
           data-action="w-swap:reflect@document->w-link#setParams"
+          data-w-link-reflect-keys-value='["__all__"]'
         >
           Reflective link
         </a>
@@ -240,6 +243,7 @@ describe('LinkController', () => {
           href="/admin/something/?export=xlsx&export=csv&foo=fii&number=1&a=b"
           data-controller="w-link"
           data-w-link-preserve-keys-value='["export", "foo"]'
+          data-w-link-reflect-keys-value='["__all__"]'
           data-action="w-swap:reflect@document->w-link#setParams"
         >
           Reflective link with preserve-keys-value

--- a/client/src/controllers/LinkController.test.js
+++ b/client/src/controllers/LinkController.test.js
@@ -22,6 +22,28 @@ describe('LinkController', () => {
   });
 
   describe('basic behaviour on connect', () => {
+    it('should set the default reflect-keys using the params available in the URL', async () => {
+      document.body.innerHTML = `
+        <a
+          id="link"
+          href="/admin/something/?color=black&color=blue&which=is&who="
+          data-controller="w-link"
+        >
+          Reflective link
+        </a>
+      `;
+
+      // Trigger next browser render cycle
+      await Promise.resolve();
+
+      // The default reflect-keys-value is set to the params available in the URL
+      expect(
+        document
+          .getElementById('link')
+          .getAttribute('data-w-link-reflect-keys-value'),
+      ).toEqual(JSON.stringify(['color', 'which', 'who']));
+    });
+
     it('should be able to reflect all params', async () => {
       setWindowLocation(
         'http://localhost:8000/admin/pages/?foo=bar&foo=baz&hello=&world=ok',

--- a/client/src/controllers/LinkController.ts
+++ b/client/src/controllers/LinkController.ts
@@ -12,7 +12,7 @@ export class LinkController extends Controller<HTMLElement> {
   static values = {
     attrName: { default: 'href', type: String },
     preserveKeys: { default: [], type: Array },
-    reflectKeys: { default: ['__all__'], type: Array },
+    reflectKeys: { default: [], type: Array },
   };
 
   /** Attribute on the controlled element containing the URL string. */

--- a/docs/releases/6.0.2.md
+++ b/docs/releases/6.0.2.md
@@ -16,9 +16,58 @@ depth: 1
  * Ensure that modal tabs width are not impacted by side panel opening (LB (Ben) Johnston)
  * Resolve issue local development of docs when running `make livehtml` (Sage Abdullah)
  * Resolve issue with unwanted padding in chooser modal listings (Sage Abdullah)
+ * Ensure filter query parameters added in `IndexView.get_add_url()` is reflected in the "add" button URL when updating the listing (Sage Abdullah)
 
 
 ### Documentation
 
  * Update Sphinx theme to `6.3.0` with a fix for the missing favicon (Sage Abdullah)
 
+## Upgrade considerations - changes to undocumented internals
+
+### Changed behavior of "add" button link in index views of non-page models
+
+In Wagtail 6.0, the behavior of how the `get_add_url()` method is used on a view that extends the Wagtail's generic `IndexView` (e.g. the index view class in a `ModelViewSet`/`SnippetViewSet`) was changed. Since the listing's filters are now applied dynamically via AJAX instead of a full page load, the link for the "add" button in the header only uses the `get_add_url()` method on the initial page load. To compensate this, the add link's element now has a client-side behavior that can reflect the query parameters from the browser's address bar or the URL of the `fetch()` request when updating the listing.
+
+Before this patch release, the client-side element's default behavior only considers the `locale` query parameter, and any other query parameters are ignored. As of Wagtail 6.0.2, the client-side behavior has been improved to reflect all query parameters that are originally in the URL at the time the page is loaded.
+
+You may have customised the `get_add_url()` method to return a URL with query parameters. For example, to apply query parameters based on the filters that have been applied, so that they are passed to the `CreateView`. If so, you may need to make some changes to ensure the parameters are still applied correctly.
+
+This can be done by ensuring that the parameters always exist in the URL returned by `get_add_url()`, even when they are empty.
+
+For example, if you have a custom `get_add_url()` method that looks like this:
+
+```python
+from wagtail.admin.utils import set_query_params
+from wagtail.snippets.views.snippets import IndexView
+
+
+class PrefilledParentIndexView(IndexView):
+    def get_add_url(self):
+        add_url = super().get_add_url()
+        parent = self.filters.data.get("parent")
+        if parent:
+            add_url = set_query_params(add_url, {"parent": parent})
+        return add_url
+```
+
+You will need to ensure that the `parent` parameter is always present in the URL returned by `get_add_url()`. This can be done by adding a default value for the parameter, like this:
+
+```python
+from wagtail.admin.utils import set_query_params
+from wagtail.snippets.views.snippets import IndexView
+
+
+class PrefilledParentIndexView(IndexView):
+    def get_add_url(self):
+        add_url = super().get_add_url()
+        parent = self.filters.data.get("parent", "")
+        add_url = set_query_params(add_url, {"parent": parent})
+        return add_url
+```
+
+This will inform the client-side behavior to reflect the `parent` parameter in the URL when the listing is updated upon filtering.
+
+Note that currently only query parameters that correspond to the filters' parameters are reflected to the "add" button URL. If you have custom query parameters that are not related to the filters, you may need to add custom JavaScript so that they are updated when the listing is refreshed. In the future, we are considering a different approach to ensure the "add" button URL always corresponds to the `get_add_url()` method when the listing is refreshed.
+
+See [the related issue](https://github.com/wagtail/wagtail/issues/11726) for more details.

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -461,3 +461,46 @@ class CustomEditorController extends window.StimulusModule.Controller {
 
 window.wagtail.app.register('custom-editor', CustomEditorController);
 ```
+
+### Changed behavior of "add" button link in index views of non-page models
+
+The behavior of how the `get_add_url()` method is used on a view that extends the Wagtail's generic `IndexView` (e.g. the index view class in a `ModelViewSet`/`SnippetViewSet`) has changed. Since the listing's filters are now applied dynamically via AJAX instead of a full page load, the link for the "add" button in the header only uses the `get_add_url()` method on the initial page load. To compensate this, the add link's element now has a client-side behavior that can reflect the query parameters from the browser's address bar or the URL of the `fetch()` request when updating the listing.
+
+You may have customised the `get_add_url()` method to return a URL with query parameters. For example, to apply query parameters based on the filters that have been applied, so that they are passed to the `CreateView`. If so, you may need to make some changes to ensure the parameters are still applied correctly. This can be done by ensuring that the parameters always exist in the URL returned by `get_add_url()`, even when they are empty.
+
+For example, if you have a custom `get_add_url()` method that looks like this:
+
+```python
+from wagtail.admin.utils import set_query_params
+from wagtail.snippets.views.snippets import IndexView
+
+
+class PrefilledParentIndexView(IndexView):
+    def get_add_url(self):
+        add_url = super().get_add_url()
+        parent = self.filters.data.get("parent")
+        if parent:
+            add_url = set_query_params(add_url, {"parent": parent})
+        return add_url
+```
+
+You will need to ensure that the `parent` parameter is always present in the URL returned by `get_add_url()`. This can be done by adding a default value for the parameter, like this:
+
+```python
+from wagtail.admin.utils import set_query_params
+from wagtail.snippets.views.snippets import IndexView
+
+
+class PrefilledParentIndexView(IndexView):
+    def get_add_url(self):
+        add_url = super().get_add_url()
+        parent = self.filters.data.get("parent", "")
+        add_url = set_query_params(add_url, {"parent": parent})
+        return add_url
+```
+
+This will inform the client-side behavior to reflect the `parent` parameter in the URL when the listing is updated upon filtering.
+
+Note that currently only query parameters that correspond to the filters' parameters are reflected to the "add" button URL. If you have custom query parameters that are not related to the filters, you may need to add custom JavaScript so that they are updated when the listing is refreshed. In the future, we are considering a different approach to ensure the "add" button URL always corresponds to the `get_add_url()` method when the listing is refreshed.
+
+See [the related issue](https://github.com/wagtail/wagtail/issues/11726) for more details.

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -352,6 +352,7 @@ class IndexView(
                     attrs={
                         "data-controller": "w-link",
                         "data-w-link-preserve-keys-value": '["export"]',
+                        "data-w-link-reflect-keys-value": '["__all__"]',
                     },
                 )
             )
@@ -364,6 +365,7 @@ class IndexView(
                     attrs={
                         "data-controller": "w-link",
                         "data-w-link-preserve-keys-value": '["export"]',
+                        "data-w-link-reflect-keys-value": '["__all__"]',
                     },
                 )
             )

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -334,7 +334,6 @@ class IndexView(
                     self.add_item_label,
                     url=self.add_url,
                     icon_name="plus",
-                    attrs={"data-w-link-reflect-keys-value": '["locale"]'},
                 )
             )
         return buttons


### PR DESCRIPTION
Fixes #11726.

Behaviour changes:
- The default for `LinkController.reflectKeys` is set to the list of keys that are in the controlled element's URL params, instead of `['__all__']`.
  - This ensures that even if `data-w-link-reflect-keys-value` isn't set initially, any URL params set before the controller is connected (e.g. when the server renders the element using `IndexView.get_add_url()` as the URL) will have their values updated when `setParams` is called. This means developers can just set specify the important parameters from the server, and not have to remember about adding `data-w-link-reflect-keys-value`. 
  - Note that they still need to set the parameters even when there is no value, e.g. an empty `parent_id=` param, so that the controller knows the keys to reflect.
- ~~Do not remove URL params that "exist in the current URL" but "we are not reflecting from the new URL (either because the param doesn't exist in the new URL or we didn't specify it in `reflectKeys`)".~~
  - ~~The old behaviour would remove such parameters from the current URL, unless it's specified in `preserveKeys`. This is too aggressive.~~
  - ~~With this change, `preserveKeys` is really only useful when you are not specifying `reflectKeys` explicitly (i.e. when `reflectKeys` is set to `['__all__']` or you're letting it auto-generated). The `preserveKeys` array can be used if you don't want the specified params to be updated from the new URL. If you're specifying `reflectKeys` explicitly, then you can just omit such keys from `reflectKeys`, no need to set `preserveKeys`.~~
  - Seems to break the export buttons, so I've reverted this.

Will add docs to the 6.0 upgrade considerations once we're happy with the implementation.