### PR TITLE
Refactor image chooser pagination to check WAGTAILIMAGES_CHOOSER_PAGE_SIZE at runtime

### DIFF
--- a/wagtail/admin/viewsets/base.py
+++ b/wagtail/admin/viewsets/base.py
@@ -46,6 +46,7 @@ class ViewSet(WagtailMenuRegisterable):
             key: value
             for key, value in self.get_common_view_kwargs().items()
             if hasattr(view_class, key)
+            and not isinstance(getattr(view_class, key), property)
         }
         filtered_kwargs.update(kwargs)
         return view_class.as_view(**filtered_kwargs)

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1681,6 +1681,22 @@ class TestImageChooserView(WagtailTestUtils, TestCase):
         response = self.get({"p": 9999})
         self.assertEqual(response.status_code, 404)
 
+    @override_settings(WAGTAILIMAGES_CHOOSER_PAGE_SIZE=4)
+    def test_chooser_page_size(self):
+        images = [
+            Image(
+                title="Test image %i" % i,
+                file=get_test_image_file(size=(1, 1)),
+            )
+            for i in range(1, 12)
+        ]
+        Image.objects.bulk_create(images)
+
+        response = self.get()
+
+        self.assertContains(response, "Page 1 of 3")
+        self.assertEqual(response.status_code, 200)
+
     def test_filter_by_tag(self):
         for i in range(0, 10):
             image = Image.objects.create(

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -72,9 +72,15 @@ class ImageCreationFormMixin(CreationFormMixin):
 class BaseImageChooseView(BaseChooseView):
     template_name = "wagtailimages/chooser/chooser.html"
     results_template_name = "wagtailimages/chooser/results.html"
-    per_page = 12
     ordering = "-created_at"
     construct_queryset_hook_name = "construct_image_chooser_queryset"
+
+    @property
+    def per_page(self):
+        # Make per_page into a property so that we can read back WAGTAILIMAGES_CHOOSER_PAGE_SIZE
+        # at runtime. This means we can no longer set it as an attribute on the viewset, but that's
+        # fine.
+        return getattr(settings, "WAGTAILIMAGES_CHOOSER_PAGE_SIZE", 20)
 
     def get_object_list(self):
         return (
@@ -309,7 +315,6 @@ class ImageChooserViewSet(ChooserViewSet):
     preserve_url_parameters = ChooserViewSet.preserve_url_parameters + ["select_format"]
 
     icon = "image"
-    per_page = getattr(settings, "WAGTAILIMAGES_CHOOSER_PAGE_SIZE", 10)
     choose_one_text = _("Choose an image")
     create_action_label = _("Upload")
     create_action_clicked_label = _("Uploading…")


### PR DESCRIPTION
Reworking of #11884, to fix #11813.

The problem with setting `per_page` as an attribute on the viewset is that it requires reading the setting on module load, which means we can't use `override_settings` to test it. Instead, make it a property on `BaseImageChooseView` so that it gets read back at runtime. (Which in turn means that the `construct_view` logic in the base ViewSet class needs to take care not to write to attributes on the view if they're actually properties.)

We could also have done this by adding a `get_per_page` method on the generic chooser view (defaulting to just returning `self.per_page`) and making it overrideable on the viewset using `inject_view_methods` - but we've pretty much settled on using properties rather than `get_foo` methods in our generic views now.

I also took the liberty of increasing the default page size to 20, since this bug inadvertently created an ambiguity over whether the "correct" value is 10 (which works for rows of 5) or 12 (which works for rows of 4) - this way it works equally well for both :-)