### PR TITLE
Accept alias for WAGTAILIMAGES_RENDITION_STORAGE (Wagtail 5.2)

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -345,12 +345,16 @@ Specifies the number of images shown per page in the image chooser modal.
 ### `WAGTAILIMAGES_RENDITION_STORAGE`
 
 ```python
+# Recommended for Django 4.2+
+WAGTAILIMAGES_RENDITION_STORAGE = 'my_custom_storage'
+# Or
 WAGTAILIMAGES_RENDITION_STORAGE = 'myapp.backends.MyCustomStorage'
+WAGTAILIMAGES_RENDITION_STORAGE = MyCustomStorage()
 ```
 
-This setting allows image renditions to be stored using an alternative storage backend. The default is `None`, which will use Django's default `FileSystemStorage`.
+This setting allows image renditions to be stored using an alternative storage configuration. For Django 4.2+, use a storage alias defined in [Django's STORAGES setting](https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-STORAGES). Alternatively, this setting also accepts a dotted module path to a `Storage` subclass, or an instance of such a subclass. The default is `None`, meaning renditions will use the project's default storage.
 
-Custom storage classes should subclass `django.core.files.storage.Storage`. See the {doc}`Django file storage API <django:ref/files/storage>`.
+Custom storage classes should subclass `django.core.files.storage.Storage`. See the {doc}`Django file storage API <django:ref/files/storage>` for more information.
 
 ### `WAGTAILIMAGES_EXTENSIONS`
 

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -1,5 +1,6 @@
 import unittest
 
+from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.core.cache import caches
 from django.core.files import File

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -3,7 +3,7 @@ import unittest
 from django.contrib.auth.models import Group, Permission
 from django.core.cache import caches
 from django.core.files import File
-from django.core.files.storage import DefaultStorage, Storage
+from django.core.files.storage import Storage, default_storage, storages
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models import Prefetch
 from django.db.utils import IntegrityError
@@ -37,8 +37,7 @@ from .utils import (
 
 
 class CustomStorage(Storage):
-    def __init__(self):
-        super().__init__()
+    pass
 
 
 class TestImage(TestCase):
@@ -850,39 +849,42 @@ class TestRenditions(TestCase):
             rendition.background_position_style, "background-position: 50% 50%;"
         )
 
-    def test_custom_rendition_backend_setting(self):
-        """
-        Test the usage of WAGTAILIMAGES_RENDITION_STORAGE setting.
-        """
-        # when setting is not set, instance.get_storage() returns DefaultStorage
-        from django.conf import settings
-
-        bkp = settings
-
+    @override_settings()
+    def test_rendition_storage_setting_absent(self):
+        del settings.WAGTAILIMAGES_RENDITION_STORAGE
         self.assertFalse(hasattr(settings, "WAGTAILIMAGES_RENDITION_STORAGE"))
-        rendition1 = self.image.get_rendition("min-120x120")
-        self.assertIsInstance(rendition1.image.file.storage, DefaultStorage)
+        self.assertEqual(get_rendition_storage(), default_storage)
 
-        # when setting is set to a path
-        setattr(
-            settings,
-            "WAGTAILIMAGES_RENDITION_STORAGE",
-            "wagtail.images.tests.test_models.CustomStorage",
+    @override_settings(
+        WAGTAILIMAGES_RENDITION_STORAGE="wagtail.images.tests.test_models.CustomStorage"
+    )
+    def test_rendition_storage_setting_given_dotted_path(self):
+        self.assertIsInstance(get_rendition_storage(), CustomStorage)
+
+    @override_settings(WAGTAILIMAGES_RENDITION_STORAGE=CustomStorage())
+    def test_rendition_storage_setting_given_storage_instance(self):
+        self.assertEqual(
+            get_rendition_storage(), settings.WAGTAILIMAGES_RENDITION_STORAGE
         )
-        backend = get_rendition_storage()
-        self.assertIsInstance(backend, CustomStorage)
 
-        # when setting is set directly, get_rendition_storage() returns the custom storage backend
-        class CustomStorage2(Storage):
-            def __init__(self):
-                super().__init__()
-
-        setattr(settings, "WAGTAILIMAGES_RENDITION_STORAGE", CustomStorage2())
-        backend = get_rendition_storage()
-        self.assertIsInstance(backend, CustomStorage2)
-
-        # clean up
-        settings = bkp
+    @override_settings(
+        STORAGES={
+            "default": {
+                "BACKEND": "django.core.files.storage.FileSystemStorage",
+            },
+            "staticfiles": {
+                "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+            },
+            "custom_storage": {
+                "BACKEND": "wagtail.images.tests.test_models.CustomStorage",
+            },
+        },
+        WAGTAILIMAGES_RENDITION_STORAGE="custom_storage",
+    )
+    def test_rendition_storage_setting_given_storage_alias(self):
+        self.assertEqual(
+            get_rendition_storage(), storages[settings.WAGTAILIMAGES_RENDITION_STORAGE]
+        )
 
 
 @override_settings(


### PR DESCRIPTION
**What is this PR for?**
New feature: Accept storage alias for WAGTAILIMAGES_RENDITION_STORAGE setting (Issue #11693).

**Changes Made:**
* Update wagtail.images.models.get_rendition_storage to handle the case when the WAGTAILIMAGES_RENDITION_STORAGE setting is given a storage alias (defined in the STORAGES setting). Preserve old behavior when a dotted module path or a Storage instance are given.
* Refactor and improve all tests related to the WAGTAILIMAGE_RENDITION_STORAGE setting.
* Update related documentation.
