### PR TITLE
Docs - Add additional reference to `wagtail_update_image_renditions` command

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ Changelog
  * Docs: Update Sphinx theme to `6.3.0` with a fix for the missing favicon (Sage Abdullah)
  * Docs: Document risk of XSS attacks on document upload (Matt Westcott, with thanks to Georgios Roumeliotis of TwelveSec for the original report)
  * Docs: Add clarity to how custom StreamField validation works (Tibor Leupold)
+ * Docs: Add additional reference to the `wagtail_update_image_renditions` management command on the using images page (LB (Ben) Johnston)
  * Maintenance: Move RichText HTML whitelist parser to use the faster, built in `html.parser` (Jake Howard)
  * Maintenance: Remove duplicate 'path' in default_exclude_fields_in_copy (Ramchandra Shahi Thakuri)
  * Maintenance: Update unit tests to always use the faster, built in `html.parser` & remove `html5lib` dependency (Jake Howard)

--- a/docs/advanced_topics/images/renditions.md
+++ b/docs/advanced_topics/images/renditions.md
@@ -68,6 +68,18 @@ By default, Wagtail will try to use the cache called "renditions". If no such ca
 
 When using a queryset to render a list of images or objects with images, you can prefetch the renditions needed with a single additional query. For long lists of items, or where multiple renditions are used for each item, this can provide a significant boost to performance.
 
+(regenerate_image_renditions)=
+
+## Regenerating existing renditions
+
+You can also directly use the image management command from the console to regenerate the renditions:
+
+```sh
+./manage.py wagtail_update_image_renditions --purge
+```
+
+You can read more about this command from [](wagtail_update_image_renditions)
+
 ### Image QuerySets
 
 When working with an Image QuerySet, you can make use of Wagtail's built-in `prefetch_renditions` queryset method to prefetch the renditions needed.

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -58,6 +58,7 @@ depth: 1
  * Update Sphinx theme to `6.3.0` with a fix for the missing favicon (Sage Abdullah)
  * Document risk of XSS attacks on document upload (Matt Westcott, with thanks to Georgios Roumeliotis of TwelveSec for the original report)
  * Add clarity to how custom [StreamField validation](streamfield_validation) works (Tibor Leupold)
+ * Add additional reference to the [`wagtail_update_image_renditions`](wagtail_update_image_renditions) management command on the [using images](regenerate_image_renditions) page (LB (Ben) Johnston)
 
 
 ### Maintenance


### PR DESCRIPTION
- We have other references to this command added in 5.2 however we did not include this in the page that goes into detail of Image renditions
- See #8166 - specifically https://github.com/wagtail/wagtail/pull/8166#issuecomment-2016336710
