### PR TITLE
Fix can_delete flag in generic edit view to account for instance-level permissions

### DIFF
--- a/wagtail/admin/tests/test_collections_views.py
+++ b/wagtail/admin/tests/test_collections_views.py
@@ -549,6 +549,19 @@ class TestEditCollection(CollectionInstanceTestUtils, WagtailTestUtils, TestCase
         # Retrieve edit form and check fields
         response = self.get(collection_id=self.marketing_sub_collection.id)
         self.assertNotContains(response, "Delete collection")
+
+        # Add delete permission to a different collection and try again,
+        # ensure that it checks against the tree structure, and not just a
+        # "delete collection" permission on any collection
+        # See https://github.com/wagtail/wagtail/issues/10084
+        GroupCollectionPermission.objects.create(
+            group=self.marketing_group,
+            collection=self.marketing_sub_collection_2,
+            permission=self.delete_permission,
+        )
+        response = self.get(collection_id=self.marketing_sub_collection.id)
+        self.assertNotContains(response, "Delete collection")
+
         # Add delete permission to parent collection and try again
         GroupCollectionPermission.objects.create(
             group=self.marketing_group,

--- a/wagtail/admin/views/collections.py
+++ b/wagtail/admin/views/collections.py
@@ -138,17 +138,6 @@ class Edit(EditView):
             instance.move(self.form.cleaned_data["parent"], "sorted-child")
         return instance
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["can_delete"] = (
-            self.permission_policy.instances_user_has_permission_for(
-                self.request.user, "delete"
-            )
-            .filter(pk=self.object.pk)
-            .first()
-        )
-        return context
-
 
 class Delete(DeleteView):
     permission_policy = collection_permission_policy

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -919,7 +919,9 @@ class EditView(
         context["submit_button_label"] = self.submit_button_label
         context["can_delete"] = (
             self.permission_policy is None
-            or self.permission_policy.user_has_permission(self.request.user, "delete")
+            or self.permission_policy.user_has_permission_for_instance(
+                self.request.user, "delete", self.object
+            )
         )
         if context["can_delete"]:
             context["delete_url"] = self.get_delete_url()


### PR DESCRIPTION
As per https://github.com/wagtail/wagtail/pull/11964#issuecomment-2152567935 - the base EditView should be checking `user_has_permission_for_instance`.

Fixes #10084, supersedes #11964
