### PR TITLE
Document use of SECRET_KEY to obscure Wagtail version

### DIFF
--- a/wagtail/admin/staticfiles.py
+++ b/wagtail/admin/staticfiles.py
@@ -29,6 +29,7 @@ except AttributeError:
 
 
 if use_version_strings:
+    # SECRET_KEY is used to prevent exposing the Wagtail version
     VERSION_HASH = hashlib.sha1(
         (__version__ + settings.SECRET_KEY).encode("utf-8")
     ).hexdigest()[:8]

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -127,6 +127,7 @@ def get_sprite_hash():
     global sprite_hash
     if not sprite_hash:
         content = str(home.sprite(None).content, "utf-8")
+        # SECRET_KEY is used to prevent exposing the Wagtail version
         sprite_hash = hashlib.sha1(
             (content + settings.SECRET_KEY).encode("utf-8")
         ).hexdigest()[:8]


### PR DESCRIPTION
Whilst ideally we wouldn't use the secret key, it's the best way to ensure the value doesn't expose the wagtail version, whilst still being deployment-specific.

_Please describe the problem you're fixing here. Include the issue number, if applicable._
