### PR TITLE
Clarify release notes for #11803

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,7 +34,6 @@ Changelog
  * Fix: Ensure dropdown content cannot get higher than the viewport and add scrolling within content if needed (Chiemezuo Akujobi)
  * Fix: Prevent snippets model index view from crashing when a model does not have an `objects` manager (Jhonatan Lopes)
  * Fix: Fix `get_dummy_request`'s resulting host name when running tests with `ALLOWED_HOSTS = ["*"]` (David Buxton)
- * Fix: Ensure JavaScript for common widgets such as `InlinePanel` is included by default when editing and creating Snippets (Sage Abdullah)
  * Docs: Add contributing development documentation on how to work with a fork of Wagtail (Nix Asteri, Dan Braghis)
  * Docs: Make sure the settings panel is listed in tabbed interface examples (Tibor Leupold)
  * Docs: Update content and page names to their US spelling instead of UK spelling (Victoria Poromon)
@@ -73,8 +72,8 @@ Changelog
  * Fix: Resolve issue local development of docs when running `make livehtml` (Sage Abdullah)
  * Fix: Resolve issue with unwanted padding in chooser modal listings (Sage Abdullah)
  * Fix: Ensure `get_add_url()` is always used to re-render the add button when the listing is refreshed in viewsets (Sage Abdullah)
- * Fix: Move modal-workflow.js script usage to base admin template instead of ad-hoc imports so that choosers work in ModelViewSets (Elhussein Almasri)
- * Fix: Ensure JavaScript for common widgets such as `InlinePanel` is included by default when editing and creating Snippets (Sage Abdullah)
+ * Fix: Move `modal-workflow.js` script usage to base admin template instead of ad-hoc imports so that choosers work in `ModelViewSet`s (Elhussein Almasri)
+ * Fix: Ensure JavaScript for common widgets such as `InlinePanel` is included by default in `ModelViewSet`'s create and edit views (Sage Abdullah)
  * Docs: Update Sphinx theme to `6.3.0` with a fix for the missing favicon (Sage Abdullah)
 
 

--- a/docs/releases/6.0.2.md
+++ b/docs/releases/6.0.2.md
@@ -17,11 +17,10 @@ depth: 1
  * Resolve issue local development of docs when running `make livehtml` (Sage Abdullah)
  * Resolve issue with unwanted padding in chooser modal listings (Sage Abdullah)
  * Ensure `get_add_url()` is always used to re-render the add button when the listing is refreshed in viewsets (Sage Abdullah)
- * Move modal-workflow.js script usage to base admin template instead of ad-hoc imports so that choosers work in ModelViewSets (Elhussein Almasri)
- * Ensure JavaScript for common widgets such as `InlinePanel` is included by default when editing and creating Snippets (Sage Abdullah)
+ * Move `modal-workflow.js` script usage to base admin template instead of ad-hoc imports so that choosers work in `ModelViewSet`s (Elhussein Almasri)
+ * Ensure JavaScript for common widgets such as `InlinePanel` is included by default in `ModelViewSet`'s create and edit views (Sage Abdullah)
 
 
 ### Documentation
 
  * Update Sphinx theme to `6.3.0` with a fix for the missing favicon (Sage Abdullah)
-

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -48,7 +48,6 @@ depth: 1
  * Ensure dropdown content cannot get higher than the viewport and add scrolling within content if needed (Chiemezuo Akujobi)
  * Prevent snippets model index view from crashing when a model does not have an `objects` manager (Jhonatan Lopes)
  * Fix `get_dummy_request`'s resulting host name when running tests with `ALLOWED_HOSTS = ["*"]` (David Buxton)
- * Ensure JavaScript for common widgets such as `InlinePanel` is included by default when editing and creating Snippets (Sage Abdullah)
 
 
 ### Documentation


### PR DESCRIPTION
The fix in #11803 is for `ModelViewSet`s, not snippets.

Also, if I remember correctly, we tend not to include bugfixes in the upcoming feature release's changelog if they are backported to a previous release branch. The idea is, the next feature release also contains bug fixes that are issued for the previous releases by default (because we merge to `main` first, then backport). Thus, the bug fixes listed for the next feature release are only those that are not backported, i.e. those that are "new" for the next feature release.