### PR TITLE
Allow multiple top-level nodes when rendering StreamField blocks

### DIFF
--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -76,13 +76,13 @@ class Widget {
     tempContainer.innerHTML = html.trim();
     const dom = tempContainer.firstChild;
 
-    /* replace the placeholder with the new element */
-    placeholder.replaceWith(dom);
+    /* execute any scripts in the new element(s) */
+    runInlineScripts(tempContainer);
 
-    /* execute any scripts in the new element */
-    runInlineScripts(dom);
+    /* replace the placeholder with the new element(s) */
+    placeholder.replaceWith(...tempContainer.childNodes);
 
-    // Add any extra attributes we received to the HTML of the widget
+    // Add any extra attributes we received to the first element of the widget
     if (typeof options?.attributes === 'object') {
       Object.entries(options.attributes).forEach(([key, value]) => {
         dom.setAttribute(key, value);

--- a/client/src/entrypoints/admin/telepath/widgets.test.js
+++ b/client/src/entrypoints/admin/telepath/widgets.test.js
@@ -133,7 +133,7 @@ describe('telepath: wagtail.widgets.Widget with multiple top-level nodes', () =>
     widgetDef = window.telepath.unpack({
       _type: 'wagtail.widgets.Widget',
       _args: [
-        '<input type="text" name="__NAME__" maxlength="255" id="__ID__"><button data-button-state="idle">Click me</button><script>document.getElementById("__ID__").className = "custom-class";</script>',
+        '<!-- here comes a widget --><input type="text" name="__NAME__" maxlength="255" id="__ID__"><button data-button-state="idle">Click me</button><script>document.getElementById("__ID__").className = "custom-class";</script>',
         '__ID__',
       ],
     });

--- a/client/src/entrypoints/admin/telepath/widgets.test.js
+++ b/client/src/entrypoints/admin/telepath/widgets.test.js
@@ -122,6 +122,40 @@ describe('telepath: wagtail.widgets.Widget with inline JS', () => {
   });
 });
 
+describe('telepath: wagtail.widgets.Widget with multiple top-level nodes', () => {
+  let boundWidget;
+  let widgetDef;
+
+  beforeEach(() => {
+    // Create a placeholder to render the widget
+    document.body.innerHTML = '<div id="placeholder"></div>';
+
+    widgetDef = window.telepath.unpack({
+      _type: 'wagtail.widgets.Widget',
+      _args: [
+        '<input type="text" name="__NAME__" maxlength="255" id="__ID__"><button data-button-state="idle">Click me</button><script>document.getElementById("__ID__").className = "custom-class";</script>',
+        '__ID__',
+      ],
+    });
+    boundWidget = widgetDef.render(
+      document.getElementById('placeholder'),
+      'the-name',
+      'the-id',
+      'The Value',
+    );
+  });
+
+  test('it renders correctly', () => {
+    expect(document.body.querySelector('input').outerHTML).toBe(
+      '<input type="text" name="the-name" maxlength="255" id="the-id" class="custom-class">',
+    );
+    expect(document.querySelector('[data-button-state]').outerHTML).toBe(
+      '<button data-button-state="idle">Click me</button>',
+    );
+    expect(document.querySelector('input').value).toBe('The Value');
+  });
+});
+
 describe('telepath: wagtail.widgets.RadioSelect', () => {
   let boundWidget;
 

--- a/client/src/utils/runInlineScripts.ts
+++ b/client/src/utils/runInlineScripts.ts
@@ -1,20 +1,27 @@
 /**
  * Runs any inline scripts contained within the given DOM element or fragment.
  */
+const runScript = (script: HTMLScriptElement) => {
+  if (!script.type || script.type === 'application/javascript') {
+    const newScript = document.createElement('script');
+    Array.from(script.attributes).forEach((key) =>
+      newScript.setAttribute(key.nodeName, key.nodeValue || ''),
+    );
+    newScript.text = script.text;
+    script.replaceWith(newScript);
+  }
+};
+
 const runInlineScripts = (element: HTMLElement | DocumentFragment) => {
-  const scripts = element.querySelectorAll(
-    'script:not([src])',
-  ) as NodeListOf<HTMLScriptElement>;
-  scripts.forEach((script) => {
-    if (!script.type || script.type === 'application/javascript') {
-      const newScript = document.createElement('script');
-      Array.from(script.attributes).forEach((key) =>
-        newScript.setAttribute(key.nodeName, key.nodeValue || ''),
-      );
-      newScript.text = script.text;
-      script.replaceWith(newScript);
-    }
-  });
+  const selector = 'script:not([src])';
+  if (element instanceof HTMLElement && element.matches(selector)) {
+    runScript(element as HTMLScriptElement);
+  } else {
+    const scripts = element.querySelectorAll(
+      'script:not([src])',
+    ) as NodeListOf<HTMLScriptElement>;
+    scripts.forEach(runScript);
+  }
 };
 
 export { runInlineScripts };

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -351,7 +351,7 @@ In the new approach, we no longer need to attach an inline script but instead us
 
 ### Removal of jQuery from base client-side Widget and BoundWidget classes
 
-The JavaScript base classes `Widget` and `BoundWidget` that provide client-side access to form widgets (see [](streamfield_widget_api)) no longer use jQuery. The `element` argument passed to the `BoundWidget` constructor, and the `input` property of `BoundWidget`, are now native DOM elements rather than jQuery collections. User code that extends these classes should be updated accordingly.
+The JavaScript base classes `Widget` and `BoundWidget` that provide client-side access to form widgets (see [](streamfield_widget_api)) no longer use jQuery. The `input` property of `BoundWidget` (previously a jQuery collection) is now a native DOM element, and the `element` argument passed to the `BoundWidget` constructor (previously a jQuery collection) is now passed as a native DOM element if the HTML representation consists of a single element, and an iterable of elements (`NodeList` or array) otherwise. User code that extends these classes should be updated accordingly.
 
 ### `window.URLify` deprecated
 


### PR DESCRIPTION
But don't change what's passed to the `BoundWidget` class (which means still just the first element), so this shouldn't affect any of the `BoundWidget`s.

Fixes #11935. ~~Will add tests if this is indeed what we want...~~ Test added.