### PR TITLE
Support forwards compatible configuration for private pages/collections

### DIFF
--- a/docs/advanced_topics/privacy.md
+++ b/docs/advanced_topics/privacy.md
@@ -12,10 +12,10 @@ Users with publish permission on a page can set it to be private by clicking the
 Shared passwords should not be used to protect sensitive content, as the password is shared between all users, and stored in plain text in the database. Where possible, it's recommended to require users log in to access private page content.
 ```
 
-You can disable shared password for pages using `WAGTAIL_ALLOW_SHARED_PASSWORD_PAGE`.
+You can disable shared password for pages using `WAGTAIL_PRIVATE_PAGE_OPTIONS`.
 
 ```python
-WAGTAIL_ALLOW_SHARED_PASSWORD_PAGE = False
+WAGTAIL_PRIVATE_PAGE_OPTIONS = {"SHARED_PASSWORD": False}
 ```
 
 Any existing shared password usage will remain active but will not be viewable by the user within the admin, these can be removed in the Django shell as follows.
@@ -33,10 +33,10 @@ for page in Page.objects.private():
 
 Similarly, documents can be made private by placing them in a collection with appropriate privacy settings (see: [](image_document_permissions)).
 
-You can also disable shared password for collections (which will impact document links) using `WAGTAIL_ALLOW_SHARED_PASSWORD_COLLECTION`.
+You can also disable shared password for collections (which will impact document links) using `WAGTAILDOCS_PRIVATE_COLLECTION_OPTIONS`.
 
 ```python
-WAGTAIL_ALLOW_SHARED_PASSWORD_COLLECTION = False
+WAGTAILDOCS_PRIVATE_COLLECTION_OPTIONS = {"SHARED_PASSWORD": False}
 ```
 
 Any existing shared password usage will remain active but will not be viewable within the admin, these can be removed in the Django shell as follows.

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -676,22 +676,22 @@ WAGTAIL_FRONTEND_LOGIN_URL = '/accounts/login/'
 
 For more details, see the [](login_page) documentation.
 
-### `WAGTAIL_ALLOW_SHARED_PASSWORD_PAGE`
+### `WAGTAIL_PRIVATE_PAGE_OPTIONS`
 
 If you'd rather users not have the ability to use a shared password to make pages private, you can disable it with this setting:
 
 ```python
-WAGTAIL_ALLOW_SHARED_PASSWORD_PAGE = False
+WAGTAIL_PRIVATE_PAGE_OPTIONS = {"SHARED_PASSWORD": False}
 ```
 
 See [](private_pages) for more details.
 
-### `WAGTAIL_ALLOW_SHARED_PASSWORD_COLLECTION`
+### `WAGTAILDOCS_PRIVATE_COLLECTION_OPTIONS`
 
 If you'd rather users not have the ability to use a shared password to make collections (used for documents) private, you can disable it with this setting:
 
 ```python
-WAGTAIL_ALLOW_SHARED_PASSWORD_COLLECTION = False
+WAGTAILDOCS_PRIVATE_COLLECTION_OPTIONS = {"SHARED_PASSWORD": False}
 ```
 
 See [](private_pages) for more details.

--- a/wagtail/admin/forms/collections.py
+++ b/wagtail/admin/forms/collections.py
@@ -23,7 +23,10 @@ class CollectionViewRestrictionForm(BaseViewRestrictionForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if not getattr(settings, "WAGTAIL_ALLOW_SHARED_PASSWORD_COLLECTION", True):
+        if not getattr(settings, "WAGTAILDOCS_PRIVATE_COLLECTION_OPTIONS", {}).get(
+            "SHARED_PASSWORD",
+            True,
+        ):
             self.fields["restriction_type"].choices = [
                 choice
                 for choice in CollectionViewRestriction.RESTRICTION_CHOICES

--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -127,7 +127,9 @@ class PageViewRestrictionForm(BaseViewRestrictionForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if not getattr(settings, "WAGTAIL_ALLOW_SHARED_PASSWORD_PAGE", True):
+        if not getattr(settings, "WAGTAIL_PRIVATE_PAGE_OPTIONS", {}).get(
+            "SHARED_PASSWORD", True
+        ):
             self.fields["restriction_type"].choices = [
                 choice
                 for choice in PageViewRestriction.RESTRICTION_CHOICES

--- a/wagtail/admin/tests/test_privacy.py
+++ b/wagtail/admin/tests/test_privacy.py
@@ -225,7 +225,7 @@ class TestSetPrivacyView(WagtailTestUtils, TestCase):
         # check that the option for password is visible
         self.assertIsNotNone(input_el)
 
-    @override_settings(WAGTAIL_ALLOW_SHARED_PASSWORD_PAGE=False)
+    @override_settings(WAGTAIL_PRIVATE_PAGE_OPTIONS={"SHARED_PASSWORD": False})
     def test_unset_shared_password_page(self):
         response = self.client.get(
             reverse("wagtailadmin_pages:set_privacy", args=(self.public_page.id,)),

--- a/wagtail/documents/tests/test_collection_privacy.py
+++ b/wagtail/documents/tests/test_collection_privacy.py
@@ -150,7 +150,9 @@ class TestCollectionPrivacyDocument(WagtailTestUtils, TestCase):
         # check that the option for password is visible
         self.assertIsNotNone(input_el)
 
-    @override_settings(WAGTAIL_ALLOW_SHARED_PASSWORD_COLLECTION=False)
+    @override_settings(
+        WAGTAILDOCS_PRIVATE_COLLECTION_OPTIONS={"SHARED_PASSWORD": False}
+    )
     def test_unset_shared_password_with_logged_in_user(self):
         self.login()
         response = self.client.get(


### PR DESCRIPTION
The new settings introduced in #11582 / #11536 only considered one use case of disabling the shared password option. However, we may want to allow for more complex configuration in the future in this area.

Ensure we can support potential future requirements such as #11640 with a more flexible structure for private pages & collections.

The following settings have been changed from boolean to dictionary values.

* `WAGTAIL_ALLOW_SHARED_PASSWORD_PAGE` → `WAGTAIL_PRIVATE_PAGE_OPTIONS`
* `WAGTAIL_ALLOW_SHARED_PASSWORD_COLLECTION` → `WAGTAILDOCS_PRIVATE_COLLECTION_OPTIONS`

Example configuration

```py
WAGTAIL_PRIVATE_PAGE_OPTIONS = {"SHARED_PASSWORD": False}
WAGTAILDOCS_PRIVATE_COLLECTION_OPTIONS = {"SHARED_PASSWORD": False}
```

Reminder: The changed settings are not yet released, no deprecation needed, hopefully this can be merged in for 6.1 so we do not have to change/deprecate things in the future here.
