### PR TITLE
Add next parameter to form submissions delete action/view

### DIFF
--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -579,7 +579,6 @@ def bulk_action_choices(context, app_label, model_name):
             ],
         )
         bulk_action_buttons.append(more_button)
-
     return {"buttons": bulk_action_buttons}
 
 

--- a/wagtail/admin/tests/pages/test_parent_page_chooser_view.py
+++ b/wagtail/admin/tests/pages/test_parent_page_chooser_view.py
@@ -1,9 +1,11 @@
+from unittest import mock
+
 from django.contrib.auth.models import Group, Permission
 from django.test import TestCase
 from django.urls import reverse
 
 from wagtail.models import GroupPagePermission, Page
-from wagtail.test.testapp.models import BusinessIndex
+from wagtail.test.testapp.models import BusinessIndex, EventPage, EventIndex
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 
@@ -116,4 +118,20 @@ class TestParentPageChooserView(AdminTemplateTestUtils, WagtailTestUtils, TestCa
             response,
             "You cannot create a page of type &quot;Event page&quot; under &quot;%s&quot;."
             % page_with_limited_subtypes.get_admin_display_title(),
+        )
+    
+    def test_skip_if_only_one_valid_parent(self):
+        self.assertEqual(EventIndex.objects.count(), 1)
+
+        with mock.patch.object(EventPage, "allowed_parent_page_models") as mock_method:
+            mock_method.return_value = [EventIndex]
+            self.assertEqual(EventPage.allowed_parent_page_models(), [EventIndex])
+            response = self.client.get(self.view_url)
+
+        self.assertRedirects(
+            response,
+            reverse(
+                "wagtailadmin_pages:add",
+                args=("tests", "eventpage", EventIndex.objects.first().pk),
+            ),
         )

--- a/wagtail/admin/tests/pages/test_parent_page_chooser_view.py
+++ b/wagtail/admin/tests/pages/test_parent_page_chooser_view.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from wagtail.models import GroupPagePermission, Page
-from wagtail.test.testapp.models import BusinessIndex, EventPage, EventIndex
+from wagtail.test.testapp.models import BusinessIndex, EventIndex, EventPage
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 
@@ -119,7 +119,7 @@ class TestParentPageChooserView(AdminTemplateTestUtils, WagtailTestUtils, TestCa
             "You cannot create a page of type &quot;Event page&quot; under &quot;%s&quot;."
             % page_with_limited_subtypes.get_admin_display_title(),
         )
-    
+
     def test_skip_if_only_one_valid_parent(self):
         self.assertEqual(EventIndex.objects.count(), 1)
 

--- a/wagtail/admin/views/pages/choose_parent.py
+++ b/wagtail/admin/views/pages/choose_parent.py
@@ -65,9 +65,8 @@ class ChooseParentView(WagtailAdminTemplateMixin, FormView):
 
         # There's only one available parent for this page type for this
         # user, so we send them along with that as the chosen parent page
