### PR TITLE
Purposefully made seo_title indexed by default

### DIFF
--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -1242,6 +1242,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
     search_fields = [
         index.SearchField("title", boost=2),
+        index.SearchField("seo_title"),
         index.AutocompleteField("title"),
         index.FilterField("title"),
         index.FilterField("id"),


### PR DESCRIPTION
`seo_title` came in model, accessible, by default. It could be indexable in app model like:

```py
    search_fields = Page.search_fields + [
        index.SearchField('seo_title'),
    ]
```

so why isn't such search-assist field being indexed for search by default? As I guess, because [`cls.promote_panels` ](https://github.com/wagtail/wagtail/blob/252bae9129f9167d371d65392ae95b2db1961de0/wagtail/admin/panels/page_utils.py#L20) might be something modifiable, as I didn't take much effort to take a look at it.

also, I didn't see this practice in [wagtail/guide](https://github.com/search?q=repo%3Awagtail%2Fguide+index.SearchField&type=code), as I tried it in my own project, it works well, and given better search result

sorry, as I couldn't check if this really work in this PR, might need more discussion