### PR TITLE
Fix ico format conversion to work in template

### DIFF
--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -449,7 +449,8 @@ You can encode the image into lossless AVIF or WebP format by using `format-avif
 You can save images as a `.ico` file using `format-ico`, which is especially useful when managing a site's favicon through the Admin.
 
 ```html+django
-<link rel="icon" href="{% image favicon_image format-ico %}" />
+{% image favicon_image format-ico as favicon_image_formatted %}
+<link rel="icon" type="image/x-icon" href="{{ favicon_image_formatted.url }}"/>
 ```
 
 (image_background_colour)=

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -59,6 +59,7 @@ IMAGE_FORMAT_EXTENSIONS = {
     "gif": ".gif",
     "webp": ".webp",
     "svg": ".svg",
+    "ico": ".ico",
 }
 
 

--- a/wagtail/images/tests/test_image_operations.py
+++ b/wagtail/images/tests/test_image_operations.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from pathlib import Path
 from unittest.mock import patch
 
 from django.test import TestCase, override_settings
@@ -11,6 +12,7 @@ from wagtail.images.exceptions import (
 )
 from wagtail.images.image_operations import TransformOperation
 from wagtail.images.models import Filter, Image
+from wagtail.images.shortcuts import get_rendition_or_not_found
 from wagtail.images.tests.utils import (
     get_test_image_file,
     get_test_image_file_avif,
@@ -692,6 +694,16 @@ class TestFormatFilter(TestCase):
         out = fil.run(image, BytesIO())
 
         self.assertEqual(out.format_name, "ico")
+
+    def test_ico_rendition(self):
+        fil = Filter(spec="width-400|format-ico")
+        good_image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+
+        rendition = get_rendition_or_not_found(good_image, fil)
+        self.assertEqual(Path(rendition.file.name).suffix, ".ico")
 
     def test_webp_lossless(self):
         fil = Filter(spec="width-400|format-webp-lossless")


### PR DESCRIPTION
The new feature for ICO format conversion (introduced in #11568 ) crash when actually used in a template.
This is because ICO was missing from `IMAGE_FORMAT_EXTENSIONS` dict.
Also, the added doc about how to use it for favicon generation was using the `image` tag result directly in an `href`. I changed it to correctly use the rendition url in the href instead.
I also added a test that was not passing before and now pass with the current fix.