### PR TITLE
Add `BasePermissionTester` interface and generic `ModelPermissionTester`

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/home/user_objects_in_workflow_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/user_objects_in_workflow_moderation.html
@@ -17,15 +17,11 @@
             <tbody>
                 {% for workflow_state in workflow_states %}
                     {% with obj=workflow_state.content_object %}
-                        {% is_page obj as is_page %}
-                        {% if is_page %}
-                            {% page_permissions obj as page_perms %}
-                        {% endif %}
                         <tr>
                             <td class="title" valign="top">
                                 <div class="title-wrapper">
                                     {% admin_edit_url obj as edit_url %}
-                                    {% if page_perms.can_edit or not is_page and edit_url %}
+                                    {% if edit_url %}
                                         <a href="{{ edit_url }}" title="{% trans 'Edit' %}">{% latest_str obj %}</a>
                                     {% else %}
                                         {% latest_str obj %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -17,15 +17,11 @@
             <tbody>
                 {% for state in states %}
                     {% with revision=state.task_state.revision obj=state.obj task_state=state.task_state actions=state.actions workflow_tasks=state.workflow_tasks %}
-                        {% is_page obj as is_page %}
-                        {% if is_page %}
-                            {% page_permissions obj as page_perms %}
-                        {% endif %}
                         <tr>
                             <td class="title" valign="top">
                                 <div class="title-wrapper">
                                     {% admin_edit_url obj as edit_url %}
-                                    {% if page_perms.can_edit or not is_page and edit_url %}
+                                    {% if edit_url %}
                                         <a href="{{ edit_url }}" title="{% trans 'Edit' %}">{% latest_str obj %}</a>
                                     {% else %}
                                         {% latest_str obj %}
@@ -48,7 +44,7 @@
                                                 {% for action_name, action_label, modal in actions %}
                                                     <button data-workflow-action-url="{% url state.workflow_action_url_name obj.pk|admin_urlquote action_name task_state.id %}" {% if modal %}data-launch-modal{% endif %}>{{ action_label }}</button>
                                                 {% endfor %}
-                                                {% if page_perms.can_edit or not is_page and edit_url %}
+                                                {% if edit_url %}
                                                     <a href="{{ edit_url }}">{% trans 'Edit' %}</a>
                                                 {% endif %}
                                                 {% if obj.is_previewable %}

--- a/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
@@ -4,15 +4,12 @@
     Choose when this {{ model_name }} should go live and/or expire
 {% endblocktrans%}
 
-{% if page %}
-    {% page_permissions instance as page_perms %}
-    {% trans 'Choose when this page should go live and/or expire' as schedule_publishing_dialog_subtitle %}
-    {% if page_perms.can_publish %}
-        {% trans 'This publishing schedule will only take effect after you select the "Publish" option' as message_heading %}
-    {% else %}
-        {% trans "Anyone with editing permissions can create schedules" as message_heading %}
-        {% trans "But only those with publishing permissions can make them effective." as message_description %}
-    {% endif %}
+{% permissions_tester instance as permissions %}
+{% if permissions.can_publish %}
+    {% trans 'This publishing schedule will only take effect after you select the "Publish" option' as message_heading %}
+{% else %}
+    {% trans "Anyone with editing permissions can create schedules" as message_heading %}
+    {% trans "But only those with publishing permissions can make them effective." as message_description %}
 {% endif %}
 
 {% dialog id='schedule-publishing-dialog' dialog_root_selector='[data-edit-form]' classname=classname icon_name='calendar-alt' title=_("Set publishing schedule") subtitle=schedule_publishing_dialog_subtitle|capfirst message_icon_name='info' message_status='info' message_heading=message_heading message_description=message_description %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -54,6 +54,7 @@ from wagtail.coreutils import cautious_slugify as _cautious_slugify
 from wagtail.models import (
     CollectionViewRestriction,
     Locale,
+    ModelPermissionTester,
     Page,
     PageViewRestriction,
 )
@@ -158,13 +159,28 @@ def widgettype(bound_field):
 
 
 @register.simple_tag(takes_context=True)
+def permissions_tester(context, object, user=None):
+    """
+    Usage: {% permissions_tester object as permissions %}
+    Sets the variable 'permissions' to a ModelPermissionTester/PagePermissionTester
+    object that can be queried to find out what actions the user can perform on
+    the given object. If user is not provided, the current logged-in user is used.
+    """
+    if not user:
+        user = context["request"].user
+    if isinstance(object, Page):
+        return object.permissions_for_user(user)
+    return ModelPermissionTester(user, object)
+
+
+@register.simple_tag(takes_context=True)
 def page_permissions(context, page):
     """
     Usage: {% page_permissions page as page_perms %}
     Sets the variable 'page_perms' to a PagePermissionTester object that can be queried to find out
     what actions the current logged-in user can perform on the given page.
     """
-    return page.permissions_for_user(context["request"].user)
+    return permissions_tester(context, page)
 
 
 @register.simple_tag

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -26,6 +26,7 @@ from wagtail.models import (
     DraftStateMixin,
     Locale,
     LockableMixin,
+    ModelPermissionTester,
     PreviewableMixin,
     RevisionMixin,
     TranslatableMixin,
@@ -250,6 +251,9 @@ class CreateEditViewOptionalFeaturesMixin:
         self.object = self.get_object()
         self.lock = self.get_lock()
         self.locked_for_user = self.lock and self.lock.for_user(request.user)
+        self.permission_tester = ModelPermissionTester(
+            request.user, self.object or self.model()
+        )
         super().setup(request, *args, **kwargs)
 
     @cached_property
@@ -286,41 +290,11 @@ class CreateEditViewOptionalFeaturesMixin:
         return self.workflow_state.all_tasks_with_status()
 
     def user_has_permission(self, permission):
-        user = self.request.user
-        if user.is_superuser:
-            return True
-
-        # Workflow lock/unlock methods take precedence before the base
-        # "lock" and "unlock" permissions -- see PagePermissionTester for reference
-        if permission == "lock" and self.current_workflow_task:
-            return self.current_workflow_task.user_can_lock(self.object, user)
-        if permission == "unlock":
-            # Allow unlocking even if the user does not have the 'unlock' permission
-            # if they are the user who locked the object
-            if self.object.locked_by_id == user.pk:
-                return True
-            if self.current_workflow_task:
-                return self.current_workflow_task.user_can_unlock(self.object, user)
-
-        # Check with base PermissionCheckedMixin logic
-        has_base_permission = super().user_has_permission(permission)
-        if has_base_permission:
-            return True
-
-        # Allow access to the editor if the current workflow task allows it,
-        # even if the user does not normally have edit access. Users with edit
-        # permissions can always edit regardless what this method returns --
-        # see Task.user_can_access_editor() for reference
-        if (
-            permission == "change"
-            and self.current_workflow_task
-            and self.current_workflow_task.user_can_access_editor(
-                self.object, self.request.user
-            )
-        ):
-            return True
-
-        return False
+        # Replace checking for "change" permission from the policy with "edit"
+        # from the tester to handle business logic
+        if permission == "change":
+            return self.permission_tester.can_edit()
+        return super().user_has_permission(permission)
 
     def workflow_action_is_valid(self):
         if not self.current_workflow_task:
@@ -340,10 +314,7 @@ class CreateEditViewOptionalFeaturesMixin:
         if self.request.method != "POST":
             return actions
 
-        if self.draftstate_enabled and (
-            not self.permission_policy
-            or self.permission_policy.user_has_permission(self.request.user, "publish")
-        ):
+        if self.permission_tester.can_publish():
             actions.append("publish")
 
         if self.workflow_enabled:
@@ -624,13 +595,13 @@ class CreateEditViewOptionalFeaturesMixin:
 
         user_can_lock = (
             not self.lock or isinstance(self.lock, WorkflowLock)
-        ) and self.user_has_permission("lock")
+        ) and self.permission_tester.can_lock()
         user_can_unlock = (
             isinstance(self.lock, BasicLock)
-        ) and self.user_has_permission("unlock")
+        ) and self.permission_tester.can_unlock()
         user_can_unschedule = (
             isinstance(self.lock, ScheduledForPublishLock)
-        ) and self.user_has_permission("publish")
+        ) and self.permission_tester.can_unschedule()
 
         context = {
             "lock": self.lock,

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -3061,10 +3061,10 @@ class BasePermissionTester:
     def user_has_lock(self):
         raise NotImplementedError
 
-    def page_locked(self):
+    def object_locked(self):
         raise NotImplementedError
 
-    def can_add_subpage(self):
+    def can_add_subobject(self):
         raise NotImplementedError
 
     def can_edit(self):
@@ -3094,7 +3094,7 @@ class BasePermissionTester:
     def can_unlock(self):
         raise NotImplementedError
 
-    def can_publish_subpage(self):
+    def can_publish_subobject(self):
         raise NotImplementedError
 
     def can_reorder_children(self):
@@ -3137,6 +3137,21 @@ class PagePermissionTester(BasePermissionTester):
         from wagtail.permissions import page_permission_policy
 
         return page_permission_policy
+
+    ### Aliases for the old methods to conform to the new BasePermissionTester interface.
+    ### The old names are still in use in the codebase, but we may want to move to the
+    ### new names in the future.
+
+    def object_locked(self):
+        return self.page_locked()
+
+    def can_add_subobject(self):
+        return self.can_add_subpage()
+
+    def can_publish_subobject(self):
+        return self.can_publish_subpage()
+
+    ### End of aliases
 
     def user_has_lock(self):
         return self.page.locked_by_id == self.user.pk
@@ -3228,7 +3243,7 @@ class PagePermissionTester(BasePermissionTester):
             return False
         if (not self.page.live) or self.page_is_root:
             return False
-        if self.page_locked():
+        if self.object_locked():
             return False
 
         return self.user.is_superuser or ("publish" in self.permissions)
@@ -3243,7 +3258,7 @@ class PagePermissionTester(BasePermissionTester):
 
     def can_submit_for_moderation(self):
         return (
-            not self.page_locked()
+            not self.object_locked()
             and self.page.has_workflow
             and not self.page.workflow_in_progress
         )

--- a/wagtail/tests/test_model_permissions.py
+++ b/wagtail/tests/test_model_permissions.py
@@ -1,0 +1,629 @@
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from wagtail.models import (
+    GroupApprovalTask,
+    ModelPermissionTester,
+    Workflow,
+    WorkflowContentType,
+    WorkflowTask,
+)
+from wagtail.test.testapp.models import Advert, FullFeaturedSnippet
+from wagtail.test.utils.wagtail_tests import WagtailTestUtils
+
+
+class TestModelPermission(WagtailTestUtils, TestCase):
+    # This follows the tests from test_page_permissions
+
+    def create_workflow_and_task(self):
+        workflow = Workflow.objects.create(name="test_workflow")
+        task_1 = GroupApprovalTask.objects.create(name="test_task_1")
+        task_1.groups.add(self.moderator_group)
+        WorkflowTask.objects.create(
+            workflow=workflow, task=task_1.task_ptr, sort_order=1
+        )
+        WorkflowContentType.objects.create(
+            workflow=workflow,
+            content_type=ContentType.objects.get_for_model(FullFeaturedSnippet),
+        )
+        return workflow, task_1
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.editor = cls.create_user("editor", password="password")
+        cls.moderator = cls.create_user("moderator", password="password")
+        cls.superuser = cls.create_superuser("superuser", password="password")
+
+        cls.editor_group = Group.objects.get(name="Editors")
+        cls.moderator_group = Group.objects.get(name="Moderators")
+
+        cls.editor.groups.add(cls.editor_group)
+        cls.moderator.groups.add(cls.moderator_group)
+
+        # Default Django permissions
+        editor_permissions = []
+        for model in [Advert, FullFeaturedSnippet]:
+            editor_permissions.append(
+                Permission.objects.get(
+                    content_type__app_label="tests",
+                    codename=f"add_{model._meta.model_name}",
+                )
+            )
+            editor_permissions.append(
+                Permission.objects.get(
+                    content_type__app_label="tests",
+                    codename=f"change_{model._meta.model_name}",
+                )
+            )
+            editor_permissions.append(
+                Permission.objects.get(
+                    content_type__app_label="tests",
+                    codename=f"delete_{model._meta.model_name}",
+                )
+            )
+
+        # Allow moderators to publish
+        moderator_permissions = editor_permissions + [
+            Permission.objects.get(
+                content_type__app_label="tests",
+                codename=f"publish_{FullFeaturedSnippet._meta.model_name}",
+            ),
+        ]
+
+        cls.editor_group.permissions.add(*editor_permissions)
+        cls.moderator_group.permissions.add(*moderator_permissions)
+
+        # Model with no extra features
+        cls.standard = Advert.objects.create(text="Hello standard")
+
+        # Model with all the features
+        cls.draft = FullFeaturedSnippet.objects.create(text="Hello draft", live=False)
+        cls.live = FullFeaturedSnippet.objects.create(text="Hello live", live=True)
+
+    def test_unimplemented_permissions(self):
+        tester = ModelPermissionTester(self.superuser, self.live)
+
+        # These are specific to pages for now
+        for method in [
+            tester.can_add_subobject,
+            tester.can_set_view_restrictions,
+            tester.can_publish_subobject,
+            tester.can_reorder_children,
+            tester.can_move,
+        ]:
+            with self.assertRaises(NotImplementedError):
+                method()
+
+        with self.assertRaises(NotImplementedError):
+            tester.can_move_to(None)
+        with self.assertRaises(NotImplementedError):
+            tester.can_copy_to(None)
+
+    def test_nonpublisher_permissions(self):
+        standard_perms = ModelPermissionTester(self.editor, self.standard)
+        draft_perms = ModelPermissionTester(self.editor, self.draft)
+        live_perms = ModelPermissionTester(self.editor, self.live)
+
+        # Can edit standard, draft, and live
+        self.assertTrue(standard_perms.can_edit())
+        self.assertTrue(draft_perms.can_edit())
+        self.assertTrue(live_perms.can_edit())
+
+        # Can only delete standard and draft
+        self.assertTrue(standard_perms.can_delete())
+        self.assertTrue(draft_perms.can_delete())
+        self.assertFalse(live_perms.can_delete())
+
+        # Can't publish standard, draft, nor live
+        self.assertFalse(standard_perms.can_publish())
+        self.assertFalse(draft_perms.can_publish())
+        self.assertFalse(live_perms.can_publish())
+
+        # Can't unpublish standard, draft, nor live
+        self.assertFalse(standard_perms.can_unpublish())
+        self.assertFalse(draft_perms.can_unpublish())
+        self.assertFalse(live_perms.can_unpublish())
+
+        # Can copy standard, draft, and live
+        self.assertTrue(standard_perms.can_copy())
+        self.assertTrue(draft_perms.can_copy())
+        self.assertTrue(live_perms.can_copy())
+
+        # Can view "revisions" (history) for standard, draft, and live
+        # This corresponds to being able to see the history view (not actual
+        # revisions) for -historical- reasons...
+        # This method in PagePermissionTester has been around since before
+        # log actions were introduced. This was used to check for access to the
+        # "revisions index" view, which has since been replaced by the "history"
+        # view. The history view is applicable to all models as it uses log
+        # entries instead of revisions, so we should not require the object to
+        # be an instance of RevisionMixin. Hence, it returns true for standard.
+        self.assertTrue(standard_perms.can_view_revisions())
+        self.assertTrue(draft_perms.can_view_revisions())
+        self.assertTrue(live_perms.can_view_revisions())
+
+    def test_publisher_permissions(self):
+        standard_perms = ModelPermissionTester(self.moderator, self.standard)
+        draft_perms = ModelPermissionTester(self.moderator, self.draft)
+        live_perms = ModelPermissionTester(self.moderator, self.live)
+
+        # Can edit standard, draft, and live
+        self.assertTrue(standard_perms.can_edit())
+        self.assertTrue(draft_perms.can_edit())
+        self.assertTrue(live_perms.can_edit())
+
+        # Can delete standard, draft, and live
+        self.assertTrue(standard_perms.can_delete())
+        self.assertTrue(draft_perms.can_delete())
+        self.assertTrue(live_perms.can_delete())
+
+        # Can't publish standard as it does not support publishing
+        self.assertFalse(standard_perms.can_publish())
+
+        # Can publish draft and live
+        self.assertTrue(draft_perms.can_publish())
+        self.assertTrue(live_perms.can_publish())
+
+        # Can't unpublish standard as it does not support publishing
+        self.assertFalse(standard_perms.can_unpublish())
+
+        # Can't unpublish draft as it is not published
+        self.assertFalse(draft_perms.can_unpublish())
+
+        # Can unpublish live
+        self.assertTrue(live_perms.can_unpublish())
+
+        # Can copy standard, draft, and live
+        self.assertTrue(standard_perms.can_copy())
+        self.assertTrue(draft_perms.can_copy())
+        self.assertTrue(live_perms.can_copy())
+
+        # Can view "revisions" (history) for standard, draft, and live
+        self.assertTrue(standard_perms.can_view_revisions())
+        self.assertTrue(draft_perms.can_view_revisions())
+        self.assertTrue(live_perms.can_view_revisions())
+
+    def test_publish_permissions_without_edit(self):
+        self.moderator_group.permissions.remove(
+            Permission.objects.get(
+                content_type__app_label="tests",
+                codename=f"change_{FullFeaturedSnippet._meta.model_name}",
+            ),
+            Permission.objects.get(
+                content_type__app_label="tests",
+                codename=f"change_{Advert._meta.model_name}",
+            ),
+        )
+
+        standard_perms = ModelPermissionTester(self.moderator, self.standard)
+        draft_perms = ModelPermissionTester(self.moderator, self.draft)
+        live_perms = ModelPermissionTester(self.moderator, self.live)
+
+        # There is no concept of ownership (as of now), so we can't edit anything
+        self.assertFalse(standard_perms.can_edit())
+        self.assertFalse(draft_perms.can_edit())
+        self.assertFalse(live_perms.can_edit())
+
+        # Can delete standard, draft, and live
+        self.assertTrue(standard_perms.can_delete())
+        self.assertTrue(draft_perms.can_delete())
+        self.assertTrue(live_perms.can_delete())
+
+        # Can't publish standard as it does not support publishing
+        self.assertFalse(standard_perms.can_publish())
+
+        # Can still publish draft and live
+        self.assertTrue(draft_perms.can_publish())
+        self.assertTrue(live_perms.can_publish())
+
+        # Can't unpublish standard as it does not support publishing
+        self.assertFalse(standard_perms.can_unpublish())
+
+        # Can't unpublish draft as it is not published
+        self.assertFalse(draft_perms.can_unpublish())
+
+        # Can still unpublish live
+        self.assertTrue(live_perms.can_unpublish())
+
+        # Can copy standard, draft, and live
+        self.assertTrue(standard_perms.can_copy())
+        self.assertTrue(draft_perms.can_copy())
+        self.assertTrue(live_perms.can_copy())
+
+        # Can view "revisions" (history) for standard, draft, and live
+        self.assertTrue(standard_perms.can_view_revisions())
+        self.assertTrue(draft_perms.can_view_revisions())
+        self.assertTrue(live_perms.can_view_revisions())
+
+    def test_inactive_user_has_no_permissions(self):
+        self.superuser.is_active = False
+        self.superuser.save()
+
+        standard_perms = ModelPermissionTester(self.superuser, self.standard)
+        draft_perms = ModelPermissionTester(self.superuser, self.draft)
+        live_perms = ModelPermissionTester(self.superuser, self.live)
+
+        # Can't do anything
+        self.assertFalse(standard_perms.can_edit())
+        self.assertFalse(draft_perms.can_edit())
+        self.assertFalse(live_perms.can_edit())
+        self.assertFalse(standard_perms.can_delete())
+        self.assertFalse(draft_perms.can_delete())
+        self.assertFalse(live_perms.can_delete())
+        self.assertFalse(standard_perms.can_publish())
+        self.assertFalse(draft_perms.can_publish())
+        self.assertFalse(live_perms.can_publish())
+        self.assertFalse(standard_perms.can_unpublish())
+        self.assertFalse(draft_perms.can_unpublish())
+        self.assertFalse(live_perms.can_unpublish())
+        self.assertFalse(standard_perms.can_copy())
+        self.assertFalse(draft_perms.can_copy())
+        self.assertFalse(live_perms.can_copy())
+        self.assertFalse(standard_perms.can_view_revisions())
+        self.assertFalse(draft_perms.can_view_revisions())
+        self.assertFalse(live_perms.can_view_revisions())
+
+    def test_superuser_has_full_permissions(self):
+        standard_perms = ModelPermissionTester(self.superuser, self.standard)
+        draft_perms = ModelPermissionTester(self.superuser, self.draft)
+        live_perms = ModelPermissionTester(self.superuser, self.live)
+
+        # Can edit standard, draft, and live
+        self.assertTrue(standard_perms.can_edit())
+        self.assertTrue(draft_perms.can_edit())
+        self.assertTrue(live_perms.can_edit())
+
+        # Can delete standard, draft, and live
+        self.assertTrue(standard_perms.can_delete())
+        self.assertTrue(draft_perms.can_delete())
+        self.assertTrue(live_perms.can_delete())
+
+        # Can't publish standard as it does not support publishing
+        self.assertFalse(standard_perms.can_publish())
+
+        # Can publish draft and live
+        self.assertTrue(draft_perms.can_publish())
+        self.assertTrue(live_perms.can_publish())
+
+        # Can't unpublish standard as it does not support publishing
+        self.assertFalse(standard_perms.can_unpublish())
+
+        # Can't unpublish draft as it is not published
+        self.assertFalse(draft_perms.can_unpublish())
+
+        # Can unpublish live
+        self.assertTrue(live_perms.can_unpublish())
+
+        # Can copy standard, draft, and live
+        self.assertTrue(standard_perms.can_copy())
+        self.assertTrue(draft_perms.can_copy())
+        self.assertTrue(live_perms.can_copy())
+
+        # Can view "revisions" (history) for standard, draft, and live
+        self.assertTrue(standard_perms.can_view_revisions())
+        self.assertTrue(draft_perms.can_view_revisions())
+        self.assertTrue(live_perms.can_view_revisions())
+
+    def test_lock_for_superuser(self):
+        standard_perms = ModelPermissionTester(self.superuser, self.standard)
+        draft_perms = ModelPermissionTester(self.superuser, self.draft)
+        live_perms = ModelPermissionTester(self.superuser, self.live)
+
+        # Can't lock standard as it does not support locking
+        self.assertFalse(standard_perms.can_lock())
+
+        # Can lock draft and live
+        self.assertTrue(draft_perms.can_lock())
+        self.assertTrue(live_perms.can_lock())
+
+        # Can't unlock standard as it does not support locking
+        self.assertFalse(standard_perms.can_unlock())
+
+        # Can unlock draft and live
+        # Historically, can_unlock returns True even if it's currently unlocked
+        # as long as the user has the permission to unlock
+        self.assertTrue(draft_perms.can_unlock())
+        self.assertTrue(live_perms.can_unlock())
+
+        # Lock by someone else
+        self.live.locked = True
+        self.live.locked_by = self.moderator
+        self.live.locked_at = timezone.now()
+        self.live.save()
+
+        # Historically, can_lock returns True even if it's currently locked by
+        # anyone as long as the user has the permission to lock
+        self.assertTrue(live_perms.can_lock())
+
+        # Can't unpublish if locked by someone else
+        self.assertFalse(live_perms.can_unpublish())
+
+        # Can unlock even if locked by someone else
+        self.assertTrue(live_perms.can_unlock())
+
+        # Lock by self
+        self.live.locked_by = self.superuser
+        self.live.save()
+
+        # Can unpublish if locked by self, as the object appears to be unlocked
+        self.assertTrue(live_perms.can_unpublish())
+
+        # Can also unlock
+        self.assertTrue(live_perms.can_unlock())
+
+    def test_lock_for_user_with_lock_and_unlock_permissions(self):
+        self.moderator_group.permissions.add(
+            Permission.objects.get(
+                content_type__app_label="tests",
+                codename=f"lock_{FullFeaturedSnippet._meta.model_name}",
+            ),
+            Permission.objects.get(
+                content_type__app_label="tests",
+                codename=f"unlock_{FullFeaturedSnippet._meta.model_name}",
+            ),
+        )
+        standard_perms = ModelPermissionTester(self.moderator, self.standard)
+        draft_perms = ModelPermissionTester(self.moderator, self.draft)
+        live_perms = ModelPermissionTester(self.moderator, self.live)
+
+        # Can't lock standard as it does not support locking
+        self.assertFalse(standard_perms.can_lock())
+
+        # Can lock draft and live
+        self.assertTrue(draft_perms.can_lock())
+        self.assertTrue(live_perms.can_lock())
+
+        # Can't unlock standard as it does not support locking
+        self.assertFalse(standard_perms.can_unlock())
+
+        # Can unlock draft and live
+        # Historically, can_unlock returns True even if it's currently unlocked
+        # as long as the user has the permission to unlock
+        self.assertTrue(draft_perms.can_unlock())
+        self.assertTrue(live_perms.can_unlock())
+
+        # Lock by someone else
+        self.live.locked = True
+        self.live.locked_by = self.superuser
+        self.live.locked_at = timezone.now()
+        self.live.save()
+
+        # Historically, can_lock returns True even if it's currently locked by
+        # anyone as long as the user has the permission to lock
+        self.assertTrue(live_perms.can_lock())
+
+        # Can't unpublish if locked by someone else
+        self.assertFalse(live_perms.can_unpublish())
+
+        # Can unlock even if locked by someone else,
+        # as long as they have the unlock permission
+        self.assertTrue(live_perms.can_unlock())
+
+        # Lock by self
+        self.live.locked_by = self.moderator
+        self.live.save()
+
+        # Can unpublish if locked by self, as the object appears to be unlocked
+        self.assertTrue(live_perms.can_unpublish())
+
+        # Can also unlock
+        self.assertTrue(live_perms.can_unlock())
+
+    def test_lock_for_user_with_lock_permission_only(self):
+        self.editor_group.permissions.add(
+            Permission.objects.get(
+                content_type__app_label="tests",
+                codename=f"lock_{FullFeaturedSnippet._meta.model_name}",
+            ),
+        )
+        standard_perms = ModelPermissionTester(self.editor, self.standard)
+        draft_perms = ModelPermissionTester(self.editor, self.draft)
+        live_perms = ModelPermissionTester(self.editor, self.live)
+
+        # Can't lock standard as it does not support locking
+        self.assertFalse(standard_perms.can_lock())
+
+        # Can lock draft and live
+        self.assertTrue(draft_perms.can_lock())
+        self.assertTrue(live_perms.can_lock())
+
+        # Can't unlock standard as it does not support locking
+        self.assertFalse(standard_perms.can_unlock())
+
+        # Can't unlock draft and live as they don't have the unlock permission
+        self.assertFalse(draft_perms.can_unlock())
+        self.assertFalse(live_perms.can_unlock())
+
+        # Lock by someone else
+        self.live.locked = True
+        self.live.locked_by = self.superuser
+        self.live.locked_at = timezone.now()
+        self.live.save()
+
+        # Historically, can_lock returns True even if it's currently locked by
+        # anyone as long as the user has the permission to lock
+        self.assertTrue(live_perms.can_lock())
+
+        # Can't unpublish as they don't have the publish permission
+        self.assertFalse(live_perms.can_unpublish())
+
+        # Can't unlock if locked by someone else,
+        # as they don't have the unlock permission
+        self.assertFalse(live_perms.can_unlock())
+
+        # Lock by self
+        self.live.locked_by = self.editor
+        self.live.save()
+
+        # Can't unpublish as they don't have the publish permission
+        self.assertFalse(live_perms.can_unpublish())
+
+        # Can unlock even without the unlock permission, as they locked it
+        self.assertTrue(live_perms.can_unlock())
+
+    def test_lock_for_user_without_lock_and_unlock_permission(self):
+        standard_perms = ModelPermissionTester(self.editor, self.standard)
+        draft_perms = ModelPermissionTester(self.editor, self.draft)
+        live_perms = ModelPermissionTester(self.editor, self.live)
+
+        # Can't lock standard as it does not support locking
+        self.assertFalse(standard_perms.can_lock())
+
+        # Can't lock draft and live as they don't have the lock permission
+        self.assertFalse(standard_perms.can_lock())
+        self.assertFalse(draft_perms.can_lock())
+
+        # Can't unlock standard as it does not support locking
+        self.assertFalse(standard_perms.can_unlock())
+
+        # Can't unlock draft and live as they don't have the unlock permission
+        self.assertFalse(draft_perms.can_unlock())
+        self.assertFalse(live_perms.can_unlock())
+
+        # Lock by someone else
+        self.live.locked = True
+        self.live.locked_by = self.superuser
+        self.live.locked_at = timezone.now()
+        self.live.save()
+
+        # Can't lock as they don't have the lock permission
+        self.assertFalse(live_perms.can_lock())
+
+        # Can't unpublish as they don't have the publish permission
+        self.assertFalse(live_perms.can_unpublish())
+
+        # Can't unlock if locked by someone else,
+        # as they don't have the unlock permission
+        self.assertFalse(live_perms.can_unlock())
+
+        # Lock by self
+        # This may happen if the user locked it before losing the permission
+        self.live.locked_by = self.editor
+        self.live.save()
+
+        # Can't unpublish as they don't have the publish permission
+        self.assertFalse(live_perms.can_unpublish())
+
+        # Can unlock even without the unlock permission, as they locked it
+        self.assertTrue(live_perms.can_unlock())
+
+    def test_lock_for_non_editing_user(self):
+        self.editor_group.permissions.clear()
+        self.editor_group.permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin",
+                codename="access_admin",
+            )
+        )
+
+        perms = ModelPermissionTester(self.editor, self.live)
+
+        self.assertFalse(perms.can_lock())
+        self.assertFalse(perms.can_unlock())
+
+    def test_object_locked_for_unlocked_object(self):
+        standard_perms = ModelPermissionTester(self.superuser, self.standard)
+        live_perms = ModelPermissionTester(self.superuser, self.live)
+
+        # Not locked as it does not support locking
+        self.assertFalse(standard_perms.object_locked())
+
+        # Not locked as it is not locked
+        self.assertFalse(live_perms.object_locked())
+
+    def test_object_locked_for_locked_object(self):
+        self.editor_group.permissions.add(
+            Permission.objects.get(
+                content_type__app_label="tests",
+                codename=f"lock_{FullFeaturedSnippet._meta.model_name}",
+            ),
+        )
+        perms = ModelPermissionTester(self.editor, self.live)
+
+        # Lock the object
+        self.live.locked = True
+        self.live.locked_by = self.editor
+        self.live.locked_at = timezone.now()
+        self.live.save()
+
+        # The user who locked the object shouldn't see the object as locked
+        self.assertFalse(perms.object_locked())
+
+        # Other users should see the object as locked
+        other_perms = ModelPermissionTester(self.superuser, self.live)
+        self.assertTrue(other_perms.object_locked())
+
+    @override_settings(WAGTAILADMIN_GLOBAL_EDIT_LOCK=True)
+    def test_object_locked_for_locked_object_with_global_lock_enabled(self):
+        self.editor_group.permissions.add(
+            Permission.objects.get(
+                content_type__app_label="tests",
+                codename=f"lock_{FullFeaturedSnippet._meta.model_name}",
+            ),
+        )
+        perms = ModelPermissionTester(self.editor, self.live)
+
+        # Lock the object
+        self.live.locked = True
+        self.live.locked_by = self.editor
+        self.live.locked_at = timezone.now()
+        self.live.save()
+
+        # The user who locked the object should now also see the object as locked
+        self.assertTrue(perms.object_locked())
+
+        # Other users should see the object as locked, like before
+        other_perms = ModelPermissionTester(self.superuser, self.live)
+        self.assertTrue(other_perms.object_locked())
+
+    def test_object_locked_in_workflow(self):
+        workflow, task = self.create_workflow_and_task()
+        self.live.save_revision()
+        workflow.start(self.live, self.editor)
+
+        moderator_perms = ModelPermissionTester(self.moderator, self.live)
+
+        # the moderator is in the group assigned to moderate the task, so the object should
+        # not be locked for them
+        self.assertFalse(moderator_perms.object_locked())
+
+        superuser_perms = ModelPermissionTester(self.superuser, self.live)
+
+        # superusers can moderate any GroupApprovalTask, so the object should not be locked
+        # for them
+        self.assertFalse(superuser_perms.object_locked())
+
+        editor_perms = ModelPermissionTester(self.editor, self.live)
+
+        # the editor is not in the group assigned to moderate the task, so the object should
+        # be locked for them
+        self.assertTrue(editor_perms.object_locked())
+
+    def test_object_lock_in_workflow(self):
+        workflow, task = self.create_workflow_and_task()
+        self.live.save_revision()
+        workflow.start(self.live, self.editor)
+
+        moderator_perms = ModelPermissionTester(self.moderator, self.live)
+
+        # the moderator is in the group assigned to moderate the task, so they can lock the object, but can't unlock it
+        # unless they're the locker
+        self.assertTrue(moderator_perms.can_lock())
+        self.assertFalse(moderator_perms.can_unlock())
+
+        editor_perms = ModelPermissionTester(self.editor, self.live)
+
+        # the editor is not in the group assigned to moderate the task, so they can't lock or unlock the object
+        self.assertFalse(editor_perms.can_lock())
+        self.assertFalse(editor_perms.can_unlock())
+
+        # Lock the object
+        self.live.locked = True
+        self.live.locked_by = self.moderator
+        self.live.locked_at = timezone.now()
+        self.live.save()
+
+        # the moderator can unlock the object as they're the locker
+        self.assertTrue(moderator_perms.can_unlock())

