### PR TITLE
Add default GenericRelations for RevisionMixin and WorkflowMixin

### DIFF
--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -282,6 +282,13 @@ class RevisionMixin(models.Model):
         "latest_revision",
     ]
 
+    _revisions = GenericRelation(
+        "wagtailcore.Revision",
+        content_type_field="content_type",
+        object_id_field="object_id",
+        for_concrete_model=False,
+    )
+
     @cached_property
     def revisions(self):
         """
@@ -1191,7 +1198,13 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         verbose_name=_("latest revision created at"), null=True, editable=False
     )
 
-    _revisions = GenericRelation("wagtailcore.Revision", related_query_name="page")
+    _revisions = GenericRelation(
+        "wagtailcore.Revision",
+        content_type_field="content_type",
+        object_id_field="object_id",
+        related_query_name="page",
+        for_concrete_model=False,
+    )
 
     # Add GenericRelation to allow WorkflowState.objects.filter(page=...) queries.
     # There is no need to override the workflow_states property, as the default

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -282,7 +282,7 @@ class RevisionMixin(models.Model):
         "latest_revision",
     ]
 
-    @property
+    @cached_property
     def revisions(self):
         """
         Returns revisions that belong to the object.
@@ -982,7 +982,7 @@ class WorkflowMixin:
         """Returns the active workflow assigned to the object."""
         return self.get_default_workflow()
 
-    @property
+    @cached_property
     def workflow_states(self):
         """
         Returns workflow states that belong to the object.
@@ -1299,7 +1299,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
     def __str__(self):
         return self.title
 
-    @property
+    @cached_property
     def revisions(self):
         # Always use the specific page instance when querying for revisions as
         # they are always saved with the specific content_type.

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -1657,7 +1657,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         clean=True,
     ):
         # Raise error if this is not the specific version of the page
-        if not isinstance(self, self.specific_class):
+        if not self.is_specific:
             raise RuntimeError(
                 "page.save_revision() must be called on the specific version of the page. "
                 "Call page.specific.save_revision() instead."
@@ -2410,7 +2410,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             and self.specific_class.permissions_for_user
             != type(self).permissions_for_user
         )
-        if is_overridden and not isinstance(self, self.specific_class):
+        if is_overridden and not self.is_specific:
             return self.specific_deferred.permissions_for_user(user)
         return PagePermissionTester(user, self)
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -911,8 +911,18 @@ class LockableMixin(models.Model):
             return BasicLock(self)
 
 
-class WorkflowMixin:
+class WorkflowMixin(models.Model):
     """A mixin that allows a model to have workflows."""
+
+    _workflow_states = GenericRelation(
+        "wagtailcore.WorkflowState",
+        content_type_field="base_content_type",
+        object_id_field="object_id",
+        for_concrete_model=False,
+    )
+
+    class Meta:
+        abstract = True
 
     @classmethod
     def check(cls, **kwargs):
@@ -1203,7 +1213,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         for_concrete_model=False,
     )
 
-    # Add GenericRelation to allow WorkflowState.objects.filter(page=...) queries.
+    # Override WorkflowMixin's GenericRelation to specify related_query_name
+    # so we can do WorkflowState.objects.filter(page=...) queries.
     # There is no need to override the workflow_states property, as the default
     # implementation in WorkflowMixin already ensures that the queryset uses the
     # base Page content type.

--- a/wagtail/models/specific.py
+++ b/wagtail/models/specific.py
@@ -119,6 +119,10 @@ class SpecificMixin:
         return self.cached_content_type.model_class()
 
     @property
+    def is_specific(self):
+        return self.specific_class is not None and isinstance(self, self.specific_class)
+
+    @property
     def cached_content_type(self):
         """
         Return this object's ``content_type`` value from the ``ContentType``

--- a/wagtail/tests/test_revision_model.py
+++ b/wagtail/tests/test_revision_model.py
@@ -173,15 +173,15 @@ class TestRevisableModel(TestCase):
     def test_revision_cascade_on_object_delete(self):
         page = self.create_page()
         full_featured_snippet = FullFeaturedSnippet.objects.create(text="foo")
+        # The RevisionMixin should provide a default `GenericRelation` so that
+        # revisions are deleted when the object is deleted, even if the
+        # model does not explicitly define a `GenericRelation` to `Revision`.
         cases = [
-            # Tuple of (instance, cascades)
-            # For models that define a GenericRelation to Revision, the revision
-            # should be deleted when the instance is deleted.
-            (page, True),
-            (full_featured_snippet, True),
-            (self.instance, False),  # No GenericRelation to Revision
+            page,
+            full_featured_snippet,
+            self.instance,  # No explicit GenericRelation to Revision
         ]
