### PR TITLE
Tweak styles for w-header-button to better match the designs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changelog
  * Implement new universal listings design for groups views (Sage Abdullah)
  * Implement new universal listings design for users views (Sage Abdullah)
  * Implement new universal listings design for workflow and task views (Sage Abdullah)
+ * Refine slim header button style to match designs (Sage Abdullah)
  * Add simple admin keyboard shortcuts overview dialog, available in the help sub-menu (Karthik Ayangar, Rohit Sharma)
  * Add ability to bulk toggle permissions in the user group editing view, including shift+click for multiple selections (LB (Ben) Johnston, Kalob Taulien)
  * Update the minimum version of `djangorestframework` to 3.15.1 (Sage Abdullah)

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -321,35 +321,42 @@
 }
 
 .w-header-button {
-  // Temporarily copied from .c-sf-add-button
   display: flex;
   align-items: center;
   justify-content: center;
   gap: theme('spacing.1');
-  height: theme('spacing.slim-header');
+  height: theme('spacing.7');
   appearance: none;
+  background-color: initial;
+  border: 1px solid transparent;
   color: theme('colors.text-button-outline-default');
-  padding: 0;
+  padding: 0 theme('spacing[1.5]');
+  font-size: theme('fontSize.14');
+  font-weight: theme('fontWeight.medium');
   cursor: pointer;
-
-  &--icon-only {
-    width: theme('spacing.7');
-  }
 
   .icon {
     width: theme('spacing.4');
     height: theme('spacing.4');
     padding: theme('spacing.[0.5]');
-    border: 1px solid theme('colors.text-button-outline-default');
+    border: 1px solid currentColor;
     border-radius: theme('borderRadius.full');
     transition: transform 0.3s ease;
+  }
+
+  &:hover {
+    border-color: theme('colors.border-button-outline-hover');
+    background-color: theme('colors.surface-button-outline-hover');
   }
 
   &:hover,
   &:focus-visible {
     .icon {
+      // This ideally should use a solid variant of the icon instead.
       color: theme('colors.surface-page');
+      border-color: theme('colors.text-button-outline-hover');
       background-color: theme('colors.text-button-outline-hover');
     }
+    color: theme('colors.text-link-hover');
   }
 }

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -11,6 +11,22 @@ depth: 1
 
 ## What's new
 
+## Universal listings continued
+
+Continuing work on the Universal Listings project, this release rolls out universal listing styles for the following views:
+
+ * Image listings
+ * Document listings
+ * Site and locale listings
+ * Page and snippet history views
+ * Form builder submissions
+ * Collections listings
+ * Groups
+ * Users
+ * Workflow and task views
+
+Universal listing components like header buttons have also been tweaked to improve usability. This feature was developed by Ben Enright and Sage Abdullah.
+
 ### Other features
 
  * Refine wording of page & collection privacy using password is a shared password and should not be used for secure content (Rohit Sharma, Jake Howard)
@@ -26,15 +42,6 @@ depth: 1
  * Reimplement redirects `IndexView` using the `generic.IndexView` (Rohit Sharma, Sage Abdullah, Temidayo Azeez)
  * Add `PageListingViewSet` for custom per-page-type page listings (Matt Westcott)
  * Add `ChooseParentView` to `PageListingViewSet` to allow creating pages from custom page listings (Abdelrahman Hamada, Sage Abdullah)
- * Implement new universal listings design for image listing view (Sage Abdullah)
- * Implement new universal listings design for document listing view (Sage Abdullah)
- * Implement new universal listings design for site and locale listing views (Sage Abdullah)
- * Implement new universal listings design for page and snippet history view (Sage Abdullah)
- * Implement new universal listings design for form builder submissions view (Sage Abdullah)
- * Implement new universal listings design for collections listing view (Sage Abdullah)
- * Implement new universal listings design for groups views (Sage Abdullah)
- * Implement new universal listings design for users views (Sage Abdullah)
- * Implement new universal listings design for workflow and task views (Sage Abdullah)
  * Added `AbstractGroupApprovalTask` to simplify [customizing behavior of custom `Task` models](../extending/custom_tasks) (John-Scott Atlakson)
  * Add simple admin keyboard shortcuts overview dialog, available in the help sub-menu (Karthik Ayangar, Rohit Sharma)
  * Add ability to bulk toggle permissions in the user group editing view, including shift+click for multiple selections (LB (Ben) Johnston, Kalob Taulien)

--- a/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
@@ -10,7 +10,8 @@
     {% page_permissions parent_page as parent_page_perms %}
     {% if parent_page_perms.can_add_subpage %}
         {% trans 'Add child page' as add_child_page_str %}