--- a/wagtail/tests/test_page_permissions.py
+++ b/wagtail/tests/test_page_permissions.py
@@ -63,6 +63,12 @@ class TestPagePermission(TestCase):
         self.assertTrue(unpub_perms.can_add_subpage())
         self.assertTrue(someone_elses_event_perms.can_add_subpage())
 
+        # Aliases for can_add_subpage
+        self.assertFalse(homepage_perms.can_add_subobject())
+        self.assertTrue(christmas_page_perms.can_add_subobject())
+        self.assertTrue(unpub_perms.can_add_subobject())
+        self.assertTrue(someone_elses_event_perms.can_add_subobject())
+
         self.assertFalse(homepage_perms.can_edit())
         self.assertTrue(christmas_page_perms.can_edit())
         self.assertTrue(unpub_perms.can_edit())
@@ -87,6 +93,11 @@ class TestPagePermission(TestCase):
         self.assertFalse(homepage_perms.can_publish_subpage())
         self.assertFalse(christmas_page_perms.can_publish_subpage())
         self.assertFalse(unpub_perms.can_publish_subpage())
+
+        # Aliases for can_publish_subpage
+        self.assertFalse(homepage_perms.can_publish_subobject())
+        self.assertFalse(christmas_page_perms.can_publish_subobject())
+        self.assertFalse(unpub_perms.can_publish_subobject())
 
         self.assertFalse(homepage_perms.can_reorder_children())
         self.assertFalse(christmas_page_perms.can_reorder_children())
