### PR TITLE
Add note about stream field validation happening on the form

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ Changelog
  * Docs: Update template components documentation to better explain the usage of the Laces library (Tibor Leupold)
  * Docs: Update Sphinx theme to `6.3.0` with a fix for the missing favicon (Sage Abdullah)
  * Docs: Document risk of XSS attacks on document upload (Matt Westcott, with thanks to Georgios Roumeliotis of TwelveSec for the original report)
+ * Docs: Add clarity to how custom StreamField validation works (Tibor Leupold)
  * Maintenance: Move RichText HTML whitelist parser to use the faster, built in `html.parser` (Jake Howard)
  * Maintenance: Remove duplicate 'path' in default_exclude_fields_in_copy (Ramchandra Shahi Thakuri)
  * Maintenance: Update unit tests to always use the faster, built in `html.parser` & remove `html5lib` dependency (Jake Howard)

--- a/docs/advanced_topics/streamfield_validation.md
+++ b/docs/advanced_topics/streamfield_validation.md
@@ -21,6 +21,14 @@ class LinkBlock(StructBlock):
         return result
 ```
 
+```{note}
+The validation of the blocks in the `StreamField` happens through the form field (`wagtail.blocks.base.BlockField`), not the model field (`wagtail.fields.StreamField`).
+
+This means that calling validation methods on your page instance (such as `my_page.full_clean()`) won't catch invalid blocks in the `StreamField` data.
+
+This should only be relevant when the data in the `StreamField` is added programmatically, through other paths than the form field.
+```
+
 ## Controlling where error messages are rendered
 
 In the above example, an exception of type `ValidationError` is raised, which causes the error to be attached and rendered against the StructBlock as a whole. For more control over where the error appears, the exception class `wagtail.blocks.StructBlockValidationError` can be raised instead. The constructor for this class accepts the following arguments:

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -54,6 +54,7 @@ depth: 1
  * Update [template components](creating_template_components) documentation to better explain the usage of the Laces library (Tibor Leupold)
  * Update Sphinx theme to `6.3.0` with a fix for the missing favicon (Sage Abdullah)
  * Document risk of XSS attacks on document upload (Matt Westcott, with thanks to Georgios Roumeliotis of TwelveSec for the original report)
+ * Add clarity to how custom [StreamField validation](streamfield_validation) works (Tibor Leupold)
 
 
 ### Maintenance


### PR DESCRIPTION
I have been wondering about how `StreamField` is validated on the page model. 

https://wagtailcms.slack.com/archives/C81FGJR2S/p1710003924760969

Matt has helpfully pointed out that, so far, the validation of stream field data happens on the form, not the model. 

This PR adds a note about this fact to the stream field validation section in the docs. 
