### PR TITLE
Allow frontend caching backends to limit which hostnames they respond to

### DIFF
--- a/docs/advanced_topics/performance.md
+++ b/docs/advanced_topics/performance.md
@@ -68,6 +68,8 @@ Many websites use a frontend cache such as Varnish, Squid, Cloudflare or CloudFr
 
 Wagtail supports being [integrated](frontend_cache_purging) with many CDNs, so it can inform them when a page changes, so the cache can be cleared immediately and users see the changes sooner.
 
+If you have multiple frontends configured (eg Cloudflare for one site, CloudFront for another), it's recommended to set the [`HOSTNAMES`](frontendcache_multiple_backends) key to the list of hostnames the backend can purge, to prevent unnecessary extra purge requests.
+
 ## Page URLs
 
 To fully resolve the URL of a page, Wagtail requires information from a few different sources.

--- a/wagtail/contrib/frontend_cache/utils.py
+++ b/wagtail/contrib/frontend_cache/utils.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from collections import defaultdict
 from urllib.parse import urlparse, urlunparse
 
 from django.conf import settings
@@ -100,11 +101,29 @@ def purge_urls_from_cache(urls, backend_settings=None, backends=None):
 
         urls = new_urls
 
-    for backend_name, backend in get_backends(backend_settings, backends).items():
-        for url in urls:
-            logger.info("[%s] Purging URL: %s", backend_name, url)
+    urls_by_hostname = defaultdict(list)
 
-        backend.purge_batch(urls)
+    for url in urls:
+        urls_by_hostname[urlparse(url).netloc].append(url)
+
+    backends = get_backends(backend_settings, backends)
+
+    for hostname, urls in urls_by_hostname.items():
+        backends_for_hostname = {
+            backend_name: backend
+            for backend_name, backend in backends.items()
+            if backend.invalidates_hostname(hostname)
+        }
+
+        if not backends_for_hostname:
+            logger.warning("Unable to find purge backend for %s", hostname)
+            continue
+
+        for backend_name, backend in backends_for_hostname.items():
+            for url in urls:
+                logger.info("[%s] Purging URL: %s", backend_name, url)
+
+            backend.purge_batch(urls)
 
 
 def _get_page_cached_urls(page):


### PR DESCRIPTION
Allow backends to validate which hostnames they're run from. This is handled by a new `HOSTNAMES` configuration key.

Note that to ensure there's only 1 correct way of doing something, the previous CloudFront-specific configuration is removed in favour of this pattern.

Fixes https://github.com/wagtail/wagtail/issues/5059

This work has been sponsored by Oxfam America.