### PR TITLE
Add alt text validation rule in the accessibility checker

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Remove reduced opacity for draft page title in listings (Inju Michorius)
  * Adopt more compact representation for StreamField definitions in migrations (Matt Westcott)
  * Implement a new design for locale labels in listings (Albina Starykova)
+ * Add alt text validation rule in the accessibility checker (Albina Starykova)
  * Fix: Make `WAGTAILIMAGES_CHOOSER_PAGE_SIZE` setting functional again (Rohit Sharma)
  * Fix: Enable `richtext` template tag to convert lazy translation values (Benjamin Bach)
  * Fix: Ensure permission labels on group permissions page are translated where available (Matt Westcott)

--- a/client/src/entrypoints/admin/preview-panel.js
+++ b/client/src/entrypoints/admin/preview-panel.js
@@ -1,6 +1,6 @@
-import axe from 'axe-core';
 import {
   getAxeConfiguration,
+  getA11yReport,
   renderA11yResults,
 } from '../../includes/a11y-result';
 import { WAGTAIL_CONFIG } from '../../config/wagtailConfig';
@@ -32,23 +32,18 @@ const runAccessibilityChecks = async (onClickSelector) => {
   }
 
   // Ensure we only test within the preview iframe, but nonetheless with the correct selectors.
-  const context = {
+  config.context = {
     include: {
       fromFrames: ['#preview-iframe'].concat(config.context.include),
     },
   };
   if (config.context.exclude?.length > 0) {
-    context.exclude = {
+    config.context.exclude = {
       fromFrames: ['#preview-iframe'].concat(config.context.exclude),
     };
   }
 
-  const results = await axe.run(context, config.options);
-
-  const a11yErrorsNumber = results.violations.reduce(
-    (sum, violation) => sum + violation.nodes.length,
-    0,
-  );
+  const { results, a11yErrorsNumber } = await getA11yReport(config);
 
   toggleCounter.innerText = a11yErrorsNumber.toString();
   toggleCounter.hidden = a11yErrorsNumber === 0;

--- a/client/src/includes/a11y-result.test.ts
+++ b/client/src/includes/a11y-result.test.ts
@@ -1,5 +1,5 @@
 import { AxeResults } from 'axe-core';
-import { sortAxeViolations } from './a11y-result';
+import { sortAxeViolations, checkImageAltText } from './a11y-result';
 
 const mockDocument = `
 <div id="a"></div>
@@ -53,5 +53,66 @@ describe('sortAxeViolations', () => {
       mockViolations.db,
       mockViolations.third,
     ]);
+  });
+});
+
+describe('checkImageAltText', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <img src="image1.jpg" alt="Good alt text with words like GIFted and moTIF">
+      <img src="image2.png" alt="Bad alt text.png">
+      <img src="image3.tiff" alt="Bad alt text.TIFF more text">
+      <img src="image4.png" alt="https://Bad.alt.text">
+      <img src="https://example.com/image5.gif" alt="">
+      <img src="image6.jpg">
+    `;
+  });
+
+  it('should not flag images with good alt text', () => {
+    const image = document.querySelector<HTMLImageElement>(
+      'img[src="image1.jpg"]',
+    );
+    if (!image) return;
+    expect(checkImageAltText(image)).toBe(true);
+  });
+
+  it('should flag images with a file extension in the alt text', () => {
+    const image = document.querySelector<HTMLImageElement>(
+      'img[src="image2.png"]',
+    );
+    if (!image) return;
+    expect(checkImageAltText(image)).toBe(false);
+  });
+
+  it('should flag images with a capitalised file extension in the alt text', () => {
+    const image = document.querySelector<HTMLImageElement>(
+      'img[src="image3.tiff"]',
+    );
+    if (!image) return;
+    expect(checkImageAltText(image)).toBe(false);
+  });
+
+  it('should flag images with a file URL in the alt text', () => {
+    const image = document.querySelector<HTMLImageElement>(
+      'img[src="image4.png"]',
+    );
+    if (!image) return;
+    expect(checkImageAltText(image)).toBe(false);
+  });
+
+  it('should not flag images with empty alt attribute', () => {
+    const image = document.querySelector<HTMLImageElement>(
+      'img[src="https://example.com/image5.gif"]',
+    );
+    if (!image) return;
+    expect(checkImageAltText(image)).toBe(true);
+  });
+
+  it('should not flag images with no alt attribute', () => {
+    const image = document.querySelector<HTMLImageElement>(
+      'img[src="image6.jpg"]',
+    );
+    if (!image) return;
+    expect(checkImageAltText(image)).toBe(true);
   });
 });

