### PR TITLE
Add "soft" client-side validation for StreamBlock / ListBlock min_num / max_num

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Changelog
  * Add word count and reading time metrics within the page editor (Albina Starykova. Sponsored by The Motley Fool)
  * Implement a new design for accessibility checks (Albina Starykova)
  * Allow changing available privacy options per page model (Shlomo Markowitz)
+ * Add "soft" client-side validation for `StreamBlock` / `ListBlock` `min_num` / `max_num` (Matt Westcott)
  * Fix: Make `WAGTAILIMAGES_CHOOSER_PAGE_SIZE` setting functional again (Rohit Sharma)
  * Fix: Enable `richtext` template tag to convert lazy translation values (Benjamin Bach)
  * Fix: Ensure permission labels on group permissions page are translated where available (Matt Westcott)

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -7,7 +7,7 @@ import {
   BaseInsertionControl,
 } from './BaseSequenceBlock';
 import { escapeHtml as h } from '../../../utils/text';
-import { range } from '../../../utils/range';
+import { gettext } from '../../../utils/gettext';
 import {
   addErrorMessages,
   removeErrorMessages,
@@ -188,18 +188,22 @@ export class ListBlock extends BaseSequenceBlock {
   blockCountChanged() {
     super.blockCountChanged();
 
-    if (typeof this.blockDef.meta.maxNum === 'number') {
-      if (this.children.length >= this.blockDef.meta.maxNum) {
-        /* prevent adding new blocks */
-        range(0, this.inserters.length).forEach((i) => {
-          this.inserters[i].disable();
-        });
-      } else {
-        /* allow adding new blocks */
-        range(0, this.inserters.length).forEach((i) => {
-          this.inserters[i].enable();
-        });
+    const errorMessages = [];
+    const maxNum = this.blockDef.meta.maxNum;
+
+    if (typeof maxNum === 'number') {
+      if (this.children.length > maxNum) {
+        const message = gettext(
+          'The maximum number of items is %(max_num)d',
+        ).replace('%(max_num)d', `${maxNum}`);
+        errorMessages.push(message);
       }
+    }
+
+    if (errorMessages.length) {
+      this.setError({ messages: errorMessages });
+    } else {
+      this.setError({});
     }
   }
 

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -200,6 +200,17 @@ export class ListBlock extends BaseSequenceBlock {
       }
     }
 
+    const minNum = this.blockDef.meta.minNum;
+
+    if (typeof minNum === 'number') {
+      if (this.children.length < minNum) {
+        const message = gettext(
+          'The minimum number of items is %(min_num)d',
+        ).replace('%(min_num)d', `${minNum}`);
+        errorMessages.push(message);
+      }
+    }
+
     if (errorMessages.length) {
       this.setError({ messages: errorMessages });
     } else {

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -345,6 +345,23 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
     },
   );
 
+  const assertCanAddBlock = () => {
+    // Test duplicate button
+    // querySelector always returns the first element it sees so this only checks the first block
+    expect(
+      document
+        .querySelector('button[title="Duplicate"]')
+        .getAttribute('disabled'),
+    ).toBe(null);
+
+    // Test menu
+    expect(
+      document
+        .querySelector('button[data-streamfield-list-add]')
+        .getAttribute('disabled'),
+    ).toBe(null);
+  };
+
   const assertShowingErrorMessage = () => {
     expect(document.querySelector('p.help-block.help-critical').innerHTML).toBe(
       'The maximum number of items is 3',
@@ -363,6 +380,7 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
       { value: 'Third value', id: '33333333-3333-3333-3333-333333333333' },
     ]);
 
+    assertCanAddBlock();
     assertNotShowingErrorMessage();
   });
 
@@ -375,6 +393,7 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
       { value: 'Fourth value', id: '44444444-4444-4444-4444-444444444444' },
     ]);
 
+    assertCanAddBlock();
     assertShowingErrorMessage();
   });
 
