### PR TITLE
Fix check when using FORMAT_MODULE_PATH

### DIFF
--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -246,40 +246,31 @@ def datetime_format_check(app_configs, **kwargs):
     """
 
     from django.conf import settings
-    from django.utils import formats, translation
+    from django.utils import formats
 
     errors = []
 
     if not getattr(settings, "USE_L10N", False):
         return errors
 
-    formats.FORMAT_SETTINGS = formats.FORMAT_SETTINGS.union(
-        [
-            "WAGTAIL_DATE_FORMAT",
-            "WAGTAIL_DATETIME_FORMAT",
-            "WAGTAIL_TIME_FORMAT",
-        ]
-    )
-
     for code, label in settings.LANGUAGES:
-        with translation.override(code):
-            for wagtail_setting, django_setting in [
-                ("WAGTAIL_DATE_FORMAT", "DATE_INPUT_FORMATS"),
-                ("WAGTAIL_DATETIME_FORMAT", "DATETIME_INPUT_FORMATS"),
-                ("WAGTAIL_TIME_FORMAT", "TIME_INPUT_FORMATS"),
-            ]:
-                wagtail_format_value = getattr(settings, wagtail_setting, None)
-                if wagtail_format_value is None:
-                    # Skip the iteration if wagtail_format is not present
-                    continue
+        for wagtail_setting, django_setting in [
+            ("WAGTAIL_DATE_FORMAT", "DATE_INPUT_FORMATS"),
+            ("WAGTAIL_DATETIME_FORMAT", "DATETIME_INPUT_FORMATS"),
+            ("WAGTAIL_TIME_FORMAT", "TIME_INPUT_FORMATS"),
+        ]:
+            wagtail_format_value = getattr(settings, wagtail_setting, None)
+            if wagtail_format_value is None:
+                # Skip the iteration if wagtail_format is not present
+                continue
 
-                input_formats = formats.get_format(django_setting, lang=code)
-                if wagtail_format_value not in input_formats:
-                    errors.append(
-                        Error(
-                            "Configuration error",
-                            hint=f"{wagtail_setting} {wagtail_format_value} must be in {django_setting} for language {label} ({code}).",
-                        )
+            input_formats = formats.get_format(django_setting, lang=code)
+            if wagtail_format_value not in input_formats:
+                errors.append(
+                    Error(
+                        "Configuration error",
+                        hint=f"{wagtail_setting} {wagtail_format_value} must be in {django_setting} for language {label} ({code}).",
                     )
+                )
 
     return errors

--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -269,7 +269,9 @@ def datetime_format_check(app_configs, **kwargs):
                 errors.append(
                     Error(
                         "Configuration error",
-                        hint=f"{wagtail_setting} {wagtail_format_value} must be in {django_setting} for language {label} ({code}).",
+                        hint=f"'{wagtail_format_value}' must be in {django_setting} for language {label} ({code}).",
+                        obj=wagtail_setting,
+                        id="wagtailadmin.E003",
                     )
                 )
 

--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -263,25 +263,22 @@ def datetime_format_check(app_configs, **kwargs):
 
     for code, label in settings.LANGUAGES:
         with translation.override(code):
-            for wagtail_format, django_formats in [
+            for wagtail_setting, django_setting in [
                 ("WAGTAIL_DATE_FORMAT", "DATE_INPUT_FORMATS"),
                 ("WAGTAIL_DATETIME_FORMAT", "DATETIME_INPUT_FORMATS"),
                 ("WAGTAIL_TIME_FORMAT", "TIME_INPUT_FORMATS"),
             ]:
-                wagtail_format_value = getattr(settings, wagtail_format, None)
-                django_formats_value = getattr(settings, django_formats, None)
-
+                wagtail_format_value = getattr(settings, wagtail_setting, None)
                 if wagtail_format_value is None:
                     # Skip the iteration if wagtail_format is not present
                     continue
 
-                input_format = formats.get_format_lazy(wagtail_format_value)
-                input_formats = formats.get_format_lazy(django_formats_value)
-                if str(input_format) not in str(input_formats):
+                input_formats = formats.get_format(django_setting, lang=code)
+                if wagtail_format_value not in input_formats:
                     errors.append(
                         Error(
                             "Configuration error",
-                            hint=f"{wagtail_format} {input_format} must be in {django_formats} for language {label} ({code}).",
+                            hint=f"{wagtail_setting} {wagtail_format_value} must be in {django_setting} for language {label} ({code}).",
                         )
                     )
 

--- a/wagtail/admin/tests/formats/en/formats.py
+++ b/wagtail/admin/tests/formats/en/formats.py
@@ -1,0 +1,1 @@
+DATETIME_INPUT_FORMATS = ["%d.%m.%Y. %H:%M"]

--- a/wagtail/admin/tests/test_checks.py
+++ b/wagtail/admin/tests/test_checks.py
@@ -110,3 +110,25 @@ class TestDateTimeChecks(WagtailTestUtils, TestCase):
             errors = datetime_format_check(None)
 
         self.assertEqual(errors, [])
+
+    def test_datetime_format_with_incorrect_overriden_format(self):
+        with override_settings(
+            WAGTAIL_CONTENT_LANGUAGES=[
+                ("en", "English"),
+            ],
+            LANGUAGES=[
+                ("en", "English"),
+            ],
+            WAGTAIL_DATETIME_FORMAT="%m.%d.%Y. %H:%M",
+            FORMAT_MODULE_PATH=["wagtail.admin.tests.formats"],
+            USE_L10N=True,
+        ):
+            errors = datetime_format_check(None)
+
+        expected_errors = [
+            Error(
+                "Configuration error",
+                hint="WAGTAIL_DATETIME_FORMAT %m.%d.%Y. %H:%M must be in DATETIME_INPUT_FORMATS for language English (en).",
+            ),
+        ]
+        self.assertEqual(errors, expected_errors)

--- a/wagtail/admin/tests/test_checks.py
+++ b/wagtail/admin/tests/test_checks.py
@@ -1,5 +1,6 @@
 from django.core.checks import Error
 from django.test import TestCase, override_settings
+from django.utils.formats import reset_format_cache
 
 from wagtail.admin.checks import datetime_format_check
 from wagtail.test.utils import WagtailTestUtils
@@ -7,6 +8,9 @@ from wagtail.test.utils import WagtailTestUtils
 
 class TestDateTimeChecks(WagtailTestUtils, TestCase):
     fixtures = ["test.json"]
+
+    def setUp(self):
+        reset_format_cache()
 
     def test_datetime_format(self):
         with override_settings(
@@ -90,3 +94,19 @@ class TestDateTimeChecks(WagtailTestUtils, TestCase):
             ),
         ]
         self.assertEqual(errors, expected_errors)
+
+    def test_datetime_format_with_overriden_format(self):
+        with override_settings(
+            WAGTAIL_CONTENT_LANGUAGES=[
+                ("en", "English"),
+            ],
+            LANGUAGES=[
+                ("en", "English"),
+            ],
+            WAGTAIL_DATETIME_FORMAT="%d.%m.%Y. %H:%M",
+            FORMAT_MODULE_PATH=["wagtail.admin.tests.formats"],
+            USE_L10N=True,
+        ):
+            errors = datetime_format_check(None)
+
+        self.assertEqual(errors, [])

--- a/wagtail/admin/tests/test_checks.py
+++ b/wagtail/admin/tests/test_checks.py
@@ -45,7 +45,9 @@ class TestDateTimeChecks(WagtailTestUtils, TestCase):
         expected_errors = [
             Error(
                 "Configuration error",
-                hint="WAGTAIL_DATE_FORMAT %d.%m.%Y. must be in DATE_INPUT_FORMATS for language English (en).",
+                hint="'%d.%m.%Y.' must be in DATE_INPUT_FORMATS for language English (en).",
+                obj="WAGTAIL_DATE_FORMAT",
+                id="wagtailadmin.E003",
             )
         ]
         self.assertEqual(errors, expected_errors)
@@ -86,11 +88,15 @@ class TestDateTimeChecks(WagtailTestUtils, TestCase):
         expected_errors = [
             Error(
                 "Configuration error",
-                hint="WAGTAIL_DATETIME_FORMAT %d.%m.%Y. %H:%M must be in DATETIME_INPUT_FORMATS for language English (en).",
+                hint="'%d.%m.%Y. %H:%M' must be in DATETIME_INPUT_FORMATS for language English (en).",
+                obj="WAGTAIL_DATETIME_FORMAT",
+                id="wagtailadmin.E003",
             ),
             Error(
                 "Configuration error",
-                hint="WAGTAIL_TIME_FORMAT %I:%M %p must be in TIME_INPUT_FORMATS for language English (en).",
+                hint="'%I:%M %p' must be in TIME_INPUT_FORMATS for language English (en).",
+                obj="WAGTAIL_TIME_FORMAT",
+                id="wagtailadmin.E003",
             ),
         ]
         self.assertEqual(errors, expected_errors)
@@ -128,7 +134,9 @@ class TestDateTimeChecks(WagtailTestUtils, TestCase):
         expected_errors = [
             Error(
                 "Configuration error",
-                hint="WAGTAIL_DATETIME_FORMAT %m.%d.%Y. %H:%M must be in DATETIME_INPUT_FORMATS for language English (en).",
+                hint="'%m.%d.%Y. %H:%M' must be in DATETIME_INPUT_FORMATS for language English (en).",
+                obj="WAGTAIL_DATETIME_FORMAT",
+                id="wagtailadmin.E003",
             ),
         ]
         self.assertEqual(errors, expected_errors)


### PR DESCRIPTION
Fixes #12005

- Dropped `formats.FORMAT_SETTINGS` being modified as we are in checks, and it would not be taken into account during production
- Passed language directly instead of using translation override
- Dropped lazy usage as none of these values should be using translation
- Formats are cached, so added a setUp for this tests class
- Added id so the check can be silenced, and setting name to the error for context