### PR TITLE
Fix for 'ManyToOneRel' object has no attribute 'verbose_name' on Document/Images Usage page

### DIFF
--- a/wagtail/models/reference_index.py
+++ b/wagtail/models/reference_index.py
@@ -649,8 +649,15 @@ class ReferenceIndex(models.Model):
 
         # ManyToOneRel (reverse accessor for ParentalKey) does not have a verbose name. So get the name of the child field instead
         if isinstance(field, models.ManyToOneRel):
-            child_field = field.related_model._meta.get_field(model_path_components[2])
-            return capfirst(child_field.verbose_name)
+            label = f"{capfirst(field.related_model._meta.verbose_name)}"
+            idx = 2
+            child_field = field.related_model._meta.get_field(model_path_components[idx])
+            while isinstance(child_field, models.ManyToOneRel):
+                label += f" → {capfirst(child_field.related_model._meta.verbose_name)}"
+                idx += 2
+                child_field = child_field.related_model._meta.get_field(model_path_components[idx])
+            label += f" → {capfirst(child_field.verbose_name)}"
+            return label
         elif isinstance(field, StreamField):
             label = f"{capfirst(field.verbose_name)}"
             block = field.stream_block


### PR DESCRIPTION
Users cannot view the usage details of documents or images (where they’re being used) used at least once in any multiple Parentalkey levels models from the Wagtail admin site. This seems to be a problem in referencing the `verbose_name` of the correct child field due to the nested structure of multi-level ManyToOneRel fields.

More information including steps to reproduce the issue on a fresh Wagtail project can be found on #11482.

This fix should also fix an initial issue where the first field level's verbose_name is excluded from the returned string.

**For example, for a field reference of ResourceItem → Document within a ResourceGroup object:**
Current result: **Document**
This fix's result: **Resource item → Document**