-        for instance, cascades in cases:
+        for instance in cases:
             with self.subTest(instance=instance):
                 revision = instance.save_revision()
                 query = {
@@ -190,4 +190,4 @@ class TestRevisableModel(TestCase):
                 }
                 self.assertEqual(Revision.objects.filter(**query).first(), revision)
                 instance.delete()
-                self.assertIs(Revision.objects.filter(**query).exists(), not cascades)
+                self.assertIs(Revision.objects.filter(**query).exists(), False)

--- a/wagtail/tests/test_workflow.py
+++ b/wagtail/tests/test_workflow.py
@@ -449,7 +449,7 @@ class TestPageWorkflows(WagtailTestUtils, TestCase):
         self.assertIsNone(self.object.locked_at)
         self.assertIsNone(self.object.locked_by)
 
-    def test_workflow_state_cascade_on_object_delete(self, cascades=True):
+    def test_workflow_state_cascade_on_object_delete(self):
         data = self.start_workflow()
         query = {
             "base_content_type": self.object.get_base_content_type(),
@@ -460,7 +460,7 @@ class TestPageWorkflows(WagtailTestUtils, TestCase):
             data["workflow_state"],
         )
         self.object.delete()
-        self.assertIs(WorkflowState.objects.filter(**query).exists(), not cascades)
+        self.assertIs(WorkflowState.objects.filter(**query).exists(), False)
 
 
 class TestSnippetWorkflows(TestPageWorkflows):
@@ -493,9 +493,6 @@ class TestSnippetWorkflowsNotLockable(TestSnippetWorkflows):
         self.assertEqual(workflow_state.content_object, self.object)
         self.assertEqual(workflow_state.status, "in_progress")
 
-    def test_workflow_state_cascade_on_object_delete(self):
-        # We expect the cascade to not happen as the model does not define
-        # a GenericRelation to WorkflowState. However, workflows should still
-        # work as expected.
-        # See https://github.com/wagtail/wagtail/issues/11300 for more details.
-        return super().test_workflow_state_cascade_on_object_delete(cascades=False)
+    # The ModeratedModel does not explicitly define a `GenericRelation` to
+    # `WorkflowState`, but the `WorkflowState` should still be deleted when the
+    # object is deleted (test_workflow_state_cascade_on_object_delete passes).


### PR DESCRIPTION
Not entirely related but fixes #11746.

For models that have multi-table inheritance, accessing a
GenericRelation will not always give you the correct results. This can
occur if the content type used by the GenericRelation does not match the
instance at hand, e.g. accessing a GenericRelation that uses
base_content_type from an instance of the specific class, or vice versa.

This is a known quirk when using GenericRelation together with MTI:
https://code.djangoproject.com/ticket/31269

To work around this, we need to have a method or property that resolves
to the correct GenericRelation (or the related model's QuerySet) to use,
depending on whether the current instance is specific or not. This
allows us to use and publicly document RevisionMixin.revisions as
something that always gives you the correct queryset of Revisions for
the object, without having to deal with the MTI quirks.

This is why the RevisionMixin has a `revisions` property that queries
the Revision model directly, so that accessing MyModelInstance.revisions
always gives you the correct results, no matter how the GenericRelation
is set up for custom models.

For pages, we have access to the model implementation, so the
Page.revisions property is implemented using a GenericRelation that is
always accessed using a specific version of the instance.

For models that don't use MTI, we advise developers to just override the
revisions property with a GenericRelation definition. However, as of
django/django@faeb92e,
the existence of a @Property and a related field accessor of the same
name triggers a system check error.

It is unknown whether the system check error is the desired result or
not. However, the approach that we documented about shadowing the
mixins' default properties with a real GenericRelation clearly worked
before, so it is probably okay.

To work around this, we can use cached_property instead, which bypasses
the check, as Django only checks for the plain Python `property`.

Additionally, we can suggest developers to **never** override the
`revisions` and `workflow_states` with `GenericRelation`s directly, and
instead define the `GenericRelation`s with other names, and override the
property as a new property that returns the `GenericRelation` (with any
additional logic as necessary, e.g. to handle MTI)._Please describe the problem you're fixing here. Include the issue number, if applicable._
