### PR TITLE
Add the ability to customize the `UserViewSet` via the app config

### DIFF
--- a/docs/advanced_topics/customisation/custom_user_models.md
+++ b/docs/advanced_topics/customisation/custom_user_models.md
@@ -1,13 +1,15 @@
 # Custom user models
 
-## Custom user forms example
+This page shows how to configure Wagtail to accommodate a custom user model.
 
-This example shows how to add a text field and foreign key field to a custom user model
-and configure Wagtail user forms to allow the fields values to be updated.
+## Creating a custom user model
 
-Create a custom user model. This must at minimum inherit from `AbstractBaseUser` and `PermissionsMixin`. In this case, we extend the `AbstractUser` class and add two fields. The foreign key references another model (not shown).
+This example uses a custom user model that adds a text field and foreign key field.
+
+The custom user model must at minimum inherit from {class}`~django.contrib.auth.models.AbstractBaseUser` and {class}`~django.contrib.auth.models.PermissionsMixin`. In this case, we extend the {class}`~django.contrib.auth.models.AbstractUser` class and add two fields. The foreign key references another model (not shown).
 
 ```python
+# myapp/models.py
 from django.contrib.auth.models import AbstractUser
 
 class User(AbstractUser):
@@ -17,21 +19,25 @@ class User(AbstractUser):
 
 Add the app containing your user model to `INSTALLED_APPS` - it must be above the `'wagtail.users'` line,
 in order to override Wagtail's built-in templates - and set [AUTH_USER_MODEL](https://docs.djangoproject.com/en/stable/topics/auth/customizing/#substituting-a-custom-user-model) to reference
-your model. In this example the app is called `users` and the model is `User`
+your model. In this example the app is called `myapp` and the model is `User`.
 
 ```python
-AUTH_USER_MODEL = 'users.User'
+AUTH_USER_MODEL = 'myapp.User'
 ```
 
+## Creating custom user forms
+
+Now we need to configure Wagtail's user forms to allow the custom fields' values to be updated.
 Create your custom user 'create' and 'edit' forms in your app:
 
 ```python
+# myapp/forms.py
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.users.forms import UserEditForm, UserCreationForm
 
-from users.models import MembershipStatus
+from myapp.models import MembershipStatus
 
 
 class CustomUserEditForm(UserEditForm):
@@ -44,8 +50,11 @@ class CustomUserCreationForm(UserCreationForm):
     status = forms.ModelChoiceField(queryset=MembershipStatus.objects, required=True, label=_("Status"))
 ```
 
+## Extending the create and edit templates
+
 Extend the Wagtail user 'create' and 'edit' templates. These extended templates should be placed in a
 template directory `wagtailusers/users`.
+Using a custom template directory is possible and will be explained later.
 
 Template create.html:
 
@@ -70,29 +79,22 @@ Template edit.html:
 ```
 
 The `extra_fields` block allows fields to be inserted below the `last_name` field
-in the default templates. Other block-overriding options exist to allow appending
+in the default templates. There is a `fields` block that allows appending
 fields to the end or beginning of the existing fields or to allow all the fields to
 be redefined.
 
-Add the Wagtail settings to your project to reference the user form additions:
-
-```python
-WAGTAIL_USER_EDIT_FORM = 'users.forms.CustomUserEditForm'
-WAGTAIL_USER_CREATION_FORM = 'users.forms.CustomUserCreationForm'
-WAGTAIL_USER_CUSTOM_FIELDS = ['country', 'status']
-```
-
-```{versionadded} 6.2
-The ability to customize the `UserViewSet` was added. Instead of customizing the forms via the `WAGTAIL_USER_EDIT_FORM`, `WAGTAIL_USER_CREATION_FORM`, and `WAGTAIL_USER_CUSTOM_FIELDS` settings, we recommend customizing them via the viewset instead, as explained below. The aforementioned settings might be deprecated in a future release.
-```
-
 (custom_userviewset)=
 
-## Custom `UserViewSet`
+## Creating a custom `UserViewSet`
 
-Alternatively, you can also customize the forms and the views by creating a `UserViewSet` subclass. For example, with the above custom form classes, you can create the following `UserViewSet` subclass:
+```{versionadded} 6.2
+The ability to customize the `UserViewSet` was added.
+```
+
+To make use of the custom forms, create a `UserViewSet` subclass.
 
 ```python
+# myapp/viewsets.py
 from wagtail.users.views.users import UserViewSet as WagtailUserViewSet
 
 from .forms import CustomUserCreationForm, CustomUserEditForm
@@ -105,14 +107,15 @@ class UserViewSet(WagtailUserViewSet):
         return CustomUserCreationForm
 ```
 
