### PR TITLE
Speed up semgrep on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,4 +52,5 @@ repos:
     rev: v1.40.0
     hooks:
       - id: semgrep
-        args: ['--config', '.semgrep.yml', '--error']
+        files: \.py$
+        args: ['--config', '.semgrep.yml', '--disable-version-check', '--error']


### PR DESCRIPTION
Semgrep is quite slow compared to our other pre-commit hooks, taking around 2 seconds to complete on my machine. Try to improve this a bit by:

* only running it on *.py files
* skipping the version check (saves about 300ms)

We're currently only using semgrep to [enforce old-style string formatting on translation strings](https://github.com/wagtail/wagtail/pull/9377), which comes up infrequently enough that we might want to consider leaving this out of pre-commit and just relying on CircleCI to catch it instead. Will see how this improvement pans out first, though...