### PR TITLE
Fix the order of InlinePanel with min_num argument

### DIFF
--- a/wagtail/admin/panels/inline_panel.py
+++ b/wagtail/admin/panels/inline_panel.py
@@ -102,7 +102,9 @@ class InlinePanel(Panel):
 
                 # ditto for the ORDER field, if present
                 if self.formset.can_order:
-                    subform.fields[ORDERING_FIELD_NAME].widget = forms.HiddenInput()
+                    subform.fields[ORDERING_FIELD_NAME].widget = forms.HiddenInput(
+                        attrs={"value": index + 1}
+                    )
 
                 self.children.append(
                     self.child_edit_handler.get_bound_panel(


### PR DESCRIPTION
Fixes #9391

this issue because the the initial forms not have `value` attribute. if "min_num" is any number and after that another item added,
this item become first despite the number of "min_num".  but if any action occurs to any item of initial forms for example the item moved up or down , in this case the item become has attribute, and this issue not exist in this case. 

After       |     Before 
:------:     |     :------:
![After](https://github.com/wagtail/wagtail/assets/90080237/01e9fbe5-caf7-4a67-a872-9a05945d8b4d) | ![Before](https://github.com/wagtail/wagtail/assets/90080237/1e0b9ff5-0213-4c7c-a8ec-323697cd65a2)




