### PR TITLE
Fix: Properly rewrite rich text with mixed links

### DIFF
--- a/wagtail/rich_text/rewriters.py
+++ b/wagtail/rich_text/rewriters.py
@@ -4,7 +4,6 @@ Utility classes for rewriting elements of HTML-like strings
 
 import re
 from collections import defaultdict
-from itertools import chain
 from typing import Callable, Tuple
 
 FIND_A_TAG = re.compile(r"<a(\b[^>]*)>")
@@ -53,16 +52,18 @@ class TagRewriter:
         ]
 
         offset = 0
-        for match, replacement in zip(
-            chain(*matches_by_tag_type.values()), chain(*replacements)
-        ):
-            html = (
-                html[: match.start() + offset]
-                + replacement
-                + html[match.end() + offset :]
-            )
+        for matches, replacements in zip(matches_by_tag_type.values(), replacements):
+            if not replacements:
+                continue
 
-            offset += len(replacement) - match.end() + match.start()
+            for match, replacement in zip(matches, replacements):
+                html = (
+                    html[: match.start() + offset]
+                    + replacement
+                    + html[match.end() + offset :]
+                )
+
+                offset += len(replacement) - match.end() + match.start()
 
         return html
 

--- a/wagtail/rich_text/rewriters.py
+++ b/wagtail/rich_text/rewriters.py
@@ -51,19 +51,24 @@ class TagRewriter:
             for tag_type, attrs_list in attrs_by_tag_type.items()
         ]
 
-        offset = 0
+        matches_to_replace = []
         for matches, replacements in zip(matches_by_tag_type.values(), replacements):
             if not replacements:
                 continue
 
-            for match, replacement in zip(matches, replacements):
-                html = (
-                    html[: match.start() + offset]
-                    + replacement
-                    + html[match.end() + offset :]
-                )
+            matches_to_replace.extend(zip(matches, replacements))
 
-                offset += len(replacement) - match.end() + match.start()
+        offset = 0
+        for match, replacement in sorted(
+            matches_to_replace, key=lambda match_to_replace: match_to_replace[0].start()
+        ):
+            html = (
+                html[: match.start() + offset]
+                + replacement
+                + html[match.end() + offset :]
+            )
+
+            offset += len(replacement) - match.end() + match.start()
 
         return html
 

--- a/wagtail/rich_text/rewriters.py
+++ b/wagtail/rich_text/rewriters.py
@@ -4,7 +4,9 @@ Utility classes for rewriting elements of HTML-like strings
 
 import re
 from collections import defaultdict
-from typing import Callable, Tuple
+from typing import Callable, Dict, List
+
+from django.utils.functional import cached_property
 
 FIND_A_TAG = re.compile(r"<a(\b[^>]*)>")
 FIND_EMBED_TAG = re.compile(r"<embed(\b[^>]*)/>")
@@ -27,6 +29,26 @@ def extract_attrs(attr_string: str) -> dict:
     return attributes
 
 
+class TagMatch:
+    """Represents a single matched tag in a rich text string"""
+
+    def __init__(self, match):
+        self.match = match  # a regexp match object
+        self.replacement = None  # to be filled in by the rewriter
+
+    @cached_property
+    def attrs(self):
+        return extract_attrs(self.match.group(1))
+
+    @property
+    def start(self):
+        return self.match.start()
+
+    @property
+    def end(self):
+        return self.match.end()
+
+
 class TagRewriter:
     def __init__(self, rules=None, bulk_rules=None, reference_extractors=None):
         self.rules = rules or {}
@@ -37,61 +59,65 @@ class TagRewriter:
         raise NotImplementedError
 
     def get_tag_type_from_attrs(self, attrs):
+        """Given a dict of attributes from a tag, return the tag type."""
         raise NotImplementedError
 
     def get_tag_replacements(self, tag_type, attrs_list):
-        # Note: return an empty list for cases when you don't want any replacements made
+        """Given a list of attribute dicts, all taken from tags of the same type, return a
+        corresponding list of replacement strings to replace the tags with.
+
+        Return an empty list for cases when you don't want any replacements made.
+        """
         raise NotImplementedError
 
     def __call__(self, html: str) -> str:
-        matches_by_tag_type, attrs_by_tag_type = self.extract_tags(html)
-
-        replacements = [
-            self.get_tag_replacements(tag_type, attrs_list)
-            for tag_type, attrs_list in attrs_by_tag_type.items()
-        ]
-
+        matches_by_tag_type = self.extract_tags(html)
         matches_to_replace = []
-        for matches, replacements in zip(matches_by_tag_type.values(), replacements):
+
+        # For each tag type, get the list of replacement strings for all tags of that type
+        for tag_type, tag_matches in matches_by_tag_type.items():
+            attr_dicts = [match.attrs for match in tag_matches]
+            replacements = self.get_tag_replacements(tag_type, attr_dicts)
+
             if not replacements:
                 continue
 
