### PR TITLE
(6.0.2) Backport - Move modal-workflow.js script to admin_base.html (#11620)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
  * Fix: Resolve issue local development of docs when running `make livehtml` (Sage Abdullah)
  * Fix: Resolve issue with unwanted padding in chooser modal listings (Sage Abdullah)
  * Fix: Ensure `get_add_url()` is always used to re-render the add button when the listing is refreshed in viewsets (Sage Abdullah)
+ * Fix: Move modal-workflow.js script usage to base admin template instead of ad-hoc imports so that choosers work in ModelViewSets (Elhussein Almasri)
  * Docs: Update Sphinx theme to `6.3.0` with a fix for the missing favicon (Sage Abdullah)
 
 

--- a/docs/releases/6.0.2.md
+++ b/docs/releases/6.0.2.md
@@ -17,6 +17,7 @@ depth: 1
  * Resolve issue local development of docs when running `make livehtml` (Sage Abdullah)
  * Resolve issue with unwanted padding in chooser modal listings (Sage Abdullah)
  * Ensure `get_add_url()` is always used to re-render the add button when the listing is refreshed in viewsets (Sage Abdullah)
+ * Move modal-workflow.js script usage to base admin template instead of ad-hoc imports so that choosers work in ModelViewSets (Elhussein Almasri)
 
 
 ### Documentation

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -56,6 +56,7 @@
     <script src="{% versioned_static 'wagtailadmin/js/wagtailadmin.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/telepath/telepath.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/sidebar.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 
     {% hook_output 'insert_global_admin_js' %}
 

--- a/wagtail/admin/templates/wagtailadmin/collections/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/collections/edit.html
@@ -7,6 +7,5 @@
 
 {% block extra_js %}
     {{ block.super }}
-    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/privacy-switch.js' %}"></script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -89,7 +89,6 @@
         </table>
     {% endpanel %}
 
-    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/workflow-action.js' %}"></script>
     <script>
         document.querySelectorAll('[data-controller="w-dropdown"]').forEach((e) => {

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
@@ -18,7 +18,6 @@
 <script src="{% versioned_static 'wagtailadmin/js/vendor/rangy-core.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/vendor/mousetrap.min.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/expanding-formset.js' %}"></script>
-<script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/page-editor.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/preview-panel.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/privacy-switch.js' %}"></script>

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -23,8 +23,6 @@
 {% block extra_js %}
     {{ block.super }}
 
-    {% comment %} modal-workflow is required by the view restrictions interface {% endcomment %}
-    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/privacy-switch.js' %}"></script>
 
     {% comment %}

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -14,6 +14,7 @@ from django.utils.timezone import make_aware
 from openpyxl import load_workbook
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.log_actions import log
 from wagtail.models import ModelLogEntry
 from wagtail.test.testapp.models import (
@@ -1463,6 +1464,11 @@ class TestEditHandler(WagtailTestUtils, TestCase):
             rendered_heading = panel.select_one("[data-panel-heading-text]")
             self.assertIsNotNone(rendered_heading)
             self.assertEqual(rendered_heading.text.strip(), expected_heading)
+
+        # Ensure modal-workflow.js is included, as it's needed by choosers
+        modal_workflow_js = versioned_static("wagtailadmin/js/modal-workflow.js")
+        modal_workflow_script = soup.select_one(f'script[src="{modal_workflow_js}"]')
+        self.assertIsNotNone(modal_workflow_script)
 
 
 class TestDefaultMessages(WagtailTestUtils, TestCase):

--- a/wagtail/sites/templates/wagtailsites/create.html
+++ b/wagtail/sites/templates/wagtailsites/create.html
@@ -3,5 +3,4 @@
 
 {% block extra_js %}
     {{ block.super }}
-    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 {% endblock %}

--- a/wagtail/sites/templates/wagtailsites/edit.html
+++ b/wagtail/sites/templates/wagtailsites/edit.html
@@ -3,5 +3,4 @@
 
 {% block extra_js %}
     {{ block.super }}
-    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 {% endblock %}

--- a/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
@@ -1,6 +1,5 @@
 {% load wagtailadmin_tags %}
 <script src="{% versioned_static 'wagtailadmin/js/expanding-formset.js' %}"></script>
-<script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 <script src="{% versioned_static 'wagtailusers/js/group-form.js' %}"></script>
 
 {{ form_media.js }}


### PR DESCRIPTION
The modal-workflow.js script is used across a wide range of views in the admin, it's simpler to include it globally instead of having to consider all places it may be used.

Also unblocks use cases that are outside of the core admin such as custom documents/user/image models that may want to leverage this functionality.

Includes a fix for the documented support for all Panels in Wagtail 6.0's release notes, even though DocumentChooser and others would not have worked.

Cherry pick of single commit 266faf63c2967f01c7be01afb0fdaf92bc77c5c4 from #11620

Backport fix for #11739
