### PR TITLE
Give translators more context about how the term 'density' is used

### DIFF
--- a/wagtail/users/models.py
+++ b/wagtail/users/models.py
@@ -89,6 +89,7 @@ class UserProfile(models.Model):
         SNUG = "snug", _("Snug")
 
     density = models.CharField(
+        # Translators: "Density" is the term used to describe the amount of space between elements in the user interface
         verbose_name=_("density"),
         choices=AdminDensityThemes.choices,
         default=AdminDensityThemes.DEFAULT,


### PR DESCRIPTION
When translating I encountered a term that I found very ambiguous.

Normally, more context can be given with a special comment that starts with the `Translators` keyword. The comment is then pulled into the corresponding django.po file entry. See the Django docs: https://docs.djangoproject.com/en/5.0/topics/i18n/translation/#comments-for-translators

Not sure if Transifex understands comments like this. I believe this is the first time we use this feature in Wagtail.