### PR TITLE
Prevent crash when loading an empty table block in the editor

### DIFF
--- a/wagtail/contrib/table_block/blocks.py
+++ b/wagtail/contrib/table_block/blocks.py
@@ -132,7 +132,7 @@ class TableBlock(FieldBlock):
         value for the header choice. I would really like to have this default to "" and force the
         editor to reaffirm they don't want any headers, but that would be a breaking change.
         """
-        if not value.get("table_header_choice", ""):
+        if value and not value.get("table_header_choice", ""):
             if value.get("first_row_is_table_header", False) and value.get(
                 "first_col_is_header", False
             ):

--- a/wagtail/contrib/table_block/tests.py
+++ b/wagtail/contrib/table_block/tests.py
@@ -439,6 +439,12 @@ class TestTableBlock(TestCase):
         """
         self.assertHTMLEqual(result, expected)
 
+    def test_empty_table_block_to_python(self):
+        # Should not raise an error
+        # See https://github.com/wagtail/wagtail/issues/11816
+        block = TableBlock()
+        self.assertIsNone(block.to_python(None))
+
 
 class TestTableBlockForm(WagtailTestUtils, SimpleTestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #11816.