### PR TITLE
Re-add base styling for footer actions to support simple customisations

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -75,6 +75,7 @@ Changelog
  * Fix: Ensure `get_add_url()` is always used to re-render the add button when the listing is refreshed in viewsets (Sage Abdullah)
  * Fix: Move `modal-workflow.js` script usage to base admin template instead of ad-hoc imports so that choosers work in `ModelViewSet`s (Elhussein Almasri)
  * Fix: Ensure JavaScript for common widgets such as `InlinePanel` is included by default in `ModelViewSet`'s create and edit views (Sage Abdullah)
+ * Fix: Reinstate styles for customizations of `extra_footer_actions` block in page create/edit templates (LB (Ben) Johnston, Sage Abdullah)
  * Docs: Update Sphinx theme to `6.3.0` with a fix for the missing favicon (Sage Abdullah)
 
 

--- a/client/scss/components/_footer.scss
+++ b/client/scss/components/_footer.scss
@@ -96,9 +96,12 @@
     gap: theme('spacing.2');
     grid-auto-flow: column;
 
-    > * {
-      // Reset the margin on any .button sibling elements
-      height: auto;
+    .button {
+      // There are default .button styles that would:
+      // - set height responsively
+      // - add a margin when there is a .button sibling
+      // Unset these styles in favor of a fixed height and the grid gap
+      height: $text-input-height;
       margin-inline-start: initial;
     }
 
@@ -122,6 +125,7 @@
 
   .icon {
     width: theme('spacing.4');
+    height: theme('spacing.4');
     margin-inline-end: theme('spacing.2');
     flex-shrink: 0;
   }

--- a/client/scss/components/_footer.scss
+++ b/client/scss/components/_footer.scss
@@ -85,12 +85,31 @@
   width: 100%;
 
   @include media-breakpoint-up(sm) {
-    width: 250px;
+    width: theme('spacing.64');
   }
 
   &--primary {
+    // Support basic layout support for items added via `extra_footer_actions`
+
+    align-items: stretch;
+    display: grid;
+    gap: theme('spacing.2');
+    grid-auto-flow: column;
+
+    > * {
+      // Reset the margin on any .button sibling elements
+      height: auto;
+      margin-inline-start: initial;
+    }
+
     @include media-breakpoint-up(sm) {
-      width: 310px;
+      min-width: theme('spacing.80');
+      width: max-content;
+
+      > *:first-child {
+        // Ensure the first child (the dropdown action usually) is always wide
+        min-width: theme('spacing.56');
+      }
     }
   }
 }

--- a/docs/releases/6.0.2.md
+++ b/docs/releases/6.0.2.md
@@ -19,6 +19,7 @@ depth: 1
  * Ensure `get_add_url()` is always used to re-render the add button when the listing is refreshed in viewsets (Sage Abdullah)
  * Move `modal-workflow.js` script usage to base admin template instead of ad-hoc imports so that choosers work in `ModelViewSet`s (Elhussein Almasri)
  * Ensure JavaScript for common widgets such as `InlinePanel` is included by default in `ModelViewSet`'s create and edit views (Sage Abdullah)
+ * Reinstate styles for customizations of `extra_footer_actions` block in page create/edit templates (LB (Ben) Johnston, Sage Abdullah)
 
 
 ### Documentation

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
@@ -12,7 +12,7 @@
 
 {% block actions %}
     <footer class="footer">
-        <nav class="actions actions--primary footer__container w-grid" aria-label="{% trans 'Actions' %}">
+        <nav class="actions actions--primary footer__container" aria-label="{% trans 'Actions' %}">
             {{ action_menu.render_html }}
         </nav>
     </footer>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
@@ -13,7 +13,7 @@
 
 {% block actions %}
     <footer class="footer">
-        <nav class="actions actions--primary footer__container w-grid" aria-label="{% trans 'Actions' %}">
+        <nav class="actions actions--primary footer__container" aria-label="{% trans 'Actions' %}">
             {{ action_menu.render_html }}
         </nav>
     </footer>


### PR DESCRIPTION
## Overview

- Fixes #11629
- Relates to clean up done as part of #11456 which removed a lot of styling for footer actions which appeared to be unused.
- Re-add some base styling to support the ability for basic customisations where buttons are added within the `extra_footer_actions` block.

I'd recommend we **also include this in `6.0.2`** as it will help packages update to support Wagtail 6.0* easier.

## Details

The PR referenced above did a lot of incredible work to clean up the complex styles in the footer, but it appears that some of that made basic customisations much easier.

This PR proposes we add some bare minimum styling back to support the common use case of showing a few buttons in the `extra_footer_actions` block.

## Testing

Follow the steps in https://github.com/wagtail/wagtail/issues/11629#issuecomment-1989470950

### Before

<img width="1501" alt="Screenshot 2024-03-12 at 7 22 32 am" src="https://github.com/wagtail/wagtail/assets/1396140/b5cccccd-81ec-48dd-a2fb-c2f443966849">


### After

<img width="1162" alt="Screenshot 2024-03-13 at 7 06 25 am" src="https://github.com/wagtail/wagtail/assets/1396140/0dd275b4-d000-46eb-a51c-4b9a907b6fc4">

