### PR TITLE
Refactor image chooser pagination to check WAGTAILIMAGES_CHOOSER_PAGE_SIZE at runtime

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Docs: Document `restriction_type` field on PageViewRestriction (Shlomo Markowitz)
  * Docs: Document Wagtail's bug bounty policy (Jake Howard)
  * Maintenance: Use `DjangoJSONEncoder` instead of custom `LazyStringEncoder` to serialize Draftail config (Sage Abdullah)
+ * Maintenance: Refactor image chooser pagination to check `WAGTAILIMAGES_CHOOSER_PAGE_SIZE` at runtime (Matt Westcott)
 
 
 6.1 (01.05.2024)

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -36,6 +36,7 @@ depth: 1
 ### Maintenance
 
  * Use `DjangoJSONEncoder` instead of custom `LazyStringEncoder` to serialize Draftail config (Sage Abdullah)
+ * Refactor image chooser pagination to check `WAGTAILIMAGES_CHOOSER_PAGE_SIZE` at runtime (Matt Westcott)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/viewsets/base.py
+++ b/wagtail/admin/viewsets/base.py
@@ -17,6 +17,10 @@ class ViewSet(WagtailMenuRegisterable):
     For more information on how to use this class, see :ref:`using_base_viewset`.
     """
 
+    #: A special value that, when passed in a kwargs dict to construct a view, indicates that
+    #: the attribute should not be written and should instead be left as the view's initial value
+    UNDEFINED = object()
+
     #: A name for this viewset, used as the default URL prefix and namespace.
     name = None
 
@@ -42,12 +46,13 @@ class ViewSet(WagtailMenuRegisterable):
         in addition to any kwargs passed to this method. Items from get_common_view_kwargs will be
         filtered to only include those that are valid for the given view_class.
         """
+        merged_kwargs = self.get_common_view_kwargs()
+        merged_kwargs.update(kwargs)
         filtered_kwargs = {
             key: value
-            for key, value in self.get_common_view_kwargs().items()
-            if hasattr(view_class, key)
+            for key, value in merged_kwargs.items()
+            if hasattr(view_class, key) and value is not self.UNDEFINED
         }
-        filtered_kwargs.update(kwargs)
         return view_class.as_view(**filtered_kwargs)
 
     def inject_view_methods(self, view_class, method_names):

--- a/wagtail/admin/viewsets/chooser.py
+++ b/wagtail/admin/viewsets/chooser.py
@@ -29,7 +29,7 @@ class ChooserViewSet(ViewSet):
     )  #: Label for the 'choose' button in the chooser widget, when an item has already been chosen
     edit_item_text = _("Edit")  #: Label for the 'edit' button in the chooser widget
 
-    per_page = 10  #: Number of results to show per page
+    per_page = ViewSet.UNDEFINED  #: Number of results to show per page
 
     #: A list of URL query parameters that should be passed on unmodified as part of any links or
     #: form submissions within the chooser modal workflow.

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1681,6 +1681,22 @@ class TestImageChooserView(WagtailTestUtils, TestCase):
         response = self.get({"p": 9999})
         self.assertEqual(response.status_code, 404)
 
+    @override_settings(WAGTAILIMAGES_CHOOSER_PAGE_SIZE=4)
+    def test_chooser_page_size(self):
+        images = [
+            Image(
+                title="Test image %i" % i,
+                file=get_test_image_file(size=(1, 1)),
+            )
+            for i in range(1, 12)
+        ]
+        Image.objects.bulk_create(images)
+
+        response = self.get()
+
+        self.assertContains(response, "Page 1 of 3")
+        self.assertEqual(response.status_code, 200)
+
     def test_filter_by_tag(self):
         for i in range(0, 10):
             image = Image.objects.create(

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -72,9 +72,14 @@ class ImageCreationFormMixin(CreationFormMixin):
 class BaseImageChooseView(BaseChooseView):
     template_name = "wagtailimages/chooser/chooser.html"
     results_template_name = "wagtailimages/chooser/results.html"
-    per_page = 12
     ordering = "-created_at"
     construct_queryset_hook_name = "construct_image_chooser_queryset"
+
+    @property
+    def per_page(self):
+        # Make per_page into a property so that we can read back WAGTAILIMAGES_CHOOSER_PAGE_SIZE
+        # at runtime.
+        return getattr(settings, "WAGTAILIMAGES_CHOOSER_PAGE_SIZE", 20)
 
     def get_object_list(self):
         return (
@@ -309,7 +314,6 @@ class ImageChooserViewSet(ChooserViewSet):
     preserve_url_parameters = ChooserViewSet.preserve_url_parameters + ["select_format"]
 
     icon = "image"
-    per_page = getattr(settings, "WAGTAILIMAGES_CHOOSER_PAGE_SIZE", 10)
     choose_one_text = _("Choose an image")
     create_action_label = _("Upload")
     create_action_clicked_label = _("Uploading…")


### PR DESCRIPTION
Follow-up to https://github.com/wagtail/wagtail/pull/11884 and #11898, to fix https://github.com/wagtail/wagtail/issues/11813. As suggested in https://github.com/wagtail/wagtail/pull/11898#pullrequestreview-2037717790, introduce a special "undefined" value to indicate that a view attribute should be left unchanged from the view's default.