@@ -401,10 +420,12 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
       { value: 'Third value', id: '33333333-3333-3333-3333-333333333333' },
     ]);
 
+    assertCanAddBlock();
     assertNotShowingErrorMessage();
 
     boundBlock.insert('Fourth value', 2);
 
+    assertCanAddBlock();
     assertShowingErrorMessage();
   });
 
@@ -417,10 +438,12 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
       { value: 'Fourth value', id: '44444444-4444-4444-4444-444444444444' },
     ]);
 
+    assertCanAddBlock();
     assertShowingErrorMessage();
 
     boundBlock.deleteBlock(2);
 
+    assertCanAddBlock();
     assertNotShowingErrorMessage();
   });
 });

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -425,6 +425,96 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
   });
 });
 
+describe('telepath: wagtail.blocks.ListBlock with minNum set', () => {
+  // Define a test block
+  const blockDef = new ListBlockDefinition(
+    'test_listblock',
+    new ParanoidFieldBlockDefinition(
+      '',
+      new DummyWidgetDefinition('The widget'),
+      {
+        label: '',
+        required: true,
+        icon: 'pilcrow',
+        classname:
+          'w-field w-field--char_field w-field--admin_auto_height_text_input',
+      },
+    ),
+    null,
+    {
+      label: 'Test listblock',
+      icon: 'placeholder',
+      classname: null,
+      helpText: 'use <strong>a few</strong> of these',
+      helpIcon: '<svg></svg>',
+      minNum: 2,
+      strings: {
+        MOVE_UP: 'Move up',
+        MOVE_DOWN: 'Move down',
+        DELETE: 'Delete',
+        DUPLICATE: 'Duplicate',
+        ADD: 'Add',
+      },
+    },
+  );
+
+  const assertShowingErrorMessage = () => {
+    expect(document.querySelector('p.help-block.help-critical').innerHTML).toBe(
+      'The minimum number of items is 2',
+    );
+  };
+
+  const assertNotShowingErrorMessage = () => {
+    expect(document.querySelector('p.help-block.help-critical')).toBe(null);
+  };
+
+  test('test error message not shown when at limit', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
+      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
+    ]);
+
+    assertNotShowingErrorMessage();
+  });
+
+  test('initialising at under minNum shows error message', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
+    ]);
+
+    assertShowingErrorMessage();
+  });
+
+  test('insert removes error message', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
+    ]);
+
+    assertShowingErrorMessage();
+
+    boundBlock.insert('Second value', 1);
+
+    assertNotShowingErrorMessage();
+  });
+
+  test('delete below limit adds error message', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
+      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
+    ]);
+
+    assertNotShowingErrorMessage();
+
+    boundBlock.deleteBlock(1);
+
+    assertShowingErrorMessage();
+  });
+});
+
 describe('telepath: wagtail.blocks.ListBlock with StreamBlock child', () => {
   let boundBlock;
 

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -345,51 +345,17 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
     },
   );
 