-        if len(parents) == 1:
-            parent = parents[0]
-            parent_id = quote(parent.pk)
+        if parents.count() == 1:
+            parent_id = quote(parents.values_list("pk", flat=True).get())
             model_opts = self.model._meta
             return redirect(
                 "wagtailadmin_pages:add",

--- a/wagtail/admin/views/pages/choose_parent.py
+++ b/wagtail/admin/views/pages/choose_parent.py
@@ -42,11 +42,11 @@ class ChooseParentView(WagtailAdminTemplateMixin, FormView):
         else:
             pages_where_user_can_add = Page.objects.none()
 
-            from wagtail.permission_policies.pages import PagePermissionPolicy
+            from wagtail.permissions import page_permission_policy
 
             perms = {
                 perm
-                for perm in PagePermissionPolicy().get_cached_permissions_for_user(user)
+                for perm in page_permission_policy.get_cached_permissions_for_user(user)
                 if perm.permission.codename == "add_page"
             }
 

--- a/wagtail/admin/views/pages/choose_parent.py
+++ b/wagtail/admin/views/pages/choose_parent.py
@@ -1,4 +1,5 @@
 from django.contrib.admin.utils import quote
+from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.functional import cached_property
@@ -6,13 +7,10 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 from django.views.generic import FormView
-from django.contrib.contenttypes.models import ContentType
 
 from wagtail.admin.forms.pages import ParentChooserForm
 from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
 from wagtail.models import Page
-
-
 
 
 class ChooseParentView(WagtailAdminTemplateMixin, FormView):
@@ -62,7 +60,6 @@ class ChooseParentView(WagtailAdminTemplateMixin, FormView):
         # Combine them
         return allowed_parent_pages & pages_where_user_can_add
 
-
     def dispatch(self, request, *args, **kwargs):
         parents = self.get_valid_parent_pages(request.user)
 
@@ -72,7 +69,6 @@ class ChooseParentView(WagtailAdminTemplateMixin, FormView):
             parent = parents[0]
             parent_id = quote(parent.pk)
             model_opts = self.model._meta
-            # raise Exception(parent)
             return redirect(
                 "wagtailadmin_pages:add",
                 model_opts.app_label,
@@ -80,8 +76,8 @@ class ChooseParentView(WagtailAdminTemplateMixin, FormView):
                 parent_id,
             )
 
-            # The page can be added in multiple places, so redirect to the
-            # choose_parent view so that the parent can be specified
+        # The page can be added in multiple places, so redirect to the
+        # choose_parent view so that the parent can be specified
         return super().dispatch(request, *args, **kwargs)
 
     def get_form(self):

--- a/wagtail/admin/views/pages/choose_parent.py
+++ b/wagtail/admin/views/pages/choose_parent.py
@@ -6,10 +6,13 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 from django.views.generic import FormView
+from django.contrib.contenttypes.models import ContentType
 
 from wagtail.admin.forms.pages import ParentChooserForm
 from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
 from wagtail.models import Page
+
+
 
 
 class ChooseParentView(WagtailAdminTemplateMixin, FormView):
@@ -17,6 +20,69 @@ class ChooseParentView(WagtailAdminTemplateMixin, FormView):
     model = Page
     index_url_name = None
     page_title = gettext_lazy("Choose parent")
+
+    def get_valid_parent_pages(self, user):
+        """
+        Identifies possible parent pages for the current user by first looking
+        at allowed_parent_page_models() on self.model to limit options to the
+        correct type of page, then checking permissions on those individual
+        pages to make sure we have permission to add a subpage to it.
+        """
+        # Get queryset of pages where this page type can be added
+        allowed_parent_page_content_types = list(
+            ContentType.objects.get_for_models(
+                *self.model.allowed_parent_page_models()
+            ).values()
+        )
+        allowed_parent_pages = Page.objects.filter(
+            content_type__in=allowed_parent_page_content_types
+        )
+
+        # Get queryset of pages where the user has permission to add subpages
+        if user.is_superuser:
+            pages_where_user_can_add = Page.objects.all()
+        else:
+            pages_where_user_can_add = Page.objects.none()
+
+            from wagtail.permission_policies.pages import PagePermissionPolicy
+
+            perms = {
+                perm
+                for perm in PagePermissionPolicy().get_cached_permissions_for_user(user)
+                if perm.permission.codename == "add_page"
+            }
+
+            for perm in perms:
+                # user has add permission on any subpage of perm.page
+                # (including perm.page itself)
+                pages_where_user_can_add |= Page.objects.descendant_of(
+                    perm.page, inclusive=True
+                )
+
+        # Combine them
+        return allowed_parent_pages & pages_where_user_can_add
+
+
+    def dispatch(self, request, *args, **kwargs):
+        parents = self.get_valid_parent_pages(request.user)
+
+        # There's only one available parent for this page type for this
+        # user, so we send them along with that as the chosen parent page
+        if len(parents) == 1:
+            parent = parents[0]
+            parent_id = quote(parent.pk)
+            model_opts = self.model._meta
+            # raise Exception(parent)
+            return redirect(
+                "wagtailadmin_pages:add",
+                model_opts.app_label,
+                model_opts.model_name,
+                parent_id,
+            )
+
+            # The page can be added in multiple places, so redirect to the
+            # choose_parent view so that the parent can be specified
+        return super().dispatch(request, *args, **kwargs)
 
     def get_form(self):
         if self.request.method == "POST":

--- a/wagtail/admin/views/pages/choose_parent.py
+++ b/wagtail/admin/views/pages/choose_parent.py
@@ -60,7 +60,7 @@ class ChooseParentView(WagtailAdminTemplateMixin, FormView):
         # Combine them
         return allowed_parent_pages & pages_where_user_can_add
 
-    def dispatch(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):
         parents = self.get_valid_parent_pages(request.user)
 
         # There's only one available parent for this page type for this
@@ -78,7 +78,7 @@ class ChooseParentView(WagtailAdminTemplateMixin, FormView):
 
         # The page can be added in multiple places, so redirect to the
         # choose_parent view so that the parent can be specified
-        return super().dispatch(request, *args, **kwargs)
+        return super().get(request, *args, **kwargs)
 
     def get_form(self):
         if self.request.method == "POST":

--- a/wagtail/contrib/forms/templates/wagtailforms/confirm_delete.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/confirm_delete.html
@@ -17,6 +17,7 @@
         </p>
         <form action="{% url 'wagtailforms:delete_submissions' page.id %}?{{ request.GET.urlencode }}" method="POST">
             {% csrf_token %}
+            <input type="hidden" value="{{ next_url }}" name="next">
             <input type="submit" value="{% trans 'Delete' %}" class="button serious">
         </form>
     </div>

--- a/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
@@ -1,7 +1,9 @@
 {% extends "wagtailadmin/generic/index_results.html" %}
 {% load i18n %}
 {% block results %}
+
     <form class="w-overflow-auto" data-controller="w-bulk" data-w-bulk-action-inactive-class="w-invisible" action="{% url 'wagtailforms:delete_submissions' form_page.id %}" method="get">
+        <input type="hidden" value="{{ next_url }}" name="next">
         <table class="listing">
             <col />
             <col />

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -12,6 +12,7 @@ from django_filters import DateFromToRangeFilter
 from wagtail.admin import messages
 from wagtail.admin.filters import DateRangePickerWidget, WagtailFilterSet
 from wagtail.admin.ui.tables import Column, TitleColumn
+from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.admin.views import generic
 from wagtail.admin.views.generic.base import BaseListingView
 from wagtail.admin.views.mixins import SpreadsheetExportMixin
@@ -111,6 +112,9 @@ class DeleteSubmissionsView(TemplateView):
 
     def get_success_url(self):
         """Returns the success URL to redirect to after a successful deletion"""
+        next_url = get_valid_next_url_from_request(self.request)
+        if next_url:
+            return next_url
         return self.success_url
 
     def dispatch(self, request, *args, **kwargs):
@@ -140,6 +144,13 @@ class DeleteSubmissionsView(TemplateView):
                 "submissions": self.submissions,
             }
         )
+        next_url = get_valid_next_url_from_request(self.request)
+        if next_url:
+            context.update(
+                {
+                    "next_url": next_url,
+                }
+            )
 
         return context
 
@@ -318,5 +329,7 @@ class SubmissionsListView(SpreadsheetExportMixin, BaseListingView):
                     "data_rows": data_rows,
                 }
             )
-
+        context["next_url"] = (
+            self.request.path + "?" + self.request.META["QUERY_STRING"]
+        )
         return context


### PR DESCRIPTION
Fixes #12007 

This adds a next query parameter to the bulk action form on the `SubmissionsListView` and passes it via hidden input to the `DeleteSubmissionsView` where it is considered in the `get_success_url` method. 