### PR TITLE
Skip ChooseParentView if only one possible valid parent page available

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Allow custom permission policies on snippets to prevent superusers from creating or editing them (Sage Abdullah)
  * Do not link to edit view from listing views if user has no permission to edit (Sage Abdullah)
  * Allow access to snippets and other model viewsets to users with "View" permission (Sage Abdullah)
+ * Skip `ChooseParentView` if only one possible valid parent page availale (Matthias Brück)
  * Fix: Make `WAGTAILIMAGES_CHOOSER_PAGE_SIZE` setting functional again (Rohit Sharma)
  * Fix: Enable `richtext` template tag to convert lazy translation values (Benjamin Bach)
  * Fix: Ensure permission labels on group permissions page are translated where available (Matt Westcott)

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -20,6 +20,7 @@ depth: 1
  * Allow custom permission policies on snippets to prevent superusers from creating or editing them (Sage Abdullah)
  * Do not link to edit view from listing views if user has no permission to edit (Sage Abdullah)
  * Allow access to snippets and other model viewsets to users with "View" permission (Sage Abdullah)
+ * Skip `ChooseParentView` if only one possible valid parent page availale (Matthias Brück)
 
 
 ### Bug fixes

--- a/wagtail/admin/views/pages/choose_parent.py
+++ b/wagtail/admin/views/pages/choose_parent.py
@@ -1,4 +1,5 @@
 from django.contrib.admin.utils import quote
+from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.functional import cached_property
@@ -10,6 +11,7 @@ from django.views.generic import FormView
 from wagtail.admin.forms.pages import ParentChooserForm
 from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
 from wagtail.models import Page
+from wagtail.permissions import page_permission_policy
 
 
 class ChooseParentView(WagtailAdminTemplateMixin, FormView):
@@ -17,6 +19,66 @@ class ChooseParentView(WagtailAdminTemplateMixin, FormView):
     model = Page
     index_url_name = None
     page_title = gettext_lazy("Choose parent")
+
+    def get_valid_parent_pages(self, user):
+        """
+        Identifies possible parent pages for the current user by first looking
+        at allowed_parent_page_models() on self.model to limit options to the
+        correct type of page, then checking permissions on those individual
+        pages to make sure we have permission to add a subpage to it.
+        """
+        # Get queryset of pages where this page type can be added
+        allowed_parent_page_content_types = list(
+            ContentType.objects.get_for_models(
+                *self.model.allowed_parent_page_models()
+            ).values()
+        )
+        allowed_parent_pages = Page.objects.filter(
+            content_type__in=allowed_parent_page_content_types
+        )
+
+        # Get queryset of pages where the user has permission to add subpages
+        if user.is_superuser:
+            pages_where_user_can_add = Page.objects.all()
+        else:
+            pages_where_user_can_add = Page.objects.none()
+
+            perms = {
+                perm
+                for perm in page_permission_policy.get_cached_permissions_for_user(user)
+                if perm.permission.codename == "add_page"
+            }
+
+            for perm in perms:
+                # user has add permission on any subpage of perm.page
+                # (including perm.page itself)
+                pages_where_user_can_add |= Page.objects.descendant_of(
+                    perm.page, inclusive=True
+                )
+
+        # Combine them
+        return allowed_parent_pages & pages_where_user_can_add
+
+    def get(self, request, *args, **kwargs):
+        parents = self.get_valid_parent_pages(request.user)
+
+        # Only fetch the IDs for the first two parents to check if there's only
+        # one valid parent, and if so, redirect to the add page view with that
+        # parent pre-selected
+        parent_ids = parents.values_list("pk", flat=True)[:2]
+        if len(parent_ids) == 1:
+            parent_id = quote(parent_ids[0])
+            model_opts = self.model._meta
+            return redirect(
+                "wagtailadmin_pages:add",
+                model_opts.app_label,
+                model_opts.model_name,
+                parent_id,
+            )
+
+        # The page can be added in multiple places, so proceed with rendering
+        # the view's form so that the parent can be specified
+        return super().get(request, *args, **kwargs)
 
     def get_form(self):
         if self.request.method == "POST":


### PR DESCRIPTION
If a User clicks on Add new page" button on a PageListingViewSet and only one valid parent page exists, the view skips the "choose parent page" prompt, and redirect directly to the main "create page" form to create a page under that parent. This matches the old behaviour of the ModelAdmin module (in Wagtail until 5.x and now available as the wagtail-modeladmin package). I copied the `get_valid_parent_pages` method from the wagtail-modeladmin module and integrated the logic into the dispatch handler.

Fixes #11969 