-Then, configure the `wagtail.users` application to use the custom viewset, by setting up a custom `AppConfig` class. Within your project folder (which will be the package containing the top-level settings and urls modules), create `apps.py` (if it does not exist already) and add:
+Then, configure the `wagtail.users` application to use the custom viewset, by setting up a custom `AppConfig` class. Within your custom `myapp` app directory, create `apps.py` (if it does not exist already) and add:
 
 ```python
+# myapp/apps.py
 from wagtail.users.apps import WagtailUsersAppConfig
 
 
 class CustomUsersAppConfig(WagtailUsersAppConfig):
-    user_viewset = "myapplication.someapp.viewsets.UserViewSet"
+    user_viewset = "myapp.viewsets.UserViewSet"
 ```
 
 Replace `wagtail.users` in `settings.INSTALLED_APPS` with the path to `CustomUsersAppConfig`.
@@ -120,10 +123,29 @@ Replace `wagtail.users` in `settings.INSTALLED_APPS` with the path to `CustomUse
 ```python
 INSTALLED_APPS = [
     ...,
-    "myapplication.apps.CustomUsersAppConfig",
+    "myapp.apps.CustomUsersAppConfig",
     # "wagtail.users",
     ...,
 ]
 ```
 
-If you want to customize the group forms and views, see [](customizing_group_views).
+The `UserViewSet` class is a subclass of {class}`~wagtail.admin.viewsets.model.ModelViewSet` and thus it supports most of [the customizations available for `ModelViewSet`](generic_views). For example, you can use a custom directory for the templates by setting {attr}`~wagtail.admin.viewsets.model.ModelViewSet.template_prefix`:
+
+```py
+class UserViewSet(WagtailUserViewSet):
+    template_prefix = "myapp/users/"
+```
+
+or customize the create and edit templates specifically:
+
+```py
+class UserViewSet(WagtailUserViewSet):
+    create_template_name = "myapp/users/create.html"
+    edit_template_name = "myapp/users/edit.html"
+```
+
+```{versionchanged} 6.2
+Instead of customizing the forms via the [`WAGTAIL_USER_EDIT_FORM`, `WAGTAIL_USER_CREATION_FORM`, and `WAGTAIL_USER_CUSTOM_FIELDS` settings](user_form_settings), we recommend customizing them via the viewset instead, as explained above. The aforementioned settings will be deprecated in a future release.
+```
+
+The group forms and views can be customized in a similar way – see [](customizing_group_views).

--- a/docs/advanced_topics/customisation/custom_user_models.md
+++ b/docs/advanced_topics/customisation/custom_user_models.md
@@ -145,7 +145,7 @@ class UserViewSet(WagtailUserViewSet):
 ```
 
 ```{versionchanged} 6.2
-Instead of customizing the forms via the [`WAGTAIL_USER_EDIT_FORM`, `WAGTAIL_USER_CREATION_FORM`, and `WAGTAIL_USER_CUSTOM_FIELDS` settings](user_form_settings), we recommend customizing them via the viewset instead, as explained above. The aforementioned settings will be deprecated in a future release.
+The [`WAGTAIL_USER_EDIT_FORM`, `WAGTAIL_USER_CREATION_FORM`, and `WAGTAIL_USER_CUSTOM_FIELDS` settings](user_form_settings) have been deprecated in favor of customizing the form classes via `UserViewSet.get_form_class()`.
 ```
 
 The group forms and views can be customized in a similar way – see [](customizing_group_views).

