### PR TITLE
Only scan `src` in `client` directory for Tailwind to prevent unnecessary rebuilds

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Changelog
  * Docs: Document Wagtail's bug bounty policy (Jake Howard)
  * Maintenance: Use `DjangoJSONEncoder` instead of custom `LazyStringEncoder` to serialize Draftail config (Sage Abdullah)
  * Maintenance: Refactor image chooser pagination to check `WAGTAILIMAGES_CHOOSER_PAGE_SIZE` at runtime (Matt Westcott)
+ * Maintenance: Exclude the `client/scss` directory in Tailwind content config to speed up CSS compilation (Sage Abdullah)
 
 
 6.1.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -37,6 +37,7 @@ depth: 1
 
  * Use `DjangoJSONEncoder` instead of custom `LazyStringEncoder` to serialize Draftail config (Sage Abdullah)
  * Refactor image chooser pagination to check `WAGTAILIMAGES_CHOOSER_PAGE_SIZE` at runtime (Matt Westcott)
+ * Exclude the `client/scss` directory in Tailwind content config to speed up CSS compilation (Sage Abdullah)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,12 @@ module.exports = {
   content: [
     './wagtail/**/*.{py,html,ts,tsx}',
     './wagtail/**/static_src/**/*.js',
-    './client/**/*.{js,ts,tsx,mdx}',
+    // Make sure NOT to include the `client/scss` directory,
+    // even if we don't specify `*.scss` files here.
+    // The directory would still be scanned for files, which would cause
+    // the styles to rebuild in a loop.
+    // https://tailwindcss.com/docs/content-configuration#styles-rebuild-in-an-infinite-loop
+    './client/src/**/*.{js,ts,tsx,mdx}',
     './docs/**/*.{md,rst}',
   ],
   corePlugins: {


### PR DESCRIPTION
Running `npm run build` or `npm start` takes excruciatingly long, not sure since when but it started a few releases back.

Per https://tailwindcss.com/docs/content-configuration#styles-rebuild-in-an-infinite-loop, we should make sure we don't accidentally specify our CSS directory (`client/scss`). We've specified the file name to only `{js,ts,tsx,mdx}`, but as explained in Tailwind's docs, webpack would still watch entire directories. As a result, it seems to cause some kind of a feedback loop in Webpack's file watching mechanism, which leads to the slow build.

Limiting Tailwind's `content` glob for `client` to `client/src` seems to fix it. This speeds up the FE production build from 60s to ~21s on my machine, and also speeds up hot rebuilds to under 3s.

The build time is now comparable to if you run `npm run build` with an empty Tailwind `content` list, which suggests that this performance is close to the "baseline" of not using Tailwind. Of course, I've verified that the styles actually do get compiled (by deleting `wagtail/admin/static` and re-running the build). I haven't checked whether the result is identical, though...