-            matches_to_replace.extend(zip(matches, replacements))
+            for match, replacement in zip(tag_matches, replacements):
+                match.replacement = replacement
+                matches_to_replace.append(match)
+
+        # Replace the tags in order of appearance in the string, so that offsets remain valid
+        matches_to_replace.sort(key=lambda match: match.start)
 
         offset = 0
-        for match, replacement in sorted(
-            matches_to_replace, key=lambda match_to_replace: match_to_replace[0].start()
-        ):
+        for match in matches_to_replace:
             html = (
-                html[: match.start() + offset]
-                + replacement
-                + html[match.end() + offset :]
+                html[: match.start + offset]
+                + match.replacement
+                + html[match.end + offset :]
             )
 
-            offset += len(replacement) - match.end() + match.start()
+            offset += len(match.replacement) - match.end + match.start
 
         return html
 
-    def extract_tags(self, html: str) -> Tuple[dict, dict]:
+    def extract_tags(self, html: str) -> Dict[str, List[TagMatch]]:
         """Helper method to extract and group HTML tags and their attributes.
 
-        Returns the full list of regex matches grouped by tag type as well as
-        the tag attribute dictionaries grouped by tag type.
+        Returns a dict of TagMatch objects, mapping tag types to a list of all TagMatch objects of that tag type.
         """
         matches_by_tag_type = defaultdict(list)
-        attrs_by_tag_type = defaultdict(list)
 
         # Regex used to match <tag ...> tags in the HTML.
         re_pattern = self.get_opening_tag_regex()
 
-        for match in re_pattern.finditer(html):
-            attrs = extract_attrs(match.group(1))
-            tag_type = self.get_tag_type_from_attrs(attrs)
+        for re_match in re_pattern.finditer(html):
+            tag_match = TagMatch(re_match)
+            tag_type = self.get_tag_type_from_attrs(tag_match.attrs)
 
-            matches_by_tag_type[tag_type].append(match)
-            attrs_by_tag_type[tag_type].append(attrs)
+            matches_by_tag_type[tag_type].append(tag_match)
 
-        return matches_by_tag_type, attrs_by_tag_type
+        return matches_by_tag_type
 
     def convert_rule_to_bulk_rule(self, rule: Callable) -> Callable:
         def bulk_rule(args):

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -191,6 +191,14 @@ This is another image: <embed embedtype="image" id="2" format="left" />
         """
             )
 
+    def test_expand_db_html_mixed_link_types(self):
+        html = '<a href="https://wagtail.org/">foo</a><a linktype="page" id="3">bar</a>'
+        result = expand_db_html(html)
+        self.assertEqual(
+            result,
+            ('<a href="https://wagtail.org/">foo</a><a href="/events/">bar</a>'),
+        )
+
 
 class TestRichTextValue(TestCase):
     fixtures = ["test.json"]
@@ -273,6 +281,12 @@ class TestLinkRewriterTagReplacing(TestCase):
         )
         self.assertNotEqual(link_with_custom_linktype, '<a href="https://wagtail.org">')
         self.assertEqual(link_with_custom_linktype, "<a>")
+
+        # And should properly handle mixed linktypes.
+        self.assertEqual(
+            rewriter('<a href="https://wagtail.org/"><a linktype="page" id="3">'),
+            '<a href="https://wagtail.org/"><a href="/article/3">',
+        )
 
     def test_supported_type_should_follow_given_rules(self):
         # we always have `page` rules by default

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -192,11 +192,25 @@ This is another image: <embed embedtype="image" id="2" format="left" />
             )
 
     def test_expand_db_html_mixed_link_types(self):
-        html = '<a href="https://wagtail.org/">foo</a><a linktype="page" id="3">bar</a>'
-        result = expand_db_html(html)
         self.assertEqual(
-            result,
-            ('<a href="https://wagtail.org/">foo</a><a href="/events/">bar</a>'),
+            expand_db_html(
+                '<a href="https://wagtail.org/">foo</a>'
+                '<a linktype="page" id="3">bar</a>'
+            ),
+            '<a href="https://wagtail.org/">foo</a><a href="/events/">bar</a>',
+        )
+
+        self.assertEqual(
+            expand_db_html(
+                '<a linktype="page" id="3">page</a>'
+                '<a linktype="document" id="1">document</a>'
+                '<a linktype="page" id="3">page</a>'
+            ),
+            (
+                '<a href="/events/">page</a>'
+                '<a href="/documents/1/test.pdf">document</a>'
+                '<a href="/events/">page</a>'
+            ),
         )
 
 


### PR DESCRIPTION
The bulk rich text link rewriter logic introduced in  #5875 doesn't work properly if the rich text contains multiple link types where one of those types doesn't need to be rewritten (for example external links like `<a href="https://wagtail.org/">`).

This commit fixes that bug by handling these cases, and adds additional unit tests to cover the failure cases.

Fixes #11957.