### PR TITLE
save white space in comment reply

### DIFF
--- a/client/src/components/CommentApp/components/CommentReply/style.scss
+++ b/client/src/components/CommentApp/components/CommentReply/style.scss
@@ -13,6 +13,7 @@
     padding-top: 10px;
     padding-bottom: 10px;
     word-break: break-all;
+    white-space: pre-wrap;
 
     &--mode-deleting {
       color: theme('colors.text-context');


### PR DESCRIPTION
 I think its better for design, make these components, comment and reply, have the same design.  its just minor change,
but its useful when the user need to write title or paragraph, or list with some elements , or in any case he want to save the space.
this just like this issue #11171 but I missed to add it in the comment reply. 
After             | Before
:----:              | :----:
![After](https://github.com/wagtail/wagtail/assets/90080237/2be5fef0-285c-466c-8a0a-c3a4a271fbdd) | ![Before](https://github.com/wagtail/wagtail/assets/90080237/4c83c99f-e20f-43c0-8d28-d4402430c02e)