@@ -136,6 +147,11 @@ class TestPagePermission(TestCase):
         self.assertTrue(christmas_page_perms.can_add_subpage())
         self.assertTrue(unpub_perms.can_add_subpage())
 
+        # Aliases for can_add_subpage
+        self.assertFalse(homepage_perms.can_add_subobject())
+        self.assertTrue(christmas_page_perms.can_add_subobject())
+        self.assertTrue(unpub_perms.can_add_subobject())
+
         self.assertFalse(homepage_perms.can_edit())
         self.assertTrue(christmas_page_perms.can_edit())
         self.assertTrue(unpub_perms.can_edit())
@@ -158,6 +174,11 @@ class TestPagePermission(TestCase):
         self.assertFalse(homepage_perms.can_publish_subpage())
         self.assertTrue(christmas_page_perms.can_publish_subpage())
         self.assertTrue(unpub_perms.can_publish_subpage())
+
+        # Aliases for can_publish_subpage
+        self.assertFalse(homepage_perms.can_publish_subobject())
+        self.assertTrue(christmas_page_perms.can_publish_subobject())
+        self.assertTrue(unpub_perms.can_publish_subobject())
 
         self.assertFalse(homepage_perms.can_reorder_children())
         self.assertTrue(christmas_page_perms.can_reorder_children())
