### PR TITLE
Adding a small README promo for Wagtail Space 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Wagtail is an open source content management system built on Django, with a stro
 
 ![Wagtail screenshot](https://cdn.jsdelivr.net/gh/wagtail/wagtail@main/.github/wagtail-screenshot-with-browser.png)
 
+### Join the Community at Wagtail Space! 🚀
+
+Wagtail Space is coming in June 2024! Don't miss your chance to meet other Wagtailers in person. The Call for Participation and registration for both Wagtail Space 2024 events is open. We;d love to have you give a talk, contribute to a sprint, or join us as an attendee in June.
+
+* [Wagtail Space NL](https://nl.wagtail.space/), Arnhem, The Netherlands. 2024-06-12 - 2024-06-14
+* [Wagtail Space US](https://us.wagtail.space/), Philadelphia, PA. 2024-06-20 to 2024-06-22
+
 ### 🔥 Features
 
 -   A fast, attractive interface for authors

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Wagtail is an open source content management system built on Django, with a stro
 
 ### Join the Community at Wagtail Space! 🚀
 
-Wagtail Space is coming in June 2024! Don't miss your chance to meet other Wagtailers in person. The Call for Participation and registration for both Wagtail Space 2024 events is open. We;d love to have you give a talk, contribute to a sprint, or join us as an attendee in June.
+Wagtail Space is coming in June 2024! Don't miss your chance to meet other Wagtailers in person. The Call for Participation and registration for both Wagtail Space 2024 events is open. We'd love to have you give a talk, contribute to a sprint, or join us as an attendee in June.
 
 * [Wagtail Space NL](https://nl.wagtail.space/), Arnhem, The Netherlands. 2024-06-12 - 2024-06-14
 * [Wagtail Space US](https://us.wagtail.space/), Philadelphia, PA. 2024-06-20 to 2024-06-22


### PR DESCRIPTION
_Please describe the problem you're fixing here. Include the issue number, if applicable._

To make as many new community members as possible aware of the Wagtail Space events coming up in June 2024, I'd like to add a small, temporary promo to our README file. My PR contains the spot I think would be best for that information, but I am open to suggestions for alternative locations.

We can also condense the promo to a single heading and link if you think the suggested text is too long. Please let me know what would work best.