### PR TITLE
Add next parameter to form submissions delete redirect

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,7 @@ Changelog
 6.3 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~
 
- * ...
+ * Redirect to the last viewed listing page after deleting form submissions (Matthias Brück)
 
 
 6.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -13,7 +13,7 @@ depth: 1
 
 ### Other features
 
- * ...
+ * Redirect to the last viewed listing page after deleting form submissions (Matthias Brück)
 
 ### Bug fixes
 

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -396,7 +396,11 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
+
+        # Check that we got page one
+        self.assertEqual(response.context["page_obj"].number, 1)
 
     def test_pagination_out_of_range(self):
         self.make_pages()
@@ -406,7 +410,14 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
+
+        # Check that we got the last page
+        self.assertEqual(
+            response.context["page_obj"].number,
+            response.context["paginator"].num_pages,
+        )
 
     def test_no_pagination_with_custom_ordering(self):
         self.make_pages()

--- a/wagtail/admin/tests/pages/test_page_search.py
+++ b/wagtail/admin/tests/pages/test_page_search.py
@@ -110,13 +110,11 @@ class TestPageSearch(WagtailTestUtils, TransactionTestCase):
         self.assertContains(response, f'href="{expected_new_page_copy_url}"')
 
     def test_pagination(self):
-        # page numbers in range should be accepted
-        response = self.get({"q": "Hello", "p": 1})
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailadmin/pages/search.html")
-        # page numbers out of range should return 404
-        response = self.get({"q": "Hello", "p": 9999})
-        self.assertEqual(response.status_code, 404)
+        pages = ["0", "1", "-1", "9999", "Not a page"]
+        for page in pages:
+            response = self.get({"q": "Hello", "p": page})
+            self.assertEqual(response.status_code, 200)
+            self.assertTemplateUsed(response, "wagtailadmin/pages/search.html")
 
     def test_root_can_appear_in_search_results(self):
         response = self.get({"q": "root"})

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -290,7 +290,15 @@ class TestWorkflowsIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase)
         self.assertContains(response, url + "?p=3")
 
         response = self.get({"p": 4})
-        self.assertEqual(response.status_code, 404)
+        # Check response
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/workflows/index.html")
+
+        # Check that we got the last page
+        self.assertEqual(
+            response.context["page_obj"].number,
+            response.context["paginator"].num_pages,
+        )
 
 
 class TestWorkflowPermissions(WagtailTestUtils, TestCase):
@@ -1199,7 +1207,15 @@ class TestTaskIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertContains(response, url + "?p=3")
 
         response = self.get({"p": 4})
-        self.assertEqual(response.status_code, 404)
+        # Check response
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/workflows/task_index.html")
+
+        # Check that we got the last page
+        self.assertEqual(
+            response.context["page_obj"].number,
+            response.context["paginator"].num_pages,
+        )
 
     def test_num_queries(self):
         workflows = [Workflow.objects.create(name=f"workflow_{i}") for i in range(7)]

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -407,6 +407,18 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
         queryset = self.filter_queryset(queryset)
         return queryset
 
+    def paginate_queryset(self, queryset, page_size):
+        paginator = self.get_paginator(
+            queryset,
+            page_size,
+            orphans=self.get_paginate_orphans(),
+            allow_empty_first_page=self.get_allow_empty(),
+        )
+
+        page_number = self.request.GET.get(self.page_kwarg)
+        page = paginator.get_page(page_number)
+        return (paginator, page, page.object_list, page.has_other_pages())
+
     def get_table_kwargs(self):
         return {
             "ordering": self.ordering,

--- a/wagtail/contrib/forms/templates/wagtailforms/confirm_delete.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/confirm_delete.html
@@ -17,6 +17,7 @@
         </p>
         <form action="{% url 'wagtailforms:delete_submissions' page.id %}?{{ request.GET.urlencode }}" method="POST">
             {% csrf_token %}
+            <input type="hidden" value="{{ next_url }}" name="next">
             <input type="submit" value="{% trans 'Delete' %}" class="button serious">
         </form>
     </div>

--- a/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% block results %}
     <form class="w-overflow-auto" data-controller="w-bulk" data-w-bulk-action-inactive-class="w-invisible" action="{% url 'wagtailforms:delete_submissions' form_page.id %}" method="get">
+        <input type="hidden" value="{{ next_url }}" name="next">
         <table class="listing">
             <col />
             <col />

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -197,7 +197,11 @@ class TestFormsIndex(WagtailTestUtils, TestCase):
         response = self.client.get(reverse("wagtailforms:index"), {"p": "Hello world!"})
 
         # Check response
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailforms/index.html")
+
+        # Check that it got page one
+        self.assertEqual(response.context["page_obj"].number, 1)
 
     def test_forms_index_pagination_out_of_range(self):
         # Create some more form pages to make pagination kick in