@@ -213,6 +234,10 @@ class TestPagePermission(TestCase):
         self.assertFalse(homepage_perms.can_add_subpage())
         self.assertTrue(christmas_page_perms.can_add_subpage())
 
+        # Aliases for can_add_subpage
+        self.assertFalse(homepage_perms.can_add_subobject())
+        self.assertTrue(christmas_page_perms.can_add_subobject())
+
         # add permission lets us edit our own event
         self.assertFalse(christmas_page_perms.can_edit())
         self.assertTrue(moderator_event_perms.can_edit())
@@ -238,6 +263,11 @@ class TestPagePermission(TestCase):
         self.assertFalse(homepage_perms.can_publish_subpage())
         self.assertTrue(christmas_page_perms.can_publish_subpage())
         self.assertTrue(unpub_perms.can_publish_subpage())
+
+        # Aliases for can_publish_subpage
+        self.assertFalse(homepage_perms.can_publish_subobject())
+        self.assertTrue(christmas_page_perms.can_publish_subobject())
+        self.assertTrue(unpub_perms.can_publish_subobject())
 
         # reorder permission is considered equivalent to publish permission
         # (so we can do it on pages we can't edit)
@@ -313,11 +343,13 @@ class TestPagePermission(TestCase):
         unpub_perms = unpublished_event_page.permissions_for_user(user)
 
         self.assertFalse(unpub_perms.can_add_subpage())
