### PR TITLE
Optimise embed finder resolution

### DIFF
--- a/wagtail/embeds/apps.py
+++ b/wagtail/embeds/apps.py
@@ -11,5 +11,7 @@ class WagtailEmbedsAppConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
+        from . import signal_handlers  # noqa
+
         # Check configuration on startup
         get_finders()

--- a/wagtail/embeds/finders/__init__.py
+++ b/wagtail/embeds/finders/__init__.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from importlib import import_module
 
 from django.conf import settings
@@ -34,6 +35,7 @@ def _get_config_from_settings():
         ]
 
 
+@lru_cache(maxsize=None)
 def get_finders():
     finders = []
 

--- a/wagtail/embeds/signal_handlers.py
+++ b/wagtail/embeds/signal_handlers.py
@@ -1,0 +1,13 @@
+from django.core.signals import setting_changed
+from django.dispatch import receiver
+
+from .finders import get_finders
+
+
+@receiver(setting_changed)
+def clear_embed_caches(*, setting: str, **kwargs: dict) -> None:
+    """
+    Clear the embed caches when settings change
+    """
+    if setting == "WAGTAILEMBEDS_FINDERS":
+        get_finders.cache_clear()

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -652,7 +652,7 @@ class TestInstagramOEmbed(TestCase):
     def test_instagram_oembed_return_values(self, urlopen):
         urlopen.return_value = self.dummy_response
         result = InstagramOEmbedFinder(app_id="123", app_secret="abc").find_embed(
-            "https://instagr.am/p/CHeRxmnDSYe/"
+            "https://instagram.com/p/CHeRxmnDSYe/"
         )
         self.assertEqual(
             result,
@@ -671,13 +671,13 @@ class TestInstagramOEmbed(TestCase):
         request = urlopen.call_args[0][0]
         self.assertEqual(
             request.get_full_url(),
-            "https://graph.facebook.com/v11.0/instagram_oembed?url=https%3A%2F%2Finstagr.am%2Fp%2FCHeRxmnDSYe%2F&format=json",
+            "https://graph.facebook.com/v11.0/instagram_oembed?url=https%3A%2F%2Finstagram.com%2Fp%2FCHeRxmnDSYe%2F&format=json",
         )
         self.assertEqual(request.get_header("Authorization"), "Bearer 123|abc")
 
     def test_instagram_request_denied_401(self):
         err = HTTPError(
-            "https://instagr.am/p/CHeRxmnDSYe/",
+            "https://instagram.com/p/CHeRxmnDSYe/",
             code=401,
             msg="invalid credentials",
             hdrs={},
@@ -688,12 +688,12 @@ class TestInstagramOEmbed(TestCase):
             self.assertRaises(
                 AccessDeniedInstagramOEmbedException,
                 InstagramOEmbedFinder().find_embed,
-                "https://instagr.am/p/CHeRxmnDSYe/",
+                "https://instagram.com/p/CHeRxmnDSYe/",
             )
 
     def test_instagram_request_not_found(self):
         err = HTTPError(
-            "https://instagr.am/p/badrequest/",
+            "https://instagram.com/p/badrequest/",
             code=404,
             msg="Not Found",
             hdrs={},
@@ -704,7 +704,7 @@ class TestInstagramOEmbed(TestCase):
             self.assertRaises(
                 EmbedNotFoundException,
                 InstagramOEmbedFinder().find_embed,
-                "https://instagr.am/p/CHeRxmnDSYe/",
+                "https://instagram.com/p/CHeRxmnDSYe/",
             )
 
     def test_instagram_failed_request(self):
@@ -713,7 +713,7 @@ class TestInstagramOEmbed(TestCase):
             self.assertRaises(
                 EmbedNotFoundException,
                 InstagramOEmbedFinder().find_embed,
-                "https://instagr.am/p/CHeRxmnDSYe/",
+                "https://instagram.com/p/CHeRxmnDSYe/",
             )
 
 


### PR DESCRIPTION
Currently, finding the embed HTML for a given URL (assuming there's no record in the DB) requires compiling the regex of each oembed provider. This is both CPU and time intensive - and mostly unnecessary.

This change caches the instantiated embed finders. Since regex compilation is done in the constructor, this means it only needs doing once. The finders are initialised during module init (through `apps.py`), which means the cache miss shouldn't hit a web request. This won't interfere with the existing DB cache for the HTML.

I went this route instead of modifying `oembed_finders` to compile them at the module level to also cache class construction, and any externally-added finders or providers.

There was also some duplication in the Facebook / Instagram finders, which I've now removed.

## Before

```
In [2]: %timeit get_finders()
58.4 µs ± 183 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

## After

```
In [2]: %timeit get_finders()
41.2 ns ± 0.519 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```