### PR TITLE
Use `wagtail.VERSION` for the 'What's new in Wagtail x.y' menu item

### DIFF
--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -64,6 +64,7 @@ from wagtail.templatetags.wagtailcore_tags import (
     wagtail_feature_release_editor_guide_link,
     wagtail_feature_release_whats_new_link,
 )
+from wagtail.utils.version import get_main_version
 from wagtail.whitelist import allow_without_attributes, attribute_rule, check_url
 
 
@@ -975,7 +976,7 @@ def register_reports_menu():
 
 @hooks.register("register_help_menu_item")
 def register_whats_new_in_wagtail_version_menu_item():
-    version = "6.2"
+    version = get_main_version(include_patch=False)
     return DismissibleMenuItem(
         _("What's new in Wagtail %(version)s") % {"version": version},
         wagtail_feature_release_whats_new_link(),

--- a/wagtail/tests/test_utils.py
+++ b/wagtail/tests/test_utils.py
@@ -29,6 +29,7 @@ from wagtail.coreutils import (
 from wagtail.models import Page, Site
 from wagtail.utils.file import hash_filelike
 from wagtail.utils.utils import deep_update
+from wagtail.utils.version import get_main_version
 
 
 class TestCamelCaseToUnderscore(TestCase):
@@ -575,3 +576,16 @@ class HashFileLikeTestCase(SimpleTestCase):
             hash_filelike(FakeLargeFile()),
             "bd36f0c5a02cd6e9e34202ea3ff8db07b533e025",
         )
+
+
+class TestVersion(SimpleTestCase):
+    def test_get_main_version(self):
+        cases = [
+            ((6, 2, 0, "final", 0), False, "6.2"),
+            ((6, 2, 1, "final", 0), False, "6.2"),
+            ((6, 2, 0, "final", 0), True, "6.2"),
+            ((6, 2, 1, "final", 0), True, "6.2.1"),
+        ]
+        for version, include_patch, expected in cases:
+            with self.subTest(version=version, include_patch=include_patch):
+                self.assertEqual(get_main_version(version, include_patch), expected)

--- a/wagtail/utils/version.py
+++ b/wagtail/utils/version.py
@@ -20,10 +20,13 @@ def get_version(version):
     return main + sub
 
 
-def get_main_version(version=None):
+def get_main_version(version=None, include_patch=True):
     """Return main version (X.Y[.Z]) from VERSION."""
     version = get_complete_version(version)
-    parts = 2 if version[2] == 0 else 3
+    if include_patch:
+        parts = 2 if version[2] == 0 else 3
+    else:
+        parts = 2
     return ".".join(str(x) for x in version[:parts])
 
 


### PR DESCRIPTION
This ensures `wagtail.VERSION` is always the source of truth for version numbers. This also means the only Python code we need to bump when working on a new version is `wagtail.VERSION`. (We still need to update the project template's `requirements.txt` and the "Upgrading Wagtail" table in the docs, but that is it.)
