### PR TITLE
Fix exclude_fields_in_copy with DeferringRelatedManager object

### DIFF
--- a/wagtail/actions/copy_page.py
+++ b/wagtail/actions/copy_page.py
@@ -222,7 +222,11 @@ class CopyPageAction:
                             )
 
                 for exclude_field in specific_page.exclude_fields_in_copy:
-                    if exclude_field in revision_content and hasattr(
+                    if hasattr(page_copy, exclude_field) and hasattr(
+                        getattr(page_copy, exclude_field), "all"
+                    ):
+                        revision_content[exclude_field] = []
+                    elif exclude_field in revision_content and hasattr(
                         page_copy, exclude_field
                     ):
                         revision_content[exclude_field] = getattr(

--- a/wagtail/test/testapp/migrations/0015_gallerypage_gallerypageimage.py
+++ b/wagtail/test/testapp/migrations/0015_gallerypage_gallerypageimage.py
@@ -66,6 +66,15 @@ class Migration(migrations.Migration):
                         to="tests.gallerypage",
                     ),
                 ),
+                (
+                    "exclude_field",
+                    modelcluster.fields.ParentalKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="related_manager",
+                        to="tests.pagewithexcludedcopyfield",
+                    ),
+                ),
             ],
             options={
                 "ordering": ["sort_order"],

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -217,12 +217,13 @@ class PageWithExcludedCopyField(Page):
 
     # Exclude this field from being copied
     special_field = models.CharField(blank=True, max_length=255, default="Very Special")
-    exclude_fields_in_copy = ["special_field"]
+    exclude_fields_in_copy = ["special_field", "related_manager"]
 
     content_panels = [
         FieldPanel("title", classname="title"),
         FieldPanel("special_field"),
         FieldPanel("content"),
+        MultipleChooserPanel("related_manager", chooser_field_name="image"),
     ]
 
 
@@ -2192,6 +2193,12 @@ class GalleryPage(Page):
 class GalleryPageImage(Orderable):
     page = ParentalKey(
         "tests.GalleryPage", related_name="gallery_images", on_delete=models.CASCADE
+    )
+    exclude_field = ParentalKey(
+        "tests.PageWithExcludedCopyField",
+        related_name="related_manager",
+        on_delete=models.CASCADE,
+        null=True,
     )
     image = models.ForeignKey(
         "wagtailimages.Image",

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -1915,7 +1915,7 @@ class TestCopyPage(TestCase):
         exclude_field_related_manager = new_page.latest_revision.content[
             "related_manager"
         ]
-        
+
         self.assertEqual(page.title, new_page.title)
         self.assertNotEqual(page.id, new_page.id)
         self.assertNotEqual(page.path, new_page.path)
@@ -1923,7 +1923,7 @@ class TestCopyPage(TestCase):
         self.assertNotEqual(page.special_field, new_page.special_field)
         self.assertEqual(new_page.special_field, exclude_field)
         self.assertEqual(exclude_field_related_manager, [])
-        
+
     def test_page_with_generic_relation(self):
         """Test that a page with a GenericRelation will have that relation ignored when
         copying.

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -1912,14 +1912,18 @@ class TestCopyPage(TestCase):
         page.save_revision()
         new_page = page.copy(to=homepage, update_attrs={"slug": "disco-2"})
         exclude_field = new_page.latest_revision.content["special_field"]
-
+        exclude_field_related_manager = new_page.latest_revision.content[
+            "related_manager"
+        ]
+        
         self.assertEqual(page.title, new_page.title)
         self.assertNotEqual(page.id, new_page.id)
         self.assertNotEqual(page.path, new_page.path)
         # special_field is in the list to be excluded
         self.assertNotEqual(page.special_field, new_page.special_field)
         self.assertEqual(new_page.special_field, exclude_field)
-
+        self.assertEqual(exclude_field_related_manager, [])
+        
     def test_page_with_generic_relation(self):
         """Test that a page with a GenericRelation will have that relation ignored when
         copying.


### PR DESCRIPTION
Fixes #11715

After                             |  Before
:------------------:         |    :------------------:
![After](https://github.com/wagtail/wagtail/assets/90080237/671bfa25-445d-4680-89c1-0caf069e0a5c) | ![Before](https://github.com/wagtail/wagtail/assets/90080237/f7ac70e8-d618-456a-a8ca-e24fb1d9cb9d)


