### PR TITLE
Document and address potential XSS from leaving /media/documents directory 

### DIFF
--- a/docs/advanced_topics/add_to_django_project.md
+++ b/docs/advanced_topics/add_to_django_project.md
@@ -343,7 +343,7 @@ WAGTAIL_SITE_NAME = 'My Project'
 # This can be omitted to allow all files, but note that this may present a security risk
 # if untrusted users are allowed to upload files -
 # see https://docs.wagtail.org/en/stable/advanced_topics/deploying.html#user-uploaded-files
-WAGTAILDOCS_EXTENSIONS = ['7z', 'bz2', 'csv', 'docx', 'gz', 'key', 'odt', 'pdf', 'pptx', 'rar', 'rtf', 'tar', 'txt', 'xlsx', 'zip']
+WAGTAILDOCS_EXTENSIONS = ['csv', 'docx', 'key', 'odt', 'pdf', 'pptx', 'rtf', 'txt', 'xlsx', 'zip']
 
 # Reverse the default case-sensitive handling of tags
 TAGGIT_CASE_INSENSITIVE = True

--- a/docs/advanced_topics/add_to_django_project.md
+++ b/docs/advanced_topics/add_to_django_project.md
@@ -339,6 +339,12 @@ WAGTAIL_SITE_NAME = 'My Project'
 # Wagtail email notification format
 # WAGTAILADMIN_NOTIFICATION_USE_HTML = True
 
