### PR TITLE
Fix dummy request SERVER_NAME when running tests

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ Changelog
  * Fix: Ensure `get_add_url()` is always used to re-render the add button when the listing is refreshed in viewsets (Sage Abdullah)
  * Fix: Ensure dropdown content cannot get higher than the viewport and add scrolling within content if needed (Chiemezuo Akujobi)
  * Fix: Prevent snippets model index view from crashing when a model does not have an `objects` manager (Jhonatan Lopes)
+ * Fix: Fix `get_dummy_request`'s resulting host name when running tests with `ALLOWED_HOSTS = ["*"]` (David Buxton)
  * Docs: Add contributing development documentation on how to work with a fork of Wagtail (Nix Asteri, Dan Braghis)
  * Docs: Make sure the settings panel is listed in tabbed interface examples (Tibor Leupold)
  * Docs: Update content and page names to their US spelling instead of UK spelling (Victoria Poromon)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -807,6 +807,7 @@
 * Maranda Provance
 * Mark Niehues
 * Georgios Roumeliotis
+* David Buxton
 
 ## Translators
 

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -46,6 +46,7 @@ depth: 1
  * Ensure `get_add_url()` is always used to re-render the add button when the listing is refreshed in viewsets (Sage Abdullah)
  * Ensure dropdown content cannot get higher than the viewport and add scrolling within content if needed (Chiemezuo Akujobi)
  * Prevent snippets model index view from crashing when a model does not have an `objects` manager (Jhonatan Lopes)
+ * Fix `get_dummy_request`'s resulting host name when running tests with `ALLOWED_HOSTS = ["*"]` (David Buxton)
 
 
 ### Documentation

--- a/wagtail/coreutils.py
+++ b/wagtail/coreutils.py
@@ -422,10 +422,11 @@ def get_dummy_request(*, path: str = "/", site: "Site" = None) -> HttpRequest:
     if site:
         server_name = site.hostname
         server_port = site.port
-    elif settings.ALLOWED_HOSTS == ["*"]:
-        server_name = "example.com"
     else:
         server_name = settings.ALLOWED_HOSTS[0]
+
+        if server_name == "*":
+            server_name = "example.com"
 
     # `SERVER_PORT` doesn't work when passed to the constructor
     return RequestFactory(SERVER_NAME=server_name).get(path, SERVER_PORT=server_port)

--- a/wagtail/tests/test_utils.py
+++ b/wagtail/tests/test_utils.py
@@ -479,6 +479,12 @@ class TestGetDummyRequest(TestCase):
         request = get_dummy_request(site=site)
         self.assertEqual(request.get_host(), "other.example.com:8888")
 
+    def test_server_name_for_wildcard_allowed_hosts(self):
+        # Django's test runner adds "testserver" at the end of ALLOWED_HOSTS.
+        with self.settings(ALLOWED_HOSTS=["*", "testserver"]):
+            request = get_dummy_request()
+            self.assertEqual(request.get_host(), "example.com")
+
 
 class TestDeepUpdate(TestCase):
     def test_deep_update(self):


### PR DESCRIPTION
Django's test runner appends 'testserver' to your ALLOWED_HOSTS
setting. If your project has `ALLOWED_HOSTS=['*']` (which is totally
legit for Google App Engine standard) this means the setting value is
`ALLOWED_HOSTS=['*', 'testserver']` and Wagtail's dummy request helper
was setting the request SERVER_NAME to '*'.
    
But '*' is not a valid host name, causing a DisallowedHost exception.
    
This change sets the SERVER_NAME to 'example.com' in that case.