### PR TITLE
Use `DjangoJSONEncoder` instead of custom `LazyStringEncoder`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Fix: Make `WAGTAILIMAGES_CHOOSER_PAGE_SIZE` setting functional again (Rohit Sharma)
  * Fix: Enable `richtext` template tag to convert lazy translation values (Benjamin Bach)
  * Docs: Remove duplicate section on frontend caching proxies from performance page (Jake Howard)
+ * Maintenance: Use `DjangoJSONEncoder` instead of custom `LazyStringEncoder` to serialize Draftail config (Sage Abdullah)
 
 
 6.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -31,7 +31,7 @@ depth: 1
 
 ### Maintenance
 
- * ...
+ * Use `DjangoJSONEncoder` instead of custom `LazyStringEncoder` to serialize Draftail config (Sage Abdullah)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/rich_text/editors/draftail/__init__.py
+++ b/wagtail/admin/rich_text/editors/draftail/__init__.py
@@ -1,33 +1,15 @@
 import json
 import warnings
 
+from django.core.serializers.json import DjangoJSONEncoder
 from django.forms import Media, widgets
-from django.urls import reverse_lazy
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy
 
 from wagtail.admin.rich_text.converters.contentstate import ContentstateConverter
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.rich_text import features as feature_registry
 from wagtail.telepath import register
 from wagtail.widget_adapters import WidgetAdapter
-
-
-class LazyStringEncoder(json.JSONEncoder):
-    """
-    Add support for lazy strings to the JSON encoder so that URLs and
-    translations can be resolved when rendering the widget only.
-    """
-
-    # The string "Edit" here is arbitrary, chosen because it exists elsewhere in the
-    # translations dictionary and is likely to remain in the future.
-    lazy_string_types = [type(reverse_lazy("Edit")), type(gettext_lazy("Edit"))]
-
-    def default(self, obj):
-        if type(obj) in self.lazy_string_types:
-            return str(obj)
-
-        return json.JSONEncoder.default(self, obj)
 
 
 class DraftailRichTextArea(widgets.HiddenInput):
@@ -90,7 +72,7 @@ class DraftailRichTextArea(widgets.HiddenInput):
         context = super().get_context(name, value, attrs)
         context["widget"]["attrs"]["data-w-init-detail-value"] = json.dumps(
             self.options,
-            cls=LazyStringEncoder,
+            cls=DjangoJSONEncoder,
         )
         return context
 


### PR DESCRIPTION
Cleanup of #11620. The built-in `DjangoJSONEncoder` can handle lazy strings and other types (e.g. `Decimal`, datetimes).

I've confirmed that without the `cls` argument, we have failing tests, and those pass when we use `DjangoJSONEncoder`.