### PR TITLE
Integrate `django-tasks`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ install_requires = [
     "anyascii>=0.1.5",
     "telepath>=0.3.1,<1",
     "laces>=0.1,<0.2",
+    "django-tasks==0.1.1",
 ]
 
 # Testing dependencies

--- a/wagtail/contrib/frontend_cache/tasks.py
+++ b/wagtail/contrib/frontend_cache/tasks.py
@@ -1,0 +1,77 @@
+import logging
+import re
+from collections import defaultdict
+from urllib.parse import urlparse, urlunparse
+
+from django.conf import settings
+from django_tasks import task
+
+from wagtail.coreutils import get_content_languages
+
+from .utils import get_backends
+
+logger = logging.getLogger("wagtail.frontendcache")
+
+
+@task()
+def purge_urls_from_cache_task(urls, backend_settings=None, backends=None):
+    # Convert each url to urls one for each managed language (WAGTAILFRONTENDCACHE_LANGUAGES setting).
+    # The managed languages are common to all the defined backends.
+    # This depends on settings.USE_I18N
+    # If WAGTAIL_I18N_ENABLED is True, this defaults to WAGTAIL_CONTENT_LANGUAGES
+    wagtail_i18n_enabled = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
+    content_languages = get_content_languages() if wagtail_i18n_enabled else {}
+    languages = getattr(
+        settings, "WAGTAILFRONTENDCACHE_LANGUAGES", list(content_languages.keys())
+    )
+    if settings.USE_I18N and languages:
+        langs_regex = "^/(%s)/" % "|".join(languages)
+        new_urls = []
+
+        # Purge the given url for each managed language
+        for isocode in languages:
+            for url in urls:
+                up = urlparse(url)
+                new_url = urlunparse(
+                    (
+                        up.scheme,
+                        up.netloc,
+                        re.sub(langs_regex, "/%s/" % isocode, up.path),
+                        up.params,
+                        up.query,
+                        up.fragment,
+                    )
+                )
+
+                # Check for best performance. True if re.sub found no match
+                # It happens when i18n_patterns was not used in urls.py to serve content for different languages from different URLs
+                if new_url in new_urls:
+                    continue
+
+                new_urls.append(new_url)
+
+        urls = new_urls
+
+    urls_by_hostname = defaultdict(list)
+
+    for url in urls:
+        urls_by_hostname[urlparse(url).netloc].append(url)
+
+    backends = get_backends(backend_settings, backends)
+
+    for hostname, urls in urls_by_hostname.items():
+        backends_for_hostname = {
+            backend_name: backend
+            for backend_name, backend in backends.items()
+            if backend.invalidates_hostname(hostname)
+        }
+
+        if not backends_for_hostname:
+            logger.info("Unable to find purge backend for %s", hostname)
+            continue
+
+        for backend_name, backend in backends_for_hostname.items():
+            for url in urls:
+                logger.info("[%s] Purging URL: %s", backend_name, url)
+
+            backend.purge_batch(urls)

--- a/wagtail/contrib/frontend_cache/utils.py
+++ b/wagtail/contrib/frontend_cache/utils.py
@@ -1,13 +1,8 @@
 import logging
-import re
-from collections import defaultdict
-from urllib.parse import urlparse, urlunparse
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
-
-from wagtail.coreutils import get_content_languages
 
 logger = logging.getLogger("wagtail.frontendcache")
 
@@ -64,66 +59,9 @@ def purge_url_from_cache(url, backend_settings=None, backends=None):
 
 
 def purge_urls_from_cache(urls, backend_settings=None, backends=None):
-    # Convert each url to urls one for each managed language (WAGTAILFRONTENDCACHE_LANGUAGES setting).
-    # The managed languages are common to all the defined backends.
-    # This depends on settings.USE_I18N
-    # If WAGTAIL_I18N_ENABLED is True, this defaults to WAGTAIL_CONTENT_LANGUAGES
-    wagtail_i18n_enabled = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
-    content_languages = get_content_languages() if wagtail_i18n_enabled else {}
-    languages = getattr(
-        settings, "WAGTAILFRONTENDCACHE_LANGUAGES", list(content_languages.keys())
-    )
-    if settings.USE_I18N and languages:
-        langs_regex = "^/(%s)/" % "|".join(languages)
-        new_urls = []
+    from .tasks import purge_urls_from_cache_task
 
-        # Purge the given url for each managed language
-        for isocode in languages:
-            for url in urls:
-                up = urlparse(url)
-                new_url = urlunparse(
-                    (
-                        up.scheme,
-                        up.netloc,
-                        re.sub(langs_regex, "/%s/" % isocode, up.path),
-                        up.params,
-                        up.query,
-                        up.fragment,
-                    )
-                )
-
-                # Check for best performance. True if re.sub found no match
-                # It happens when i18n_patterns was not used in urls.py to serve content for different languages from different URLs
-                if new_url in new_urls:
-                    continue
-
-                new_urls.append(new_url)
-
-        urls = new_urls
-
-    urls_by_hostname = defaultdict(list)
-
-    for url in urls:
-        urls_by_hostname[urlparse(url).netloc].append(url)
-
-    backends = get_backends(backend_settings, backends)
-
-    for hostname, urls in urls_by_hostname.items():
-        backends_for_hostname = {
-            backend_name: backend
-            for backend_name, backend in backends.items()
-            if backend.invalidates_hostname(hostname)
-        }
-
-        if not backends_for_hostname:
-            logger.info("Unable to find purge backend for %s", hostname)
-            continue
-
-        for backend_name, backend in backends_for_hostname.items():
-            for url in urls:
-                logger.info("[%s] Purging URL: %s", backend_name, url)
-
-            backend.purge_batch(urls)
+    purge_urls_from_cache_task.enqueue(urls, backend_settings, backends)
 
 
 def _get_page_cached_urls(page):

--- a/wagtail/documents/signal_handlers.py
+++ b/wagtail/documents/signal_handlers.py
@@ -2,11 +2,15 @@ from django.db import transaction
 from django.db.models.signals import post_delete
 
 from wagtail.documents import get_document_model
+from wagtail.tasks import delete_file_from_storage_task
 
 
 def post_delete_file_cleanup(instance, **kwargs):
-    # Pass false so FileField doesn't save the model.
-    transaction.on_commit(lambda: instance.file.delete(False))
+    transaction.on_commit(
+        lambda: delete_file_from_storage_task.enqueue(
+            instance.file.storage.deconstruct(), instance.file.name
+        )
+    )
 
 
 def register_signal_handlers():

--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -3,7 +3,6 @@ from django.db.models import ForeignKey
 from django.utils.translation import gettext_lazy as _
 
 from . import checks, get_image_model  # NOQA: F401
-from .signal_handlers import register_signal_handlers
 
 
 class WagtailImagesAppConfig(AppConfig):
@@ -14,6 +13,8 @@ class WagtailImagesAppConfig(AppConfig):
     default_attrs = {}
 
     def ready(self):
+        from .signal_handlers import register_signal_handlers
+
         register_signal_handlers()
 
         # Set up model forms to use AdminImageChooser for any ForeignKey to the image model

--- a/wagtail/images/signal_handlers.py
+++ b/wagtail/images/signal_handlers.py
@@ -1,8 +1,10 @@
 from django.conf import settings
 from django.db import transaction
-from django.db.models.signals import post_delete, pre_save
+from django.db.models.signals import post_delete, post_save
 
 from wagtail.images import get_image_model
+
+from .tasks import set_image_focal_point_task
 
 
 def post_delete_file_cleanup(instance, **kwargs):
@@ -14,21 +16,22 @@ def post_delete_purge_rendition_cache(instance, **kwargs):
     instance.purge_from_cache()
 
 
-def pre_save_image_feature_detection(instance, **kwargs):
+def post_save_image_feature_detection(instance, **kwargs):
     if getattr(settings, "WAGTAILIMAGES_FEATURE_DETECTION_ENABLED", False):
         # Make sure the image is not from a fixture
-        if kwargs["raw"] is False:
-            # Make sure the image doesn't already have a focal point
-            if not instance.has_focal_point():
-                # Set the focal point
-                instance.set_focal_point(instance.get_suggested_focal_point())
+        # and the image doesn't already have a focal point
+        if kwargs["raw"] is False and not instance.has_focal_point():
+            # Set the focal point
+            set_image_focal_point_task.enqueue(
+                instance._meta.app_label, instance._meta.model_name, instance.pk
+            )
 
 
 def register_signal_handlers():
     Image = get_image_model()
     Rendition = Image.get_rendition_model()
 
-    pre_save.connect(pre_save_image_feature_detection, sender=Image)
+    post_save.connect(post_save_image_feature_detection, sender=Image)
     post_delete.connect(post_delete_file_cleanup, sender=Image)
     post_delete.connect(post_delete_file_cleanup, sender=Rendition)
     post_delete.connect(post_delete_purge_rendition_cache, sender=Rendition)

--- a/wagtail/images/tasks.py
+++ b/wagtail/images/tasks.py
@@ -1,0 +1,18 @@
+from django.apps import apps
+from django_tasks import task
+
+
+@task()
+def set_image_focal_point_task(app_label, model_name, pk):
+    model = apps.get_model(app_label, model_name)
+    instance = model.objects.get(pk=pk)
+    instance.set_focal_point(instance.get_suggested_focal_point())
+
+    instance.save(
+        update_fields=[
+            "focal_point_x",
+            "focal_point_y",
+            "focal_point_width",
+            "focal_point_height",
+        ]
+    )

--- a/wagtail/search/signal_handlers.py
+++ b/wagtail/search/signal_handlers.py
@@ -1,16 +1,13 @@
 from django.db.models.signals import post_delete, post_save
 
-from wagtail.search import index
+from . import index
+from .tasks import insert_or_update_object_task
 
 
-def post_save_signal_handler(instance, update_fields=None, **kwargs):
-    if update_fields is not None:
-        # fetch a fresh copy of instance from the database to ensure
-        # that we're not indexing any of the unsaved data contained in
-        # the fields that were not passed in update_fields
-        instance = type(instance).objects.get(pk=instance.pk)
-
-    index.insert_or_update_object(instance)
+def post_save_signal_handler(instance, **kwargs):
+    insert_or_update_object_task.enqueue(
+        instance._meta.app_label, instance._meta.model_name, instance.pk
+    )
 
 
 def post_delete_signal_handler(instance, **kwargs):

--- a/wagtail/search/tasks.py
+++ b/wagtail/search/tasks.py
@@ -1,0 +1,10 @@
+from django.apps import apps
+from django_tasks import task
+
+from wagtail.search import index
+
+
+@task()
+def insert_or_update_object_task(app_label, model_name, pk):
+    model = apps.get_model(app_label, model_name)
+    index.insert_or_update_object(model.objects.get(pk=pk))

--- a/wagtail/tasks.py
+++ b/wagtail/tasks.py
@@ -1,5 +1,6 @@
 from django.apps import apps
 from django.db import transaction
+from django.utils.module_loading import import_string
 from django_tasks import task
 from modelcluster.fields import ParentalKey
 
@@ -30,3 +31,11 @@ def update_reference_index_task(app_label, model_name, pk):
     if ReferenceIndex.is_indexed(instance._meta.model):
         with transaction.atomic():
             ReferenceIndex.create_or_update_for_object(instance)
+
+
+@task()
+def delete_file_from_storage_task(deconstructed_storage, path):
+    storage_module, storage_args, storage_kwargs = deconstructed_storage
+    storage = import_string(storage_module)(*storage_args, **storage_kwargs)
+
+    storage.delete(path)

--- a/wagtail/tasks.py
+++ b/wagtail/tasks.py
@@ -1,0 +1,32 @@
+from django.apps import apps
+from django.db import transaction
+from django_tasks import task
+from modelcluster.fields import ParentalKey
+
+from wagtail.models import ReferenceIndex
+
+
+@task()
+def update_reference_index_task(app_label, model_name, pk):
+    model = apps.get_model(app_label, model_name)
+    instance = model.objects.get(pk=pk)
+
+    # If the model is a child model, find the parent instance and index that instead
+    while True:
+        parental_keys = list(
+            filter(
+                lambda field: isinstance(field, ParentalKey),
+                instance._meta.get_fields(),
+            )
+        )
+        if not parental_keys:
+            break
+
+        instance = getattr(instance, parental_keys[0].name)
+        if instance is None:
+            # parent is null, so there is no valid object to record references against
+            return
+
+    if ReferenceIndex.is_indexed(instance._meta.model):
+        with transaction.atomic():
+            ReferenceIndex.create_or_update_for_object(instance)


### PR DESCRIPTION
This PR adds the initial integration of [`django-tasks`](https://github.com/realOrangeOne/django-tasks) following the [acceptance of DEP 14](https://www.djangoproject.com/weblog/2024/may/29/django-enhancement-proposal-14-background-workers/). This moves computational complexity from the request-response lifecycle into the background.

By default, `django-tasks` uses its `ImmediateBackend`, meaning tasks are still run inside the request-response lifecycle. This means introducing this is a non-breaking change, and merely an extra dependency.

Because the state of `django-tasks` is still in very active development, the specific version is pinned rather than a range.

## Functionality moved to the background

- Updating or creating a search index entry when modifying a page
- Updating or creating entries for the reference index
- Calculating image focal point.
- Purging frontend caching URLs
- Deleting document files when the model is deleted (`documents/signal_handlers.py`)
- Deleting image files when the model is deleted (`images/signal_handlers.py`)

## To do

- Admin email sending (`admin/mail.py`)
- Moving pages?

...

- Documentation, probably

## Functionality tried and failed

- I attempted to move removing search and reference indexes, however the current APIs assume they can get a full object instance, which isn't correct if the instance has already been deleted (which it would have by the time the task runs). This could be solved using `pickle` (and some signing), but I don't want to venture down that path if we can avoid it.
- I had originally planned to move creating redirects when pages are moved, but this would result in a race condition, where the page would 404 between the page being moved and the redirect being added. As it should be relative simple to add these, the impact of leaving it in the request cycle shouldn't be huge.

--- 

The diff here is quite large, but most of it is just moving existing code into different files. I've done this so that anyone using these functions in their code doesn't need to change anything, thus making the change non-breaking. I've standardised on `tasks.py` as the location for tasks. The `_tasks` suffix is merely to avoid confusion with existing methods, as currently the changes are non-intrusive.

This PR is opened simply for reference - it's not yet at a point to be seriously reviewed or considered (hence "Draft").