### PR TITLE
Partially revert listing styles changes to fix layout issues

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Fix: Enable `richtext` template tag to convert lazy translation values (Benjamin Bach)
  * Fix: Ensure permission labels on group permissions page are translated where available (Matt Westcott)
  * Fix: Preserve whitespace in comment replies (Elhussein Almasri)
+ * Fix: Address layout issues in the title cell of universal listings (Sage Abdullah)
  * Docs: Remove duplicate section on frontend caching proxies from performance page (Jake Howard)
  * Docs: Document `restriction_type` field on PageViewRestriction (Shlomo Markowitz)
  * Docs: Document Wagtail's bug bounty policy (Jake Howard)
@@ -23,6 +24,7 @@ Changelog
 
  * Fix: Fix form action URL in user edit and delete views for custom user models (Sage Abdullah)
  * Fix: Fix snippet copy view not prefilling form data (Sage Abdullah)
+ * Fix: Address layout issues in the title cell of universal listings (Sage Abdullah)
 
 
 6.1 (01.05.2024)

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -223,19 +223,13 @@ ul.listing {
 
   .title {
     word-break: break-word;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: theme('spacing.2');
 
     .title-wrapper,
     h2 {
       @apply w-label-1;
-      display: inline-flex;
-      gap: theme('spacing.2');
+      display: inline;
       margin: 0;
       vertical-align: middle;
-      align-items: center;
 
       a {
         color: inherit;
@@ -246,6 +240,11 @@ ul.listing {
           color: theme('colors.text-link-default');
         }
       }
+    }
+
+    .icon-folder {
+      margin: 3px 0.3em 0 0;
+      vertical-align: top;
     }
   }
 

--- a/docs/releases/6.1.1.md
+++ b/docs/releases/6.1.1.md
@@ -15,3 +15,4 @@ depth: 1
 
  * Fix form action URL in user edit and delete views for custom user models (Sage Abdullah)
  * Fix snippet copy view not prefilling form data (Sage Abdullah)
+ * Address layout issues in the title cell of universal listings (Sage Abdullah)

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -24,6 +24,7 @@ depth: 1
  * Enable `richtext` template tag to convert lazy translation values (Benjamin Bach)
  * Ensure permission labels on group permissions page are translated where available (Matt Westcott)
  * Preserve whitespace in comment replies (Elhussein Almasri)
+ * Address layout issues in the title cell of universal listings (Sage Abdullah)
 
 
 ### Documentation

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -5,7 +5,7 @@
 <div class="title-wrapper">
     {% if page.is_site_root %}
         {% if perms.wagtailcore.add_site or perms.wagtailcore.change_site or perms.wagtailcore.delete_site %}
-            <a href="{% url 'wagtailsites:index' %}" title="{% trans 'Sites menu' %}" class="w-flex w-items-center">{% icon name="site" classname="initial" %}</a>
+            <a href="{% url 'wagtailsites:index' %}" title="{% trans 'Sites menu' %}">{% icon name="site" classname="initial" %}</a>
         {% endif %}
     {% endif %}
 
@@ -17,7 +17,7 @@
         without also reading out the buttons and indicators.
     {% endcomment %}
     {% fragment as page_title %}
-        <span id="page_{{ page.pk|unlocalize|admin_urlquote }}_title" class="w-flex w-items-center w-gap-2">
+        <span id="page_{{ page.pk|unlocalize|admin_urlquote }}_title">
             {% if not page.is_site_root and not page.is_leaf %}{% icon name="folder" classname="initial" %}{% endif %}
             {{ page.get_admin_display_title }}
         </span>

--- a/wagtail/users/templates/wagtailusers/users/user_cell.html
+++ b/wagtail/users/templates/wagtailusers/users/user_cell.html
@@ -2,7 +2,7 @@
 {% load wagtailadmin_tags %}
 
 {% block title %}
-    <div class="w-flex w-items-center">
+    <div class="w-inline-flex w-items-center">
         {% avatar user=instance size="small" classname="w-shrink-0" %}
         {{ block.super }}
     </div>


### PR DESCRIPTION
Redo of #11933. Fixes #11949.

In bb12877, the change of `.title-wrapper` from `inline` to `inline-flex` caused an issue with Safari, which b8dd7f4 tried to fix.

Then, further cleanup in 08ee15a caused an issue to the title cell. While we intended the styles to vertically align the title cells, this wasn't a good idea for a few reasons:

- The styles get applied to both `td` and `th` elements
- Even if we limit this to `td.title`, setting `display: flex` directly on the `td` element is bad, as it would cause the table layout to break in some cases (e.g. if two `td.title` elements are adjacent). This issue technically also existed in the old `--inline-actions` styles before 08ee15a, but it was pretty isolated as only `HistoryView` used it.

bb12877 was the commit that started it all. The styling changes in there was to ensure the user avatar and the user name is vertically aligned. However, since the changes in that commit caused a chain reaction to this point, I'll try a different approach instead. Using `inline-flex` instead of `flex` for the user avatar + name wrapper seems to do the trick.

## In summary

We revert the changes to `listing.scss` that happened in:
  - bb12877: revert the `inline` to `inline-flex` change
  - b8dd7f4: revert the `align-items: center` addition and `.icon-folder` margin adjustment removal, as well as the classes added to elements in `_page_title_explore.html`
  - 08ee15a: revert the `flex` styling added to `.title` (but keeping the removal of the unused `--inline-actions` styles

Then we slightly tweak the `user_cell.html` added in bb12877 to use `w-inline-flex` instead of `w-flex` for the wrapper around the user avatar and the name. The use of `w-flex` was what led me to make additional changes to the listing styles (changing `inline` to `inline-flex`, and all the chaos that ensued).

## Comparison

<table>
<tr>
 <th>Section</th>
 <th>Wagtail 6.1</th>
 <th>This PR</th>
 <th>Wagtail 6.0</th>
</tr>

<tr>
 <th>Page listing, root level</th>
 <td>
<img width="985" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/04f2760b-005c-4bd3-93b2-90110a29c64a">
</td>
 <td>
<img width="985" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/8f513973-fda6-4151-a8bc-4eb979b2b6cc">

</td>
 <td>
<img width="985" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/d3eb647a-6a3d-4793-b74f-39e3bd9a4209">

</td>
</tr>

<tr>
<th>Page listing, home</th>
<td>
<img width="972" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/f9865310-2e63-4adb-9624-aae84e44652f">
</td>
<td>
<img width="972" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/a8046ab1-51fb-456a-95b1-c8b4ada31a12">
</td>
<td>
<img width="972" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/bc8cc602-ffb6-48b3-a626-237a5441b144">
</td>
</tr>

<tr>
<th>Dashboard</th>
<td>
<img width="972" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/77c4ea61-0dbe-45c1-b5fa-3a85b9bd6658">
</td>
<td>
<img width="972" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/af159077-03af-47c0-854d-bb4ebc5a388b">
</td>
<td>
<img width="972" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/a2bebc5c-2a50-47d7-ba69-9667b224f005">
</td>
</tr>

<tr>
<th>Workflow listing</th>
<td>
<img width="991" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/8b68ec7d-62d0-4f64-be12-c5997bd925cd">
</td>
<td>
<img width="991" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/0175abe2-40c8-4c84-8dae-88ed62d0f85c">
</td>
<td>
<img width="991" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/13b6e32c-7968-4a5e-8960-f80325b68013">
</td>
</tr>

<tr>
<th>History</th>

<td>
<img width="1104" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/248f5458-3cd7-40a5-9976-c3f154cd06e3">

</td>

<td>
<img width="1104" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/17ee4021-e483-4c71-84e2-c5cb12f094a8">

</td>
<td>
<img width="1104" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/f0db9c5d-23b4-4120-ad34-dc9eed0fb8b5">
</td>
</tr>

<tr>
<th>User listing</th>
<td>
<img width="1032" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/33ad92cc-5f33-4fa0-af5a-8f24b5142d45">
</td>
<td>
<img width="1032" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/11340d5f-972f-46bd-80bd-632442849e61">
</td>
<td>
<img width="1032" alt="image" src="https://github.com/wagtail/wagtail/assets/6379424/411bfe0e-f97a-4643-a5eb-ce57aac64686">
</td>
</tr>

</table>
