### PR TITLE
Do not bypass permission policy check for superusers in snippets Create/Edit view

### DIFF
--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -287,14 +287,19 @@ class CreateEditViewOptionalFeaturesMixin:
 
     def user_has_permission(self, permission):
         user = self.request.user
-        if user.is_superuser:
-            return True
-
         # Workflow lock/unlock methods take precedence before the base
         # "lock" and "unlock" permissions -- see PagePermissionTester for reference
         if permission == "lock" and self.current_workflow_task:
+            # Follow the logic in PagePermissionTester.user_can_lock()
+            # (superusers can always lock)
+            if user.is_superuser:
+                return True
             return self.current_workflow_task.user_can_lock(self.object, user)
         if permission == "unlock":
+            # Follow the logic in PagePermissionTester.user_can_unlock()
+            # (superusers can always unlock)
+            if user.is_superuser:
+                return True
             # Allow unlocking even if the user does not have the 'unlock' permission
             # if they are the user who locked the object
             if self.object.locked_by_id == user.pk:

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -21,6 +21,7 @@ from wagtail.admin.ui.tables import BooleanColumn, UpdatedAtColumn
 from wagtail.admin.utils import set_query_params
 from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail.admin.widgets import Button
+from wagtail.permission_policies.base import ModelPermissionPolicy
 from wagtail.snippets.bulk_actions.snippet_bulk_action import SnippetBulkAction
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.chooser import SnippetChooserViewSet
@@ -264,6 +265,13 @@ class FullFeaturedSnippetFilterSet(WagtailFilterSet):
         fields = ["country_code", "some_date"]
 
 
+class FullFeaturedPermissionPolicy(ModelPermissionPolicy):
+    def user_has_permission(self, user, action):
+        if not user.is_anonymous and "[FORBIDDEN]" in user.get_full_name():
+            return False
+        return super().user_has_permission(user, action)
+
+
 class FullFeaturedSnippetChooserViewSet(SnippetChooserViewSet):
     form_fields = ["text", "country_code", "some_number"]
 
@@ -303,6 +311,7 @@ class FullFeaturedSnippetViewSet(SnippetViewSet):
     # Ensure that the menu item is placed last
     menu_order = 999999
     inspect_view_enabled = True
+    permission_policy = FullFeaturedPermissionPolicy(FullFeaturedSnippet)
 
     class IndexView(SnippetViewSet.index_view_class):
         def get_add_url(self):


### PR DESCRIPTION
Fixes #11707.

Except for the lock/unlock permission, since we still need to sync that logic with `PagePermissionTester`...