### PR TITLE
Universal listing: implement new UI for groups views

### DIFF
--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -230,7 +230,7 @@ class StatusSidePanel(BaseSidePanel):
         context["last_updated_info"] = self.last_updated_info
         context.update(self.get_scheduled_publishing_context(parent_context))
         context.update(self.get_lock_context(parent_context))
-        if self.object.pk:
+        if self.object.pk and self.usage_url:
             context.update(self.get_usage_context())
         return context
 

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -753,7 +753,11 @@ class EditView(
         return MediaContainer(side_panels)
 
     def get_last_updated_info(self):
-        return log_registry.get_logs_for_instance(self.object).first()
+        return (
+            log_registry.get_logs_for_instance(self.object)
+            .select_related("user")
+            .first()
+        )
 
     def get_edit_url(self):
         if not self.edit_url_name:

--- a/wagtail/users/templates/wagtailusers/groups/create.html
+++ b/wagtail/users/templates/wagtailusers/groups/create.html
@@ -1,11 +1,5 @@
-{% extends "wagtailadmin/generic/base.html" %}
+{% extends "wagtailadmin/generic/create.html" %}
 {% load wagtailusers_tags i18n wagtailadmin_tags %}
-
-{% block extra_css %}
-    {{ block.super }}
-
-    {{ form_media.css }}
-{% endblock %}
 
 {% block main_content %}
     <form action="{% url 'wagtailusers_groups:add' %}" method="POST" novalidate>

--- a/wagtail/users/templates/wagtailusers/groups/edit.html
+++ b/wagtail/users/templates/wagtailusers/groups/edit.html
@@ -1,11 +1,5 @@
-{% extends "wagtailadmin/generic/base.html" %}
+{% extends "wagtailadmin/generic/edit.html" %}
 {% load wagtailusers_tags wagtailadmin_tags i18n %}
-
-{% block extra_css %}
-    {{ block.super }}
-
-    {{ form_media.css }}
-{% endblock %}
 
 {% block main_header %}
     {% trans "View users in this group" as users_str %}

--- a/wagtail/users/templates/wagtailusers/groups/edit.html
+++ b/wagtail/users/templates/wagtailusers/groups/edit.html
@@ -1,12 +1,6 @@
 {% extends "wagtailadmin/generic/edit.html" %}
 {% load wagtailusers_tags wagtailadmin_tags i18n %}
 
-{% block main_header %}
-    {% trans "View users in this group" as users_str %}
-    {% url 'wagtailusers_groups:users' group.id as group_users_url %}
-    {% include "wagtailadmin/shared/header.html" with title=page_title action_icon="user" action_url=group_users_url action_text=users_str subtitle=page_subtitle icon="group" %}
-{% endblock %}
-
 {% block main_content %}
     <form action="{% url 'wagtailusers_groups:edit' group.id %}" method="POST" novalidate>
         {% csrf_token %}

--- a/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
@@ -1,5 +1,3 @@
 {% load wagtailadmin_tags %}
 <script src="{% versioned_static 'wagtailadmin/js/expanding-formset.js' %}"></script>
 <script src="{% versioned_static 'wagtailusers/js/group-form.js' %}"></script>
-
-{{ form_media.js }}

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -16,6 +16,7 @@ from django.urls import reverse
 from wagtail import hooks
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.models import Admin
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 from wagtail.models import (
     Collection,
@@ -1424,6 +1425,11 @@ class TestGroupCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
             ],
             response.content,
         )
+        # Should contain the JS from the form and the template include
+        page_chooser_js = versioned_static("wagtailadmin/js/page-chooser.js")
+        group_form_js = versioned_static("wagtailusers/js/group-form.js")
+        self.assertContains(response, page_chooser_js)
+        self.assertContains(response, group_form_js)
 
     def test_num_queries(self):
         # Warm up the cache
@@ -1784,6 +1790,11 @@ class TestGroupEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
             ],
             response.content,
         )
+        # Should contain the JS from the form and the template include
+        page_chooser_js = versioned_static("wagtailadmin/js/page-chooser.js")
+        group_form_js = versioned_static("wagtailusers/js/group-form.js")
+        self.assertContains(response, page_chooser_js)
+        self.assertContains(response, group_form_js)
 
         url_finder = AdminURLFinder(self.user)
         expected_url = "/admin/groups/edit/%d/" % self.test_group.id

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -1342,7 +1342,9 @@ class TestGroupIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailadmin/generic/index.html")
         # response should contain page furniture, including the "Add a group" button
         self.assertContains(response, "Add a group")
-        self.assertBreadcrumbsNotRendered(response.content)
+        self.assertBreadcrumbsItemsRendered(
+            [{"url": "", "label": "Groups"}], response.content
+        )
 
     def test_search(self):
         response = self.get({"q": "Hello"})
