### PR TITLE
Improve exception handling in `AbstractImage.create_renditions()`

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -18,7 +18,6 @@ from django.core import checks
 from django.core.cache import DEFAULT_CACHE_ALIAS, InvalidCacheBackendError, caches
 from django.core.cache.backends.base import BaseCache
 from django.core.files import File
-from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.db import models
 from django.db.models import Q

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -695,7 +695,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
             filter = filter_map[existing.filter_spec]
             return_value[filter] = existing
 
-            for new in to_create:
+            for new in list(to_create):
                 if (
                     new.filter_spec == existing.filter_spec
                     and new.focal_point_key == existing.focal_point_key

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -715,6 +715,23 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
 
         return return_value
 
+    def generate_rendition_instance(
+        self, filter: "Filter", source: BytesIO
+    ) -> "AbstractRendition":
+        """
+        Use the supplied ``source`` image to create and return an
+        **unsaved** ``Rendition`` instance, with a ``file`` value reflecting
+        the supplied ``filter`` value and focal point values from this object.
+        """
+        return self.get_rendition_model()(
+            image=self,
+            filter_spec=filter.spec,
+            focal_point_key=filter.get_cache_key(self),
+            file=self.generate_rendition_file(
+                filter, source=File(source, name=self.file.name)
+            ),
+        )
+
     def generate_rendition_file(self, filter: "Filter", *, source: File = None) -> File:
         """
         Generates an in-memory image matching the supplied ``filter`` value

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import hashlib
 import itertools
 import logging
@@ -5,7 +6,6 @@ import os.path
 import re
 import time
 from collections import OrderedDict, defaultdict
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from io import BytesIO
 from tempfile import SpooledTemporaryFile
@@ -653,28 +653,22 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         return_value: Dict[Filter, AbstractRendition] = {}
         filter_map: Dict[str, Filter] = {f.spec: f for f in filters}
 
+        # Read file contents into memory
         with self.open_file() as file:
             original_image_bytes = file.read()
 
         to_create = []
 
-        def _generate_single_rendition(filter):
-            # Using ContentFile here ensures we generate all renditions. Simply
-            # passing self.file required several page reloads to generate all
-            image_file = self.generate_rendition_file(
-                filter, source=ContentFile(original_image_bytes, name=self.file.name)
-            )
-            to_create.append(
-                Rendition(
-                    image=self,
-                    filter_spec=filter.spec,
-                    focal_point_key=filter.get_cache_key(self),
-                    file=image_file,
+        with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+            for future in concurrent.futures.as_completed(
+                executor.submit(
+                    self.generate_rendition_instance,
+                    filter,
+                    BytesIO(original_image_bytes),
                 )
-            )
-
-        with ThreadPoolExecutor() as executor:
-            executor.map(_generate_single_rendition, filters)
+                for filter in filters
+            ):
+                to_create.append(future.result())
 
         # Rendition generation can take a while. So, if other processes have created
         # identical renditions in the meantime, we should find them to avoid clashes.


### PR DESCRIPTION
Following some panic and confusion over at https://github.com/wagtail/bakerydemo/issues/480, I thought it would be a good idea to revisit the implementation to better surface errors encountered by individual threads, whilst also refining the design / in-code documentation a little.

While there, I also:

- Fixed a list mutation issue that was picked up by my new linter configuration
- Added `max_workers=3` to the `ThreadPoolExecutor`. The thinking here is that the processing done by each thread is intensive in more ways than just I/O - so, the default maximum of "number of processors on the machine, multiplied by 5" feels too generous