-        <a href="{% url "wagtailadmin_pages:add_subpage" parent_page.id %}" class="w-header-button" data-controller="w-tooltip" data-w-tooltip-content-value="{{ add_child_page_str }}" aria-label="{{ add_child_page_str }}">{% icon name="plus" %}</a>
+        {# Keep this in sync with the styles of HeaderButton. #}
+        <a href="{% url "wagtailadmin_pages:add_subpage" parent_page.id %}" class="w-header-button button" data-controller="w-tooltip" data-w-tooltip-content-value="{{ add_child_page_str }}" aria-label="{{ add_child_page_str }}">{% icon name="plus" %}</a>
     {% endif %}
 
     {# Page actions dropdown #}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -56,7 +56,7 @@
                         {% if actions %}
                             {# Actions divider #}
                             <div class="w-w-px w-h-[30px] w-ml-auto sm:w-ml-0 w-bg-border-furniture"></div>
-                            <div id="w-slim-header-buttons" class="w-flex w-items-center w-ml-3">
+                            <div id="w-slim-header-buttons" class="w-flex w-items-center w-ml-2.5 w-gap-1">
                                 {{ actions }}
                             </div>
                         {% endif %}

--- a/wagtail/admin/tests/pages/test_page_usage.py
+++ b/wagtail/admin/tests/pages/test_page_usage.py
@@ -64,7 +64,9 @@ class TestPageUsage(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         edit_links = soup.select(f"a[href='{edit_url}']")
         self.assertEqual(len(edit_links), 1)
         edit_link = edit_links[0]
-        self.assertIn("w-header-button", edit_link.attrs.get("class"))
+        classes = edit_link.attrs.get("class")
+        self.assertIn("w-header-button", classes)
+        self.assertIn("button", classes)
 
     def test_has_private_usage(self):
         PageChooserModel.objects.create(page=self.page)

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -106,10 +106,9 @@ class HeaderButton(Button):
         icon_only=False,
         **kwargs,
     ):
-        classname = f"{classname} w-header-button".strip()
+        classname = f"{classname} w-header-button button".strip()
         attrs = attrs.copy()
         if icon_only:
-            classname = f"{classname} w-header-button--icon-only"
             controller = f"{attrs.get('data-controller', '')} w-tooltip".strip()
             attrs["data-controller"] = controller
             attrs["data-w-tooltip-content-value"] = label


### PR DESCRIPTION
Ideally, the hover state of the icon should be implemented by using the regular variant and switching to the solid variant on hover, instead of manually setting the color and background color. And ideally, the add button should use the FA circle-plus icon instead of the plus icon. However, this is how the StreamField add button is styled, which is the closest existing implementation of the styles.

Remove the `--icon-only` variant added in 88fad9a07143fd3872992fe6f7e0e2f5841fc2ef as it is now redundant. The styles now work for both icon-only and labelled buttons.

Adjust the spacing per feedback from Ben.

## Designs

![image](https://github.com/wagtail/wagtail/assets/6379424/e579aa97-5a35-488a-9213-2f512ae94d68)

![image](https://github.com/wagtail/wagtail/assets/6379424/ab862b57-a038-4411-b290-42f78ad4c0a6)

<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/afae2aa0-56e1-41ef-9a09-93a4a6d9a3b5">

<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/0695f80a-2dbe-47fc-8a3b-1821d5a38a00">



## Before

<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/ab75c279-3d0a-4a51-8218-fabd0eaadb43">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/5e714d2b-7ec9-4dbb-9a7c-fecddb293ed8">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/d8cac03f-d7fb-4a20-be2f-23f600d40366">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/bcdb4159-5ae5-444d-a27b-95b6817b2901">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/1e9060ad-9970-470f-a38f-2b73b4f9145f">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/e4b93ace-4b60-45f7-bae7-b8876ceabfc0">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/5d601c30-c0c3-44e9-bd75-51f0daa188f5">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/3bcb270e-f42a-4a14-80b1-c5c14f11084b">


## After

<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/25ae8cdd-6379-4414-8bcf-29615ef85a12">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/c670d66d-c3cc-4d68-ad39-806dcc0fc7a4">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/87c94c9e-96cd-4ed4-b773-aa0d4c9f29c1">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/70bb2cfa-9065-4ffa-b550-586d7e2d2fef">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/23ab7f20-d41c-4b2e-914c-c6091218fea6">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/7977111f-5b7f-4d90-9fb6-0f46f50084b2">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/5232cf47-04a6-42d0-91a6-48db6c288d53">
<img width="383" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/efcc485f-ecfa-4e51-9d54-80991d7369bf">
