### PR TITLE
Add `_editor_js.html` include to `wagtailadmin/generic/form.html`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ Changelog
  * Fix: Ensure dropdown content cannot get higher than the viewport and add scrolling within content if needed (Chiemezuo Akujobi)
  * Fix: Prevent snippets model index view from crashing when a model does not have an `objects` manager (Jhonatan Lopes)
  * Fix: Fix `get_dummy_request`'s resulting host name when running tests with `ALLOWED_HOSTS = ["*"]` (David Buxton)
+ * Fix: Ensure JavaScript for common widgets such as `InlinePanel` is included by default when editing and creating Snippets (Sage Abdullah)
  * Docs: Add contributing development documentation on how to work with a fork of Wagtail (Nix Asteri, Dan Braghis)
  * Docs: Make sure the settings panel is listed in tabbed interface examples (Tibor Leupold)
  * Docs: Update content and page names to their US spelling instead of UK spelling (Victoria Poromon)

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -48,6 +48,7 @@ depth: 1
  * Ensure dropdown content cannot get higher than the viewport and add scrolling within content if needed (Chiemezuo Akujobi)
  * Prevent snippets model index view from crashing when a model does not have an `objects` manager (Jhonatan Lopes)
  * Fix `get_dummy_request`'s resulting host name when running tests with `ALLOWED_HOSTS = ["*"]` (David Buxton)
+ * Ensure JavaScript for common widgets such as `InlinePanel` is included by default when editing and creating Snippets (Sage Abdullah)
 
 
 ### Documentation

--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -45,6 +45,7 @@
 {% block extra_js %}
     {{ block.super }}
     {{ media.js }}
+    {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}
 
 {% block extra_css %}

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -1448,6 +1448,10 @@ class TestEditHandler(WagtailTestUtils, TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/shared/panel.html")
+        # Many features from the Panels API are powered by client-side JS in
+        # _editor_js.html. We need to make sure that this template is included
+        # in the response for now.
+        self.assertTemplateUsed(response, "wagtailadmin/pages/_editor_js.html", count=1)
 
         soup = self.get_soup(response.content)
 

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
@@ -20,7 +20,6 @@
 
 {% block extra_js %}
     {{ block.super }}
-    {% include "wagtailadmin/pages/_editor_js.html" %}
 
     <script>
         // Set wagtailConfig.ACTIVE_CONTENT_LOCALE if this is a translated page

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
@@ -21,7 +21,6 @@
 
 {% block extra_js %}
     {{ block.super }}
-    {% include "wagtailadmin/pages/_editor_js.html" %}
 
     <script>
         // Set wagtailConfig.ACTIVE_CONTENT_LOCALE if this is a translated page

--- a/wagtail/users/templates/wagtailusers/users/create.html
+++ b/wagtail/users/templates/wagtailusers/users/create.html
@@ -73,8 +73,3 @@
         </form>
     </div>
 {% endblock %}
-
-{% block extra_js %}
-    {{ block.super }}
-    {% include "wagtailadmin/pages/_editor_js.html" %}
-{% endblock %}

--- a/wagtail/users/templates/wagtailusers/users/edit.html
+++ b/wagtail/users/templates/wagtailusers/users/edit.html
@@ -85,8 +85,3 @@
         </form>
     </div>
 {% endblock %}
-
-{% block extra_js %}
-    {{ block.super }}
-    {% include "wagtailadmin/pages/_editor_js.html" %}
-{% endblock %}


### PR DESCRIPTION
and remove any other `_editor_js.html` includes from templates that extend `wagtailadmin/generic/form.html`, either directly or via `wagtailadmin/generic/{create,edit}.html` templates. The only ones I found are the `wagtailsnippets/snippets/{create,edit}.html` and `wagtailusers/users/{create,edit}.html`, but please double check by:
- Searching for `wagtailadmin/pages/_editor_js.html`
- Make sure that the template that includes it does not extend from `wagtailadmin/generic/form.html`, either directly or indirectly.

Fixes #11760 and fixes #11799.