### PR TITLE
Add support for 'view' permission to access the index and inspect views of `ModelViewSet` and `SnippetViewSet`

### DIFF
--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -1535,6 +1535,27 @@ class TestListingButtons(WagtailTestUtils, TestCase):
             self.assertEqual(rendered_button.attrs.get("aria-label"), aria_label)
             self.assertEqual(rendered_button.attrs.get("href"), url)
 
+    def test_dropdown_not_rendered_when_no_child_buttons_exist(self):
+        self.user.is_superuser = False
+        self.user.save()
+        admin_permission = Permission.objects.get(
+            content_type__app_label="wagtailadmin",
+            codename="access_admin",
+        )
+        add_permission = Permission.objects.get(
+            content_type__app_label=self.object._meta.app_label,
+            codename=get_permission_codename("add", self.object._meta),
+        )
+        self.user.user_permissions.add(admin_permission, add_permission)
+
+        # The alt3 viewset doesn't have "copy" and "inspect" views enabled,
+        # so when only "add" permission is granted, the dropdown should have
+        # no items and thus not be rendered at all
+        response = self.client.get(reverse("fctoy-alt3:index"))
+        soup = self.get_soup(response.content)
+        actions = soup.select_one("tbody tr td ul.actions")
+        self.assertIsNone(actions)
+
 
 class TestCopyView(WagtailTestUtils, TestCase):
     def setUp(self):

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -1375,7 +1375,7 @@ class TestInspectView(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse("wagtailadmin_home"))
 
-    def test_only_add_permission(self):
+    def assert_minimal_permission(self, permission):
         self.user.is_superuser = False
         self.user.user_permissions.add(
             Permission.objects.get(
@@ -1383,7 +1383,7 @@ class TestInspectView(WagtailTestUtils, TestCase):
             ),
             Permission.objects.get(
                 content_type__app_label=self.object._meta.app_label,
-                codename=get_permission_codename("add", self.object._meta),
+                codename=get_permission_codename(permission, self.object._meta),
             ),
         )
         self.user.save()
@@ -1405,6 +1405,12 @@ class TestInspectView(WagtailTestUtils, TestCase):
         self.assertEqual(values, expected_values)
         self.assertEqual(len(soup.find_all("a", attrs={"href": self.edit_url})), 0)
         self.assertEqual(len(soup.find_all("a", attrs={"href": self.delete_url})), 0)