+# Allowed file extensions for documents in the document library.
+# This can be omitted to allow all files, but note that this may present a security risk
+# if untrusted users are allowed to upload files -
+# see https://docs.wagtail.org/en/stable/advanced_topics/deploying.html#user-uploaded-files
+WAGTAILDOCS_EXTENSIONS = ['7z', 'bz2', 'csv', 'docx', 'gz', 'key', 'odt', 'pdf', 'pptx', 'rar', 'rtf', 'tar', 'txt', 'xlsx', 'zip']
+
 # Reverse the default case-sensitive handling of tags
 TAGGIT_CASE_INSENSITIVE = True
 ```

--- a/docs/advanced_topics/deploying.md
+++ b/docs/advanced_topics/deploying.md
@@ -34,20 +34,37 @@ Alternatively, Wagtail can be configured to store uploaded images and documents 
 this is done through the [`STORAGES["default"]`](https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-STORAGES)
 setting in conjunction with an add-on package such as [django-storages](https://django-storages.readthedocs.io/).
 
+#### Security
+
+Any system that allows user-uploaded files is a potential security risk. For example, a user with the ability to upload HTML files could potentially launch a [cross-site scripting attack](https://owasp.org/www-community/attacks/xss/) against a user viewing that file. This may not be a concern if all users with access to the Wagtail admin are fully trusted - for example, a personal site where you are the only editor. With this in mind, Wagtail aims to provide a secure configuration by default, but developers may choose a more permissive setup if they understand the risks, as detailed below.
+
+#### Images
+
 When using `FileSystemStorage`, image urls are constructed starting from the path specified by the `MEDIA_URL`.
-In most cases, you should configure your web server to serve image files directly (without passing through Django/Wagtail).
+In most cases, you should configure your web server to serve image files directly from the `images` subdirectory of `MEDIA_ROOT` (without passing through Django/Wagtail).
+If [](svg_images) are enabled, it is possible for a user to upload an SVG file containing scripts that execute when the file is viewed directly; if this is a concern, several approaches for avoiding this are detailed under [](svg_security_considerations).
+
 When using one of the cloud storage backends, images urls go directly to the cloud storage file url.
 If you would like to serve your images from a separate asset server or CDN, you can [configure the image serve view](image_serve_view_redirect_action) to redirect instead.
 
+#### Documents
+
 Document serving is controlled by the [WAGTAILDOCS_SERVE_METHOD](wagtaildocs_serve_method) method.
-When using `FileSystemStorage`, documents are stored in a `documents` subdirectory within your site's `MEDIA_ROOT`.
-If all your documents are public, you can set the `WAGTAILDOCS_SERVE_METHOD` to `direct` and configure your web server to serve the files itself.
-However, if you use Wagtail's [Collection Privacy settings](https://guide.wagtail.org/en-latest/how-to-guides/manage-collections/#privacy-settings) to restrict access to some or all of your documents, you may or may not want to configure your web server to serve the documents directly.
-The default setting is `redirect` which allows Wagtail to perform any configured privacy checks before offloading serving the actual document to your web server or CDN.
-This means that Wagtail constructs document links that pass through Wagtail, but the final url in the user's browser is served directly by your web server.
-If a user bookmarks this url, they will be able to access the file without passing through Wagtail's privacy checks.
-If this is not acceptable, you may want to set the `WAGTAILDOCS_SERVE_METHOD` to `serve_view` and configure your web server so it will not serve document files itself.
-If you are serving documents from the cloud and need to enforce privacy settings, you should make sure the documents are not publicly accessible using the cloud service's file url.
+When using `FileSystemStorage`, documents are stored in a `documents` subdirectory within your site's `MEDIA_ROOT`. In this case, `WAGTAILDOCS_SERVE_METHOD` defaults to `serve_view`, where Wagtail serves the document through a Django view that enforces privacy checks. This has the following implications:
+
+* **You should block direct access to the `documents` subdirectory of `MEDIA_ROOT` within your web server configuration.** This prevents users from bypassing [collection privacy settings](https://guide.wagtail.org/en-latest/how-to-guides/manage-collections/#privacy-settings) by accessing documents at their direct URL.
+* Documents are served as downloads rather than displayed in the browser (unless specified explicitly via [](wagtaildocs_inline_content_types)) - this ensures that if the document is a type that can contain scripts (such as HTML or SVG), the browser is prevented from executing them.
+* However, since the document is served through the Django application server, this may consume more server resources than serving the document directly from the web server.
+
+The alternative serve methods `'direct'` and `'redirect'` work by serving the documents directly from `MEDIA_ROOT`. This means it is not possible to block direct access to the `documents` subdirectory, and so users may bypass permission checks by accessing the direct URL. Also, in the case that users with access to the Wagtail admin are not fully trusted, you will need to take additional steps to prevent the execution of scripts in documents:
+
+* The `WAGTAILDOCS_EXTENSIONS` setting may be used to restrict uploaded documents to an "allow list" of safe types.
+* The web server can be configured to return a `Content-Security-Policy: default-src 'none'` header for files within the `documents` subdirectory, which will prevent the execution of scripts in those files.
+* The web server can be configured to return a `Content-Disposition: attachment` header for files within the `documents` subdirectory, which will force the browser to download the file rather than displaying it inline.
+
+If a remote ("cloud") storage backend is used, the serve method will default to `'redirect'` and the document will be served directly from the cloud storage file url. In this case, users may be able to bypass permission checks, and scripts within documents may be executed (depending on the cloud storage service's configuration). However, the impact of cross-site scripting attacks is reduced, as the document is served from a different domain to the main site.
+
+If these limitations are not acceptable, you may set the `WAGTAILDOCS_SERVE_METHOD` to `serve_view` and ensure that the documents are not publicly accessible using the cloud service's file url.
 
 #### Cloud storage
 

--- a/docs/getting_started/integrating_into_django.md
+++ b/docs/getting_started/integrating_into_django.md
@@ -64,6 +64,12 @@ WAGTAILADMIN_BASE_URL = 'http://example.com'
 
 If this setting is not present, Wagtail will fall back to `request.site.root_url` or to the hostname of the request. Although this setting is not strictly required, it is highly recommended because leaving it out may produce unusable URLs in notification emails.
 
+Add a `WAGTAILDOCS_EXTENSIONS` setting to specify the file types that Wagtail will allow to be uploaded as documents. This can be omitted to allow all file types, but this may present a security risk if untrusted users are allowed to upload documents - see [](user_uploaded_files).
+
+```python
+WAGTAILDOCS_EXTENSIONS = ['7z', 'bz2', 'csv', 'docx', 'gz', 'key', 'odt', 'pdf', 'pptx', 'rar', 'rtf', 'tar', 'txt', 'xlsx', 'zip']
+```
+
 Various other settings are available to configure Wagtail's behaviour - see [Settings](/reference/settings).
 
 ## URL configuration

--- a/docs/getting_started/integrating_into_django.md
+++ b/docs/getting_started/integrating_into_django.md
@@ -67,7 +67,7 @@ If this setting is not present, Wagtail will fall back to `request.site.root_url
 Add a `WAGTAILDOCS_EXTENSIONS` setting to specify the file types that Wagtail will allow to be uploaded as documents. This can be omitted to allow all file types, but this may present a security risk if untrusted users are allowed to upload documents - see [](user_uploaded_files).
 
 ```python
-WAGTAILDOCS_EXTENSIONS = ['7z', 'bz2', 'csv', 'docx', 'gz', 'key', 'odt', 'pdf', 'pptx', 'rar', 'rtf', 'tar', 'txt', 'xlsx', 'zip']
+WAGTAILDOCS_EXTENSIONS = ['csv', 'docx', 'key', 'odt', 'pdf', 'pptx', 'rtf', 'txt', 'xlsx', 'zip']
 ```
 
 Various other settings are available to configure Wagtail's behaviour - see [Settings](/reference/settings).

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -404,6 +404,10 @@ For this reason, Wagtail provides several serving methods that trade some of the
 
 If `WAGTAILDOCS_SERVE_METHOD` is unspecified or set to `None`, the default method is `'redirect'` when a remote storage backend is in use (one that exposes a URL but not a local filesystem path), and `'serve_view'` otherwise. Finally, some storage backends may not expose a URL at all; in this case, serving will proceed as for `'serve_view'`.
 
