### PR TITLE
Content checks results redesign

### DIFF
--- a/client/scss/components/_a11y-result.scss
+++ b/client/scss/components/_a11y-result.scss
@@ -1,32 +1,43 @@
 .w-a11y-result__row {
-  border-top: 1px solid theme('colors.border-furniture');
+  @include box;
+  padding: theme('spacing.4');
 }
 
 .w-a11y-result__header {
   margin: 0;
-  padding: theme('spacing.4') theme('spacing.5');
   width: 100%;
   display: flex;
   justify-content: space-between;
   gap: theme('spacing.2');
-  font: inherit;
-  font-weight: theme('fontWeight.bold');
+  font-size: theme('fontSize.14');
+
+  .w-dialog--userbar & {
+    font-size: theme('fontSize.16');
+  }
 }
 
 .w-a11y-result__name {
-  color: theme('colors.text-label');
+  color: theme('colors.text-context');
+  font-weight: theme('fontWeight.semibold');
 }
 
 .w-a11y-result__container {
   display: flex;
   flex-wrap: wrap;
-  padding: 0 theme('spacing.5') theme('spacing.5') theme('spacing.5');
+  gap: theme('spacing.[2.5]');
+  padding-top: theme('spacing.3');
 }
 
 .w-a11y-result__subtotal_count {
-  color: theme('colors.text-context');
+  color: theme('colors.icon-primary');
   width: theme('spacing.5');
   text-align: center;
+  font-size: theme('fontSize.11');
+  font-weight: theme('fontWeight.normal');
+
+  .w-dialog--userbar & {
+    font-size: theme('fontSize.14');
+  }
 }
 
 .w-a11y-result__selector {
@@ -35,8 +46,6 @@
   background: theme('colors.surface-field-inactive');
   color: theme('colors.text-context');
   border-radius: theme('borderRadius.DEFAULT');
-  margin-inline-end: theme('spacing.[2.5]');
-  margin-bottom: theme('spacing.[2.5]');
   padding: theme('spacing.[1.5]');
 
   &:hover,
@@ -59,7 +68,7 @@
   fill: theme('colors.surface-button-default');
   height: theme('spacing.[3.5]');
   width: theme('spacing.[3.5]');
-  margin-inline-end: theme('spacing.[2.5]');
+  margin-inline-end: theme('spacing.[1.5]');
 }
 
 .w-a11y-result__count {
@@ -69,10 +78,10 @@
   align-items: center;
   background-color: theme('colors.positive.100');
   border-radius: theme('borderRadius.full');
-  font-size: theme('fontSize.14');
+  font-size: theme('fontSize.11');
   line-height: theme('lineHeight.none');
-  height: theme('spacing.5');
-  width: theme('spacing.5');
+  height: theme('spacing.4');
+  width: theme('spacing.4');
   color: theme('colors.text-button');
 
   &.has-errors {

--- a/client/scss/components/_userbar.scss
+++ b/client/scss/components/_userbar.scss
@@ -239,6 +239,7 @@ $positions: (
     padding: 0;
     min-height: unset;
     max-height: 60vh;
+    font-size: theme('fontSize.14');
   }
 
   .w-dialog__header {
@@ -247,15 +248,23 @@ $positions: (
     justify-content: space-between;
   }
 
+  .w-dialog__body {
+    padding: 0 theme('spacing.[7.5]') theme('spacing.[7.5]');
+    display: flex;
+    flex-direction: column;
+    gap: theme('spacing.[2.5]');
+  }
+
   .w-dialog__title {
     @apply w-h3;
-    padding: theme('spacing.4') theme('spacing.5');
+    color: theme('colors.text-context');
+    padding: theme('spacing.[7.5]');
     margin-bottom: 0;
   }
 
   .w-dialog__subtitle {
     @apply w-body-text;
-    padding-inline-end: theme('spacing.5');
+    padding-inline-end: theme('spacing.[7.5]');
     display: flex;
     align-items: center;
     gap: theme('spacing.2');

--- a/client/src/components/CommentApp/main.scss
+++ b/client/src/components/CommentApp/main.scss
@@ -4,7 +4,7 @@ $color-comment-separator: theme('colors.border-furniture');
 
 $color-box-background: theme('colors.surface-page');
 $color-box-background-focused: theme('colors.surface-page');
-$color-box-border: theme('colors.border-field-default');
+$color-box-border: theme('colors.border-furniture');
 $color-box-border-focused: theme('colors.border-field-hover');
 $color-box-text: theme('colors.text-context');
 $box-border-radius: 5px;

--- a/client/src/tokens/typography.js
+++ b/client/src/tokens/typography.js
@@ -72,6 +72,7 @@ const fontFamily = {
  * These values are used in combinations create typography defaults
  */
 const fontSize = {
+  11: '0.6875rem',
   14: '0.875rem',
   15: '0.9375rem',
   16: '1rem',

--- a/wagtail/admin/templates/wagtailadmin/shared/dialog/dialog.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/dialog/dialog.html
@@ -40,7 +40,7 @@
                     {% endif %}
                 </div>
 
-                <div data-w-dialog-target="body">
+                <div class="w-dialog__body" data-w-dialog-target="body">
                     {{ children }}
                 </div>
             </div>

--- a/wagtail/admin/templates/wagtailadmin/shared/page_status_tag_new.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/page_status_tag_new.html
@@ -21,7 +21,7 @@
               w-whitespace-nowrap
               w-px-1
               w-ml-3
-              w-text-[0.6875rem]
+              w-text-11
               w-rounded-sm
               w-bg-transparent
               w-text-text-meta

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/checks.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/checks.html
@@ -17,7 +17,7 @@
 </template>
 
 <div class="w-mt-12">
-    <h2 class="w-flex w-items-center w-gap-2"><span>{% trans 'Issues found' %}</span><span class="w-a11y-result__count" data-a11y-result-count>0</span></h2>
-    <div data-checks-panel></div>
+    <h2 class="w-flex w-items-center w-gap-2 w-my-5 w-text-16 w-font-bold"><span>{% trans 'Issues found' %}</span><span class="w-a11y-result__count" data-a11y-result-count>0</span></h2>
+    <div class="w-flex w-flex-col w-gap-2.5" data-checks-panel></div>
 </div>
 {{ axe_configuration|json_script:"accessibility-axe-configuration" }}


### PR DESCRIPTION
Addresses #12000 

This is the implementation of the [interim state of the content checks results design](https://www.figma.com/design/h67EsVXdWsfu38WGGxWfpi/Wagtail-CMS?node-id=13864-11373&t=pwrLO6xatrWqYeFv-0) that Ben produced for both the side panel and the userbar.

Here, we've added results "cards" without yet accommodating varying types of checks or means for interaction that we will add in the future.

**Side panel**
| Before | After |
|----------|----------|
| <img width="354" alt="image" src="https://github.com/wagtail/wagtail/assets/51043550/2878644a-2fdb-4e9a-9993-8ff615877d9e">   | <img width="365" alt="image" src="https://github.com/wagtail/wagtail/assets/51043550/9134dbdf-52bb-4c09-9caa-1eab3d9e1cc6">   |
| <img width="357" alt="image" src="https://github.com/wagtail/wagtail/assets/51043550/3ca12d16-b1ae-44d0-8464-10b08b9601e1">    | <img width="363" alt="image" src="https://github.com/wagtail/wagtail/assets/51043550/41f27c25-ecae-4eea-8aeb-18f399516365">    |

**Userbar**
| Before | After |
|----------|----------|
| <img width="431" alt="image" src="https://github.com/wagtail/wagtail/assets/51043550/c25dec21-cacb-4c43-bd15-7002a4cb601d"> | <img width="424" alt="image" src="https://github.com/wagtail/wagtail/assets/51043550/49c05c43-d827-4c8f-babb-7100a69a07a2"> |
 | <img width="431" alt="image" src="https://github.com/wagtail/wagtail/assets/51043550/821067bf-20d5-4860-bf4a-e38a040f8091"> | <img width="429" alt="image" src="https://github.com/wagtail/wagtail/assets/51043550/9a13dd16-8f8f-44d9-ab32-518170f749b9"> |

Comments:
- updated the part of the `box` mixin that is used by both the comment component and the content check result component
- added a new font size of 11, which is likely to be used across multiple components in the future
- changed 15px spacing to 16px spacing to ensure consistency with the theme spacing
- for some of the new designs, we didn’t have exact matching color tokens, so we used the closest available ones. The biggest difference is in the `w-dialog__title` component: in the dark theme, we used `grey-150` instead of `white`.
