### PR TITLE
Migrate initBlockWidget & inline script usage to Stimulus w-block controller

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -64,6 +64,7 @@ Changelog
  * Maintenance: Remove dead code in the minimap when elements are not found (LB (Ben) Johnston)
  * Maintenance: Ensure untrusted data sources are logged correctly in the Stimulus `SwapController` (LB (Ben) Johnston)
  * Maintenance: Update Wagtail logo in admin sidebar & favicon plus documentation to the latest version (Osaf AliSayed, Albina Starykova, LB (Ben) Johnston)
+ * Maintenance: Remove usage of inline scripts and instead use a new Stimulus controller (`w-block`/`BlockController`) to instantiate `StreamField` blocks (Karthik Ayangar)
 
 
 6.0.2 (03.04.2024)

--- a/client/src/controllers/BlockController.test.js
+++ b/client/src/controllers/BlockController.test.js
@@ -1,0 +1,125 @@
+import { Application } from '@hotwired/stimulus';
+import { BlockController } from './BlockController';
+
+const render = jest.fn();
+const unpack = jest.fn(() => ({ render }));
+window.telepath = { unpack };
+
+describe('BlockController', () => {
+  const eventNames = ['w-block:ready'];
+
+  const events = {};
+
+  eventNames.forEach((name) => {
+    document.addEventListener(name, (event) => {
+      events[name].push(event);
+    });
+  });
+
+  let application;
+  let errors = [];
+
+  const setup = (html, { identifier = 'w-block' } = {}) => {
+    document.body.innerHTML = `<main>${html}</main>`;
+
+    application = new Application();
+
+    application.register(identifier, BlockController);
+
+    application.handleError = (error, message) => {
+      errors.push({ error, message });
+    };
+
+    application.start();
+
+    return Promise.resolve();
+  };
+
+  beforeEach(() => {
+    application?.stop();
+    document.body.innerHTML = '';
+    errors = [];
+    eventNames.forEach((name) => {
+      events[name] = [];
+    });
+    jest.clearAllMocks();
+  });
+
+  it('does nothing if block element is not found', async () => {
+    await setup('<div></div>');
+
+    expect(errors).toHaveLength(0);
+
+    expect(unpack).not.toHaveBeenCalled();
+
+    expect(events['w-block:ready']).toHaveLength(0);
+  });
+
+  it('should render block if element is controlled', async () => {
+    const data = { _args: ['...'], _type: 'wagtail.blocks.StreamBlock' };
+
+    await setup(
+      `<div
+        id="my-element"
+        data-controller="w-block"
+        data-w-block-data-value='${JSON.stringify(data)}'
+        >
+      </div>`,
+    );
+
+    expect(errors).toHaveLength(0);
+    expect(unpack).toHaveBeenCalledWith(data);
+    expect(render).toHaveBeenCalledWith(
+      document.getElementById('my-element'),
+      'my-element',
+    );
+    expect(events['w-block:ready']).toHaveLength(1);
+  });
+
+  it('should call the unpacked render function with provided initial & error data', async () => {
+    const data = { _args: ['...'], _type: 'wagtail.blocks.StreamBlock' };
+    const initialData = [{ type: 'paragraph_block', value: '...' }];
+    const errorData = { messages: ['An error...'] };
+
+    await setup(
+      `<div
+        id="my-element"
+        data-controller="w-block"
+        data-w-block-arguments-value='${JSON.stringify([initialData, errorData])}'
+        data-w-block-data-value='${JSON.stringify(data)}'
+        >
+      </div>`,
+    );
+
+    expect(errors).toHaveLength(0);
+    expect(unpack).toHaveBeenCalledWith(data);
+    expect(render).toHaveBeenCalledWith(
+      document.getElementById('my-element'),
+      'my-element',
+      initialData,
+      errorData,
+    );
+    expect(events['w-block:ready']).toHaveLength(1);
+  });
+
+  it('should throw an error if used on an element without an id', async () => {
+    await setup('<div data-controller="w-block"></div>');
+
+    expect(errors).toHaveLength(1);
+    expect(errors).toHaveProperty(
+      '0.error.message',
+      'Controlled element needs an id attribute.',
+    );
+  });
+
+  it('should throw an error if Telepath is not available in the window global', async () => {
+    delete window.telepath;
+    await setup('<div id="my-element" data-controller="w-block"></div>');
+
+    expect(errors).toHaveLength(1);
+    expect(errors).toHaveProperty(
+      '0.error.message',
+      '`window.telepath` is not available.',
+    );
+  });
+});