+```{warning}
+Allowing direct access to document URLs within `MEDIA_ROOT` may present a security risk if untrusted users are allowed to upload documents - in this case additional configuration will be required at the webserver level to handle these securely. See [](user_uploaded_files).
+```
+
 (wagtaildocs_content_types)=
 
 ### `WAGTAILDOCS_CONTENT_TYPES`
@@ -436,9 +440,11 @@ WAGTAILDOCS_EXTENSIONS = ['pdf', 'docx']
 ```
 
 A list of allowed document extensions that will be validated during document uploading.
-If this isn't supplied all document extensions are allowed.
-Warning: this doesn't always ensure that the uploaded file is valid as files can
-be renamed to have an extension no matter what data they contain.
+If this isn't supplied all document extensions are allowed. This doesn't ensure that the uploaded file is valid, as files can be renamed to have an extension no matter what data they contain.
+
+```{warning}
+Allowing all file types may present a security risk if untrusted users are allowed to upload documents - in this case additional configuration will be required at the webserver level to handle these securely. See [](user_uploaded_files).
+```
 
 ## User Management
 

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -549,6 +549,8 @@ The `image` tag's `preserve-svg` positional argument may be used to restrict the
 
 In this example, any of the image objects that are SVGs will only have the `fill-400x400` operation applied to them, while raster images will have both the `fill-400x400` and `format-webp` operations applied. If the `preserve-svg` argument is not used in this example, an error will be raised when attempting to convert SVG images to webp, as this is not possible without a rasterization library.
 
+(svg_security_considerations)=
+
 ### Security considerations
 
 Wagtail's underlying image library, Willow, is configured to mitigate known XML parser exploits (e.g. billion laughs, quadratic blowup) by rejecting suspicious files.

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -177,4 +177,4 @@ WAGTAILADMIN_BASE_URL = "http://example.com"
 # This can be omitted to allow all files, but note that this may present a security risk
 # if untrusted users are allowed to upload files -
 # see https://docs.wagtail.org/en/stable/advanced_topics/deploying.html#user-uploaded-files
-WAGTAILDOCS_EXTENSIONS = ['7z', 'bz2', 'csv', 'docx', 'gz', 'key', 'odt', 'pdf', 'pptx', 'rar', 'rtf', 'tar', 'txt', 'xlsx', 'zip']
+WAGTAILDOCS_EXTENSIONS = ['csv', 'docx', 'key', 'odt', 'pdf', 'pptx', 'rtf', 'txt', 'xlsx', 'zip']

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -172,3 +172,9 @@ WAGTAILSEARCH_BACKENDS = {
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 WAGTAILADMIN_BASE_URL = "http://example.com"
+
+# Allowed file extensions for documents in the document library.
+# This can be omitted to allow all files, but note that this may present a security risk
+# if untrusted users are allowed to upload files -
+# see https://docs.wagtail.org/en/stable/advanced_topics/deploying.html#user-uploaded-files
+WAGTAILDOCS_EXTENSIONS = ['7z', 'bz2', 'csv', 'docx', 'gz', 'key', 'odt', 'pdf', 'pptx', 'rar', 'rtf', 'tar', 'txt', 'xlsx', 'zip']


### PR DESCRIPTION
A security investigator has raised the possibility that a user with access to the Wagtail admin could use the document upload feature to upload an HTML file to execute an XSS attack, if direct access to /media/documents has not been restricted.

Following some internal discussion, we have chosen not to handle this through [our regular security process](https://docs.wagtail.org/en/stable/contributing/security.html#how-wagtail-discloses-security-issues), as it is a detail of how Wagtail is deployed rather than a vulnerability in Wagtail itself, and there is no single fix to Wagtail that would address this without rolling back functionality that is desirable to many users (for whom the risk of an attack from an existing Wagtail user is often not a concern). Instead, we are addressing this by updating the documentation and raising developer awareness of the security issue.

This PR updates the deployment docs - these docs already (weakly) recommend locking down /media/documents to prevent bypassing permission checks, but the new text emphasises the possibility of an XSS attack as a secondary issue. Additionally, we are setting an initial `WAGTAILDOCS_EXTENSIONS` list in the project template for new projects, so that the out-of-the-box configuration is secure.

Many thanks to Georgios Roumeliotis (@RoboGR00t) of TwelveSec for the report.