--- a/docs/advanced_topics/customisation/custom_user_models.md
+++ b/docs/advanced_topics/customisation/custom_user_models.md
@@ -81,3 +81,49 @@ WAGTAIL_USER_EDIT_FORM = 'users.forms.CustomUserEditForm'
 WAGTAIL_USER_CREATION_FORM = 'users.forms.CustomUserCreationForm'
 WAGTAIL_USER_CUSTOM_FIELDS = ['country', 'status']
 ```
+
+```{versionadded} 6.2
+The ability to customize the `UserViewSet` was added. Instead of customizing the forms via the `WAGTAIL_USER_EDIT_FORM`, `WAGTAIL_USER_CREATION_FORM`, and `WAGTAIL_USER_CUSTOM_FIELDS` settings, we recommend customizing them via the viewset instead, as explained below. The aforementioned settings might be deprecated in a future release.
+```
+
+(custom_userviewset)=
+
+## Custom `UserViewSet`
+
+Alternatively, you can also customize the forms and the views by creating a `UserViewSet` subclass. For example, with the above custom form classes, you can create the following `UserViewSet` subclass:
+
+```python
+from wagtail.users.views.users import UserViewSet as WagtailUserViewSet
+
+from .forms import CustomUserCreationForm, CustomUserEditForm
+
+
+class UserViewSet(WagtailUserViewSet):
+    def get_form_class(self, for_update=False):
+        if for_update:
+            return CustomUserEditForm
+        return CustomUserCreationForm
+```
+
+Then, configure the `wagtail.users` application to use the custom viewset, by setting up a custom `AppConfig` class. Within your project folder (which will be the package containing the top-level settings and urls modules), create `apps.py` (if it does not exist already) and add:
+
+```python
+from wagtail.users.apps import WagtailUsersAppConfig
+
+
+class CustomUsersAppConfig(WagtailUsersAppConfig):
+    user_viewset = "myapplication.someapp.viewsets.UserViewSet"
+```
+
+Replace `wagtail.users` in `settings.INSTALLED_APPS` with the path to `CustomUsersAppConfig`.
+
+```python
+INSTALLED_APPS = [
+    ...,
+    "myapplication.apps.CustomUsersAppConfig",
+    # "wagtail.users",
+    ...,
+]
+```
+
+If you want to customize the group forms and views, see [](customizing_group_views).

--- a/docs/extending/customizing_group_views.md
+++ b/docs/extending/customizing_group_views.md
@@ -107,6 +107,8 @@ INSTALLED_APPS = [
 ]
 ```
 
+If you want to customize the user forms and views instead, see [](custom_userviewset).
+
 (customizing_group_views_permissions_order)=
 
 ## Customizing the group editor permissions ordering

--- a/docs/extending/customizing_group_views.md
+++ b/docs/extending/customizing_group_views.md
@@ -12,6 +12,7 @@ Let's say you need to connect Active Directory groups with Django groups.
 We create a model for Active Directory groups as follows:
 
 ```python
+# myapp/models.py
 from django.contrib.auth.models import Group
 from django.db import models
 
@@ -32,6 +33,7 @@ However, there is no role field on the Wagtail group 'edit' or 'create' view.
 To add it, inherit from `wagtail.users.forms.GroupForm` and add a new field:
 
 ```python
+# myapp/forms.py
 from django import forms
 
 from wagtail.users.forms import GroupForm as WagtailGroupForm
@@ -65,6 +67,7 @@ class GroupForm(WagtailGroupForm):
 Now add your custom form into the group viewset by inheriting the default Wagtail `GroupViewSet` class and overriding the `get_form_class` method.
 
 ```python
+# myapp/viewsets.py
 from wagtail.users.views.groups import GroupViewSet as WagtailGroupViewSet
 
 from .forms import GroupForm
@@ -86,14 +89,15 @@ Add the field to the group 'edit'/'create' templates:
 {% endblock extra_fields %}
 ```
 
-Finally, we configure the `wagtail.users` application to use the custom viewset, by setting up a custom `AppConfig` class. Within your project folder (which will be the package containing the top-level settings and urls modules), create `apps.py` (if it does not exist already) and add:
+Finally, we configure the `wagtail.users` application to use the custom viewset, by setting up a custom `AppConfig` class. Within your custom `myapp` app directory, create `apps.py` (if it does not exist already) and add:
 
 ```python
+# myapp/apps.py
 from wagtail.users.apps import WagtailUsersAppConfig
 
 
 class CustomUsersAppConfig(WagtailUsersAppConfig):
-    group_viewset = "myapplication.someapp.viewsets.GroupViewSet"
+    group_viewset = "myapp.viewsets.GroupViewSet"
 ```
 
 Replace `wagtail.users` in `settings.INSTALLED_APPS` with the path to `CustomUsersAppConfig`.
