### PR TITLE
Add test for redirects without trailing slash being redirected in one go

### DIFF
--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -200,6 +200,21 @@ class TestRedirects(TestCase):
             response, "/redirectto", status_code=302, fetch_redirect_response=False
         )
 
+    def test_redirect_without_trailing_slash(self):
+        # Create a redirect
+        redirect = models.Redirect(old_path="/redirectme", redirect_link="/redirectto")
+        redirect.save()
+
+        response = self.client.get("/redirectme")
+        # Request should be picked up by RedirectMiddleware, not CommonMiddleware
+        # (which would redirect to /redirectme/ instead).
+        # Before Django 4.2, CommonMiddleware performed the 'add trailing slash' test
+        # during the initial request processing, which took precedence over RedirectMiddleware
+        # and caused a double redirect (/redirectme -> /redirectme/ -> /redirectto).
+        self.assertRedirects(
+            response, "/redirectto", status_code=301, fetch_redirect_response=False
+        )
+
     def test_redirect_stripping_query_string(self):
         # Create a redirect which includes a query string
         redirect_with_query_string = models.Redirect(


### PR DESCRIPTION
The normalisation logic in RedirectMiddleware ensures that a redirect from `/foo` to `/bar` is picked up when the incoming URL is either `/foo` or `/foo/`. However, if CommonMiddleware's "add trailing slash" logic activates first, this will result in a double redirect, from `/foo` to `/foo/` and then to `/bar`. Double redirects are undesirable as they cause the site to be penalised in Google search rankings.

This was the case prior to Django 4.2 - as CommonMiddleware performed the trailing slash test in the initial "process request" phase - and was fixed in https://github.com/django/django/commit/fbac2a4dd846b52c4f379eacb5bab654fe9540cc.

This PR adds a test to confirm that an incoming request without the trailing slash is handled in a single redirect, so that we'll be made aware if this regression returns.