@@ -1415,7 +1417,13 @@ class TestGroupCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailusers/groups/create.html")
-        self.assertBreadcrumbsNotRendered(response.content)
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {"url": "/admin/groups/", "label": "Groups"},
+                {"url": "", "label": "New: Group"},
+            ],
+            response.content,
+        )
 
     def test_num_queries(self):
         # Warm up the cache
@@ -1766,7 +1774,16 @@ class TestGroupEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailusers/groups/edit.html")
-        self.assertBreadcrumbsNotRendered(response.content)
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {
+                    "url": "/admin/groups/",
+                    "label": "Groups",
+                },
+                {"url": "", "label": str(self.test_group)},
+            ],
+            response.content,
+        )
 
         url_finder = AdminURLFinder(self.user)
         expected_url = "/admin/groups/edit/%d/" % self.test_group.id

--- a/wagtail/users/views/groups.py
+++ b/wagtail/users/views/groups.py
@@ -157,7 +157,6 @@ class GroupViewSet(ModelViewSet):
     model = Group
     ordering = ["name"]
     add_to_reference_index = False
-    _show_breadcrumbs = False
 
     index_view_class = IndexView
     add_view_class = CreateView

--- a/wagtail/users/views/groups.py
+++ b/wagtail/users/views/groups.py
@@ -1,11 +1,14 @@
 from django.contrib.auth.models import Group
-from django.urls import re_path
+from django.urls import re_path, reverse
+from django.utils.functional import cached_property
+from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.admin.ui.tables import TitleColumn
 from wagtail.admin.views import generic
 from wagtail.admin.viewsets.model import ModelViewSet
+from wagtail.admin.widgets.button import HeaderButton
 from wagtail.users.forms import GroupForm, GroupPagePermissionFormSet
 from wagtail.users.views.users import Index
 
@@ -108,6 +111,16 @@ class EditView(PermissionPanelFormsMixin, generic.EditView):
     error_message = _("The group could not be saved due to errors.")
     delete_item_label = _("Delete group")
     context_object_name = "group"
+
+    @cached_property
+    def header_buttons(self):
+        return [
+            HeaderButton(
+                gettext("View users in this group"),
+                url=reverse("wagtailusers_groups:users", args=[self.object.pk]),
+                icon_name="user",
+            )
+        ]
 
     def post(self, request, *args, **kwargs):
         """

--- a/wagtail/users/views/groups.py
+++ b/wagtail/users/views/groups.py
@@ -64,11 +64,9 @@ class PermissionPanelFormsMixin:
 
         context = super().get_context_data(**kwargs)
 
-        # add a 'form_media' variable for the collected js/css media from the form and all formsets
-        form_media = context["form"].media
+        # Add js/css media from the formsets to the existing media
         for panel in context["permission_panels"]:
-            form_media += panel.media
-        context["form_media"] = form_media
+            context["media"] += panel.media
 
         return context
 
@@ -94,9 +92,6 @@ class IndexView(generic.IndexView):
 class CreateView(PermissionPanelFormsMixin, generic.CreateView):
     page_title = _("Add group")
     success_message = _("Group '%(object)s' created.")
-
-    def get_page_subtitle(self):
-        return ""
 
     def post(self, request, *args, **kwargs):
         """

--- a/wagtail/users/views/groups.py
+++ b/wagtail/users/views/groups.py
@@ -161,7 +161,6 @@ class GroupViewSet(ModelViewSet):
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(
             **{
-                "history_url_name": None,
                 "usage_url_name": None,
                 **kwargs,
             }


### PR DESCRIPTION
## Listing view

<img width="811" alt="group listing view" src="https://github.com/wagtail/wagtail/assets/6379424/2ad9a4c4-5a70-4aac-a48a-80b6b02ffef1">

## Create view

<img width="1126" alt="group create view" src="https://github.com/wagtail/wagtail/assets/6379424/df3c319e-46b4-46da-97d6-2058fc4aa3fc">

## Edit view

(Now it also has the status side panel with the last updated information displayed)

<img width="1080" alt="group edit view" src="https://github.com/wagtail/wagtail/assets/6379424/e941a586-c409-49c2-8905-a09e3e287527">

## History view

This was previously accessible directly from the URL when the history view was added to the base `ModelViewSet`. However, there was no way to access it normally. Now that we render the breadcrumbs in the edit view as well, we can link to the history view properly like in other edit views.

<img width="1080" alt="group history view" src="https://github.com/wagtail/wagtail/assets/6379424/828127bc-57cc-445a-a5ab-845b094c18dd">
