### PR TITLE
Add ability for Settings icons to be reflected on Setting edit views

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@ Changelog
  * Allow specifying a `STORAGES` alias name for `WAGTAILIMAGES_RENDITION_STORAGE` (Alex Baron)
  * Update `PASSWORD_REQUIRED_TEMPLATE` setting to `WAGTAIL_PASSWORD_REQUIRED_TEMPLATE` with deprecation of previous naming (Saksham Misra, LB (Ben) Johnston)
  * Update `DOCUMENT_PASSWORD_REQUIRED_TEMPLATE` setting to `WAGTAILDOCS_PASSWORD_REQUIRED_TEMPLATE` with deprecation of previous naming (Saksham Misra, LB (Ben) Johnston)
+ * When editing settings (contrib) use the same icon in the editing view that was declared when registering the setting (Vince Salvino, Rohit Sharma)
  * Fix: Fix typo in `__str__` for MySQL search index (Jake Howard)
  * Fix: Ensure that unit tests correctly check for migrations in all core Wagtail apps (Matt Westcott)
  * Fix: Correctly handle `date` objects on `human_readable_date` template tag (Jhonatan Lopes)

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -47,6 +47,7 @@ depth: 1
  * Allow specifying a `STORAGES` alias name for `WAGTAILIMAGES_RENDITION_STORAGE` (Alex Baron)
  * Update `PASSWORD_REQUIRED_TEMPLATE` setting to `WAGTAIL_PASSWORD_REQUIRED_TEMPLATE` with deprecation of previous naming (Saksham Misra, LB (Ben) Johnston)
  * Update `DOCUMENT_PASSWORD_REQUIRED_TEMPLATE` setting to `WAGTAILDOCS_PASSWORD_REQUIRED_TEMPLATE` with deprecation of previous naming (Saksham Misra, LB (Ben) Johnston)
+ * When editing settings (contrib) use the same icon in the editing view that was declared when registering the setting (Vince Salvino, Rohit Sharma)
 
 
 ### Bug fixes

--- a/wagtail/contrib/settings/registry.py
+++ b/wagtail/contrib/settings/registry.py
@@ -67,12 +67,17 @@ class GenericSettingAdminURLFinder(ModelAdminURLFinder):
 
 
 class Registry(list):
-    def register(self, model, **kwargs):
+    def __init__(self):
+        self._model_icons = {}
+
+    def register(self, model, icon="cog", **kwargs):
         from .models import BaseGenericSetting, BaseSiteSetting
 
         """
         Register a model as a setting, adding it to the wagtail admin menu
         """
+        if icon:
+            self._model_icons[model] = icon
 
         # Don't bother registering this if it is already registered
         if model in self:
@@ -82,7 +87,7 @@ class Registry(list):
         # Register a new menu item in the settings menu
         @hooks.register("register_settings_menu_item")
         def menu_hook():
-            return SettingMenuItem(model, **kwargs)
+            return SettingMenuItem(model, icon=self._model_icons.get(model), **kwargs)
 
         @hooks.register("register_permissions")
         def permissions_hook():
@@ -113,13 +118,13 @@ class Registry(list):
 
         return model
 
-    def register_decorator(self, model=None, **kwargs):
+    def register_decorator(self, model=None, icon="cog", **kwargs):
         """
         Register a model as a setting in the Wagtail admin
         """
         if model is None:
-            return lambda model: self.register(model, **kwargs)
-        return self.register(model, **kwargs)
+            return lambda model: self.register(model, icon=icon, **kwargs)
+        return self.register(model, icon=icon, **kwargs)
 
     def get_by_natural_key(self, app_label, model_name):
         """

--- a/wagtail/contrib/settings/tests/generic/test_admin.py
+++ b/wagtail/contrib/settings/tests/generic/test_admin.py
@@ -126,6 +126,15 @@ class TestGenericSettingEditView(BaseTestGenericSettingView):
         )
         self.assertEqual(response.status_code, 404)
 
+    def test_register_with_icon(self):
+        edit_url = reverse("wagtailsettings:edit", args=("tests", "IconGenericSetting"))
+        edit_response = self.client.get(edit_url, follow=True)
+
+        self.assertContains(
+            edit_response,
+            """<svg class="icon icon-icon-setting-tag w-header__glyph" aria-hidden="true"><use href="#icon-icon-setting-tag"></use></svg>""",
+        )
+
     def test_edit_invalid(self):
         response = self.post(post_data={"foo": "bar"})
         self.assertContains(response, "The setting could not be saved due to errors.")

--- a/wagtail/contrib/settings/tests/site_specific/test_admin.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_admin.py
@@ -126,6 +126,15 @@ class TestSiteSettingEditView(BaseTestSiteSettingView):
         )
         self.assertEqual(response.status_code, 404)
 
+    def test_register_with_icon(self):
+        edit_url = reverse("wagtailsettings:edit", args=("tests", "IconGenericSetting"))
+        edit_response = self.client.get(edit_url, follow=True)
+
+        self.assertContains(
+            edit_response,
+            """<svg class="icon icon-icon-setting-tag w-header__glyph" aria-hidden="true"><use href="#icon-icon-setting-tag"></use></svg>""",
+        )
+
     def test_edit_invalid(self):
         response = self.post(post_data={"foo": "bar"})
         self.assertContains(response, "The setting could not be saved due to errors.")

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -80,7 +80,6 @@ def redirect_to_relevant_instance(request, app_name, model_name):
 
 class EditView(generic.EditView):
     template_name = "wagtailsettings/edit.html"
-    header_icon = "cogs"
     error_message = gettext_lazy("The setting could not be saved due to errors.")
 
     def setup(self, request, app_name, model_name, *args, **kwargs):
@@ -129,11 +128,14 @@ class EditView(generic.EditView):
 
         media = form.media + edit_handler.media
 
+        header_icon = registry._model_icons.get(self.model)
+
         context.update(
             {
                 "edit_handler": edit_handler,
                 "site_switcher": site_switcher,
                 "media": media,
+                "header_icon": header_icon,
             }
         )
 


### PR DESCRIPTION
Fixes #11790 

Currently, when we register a setting with an icon, the icon only appears on the menu item list in the admin panel. However, the edit view of that setting always displays a default 'cogs' icon, regardless of the setting's registered icon. This PR addresses this issue by ensuring that the same icon also appears in its corresponding edit view.

### After

![image](https://github.com/wagtail/wagtail/assets/111359305/1cb7dc80-9b57-4e6d-9a62-b9f9e8474433)

![image](https://github.com/wagtail/wagtail/assets/111359305/18577085-f527-4650-b847-22b33649b5d7)
