### PR TITLE
Copy for translations done signal and test

### DIFF
--- a/docs/reference/signals.md
+++ b/docs/reference/signals.md
@@ -194,3 +194,11 @@ This signal is emitted from a `TaskState` when a page's task is canceled.
 -   `instance` - The specific `TaskState` instance.
 -   `user` - The user who canceled the task
 -   `kwargs` - Any other arguments passed to `task_cancelled.send()`
+
+## copy_for_translation_done
+
+This signal is emitted from a `CopyPageForTranslationAction` when a page is being copied to a new locale (translated).
+
+-   `sender` - `CopyPageForTranslationAction`
+-   `source_obj` - The source page
+-   `target_obj` - The copy of the source page in the new locale

--- a/wagtail/actions/copy_for_translation.py
+++ b/wagtail/actions/copy_for_translation.py
@@ -3,6 +3,7 @@ from django.db import transaction
 
 from wagtail.coreutils import find_available_slug
 from wagtail.models.copying import _copy
+from wagtail.signals import copy_for_translation_done
 
 
 class ParentNotTranslatedError(Exception):
@@ -79,7 +80,7 @@ class CopyPageForTranslationAction:
 
     def walk(self, current_page):
         for child_page in current_page.get_children():
-            self._copy_for_translation(
+            translated_page = self._copy_for_translation(
                 child_page
                 if child_page.live
                 else child_page.get_latest_revision_as_object(),
@@ -88,6 +89,13 @@ class CopyPageForTranslationAction:
                 self.alias,
                 self.exclude_fields,
             )
+
+            copy_for_translation_done.send(
+                sender=self.__class__,
+                source_obj=child_page.specific,
+                target_obj=translated_page,
+            )
+
             self.walk(child_page)
 
     @transaction.atomic
@@ -158,6 +166,12 @@ class CopyPageForTranslationAction:
             self.copy_parents,
             self.alias,
             self.exclude_fields,
+        )
+
+        copy_for_translation_done.send(
+            sender=self.__class__,
+            source_obj=self.page,
+            target_obj=translated_page,
         )
 
         if self.include_subtree:

--- a/wagtail/signals.py
+++ b/wagtail/signals.py
@@ -66,4 +66,5 @@ task_cancelled = Signal()
 pre_validate_delete = Signal()
 
 # Translation signals
+# provides args: sender, source_obj, target_obj
 copy_for_translation_done = Signal()

--- a/wagtail/signals.py
+++ b/wagtail/signals.py
@@ -64,3 +64,6 @@ task_cancelled = Signal()
 # Required as a workaround for https://code.djangoproject.com/ticket/6870
 # provides args: sender, instance
 pre_validate_delete = Signal()
+
+# Translation signals
+copy_for_translation_done = Signal()

--- a/wagtail/tests/test_signals.py
+++ b/wagtail/tests/test_signals.py
@@ -1,9 +1,10 @@
 from unittest import mock
 
+from django.conf import settings
 from django.test import TestCase
 
-from wagtail.models import Site
-from wagtail.signals import page_slug_changed
+from wagtail.models import Locale, Site
+from wagtail.signals import copy_for_translation_done, page_slug_changed
 from wagtail.test.testapp.models import SimplePage
 from wagtail.test.utils import WagtailTestUtils
 
@@ -97,3 +98,49 @@ class TestPageSlugChangedSignal(WagtailTestUtils, TestCase):
 
         # Check the signal was NOT fired
         self.assertEqual(handler.call_count, 0)
+
+
+class TestCopyForTranslationDoneSignal(WagtailTestUtils, TestCase):
+    """
+    Tests for the `wagtail.signals.page_slug_changed` signal
+    """
+
+    def setUp(self):
+        # Find root page
+        site = Site.objects.select_related("root_page").get(is_default_site=True)
+        root_page = site.root_page
+
+        # Create a subpage
+        self.subpage = SimplePage(
+            title="Subpage in english", slug="subpage-in-english", content="hello"
+        )
+        root_page.add_child(instance=self.subpage)
+
+        # Get the languages and create locales
+        language_codes = dict(settings.LANGUAGES).keys()
+
+        for language_code in language_codes:
+            Locale.objects.get_or_create(language_code=language_code)
+
+        # Get the locales needed
+        self.locale = Locale.objects.get(language_code="en")
+        self.another_locale = Locale.objects.get(language_code="fr")
+
+        root_page.copy_for_translation(self.another_locale)
+
+    def test_signal_emitted_on_copy_for_translation_done(self):
+        # Connect a mock signal handler to the signal
+        handler = mock.MagicMock()
+        copy_for_translation_done.connect(handler)
+
+        page_to_translate = SimplePage.objects.get(id=self.subpage.id)
+
+        try:
+            with self.captureOnCommitCallbacks(execute=True):
+                page_to_translate.copy_for_translation(self.another_locale)
+        finally:
+            # Disconnect mock handler to prevent cross-test pollution
+            copy_for_translation_done.disconnect(handler)
+
+        # Check the signal was fired
+        self.assertEqual(handler.call_count, 1)


### PR DESCRIPTION
Adds a signal that triggers when a page is copied for translation, which then allows us to implement post processing of the data in the copied page, e.g. for machine translations.

See RFC: [Copy for translation done signal](https://github.com/wagtail/rfcs/blob/617018746f6ce5ebc5d50770b927473496c25abf/text/000-copy-for-translation-done-signal.md)