--- a/client/src/includes/a11y-result.test.ts
+++ b/client/src/includes/a11y-result.test.ts
@@ -2,7 +2,6 @@ import axe, { AxeResults, Spec } from 'axe-core';
 import {
   sortAxeViolations,
   WagtailAxeConfiguration,
-  customChecks,
   addCustomChecks,
   checkImageAltText,
   getA11yReport,
@@ -63,14 +62,6 @@ describe('sortAxeViolations', () => {
   });
 });
 
-describe('customChecks', () => {
-  it('should have function values for each custom check', () => {
-    Object.values(customChecks).forEach((value) => {
-      expect(typeof value).toBe('function');
-    });
-  });
-});
-
 describe('addCustomChecks', () => {
   it('should integrate custom checks into the Axe spec', () => {
     const spec: Spec = {
@@ -102,16 +93,13 @@ describe('addCustomChecks', () => {
 
 // Options for checkImageAltText function
 const options = {
-  pattern:
-    '\\.(apng|avif|gif|jpg|jpeg|jfif|pjp|png|svg|tif|webp)|(http:\\/\\/|https:\\/\\/|www\\.)',
+  pattern: '\\.(avif|gif|jpg|jpeg|png|svg|webp)$',
 };
 
 describe.each`
   text                                                | result
   ${'Good alt text with words like GIFted and motif'} | ${true}
   ${'Bad alt text.png'}                               | ${false}
-  ${'Bad alt text.TIFF more text'}                    | ${false}
-  ${'https://Bad.alt.text'}                           | ${false}
   ${''}                                               | ${true}
 `('checkImageAltText', ({ text, result }) => {
   const resultText = result ? 'should not be flagged' : 'should be flagged';
@@ -126,12 +114,6 @@ describe('checkImageAltText edge cases', () => {
   test('should not flag images with no alt attribute', () => {
     const image = document.createElement('img');
     expect(checkImageAltText(image, options)).toBe(true);
-  });
-
-  test('should return null if no pattern is provided', () => {
-    const image = document.createElement('img');
-    image.setAttribute('alt', 'Good alt text with words like GIFted and moTIF');
-    expect(checkImageAltText(image, {})).toBeUndefined();
   });
 });
 

--- a/client/src/includes/a11y-result.ts
+++ b/client/src/includes/a11y-result.ts
@@ -74,7 +74,7 @@ export const getAxeConfiguration = (
 
 /**
  * Custom rule for checking image alt text. This rule checks if the alt text for images
- * contains poor quality text like file extensions or URLs.
+ * contains poor quality text like file extensions.
  * The rule will be added via the Axe.configure() API.
  * https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure
  */

--- a/client/src/includes/a11y-result.ts
+++ b/client/src/includes/a11y-result.ts
@@ -78,9 +78,10 @@ export const getAxeConfiguration = (
  * The rule will be added via the Axe.configure() API.
  * https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure
  */
-export const checkImageAltText = (node: HTMLImageElement, options) => {
-  if (!options.pattern) return undefined;
-
+export const checkImageAltText = (
+  node: HTMLImageElement,
+  options: { pattern: string },
+) => {
   const altTextAntipatterns = new RegExp(options.pattern, 'i');
   const altText = node.getAttribute('alt') || '';
 
@@ -129,15 +130,8 @@ interface A11yReport {
 export const getA11yReport = async (
   config: WagtailAxeConfiguration,
 ): Promise<A11yReport> => {
-  let spec = config.spec;
-  // Apply custom configuration for Axe. Custom 'check-image-alt-text' is enabled by default
-  if (spec) {
-    if (spec.checks) {
-      spec = addCustomChecks(spec);
-    }
-    axe.configure(spec);
-  }
-  // Initialise Axe based on the context (whole page body by default) and options ('button-name', empty-heading', 'empty-table-header', 'frame-title', 'heading-order', 'input-button-name', 'link-name', 'p-as-heading', and a custom 'alt-text-quality' rules by default)
+  axe.configure(addCustomChecks(config.spec));
+  // Initialise Axe based on the context and options defined in Python.
   const results = await axe.run(config.context, config.options);
   const a11yErrorsNumber = results.violations.reduce(
     (sum, violation) => sum + violation.nodes.length,

--- a/client/src/includes/a11y-result.ts
+++ b/client/src/includes/a11y-result.ts
@@ -4,6 +4,9 @@ import {
   NodeResult,
   Result,
   RunOptions,
+  ImpactValue,
+  Check,
+  Rule,
 } from 'axe-core';
 
 const toSelector = (str: string | string[]) =>
@@ -43,6 +46,7 @@ interface WagtailAxeConfiguration {
   context: ElementContext;
   options: RunOptions;
   messages: Record<string, string>;
+  customAltTextRuleConfig: any;
 }
 
 /**
@@ -68,6 +72,28 @@ export const getAxeConfiguration = (
 
   // Skip initialization of Axe if config fails to load
   return null;
+};
+
+/**
+ * Configuration for the custom Axe rules. Custom 'Image alt text quality' rule is disabled by default.
+ * https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure
+ */
+export const customAxeRulesConfig = {
+  checks: [
+    {
+      id: 'check-image-alt-text',
+    },
+  ] as Check[],
+  rules: [
+    {
+      id: 'alt-text-quality',
+      impact: 'serious' as ImpactValue,
+      selector: 'img[alt]',
+      tags: ['best-practice'],
+      any: ['check-image-alt-text'],
+      enabled: false,
+    },
+  ] as Rule[],
 };
 
 /**

--- a/client/src/includes/userbar.ts
+++ b/client/src/includes/userbar.ts
@@ -1,11 +1,9 @@
-import axe from 'axe-core';
-
 import A11yDialog from 'a11y-dialog';
 import { Application } from '@hotwired/stimulus';
 import {
   getAxeConfiguration,
+  getA11yReport,
   renderA11yResults,
-  customAxeRulesConfig,
 } from './a11y-result';
 import { DialogController } from '../controllers/DialogController';
 import { TeleportController } from '../controllers/TeleportController';
@@ -315,36 +313,7 @@ export class Userbar extends HTMLElement {
 
     if (!this.shadowRoot || !accessibilityTrigger || !config) return;
 
-    // If enabled in configurations, add a custom 'Image alt text quality' rule
-    // via Axe API https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure
-    if (config.customAltTextRuleConfig.enabled) {
-      const imageFileExtensions = config.customAltTextRuleConfig.patterns;
-      const imageFileExtensionsRegex = new RegExp(
-        `\\.(${imageFileExtensions.join('|')})`,
-        'i',
-      );
-
-      const checkImageAltText = (node: Element) => {
-        const image = node as HTMLImageElement;
-        const altText = image.getAttribute('alt') || '';
-        const hasBadAltText = imageFileExtensionsRegex.test(altText);
-        return !hasBadAltText;
-      };
-
-      customAxeRulesConfig.rules[0].enabled = true;
-      customAxeRulesConfig.checks[0].evaluate = checkImageAltText;
-    }
-
-    // Configure custom rules for Axe if any. None of them are enabled by default.
-    axe.configure(customAxeRulesConfig);
-
-    // Initialise Axe based on the configurable context (whole page body by default) and options ('button-name', empty-heading', 'empty-table-header', 'frame-title', 'heading-order', 'input-button-name', 'link-name', and 'p-as-heading' rules by default)
-    const results = await axe.run(config.context, config.options);
-
-    const a11yErrorsNumber = results.violations.reduce(
-      (sum, violation) => sum + violation.nodes.length,
-      0,
-    );
+    const { results, a11yErrorsNumber } = await getA11yReport(config);
 
     if (results.violations.length) {
       const a11yErrorBadge = document.createElement('span');

--- a/docs/advanced_topics/accessibility_considerations.md
+++ b/docs/advanced_topics/accessibility_considerations.md
@@ -142,6 +142,7 @@ By default, the checker includes the following rules to find common accessibilit
 -   `input-button-name`: `<input>` button elements must always have a text label.
 -   `link-name`: `<a>` link elements must always have a text label.
 -   `p-as-heading`: This rule checks for paragraphs that are styled as headings. Paragraphs should not be styled as headings, as they don’t help users who rely on headings to navigate content.
+-   `alt-text-quality`: A custom rule ensures that image alt texts don't contain antipatterns like file extensions.
 
 To customize how the checker is run (such as what rules to test), you can define a custom subclass of {class}`~wagtail.admin.userbar.AccessibilityItem` and override the attributes to your liking. Then, swap the instance of the default `AccessibilityItem` with an instance of your custom class via the [`construct_wagtail_userbar`](construct_wagtail_userbar) hook.
 
@@ -155,6 +156,8 @@ The following is the reference documentation for the `AccessibilityItem` class:
     .. autoattribute:: axe_run_only
        :no-value:
     .. autoattribute:: axe_rules
+    .. autoattribute:: axe_custom_rules
+    .. autoattribute:: axe_custom_checks
     .. autoattribute:: axe_messages
        :no-value:
 
@@ -167,12 +170,15 @@ The following is the reference documentation for the `AccessibilityItem` class:
     .. method:: get_axe_exclude(request)
     .. method:: get_axe_run_only(request)
     .. method:: get_axe_rules(request)
+    .. method:: get_axe_custom_rules(request)
+    .. method:: get_axe_custom_checks(request)
     .. method:: get_axe_messages(request)
 
     For more advanced customization, you can also override the following methods:
 
     .. automethod:: get_axe_context
     .. automethod:: get_axe_options
+    .. automethod:: get_axe_spec
 ```
 
 Here is an example of a custom `AccessibilityItem` subclass that enables more rules:

--- a/docs/advanced_topics/accessibility_considerations.md
+++ b/docs/advanced_topics/accessibility_considerations.md
@@ -142,7 +142,7 @@ By default, the checker includes the following rules to find common accessibilit
 -   `input-button-name`: `<input>` button elements must always have a text label.
 -   `link-name`: `<a>` link elements must always have a text label.
 -   `p-as-heading`: This rule checks for paragraphs that are styled as headings. Paragraphs should not be styled as headings, as they don’t help users who rely on headings to navigate content.
--   `alt-text-quality`: A custom rule ensures that image alt texts don't contain antipatterns like file extensions.
+-   `alt-text-quality`: A custom rule ensures that image alt texts don't contain anti-patterns like file extensions.
 
 To customize how the checker is run (such as what rules to test), you can define a custom subclass of {class}`~wagtail.admin.userbar.AccessibilityItem` and override the attributes to your liking. Then, swap the instance of the default `AccessibilityItem` with an instance of your custom class via the [`construct_wagtail_userbar`](construct_wagtail_userbar) hook.
 
@@ -157,7 +157,9 @@ The following is the reference documentation for the `AccessibilityItem` class:
        :no-value:
     .. autoattribute:: axe_rules
     .. autoattribute:: axe_custom_rules
+       :no-value:
     .. autoattribute:: axe_custom_checks
+       :no-value:
     .. autoattribute:: axe_messages
        :no-value:
 

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -11,6 +11,11 @@ depth: 1
 
 ## What's new
 
+### Alt text accessibility check
+
+The [built-in accessibility checker](authoring_accessible_content) now enforces a new `alt-text-quality` rule, which tests alt text for the presence of known bad patterns such as file extensions. This rule is enabled by default, but can be disabled if necessary.
+
+This feature was implemented by Albina Starykova, with support from the Wagtail accessibility team.
 
 ### Other features
 

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -341,6 +341,131 @@ class TestAccessibilityCheckerConfig(WagtailTestUtils, TestCase):
                 },
             )
 
+    def test_custom_rules_and_checks(self):
+        class CustomRulesAndChecksAccessibilityItem(AccessibilityItem):
+            # Override via class attribute
+            axe_custom_rules = [
+                {
+                    "id": "alt-text-quality",
+                    "impact": "serious",
+                    "selector": "img[alt]",
+                    "tags": ["best-practice"],
+                    "any": ["check-image-alt-text"],
+                    "enabled": True,
+                },
+            ]
+            axe_custom_checks = [
+                {
+                    "id": "check-image-alt-text",
+                    "options": {"pattern": "\\.(avif|gif|jpg|jpeg|png|svg|webp)$"},
+                },
+            ]
+
+            # Override via method
+            def get_axe_custom_rules(self, request):
+                return [
+                    {
+                        "id": "link-text-quality",
+                        "impact": "serious",
+                        "selector": "a",
+                        "tags": ["best-practice"],
+                        "any": ["check-link-text"],
+                        "enabled": True,
+                    }
+                ] + super().get_axe_custom_rules(request)
+
+            def get_axe_custom_checks(self, request):
+                return [
+                    {
+                        "id": "check-link-text",
+                        "options": {"pattern": "learn more$"},
+                    }
+                ] + super().get_axe_custom_checks(request)
+
+        with hooks.register_temporarily(
+            "construct_wagtail_userbar",
+            self.get_hook(CustomRulesAndChecksAccessibilityItem),
+        ):
+            config = self.get_config()
+            self.assertEqual(
+                config["spec"],
+                {
+                    "rules": [
+                        # Override via class attribute
+                        {
+                            "id": "alt-text-quality",
+                            "impact": "serious",
+                            "selector": "img[alt]",
+                            "tags": ["best-practice"],
+                            "any": ["check-image-alt-text"],
+                            "enabled": True,
+                        },
+                        # Override via method
+                        {
+                            "id": "link-text-quality",
+                            "impact": "serious",
+                            "selector": "a",
+                            "tags": ["best-practice"],
+                            "any": ["check-link-text"],
+                            "enabled": True,
+                        },
+                    ],
+                    "checks": [
+                        # Override via class attribute
+                        {
+                            "id": "check-image-alt-text",
+                            "options": {
+                                "pattern": "\\.(avif|gif|jpg|jpeg|png|svg|webp)$"
+                            },
+                        },
+                        # Override via method
+                        {
+                            "id": "check-link-text",
+                            "options": {"pattern": "learn more$"},
+                        },
+                    ],
+                },
+            )
+
+    def test_pattern_if_custom_alt_text_check_enabled(self):
+        class CustomAltTextAccessibilityItem(AccessibilityItem):
+            axe_custom_checks = [
+                {
+                    "id": "check-image-alt-text",
+                    "options": {"pattern": "\\.(avif|gif|jpg|jpeg|png|svg|webp)$"},
+                },
+            ]
+
+            def get_axe_custom_checks(self, request):
+                return self.axe_custom_checks + super().get_axe_custom_checks(request)
+
+        with hooks.register_temporarily(
+            "construct_wagtail_userbar",
+            self.get_hook(CustomAltTextAccessibilityItem),
+        ):
+            config = self.get_config()
+            custom_checks = config["spec"]["checks"]
+            self.assertIsInstance(custom_checks, list)
+
+            # Check if the custom check is present
+            check_image_alt_text = next(
+                (
+                    check
+                    for check in custom_checks
+                    if check["id"] == "check-image-alt-text"
+                ),
+                None,
+            )
+
+            if check_image_alt_text:
+                # Verify pattern only if the check is enabled
+                self.assertEqual(
+                    check_image_alt_text["options"]["pattern"],
+                    "\\.(avif|gif|jpg|jpeg|png|svg|webp)$",
+                )
+            else:
+                self.skipTest("check-image-alt-text not enabled in custom checks")
+
 
 class TestUserbarInPageServe(WagtailTestUtils, TestCase):
     def setUp(self):

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -363,7 +363,7 @@ class TestAccessibilityCheckerConfig(WagtailTestUtils, TestCase):
 
             # Override via method
             def get_axe_custom_rules(self, request):
-                return [
+                return super().get_axe_custom_rules(request) + [
                     {
                         "id": "link-text-quality",
                         "impact": "serious",
@@ -372,15 +372,15 @@ class TestAccessibilityCheckerConfig(WagtailTestUtils, TestCase):
                         "any": ["check-link-text"],
                         "enabled": True,
                     }
-                ] + super().get_axe_custom_rules(request)
+                ]
 
             def get_axe_custom_checks(self, request):
-                return [
+                return super().get_axe_custom_checks(request) + [
                     {
                         "id": "check-link-text",
                         "options": {"pattern": "learn more$"},
                     }
-                ] + super().get_axe_custom_checks(request)
+                ]
 
         with hooks.register_temporarily(
             "construct_wagtail_userbar",

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -63,12 +63,8 @@ class AccessibilityItem(BaseItem):
     #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#options-parameter-examples>`__.
     axe_rules = {}
 
-    #: A list used to add custom rules to the existing set of Axe rules,
-    #: or to override the properties of existing Axe rules. A custom rule
-    #: to check the quality of the images alt texts is added to the list
-    #: and enabled by default. This rule ensures that alt texts don't contain
-    #: antipatterns like file extensions. Returns zero false positives.
-    #: Should be used in conjunction with `axe_custom_checks`
+    #: A list to add custom Axe rules or override their properties,
+    #: alongside with ``axe_custom_checks``. Includes Wagtail’s custom rules.
     #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`_.
     axe_custom_rules = [
         {
@@ -82,10 +78,8 @@ class AccessibilityItem(BaseItem):
         },
     ]
 
-    #: A list used to add custom checks to the existing set of Axe checks,
-    #: or to override the properties of existing Axe checks. A custom check
-    #: for the quality of the images alt texts is added and enabled by default.
-    #: Should be used in conjunction with `axe_custom_rules`
+    #: A list to add custom Axe checks or override their properties.
+    #: Should be used in conjunction with ``axe_custom_rules``.
     #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`_.
     axe_custom_checks = [
         {

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -57,31 +57,31 @@ class AccessibilityItem(BaseItem):
         "p-as-heading",
     ]
 
-    #: Configures whether the custom 'Image alt text quality' rule is enabled.
-    #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`__
-    axe_alt_text_rule_enabled = True
-
-    #: A list of bad alt text patterns checked by the 'Image alt text quality' rule.
-    axe_alt_text_rule_patterns = [
-        "apng",
-        "avif",
-        "gif",
-        "jpg",
-        "jpeg",
-        "jfif",
-        "pjpeg",
-        "pjp",
-        "png",
-        "svg",
-        "tif",
-        "webp",
-    ]
-
     #: A dictionary that maps axe-core rule IDs to a dictionary of rule options,
     #: commonly in the format of ``{"enabled": True/False}``. This can be used in
     #: conjunction with :attr:`axe_run_only` to enable or disable specific rules.
     #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#options-parameter-examples>`__.
     axe_rules = {}
+
+    # Spec object for axe.configure()
+    # If a rule is added, it's enabled by default, unless specificed "enabled: False"
+    axe_custom_rules = {
+        "checks": [
+            {
+                "id": "check-image-alt-text",
+            }
+        ],
+        "rules": [
+            {
+                "id": "alt-text-quality",
+                "impact": "serious",
+                "selector": "img[alt]",
+                "tags": ["best-practice"],
+                "any": ["check-image-alt-text"],
+                "enabled": True,  # Defaults to True
+            }
+        ],
+    }
 
     #: A dictionary that maps axe-core rule IDs to custom translatable strings
     #: to use as the error messages. If an enabled rule does not exist in this
@@ -128,25 +128,9 @@ class AccessibilityItem(BaseItem):
         """Returns a dictionary that maps axe-core rule IDs to a dictionary of rule options."""
         return self.axe_rules
 
-    def get_axe_custom_alt_text_rule_enabled(self, request):
+    def get_axe_custom_rules(self, request):
         """Returns if the custom 'Image alt text quality' rule is enabled."""
-        return self.axe_alt_text_rule_enabled
-
-    def get_axe_custom_alt_text_rule_patterns(self, request):
-        """Returns bad image alt text patterns for the custom 'Image alt text quality' rule."""
-        return self.axe_alt_text_rule_patterns
-
-    def get_axe_custom_alt_text_rule(self, request):
-        """Returns the custom 'Image alt text quality' rule configurations for
-        `axe.configure <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`_."""
-        custom_alt_text_rule = {
-            "enabled": self.get_axe_custom_alt_text_rule_enabled(request),
-            "patterns": self.get_axe_custom_alt_text_rule_patterns(request),
-        }
-        # If no patterns are provided, disable the rule
-        if not custom_alt_text_rule["patterns"]:
-            custom_alt_text_rule["enabled"] = False
-        return custom_alt_text_rule
+        return self.axe_custom_rules
 
     def get_axe_messages(self, request):
         """Returns a dictionary that maps axe-core rule IDs to custom translatable strings."""
@@ -187,7 +171,7 @@ class AccessibilityItem(BaseItem):
             "context": self.get_axe_context(request),
             "options": self.get_axe_options(request),
             "messages": self.get_axe_messages(request),
-            "customAltTextRuleConfig": self.get_axe_custom_alt_text_rule(request),
+            "custom": self.get_axe_custom_rules(request),
         }
 
     def get_context_data(self, request):

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -67,7 +67,7 @@ class AccessibilityItem(BaseItem):
     #: or to override the properties of existing Axe rules. A custom rule
     #: to check the quality of the images alt texts is added to the list
     #: and enabled by default. This rule ensures that alt texts don't contain
-    #: antipatterns like file extensions or URLs. Returns zero false positives.
+    #: antipatterns like file extensions. Returns zero false positives.
     #: Should be used in conjunction with `axe_custom_checks`
     #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`_.
     axe_custom_rules = [
@@ -147,13 +147,6 @@ class AccessibilityItem(BaseItem):
         """List of check objects per axe.run API, without evaluate function."""
         return self.axe_custom_checks
 
-    def get_axe_spec(self, request):
-        """Returns spec for Axe, including custom rules and custom checks"""
-        return {
-            "rules": self.get_axe_custom_rules(request),
-            "checks": self.get_axe_custom_checks(request),
-        }
-
     def get_axe_messages(self, request):
         """Returns a dictionary that maps axe-core rule IDs to custom translatable strings."""
         return self.axe_messages
@@ -187,6 +180,13 @@ class AccessibilityItem(BaseItem):
         if not options["runOnly"]:
             options.pop("runOnly")
         return options
+
+    def get_axe_spec(self, request):
+        """Returns spec for Axe, including custom rules and custom checks"""
+        return {
+            "rules": self.get_axe_custom_rules(request),
+            "checks": self.get_axe_custom_checks(request),
+        }
 
     def get_axe_configuration(self, request):
         return {

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -63,34 +63,36 @@ class AccessibilityItem(BaseItem):
     #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#options-parameter-examples>`__.
     axe_rules = {}
 
-    #: A list used to add custom rules to the existing set of Axe rules, or to override the properties of existing Axe rules
+    #: A list used to add custom rules to the existing set of Axe rules,
+    #: or to override the properties of existing Axe rules. A custom rule
+    #: to check the quality of the images alt texts is added to the list
+    #: and enabled by default. This rule ensures that alt texts don't contain
+    #: antipatterns like file extensions or URLs. Returns zero false positives.
+    #: Should be used in conjunction with `axe_custom_checks`
     #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`__.
-    axe_custom_rules = []
-
-    #: A custom rule to check the quality of the Images alt texts. Added to the list of custom rules and enabled by default.
-    #: Should be used in conjunction with :attr:`_axe_custom_alt_text_check`
-    #: This rule ensures that alt texts doesn't contain antipatterns like file extensions. Returns zero false positives.
-    _axe_custom_alt_text_rule = [
+    axe_custom_rules = [
         {
             "id": "alt-text-quality",
             "impact": "serious",
             "selector": "img[alt]",
             "tags": ["best-practice"],
             "any": ["check-image-alt-text"],
-            "enabled": True,  # If ommited, defaults to True
-        }
+            "enabled": True,  # If ommited, defaults to True and overrrides configs in `axe_run_only`
+        },
     ]
 
-    #: A list used to add custom checks to the existing set of Axe checks, or to override the properties of existing Axe checks
+    #: A list used to add custom checks to the existing set of Axe checks,
+    #: or to override the properties of existing Axe checks. A custom check
+    #: for the quality of the images alt texts is added and enabled by default.
+    #: Should be used in conjunction with `axe_custom_rules`
     #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`__.
-    axe_custom_checks = []
-
-    #: A custom check for the custom Image alt text quality rule. Added to the list of custom checks and enabled by default.
-    #: Should be used in conjunction with :attr:`_axe_custom_alt_text_rule`
-    _axe_custom_alt_text_check = [
+    axe_custom_checks = [
         {
             "id": "check-image-alt-text",
-        }
+            "options": {
+                "pattern": "\.(apng|avif|gif|jpg|jpeg|jfif|pjp|png|svg|tif|webp)|(http:\/\/|https:\/\/|www.)"
+            },
+        },
     ]
 
     #: A dictionary that maps axe-core rule IDs to custom translatable strings
@@ -139,24 +141,25 @@ class AccessibilityItem(BaseItem):
         return self.axe_rules
 
     def get_axe_custom_rules(self, request):
-        """Returns TODO return nothing if empty both rules and checks"""
-        return self.axe_custom_rules + self._axe_custom_alt_text_rule
+        """Returns custom rules for Axe"""
+        return self.axe_custom_rules
 
     def get_axe_custom_checks(self, request):
-        """Returns TODO return nothing if empty both rules and checks"""
-        return self.axe_custom_checks + self._axe_custom_alt_text_check
+        """Returns custom checks for Axe"""
+        return self.axe_custom_checks
 
-    def get_axe_custom_config(self, request):
-        """Returns TODO return nothing if empty both rules and checks"""
-        custom_config = {
+    def get_axe_spec(self, request):
+        """Returns spec for Axe, including custom rules and custom checks"""
+        spec = {
             "rules": self.get_axe_custom_rules(request),
             "checks": self.get_axe_custom_checks(request),
         }
 
-        # If both the lists of custom rules and custom checks are empty, no custom configuration should be applied for Axe
-        if not custom_config["rules"] and not custom_config["checks"]:
-            custom_config = ""
-        return custom_config
+        # If both the lists of custom rules and custom checks are empty,
+        # no custom configuration should be applied for Axe
+        if not spec["rules"] and not spec["checks"]:
+            spec = ""
+        return spec
 
     def get_axe_messages(self, request):
         """Returns a dictionary that maps axe-core rule IDs to custom translatable strings."""
@@ -197,7 +200,7 @@ class AccessibilityItem(BaseItem):
             "context": self.get_axe_context(request),
             "options": self.get_axe_options(request),
             "messages": self.get_axe_messages(request),
-            "custom": self.get_axe_custom_config(request),
+            "spec": self.get_axe_spec(request),
         }
 
     def get_context_data(self, request):

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -69,7 +69,7 @@ class AccessibilityItem(BaseItem):
     #: and enabled by default. This rule ensures that alt texts don't contain
     #: antipatterns like file extensions or URLs. Returns zero false positives.
     #: Should be used in conjunction with `axe_custom_checks`
-    #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`__.
+    #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`_.
     axe_custom_rules = [
         {
             "id": "alt-text-quality",
@@ -77,7 +77,8 @@ class AccessibilityItem(BaseItem):
             "selector": "img[alt]",
             "tags": ["best-practice"],
             "any": ["check-image-alt-text"],
-            "enabled": True,  # If ommited, defaults to True and overrrides configs in `axe_run_only`
+            # If omitted, defaults to True and overrides configs in `axe_run_only`.
+            "enabled": True,
         },
     ]
 
@@ -85,13 +86,11 @@ class AccessibilityItem(BaseItem):
     #: or to override the properties of existing Axe checks. A custom check
     #: for the quality of the images alt texts is added and enabled by default.
     #: Should be used in conjunction with `axe_custom_rules`
-    #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`__.
+    #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`_.
     axe_custom_checks = [
         {
             "id": "check-image-alt-text",
-            "options": {
-                "pattern": "\.(apng|avif|gif|jpg|jpeg|jfif|pjp|png|svg|tif|webp)|(http:\/\/|https:\/\/|www.)"
-            },
+            "options": {"pattern": "\\.(avif|gif|jpg|jpeg|png|svg|webp)$"},
         },
     ]
 
@@ -141,25 +140,19 @@ class AccessibilityItem(BaseItem):
         return self.axe_rules
 
     def get_axe_custom_rules(self, request):
-        """Returns custom rules for Axe"""
+        """List of rule objects per axe.run API."""
         return self.axe_custom_rules
 
     def get_axe_custom_checks(self, request):
-        """Returns custom checks for Axe"""
+        """List of check objects per axe.run API, without evaluate function."""
         return self.axe_custom_checks
 
     def get_axe_spec(self, request):
         """Returns spec for Axe, including custom rules and custom checks"""
-        spec = {
+        return {
             "rules": self.get_axe_custom_rules(request),
             "checks": self.get_axe_custom_checks(request),
         }
-
-        # If both the lists of custom rules and custom checks are empty,
-        # no custom configuration should be applied for Axe
-        if not spec["rules"] and not spec["checks"]:
-            spec = ""
-        return spec
 
     def get_axe_messages(self, request):
         """Returns a dictionary that maps axe-core rule IDs to custom translatable strings."""

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -57,6 +57,26 @@ class AccessibilityItem(BaseItem):
         "p-as-heading",
     ]
 
+    #: Configures whether the custom 'Image alt text quality' rule is enabled.
+    #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`__
+    axe_alt_text_rule_enabled = True
+
+    #: A list of bad alt text patterns checked by the 'Image alt text quality' rule.
+    axe_alt_text_rule_patterns = [
+        "apng",
+        "avif",
+        "gif",
+        "jpg",
+        "jpeg",
+        "jfif",
+        "pjpeg",
+        "pjp",
+        "png",
+        "svg",
+        "tif",
+        "webp",
+    ]
+
     #: A dictionary that maps axe-core rule IDs to a dictionary of rule options,
     #: commonly in the format of ``{"enabled": True/False}``. This can be used in
     #: conjunction with :attr:`axe_run_only` to enable or disable specific rules.
@@ -87,6 +107,9 @@ class AccessibilityItem(BaseItem):
             "Link text is empty. Use meaningful text for screen reader users."
         ),
         "p-as-heading": _("Misusing paragraphs as headings. Use proper heading tags."),
+        "alt-text-quality": _(
+            "Image alt text has inappropriate pattern. Use meaningful text."
+        ),
     }
 
     def get_axe_include(self, request):
@@ -104,6 +127,26 @@ class AccessibilityItem(BaseItem):
     def get_axe_rules(self, request):
         """Returns a dictionary that maps axe-core rule IDs to a dictionary of rule options."""
         return self.axe_rules
+
+    def get_axe_custom_alt_text_rule_enabled(self, request):
+        """Returns if the custom 'Image alt text quality' rule is enabled."""
+        return self.axe_alt_text_rule_enabled
+
+    def get_axe_custom_alt_text_rule_patterns(self, request):
+        """Returns bad image alt text patterns for the custom 'Image alt text quality' rule."""
+        return self.axe_alt_text_rule_patterns
+
+    def get_axe_custom_alt_text_rule(self, request):
+        """Returns the custom 'Image alt text quality' rule configurations for
+        `axe.configure <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`_."""
+        custom_alt_text_rule = {
+            "enabled": self.get_axe_custom_alt_text_rule_enabled(request),
+            "patterns": self.get_axe_custom_alt_text_rule_patterns(request),
+        }
+        # If no patterns are provided, disable the rule
+        if not custom_alt_text_rule["patterns"]:
+            custom_alt_text_rule["enabled"] = False
+        return custom_alt_text_rule
 
     def get_axe_messages(self, request):
         """Returns a dictionary that maps axe-core rule IDs to custom translatable strings."""
@@ -144,6 +187,7 @@ class AccessibilityItem(BaseItem):
             "context": self.get_axe_context(request),
             "options": self.get_axe_options(request),
             "messages": self.get_axe_messages(request),
+            "customAltTextRuleConfig": self.get_axe_custom_alt_text_rule(request),
         }
 
     def get_context_data(self, request):


### PR DESCRIPTION
Addresses #11967 

Alt text validation rule in the accessibility checker via [axe.configure API](https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure).

- custom Axe configuration, used for adding new rules and/or checks, or overriding the properties of the existing ones is now configurable in Python
- Alt text validation rule & check are added to the custom Axe configuration and enabled by default. File extensions and URL patterns are used as alt text antipatterns for now to guarantee zero false positives
- Unit tests added for the new Alt text validation rule
- a11y testing logic moved to `a11y-result` and re-used in the `preview-panel`

Tested in Chrome 124, Firefox 126, and Safari 17.4.