### PR TITLE
Sticky table headers on universal listings 

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -107,6 +107,16 @@ ul.listing {
 
   &.full-width {
     margin-bottom: -3em; // this negates the padding added to the bottom of .content
+
+    thead {
+      position: sticky;
+      top: 140px;
+      @include media-breakpoint-up(sm) {
+        top: 70px;
+      }
+      background-color: theme('colors.surface-page');
+      z-index: 3;
+    }
   }
 
   .table-headers {


### PR DESCRIPTION
Makes table headers sticky for tables with the `full-width` class.

This should implement the enhancement for the issue #11705 

![image](https://github.com/wagtail/wagtail/assets/63517269/fdc4d5be-a131-4e75-8c22-757259d3051c)

![image](https://github.com/wagtail/wagtail/assets/63517269/73f06dfd-f17b-49dc-8466-b7c0232fe59c)
