### PR TITLE
Add mention of html5lib in upgrade considerations

### DIFF
--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -142,7 +142,7 @@ Many thanks to Ben Morse and Joshua Munn for reporting this issue, and Jake Howa
 
 ### Maintenance
 
- * Move RichText HTML whitelist parser to use the faster, built in `html.parser` (Jake Howard)
+ * Move RichText HTML whitelist parser to use the faster, built in `html.parser` rather than `html5lib` (Jake Howard)
  * Remove duplicate 'path' in default_exclude_fields_in_copy (Ramchandra Shahi Thakuri)
  * Update unit tests to always use the faster, built in `html.parser` & remove `html5lib` dependency (Jake Howard)
  * Adjust Eslint rules for TypeScript files (Karthik Ayangar)
@@ -198,6 +198,10 @@ The setting `DOCUMENT_PASSWORD_REQUIRED_TEMPLATE` has been deprecated, it will c
 See [](frontend_authentication).
 
 ## Upgrade considerations - changes to undocumented internals
+
+### Removal of `html5lib` dependency
+
+Wagtail now uses `html.parser` for its rich text processing, and no longer depends on `html5lib`. If your project relies on `html5lib`, update rich text code to use Wagtail’s documented rich text APIs like [rewrite handlers](rich_text_rewrite_handlers) and [format converters](rich_text_format_converters). Or update project dependencies to include `html5lib`.
 
 ### Deprecation of `user_listing_buttons` template tag
 


### PR DESCRIPTION
We have received feedback a few projects relied on Wagtail coming with `html5lib` as a dependency. The removal needs calling attention in the upgrade considerations.