### PR TITLE
Ensure `get_add_url()` is always used to re-render the add button when the listing is refreshed

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Changelog
  * Fix: Resolve issue with unwanted padding in chooser modal listings (Sage Abdullah)
  * Fix: Ensure form builder emails that have date or datetime fields correctly localize dates based on the configured `LANGUAGE_CODE` (Mark Niehues)
  * Fix: Ensure the Stimulus `UnsavedController` checks for nested removal/additions of inputs so that the unsaved warning shows in more valid cases when editing a page (Karthik Ayangar)
+ * Fix: Ensure `get_add_url()` is always used to re-render the add button when the listing is refreshed in viewsets (Sage Abdullah)
  * Docs: Add contributing development documentation on how to work with a fork of Wagtail (Nix Asteri, Dan Braghis)
  * Docs: Make sure the settings panel is listed in tabbed interface examples (Tibor Leupold)
  * Docs: Update content and page names to their US spelling instead of UK spelling (Victoria Poromon)

--- a/client/src/controllers/TeleportController.test.js
+++ b/client/src/controllers/TeleportController.test.js
@@ -89,9 +89,9 @@ describe('TeleportController', () => {
 
       await Promise.resolve();
 
-      expect(document.getElementById('target-container').innerHTML).toEqual(
-        '<div id="content">Some content</div>',
-      );
+      expect(
+        document.getElementById('target-container').innerHTML.trim(),
+      ).toEqual('<div id="content">Some content</div>');
     });
 
     it('should allow for a default target container within the root element of a shadow DOM', async () => {
@@ -136,9 +136,9 @@ describe('TeleportController', () => {
 
       await Promise.resolve();
 
-      expect(document.getElementById('target-container').innerHTML).toEqual(
-        '<div id="content">Some content</div>',
-      );
+      expect(
+        document.getElementById('target-container').innerHTML.trim(),
+      ).toEqual('<div id="content">Some content</div>');
     });
 
     it('should not clear the target container if the reset value is unset (false)', async () => {
@@ -160,12 +160,84 @@ describe('TeleportController', () => {
 
       await Promise.resolve();
 
+      const contents = document.getElementById('target-container').innerHTML;
+      expect(contents).toContain('<p>I should still be here</p>');
+      expect(contents).toContain('<div id="content">Some content</div>');
+    });
+
+    it('should allow the template to contain multiple children', async () => {
+      document.body.innerHTML += `
+        <div id="target-container"></div>
+        `;
+
+      const template = document.querySelector('template');
+      template.setAttribute(
+        'data-w-teleport-target-value',
+        '#target-container',
+      );
+
+      const otherTemplateContent = document.createElement('div');
+      otherTemplateContent.innerHTML = 'Other content';
+      otherTemplateContent.id = 'other-content';
+      template.content.appendChild(otherTemplateContent);
+
+      expect(document.getElementById('target-container').innerHTML).toEqual('');
+
+      application.start();
+
+      await Promise.resolve();
+
+      const container = document.getElementById('target-container');
+      const content = container.querySelector('#content');
+      const otherContent = container.querySelector('#other-content');
+      expect(content).not.toBeNull();
+      expect(otherContent).not.toBeNull();
+      expect(content.innerHTML.trim()).toEqual('Some content');
+      expect(otherContent.innerHTML.trim()).toEqual('Other content');
+    });
+
+    it('should not throw an error if the template content is empty', async () => {
+      document.body.innerHTML += `
+        <div id="target-container"><p>I should still be here</p></div>
+        `;
+
+      const template = document.querySelector('template');
+      template.setAttribute(
+        'data-w-teleport-target-value',
+        '#target-container',
+      );
+
       expect(document.getElementById('target-container').innerHTML).toEqual(
-        '<p>I should still be here</p><div id="content">Some content</div>',
+        '<p>I should still be here</p>',
+      );
+
+      const errors = [];
+
+      document.getElementById('template').innerHTML = '';
+      application.handleError = (error, message) => {
+        errors.push({ error, message });
+      };
+
+      await Promise.resolve(application.start());
+
+      expect(errors).toEqual([]);
+
+      expect(document.getElementById('target-container').innerHTML).toEqual(
+        '<p>I should still be here</p>',
       );
     });
 
-    it('should throw an error if the template content is empty', async () => {
+    it('should allow erasing the target container by using an empty template with reset value set to true', async () => {
+      document.body.innerHTML += `
+        <div id="target-container"><p>I should not be here</p></div>
+        `;
+
+      const template = document.querySelector('template');
+      template.setAttribute(
+        'data-w-teleport-target-value',
+        '#target-container',
+      );
+      template.setAttribute('data-w-teleport-reset-value', 'true');
       const errors = [];
 
       document.getElementById('template').innerHTML = '';
@@ -176,12 +248,10 @@ describe('TeleportController', () => {
 
       await Promise.resolve(application.start());
 
-      expect(errors).toEqual([
-        {
-          error: new Error('Invalid template content.'),
-          message: 'Error connecting controller',
-        },
-      ]);
+      expect(errors).toEqual([]);
+
+      const contents = document.getElementById('target-container').innerHTML;
+      expect(contents).toEqual('');
     });
 
     it('should throw an error if a valid target container cannot be resolved', async () => {

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -37,6 +37,7 @@ depth: 1
  * Resolve issue with unwanted padding in chooser modal listings (Sage Abdullah)
  * Ensure form builder emails that have date or datetime fields correctly localize dates based on the configured `LANGUAGE_CODE` (Mark Niehues)
  * Ensure the Stimulus `UnsavedController` checks for nested removal/additions of inputs so that the unsaved warning shows in more valid cases when editing a page (Karthik Ayangar)
+ * Ensure `get_add_url()` is always used to re-render the add button when the listing is refreshed in viewsets (Sage Abdullah)
 
 
 ### Documentation

--- a/wagtail/admin/templates/wagtailadmin/generic/index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index_results.html
@@ -12,6 +12,14 @@
         </template>
     {% endif %}
 
+    {% if render_buttons_fragment %}
+        <template data-controller="w-teleport" data-w-teleport-target-value="#w-slim-header-buttons" data-w-teleport-reset-value="true">
+            {% for button in header_buttons %}
+                {% component button %}
+            {% endfor %}
+        </template>
+    {% endif %}
+
     {% if is_searching and view.show_other_searches %}
         <div class="nice-padding">
             {% search_other %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -50,7 +50,7 @@
                         {% if actions or block_actions %}
                             {# Actions divider #}
                             <div class="w-w-px w-h-[30px] w-ml-auto sm:w-ml-0 w-bg-border-furniture"></div>
-                            <div class="w-flex w-items-center w-ml-3">
+                            <div id="w-slim-header-buttons" class="w-flex w-items-center w-ml-3">
                                 {% firstof actions block_actions %}
                             </div>
                         {% endif %}

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -442,5 +442,8 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
             and self.filters
             and self.results_only
         )
+        context["render_buttons_fragment"] = (
+            context.get("header_buttons") and self.results_only
+        )
 
         return context

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -334,7 +334,6 @@ class IndexView(
                     self.add_item_label,
                     url=self.add_url,
                     icon_name="plus",
-                    attrs={"data-w-link-reflect-keys-value": '["locale"]'},
                 )
             )
         return buttons
@@ -349,10 +348,6 @@ class IndexView(
                     url=self.xlsx_export_url,
                     icon_name="download",
                     priority=90,
-                    attrs={
-                        "data-controller": "w-link",
-                        "data-w-link-preserve-keys-value": '["export"]',
-                    },
                 )
             )
             buttons.append(
@@ -361,10 +356,6 @@ class IndexView(
                     url=self.csv_export_url,
                     icon_name="download",
                     priority=100,
-                    attrs={
-                        "data-controller": "w-link",
-                        "data-w-link-preserve-keys-value": '["export"]',
-                    },
                 )
             )
 

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -109,9 +109,8 @@ class HeaderButton(Button):
         attrs = attrs.copy()
         attrs.update(
             {
-                "data-controller": "w-tooltip w-link",
+                "data-controller": "w-tooltip",
                 "data-w-tooltip-content-value": label,
-                "data-action": "w-swap:reflect@document->w-link#setParams",
                 "aria-label": label,
             }
         )

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -1536,3 +1536,35 @@ class TestCustomMethods(BaseSnippetViewSetTests):
         soup = self.get_soup(response.content)
         links = soup.find_all("a", attrs={"href": add_url})
         self.assertEqual(len(links), 1)
+
+    def test_index_results_view_get_add_url_teleports_to_header(self):
+        response = self.client.get(self.get_url("list_results"))
+        add_url = self.get_url("add") + "?customised=param"
+        soup = self.get_soup(response.content)
+        template = soup.find(
+            "template",
+            {
+                "data-controller": "w-teleport",
+                "data-w-teleport-target-value": "#w-slim-header-buttons",
+            },
+        )
+        self.assertIsNotNone(template)
+        links = template.find_all("a", attrs={"href": add_url})
+        self.assertEqual(len(links), 1)
+
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_index_results_view_get_add_url_teleports_to_header_with_i18n(self):
+        Locale.objects.create(language_code="fr")
+        response = self.client.get(self.get_url("list_results") + "?locale=fr")
+        add_url = self.get_url("add") + "?locale=fr&customised=param"
+        soup = self.get_soup(response.content)
+        template = soup.find(
+            "template",
+            {
+                "data-controller": "w-teleport",
+                "data-w-teleport-target-value": "#w-slim-header-buttons",
+            },
+        )
+        self.assertIsNotNone(template)
+        links = template.find_all("a", attrs={"href": add_url})
+        self.assertEqual(len(links), 1)


### PR DESCRIPTION
Fixes #11726, supersedes #11727.

Use `TeleportController` to re-render slim header's buttons on results refresh. Unfortunately this means we don't need `LinkController` after all 🫠

To test, replace the `FooterTextViewSet` in `bakerydemo/base/wagtail_hooks.py` with the following:

```py
class FooterIndexView(SnippetViewSet.index_view_class):
    def get_add_url(self):
        return set_query_params(super().get_add_url(), {"foo": "bar"})


class FooterTextViewSet(SnippetViewSet):
    model = FooterText
    search_fields = ("body",)
    list_export = ("body",)
    index_view_class = FooterIndexView
```

Then, observe that:
- The add button points to http://127.0.0.1:8000/admin/snippets/base/footertext/add/?locale=en&foo=bar
- The ... > Download XLSX button points to http://127.0.0.1:8000/admin/snippets/base/footertext/?export=xlsx
- Filter by a different locale, e.g. "Deutsch", then
  - the add button points to http://127.0.0.1:8000/admin/snippets/base/footertext/add/?locale=de&foo=bar
  - the ... > Download XLSX button points to http://127.0.0.1:8000/admin/snippets/base/footertext/results/?q=&locale=de&export=xlsx.
- Enter a search query `abc`, then
  - the add button points to http://127.0.0.1:8000/admin/snippets/base/footertext/add/?locale=de&foo=bar
  - the ... > Download XLSX button points to http://127.0.0.1:8000/admin/snippets/base/footertext/results/?q=abc&locale=de&export=xlsx
- Clear the active locale filter, then
  - the add button points to http://127.0.0.1:8000/admin/snippets/base/footertext/add/?locale=en&foo=bar
  - the ... > Download XLSX button points to http://127.0.0.1:8000/admin/snippets/base/footertext/results/?q=abc&_w_filter_fragment=1&export=xlsx (yes, the `_w_filter_fragment=1` is unfortunately expected because the `SpreadsheetExportMixin` code naively copies the whole `request.GET.copy()` (to ensure all query params are preserved when exporting).

Before this PR, the add button would only update the `locale` param on filtering. If developers want to add more params, they would have to override `header_buttons` and add the appropriate `LinkController` `preserve-keys` and `reflect-keys` values. Even then, this wouldn't work if the value for the `foo` param is dynamically calculated each time, because the `LinkController` only supports either preserving the current value or reflecting a new value from a `w-swap:reflect` event. This means that the `foo` param can only be updated if it's related to a corresponding filter.