### PR TITLE
Fix MultipleChooserPanel in nested InlinePanel

### DIFF
--- a/wagtail/images/widgets.py
+++ b/wagtail/images/widgets.py
@@ -44,6 +44,7 @@ class AdminImageChooser(BaseChooser):
             js=[
                 versioned_static("wagtailimages/js/image-chooser-modal.js"),
                 versioned_static("wagtailimages/js/image-chooser.js"),
+                versioned_static("wagtailimages/js/image-chooser-telepath.js"),
             ]
         )
 


### PR DESCRIPTION
Fixes #11233

the same issue exist in "ImageChooser" and most of the other widget like "SnippetChooser" and "DocumentChooser".
if this solution is suitable, other widgets  could by solved by the same solution.

the other widgets not work but "MultipleChooserPanel" with "ImageChooser" widget in nested "InlinePanel" works, as shown below:

After          |    Before 
:---:             | :---:
![After](https://github.com/wagtail/wagtail/assets/90080237/a547d0f9-570f-49ab-8ac3-a98f15a9ac17) | ![Before](https://github.com/wagtail/wagtail/assets/90080237/abac76b5-6ba6-4f49-b9c8-de53590d0708)