@@ -101,13 +105,15 @@ Replace `wagtail.users` in `settings.INSTALLED_APPS` with the path to `CustomUse
 ```python
 INSTALLED_APPS = [
     ...,
-    "myapplication.apps.CustomUsersAppConfig",
+    "myapp.apps.CustomUsersAppConfig",
     # "wagtail.users",
     ...,
 ]
 ```
 
-If you want to customize the user forms and views instead, see [](custom_userviewset).
+The `GroupViewSet` class is a subclass of {class}`~wagtail.admin.viewsets.model.ModelViewSet` and thus it supports most of [the customizations available for `ModelViewSet`](./generic_views).
+
+The user forms and views can be customized in a similar way - see [](custom_userviewset).
 
 (customizing_group_views_permissions_order)=
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -514,7 +514,9 @@ WAGTAIL_USER_EDIT_FORM = 'users.forms.CustomUserEditForm'
 
 Allows the default `UserEditForm` class to be overridden with a custom form when a custom user model is being used and extra fields are required in the user edit form.
 
-For further information See {doc}`/advanced_topics/customisation/custom_user_models`.
+```{versionchanged} 6.2
+This setting has been deprecated in favor of customizing the form classes via `UserViewSet.get_form_class()` and will be removed in a future release. For further information, see [](custom_userviewset).
+```
 
 ### `WAGTAIL_USER_CREATION_FORM`
 
@@ -524,7 +526,9 @@ WAGTAIL_USER_CREATION_FORM = 'users.forms.CustomUserCreationForm'
 
 Allows the default `UserCreationForm` class to be overridden with a custom form when a custom user model is being used and extra fields are required in the user creation form.
 
-For further information See {doc}`/advanced_topics/customisation/custom_user_models`.
+```{versionchanged} 6.2
+This setting has been deprecated in favor of customizing the form classes via `UserViewSet.get_form_class()` and will be removed in a future release. For further information, see [](custom_userviewset).
+```
 
 ### `WAGTAIL_USER_CUSTOM_FIELDS`
 
@@ -532,9 +536,11 @@ For further information See {doc}`/advanced_topics/customisation/custom_user_mod
 WAGTAIL_USER_CUSTOM_FIELDS = ['country']
 ```
 
-A list of the extra custom fields to be appended to the default list.
+A list of the extra custom fields to be appended to the default list. The resulting list is passed to {class}`~django.forms.ModelForm`'s `Meta.fields` to generate the form fields.
 
-For further information See {doc}`/advanced_topics/customisation/custom_user_models`.
+```{versionchanged} 6.2
+This setting has been deprecated in favor of customizing the form classes via `UserViewSet.get_form_class()` and will be removed in a future release. For further information, see [](custom_userviewset).
+```
 
 ### `WAGTAILADMIN_USER_LOGIN_FORM`
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -504,6 +504,8 @@ WAGTAILADMIN_USER_PASSWORD_RESET_FORM = 'users.forms.PasswordResetForm'
 
 Allows the default `PasswordResetForm` to be extended with extra fields.
 
+(user_form_settings)=
+
 ### `WAGTAIL_USER_EDIT_FORM`
 
 ```python

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -143,6 +143,109 @@ class FooViewSet(SnippetViewSet):
         return Permission.objects.filter(content_type=content_type)
 ```
 
+### Deprecation of `WAGTAIL_USER_EDIT_FORM`, `WAGTAIL_USER_CREATION_FORM`, and `WAGTAIL_USER_CUSTOM_FIELDS` settings
+
+This release introduces a customizable `UserViewSet` class, which can be used to customize various aspects of Wagtail's admin views for managing users, including the form classes for creating and editing users. As a result, the [`WAGTAIL_USER_EDIT_FORM`, `WAGTAIL_USER_CREATION_FORM`, and `WAGTAIL_USER_CUSTOM_FIELDS` settings](user_form_settings) have been deprecated in favor of customizing the form classes via `UserViewSet.get_form_class()`.
+
+If you use the aforementioned settings, you can migrate your code by making the following changes.
+
+#### Before
+
+Given the following custom user model:
+
+```py
+class User(AbstractUser):
+    country = models.CharField(verbose_name='country', max_length=255)
+    status = models.ForeignKey(MembershipStatus, on_delete=models.SET_NULL, null=True, default=1)
+```
+
+The following custom forms:
+
+```py
+class CustomUserEditForm(UserEditForm):
+    status = forms.ModelChoiceField(queryset=MembershipStatus.objects, required=True, label=_("Status"))
+
+
+class CustomUserCreationForm(UserCreationForm):
+    status = forms.ModelChoiceField(queryset=MembershipStatus.objects, required=True, label=_("Status"))
+```
+
+And the following settings:
+
+```py
+WAGTAIL_USER_EDIT_FORM = "myapp.forms.CustomUserEditForm"
+WAGTAIL_USER_CREATION_FORM = "myapp.forms.CustomUserCreationForm"
+WAGTAIL_USER_CUSTOM_FIELDS = ["country"]
+```
+
+#### After
+
+Change the custom forms to the following:
+
+```py
+class CustomUserEditForm(UserEditForm):
+    status = forms.ModelChoiceField(queryset=MembershipStatus.objects, required=True, label=_("Status"))
+
+    # Use ModelForm's automatic form fields generation for the model's `country` field.
+    # Alternatively, you can also define a `country` form field directly on
+    # `CustomUserEditForm` along with any desired options for the field, and skip
+    # the following custom Meta subclass.
+    class Meta(UserEditForm.Meta):
+        fields = UserEditForm.Meta.fields | {"country"}
+
+class CustomUserCreationForm(UserCreationForm):
+    status = forms.ModelChoiceField(queryset=MembershipStatus.objects, required=True, label=_("Status"))
+
+    # Use ModelForm's automatic form fields generation for the model's `country` field.
+    # Alternatively, you can also define a `country` form field directly on
+    # `CustomUserCreationForm` along with any desired options for the field, and skip
+    # the following custom Meta subclass.
+    class Meta(UserCreationForm.Meta):
+        fields = UserEditForm.Meta.fields | {"country"}
+```
+
+Create a custom `UserViewSet` subclass in e.g. `myapp/viewsets.py`:
+
+```py
+# myapp/viewsets.py
+from wagtail.users.views.users import UserViewSet as WagtailUserViewSet
+
+from .forms import CustomUserCreationForm, CustomUserEditForm
+
+
+class UserViewSet(WagtailUserViewSet):
+    def get_form_class(self, for_update=False):
+        if for_update:
+            return CustomUserEditForm
+        return CustomUserCreationForm
+```
+
+Create a custom `WagtailUsersAppConfig` subclass in e.g. `myapp/apps.py` (or reuse the same class if you have a custom `GroupViewSet` as described in [](customizing_group_views)). Then, set a `user_viewset` attribute pointing to the custom `UserViewSet` subclass:
+
+```py
+# myapp/apps.py
+from wagtail.users.apps import WagtailUsersAppConfig
+
+
+class CustomUsersAppConfig(WagtailUsersAppConfig):
+    user_viewset = "myapp.viewsets.UserViewSet"
+    # If you have customized the GroupViewSet before
+    group_viewset = "myapp.viewsets.GroupViewSet"
+```
+
+Replace `wagtail.users` in `settings.INSTALLED_APPS` with the path to `CustomUsersAppConfig`:
+
+```python
+INSTALLED_APPS = [
+    ...,
+    "myapp.apps.CustomUsersAppConfig",
+    # "wagtail.users",
+    ...,
+]
+```
+
+For more details, see [](custom_userviewset).
+
 ## Upgrade considerations - deprecation of old functionality
 
 ## Upgrade considerations - changes affecting Wagtail customisations

--- a/wagtail/admin/views/generic/__init__.py
+++ b/wagtail/admin/views/generic/__init__.py
@@ -4,6 +4,7 @@ from .base import (  # noqa: F401
     BaseOperationView,
     WagtailAdminTemplateMixin,
 )
+from .history import HistoryView  # noqa: F401
 from .mixins import (  # noqa: F401
     BeforeAfterHookMixin,
     CreateEditViewOptionalFeaturesMixin,

--- a/wagtail/users/apps.py
+++ b/wagtail/users/apps.py
@@ -8,3 +8,4 @@ class WagtailUsersAppConfig(AppConfig):
     verbose_name = _("Wagtail users")
     default_auto_field = "django.db.models.AutoField"
     group_viewset = "wagtail.users.views.groups.GroupViewSet"
+    user_viewset = "wagtail.users.views.users.UserViewSet"

--- a/wagtail/users/forms.py
+++ b/wagtail/users/forms.py
@@ -1,4 +1,5 @@
 from itertools import groupby
+from warnings import warn
 
 from django import forms
 from django.conf import settings
@@ -21,6 +22,7 @@ from wagtail.models import (
     GroupPagePermission,
     Page,
 )
+from wagtail.utils.deprecation import RemovedInWagtail70Warning
 
 User = get_user_model()
 
@@ -29,6 +31,11 @@ standard_fields = {"email", "first_name", "last_name", "is_superuser", "groups"}
 # Custom fields
 if hasattr(settings, "WAGTAIL_USER_CUSTOM_FIELDS"):
     custom_fields = set(settings.WAGTAIL_USER_CUSTOM_FIELDS)
+    warn(
+        "The `WAGTAIL_USER_CUSTOM_FIELDS` setting is deprecated. Use a custom "
+        "`UserViewSet` subclass and override `get_form_class()` instead.",
+        RemovedInWagtail70Warning,
+    )
 else:
     custom_fields = set()
 

--- a/wagtail/users/tests/__init__.py
+++ b/wagtail/users/tests/__init__.py
@@ -2,6 +2,12 @@ from .test_admin_views import (
     CustomGroupViewSet,
     CustomUserCreationForm,
     CustomUserEditForm,
+    CustomUserViewSet,
 )
 
-__all__ = ["CustomGroupViewSet", "CustomUserCreationForm", "CustomUserEditForm"]
+__all__ = [
+    "CustomGroupViewSet",
+    "CustomUserViewSet",
+    "CustomUserCreationForm",
+    "CustomUserEditForm",
+]

--- a/wagtail/users/views/groups.py
+++ b/wagtail/users/views/groups.py
@@ -149,6 +149,10 @@ class GroupViewSet(ModelViewSet):
     model = Group
     ordering = ["name"]
     add_to_reference_index = False
+    menu_name = "groups"
+    menu_label = _("Groups")
+    menu_order = 601
+    add_to_settings_menu = True
 
     index_view_class = IndexView
     add_view_class = CreateView

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -25,8 +25,7 @@ from wagtail.admin.ui.tables import (
     TitleColumn,
 )
 from wagtail.admin.utils import get_user_display_name
-from wagtail.admin.views.generic import CreateView, DeleteView, EditView, IndexView
-from wagtail.admin.views.generic.history import HistoryView
+from wagtail.admin.views import generic
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.admin.widgets.boolean_radio_select import BooleanRadioSelect
 from wagtail.admin.widgets.button import (
@@ -128,7 +127,7 @@ class UserFilterSet(WagtailFilterSet):
         fields = []
 
 
-class Index(IndexView):
+class IndexView(generic.IndexView):
     """
     Lists the users for management within the admin.
     """
@@ -260,7 +259,7 @@ class Index(IndexView):
         return queryset
 
 
-class Create(CreateView):
+class CreateView(generic.CreateView):
     """
     Provide the ability to create a user within the admin.
     """
@@ -282,7 +281,7 @@ class Create(CreateView):
         )
 
 
-class Edit(EditView):
+class EditView(generic.EditView):
     """
     Provide the ability to edit a user within the admin.
     """
@@ -336,7 +335,7 @@ class Edit(EditView):
         return context
 
 
-class Delete(DeleteView):
+class DeleteView(generic.DeleteView):
     """
     Provide the ability to delete a user within the admin.
     """
@@ -366,7 +365,7 @@ class Delete(DeleteView):
         )
 
 
-class History(HistoryView):
+class HistoryView(generic.HistoryView):
     def get_page_subtitle(self):
         return get_user_display_name(self.object)
 
@@ -378,11 +377,11 @@ class UserViewSet(ModelViewSet):
     add_to_reference_index = False
     filterset_class = UserFilterSet
 
-    index_view_class = Index
-    add_view_class = Create
-    edit_view_class = Edit
-    delete_view_class = Delete
-    history_view_class = History
+    index_view_class = IndexView
+    add_view_class = CreateView
+    edit_view_class = EditView
+    delete_view_class = DeleteView
+    history_view_class = HistoryView
 
     template_prefix = "wagtailusers/users/"
 

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -17,6 +17,7 @@ from django.utils.translation import gettext_lazy
 
 from wagtail import hooks
 from wagtail.admin.filters import DateRangePickerWidget, WagtailFilterSet
+from wagtail.admin.menu import MenuItem
 from wagtail.admin.ui.tables import (
     BulkActionsCheckboxColumn,
     Column,
@@ -370,12 +371,26 @@ class HistoryView(generic.HistoryView):
         return get_user_display_name(self.object)
 
 
+class UsersMenuItem(MenuItem):
+    def is_shown(self, request):
+        return (
+            request.user.has_perm(add_user_perm)
+            or request.user.has_perm(change_user_perm)
+            or request.user.has_perm(delete_user_perm)
+        )
+
+
 class UserViewSet(ModelViewSet):
     icon = "user"
     model = User
     ordering = "name"
     add_to_reference_index = False
     filterset_class = UserFilterSet
+    menu_name = "users"
+    menu_label = gettext_lazy("Users")
+    menu_order = 600
+    menu_item_class = UsersMenuItem
+    add_to_settings_menu = True
 
     index_view_class = IndexView
     add_view_class = CreateView

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -58,6 +58,11 @@ delete_user_perm = "{}.delete_{}".format(
 def get_user_creation_form():
     form_setting = "WAGTAIL_USER_CREATION_FORM"
     if hasattr(settings, form_setting):
+        warn(
+            "The `WAGTAIL_USER_CREATION_FORM` setting is deprecated. Use a custom "
+            "`UserViewSet` subclass and override `get_form_class()` instead.",
+            RemovedInWagtail70Warning,
+        )
         return get_custom_form(form_setting)
     else:
         return UserCreationForm
@@ -66,6 +71,11 @@ def get_user_creation_form():
 def get_user_edit_form():
     form_setting = "WAGTAIL_USER_EDIT_FORM"
     if hasattr(settings, form_setting):
+        warn(
+            "The `WAGTAIL_USER_EDIT_FORM` setting is deprecated. Use a custom "
+            "`UserViewSet` subclass and override `get_form_class()` instead.",
+            RemovedInWagtail70Warning,
+        )
         return get_custom_form(form_setting)
     else:
         return UserEditForm

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -17,7 +17,6 @@ from django.utils.translation import gettext_lazy
 
 from wagtail import hooks
 from wagtail.admin.filters import DateRangePickerWidget, WagtailFilterSet
-from wagtail.admin.menu import MenuItem
 from wagtail.admin.ui.tables import (
     BulkActionsCheckboxColumn,
     Column,
@@ -371,15 +370,6 @@ class HistoryView(generic.HistoryView):
         return get_user_display_name(self.object)
 
 
-class UsersMenuItem(MenuItem):
-    def is_shown(self, request):
-        return (
-            request.user.has_perm(add_user_perm)
-            or request.user.has_perm(change_user_perm)
-            or request.user.has_perm(delete_user_perm)
-        )
-
-
 class UserViewSet(ModelViewSet):
     icon = "user"
     model = User
@@ -389,7 +379,6 @@ class UserViewSet(ModelViewSet):
     menu_name = "users"
     menu_label = gettext_lazy("Users")
     menu_order = 600
-    menu_item_class = UsersMenuItem
     add_to_settings_menu = True
 
     index_view_class = IndexView

--- a/wagtail/users/wagtail_hooks.py
+++ b/wagtail/users/wagtail_hooks.py
@@ -1,12 +1,8 @@
 from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
-from django.urls import reverse
 from django.utils.module_loading import import_string
-from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
-from wagtail.admin.search import SearchArea
-from wagtail.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 from wagtail.users.views.bulk_actions import (
     AssignRoleBulkAction,
     DeleteBulkAction,
@@ -33,38 +29,6 @@ def register_viewset():
         user_viewset_cls("wagtailusers_users", url_prefix="users"),
         group_viewset_cls("wagtailusers_groups", url_prefix="groups"),
     ]
-
-
-# Typically we would check the permission 'auth.change_user' (and 'auth.add_user' /
-# 'auth.delete_user') for user management actions, but this may vary according to
-# the AUTH_USER_MODEL setting
-add_user_perm = f"{AUTH_USER_APP_LABEL}.add_{AUTH_USER_MODEL_NAME.lower()}"
-change_user_perm = "{}.change_{}".format(
-    AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME.lower()
-)
-delete_user_perm = "{}.delete_{}".format(
-    AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME.lower()
-)
-
-
-class UsersSearchArea(SearchArea):
-    def is_shown(self, request):
-        return (
-            request.user.has_perm(add_user_perm)
-            or request.user.has_perm(change_user_perm)
-            or request.user.has_perm(delete_user_perm)
-        )
-
-
-@hooks.register("register_admin_search_area")
-def register_users_search_area():
-    return UsersSearchArea(
-        _("Users"),
-        reverse("wagtailusers_users:index"),
-        name="users",
-        icon_name="user",
-        order=600,
-    )
 
 
 for action_class in [AssignRoleBulkAction, DeleteBulkAction, SetActiveStateBulkAction]:

--- a/wagtail/users/wagtail_hooks.py
+++ b/wagtail/users/wagtail_hooks.py
@@ -10,7 +10,6 @@ from wagtail.admin.admin_url_finder import (
     ModelAdminURLFinder,
     register_admin_url_finder,
 )
-from wagtail.admin.menu import MenuItem
 from wagtail.admin.search import SearchArea
 from wagtail.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 from wagtail.permission_policies import ModelPermissionPolicy
@@ -52,46 +51,6 @@ change_user_perm = "{}.change_{}".format(
 delete_user_perm = "{}.delete_{}".format(
     AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME.lower()
 )
-
-
-class UsersMenuItem(MenuItem):
-    def is_shown(self, request):
-        return (
-            request.user.has_perm(add_user_perm)
-            or request.user.has_perm(change_user_perm)
-            or request.user.has_perm(delete_user_perm)
-        )
-
-
-@hooks.register("register_settings_menu_item")
-def register_users_menu_item():
-    return UsersMenuItem(
-        _("Users"),
-        reverse("wagtailusers_users:index"),
-        name="users",
-        icon_name="user",
-        order=600,
-    )
-
-
-class GroupsMenuItem(MenuItem):
-    def is_shown(self, request):
-        return (
-            request.user.has_perm("auth.add_group")
-            or request.user.has_perm("auth.change_group")
-            or request.user.has_perm("auth.delete_group")
-        )
-
-
-@hooks.register("register_settings_menu_item")
-def register_groups_menu_item():
-    return GroupsMenuItem(
-        _("Groups"),
-        reverse("wagtailusers_groups:index"),
-        name="groups",
-        icon_name="group",
-        order=601,
-    )
 
 
 class UsersSearchArea(SearchArea):

--- a/wagtail/users/wagtail_hooks.py
+++ b/wagtail/users/wagtail_hooks.py
@@ -19,27 +19,25 @@ from wagtail.users.views.bulk_actions import (
     DeleteBulkAction,
     SetActiveStateBulkAction,
 )
-from wagtail.users.views.users import UserViewSet
 
 
-def get_group_viewset_cls(app_config):
+def get_viewset_cls(app_config, viewset_name):
     try:
-        group_viewset_cls = import_string(app_config.group_viewset)
+        viewset_cls = import_string(getattr(app_config, viewset_name))
     except (AttributeError, ImportError) as e:
         raise ImproperlyConfigured(
-            "Invalid setting for {appconfig}.group_viewset: {message}".format(
-                appconfig=app_config.__class__.__name__, message=e
-            )
+            f"Invalid setting for {app_config.__class__.__name__}.{viewset_name}: {e}"
         )
-    return group_viewset_cls
+    return viewset_cls
 
 
 @hooks.register("register_admin_viewset")
 def register_viewset():
     app_config = apps.get_app_config("wagtailusers")
-    group_viewset_cls = get_group_viewset_cls(app_config)
+    user_viewset_cls = get_viewset_cls(app_config, "user_viewset")
+    group_viewset_cls = get_viewset_cls(app_config, "group_viewset")
     return [
-        UserViewSet("wagtailusers_users", url_prefix="users"),
+        user_viewset_cls("wagtailusers_users", url_prefix="users"),
         group_viewset_cls("wagtailusers_groups", url_prefix="groups"),
     ]
 

--- a/wagtail/users/wagtail_hooks.py
+++ b/wagtail/users/wagtail_hooks.py
@@ -1,18 +1,12 @@
 from django.apps import apps
-from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
-from wagtail.admin.admin_url_finder import (
-    ModelAdminURLFinder,
-    register_admin_url_finder,
-)
 from wagtail.admin.search import SearchArea
 from wagtail.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
-from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.users.views.bulk_actions import (
     AssignRoleBulkAction,
     DeleteBulkAction,
@@ -71,17 +65,6 @@ def register_users_search_area():
         icon_name="user",
         order=600,
     )
-
-
-User = get_user_model()
-
-
-class UserAdminURLFinder(ModelAdminURLFinder):
-    edit_url_name = "wagtailusers_users:edit"
-    permission_policy = ModelPermissionPolicy(User)
-
-
-register_admin_url_finder(User, UserAdminURLFinder)
 
 
 for action_class in [AssignRoleBulkAction, DeleteBulkAction, SetActiveStateBulkAction]:


### PR DESCRIPTION
Fixes #11954 and fixes #11255. Somewhat "solves" the step 2 in #11915 indirectly, albeit not yet documented (via `IndexView.get_list_buttons`/`IndexView.get_list_more_buttons`).

The mechanism follows what we already have for the `GroupViewSet`. We could go a step further by also deprecating the `WAGTAIL_USER_EDIT_FORM`, `WAGTAIL_USER_CREATION_FORM`, and `WAGTAIL_USER_CUSTOM_FIELDS` settings, but I thought I'd test the waters with a smaller-scoped PR for now.