### PR TITLE
Fix next redirect URL in page search results view

### DIFF
--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -162,6 +162,7 @@ class BaseSearchView(PermissionCheckedMixin, BaseListingView):
     def get_table_kwargs(self):
         kwargs = super().get_table_kwargs()
         kwargs["show_locale_labels"] = self.show_locale_labels
+        kwargs["actions_next_url"] = self.get_index_url()
         return kwargs
 
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:


### PR DESCRIPTION
Fixes #11856. This is a similar issue to #11177 which was fixed in #11191.

#11191 was backported to 5.2 so we might want to do the same.