### PR TITLE
Fix issue where allow unicode slugs was not correctly used for urlify

### DIFF
--- a/client/src/controllers/SlugController.test.js
+++ b/client/src/controllers/SlugController.test.js
@@ -45,7 +45,7 @@ describe('SlugController', () => {
     expect(slugInput.value).toEqual('visiter-toulouse-en-t-2025');
   });
 
-  it('should now allow unicode characters by default', () => {
+  it('should allow unicode characters when allow-unicode-value is set to truthy', () => {
     const slugInput = document.querySelector('#id_slug');
     slugInput.setAttribute('data-w-slug-allow-unicode-value', 'true');
 
@@ -267,7 +267,7 @@ describe('urlify behaviour', () => {
     expect(slugInput.value).toBe('urlify-testing-on-edit-page');
   });
 
-  it('should transform input with special characters to their ASCII equivalent', () => {
+  it('should transform input with special (unicode) characters to their ASCII equivalent by default', () => {
     const slugInput = document.getElementById('id_slug');
     slugInput.value = 'Some Title with éçà Spaces';
 
@@ -278,6 +278,21 @@ describe('urlify behaviour', () => {
     document.getElementById('id_slug').dispatchEvent(event);
 
     expect(slugInput.value).toBe('some-title-with-eca-spaces');
+  });
+
+  it('should transform input with special (unicode) characters to keep unicode values if allow unicode value is truthy', () => {
+    const value = 'Dê-me fatias de   pizza de manhã --ou-- à noite';
+
+    const slugInput = document.getElementById('id_slug');
+    slugInput.setAttribute('data-w-slug-allow-unicode-value', 'true');
+
+    slugInput.value = value;
+
+    const event = new CustomEvent('custom:event', { detail: { value } });
+
+    document.getElementById('id_slug').dispatchEvent(event);
+
+    expect(slugInput.value).toBe('dê-me-fatias-de-pizza-de-manhã-ou-à-noite');
   });
 
   it('should return an empty string when input contains only special characters', () => {

--- a/client/src/controllers/SlugController.ts
+++ b/client/src/controllers/SlugController.ts
@@ -89,12 +89,12 @@ export class SlugController extends Controller<HTMLInputElement> {
     event: CustomEvent<{ value: string }> | { detail: { value: string } },
     ignoreUpdate = false,
   ) {
+    const allowUnicode = this.allowUnicodeValue;
     const { value = this.element.value } = event?.detail || {};
-
     const trimmedValue = value.trim();
 
     const newValue =
-      urlify(trimmedValue) ||
+      urlify(trimmedValue, { allowUnicode }) ||
       this.slugify({ detail: { value: trimmedValue } }, true);
 
     if (!ignoreUpdate) {


### PR DESCRIPTION
When the urlify util is used, ensure that we pass in the allow unicode value correctly in the SlugController.

Note: This was passed in for slugify but the usage of slugify, not urlify.

Fixes #11828

### Validation screenshots (with settings shown)

<img width="1434" alt="Screenshot 2024-04-18 at 7 49 40 pm" src="https://github.com/wagtail/wagtail/assets/1396140/eb938d68-cf91-48c8-8f2e-a569bae1d201">

<img width="1237" alt="Screenshot 2024-04-18 at 7 49 04 pm" src="https://github.com/wagtail/wagtail/assets/1396140/2b2b4aa4-af92-486f-ba01-b19f5e0db3f2">

<img width="1262" alt="Screenshot 2024-04-18 at 7 48 36 pm" src="https://github.com/wagtail/wagtail/assets/1396140/452f4f31-1de1-4e8f-a2e3-24bcaafacfb4">

