### PR TITLE
Run permission labels through translation on the permission management template

### DIFF
--- a/wagtail/admin/models.py
+++ b/wagtail/admin/models.py
@@ -1,5 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, Model
+from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from taggit.models import Tag
 
@@ -18,7 +19,7 @@ class Admin(Model):
     class Meta:
         default_permissions = []  # don't create the default add / change / delete / view perms
         permissions = [
-            ("access_admin", "Can access Wagtail admin"),
+            ("access_admin", _("Can access Wagtail admin")),
         ]
 
 

--- a/wagtail/contrib/simple_translation/models.py
+++ b/wagtail/contrib/simple_translation/models.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.db.models import Model
+from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.models import Locale
@@ -17,7 +18,7 @@ class SimpleTranslation(Model):
     class Meta:
         default_permissions = []
         permissions = [
-            ("submit_translation", "Can submit translations"),
+            ("submit_translation", _("Can submit translations")),
         ]
 
 

--- a/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
@@ -96,7 +96,8 @@
                                     <fieldset class="w-p-0">
                                         <legend class="w-sr-only">{% trans "Custom permissions" %}</legend>
                                         {% for custom_perm in content_perms_dict.custom %}
-                                            {% include "wagtailadmin/shared/forms/single_checkbox.html" with name="permissions" value=custom_perm.perm.id checked=custom_perm.selected text=custom_perm.name attrs=custom_perm.attrs %}
+                                            {% trans custom_perm.name as custom_perm_label %}
+                                            {% include "wagtailadmin/shared/forms/single_checkbox.html" with name="permissions" value=custom_perm.perm.id checked=custom_perm.selected text=custom_perm_label attrs=custom_perm.attrs %}
                                         {% endfor %}
                                     </fieldset>
                                 {% endif %}
@@ -170,7 +171,7 @@
             <tbody>
                 {% for perm_tuple in other_perms %}
                     <tr>
-                        <td class="title"><label for="{{ perm_tuple.1.id_for_label }}" class="w-label-3">{{ perm_tuple.0.name }}</label></td>
+                        <td class="title"><label for="{{ perm_tuple.1.id_for_label }}" class="w-label-3">{% trans perm_tuple.0.name %}</label></td>
                         <td>
                             {{ perm_tuple.1.tag }}
                         </td>

--- a/wagtail/users/templatetags/wagtailusers_tags.py
+++ b/wagtail/users/templatetags/wagtailusers_tags.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.utils.text import camel_case_to_spaces
+from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.admin.models import Admin
@@ -53,6 +54,14 @@ def normalize_permission_label(permission: Permission):
             return label[: -len(name)].strip()
 
     return label
+
+
+# normalize_permission_label will return "Can view" for Django's standard "Can view X" permission.
+# formatted_permissions.html passes these labels through {% trans %} - since this is a variable
+# within the template it will not be picked up by makemessages, so we define a translation here
+# instead.
+
+VIEW_PERMISSION_LABEL = _("Can view")
 
 
 @register.inclusion_tag("wagtailusers/groups/includes/formatted_permissions.html")


### PR DESCRIPTION
Fixes #5341. Run permission labels through translation at the point of outputting them on `formatted_permissions.html` - since the `{% trans %}` template tag here is working with a variable (and thus can't be handled by `makemessages`), we also need to make sure a `_("...")` declaration exists somewhere in the codebase for any string that arises from Wagtail's native permissions (such as "Can view" or "Can access Wagtail admin"). As discussed at https://github.com/wagtail/wagtail/issues/5341#issuecomment-2090839389, the `permissions` definition in a model's meta options appears to be a suitable place to do this.

Have tested by running `./scripts/rebuild-translation-sources.sh` locally, adding German translations for the new strings in the corresponding .po files, running `django-admin compilemessages`, and verifying that the translations appear in the "edit group" view.