### PR TITLE
Fix timezone handling in timesince_last_update

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,7 @@ Changelog
  * Fix: Ensure dropdown content cannot get higher than the viewport and add scrolling within content if needed (Chiemezuo Akujobi)
  * Fix: Prevent snippets model index view from crashing when a model does not have an `objects` manager (Jhonatan Lopes)
  * Fix: Fix `get_dummy_request`'s resulting host name when running tests with `ALLOWED_HOSTS = ["*"]` (David Buxton)
+ * Fix: Fix timezone handling in the `timesince_last_update` template tag (Matt Westcott)
  * Docs: Add contributing development documentation on how to work with a fork of Wagtail (Nix Asteri, Dan Braghis)
  * Docs: Make sure the settings panel is listed in tabbed interface examples (Tibor Leupold)
  * Docs: Update content and page names to their US spelling instead of UK spelling (Victoria Poromon)

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -53,6 +53,7 @@ depth: 1
  * Ensure dropdown content cannot get higher than the viewport and add scrolling within content if needed (Chiemezuo Akujobi)
  * Prevent snippets model index view from crashing when a model does not have an `objects` manager (Jhonatan Lopes)
  * Fix `get_dummy_request`'s resulting host name when running tests with `ALLOWED_HOSTS = ["*"]` (David Buxton)
+ * Fix timezone handling in the `timesince_last_update` template tag (Matt Westcott)
 
 
 ### Documentation

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -761,7 +761,6 @@ def timesince_simple(d):
     1 week, 1 day ago -> 1 week ago
     0 minutes ago -> just now
     """
-    # Note: Duplicate code in timesince_last_update()
     time_period = timesince(d).split(",")[0]
     if time_period == avoid_wrapping(_("0 minutes")):
         return _("just now")
@@ -780,11 +779,25 @@ def timesince_last_update(
     """
     # translation usage below is intentionally verbose to be easier to work with translations
 
-    if last_update.date() == datetime.datetime.today().date():
+    current_datetime = timezone.now()
+    if timezone.is_aware(current_datetime):
+        # timezone support is enabled - make last_update timezone-aware and set to the user's
+        # timezone
+        current_datetime = timezone.localtime(current_datetime)
         if timezone.is_aware(last_update):
-            time_str = timezone.localtime(last_update).strftime("%H:%M")
+            local_datetime = timezone.localtime(last_update)
         else:
-            time_str = last_update.strftime("%H:%M")
+            local_datetime = timezone.make_aware(last_update)
+    else:
+        # timezone support is disabled - use naive datetimes
+        if timezone.is_aware(last_update):
+            local_datetime = timezone.make_naive(last_update)
+        else:
+            local_datetime = last_update
+
+    # Use an explicit timestamp if last_update is today as seen in the current user's time zone
+    if local_datetime.date() == current_datetime.date():
+        time_str = local_datetime.strftime("%H:%M")
 
         if show_time_prefix:
             if user_display_name:
@@ -804,17 +817,9 @@ def timesince_last_update(
                 return time_str
     else:
         if use_shorthand:
-            # Note: Duplicate code in timesince_simple()
-            time_period = timesince(last_update).split(",")[0]
-            if time_period == avoid_wrapping(_("0 minutes")):
-                if user_display_name:
-                    return _("just now by %(user_display_name)s") % {
-                        "user_display_name": user_display_name
-                    }
-                else:
-                    return _("just now")
+            time_period = timesince(local_datetime, now=current_datetime).split(",")[0]
         else:
-            time_period = timesince(last_update)
+            time_period = timesince(local_datetime, now=current_datetime)
 
         if user_display_name:
             return _("%(time_period)s ago by %(user_display_name)s") % {


### PR DESCRIPTION
Ref: https://github.com/wagtail/wagtail/pull/11815/files#r1556095493

test_group_edit was failing when run after 3pm UTC, due to the output being rendered as "Just now" instead of an explicit time. This was due to a previously unsurfaced logic error in the timesince_last_update tag: if the timestamp was passed as a timezone-aware datetime in UTC, it was failing to translate this to local time and thus it compared as a different date, even if it was only from a moment ago. Consequently, it was following the "X days ago" path that was only supposed to be used for timestamps before today.

With this fixed, the special-case for "Just now" can be removed since it won't come into play for timestamps of yesterday and earlier. (Well, technically it could in the first minute after midnight, but that really doesn't warrant a special case...)