@@ -207,7 +211,13 @@ class TestFormsIndex(WagtailTestUtils, TestCase):
         response = self.client.get(reverse("wagtailforms:index"), {"p": 99999})
 
         # Check response
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailforms/index.html")
+
+        # Check that it got the last page
+        self.assertEqual(
+            response.context["page_obj"].number, response.context["paginator"].num_pages
+        )
 
     def test_cannot_see_forms_without_permission(self):
         # Login with as a user without permission to see forms
@@ -319,7 +329,15 @@ class TestFormsIndexWithLocalisationEnabled(WagtailTestUtils, TestCase):
         self.assertEqual(len(response.context["page_obj"].object_list), 3)
 
         response = self.client.get(self.forms_index_url, {"p": 4})
-        self.assertEqual(response.status_code, 404)
+        # Check response
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailforms/index.html")
+
+        # Check that we got the last page
+        self.assertEqual(
+            response.context["page_obj"].number,
+            response.context["paginator"].num_pages,
+        )
 
         # now check the French pages.
         response = self.client.get(
@@ -484,7 +502,11 @@ class TestFormsSubmissionsList(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailforms/submissions_index.html")
+
+        # Check that we got page one
+        self.assertEqual(response.context["page_obj"].number, 1)
 
     def test_list_submissions_pagination_out_of_range(self):
         self.make_list_submissions()
@@ -495,7 +517,13 @@ class TestFormsSubmissionsList(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailforms/submissions_index.html")
+
+        # Check that we got the last page
+        self.assertEqual(
+            response.context["page_obj"].number, response.context["paginator"].num_pages
+        )
 
     def test_list_submissions_default_order(self):
         response = self.client.get(
@@ -1183,7 +1211,11 @@ class TestCustomFormsSubmissionsList(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailforms/submissions_index.html")
+
+        # Check that we got page one
+        self.assertEqual(response.context["page_obj"].number, 1)
 
     def test_list_submissions_pagination_out_of_range(self):
         self.make_list_submissions()
@@ -1194,7 +1226,13 @@ class TestCustomFormsSubmissionsList(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailforms/submissions_index.html")
+
+        # Check that we got the last page
+        self.assertEqual(
+            response.context["page_obj"].number, response.context["paginator"].num_pages
+        )
 
 
 class TestDeleteFormSubmission(WagtailTestUtils, TestCase):

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -12,6 +12,7 @@ from django_filters import DateFromToRangeFilter
 from wagtail.admin import messages
 from wagtail.admin.filters import DateRangePickerWidget, WagtailFilterSet
 from wagtail.admin.ui.tables import Column, TitleColumn
+from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.admin.views import generic
 from wagtail.admin.views.generic.base import BaseListingView
 from wagtail.admin.views.mixins import SpreadsheetExportMixin
@@ -111,6 +112,9 @@ class DeleteSubmissionsView(TemplateView):
 
     def get_success_url(self):
         """Returns the success URL to redirect to after a successful deletion"""
+        next_url = get_valid_next_url_from_request(self.request)
+        if next_url:
+            return next_url
         return self.success_url
 
     def dispatch(self, request, *args, **kwargs):
@@ -140,6 +144,9 @@ class DeleteSubmissionsView(TemplateView):
                 "submissions": self.submissions,
             }
         )
+        next_url = get_valid_next_url_from_request(self.request)
+        if next_url:
+            context["next_url"] = next_url
 
         return context
 
@@ -319,4 +326,5 @@ class SubmissionsListView(SpreadsheetExportMixin, BaseListingView):
                 }
             )
 
+        context["next_url"] = self.request.get_full_path()
         return context

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -88,7 +88,7 @@ class DeleteSubmissionsView(TemplateView):
     template_name = "wagtailforms/confirm_delete.html"
     page = None
     submissions = None
-    success_url = "wagtailforms:list_submissions"
+    success_url_name = "wagtailforms:list_submissions"
 
     def get_queryset(self):
         """Returns a queryset for the selected submissions"""
@@ -115,7 +115,7 @@ class DeleteSubmissionsView(TemplateView):
         next_url = get_valid_next_url_from_request(self.request)
         if next_url:
             return next_url
-        return self.success_url
+        return reverse(self.success_url_name, args=(self.page.id,))
 
     def dispatch(self, request, *args, **kwargs):
         """Check permissions, set the page and submissions, handle delete"""
@@ -130,7 +130,7 @@ class DeleteSubmissionsView(TemplateView):
 
         if self.request.method == "POST":
             self.handle_delete(self.submissions)
-            return redirect(self.get_success_url(), page_id)
+            return redirect(self.get_success_url())
 
         return super().dispatch(request, *args, **kwargs)
 
@@ -144,9 +144,7 @@ class DeleteSubmissionsView(TemplateView):
                 "submissions": self.submissions,
             }
         )