+
+    def test_only_add_permission(self):
+        self.assert_minimal_permission("add")
+
+    def test_only_view_permission(self):
+        self.assert_minimal_permission("view")
 
 
 class TestListingButtons(WagtailTestUtils, TestCase):

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -320,11 +320,11 @@ class IndexView(
         return columns
 
     def get_edit_url(self, instance):
-        if self.edit_url_name:
+        if self.edit_url_name and self.user_has_permission("change"):
             return reverse(self.edit_url_name, args=(quote(instance.pk),))
 
     def get_copy_url(self, instance):
-        if self.copy_url_name:
+        if self.copy_url_name and self.user_has_permission("add"):
             return reverse(self.copy_url_name, args=(quote(instance.pk),))
 
     def get_inspect_url(self, instance):
@@ -332,15 +332,11 @@ class IndexView(
             return reverse(self.inspect_url_name, args=(quote(instance.pk),))
 
     def get_delete_url(self, instance):
-        if self.delete_url_name:
+        if self.delete_url_name and self.user_has_permission("delete"):
             return reverse(self.delete_url_name, args=(quote(instance.pk),))
 
     def get_add_url(self):
-        if self.permission_policy and not self.permission_policy.user_has_permission(
-            self.request.user, "add"
-        ):
-            return None
-        if self.add_url_name:
+        if self.add_url_name and self.user_has_permission("add"):
             return self._set_locale_query_param(reverse(self.add_url_name))
 
     @cached_property
@@ -374,16 +370,11 @@ class IndexView(
 
     def get_list_more_buttons(self, instance):
         buttons = []
-        edit_url = self.get_edit_url(instance)
-        can_edit = (
-            not self.permission_policy
-            or self.permission_policy.user_has_permission(self.request.user, "change")
-        )
-        if edit_url and can_edit:
+        if edit_url := self.get_edit_url(instance):
             buttons.append(
                 ListingButton(
                     _("Edit"),
-                    url=self.get_edit_url(instance),
+                    url=edit_url,
                     icon_name="edit",
                     attrs={
                         "aria-label": _("Edit '%(title)s'") % {"title": str(instance)}
@@ -391,9 +382,7 @@ class IndexView(
                     priority=10,
                 )
             )
-        copy_url = self.get_copy_url(instance)
-        can_copy = self.permission_policy.user_has_permission(self.request.user, "add")
-        if copy_url and can_copy:
+        if copy_url := self.get_copy_url(instance):
             buttons.append(
                 ListingButton(
                     _("Copy"),
@@ -405,8 +394,7 @@ class IndexView(
                     priority=20,
                 )
             )
-        inspect_url = self.get_inspect_url(instance)
-        if inspect_url:
+        if inspect_url := self.get_inspect_url(instance):
             buttons.append(
                 ListingButton(
                     _("Inspect"),
@@ -419,12 +407,7 @@ class IndexView(
                     priority=20,
                 )
             )
-        delete_url = self.get_delete_url(instance)
-        can_delete = (
-            not self.permission_policy
-            or self.permission_policy.user_has_permission(self.request.user, "delete")
-        )
-        if delete_url and can_delete:
+        if delete_url := self.get_delete_url(instance):
             buttons.append(
                 ListingButton(
                     _("Delete"),
@@ -462,10 +445,7 @@ class IndexView(
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
 
-        context["can_add"] = (
-            self.permission_policy is None
-            or self.permission_policy.user_has_permission(self.request.user, "add")
-        )
+        context["can_add"] = self.user_has_permission("add")
         if context["can_add"]:
             context["add_url"] = context["header_action_url"] = self.add_url
             context["header_action_label"] = self.add_item_label
@@ -874,11 +854,7 @@ class EditView(
         )
 
     def get_success_buttons(self):
-        return [
-            messages.button(
-                reverse(self.edit_url_name, args=(quote(self.object.pk),)), _("Edit")
-            )
-        ]
+        return [messages.button(self.get_edit_url(), _("Edit"))]
 
     def get_error_message(self):
         if self.error_message is None:
@@ -917,10 +893,7 @@ class EditView(
         context["side_panels"] = side_panels
         context["media"] += side_panels.media
         context["submit_button_label"] = self.submit_button_label
-        context["can_delete"] = (
-            self.permission_policy is None
-            or self.permission_policy.user_has_permission(self.request.user, "delete")
-        )
+        context["can_delete"] = self.user_has_permission("delete")
         if context["can_delete"]:
             context["delete_url"] = self.get_delete_url()
             context["delete_item_label"] = self.delete_item_label
@@ -1149,24 +1122,12 @@ class InspectView(PermissionCheckedMixin, WagtailAdminTemplateMixin, TemplateVie
         return [self.get_context_for_field(field_name) for field_name in self.fields]
 
     def get_edit_url(self):
-        if not self.edit_url_name or (
-            self.permission_policy
-            and not self.permission_policy.user_has_permission(
-                self.request.user, "change"
-            )
-        ):
-            return None
-        return reverse(self.edit_url_name, args=(quote(self.object.pk),))
+        if self.edit_url_name and self.user_has_permission("change"):
+            return reverse(self.edit_url_name, args=(quote(self.object.pk),))
 
     def get_delete_url(self):
-        if not self.delete_url_name or (
-            self.permission_policy
-            and not self.permission_policy.user_has_permission(
-                self.request.user, "delete"
-            )
-        ):
-            return None
-        return reverse(self.delete_url_name, args=(quote(self.object.pk),))
+        if self.delete_url_name and self.user_has_permission("delete"):
+            return reverse(self.delete_url_name, args=(quote(self.object.pk),))
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -1022,7 +1022,7 @@ class DeleteView(
 
 
 class InspectView(PermissionCheckedMixin, WagtailAdminTemplateMixin, TemplateView):
-    any_permission_required = ["add", "change", "delete"]
+    any_permission_required = ["add", "change", "delete", "view"]
     template_name = "wagtailadmin/generic/inspect.html"
     page_title = gettext_lazy("Inspecting")
     model = None

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -422,17 +422,20 @@ class IndexView(
         return buttons
 
     def get_list_buttons(self, instance):
-        buttons = self.get_list_more_buttons(instance)
-        return [
-            ButtonWithDropdown(
-                buttons=buttons,
-                icon_name="dots-horizontal",
-                attrs={
-                    "aria-label": _("More options for '%(title)s'")
-                    % {"title": str(instance)},
-                },
+        more_buttons = self.get_list_more_buttons(instance)
+        buttons = []
+        if more_buttons:
+            buttons.append(
+                ButtonWithDropdown(
+                    buttons=more_buttons,
+                    icon_name="dots-horizontal",
+                    attrs={
+                        "aria-label": _("More options for '%(title)s'")
+                        % {"title": str(instance)},
+                    },
+                )
             )
-        ]
+        return buttons
 
     @cached_property
     def add_item_label(self):

--- a/wagtail/admin/views/generic/permissions.py
+++ b/wagtail/admin/views/generic/permissions.py
@@ -19,21 +19,24 @@ class PermissionCheckedMixin:
     any_permission_required = None
 
     def dispatch(self, request, *args, **kwargs):
-        if self.permission_policy is not None:
-            if self.permission_required is not None:
-                if not self.user_has_permission(self.permission_required):
-                    raise PermissionDenied
+        if self.permission_required is not None:
+            if not self.user_has_permission(self.permission_required):
+                raise PermissionDenied
 
-            if self.any_permission_required is not None:
-                if not self.user_has_any_permission(self.any_permission_required):
-                    raise PermissionDenied
+        if self.any_permission_required is not None:
+            if not self.user_has_any_permission(self.any_permission_required):
+                raise PermissionDenied
 
         return super().dispatch(request, *args, **kwargs)
 
     def user_has_permission(self, permission):
-        return self.permission_policy.user_has_permission(self.request.user, permission)
+        return not self.permission_policy or (
+            self.permission_policy.user_has_permission(self.request.user, permission)
+        )
 
     def user_has_any_permission(self, permissions):
-        return self.permission_policy.user_has_any_permission(
-            self.request.user, permissions
+        return not self.permission_policy or (
+            self.permission_policy.user_has_any_permission(
+                self.request.user, permissions
+            )
         )

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -518,7 +518,7 @@ class ModelViewSet(ViewSet):
 
         def is_shown(_self, request):
             return self.permission_policy.user_has_any_permission(
-                request.user, ("add", "change", "delete")
+                request.user, self.index_view_class.any_permission_required
             )
 
         return type(

--- a/wagtail/snippets/permissions.py
+++ b/wagtail/snippets/permissions.py
@@ -19,15 +19,17 @@ def user_can_edit_snippet_type(user, model):
     return False
 
 
-def user_can_edit_snippets(user):
+def user_can_access_snippets(user):
     """
-    true if user has 'add', 'change' or 'delete' permission
+    true if user has 'add', 'change', 'delete', or 'view' permission
     on any model registered as a snippet type
     """
     snippet_models = get_snippet_models()
 
     for model in snippet_models:
-        if user_can_edit_snippet_type(user, model):
+        if model.snippet_viewset.permission_policy.user_has_any_permission(
+            user, {"add", "change", "delete", "view"}
+        ):
             return True
 
     return False

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -319,6 +319,23 @@ class TestSnippetListView(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/shared/buttons.html")
 
+    def test_dropdown_not_rendered_when_no_child_buttons_exist(self):
+        Advert.objects.create(text="My Lovely advert")
+
+        def remove_all_buttons(buttons, snippet, user):
+            buttons[:] = []
+            self.assertEqual(len(buttons), 0)
+
+        with hooks.register_temporarily(
+            "construct_snippet_listing_buttons",
+            remove_all_buttons,
+        ):
+            response = self.get()
+
+        soup = self.get_soup(response.content)
+        actions = soup.select_one("tbody tr td ul.actions")
+        self.assertIsNone(actions)
+
     def test_use_latest_draft_as_title(self):
         snippet = DraftStateModel.objects.create(text="Draft-enabled Foo, Published")
         snippet.save_revision().publish()

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -24,9 +24,11 @@ from taggit.models import Tag
 from wagtail import hooks
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.forms import WagtailAdminModelForm
+from wagtail.admin.menu import admin_menu
 from wagtail.admin.panels import FieldPanel, ObjectList, get_edit_handler
 from wagtail.admin.widgets.button import ButtonWithDropdown
 from wagtail.blocks.field_block import FieldBlockAdapter
+from wagtail.coreutils import get_dummy_request
 from wagtail.models import Locale, ModelLogEntry, Revision
 from wagtail.signals import published, unpublished
 from wagtail.snippets.action_menu import (
@@ -95,6 +97,26 @@ class TestSnippetIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 302)
 
+    def test_get_with_only_view_permissions(self):
+        self.user.is_superuser = False
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            ),
+            Permission.objects.get(
+                content_type__app_label="tests", codename="view_advert"
+            ),
+        )
+        self.user.save()
+
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/generic/listing.html")
+        soup = self.get_soup(response.content)
+        link = soup.select_one("tr td a")
+        self.assertEqual(link["href"], reverse("wagtailsnippets_tests_advert:list"))
+        self.assertEqual(link.text.strip(), "Adverts")
+
     def test_simple(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
@@ -109,6 +131,29 @@ class TestSnippetIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
 
     def test_displays_snippet(self):
         self.assertContains(self.get(), "Adverts")
+
+    def test_snippets_menu_item_shown_with_only_view_permission(self):
+        self.user.is_superuser = False
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            ),
+            Permission.objects.get(
+                content_type__app_label="tests", codename="view_advert"
+            ),
+        )
+        self.user.save()
+
+        request = get_dummy_request()
+        request.user = self.user
+        menu_items = admin_menu.menu_items_for_request(request)
+        snippets = [item for item in menu_items if item.name == "snippets"]
+        self.assertEqual(len(snippets), 1)
+        item = snippets[0]
+        self.assertEqual(item.name, "snippets")
+        self.assertEqual(item.label, "Snippets")
+        self.assertEqual(item.icon_name, "snippet")
+        self.assertEqual(item.url, reverse("wagtailsnippets:index"))
 
 
 class TestSnippetListView(WagtailTestUtils, TestCase):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -47,7 +47,6 @@ from wagtail.models import (
 from wagtail.permissions import ModelPermissionPolicy
 from wagtail.snippets.action_menu import SnippetActionMenu
 from wagtail.snippets.models import SnippetAdminURLFinder, get_snippet_models
-from wagtail.snippets.permissions import user_can_edit_snippet_type
 from wagtail.snippets.side_panels import SnippetStatusSidePanel
 from wagtail.snippets.views.chooser import SnippetChooserViewSet
 from wagtail.utils.deprecation import RemovedInWagtail70Warning
@@ -90,9 +89,10 @@ class ModelIndexView(generic.BaseListingView):
                 "name": capfirst(model._meta.verbose_name_plural),
                 "count": model._default_manager.all().count(),
                 "model": model,
+                "url": url,
             }
             for model in get_snippet_models()
-            if user_can_edit_snippet_type(self.request.user, model)
+            if (url := self.get_list_url(model))
         ]
 
     def dispatch(self, request, *args, **kwargs):
@@ -103,8 +103,12 @@ class ModelIndexView(generic.BaseListingView):
     def get_breadcrumbs_items(self):
         return self.breadcrumbs_items + [{"url": "", "label": _("Snippets")}]
 
-    def get_list_url(self, type):
-        return reverse(type["model"].snippet_viewset.get_url_name("list"))
+    def get_list_url(self, model):
+        if model.snippet_viewset.permission_policy.user_has_any_permission(
+            self.request.user,
+            {"add", "change", "delete", "view"},
+        ):
+            return reverse(model.snippet_viewset.get_url_name("list"))
 
     def get_queryset(self):
         return None
@@ -115,7 +119,7 @@ class ModelIndexView(generic.BaseListingView):
             TitleColumn(
                 "name",
                 label=_("Name"),
-                get_url=self.get_list_url,
+                get_url=lambda type: type["url"],
                 sort_key="name",
             ),
             Column(

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -206,16 +206,17 @@ class IndexView(generic.IndexViewOptionalFeaturesMixin, generic.IndexView):
                 )
                 hook(more_buttons, instance, self.request.user, {})
 
-        list_buttons.append(
-            ButtonWithDropdown(
-                buttons=more_buttons,
-                icon_name="dots-horizontal",
-                attrs={
-                    "aria-label": _("More options for '%(title)s'")
-                    % {"title": str(instance)},
-                },
+        if more_buttons:
+            list_buttons.append(
+                ButtonWithDropdown(
+                    buttons=more_buttons,
+                    icon_name="dots-horizontal",
+                    attrs={
+                        "aria-label": _("More options for '%(title)s'")
+                        % {"title": str(instance)},
+                    },
+                )
             )
-        )
 
         return list_buttons
 

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -8,7 +8,7 @@ from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 from wagtail.snippets.bulk_actions.delete import DeleteBulkAction
 from wagtail.snippets.models import get_snippet_models
-from wagtail.snippets.permissions import user_can_edit_snippets
+from wagtail.snippets.permissions import user_can_access_snippets
 from wagtail.snippets.views import snippets as snippet_views
 
 
@@ -35,7 +35,7 @@ class SnippetsMenuItem(MenuItem):
         )
 
     def is_shown(self, request):
-        return not self._all_have_menu_items and user_can_edit_snippets(request.user)
+        return not self._all_have_menu_items and user_can_access_snippets(request.user)
 
 
 @hooks.register("register_admin_menu_item")

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -278,6 +278,7 @@ class ToyViewSetGroup(ModelViewSetGroup):
             index_view_class=FeatureCompleteToyIndexView,
             list_display=["name", "strid", "release_date"],
             ordering=["strid"],
+            copy_view_enabled=False,
         ),
     )
 


### PR DESCRIPTION
Fixes #11909.

Built on top of #11995.

Without #12001, testing the `ModelViewSet` support with bakerydemo needs a `register_permissions` hook so you can assign the "view" permission in the admin, so I'd suggest reviewing that first if you have time 🙂

Once either #12001 is merged or the `register_permissions` hook is added, you can try the following to test for `ModelViewSet`:
- Assign "can view" permission on the "Country of origin" model to the Editors group
- Sign in as an editor
- The "Bread categories" > "Country of origin" menu item should show up and be accessible
- The items in the listing should link to the inspect view
- Set `inspect_view_enabled = False` in `CountryViewSet`
- The items in the listing view should now not link anywhere

For snippets, we no longer have the "Snippets" menu since all snippets in bakerydemo have their own menu item, but we can temporarily change this:
- In `bakerydemo/base/wagtail_hooks.py`, change `register_snippet(BakerySnippetViewSetGroup)` to:
  ```py
  register_snippet(PersonViewSet)
  register_snippet(FooterTextViewSet)
  ```
- Edit the Editors group
  - Remove permissions for all snippet models
  - Assign the "view" permission on the "Person" model
- Sign in as the editor user
- The "Snippets" menu should show up
- The "Person" model should be the only one on the list and it takes you to the people index view
- The `PersonViewSet` doesn't have `inspect_view_enabled = True`, so it shouldn't link anywhere
- If you add `inspect_view_enabled = True` to `PersonViewSet`, you'll be able to access the inspect view.