### PR TITLE
Reinstate wagtail.models.collections to prevent import errors in migrations

### DIFF
--- a/wagtail/models/collections.py
+++ b/wagtail/models/collections.py
@@ -1,0 +1,5 @@
+# wagtail.models.collections was moved to wagtail.models.media in #11555;
+# this import is retained to accommodate migration files importing from the old location.
+# See #11874
+
+from wagtail.models.media import get_root_collection_id  # noqa


### PR DESCRIPTION
Fixes #11874
