### PR TITLE
Fix minor spelling (customizations) in 6.1 release notes

### DIFF
--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -72,7 +72,7 @@ depth: 1
  * Update unit tests to always use the faster, built in `html.parser` & remove `html5lib` dependency (Jake Howard)
  * Adjust Eslint rules for TypeScript files (Karthik Ayangar)
  * Rename the React `Button` that only renders links (a element) to `Link` and remove unused prop & behaviors that was non-compliant for aria role usage (Advik Kabra)
- * Set up an `wagtail.models.AbstractWorkflow` model to support future customisations around workflows (Hossein)
+ * Set up an `wagtail.models.AbstractWorkflow` model to support future customizations around workflows (Hossein)
  * Improve `classnames` template tag to handle nested lists of strings, use template tag for admin `body` element (LB (Ben) Johnston)
  * Merge `UploadedDocument` and `UploadedImage` into new `UploadedFile` model for easier shared code usage (Advik Kabra, Karl Hobley)
  * Optimize queries in dashboard panels (Sage Abdullah)
@@ -110,7 +110,7 @@ Overriding these inner values on the global `window.chooserUrls` object will sti
 
 #### Example
 
-It's recommended that usage of this global is removed in any customisations or third party packages and instead a custom Draftail Entity be used instead. See example below.
+It's recommended that usage of this global is removed in any customizations or third party packages and instead a custom Draftail Entity be used instead. See example below.
 
 ##### Old
 
@@ -165,7 +165,7 @@ def register_my_custom_feature(features):
 
 To override existing chooser Entities' `chooserUrls` values, here is an example of an unsupported monkey patch can achieve a similar goal.
 
-However, it's recommended that a [custom Entity be created](creating_new_draftail_editor_entities) to be registered as a replacement feature for Draftail customisations as per the documentation.
+However, it's recommended that a [custom Entity be created](creating_new_draftail_editor_entities) to be registered as a replacement feature for Draftail customizations as per the documentation.
 
 ```py
 # .../wagtail_hooks.py


### PR DESCRIPTION
Just a few small spelling updates to align with our latest documentation styleguide.

I am still getting into the habit of using `z` not `s`.