### PR TITLE
Update some remaining Sphinx-style code refrences roles to MyST style so they work

### DIFF
--- a/docs/reference/contrib/redirects.md
+++ b/docs/reference/contrib/redirects.md
@@ -43,7 +43,7 @@ Wagtail automatically creates permanent redirects for pages (and their descendan
 
 If your project uses `RoutablePageMixin` to create pages with alternative routes, you might want to consider overriding the `get_route_paths()` method for those page types. Adding popular route paths to this list will result in the creation of additional redirects; helping visitors to alternative routes to get to the right place also.
 
-For more information, please see :meth:`~wagtail.models.Page.get_route_paths`.
+For more information, please see {meth}`~wagtail.models.Page.get_route_paths`.
 
 ### Disabling automatic redirect creation
 

--- a/docs/reference/contrib/routablepage.md
+++ b/docs/reference/contrib/routablepage.md
@@ -26,7 +26,7 @@ INSTALLED_APPS = [
 
 ## The basics
 
-To use `RoutablePageMixin`, you need to make your class inherit from both :class:`wagtail.contrib.routable_page.models.RoutablePageMixin` and {class}`wagtail.models.Page`, then define some view methods and decorate them with `path` or `re_path`.
+To use `RoutablePageMixin`, you need to make your class inherit from both {class}`wagtail.contrib.routable_page.models.RoutablePageMixin` and {class}`wagtail.models.Page`, then define some view methods and decorate them with `path` or `re_path`.
 
 These view methods behave like ordinary Django view functions, and must return an `HttpResponse` object; typically this is done through a call to `django.shortcuts.render`.
 

--- a/docs/reference/pages/index.md
+++ b/docs/reference/pages/index.md
@@ -1,6 +1,6 @@
 # Pages
 
-Wagtail requires a little careful setup to define the types of content that you want to present through your website. The basic unit of content in Wagtail is the :class:`~wagtail.models.Page`, and all of your page-level content will inherit basic webpage-related properties from it. But for the most part, you will be defining content yourself, through the construction of Django models using Wagtail's `Page` as a base.
+Wagtail requires a little careful setup to define the types of content that you want to present through your website. The basic unit of content in Wagtail is the {class}`~wagtail.models.Page`, and all of your page-level content will inherit basic webpage-related properties from it. But for the most part, you will be defining content yourself, through the construction of Django models using Wagtail's `Page` as a base.
 
 Wagtail organizes content created from your models in a tree, which can have any structure and combination of model objects in it. Wagtail doesn't prescribe ways to organize and interrelate your content, but here we've sketched out some strategies for organizing your models.
 

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -437,7 +437,7 @@ The {meth}`~wagtail.models.Site.find_for_request` function returns the Site obje
 ## `Locale`
 
 The `Locale` model defines the set of languages and/or locales that can be used on a site.
-Each `Locale` record corresponds to a "language code" defined in the :ref:`wagtail_content_languages_setting` setting.
+Each `Locale` record corresponds to a "language code" defined in the {ref}`wagtail_content_languages_setting` setting.
 
 Wagtail will initially set up one `Locale` to act as the default language for all existing content.
 This first locale will automatically pick the value from `WAGTAIL_CONTENT_LANGUAGES` that most closely matches the site primary language code defined in `LANGUAGE_CODE`.


### PR DESCRIPTION
The below have a few remaining Sphinx-style (``:class:`Foo` ``) inline roles that render with some of the markup visible and no linking. This changes them to what I believe is the correct style (``{class}`Foo` ``) based on the MyST docs and other references in the documentation.

* https://docs.wagtail.org/en/latest/reference/pages/index.html
* https://docs.wagtail.org/en/latest/reference/contrib/routablepage.html
* https://docs.wagtail.org/en/latest/reference/contrib/redirects.html
* https://docs.wagtail.org/en/latest/reference/pages/model_reference.html

