### PR TITLE
Fix title of page for UI guidelines

### DIFF
--- a/docs/contributing/ui_guidelines.md
+++ b/docs/contributing/ui_guidelines.md
@@ -1,4 +1,4 @@
-# UI Guidelines
+# UI guidelines
 
 Wagtail’s user interface is built with:
 


### PR DESCRIPTION
- Guidelines is not a proper noun here and should not be capitalised.