-  const assertCanAddBlock = () => {
-    // Test duplicate button
-    // querySelector always returns the first element it sees so this only checks the first block
-    expect(
-      document
-        .querySelector('button[title="Duplicate"]')
-        .getAttribute('disabled'),
-    ).toBe(null);
-
-    // Test menu
-    expect(
-      document
-        .querySelector('button[data-streamfield-list-add]')
-        .getAttribute('disabled'),
-    ).toBe(null);
+  const assertShowingErrorMessage = () => {
+    expect(document.querySelector('p.help-block.help-critical').innerHTML).toBe(
+      'The maximum number of items is 3',
+    );
   };
 
-  const assertCannotAddBlock = () => {
-    // Test duplicate button is always enabled
-    // querySelector always returns the first element it sees so this only checks the first block
-    expect(
-      document
-        .querySelector('button[title="Duplicate"]')
-        .getAttribute('disabled'),
-    ).toBe(null);
-
-    // Test menu
-    expect(
-      document
-        .querySelector('button[data-streamfield-list-add]')
-        .getAttribute('disabled'),
-    ).toEqual('disabled');
+  const assertNotShowingErrorMessage = () => {
+    expect(document.querySelector('p.help-block.help-critical')).toBe(null);
   };
 
-  test('test can add block when under limit', () => {
-    document.body.innerHTML = '<div id="placeholder"></div>';
-    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
-      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
-    ]);
-
-    assertCanAddBlock();
-  });
-
-  test('initialising at maxNum disables adding new block and duplication', () => {
+  test('test error message not show when at limit', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
       { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
@@ -397,7 +363,19 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
       { value: 'Third value', id: '33333333-3333-3333-3333-333333333333' },
     ]);
 
-    assertCannotAddBlock();
+    assertNotShowingErrorMessage();
+  });
+
+  test('initialising at over maxNum shows error message', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
+      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
+      { value: 'Third value', id: '33333333-3333-3333-3333-333333333333' },
+      { value: 'Fourth value', id: '44444444-4444-4444-4444-444444444444' },
+    ]);
+
+    assertShowingErrorMessage();
   });
 
   test('addSibling capability works', () => {
@@ -415,21 +393,7 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
     expect(boundBlock.children.length).toEqual(4);
   });
 
-  test('insert disables new block', () => {
-    document.body.innerHTML = '<div id="placeholder"></div>';
-    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
-      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
-    ]);
-
-    assertCanAddBlock();
-
-    boundBlock.insert('Third value', 2);
-
-    assertCannotAddBlock();
-  });
-
-  test('delete enables new block', () => {
+  test('insert adds error message', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
       { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
@@ -437,11 +401,27 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
       { value: 'Third value', id: '33333333-3333-3333-3333-333333333333' },
     ]);
 
-    assertCannotAddBlock();
+    assertNotShowingErrorMessage();
+
+    boundBlock.insert('Fourth value', 2);
+
+    assertShowingErrorMessage();
+  });
+
+  test('delete removes error message', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
+      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
+      { value: 'Third value', id: '33333333-3333-3333-3333-333333333333' },
+      { value: 'Fourth value', id: '44444444-4444-4444-4444-444444444444' },
+    ]);
+
+    assertShowingErrorMessage();
 
     boundBlock.deleteBlock(2);
 
-    assertCanAddBlock();
+    assertNotShowingErrorMessage();
   });
 });
 

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -11,7 +11,7 @@ import {
 } from './BaseSequenceBlock';
 import { escapeHtml as h } from '../../../utils/text';
 import { hasOwn } from '../../../utils/hasOwn';
