### PR TITLE
Correct LF vs CRLF instruction in Windows development docs

### DIFF
--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -62,10 +62,9 @@ If you are confident with Python and Node development on Windows and wish to pro
 
 We recommend [Chocolatey](https://chocolatey.org/install) for managing packages in Windows. Once Chocolatey is installed you can then install the [`make`](https://community.chocolatey.org/packages/make) utility in order to run common build and development commands.
 
-To effectively collaborate with other developers on different operating systems, we use CRLF to handle our line endings. You can configure this in Git using:
+We use LF for our line endings. To effectively collaborate with other developers on different operating systems, use Git's automatic CRLF handling by setting the `core.autocrlf` config to `true`:
 
 ```doscon
-#  Configures how Git handles line endings and sets the value to True
 git config --global core.autocrlf true
 ```
 


### PR DESCRIPTION
The docs states that we use CRLF for our line endings, which is not true:
https://github.com/wagtail/wagtail/blob/bd1a81d88f063bfadfa32c31b5289d6313051703/.editorconfig#L4

Repositories almost always use LF instead of CRLF. See also: https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf