### PR TITLE
Remove undocumented autobuild.sh script

### DIFF
--- a/docs/autobuild.sh
+++ b/docs/autobuild.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-# If you want to run this script inside a vm and save changes outside of it
-# You should upgrade watchdog library to the latest in https://github.com/gorakhargosh/watchdog
-# and add --debug-force-polling argument to shell-command
-# watchmedo shell-command --debug-force-polling --patterns="*.rst" --ignore-pattern='_build/*' --recursive --command='make html; echo "Waiting for more changes..."'
-
-echo "Waiting for you to save the docs..."
-watchmedo shell-command --patterns="*.rst" --ignore-pattern='_build/*' --recursive --command='make html; echo "Waiting for more changes..."'


### PR DESCRIPTION
This script is undocumented and has a dependency that is not in the packages list for the documentation. There is a documented option that is preferred (https://github.com/wagtail/wagtail/blob/main/docs/README.md)

Run `sphinx-autobuild . _build` in the `docs` folder.