+        self.assertFalse(unpub_perms.can_add_subobject())
         self.assertFalse(unpub_perms.can_edit())
         self.assertFalse(unpub_perms.can_delete())
         self.assertFalse(unpub_perms.can_publish())
         self.assertFalse(christmas_page_perms.can_unpublish())
         self.assertFalse(unpub_perms.can_publish_subpage())
+        self.assertFalse(unpub_perms.can_publish_subobject())
         self.assertFalse(unpub_perms.can_reorder_children())
         self.assertFalse(unpub_perms.can_move())
         self.assertFalse(unpub_perms.can_move_to(christmas_page))
@@ -341,6 +373,10 @@ class TestPagePermission(TestCase):
         self.assertTrue(homepage_perms.can_add_subpage())
         self.assertTrue(root_perms.can_add_subpage())
 
+        # Aliases for can_add_subpage
+        self.assertTrue(homepage_perms.can_add_subobject())
+        self.assertTrue(root_perms.can_add_subobject())
+
         self.assertTrue(homepage_perms.can_edit())
         self.assertFalse(
             root_perms.can_edit()
@@ -358,6 +394,10 @@ class TestPagePermission(TestCase):
 
         self.assertTrue(homepage_perms.can_publish_subpage())
         self.assertTrue(root_perms.can_publish_subpage())
+
+        # Aliases for can_publish_subpage
+        self.assertTrue(homepage_perms.can_publish_subobject())
+        self.assertTrue(root_perms.can_publish_subobject())
 
         self.assertTrue(homepage_perms.can_reorder_children())
         self.assertTrue(root_perms.can_reorder_children())
@@ -753,6 +793,7 @@ class TestPagePermission(TestCase):
         perms = christmas_page.permissions_for_user(user)
 
         self.assertFalse(perms.page_locked())
+        self.assertFalse(perms.object_locked())
 
     def test_page_locked_for_locked_page(self):
         user = get_user_model().objects.get(email="eventmoderator@example.com")
@@ -768,12 +809,14 @@ class TestPagePermission(TestCase):
 
         # The user who locked the page shouldn't see the page as locked
         self.assertFalse(perms.page_locked())
+        self.assertFalse(perms.object_locked())
 
         # Other users should see the page as locked
         other_user = get_user_model().objects.get(email="eventeditor@example.com")
 
         other_perms = christmas_page.permissions_for_user(other_user)
         self.assertTrue(other_perms.page_locked())
+        self.assertTrue(other_perms.object_locked())
 
     @override_settings(WAGTAILADMIN_GLOBAL_EDIT_LOCK=True)
     def test_page_locked_for_locked_page_with_global_lock_enabled(self):
@@ -790,6 +833,7 @@ class TestPagePermission(TestCase):
 
         # The user who locked the page should now also see the page as locked
         self.assertTrue(perms.page_locked())
+        self.assertTrue(perms.object_locked())
 
         # Other users should see the page as locked, like before
         other_user = get_user_model().objects.get(email="eventeditor@example.com")
@@ -797,6 +841,7 @@ class TestPagePermission(TestCase):
         other_perms = christmas_page.permissions_for_user(other_user)
 
         self.assertTrue(other_perms.page_locked())
+        self.assertTrue(other_perms.object_locked())
 
     def test_page_locked_in_workflow(self):
         workflow, task = self.create_workflow_and_task()
@@ -812,18 +857,21 @@ class TestPagePermission(TestCase):
         # the moderator is in the group assigned to moderate the task, so the page should
         # not be locked for them
         self.assertFalse(moderator_perms.page_locked())
+        self.assertFalse(moderator_perms.object_locked())
 
         superuser_perms = christmas_page.permissions_for_user(superuser)
 
         # superusers can moderate any GroupApprovalTask, so the page should not be locked
         # for them
         self.assertFalse(superuser_perms.page_locked())
+        self.assertFalse(superuser_perms.object_locked())
 
         editor_perms = christmas_page.permissions_for_user(editor)
 
         # the editor is not in the group assigned to moderate the task, so the page should
         # be locked for them
         self.assertTrue(editor_perms.page_locked())
+        self.assertTrue(editor_perms.object_locked())
 
     def test_page_lock_in_workflow(self):
         workflow, task = self.create_workflow_and_task()


### PR DESCRIPTION
A fresh take on #10578.

Instead of making `PagePermissionTester` a subclass of `ModelPermissionTester` (and making sure the latter could allow the former to retain its logic), I tried to start off `ModelPermissionTester` from scratch, so I can better see where the difference lies between the two.

From what I've seen, it's looking a lot like we can delegate most things to `ModelPermissionPolicy.user_has_permission{_for_instance}`. The only exceptions seem to be `can_lock` and `can_unlock`, which saw a conspicuous change in #6156 that went against the documented behaviour of `user_can_lock` and `user_can_unlock`. I added more details in the code comments.

This isn't its final form, as `ModelPermissionTester.get_permission_policy()` is still unimplemented, but I can't see how it can be implemented without subclassing it. The subclass is probably something we generate at runtime when you try to get a tester/policy of a model that hasn't been registered in the registry (the registry is still to be implemented).