### PR TITLE
Fix delete button from showing up in collections edit view for users with insufficient permissions

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/generic/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/edit.html
@@ -3,7 +3,7 @@
 
 {% block actions %}
     {{ block.super }}
-    {% if delete_url %}
+    {% if can_delete and delete_url %}
         <a href="{{ delete_url }}" class="button no">{{ delete_item_label }}</a>
     {% endif %}
 {% endblock %}

--- a/wagtail/admin/tests/test_collections_views.py
+++ b/wagtail/admin/tests/test_collections_views.py
@@ -549,6 +549,17 @@ class TestEditCollection(CollectionInstanceTestUtils, WagtailTestUtils, TestCase
         # Retrieve edit form and check fields
         response = self.get(collection_id=self.marketing_sub_collection.id)
         self.assertNotContains(response, "Delete collection")
+        # Add delete permission to a different collection and try again,
+        # ensure that it checks against the tree structure, and not just a
+        # "delete collection" permission on any collection
+        # See https://github.com/wagtail/wagtail/issues/10084
+        GroupCollectionPermission.objects.create(
+            group=self.marketing_group,
+            collection=self.marketing_sub_collection_2,
+            permission=self.delete_permission,
+        )
+        response = self.get(collection_id=self.marketing_sub_collection.id)
+        self.assertNotContains(response, "Delete collection")
         # Add delete permission to parent collection and try again
         GroupCollectionPermission.objects.create(
             group=self.marketing_group,

--- a/wagtail/admin/views/collections.py
+++ b/wagtail/admin/views/collections.py
@@ -140,12 +140,8 @@ class Edit(EditView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["can_delete"] = (
-            self.permission_policy.instances_user_has_permission_for(
-                self.request.user, "delete"
-            )
-            .filter(pk=self.object.pk)
-            .first()
+        context["can_delete"] = self.permission_policy.user_has_permission_for_instance(
+            self.request.user, "delete", self.object
         )
         return context
 


### PR DESCRIPTION
Regression in 45ac80bb8994dafe62e090c658030fe4438ff0b6. The template no longer checks for `can_delete`. Instead, it generates the `delete_url` based on `can_delete` in the generic `EditView`'s `get_context_data()`. As a result, any modification to the `can_delete` context value by a subclass is ignored.

Also add a small optimisation by using `user_has_any_permission_for_instance` instead of making a query for objects that the user has delete permission for and fetching the object with the same ID.

Fixes #10084.