### PR TITLE
Added the function get_gravatar_url with Unit Test

### DIFF
--- a/wagtail/users/tests/test_utils.py
+++ b/wagtail/users/tests/test_utils.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from wagtail.users.utils import get_gravatar_url
+
+class TestGravatar(TestCase):
+    def test_gravatar_default(self):
+        # Test with the default settings
+        self.assertEqual(
+            get_gravatar_url("something@example.com"),
+            "//www.gravatar.com/avatar/76ebd6fecabc982c205dd056e8f0415a?d=mp&s=100",
+        )
+
+    def test_gravatar_custom_size(self):
+        # Test with a custom size (note that the size will be doubled)
+        self.assertEqual(
+            get_gravatar_url("something@example.com", size=100),
+            "//www.gravatar.com/avatar/76ebd6fecabc982c205dd056e8f0415a?d=mp&s=200",
+        )

--- a/wagtail/users/utils.py
+++ b/wagtail/users/utils.py
@@ -1,4 +1,4 @@
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from urllib.parse import parse_qs, urlparse, urlunparse
 
 from django.conf import settings
 from django.utils.http import urlencode

--- a/wagtail/users/utils.py
+++ b/wagtail/users/utils.py
@@ -1,7 +1,9 @@
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
 from django.conf import settings
 from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
 from wagtail.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 from wagtail.coreutils import safe_md5
 

--- a/wagtail/users/utils.py
+++ b/wagtail/users/utils.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
-
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from wagtail.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 from wagtail.coreutils import safe_md5
 
@@ -26,27 +26,39 @@ def user_can_delete_user(current_user, user_to_delete):
 
 
 def get_gravatar_url(email, size=50):
-    default = "mm"
-    size = (
-        int(size) * 2
-    )  # requested at retina size by default and scaled down at point of use with css
+    """
+    Generates a Gravatar URL for the given email with customizable size and default image.
+    See https://gravatar.com/site/implement/images/ for Gravatar image options.
+    """
     gravatar_provider_url = getattr(
         settings, "WAGTAIL_GRAVATAR_PROVIDER_URL", "//www.gravatar.com/avatar"
     )
 
-    if (not email) or (gravatar_provider_url is None):
+    if not email or not gravatar_provider_url:
         return None
 
+    # Set default image type and adjust size for retina displays
+    default = "mp"
+    size *= 2  # Retina display support
+
+    # Parse the provided URL and extract query parameters
+    parsed_url = urlparse(gravatar_provider_url)
+    query_params = parse_qs(parsed_url.query)
     email_bytes = email.lower().encode("utf-8")
-    hash = safe_md5(email_bytes, usedforsecurity=False).hexdigest()
-    gravatar_url = "{gravatar_provider_url}/{hash}?{params}".format(
-        gravatar_provider_url=gravatar_provider_url.rstrip("/"),
-        hash=hash,
-        params=urlencode({"s": size, "d": default}),
-    )
+    email_hash = safe_md5(email_bytes).hexdigest()
+    email_hash='/'+ email_hash
+
+    # Merge default parameters with those extracted from the provided URL
+    query_params.update({"d": default, "s": str(size)})
+    query_string = urlencode(query_params, doseq=True)
+
+    # Rebuild the URL with the merged parameters
+    gravatar_url = urlunparse((
+        parsed_url.scheme, parsed_url.netloc, parsed_url.path + email_hash, 
+        parsed_url.params, query_string, parsed_url.fragment
+    ))
 
     return gravatar_url
-
 
 def get_deleted_user_display_name(user_id):
     # Use a string placeholder as the user id could be non-numeric


### PR DESCRIPTION
This is an extension of PR #11077, where a new improvement of adding gravatar images was to be added, I have done the same and written two test cases, first for default size and second for custom_size, the function increases the original size to 2X and generated a safe_md5 hash for the email to constitute a URL,

Below is the screenshot of the passing test case.

![Screenshot 2024-03-26 103751](https://github.com/wagtail/wagtail/assets/117419442/fcad5d25-337d-4e07-99ab-8c86ce06f9b8)

