### PR TITLE
Handle choice groups in active filters

### DIFF
--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -23,6 +23,7 @@ from wagtail.admin import messages
 from wagtail.admin.ui.tables import Column, Table
 from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.admin.widgets.button import ButtonWithDropdown
+from wagtail.utils.utils import flatten_choices
 
 
 class WagtailAdminTemplateMixin(TemplateResponseMixin, ContextMixin):
@@ -288,7 +289,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                         )
                     )
             elif isinstance(filter_def, MultipleChoiceFilter):
-                choices = {str(id): label for id, label in filter_def.field.choices}
+                choices = flatten_choices(filter_def.field.choices)
                 for item in value:
                     filters.append(
                         ActiveFilter(
@@ -326,7 +327,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
                     )
                 )
             elif isinstance(filter_def, ChoiceFilter):
-                choices = {str(id): label for id, label in filter_def.field.choices}
+                choices = flatten_choices(filter_def.field.choices)
                 filters.append(
                     ActiveFilter(
                         bound_field.auto_id,

--- a/wagtail/tests/test_utils.py
+++ b/wagtail/tests/test_utils.py
@@ -28,7 +28,7 @@ from wagtail.coreutils import (
 )
 from wagtail.models import Page, Site
 from wagtail.utils.file import hash_filelike
-from wagtail.utils.utils import deep_update
+from wagtail.utils.utils import deep_update, flatten_choices
 from wagtail.utils.version import get_main_version
 
 
@@ -589,3 +589,12 @@ class TestVersion(SimpleTestCase):
         for version, include_patch, expected in cases:
             with self.subTest(version=version, include_patch=include_patch):
                 self.assertEqual(get_main_version(version, include_patch), expected)
+
+class TestFlattenChoices(SimpleTestCase):
+    def test_tuple_choices(self):
+        choices = [(1, "1st"), (2, "2nd")]
+        self.assertEqual(flatten_choices(choices), {"1": "1st", "2": "2nd"})
+
+    def test_grouped_tuple_choices(self):
+        choices = [("Group", [(1, "1st"), (2, "2nd")])]
+        self.assertEqual(flatten_choices(choices), {"1": "1st", "2": "2nd"})

--- a/wagtail/tests/test_utils.py
+++ b/wagtail/tests/test_utils.py
@@ -590,6 +590,7 @@ class TestVersion(SimpleTestCase):
             with self.subTest(version=version, include_patch=include_patch):
                 self.assertEqual(get_main_version(version, include_patch), expected)
 
+
 class TestFlattenChoices(SimpleTestCase):
     def test_tuple_choices(self):
         choices = [(1, "1st"), (2, "2nd")]

--- a/wagtail/tests/test_utils.py
+++ b/wagtail/tests/test_utils.py
@@ -599,3 +599,20 @@ class TestFlattenChoices(SimpleTestCase):
     def test_grouped_tuple_choices(self):
         choices = [("Group", [(1, "1st"), (2, "2nd")])]
         self.assertEqual(flatten_choices(choices), {"1": "1st", "2": "2nd"})
+
+    def test_dictionary_choices(self):
+        choices = {
+            "Martial Arts": {"judo": "Judo", "karate": "Karate"},
+            "Racket": {"badminton": "Badminton", "tennis": "Tennis"},
+            "unknown": "Unknown",
+        }
+        self.assertEqual(
+            flatten_choices(choices),
+            {
+                "judo": "Judo",
+                "karate": "Karate",
+                "badminton": "Badminton",
+                "tennis": "Tennis",
+                "unknown": "Unknown",
+            },
+        )

--- a/wagtail/utils/utils.py
+++ b/wagtail/utils/utils.py
@@ -13,3 +13,22 @@ def deep_update(source, overrides):
         else:
             source[key] = overrides[key]
     return source
+
+
+def flatten_choices(choices):
+    """
+    Convert potentially grouped choices into a flat dict of choices.
+
+    flatten_choices([(1, '1st'), (2, '2nd')]) -> {1: '1st', 2: '2nd'}
+    flatten_choices([('Group', [(1, '1st'), (2, '2nd')])]) -> {1: '1st', 2: '2nd'}
+    """
+    ret = {}
+    for key, value in choices:
+        if isinstance(value, (list, tuple)):
+            # grouped choices (category, sub choices)
+            for sub_key, sub_value in value:
+                ret[str(sub_key)] = sub_value
+        else:
+            # choice (key, display value)
+            ret[str(key)] = value
+    return ret

--- a/wagtail/utils/utils.py
+++ b/wagtail/utils/utils.py
@@ -21,12 +21,20 @@ def flatten_choices(choices):
 
     flatten_choices([(1, '1st'), (2, '2nd')]) -> {1: '1st', 2: '2nd'}
     flatten_choices([('Group', [(1, '1st'), (2, '2nd')])]) -> {1: '1st', 2: '2nd'}
+    flatten_choices({'Group': {'1': '1st', '2': '2nd'}}) -> {'1': '1st', '2': '2nd'}
     """
     ret = {}
-    for key, value in choices:
+
+    to_unpack = choices.items() if isinstance(choices, dict) else choices
+
+    for key, value in to_unpack:
         if isinstance(value, (list, tuple)):
             # grouped choices (category, sub choices)
             for sub_key, sub_value in value:
+                ret[str(sub_key)] = sub_value
+        elif isinstance(value, (dict)):
+            # grouped choices using dict (category, sub choices)
+            for sub_key, sub_value in value.items():
                 ret[str(sub_key)] = sub_value
         else:
             # choice (key, display value)


### PR DESCRIPTION
When using grouped choices in `ChoiceFilter`, the `active_filters` property of a `ModelViewSet` does not display the correct label, this PR flatten the choices to fix this issue.
