### PR TITLE
Fix #11716: Failure in Dynamic Image ServeView

### DIFF
--- a/wagtail/admin/tests/viewsets/test_image_presence.py
+++ b/wagtail/admin/tests/viewsets/test_image_presence.py
@@ -1,0 +1,49 @@
+import io
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+from django.test import TestCase
+
+from wagtail.test.utils import WagtailTestUtils
+
+# This test was made in order to test the Dynamic Image Serve View.
+# For this test you will need to change your "mysite" in order for its home_page.html to show
+# an image.
+# To do that, you need to ensure that you have (it can be dynamic) serve view in the template and update
+# the urls.py. Problably an addition of "image = models.ForeignKey( get_image_model(), ...)"
+# field to the HomePage class will also be needed
+
+
+class TestImagePresence(WagtailTestUtils, TestCase):
+    def test_image_presence(self):
+        # Make request to localhost
+        response = requests.get("http://localhost:8000")
+
+        # Check if the request was successful
+        self.assertEqual(response.status_code, 200)
+
+        # Parse the HTML content of the response
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        # Find img elements with src="/images/"
+        images = soup.find_all("img", src=lambda x: x and "/images/" in x)
+
+        # Check if at least one image was found
+        self.assertTrue(images)
+
+        # Check for images with error (status code 500)
+        for img in images:
+            img_src = img.get("src")
+            full_img_url = urljoin(
+                "http://localhost:8000", img_src
+            )  # Construct full image URL
+
+            # Request the image
+            img_response = requests.get(full_img_url, stream=True)
+
+            # Check if the response is a properly opened file
+            if img_response.ok:
+                self.assertTrue(isinstance(img_response.raw, io.IOBase))
+            else:
+                self.fail(f"Error accessing image: {img_src}")

--- a/wagtail/images/views/serve.py
+++ b/wagtail/images/views/serve.py
@@ -65,6 +65,7 @@ class ServeView(View):
             mime_type = willow_image.mime_type
 
         # Serve the file
+        rendition.file.open("rb")
         return FileResponse(rendition.file, content_type=mime_type)
 
     def redirect(self, rendition):


### PR DESCRIPTION
Following the line of thought of @LANCECORREIA, I added back the line that was removed in a previous commit,"rendition.file.open("rb")" in serve.py. I also, created a test in admin/tests/viewsets , test_image_presence.py that confirms that the issue has been resolved. The test looks for a status error code 500 in the display of an image, something that happenned when the dynamic serve view failed. If it finds it, the test fails. The test also passes when we dont't use a dynamic serve view.
Have in mind that test_image_presence.py in order to run, needs to have already have an image in our home page that we are trying to display.
I am new to wagtail so if something isn't to your liking, please let me know.


Fixes #11716