### PR TITLE
Fix icon alignment in page listings

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -231,6 +231,7 @@ ul.listing {
       gap: theme('spacing.2');
       margin: 0;
       vertical-align: middle;
+      align-items: center;
 
       a {
         color: inherit;
@@ -241,11 +242,6 @@ ul.listing {
           color: theme('colors.text-link-default');
         }
       }
-    }
-
-    .icon-folder {
-      margin: 3px 0.3em 0 0;
-      vertical-align: top;
     }
   }
 

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -223,6 +223,10 @@ ul.listing {
 
   .title {
     word-break: break-word;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: theme('spacing.2');
 
     .title-wrapper,
     h2 {
@@ -258,36 +262,6 @@ ul.listing {
       float: inline-start;
       padding: 0 0.5em 0 0;
       vertical-align: middle;
-    }
-  }
-
-  &--inline-actions td.title {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-
-    .title-wrapper {
-      margin-inline-end: 2.5em;
-    }
-
-    .w-status {
-      margin: 0;
-    }
-  }
-
-  &--inline-actions .actions {
-    display: inline-block;
-    margin-top: 0;
-    vertical-align: inherit;
-
-    li {
-      margin-bottom: 0;
-    }
-
-    .button {
-      vertical-align: inherit;
     }
   }
 

--- a/client/scss/components/_status-tag.scss
+++ b/client/scss/components/_status-tag.scss
@@ -4,6 +4,7 @@
   border-radius: 2px;
   text-align: center;
   display: inline-block;
+  word-break: normal;
   // stylelint-disable-next-line property-disallowed-list
   text-transform: uppercase;
   padding: 0 0.5em;

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -5,7 +5,7 @@
 <div class="title-wrapper">
     {% if page.is_site_root %}
         {% if perms.wagtailcore.add_site or perms.wagtailcore.change_site or perms.wagtailcore.delete_site %}
-            <a href="{% url 'wagtailsites:index' %}" title="{% trans 'Sites menu' %}">{% icon name="site" classname="initial" %}</a>
+            <a href="{% url 'wagtailsites:index' %}" title="{% trans 'Sites menu' %}" class="w-flex w-items-center">{% icon name="site" classname="initial" %}</a>
         {% endif %}
     {% endif %}
 
@@ -17,7 +17,7 @@
         without also reading out the buttons and indicators.
     {% endcomment %}
     {% fragment as page_title %}
-        <span id="page_{{ page.pk|unlocalize|admin_urlquote }}_title">
+        <span id="page_{{ page.pk|unlocalize|admin_urlquote }}_title" class="w-flex w-items-center w-gap-2">
             {% if not page.is_site_root and not page.is_leaf %}{% icon name="folder" classname="initial" %}{% endif %}
             {{ page.get_admin_display_title }}
         </span>

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -133,13 +133,15 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
     def test_explore_root_shows_icon(self):
         response = self.client.get(reverse("wagtailadmin_explore_root"))
         self.assertEqual(response.status_code, 200)
+        soup = self.get_soup(response.content)
 
         # Administrator (or user with add_site permission) should see the
         # sites link with its icon
-        self.assertContains(
-            response,
-            '<a href="/admin/sites/" title="Sites menu"><svg',
-        )
+        url = reverse("wagtailsites:index")
+        link = soup.select_one(f'td a[href="{url}"]')
+        self.assertIsNotNone(link)
+        icon = link.select_one("svg use[href='#icon-site']")
+        self.assertIsNotNone(icon)
 
     def test_ordering(self):
         response = self.client.get(

--- a/wagtail/admin/ui/tables/__init__.py
+++ b/wagtail/admin/ui/tables/__init__.py
@@ -518,7 +518,3 @@ class Table(Component):
         @cached_property
         def attrs(self):
             return self.table.get_row_attrs(self.instance)
-
-
-class InlineActionsTable(Table):
-    classname = "listing listing--inline-actions"

--- a/wagtail/admin/views/generic/history.py
+++ b/wagtail/admin/views/generic/history.py
@@ -16,7 +16,7 @@ from wagtail.admin.filters import (
     MultipleUserFilter,
     WagtailFilterSet,
 )
-from wagtail.admin.ui.tables import Column, DateColumn, InlineActionsTable, UserColumn
+from wagtail.admin.ui.tables import Column, DateColumn, UserColumn
 from wagtail.admin.utils import get_latest_str
 from wagtail.admin.views.generic.base import (
     BaseListingView,
@@ -197,7 +197,6 @@ class HistoryView(PermissionCheckedMixin, BaseObjectMixin, BaseListingView):
     is_searchable = False
     paginate_by = 20
     filterset_class = HistoryFilterSet
-    table_class = InlineActionsTable
     history_url_name = None
     history_results_url_name = None
     edit_url_name = None


### PR DESCRIPTION
Fixes an issue on Safari introduced in bb12877f7903a62736f3e9058f235dc7ed5a4d04, while also improving the alignment of the site/folder icon on other browsers. The second commit fixes #11875.

<img width="520" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/eede7c39-29e5-41aa-abcf-8b4c672f78a6">


## Safari before/after

<details>
<summary>Screenshots</summary>

<img width="400" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/d96d4ff5-f953-4182-b0eb-30340c57b2dd">

<img width="400" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/e8547642-5b8c-43eb-9325-3257424920e7">

</details>


## Chrome before/after

<details>
<summary>Screenshots</summary>

<img width="400" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/34b8707e-0167-4918-9fec-6072ec428931">

<img width="400" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/2a5e65c5-33b4-41c6-ab2f-e0eb1754e82a">

</details>

## Firefox before/after

<details>
<summary>Screenshots</summary>

<img width="400" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/a889dba6-fd46-43f4-aa15-03074bffe031">

<img width="400" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/60ad6cfa-2d96-424c-b2aa-a5406cdfc3c8">

</details>
