### PR TITLE
Fix form action URL in user edit and delete views for custom user models

### DIFF
--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -782,6 +782,12 @@ class TestUserDeleteView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailusers/users/confirm_delete.html")
         self.assertBreadcrumbsNotRendered(response.content)
 
+        # Should render the form with the correct action URL
+        soup = self.get_soup(response.content)
+        delete_url = reverse("wagtailusers_users:delete", args=(self.test_user.pk,))
+        form_action = soup.select_one("form").attrs["action"]
+        self.assertEqual(form_action, delete_url)
+
     def test_delete(self):
         response = self.post(follow=True)
 
@@ -990,9 +996,13 @@ class TestUserEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         history_link = header.find("a", attrs={"href": history_url})
         self.assertIsNotNone(history_link)
 
+        # Should render the form with the correct action URL
+        edit_url = reverse("wagtailusers_users:edit", args=(self.test_user.pk,))
+        form_action = soup.select_one("form").attrs["action"]
+        self.assertEqual(form_action, edit_url)
+
         url_finder = AdminURLFinder(self.current_user)
-        expected_url = f"/admin/users/edit/{self.test_user.pk}/"
-        self.assertEqual(url_finder.get_edit_url(self.test_user), expected_url)
+        self.assertEqual(url_finder.get_edit_url(self.test_user), edit_url)
 
     def test_legacy_url_redirect(self):
         with self.assertWarnsMessage(

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -286,6 +286,7 @@ class Edit(EditView):
 
     success_message = gettext_lazy("User '%(object)s' updated.")
     error_message = gettext_lazy("The user could not be saved due to errors.")
+    context_object_name = "user"
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
@@ -339,6 +340,7 @@ class Delete(DeleteView):
 
     page_title = gettext_lazy("Delete user")
     success_message = gettext_lazy("User '%(object)s' deleted.")
+    context_object_name = "user"
 
     def dispatch(self, request, *args, **kwargs):
         self.object = self.get_object()


### PR DESCRIPTION
I was working on adding `UserViewSet` customisation support, then I encountered this issue...

83e79301a945267da4c0aff4c8dff9228992c658 mistakenly removed the `context_object_name` from the `EditView` and `DeleteView`. Since the view still uses the custom templates that render the form action with a `{% url %}` instead of the available `edit_url` context variable, this results in the template being rendered with the _current_ user as the `user` that is used to generate the URL. This only applies to installations where the auth user model's `model_name` is not `user`, so the bakerydemo is not affected.