--- a/client/src/controllers/BlockController.ts
+++ b/client/src/controllers/BlockController.ts
@@ -1,0 +1,86 @@
+import { Controller } from '@hotwired/stimulus';
+
+declare global {
+  interface Window {
+    initBlockWidget?: (id: string) => void;
+    telepath: any;
+  }
+}
+
+/**
+ * Adds the ability to unpack a Telepath object and render it on the controlled element.
+ * Used to initialize the top-level element of a BlockWidget (the form widget for a StreamField).
+ *
+ * @example
+ * <div
+ *  id="some-id"
+ *  data-controller="w-block"
+ *  data-w-block-data-value='{"_args":["..."], "_type": "wagtail.blocks.StreamBlock"}'
+ * >
+ * </div>
+ *
+ * @example - with initial arguments
+ * <div
+ *  id="some-id"
+ *  data-controller="w-block"
+ *  data-w-block-data-value='{"_args":["..."], "_type": "wagtail.blocks.StreamBlock"}'
+ *  data-w-block-arguments-value='[[{ type: "paragraph_block", value: "..."}], {messages:["An error..."]}]'
+ * >
+ * </div>
+ */
+export class BlockController extends Controller<HTMLElement> {
+  static values = {
+    arguments: { type: Array, default: [] },
+    data: { type: Object, default: {} },
+  };
+
+  /** Array of arguments to pass to the render method of the block [initial value, errors]. */
+  declare argumentsValue: Array<string>;
+  /** Block definition to be passed to `telepath.unpack`, used to obtain a JavaScript representation of the block. */
+  declare dataValue: object;
+
+  connect() {
+    const telepath = window.telepath;
+
+    if (!telepath) {
+      throw new Error('`window.telepath` is not available.');
+    }
+
+    const element = this.element;
+    const id = element.id;
+
+    if (!id) {
+      throw new Error('Controlled element needs an id attribute.');
+    }
+
+    const output = telepath.unpack(this.dataValue);
+    output.render(element, id, ...this.argumentsValue);
+    this.dispatch('ready', { detail: { ...output }, cancelable: false });
+  }
+
+  static afterLoad() {
+    /**
+     * Provide a backwards compatible version of the original window global function.
+     *
+     * @deprecated RemovedInWagtail70
+     */
+    window.initBlockWidget = (id: string) => {
+      const body = document.querySelector(
+        '#' + id + '[data-block]',
+      ) as HTMLElement;
+
+      if (!body) {
+        return;
+      }
+
+      const blockDefData = JSON.parse(body.dataset.data as string);
+      if (window.telepath) {
+        const blockDef = window.telepath.unpack(blockDefData);
+        const blockValue = JSON.parse(body.dataset.value as string);
+        const blockError = JSON.parse(body.dataset.error as string);
+
+        blockDef.render(body, id, blockValue, blockError);
+      }
+    };
+  }
+}

--- a/client/src/controllers/index.ts
+++ b/client/src/controllers/index.ts
@@ -3,6 +3,7 @@ import type { Definition } from '@hotwired/stimulus';
 // Order controller imports alphabetically.
 import { ActionController } from './ActionController';
 import { AutosizeController } from './AutosizeController';
+import { BlockController } from './BlockController';
 import { BulkController } from './BulkController';
 import { ClipboardController } from './ClipboardController';
 import { CloneController } from './CloneController';
