### PR TITLE
User group permissions table - simplify layout styling & fix long first column labels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,14 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: pipenv-v1-{{ checksum "setup.py" }}
+          key: pipenv-v2-{{ checksum "setup.py" }}
       # Only install if .venv wasn’t cached.
       - run: |
           if [[ ! -e ".venv" ]]; then
               pipenv install -e .[testing,docs]
           fi
       - save_cache:
-          key: pipenv-v1-{{ checksum "setup.py" }}
+          key: pipenv-v2-{{ checksum "setup.py" }}
           paths:
             - .venv
       - run: pipenv run ruff check .

--- a/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
@@ -7,21 +7,21 @@
 
         <table class="listing" data-controller="w-bulk">
             <colgroup>
+                <col class="w-w-1/4" />
                 <col />
-                <col width="10%" />
-                <col width="10%" />
-                <col width="10%" />
+                <col />
+                <col />
                 {% if extra_perms_exist.publish %}
-                    <col width="10%" />
+                    <col />
                 {% endif %}
                 {% if extra_perms_exist.lock %}
-                    <col width="10%" />
+                    <col />
                 {% endif %}
                 {% if extra_perms_exist.unlock %}
-                    <col width="10%" />
+                    <col />
                 {% endif %}
                 {% if extra_perms_exist.custom %}
-                    <col width="25%" />
+                    <col class="w-w-1/4" />
                 {% endif %}
             </colgroup>
             <thead>


### PR DESCRIPTION
- Remove the deprecated `width` attribute usage in the table `col` elements.
- Add a defined width to the first column (model names) so these avoid wrapping unless really needed.
- Remove 10% widths on others, table layout auto being used will automatically space these out.

Follow up to #10867 - see comment from @zerolab in https://github.com/wagtail/wagtail/issues/10867#issuecomment-1929475139_

I think we could do a lot better on this table but it will need some more time and maybe a rethink of how to support really wide tables, hopefully this solution is a small surface area and gives us a nicer layout.

Note: I also tried table layout fixed, this was not suitable for this kind of problem.

### Screenshots

#### Before

<img width="1496" alt="Screenshot 2024-03-23 at 2 29 07 pm" src="https://github.com/wagtail/wagtail/assets/1396140/c7e7a1f4-b837-409e-834d-c010a98f5307">


#### After

<img width="938" alt="Screenshot 2024-03-23 at 2 49 53 pm" src="https://github.com/wagtail/wagtail/assets/1396140/3771e698-08c2-4ab7-8274-595b59a8fe73">
