### PR TITLE
Add missing field types to ElasticSearch mapping

### DIFF
--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -52,6 +52,8 @@ class Elasticsearch7Mapping:
 
     type_map = {
         "AutoField": "integer",
+        "SmallAutoField": "integer",
+        "BigAutoField": "long",
         "BinaryField": "binary",
         "BooleanField": "boolean",
         "CharField": "string",
@@ -69,10 +71,12 @@ class Elasticsearch7Mapping:
         "NullBooleanField": "boolean",
         "PositiveIntegerField": "integer",
         "PositiveSmallIntegerField": "integer",
+        "PositiveBigIntegerField": "long",
         "SlugField": "string",
         "SmallIntegerField": "integer",
         "TextField": "string",
         "TimeField": "date",
+        "URLField": "string",
     }
 
     keyword_type = "keyword"


### PR DESCRIPTION
The ElasticSearch mapping is missing a few field types, leading to indices created with the wrong field types.

This PR maps:
* `SmallAutoField` -> `integer`
* `BigAutoField` -> `long`
* `PositiveBigIntegerField` -> `long`
* `URLField` -> `string`