@@ -34,6 +35,7 @@ export const coreControllerDefinitions: Definition[] = [
   // Keep this list in alphabetical order
   { controllerConstructor: ActionController, identifier: 'w-action' },
   { controllerConstructor: AutosizeController, identifier: 'w-autosize' },
+  { controllerConstructor: BlockController, identifier: 'w-block' },
   { controllerConstructor: BulkController, identifier: 'w-bulk' },
   { controllerConstructor: ClipboardController, identifier: 'w-clipboard' },
   { controllerConstructor: CloneController, identifier: 'w-clone' },

--- a/client/src/entrypoints/admin/telepath/blocks.js
+++ b/client/src/entrypoints/admin/telepath/blocks.js
@@ -38,30 +38,6 @@ wagtailStreamField.blocks = {
   StreamBlockDefinition,
 };
 
-function initBlockWidget(id) {
-  /*
-  Initialises the top-level element of a BlockWidget
-  (the form widget for a StreamField).
-  Receives the ID of a DOM element with the attributes:
-    data-block: JSON-encoded block definition to be passed to telepath.unpack
-      to obtain a Javascript representation of the block
-      (an instance of one of the Block classes below)
-    data-value: JSON-encoded value for this block
-  */
-
-  const body = document.querySelector('#' + id + '[data-block]');
-
-  // unpack the block definition and value
-  const blockDefData = JSON.parse(body.dataset.block);
-  const blockDef = window.telepath.unpack(blockDefData);
-  const blockValue = JSON.parse(body.dataset.value);
-  const blockError = JSON.parse(body.dataset.error);
-
-  // replace the 'body' element with the populated HTML structure for the block
-  blockDef.render(body, id, blockValue, blockError);
-}
-window.initBlockWidget = initBlockWidget;
-
 window.telepath.register('wagtail.blocks.FieldBlock', FieldBlockDefinition);
 window.telepath.register('wagtail.blocks.StaticBlock', StaticBlockDefinition);
 window.telepath.register('wagtail.blocks.StructBlock', StructBlockDefinition);

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -86,6 +86,7 @@ depth: 1
  * Remove dead code in the minimap when elements are not found (LB (Ben) Johnston)
  * Ensure untrusted data sources are logged correctly in the Stimulus `SwapController` (LB (Ben) Johnston)
  * Update Wagtail logo in admin sidebar & favicon plus documentation to the latest version (Osaf AliSayed, Albina Starykova, LB (Ben) Johnston)
+ * Remove usage of inline scripts and instead use a new Stimulus controller (`w-block`/`BlockController`) to instantiate `StreamField` blocks (Karthik Ayangar)
 
 
 ## Upgrade considerations
@@ -176,4 +177,46 @@ from wagtail import hooks
 @hooks.register("register_rich_text_features")
 def override_embed_feature_url(features):
     features.plugins_by_editor["draftail"]["embed"].data["chooserUrls"]["embedsChooser"] = reverse_lazy("my_embeds:chooser")
+```
+
+### Deprecation of `window.initBlockWidget` to initialize a StreamField block
+
+The undocumented global function `window.initBlockWidget` has now been deprecated and will be removed in a future release.
+
+Any complex customizations that have re-implemented parts of this functionality will need to be modified to adopt the new approach that uses Stimulus and avoids inline scripts.
+
+The usage of this new approach is still unofficial and could change in the future, it's recommended that the documented `BlockWidget` and `StreamField` approaches be used instead.
+
+However, for comparison, here is the old and new approach below.
+
+### Old
+
+Assuming we are using Django's `format_html` to prepare the HTML output with `JSON.dumps` strings for the block data values.
+
+The old approach would call the `window.initBlockWidget` global function with an inline script as follows:
+
+```html
+<div
+    id="{id}"
+    data-block="{block_json}"
+    data-value="{value_json}"
+    data-error="{error_json}"
+></div>
+<script>
+    initBlockWidget('{id}');
+</script>
+```
+
+### New
+
+In the new approach, we no longer need to attach an inline script but instead use the Stimulus data attributes to attach the behavior with the `w-block` identifier as follows:
+
+```html
+<div
+    id="{id}"
+    data-block
+    data-controller="w-block"
+    data-w-block-data-value="{block_json}"
+    data-w-block-arguments-value="[{value_json},{error_json}]"
+></div>
 ```

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -1494,7 +1494,13 @@ class TestInlineStreamField(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
 
         # response should include HTML declarations for streamfield child blocks
-        self.assertContains(response, '<div id="sections-__prefix__-body" data-block="')
+        self.assertContains(response, '<div id="sections-__prefix__-body" data-block')
+        soup = self.get_soup(response.content)
+        blockDiv = soup.find("div", {"data-controller": "w-block"})
+        self.assertIsNotNone(blockDiv)
+        # block div should contain this attributes
+        self.assertTrue(blockDiv.has_attr("data-w-block-arguments-value"))
+        self.assertTrue(blockDiv.has_attr("data-w-block-data-value"))
 
 
 class TestIssue2994(WagtailTestUtils, TestCase):

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -564,14 +564,11 @@ class BlockWidget(forms.Widget):
             error = errors.as_data()[0]
             error_json = json.dumps(get_error_json_data(error))
         else:
-            error_json = "null"
+            error_json = json.dumps(None)
 
         return format_html(
             """
-                <div id="{id}" data-block="{block_json}" data-value="{value_json}" data-error="{error_json}"></div>
-                <script>
-                    initBlockWidget('{id}');
-                </script>
+                <div id="{id}" data-block data-controller="w-block" data-w-block-data-value="{block_json}" data-w-block-arguments-value="[{value_json},{error_json}]"></div>
             """,
             id=name,
             block_json=self.block_json,


### PR DESCRIPTION
Related to #11597 
This PR introduced a new Stimulus controller, BlockController, with the identifier w-block, which would allow the unpacking and rendering of the unpacked block widget from Telepath JSON.

- Created BlockController.
- Removed old init method
- Written a new jest test for block controller.
- a few changes in existing python tests.
- manual testing on bakery site.


- streamfield not visible or working when the BlockController code is commented
<img width="1728" alt="Screenshot 2024-03-30 at 6 31 00 AM" src="https://github.com/wagtail/wagtail/assets/66073214/f7ae8419-bd09-442b-862d-0d5f4b93346f">

- streamfield working fine when BlockController is present.
<img width="1728" alt="Screenshot 2024-03-30 at 6 36 17 AM" src="https://github.com/wagtail/wagtail/assets/66073214/656ee60b-d2b2-481c-98fc-8c7bbbe5d71d">