-        next_url = get_valid_next_url_from_request(self.request)
-        if next_url:
-            context["next_url"] = next_url
+        context["next_url"] = self.get_success_url()
 
         return context
 

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -652,12 +652,10 @@ class TestRedirectsIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase)
         self.assertEqual(response.context["query_string"], "Aaargh")
 
     def test_pagination(self):
-        # page numbers in range should be accepted
-        response = self.get({"p": 1})
-        self.assertEqual(response.status_code, 200)
-        # page numbers out of range should return 404
-        response = self.get({"p": 9999})
-        self.assertEqual(response.status_code, 404)
+        pages = ["0", "1", "-1", "9999", "Not a page"]
+        for page in pages:
+            response = self.get({"p": page})
+            self.assertEqual(response.status_code, 200)
 
     def test_default_ordering(self):
         for i in range(0, 10):

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -241,7 +241,11 @@ class TestSearchPromotionsIndexView(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailsearchpromotions/index.html")
+
+        # Check that we got page one
+        self.assertEqual(response.context["page_obj"].number, 1)
 
     def test_pagination_out_of_range(self):
         self.make_search_picks()
@@ -251,7 +255,14 @@ class TestSearchPromotionsIndexView(WagtailTestUtils, TestCase):
         )
 
         # Check response
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailsearchpromotions/index.html")
+
+        # Check that we got the last page
+        self.assertEqual(
+            response.context["page_obj"].number,
+            response.context["paginator"].num_pages,
+        )
 
     def test_num_queries(self):
         url = reverse("wagtailsearchpromotions:index")

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -71,7 +71,11 @@ class TestDocumentIndexView(WagtailTestUtils, TestCase):
         response = self.get({"p": "Hello World!"})
 
         # Check response
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtaildocs/documents/index.html")
+
+        # Check that we got page one
+        self.assertEqual(response.context["page_obj"].number, 1)
 
     def test_pagination_out_of_range(self):
         self.make_docs()
@@ -79,7 +83,14 @@ class TestDocumentIndexView(WagtailTestUtils, TestCase):
         response = self.get({"p": 99999})
 
         # Check response
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtaildocs/documents/index.html")
+
+        # Check that we got the last page
+        self.assertEqual(
+            response.context["page_obj"].number,
+            response.context["paginator"].num_pages,
+        )
 
     def test_ordering(self):
         orderings = ["title", "-created_at"]

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -81,12 +81,10 @@ class TestImageIndexView(WagtailTestUtils, TestCase):
         self.assertContains(response, "a cute puppy")
 
     def test_pagination(self):
-        # page numbers in range should be accepted
-        response = self.get({"p": 1})
-        self.assertEqual(response.status_code, 200)
-        # page numbers out of range should return 404
-        response = self.get({"p": 9999})
-        self.assertEqual(response.status_code, 404)
+        pages = ["0", "1", "-1", "9999", "Not a page"]
+        for page in pages:
+            response = self.get({"p": page})
+            self.assertEqual(response.status_code, 200)
 
     def test_pagination_preserves_other_params(self):
         root_collection = Collection.get_first_root_node()

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -215,13 +215,11 @@ class TestSnippetListView(WagtailTestUtils, TestCase):
         self.assertEqual(response.context["page_obj"][0].text, "advert 10")
 
     def test_simple_pagination(self):
-        # page numbers in range should be accepted
-        response = self.get({"p": 1})
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailsnippets/snippets/index.html")
-        # page numbers out of range should return 404
-        response = self.get({"p": 9999})
-        self.assertEqual(response.status_code, 404)
+        pages = ["0", "1", "-1", "9999", "Not a page"]
+        for page in pages:
+            response = self.get({"p": page})
+            self.assertEqual(response.status_code, 200)
+            self.assertTemplateUsed(response, "wagtailsnippets/snippets/index.html")
 
     def test_displays_add_button(self):
         self.assertContains(self.get(), "Add advert")

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -238,12 +238,10 @@ class TestUserIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertIn(self.test_user, results)
 
     def test_pagination(self):
-        # page numbers in range should be accepted
-        response = self.get({"p": 1})
-        self.assertEqual(response.status_code, 200)
-        # page numbers out of range should return 404
-        response = self.get({"p": 9999})
-        self.assertEqual(response.status_code, 404)
+        pages = ["0", "1", "-1", "9999", "Not a page"]
+        for page in pages:
+            response = self.get({"p": page})
+            self.assertEqual(response.status_code, 200)
 
     def test_ordering(self):
         # checking that only valid ordering used, in case of `IndexView` the valid


### PR DESCRIPTION
Fixes #12007

This adds a next query parameter to the bulk action form on the `SubmissionsListView` and passes it via hidden input to the `DeleteSubmissionsView` where it is considered in the `get_success_url` method.

Looking for feedback. Will add tests once the implementation is approved.