### PR TITLE
Fix missing static files in the styleguide

### DIFF
--- a/wagtail/contrib/styleguide/tests.py
+++ b/wagtail/contrib/styleguide/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.test.utils import WagtailTestUtils
 
 
@@ -13,3 +14,10 @@ class TestStyleGuide(WagtailTestUtils, TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailstyleguide/base.html")
+
+        custom_css = versioned_static("wagtailstyleguide/css/animate-progress.css")
+        widget_css = versioned_static("wagtailadmin/css/panels/draftail.css")
+        widget_js = versioned_static("wagtailadmin/js/draftail.js")
+        self.assertContains(response, custom_css)
+        self.assertContains(response, widget_css)
+        self.assertContains(response, widget_js)

--- a/wagtail/contrib/styleguide/views.py
+++ b/wagtail/contrib/styleguide/views.py
@@ -94,7 +94,7 @@ class ExampleForm(forms.Form):
 
     @property
     def media(self):
-        return forms.Media(
+        return super().media + forms.Media(
             css={
                 "all": [versioned_static("wagtailstyleguide/css/animate-progress.css")]
             }


### PR DESCRIPTION
Regression in #11647. Fixes #11896. Without including `super().media`, the media files from the form field widgets do not get included.

My bad, I should've checked the browser console when testing the PR 🤦