### PR TITLE
Fix client-side handling of select inputs within ChoiceBlock

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,12 @@ Changelog
  * Maintenance: Exclude the `client/scss` directory in Tailwind content config to speed up CSS compilation (Sage Abdullah)
 
 
+6.1.2 (xx.xx.xxxx) - IN DEVELOPMENT
+~~~~~~~~~~~~~~~~~~
+
+ * Fix: Fix client-side handling of select inputs within `ChoiceBlock` (Matt Westcott)
+
+
 6.1.1 (21.05.2024)
 ~~~~~~~~~~~~~~~~~~
 

--- a/client/src/entrypoints/admin/telepath/__snapshots__/widgets.test.js.snap
+++ b/client/src/entrypoints/admin/telepath/__snapshots__/widgets.test.js.snap
@@ -19,3 +19,11 @@ exports[`telepath: wagtail.widgets.Select it renders correctly 1`] = `
           <option value="2">Option 2</option>
         </select>"
 `;
+
+exports[`telepath: wagtail.widgets.Select multiple it renders correctly 1`] = `
+"<select name="the-name" id="the-id" multiple="">
+          <option value="red">Red</option>
+          <option value="green">Green</option>
+          <option value="blue">Blue</option>
+        </select>"
+`;

--- a/client/src/entrypoints/admin/telepath/__snapshots__/widgets.test.js.snap
+++ b/client/src/entrypoints/admin/telepath/__snapshots__/widgets.test.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`telepath: wagtail.widgets.RadioSelect for CheckboxSelectMultiple it renders correctly 1`] = `
+"<ul id="the-id">
+          <li>
+            <label for="the-id_0">
+            <input type="checkbox" name="the-name" value="red" id="the-id_0"> Red</label>
+          </li>
+          <li>
+            <label for="the-id_1">
+            <input type="checkbox" name="the-name" value="green" id="the-id_1"> Green</label>
+          </li>
+          <li>
+            <label for="the-id_2">
+            <input type="checkbox" name="the-name" value="blue" id="the-id_2"> Blue</label>
+          </li>
+        </ul>"
+`;
+
 exports[`telepath: wagtail.widgets.RadioSelect it renders correctly 1`] = `
 "<ul id="the-id">
           <li>

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -185,8 +185,29 @@ window.telepath.register('wagtail.widgets.RadioSelect', RadioSelect);
 
 class BoundSelect extends BoundWidget {
   getTextLabel() {
-    const selectedOption = this.input.selectedOptions[0];
-    return selectedOption ? selectedOption.text : '';
+    return Array.from(this.input.selectedOptions)
+      .map((option) => option.text)
+      .join(', ');
+  }
+
+  getValue() {
+    if (this.input.multiple) {
+      return Array.from(this.input.selectedOptions).map(
+        (option) => option.value,
+      );
+    }
+    return this.input.value;
+  }
+
+  getState() {
+    return Array.from(this.input.selectedOptions).map((option) => option.value);
+  }
+
+  setState(state) {
+    const options = this.input.options;
+    for (let i = 0; i < options.length; i += 1) {
+      options[i].selected = state.includes(options[i].value);
+    }
   }
 }
 

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -161,14 +161,16 @@ class BoundRadioSelect {
   }
 
   getState() {
-    return this.element.querySelector(this.selector)?.value;
+    return [this.element.querySelector(this.selector)?.value];
   }
 
   setState(state) {
     const inputs = this.element.querySelectorAll(`input[name="${this.name}"]`);
-    for (let i = 0; i < inputs.length; i += 1) {
-      inputs[i].checked = inputs[i].value === state;
-    }
+    state.forEach((selectedValue) => {
+      for (let i = 0; i < inputs.length; i += 1) {
+        inputs[i].checked = inputs[i].value === selectedValue;
+      }
+    });
   }
 
   focus() {

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -152,25 +152,33 @@ class BoundRadioSelect {
     this.element = element;
     this.name = name;
     this.idForLabel = idForLabel;
+    this.isMultiple = !!this.element.querySelector(
+      `input[name="${name}"][type="checkbox"]`,
+    );
     this.selector = `input[name="${name}"]:checked`;
     this.setState(initialState);
   }
 
   getValue() {
+    if (this.isMultiple) {
+      return Array.from(this.element.querySelectorAll(this.selector)).map(
+        (el) => el.value,
+      );
+    }
     return this.element.querySelector(this.selector)?.value;
   }
 
   getState() {
-    return [this.element.querySelector(this.selector)?.value];
+    return Array.from(this.element.querySelectorAll(this.selector)).map(
+      (el) => el.value,
+    );
   }
 
   setState(state) {
     const inputs = this.element.querySelectorAll(`input[name="${this.name}"]`);
-    state.forEach((selectedValue) => {
-      for (let i = 0; i < inputs.length; i += 1) {
-        inputs[i].checked = inputs[i].value === selectedValue;
-      }
-    });
+    for (let i = 0; i < inputs.length; i += 1) {
+      inputs[i].checked = state.includes(inputs[i].value);
+    }
   }
 
   focus() {

--- a/client/src/entrypoints/admin/telepath/widgets.test.js
+++ b/client/src/entrypoints/admin/telepath/widgets.test.js
@@ -183,7 +183,7 @@ describe('telepath: wagtail.widgets.RadioSelect', () => {
       document.getElementById('placeholder'),
       'the-name',
       'the-id',
-      'tea',
+      ['tea'],
     );
   });
 
@@ -198,11 +198,11 @@ describe('telepath: wagtail.widgets.RadioSelect', () => {
   });
 
   test('getState() returns the current state', () => {
-    expect(boundWidget.getState()).toBe('tea');
+    expect(boundWidget.getState()).toStrictEqual(['tea']);
   });
 
   test('setState() changes the current state', () => {
-    boundWidget.setState('coffee');
+    boundWidget.setState(['coffee']);
     expect(document.querySelector('input[value="tea"]').checked).toBe(false);
     expect(document.querySelector('input[value="coffee"]').checked).toBe(true);
   });

--- a/client/src/entrypoints/admin/telepath/widgets.test.js
+++ b/client/src/entrypoints/admin/telepath/widgets.test.js
@@ -216,6 +216,64 @@ describe('telepath: wagtail.widgets.RadioSelect', () => {
   });
 });
 
+describe('telepath: wagtail.widgets.RadioSelect for CheckboxSelectMultiple', () => {
+  let boundWidget;
+
+  beforeEach(() => {
+    // Create a placeholder to render the widget
+    document.body.innerHTML = '<div id="placeholder"></div>';
+
+    const widgetDef = window.telepath.unpack({
+      _type: 'wagtail.widgets.RadioSelect',
+      _args: [
+        `<ul id="__ID__">
+          <li>
+            <label for="__ID___0">
+            <input type="checkbox" name="__NAME__" value="red" id="__ID___0"> Red</label>
+          </li>
+          <li>
+            <label for="__ID___1">
+            <input type="checkbox" name="__NAME__" value="green" id="__ID___1"> Green</label>
+          </li>
+          <li>
+            <label for="__ID___2">
+            <input type="checkbox" name="__NAME__" value="blue" id="__ID___2"> Blue</label>
+          </li>
+        </ul>`,
+        '__ID___0',
+      ],
+    });
+    boundWidget = widgetDef.render(
+      document.getElementById('placeholder'),
+      'the-name',
+      'the-id',
+      ['red', 'blue'],
+    );
+  });
+
+  test('it renders correctly', () => {
+    expect(document.body.innerHTML).toMatchSnapshot();
+    expect(document.querySelector('input[value="red"]').checked).toBe(true);
+    expect(document.querySelector('input[value="green"]').checked).toBe(false);
+    expect(document.querySelector('input[value="blue"]').checked).toBe(true);
+  });
+
+  test('getValue() returns the current value', () => {
+    expect(boundWidget.getValue()).toStrictEqual(['red', 'blue']);
+  });
+
+  test('getState() returns the current state', () => {
+    expect(boundWidget.getState()).toStrictEqual(['red', 'blue']);
+  });
+
+  test('setState() changes the current state', () => {
+    boundWidget.setState(['red', 'green']);
+    expect(document.querySelector('input[value="red"]').checked).toBe(true);
+    expect(document.querySelector('input[value="green"]').checked).toBe(true);
+    expect(document.querySelector('input[value="blue"]').checked).toBe(false);
+  });
+});
+
 describe('telepath: wagtail.widgets.CheckboxInput', () => {
   let boundWidget;
 

--- a/client/src/entrypoints/admin/telepath/widgets.test.js
+++ b/client/src/entrypoints/admin/telepath/widgets.test.js
@@ -284,7 +284,7 @@ describe('telepath: wagtail.widgets.Select', () => {
       document.getElementById('placeholder'),
       'the-name',
       'the-id',
-      '1',
+      ['1'],
     );
   });
 
@@ -292,10 +292,85 @@ describe('telepath: wagtail.widgets.Select', () => {
     expect(document.body.innerHTML).toMatchSnapshot();
     const select = document.querySelector('select');
     expect(select.options[select.selectedIndex].value).toBe('1');
+    const selectedOptions = document.querySelector('select').selectedOptions;
+    expect(selectedOptions.length).toBe(1);
+    expect(selectedOptions[0].value).toBe('1');
   });
 
   test('getTextLabel() returns the text of selected option', () => {
     expect(boundWidget.getTextLabel()).toBe('Option 1');
+  });
+
+  test('getValue() returns the current value', () => {
+    expect(boundWidget.getValue()).toBe('1');
+  });
+
+  test('getState() returns the current state', () => {
+    expect(boundWidget.getState()).toStrictEqual(['1']);
+  });
+
+  test('setState() changes the current state', () => {
+    boundWidget.setState(['2']);
+    const selectedOptions = document.querySelector('select').selectedOptions;
+    expect(selectedOptions.length).toBe(1);
+    expect(selectedOptions[0].value).toBe('2');
+  });
+});
+
+describe('telepath: wagtail.widgets.Select multiple', () => {
+  let boundWidget;
+
+  beforeEach(() => {
+    // Create a placeholder to render the widget
+    document.body.innerHTML = '<div id="placeholder"></div>';
+
+    const widgetDef = window.telepath.unpack({
+      _type: 'wagtail.widgets.Select',
+      _args: [
+        `<select name="__NAME__" id="__ID__" multiple>
+          <option value="red">Red</option>
+          <option value="green">Green</option>
+          <option value="blue">Blue</option>
+        </select>`,
+        '__ID__',
+      ],
+    });
+    boundWidget = widgetDef.render(
+      document.getElementById('placeholder'),
+      'the-name',
+      'the-id',
+      ['red', 'blue'],
+    );
+  });
+
+  test('it renders correctly', () => {
+    expect(document.body.innerHTML).toMatchSnapshot();
+    const select = document.querySelector('select');
+    expect(select.options[select.selectedIndex].value).toBe('red');
+    const selectedOptions = document.querySelector('select').selectedOptions;
+    expect(selectedOptions.length).toBe(2);
+    expect(selectedOptions[0].value).toBe('red');
+    expect(selectedOptions[1].value).toBe('blue');
+  });
+
+  test('getTextLabel() returns the text of selected options', () => {
+    expect(boundWidget.getTextLabel()).toBe('Red, Blue');
+  });
+
+  test('getValue() returns the current values', () => {
+    expect(boundWidget.getValue()).toStrictEqual(['red', 'blue']);
+  });
+
+  test('getState() returns the current state', () => {
+    expect(boundWidget.getState()).toStrictEqual(['red', 'blue']);
+  });
+
+  test('setState() changes the current state', () => {
+    boundWidget.setState(['red', 'green']);
+    const selectedOptions = document.querySelector('select').selectedOptions;
+    expect(selectedOptions.length).toBe(2);
+    expect(selectedOptions[0].value).toBe('red');
+    expect(selectedOptions[1].value).toBe('green');
   });
 });
 

--- a/docs/releases/6.1.2.md
+++ b/docs/releases/6.1.2.md
@@ -1,0 +1,16 @@
+# Wagtail 6.1.2 release notes - IN DEVELOPMENT
+
+_Unreleased_
+
+```{contents}
+---
+local:
+depth: 1
+---
+```
+
+## What's new
+
+### Bug fixes
+
+ * Fix client-side handling of select inputs within `ChoiceBlock` (Matt Westcott)

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -6,6 +6,7 @@ Release notes
 
    upgrading
    6.2
+   6.1.2
    6.1.1
    6.1
    6.0.4

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -1122,6 +1122,18 @@ class TestChoiceBlock(WagtailTestUtils, SimpleTestCase):
         with self.assertRaises(ValidationError):
             block.clean("coffee")
 
+    def test_get_form_state(self):
+        block = blocks.ChoiceBlock(choices=[("tea", "Tea"), ("coffee", "Coffee")])
+        form_state = block.get_form_state("tea")
+        self.assertEqual(form_state, ["tea"])
+
+    def test_get_form_state_with_radio_widget(self):
+        block = blocks.ChoiceBlock(
+            choices=[("tea", "Tea"), ("coffee", "Coffee")], widget=forms.RadioSelect
+        )
+        form_state = block.get_form_state("tea")
+        self.assertEqual(form_state, ["tea"])
+
 
 class TestMultipleChoiceBlock(WagtailTestUtils, SimpleTestCase):
     def setUp(self):
@@ -1507,6 +1519,21 @@ class TestMultipleChoiceBlock(WagtailTestUtils, SimpleTestCase):
 
         with self.assertRaises(ValidationError):
             block.clean("coffee")
+
+    def test_get_form_state(self):
+        block = blocks.MultipleChoiceBlock(
+            choices=[("tea", "Tea"), ("coffee", "Coffee")]
+        )
+        form_state = block.get_form_state(["tea", "coffee"])
+        self.assertEqual(form_state, ["tea", "coffee"])
+
+    def test_get_form_state_with_checkbox_widget(self):
+        block = blocks.ChoiceBlock(
+            choices=[("tea", "Tea"), ("coffee", "Coffee")],
+            widget=forms.CheckboxSelectMultiple,
+        )
+        form_state = block.get_form_state(["tea", "coffee"])
+        self.assertEqual(form_state, ["tea", "coffee"])
 
 
 class TestRawHTMLBlock(unittest.TestCase):

--- a/wagtail/widget_adapters.py
+++ b/wagtail/widget_adapters.py
@@ -36,7 +36,6 @@ class WidgetAdapter(Adapter):
 
 register(WidgetAdapter(), forms.widgets.Input)
 register(WidgetAdapter(), forms.Textarea)
-register(WidgetAdapter(), forms.CheckboxSelectMultiple)
 
 
 class CheckboxInputAdapter(WidgetAdapter):
@@ -51,6 +50,7 @@ class RadioSelectAdapter(WidgetAdapter):
 
 
 register(RadioSelectAdapter(), forms.RadioSelect)
+register(RadioSelectAdapter(), forms.CheckboxSelectMultiple)
 
 
 class SelectAdapter(WidgetAdapter):


### PR DESCRIPTION
Fixes #11990

The updated widget adapters in #11839 (and corresponding tests) incorrectly assumed that the field/widget state [passed from the server-side code](https://github.com/wagtail/wagtail/blob/252bae9129f9167d371d65392ae95b2db1961de0/wagtail/blocks/field_block.py#L78-L81) for a single-choice input would be a single value, when in fact it's an array of values. This wasn't an issue in the jQuery version, because jquery handles multiple values transparently when getting/setting input values.

To test: open a recipe page on bakerydemo, and observe the behaviour of the 'difficulty' radio buttons on the recipe steps. Confirm that the page loads with the appropriate options populated (which tests that `setState` behaves correctly when receiving the initial value passed from the server), block duplication works (which tests that `getState` and `setState` are consistent), and that values are remembered on submitting and re-displaying the form. Repeat with the `widget=forms.RadioSelect` in recipes/blocks.py commented out (to get a Select dropdown), with ChoiceBlock changed to MultipleChoiceBlock (for a multiple select input), and with MultipleChoiceBlock and `widget=forms.CheckboxSelectMultiple` (for a multiple checkbox input). Bear in mind that data won't necessarily be preserved when switching between ChoiceBlock and MultipleChoiceBlock, as these have different database representations.