### PR TITLE
ensure MultipleChooserPanel selecting unique objects

### DIFF
--- a/client/src/components/InlinePanel/index.js
+++ b/client/src/components/InlinePanel/index.js
@@ -181,6 +181,25 @@ export class InlinePanel extends ExpandingFormset {
     return forms.length;
   }
 
+  getChoiceSelectIds() {
+    const choiceIds = [];
+    $('> [data-inline-panel-child]', this.formsElt)
+      .not('.deleted')
+      // eslint-disable-next-line func-names
+      .each(function () {
+        const inputValId = $(this).find('input[type="hidden"]').val();
+
+        if (
+          inputValId !== undefined &&
+          typeof parseInt(inputValId, 10) === 'number' &&
+          inputValId !== ''
+        ) {
+          choiceIds.push(inputValId);
+        }
+      });
+    return choiceIds;
+  }
+
   updateAddButtonState() {
     if (this.opts.maxForms) {
       const addButton = $('#' + this.opts.formsetPrefix + '-ADD');

--- a/client/src/components/MultipleChooserPanel/index.js
+++ b/client/src/components/MultipleChooserPanel/index.js
@@ -30,6 +30,10 @@ export class MultipleChooserPanel extends InlinePanel {
         },
         { multiple: true },
       );
+      openModalButton.setAttribute(
+        'chooserids',
+        this.getChoiceSelectIds().join(','),
+      );
     });
   }
 

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -234,6 +234,8 @@ class ChooserModalOnloadHandlerFactory {
     $('[data-multiple-choice-select]', containerElement).on('change', () => {
       this.updateMultipleChoiceSubmitEnabledState(modal);
     });
+
+    this.disabledDuplicateCheckboxes(modal);
   }
 
   updateMultipleChoiceSubmitEnabledState(modal) {
@@ -244,6 +246,23 @@ class ChooserModalOnloadHandlerFactory {
     } else {
       $('[data-multiple-choice-submit]', modal.body).attr('disabled', true);
     }
+  }
+
+  disabledDuplicateCheckboxes(modal) {
+    const openModalButton = modal.triggerElement;
+    const selectedObjectIds = openModalButton.hasAttribute('chooserids')
+      ? openModalButton.getAttribute('chooserids').split(',').map(Number)
+      : [];
+    // eslint-disable-next-line func-names
+    $('[data-multiple-choice-select]', modal.body).each(function () {
+      const value = $(this).val();
+
+      if (selectedObjectIds.includes(parseInt(value, 10))) {
+        $(this).prop('disabled', true);
+      } else {
+        $(this).prop('disabled', false);
+      }
+    });
   }
 
   modalHasTabs(modal) {


### PR DESCRIPTION
Fixes #10496 

one solution for this issue is disable the duplicate objects or checkboxes, as shown below:

![attachment](https://github.com/wagtail/wagtail/assets/90080237/a30ca632-063e-4f31-94d9-a765ef30d6a6)

another solution instead of disable the already selected objects, just not add the duplicate objects , when the user add 
duplicate object , this object not added to the selection objects. I can update the PR , if this solution is better.
