### PR TITLE
Fix (some) multiple chooser search issues

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/chooser/browse.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/browse.html
@@ -5,7 +5,7 @@
     {% trans "Choose a page" as choose_str %}
 {% endif %}
 
-{% include "wagtailadmin/shared/header.html" with title=choose_str subtitle=page_type_names|join:", " search_url="wagtailadmin_choose_page_search" query_parameters="page_type="|add:page_type_string icon="doc-empty-inverse" search_disable_async=True %}
+{% include "wagtailadmin/shared/header.html" with title=choose_str subtitle=page_type_names|join:", " search_url="wagtailadmin_choose_page_search" query_parameters="page_type="|add:page_type_string|add:"&multiple="|add:is_multiple_choice icon="doc-empty-inverse" search_disable_async=True %}
 
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='internal' %}

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -368,6 +368,15 @@ class TestChooserSearch(WagtailTestUtils, TransactionTestCase):
         self.assertTemplateUsed(response, "wagtailadmin/chooser/_search_results.html")
         self.assertContains(response, "There is 1 match")
         self.assertContains(response, "foobarbaz")
+        self.assertContains(response, "Parent")
+        self.assertNotContains(response, "data-multiple-choice-select")
+
+    def test_multiple(self):
+        response = self.get({"q": "foobarbaz", "multiple": "1"})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/chooser/_search_results.html")
+        self.assertNotContains(response, "Parent")
+        self.assertContains(response, "data-multiple-choice-select")
 
     def test_partial_match(self):
         response = self.get({"q": "fooba"})

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -405,9 +405,22 @@ class BrowseView(View):
 class SearchView(View):
     @property
     def columns(self):
-        cols = [
-            PageTitleColumn("title", label=_("Title")),
-            ParentPageColumn("parent", label=_("Parent")),
+        cols = []
+
+        if self.is_multiple_choice:
+            cols += [
+                PageCheckboxSelectColumn(
+                    "select", label=_("Select"), width="1%", accessor="pk"
+                ),
+                PageTitleColumn("title", label=_("Title")),
+            ]
+        else:
+            cols += [
+                PageTitleColumn("title", label=_("Title")),
+                ParentPageColumn("parent", label=_("Parent")),
+            ]
+
+        cols += [
             DateColumn(
                 "updated",
                 label=_("Updated"),
@@ -422,13 +435,6 @@ class SearchView(View):
             ),
             PageStatusColumn("status", label=_("Status"), width="12%"),
         ]
-        if self.is_multiple_choice:
-            cols.insert(
-                0,
-                PageCheckboxSelectColumn(
-                    "select", label=_("Select"), width="1%", accessor="pk"
-                ),
-            )
         return cols
 
     def get(self, request):


### PR DESCRIPTION
Fixes #10451 (I know this one was closed as a duplicate of #10754, but it feels like there's multiple issues)
Partial fixes towards #10754

### To test:
Feel free to use https://github.com/tomkins/multichooserdemo/tree/page-chooser-demo as a demo project. Quick script to create a bunch of Standard Pages in that demo:

```
from home.models import HomePage, StandardPage
home_page = HomePage.objects.get()

for i in range(100):
    home_page.add_child(instance=StandardPage(title=i))
```

Go to: http://127.0.0.1:8000/admin/pages/3/edit/ - and use the multi chooser. It should fix the following issues:

- When searching, the chooser on the left hand side disappears
- When searching, a "Parent" column appears, when you click this it breaks the multi chooser experience a bit

<img width="841" alt="Screenshot 2024-06-12 at 16 53 23" src="https://github.com/wagtail/wagtail/assets/177332/68540223-249e-4519-aac2-a30acbf4aed8">
<img width="834" alt="Screenshot 2024-06-12 at 16 53 31" src="https://github.com/wagtail/wagtail/assets/177332/654b7cde-4e81-4140-82ac-dcf7fb5dd252">

It should now look like:

<img width="836" alt="Screenshot 2024-06-12 at 16 55 43" src="https://github.com/wagtail/wagtail/assets/177332/63255a09-d979-4b8d-b60d-cb247964b37e">