-import { range } from '../../../utils/range';
+import { gettext } from '../../../utils/gettext';
 import ComboBox, {
   comboBoxLabel,
   comboBoxNoResults,
@@ -98,8 +98,6 @@ class StreamBlockMenu extends BaseInsertionControl {
     }
 
     this.combobox = document.createElement('div');
-    this.canAddBlock = true;
-    this.disabledBlockTypes = new Set();
 
     this.tooltip = tippy(this.addButton.get(0), {
       content: this.combobox,
@@ -118,15 +116,11 @@ class StreamBlockMenu extends BaseInsertionControl {
 
   get blockItems() {
     return this.groupedChildBlockDefs.map(([group, blockDefs]) => {
-      const groupItems = blockDefs
-        // Allow adding all blockDefs even when disabled, so validation only impedes when saving.
-        // Keeping the previous filtering here for future reference.
-        // .filter((blockDef) => !this.disabledBlockTypes.has(blockDef.name))
-        .map((blockDef) => ({
-          type: blockDef.name,
-          label: blockDef.meta.label,
-          icon: blockDef.meta.icon,
-        }));
+      const groupItems = blockDefs.map((blockDef) => ({
+        type: blockDef.name,
+        label: blockDef.meta.label,
+        icon: blockDef.meta.icon,
+      }));
 
       return {
         label: group || '',
@@ -160,21 +154,7 @@ class StreamBlockMenu extends BaseInsertionControl {
     this.close();
   }
 
-  setNewBlockRestrictions(canAddBlock, disabledBlockTypes) {
-    this.canAddBlock = canAddBlock;
-    this.disabledBlockTypes = disabledBlockTypes;
-    // Disable/enable menu open button
-    if (this.canAddBlock) {
-      this.addButton.removeAttr('disabled');
-    } else {
-      this.addButton.attr('disabled', 'true');
-    }
-  }
-
   open() {
-    if (!this.canAddBlock) {
-      return;
-    }
     this.addButton.attr('aria-expanded', 'true');
     this.tooltip.show();
   }
@@ -212,6 +192,7 @@ export class StreamBlock extends BaseSequenceBlock {
         </div>
       `).insertBefore(dom);
     }
+    this.container = dom;
 
     // StreamChild objects for the current (non-deleted) child blocks
     this.children = [];
@@ -238,7 +219,6 @@ export class StreamBlock extends BaseSequenceBlock {
         block.collapse();
       });
     }
-    this.container = dom;
 
     if (initialError) {
       this.setError(initialError);
@@ -282,38 +262,43 @@ export class StreamBlock extends BaseSequenceBlock {
    */
   blockCountChanged() {
     super.blockCountChanged();
-    this.canAddBlock = true;
     this.childBlockCounts.clear();
 
-    if (
-      typeof this.blockDef.meta.maxNum === 'number' &&
-      this.children.length >= this.blockDef.meta.maxNum
-    ) {
-      this.canAddBlock = false;
+    const errorMessages = [];
+
+    const maxNum = this.blockDef.meta.maxNum;
+    if (typeof maxNum === 'number' && this.children.length > maxNum) {
+      const message = gettext(
+        'The maximum number of items is %(max_num)d',
+      ).replace('%(max_num)d', `${maxNum}`);
+      errorMessages.push(message);
     }
 
     // Check if there are any block types that have count limits
-    this.disabledBlockTypes = new Set();
     for (const blockType in this.blockDef.meta.blockCounts) {
       if (hasOwn(this.blockDef.meta.blockCounts, blockType)) {
-        const maxNum = this.getBlockMax(blockType);
+        const blockMaxNum = this.getBlockMax(blockType);
 
-        if (typeof maxNum === 'number') {
+        if (typeof blockMaxNum === 'number') {
           const currentBlockCount = this.getBlockCount(blockType);
 
-          if (currentBlockCount >= maxNum) {
-            this.disabledBlockTypes.add(blockType);
+          if (currentBlockCount > blockMaxNum) {
+            const childBlockDef = this.blockDef.childBlockDefsByName[blockType];
+            const message = gettext(
+              'The maximum number of items is %(max_num)d',
+            ).replace('%(max_num)d', `${blockMaxNum}`);
+            const messageWithPrefix = `${childBlockDef.meta.label}: ${message}`;
+            errorMessages.push(messageWithPrefix);
           }
         }
       }
     }
 
-    range(0, this.inserters.length).forEach((i) => {
-      this.inserters[i].setNewBlockRestrictions(
-        this.canAddBlock,
-        this.disabledBlockTypes,
-      );
-    });
+    if (errorMessages.length) {
+      this.setError({ messages: errorMessages });
+    } else {
+      this.setError({});
+    }
   }
 
   _createChild(

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -1105,6 +1105,133 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
   });
 });
 
+describe('telepath: wagtail.blocks.StreamBlock with blockCounts.min_num set', () => {
+  // Define a test block
+  const blockDef = new StreamBlockDefinition(
+    '',
+    [
+      [
+        '',
+        [
+          new FieldBlockDefinition(
+            'test_block_a',
+            new DummyWidgetDefinition('Block A widget'),
+            {
+              label: 'Test Block <A>',
+              required: true,
+              icon: 'placeholder',
+              classname: 'w-field w-field--char_field w-field--text_input',
+            },
+          ),
+          new FieldBlockDefinition(
+            'test_block_b',
+            new DummyWidgetDefinition('Block B widget'),
+            {
+              label: 'Test Block <B>',
+              required: true,
+              icon: 'pilcrow',
+              classname:
+                'w-field w-field--char_field w-field--admin_auto_height_text_input',
+            },
+          ),
+        ],
+      ],
+    ],
+    {
+      test_block_a: 'Block A options',
+      test_block_b: 'Block B options',
+    },
+    {
+      label: '',
+      required: true,
+      icon: 'placeholder',
+      classname: null,
+      helpText: 'use <strong>plenty</strong> of these',
+      helpIcon: '<svg></svg>',
+      maxNum: null,
+      minNum: null,
+      blockCounts: {
+        test_block_a: {
+          min_num: 2,
+        },
+      },
+      strings: {
+        MOVE_UP: 'Move up',
+        MOVE_DOWN: 'Move down',
+        DELETE: 'Delete & kill with fire',
+        DUPLICATE: 'Duplicate',
+        ADD: 'Add',
+      },
+    },
+  );
+
+  const assertShowingErrorMessage = () => {
+    expect(document.querySelector('p.help-block.help-critical').innerHTML).toBe(
+      'Test Block &lt;A&gt;: The minimum number of items is 2',
+    );
+  };
+
+  const assertNotShowingErrorMessage = () => {
+    expect(document.querySelector('p.help-block.help-critical')).toBe(null);
+  };
+
+  test('inserting block to get count above min_num removes error mesage', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      {
+        id: '1',
+        type: 'test_block_a',
+        value: 'First value',
+      },
+      {
+        id: '2',
+        type: 'test_block_b',
+        value: 'Second value',
+      },
+    ]);
+
+    assertShowingErrorMessage();
+
+    boundBlock.insert(
+      {
+        id: '3',
+        type: 'test_block_a',
+        value: 'Third value',
+      },
+      2,
+    );
+
+    assertNotShowingErrorMessage();
+  });
+
+  test('deleting block to get count below min_num shows error message', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      {
+        id: '1',
+        type: 'test_block_a',
+        value: 'First value',
+      },
+      {
+        id: '2',
+        type: 'test_block_b',
+        value: 'Second value',
+      },
+      {
+        id: '3',
+        type: 'test_block_a',
+        value: 'Third value',
+      },
+    ]);
+
+    assertNotShowingErrorMessage();
+
+    boundBlock.deleteBlock(2);
+
+    assertShowingErrorMessage();
+  });
+});
+
 describe('telepath: wagtail.blocks.StreamBlock with unique block type', () => {
   let boundBlock;
 

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -722,6 +722,154 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
   });
 });
 
+describe('telepath: wagtail.blocks.StreamBlock with minNum set', () => {
+  // Define a test block
+  const blockDef = new StreamBlockDefinition(
+    '',
+    [
+      [
+        '',
+        [
+          new FieldBlockDefinition(
+            'test_block_a',
+            new DummyWidgetDefinition('Block A widget'),
+            {
+              label: 'Test Block <A>',
+              required: true,
+              icon: 'placeholder',
+              classname: 'w-field w-field--char_field w-field--text_input',
+            },
+          ),
+          new FieldBlockDefinition(
+            'test_block_b',
+            new DummyWidgetDefinition('Block B widget'),
+            {
+              label: 'Test Block <B>',
+              required: true,
+              icon: 'pilcrow',
+              classname:
+                'w-field w-field--char_field w-field--admin_auto_height_text_input',
+            },
+          ),
+        ],
+      ],
+    ],
+    {
+      test_block_a: 'Block A options',
+      test_block_b: 'Block B options',
+    },
+    {
+      label: '',
+      required: true,
+      icon: 'placeholder',
+      classname: null,
+      helpText: 'use <strong>plenty</strong> of these',
+      helpIcon: '<svg></svg>',
+      maxNum: null,
+      minNum: 2,
+      blockCounts: {},
+      strings: {
+        MOVE_UP: 'Move up',
+        MOVE_DOWN: 'Move down',
+        DELETE: 'Delete & kill with fire',
+        DUPLICATE: 'Duplicate',
+        ADD: 'Add',
+      },
+    },
+  );
+
+  const assertShowingErrorMessage = () => {
+    expect(document.querySelector('p.help-block.help-critical').innerHTML).toBe(
+      'The minimum number of items is 2',
+    );
+  };
+
+  const assertNotShowingErrorMessage = () => {
+    expect(document.querySelector('p.help-block.help-critical')).toBe(null);
+  };
+
+  test('test no error message when at lower limit', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      {
+        id: '1',
+        type: 'test_block_a',
+        value: 'First value',
+      },
+      {
+        id: '2',
+        type: 'test_block_b',
+        value: 'Second value',
+      },
+    ]);
+    boundBlock.inserters[0].open();
+
+    assertNotShowingErrorMessage();
+  });
+
+  test('initialising under minNum shows error message', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      {
+        id: '1',
+        type: 'test_block_a',
+        value: 'First value',
+      },
+    ]);
+    boundBlock.inserters[0].open();
+
+    assertShowingErrorMessage();
+  });
+
+  test('inserting to reach lower limit removes error', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      {
+        id: '1',
+        type: 'test_block_a',
+        value: 'First value',
+      },
+    ]);
+    boundBlock.inserters[0].open();
+
+    assertShowingErrorMessage();
+
+    boundBlock.insert(
+      {
+        id: '2',
+        type: 'test_block_b',
+        value: 'Second value',
+      },
+      1,
+    );
+
+    assertNotShowingErrorMessage();
+  });
+
+  test('deleting to under lower limit shows error mesage', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      {
+        id: '1',
+        type: 'test_block_a',
+        value: 'First value',
+      },
+      {
+        id: '2',
+        type: 'test_block_b',
+        value: 'Second value',
+      },
+    ]);
+    boundBlock.inserters[0].open();
+
+    assertNotShowingErrorMessage();
+
+    boundBlock.deleteBlock(1);
+
+    assertShowingErrorMessage();
+  });
+});
+
 describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', () => {
   // Define a test block
   const blockDef = new StreamBlockDefinition(

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -566,60 +566,17 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
     },
   );
 
-  const assertCanAddBlock = () => {
-    // Test duplicate button
-    // querySelector always returns the first element it sees so this only checks the first block
-    expect(
-      document
-        .querySelector('button[title="Duplicate"]')
-        .getAttribute('disabled'),
-    ).toBe(null);
-
-    // Test menu
-    expect(
-      document
-        .querySelector('button[title="Insert a block"]')
-        .getAttribute('disabled'),
-    ).toBe(null);
+  const assertShowingErrorMessage = () => {
+    expect(document.querySelector('p.help-block.help-critical').innerHTML).toBe(
+      'The maximum number of items is 3',
+    );
   };
 
-  const assertCannotAddBlock = () => {
-    // Test duplicate button is still enabled even when at block limit
-    // querySelector always returns the first element it sees so this only checks the first block
-    expect(
-      document
-        .querySelector('button[title="Duplicate"]')
-        .getAttribute('disabled'),
-    ).toBe(null);
-
-    // Test menu
-    expect(
-      document
-        .querySelector('button[title="Insert a block"]')
-        .getAttribute('disabled'),
-    ).toEqual('disabled');
+  const assertNotShowingErrorMessage = () => {
+    expect(document.querySelector('p.help-block.help-critical')).toBe(null);
   };
 
-  test('test can add block when under limit', () => {
-    document.body.innerHTML = '<div id="placeholder"></div>';
-    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      {
-        id: '1',
-        type: 'test_block_a',
-        value: 'First value',
-      },
-      {
-        id: '2',
-        type: 'test_block_b',
-        value: 'Second value',
-      },
-    ]);
-    boundBlock.inserters[0].open();
-
-    assertCanAddBlock();
-  });
-
-  test('initialising at maxNum disables adding new block and duplication', () => {
+  test('test no error message when at limit', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
       {
@@ -640,7 +597,36 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
     ]);
     boundBlock.inserters[0].open();
 
-    assertCannotAddBlock();
+    assertNotShowingErrorMessage();
+  });
+
+  test('initialising over maxNum shows error message', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      {
+        id: '1',
+        type: 'test_block_a',
+        value: 'First value',
+      },
+      {
+        id: '2',
+        type: 'test_block_b',
+        value: 'Second value',
+      },
+      {
+        id: '3',
+        type: 'test_block_b',
+        value: 'Third value',
+      },
+      {
+        id: '4',
+        type: 'test_block_b',
+        value: 'Fourth value',
+      },
+    ]);
+    boundBlock.inserters[0].open();
+
+    assertShowingErrorMessage();
   });
 
   test('addSibling capability works', () => {
@@ -667,7 +653,7 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
     expect(boundBlock.children[1].type).toEqual('test_block_a');
   });
 
-  test('insert disables new block', () => {
+  test('insert at limit triggers error', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
       {
@@ -680,24 +666,29 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
         type: 'test_block_b',
         value: 'Second value',
       },
-    ]);
-    boundBlock.inserters[0].open();
-
-    assertCanAddBlock();
-
-    boundBlock.insert(
       {
         id: '3',
         type: 'test_block_b',
         value: 'Third value',
+      },
+    ]);
+    boundBlock.inserters[0].open();
+
+    assertNotShowingErrorMessage();
+
+    boundBlock.insert(
+      {
+        id: '4',
+        type: 'test_block_b',
+        value: 'Fourth value',
       },
       2,
     );
 
-    assertCannotAddBlock();
+    assertShowingErrorMessage();
   });
 
-  test('delete enables new block', () => {
+  test('delete removes error mesage', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
       {
@@ -715,14 +706,19 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
         type: 'test_block_b',
         value: 'Third value',
       },
+      {
+        id: '4',
+        type: 'test_block_b',
+        value: 'Fourth value',
+      },
     ]);
     boundBlock.inserters[0].open();
 
-    assertCannotAddBlock();
+    assertShowingErrorMessage();
 
     boundBlock.deleteBlock(2);
 
-    assertCanAddBlock();
+    assertNotShowingErrorMessage();
   });
 });
 

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -566,6 +566,23 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
     },
   );
 
+  const assertCanAddBlock = () => {
+    // Test duplicate button
+    // querySelector always returns the first element it sees so this only checks the first block
+    expect(
+      document
+        .querySelector('button[title="Duplicate"]')
+        .getAttribute('disabled'),
+    ).toBe(null);
+
+    // Test menu
+    expect(
+      document
+        .querySelector('button[title="Insert a block"]')
+        .getAttribute('disabled'),
+    ).toBe(null);
+  };
+
   const assertShowingErrorMessage = () => {
     expect(document.querySelector('p.help-block.help-critical').innerHTML).toBe(
       'The maximum number of items is 3',
@@ -597,6 +614,7 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
     ]);
     boundBlock.inserters[0].open();
 
+    assertCanAddBlock();
     assertNotShowingErrorMessage();
   });
 
@@ -626,6 +644,7 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
     ]);
     boundBlock.inserters[0].open();
 
+    assertCanAddBlock();
     assertShowingErrorMessage();
   });
 
@@ -674,6 +693,7 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
     ]);
     boundBlock.inserters[0].open();
 
+    assertCanAddBlock();
     assertNotShowingErrorMessage();
 
     boundBlock.insert(
@@ -685,6 +705,7 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
       2,
     );
 
+    assertCanAddBlock();
     assertShowingErrorMessage();
   });
 
@@ -714,10 +735,12 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
     ]);
     boundBlock.inserters[0].open();
 
+    assertCanAddBlock();
     assertShowingErrorMessage();
 
     boundBlock.deleteBlock(2);
 
+    assertCanAddBlock();
     assertNotShowingErrorMessage();
   });
 });

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -945,6 +945,16 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
     );
   };
 
+  const assertShowingErrorMessage = () => {
+    expect(document.querySelector('p.help-block.help-critical').innerHTML).toBe(
+      'Test Block &lt;A&gt;: The maximum number of items is 2',
+    );
+  };
+
+  const assertNotShowingErrorMessage = () => {
+    expect(document.querySelector('p.help-block.help-critical')).toBe(null);
+  };
+
   test('addSibling capability works', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
@@ -959,6 +969,7 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
         value: 'Second value',
       },
     ]);
+    assertNotShowingErrorMessage();
     const addSibling =
       boundBlock.children[0].block.parentCapabilities.get('addSibling');
     expect(addSibling.getBlockMax('test_block_a')).toEqual(2);
@@ -966,6 +977,7 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
     addSibling.fn({ type: 'test_block_a' });
     expect(boundBlock.children.length).toEqual(3);
     expect(boundBlock.children[1].type).toEqual('test_block_a');
+    assertNotShowingErrorMessage();
   });
 
   test('single instance allows creation of new block and duplication', () => {
@@ -985,6 +997,7 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
     boundBlock.inserters[0].open();
 
     assertCanAddBlock();
+    assertNotShowingErrorMessage();
   });
 
   test('initialising at max_num retains ability to add new block of that type', () => {
@@ -1009,6 +1022,7 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
     boundBlock.inserters[0].open();
 
     assertCanAddBlock();
+    assertNotShowingErrorMessage();
   });
 
   test('insert retains ability to add new block', () => {
@@ -1028,6 +1042,7 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
     boundBlock.inserters[0].open();
 
     assertCanAddBlock();
+    assertNotShowingErrorMessage();
 
     boundBlock.insert(
       {
@@ -1039,9 +1054,22 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
     );
 
     assertCanAddBlock();
+    assertNotShowingErrorMessage();
+
+    boundBlock.insert(
+      {
+        id: '4',
+        type: 'test_block_a',
+        value: 'Fourth value',
+      },
+      2,
+    );
+
+    assertCanAddBlock();
+    assertShowingErrorMessage();
   });
 
-  test('delete does not change availability of new block', () => {
+  test('delete removes error message and does not change availability of new block', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
       {
@@ -1059,14 +1087,21 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
         type: 'test_block_a',
         value: 'Third value',
       },
+      {
+        id: '4',
+        type: 'test_block_a',
+        value: 'Fourth value',
+      },
     ]);
     boundBlock.inserters[0].open();
 
     assertCanAddBlock();
+    assertShowingErrorMessage();
 
     boundBlock.deleteBlock(2);
 
     assertCanAddBlock();
+    assertNotShowingErrorMessage();
   });
 });
 

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -45,6 +45,7 @@ This feature was developed by Albina Starykova and sponsored by The Motley Fool.
  * Support customizations to `UserViewSet` via the app config (Sage Abdullah)
  * Implement a new design for accessibility checks (Albina Starykova, sponsored by The Motley Fool)
  * Allow changing available privacy options per page model (Shlomo Markowitz)
+ * Add "soft" client-side validation for `StreamBlock` / `ListBlock` `min_num` / `max_num` (Matt Westcott)
 
 ### Bug fixes
 


### PR DESCRIPTION
Fixes #9513. Rather than disabling the 'add' controls on reaching max_num (which is not handled consistently with other controls that can increase the block count, such as split and duplicate), we dynamically show/hide validation errors when various limits are reached. This is friendlier to editors as it means they can temporarily exceed the block count while reorganising content, and allows us to make the UX consistent across min_num, max_num and per-block-type min/max.

I haven't yet applied the new designs from #9784 - that will be the next step.