### PR TITLE
Add a documentation page for extending on richtext output

### DIFF
--- a/docs/extending/customizing_richtext_output.md
+++ b/docs/extending/customizing_richtext_output.md
@@ -1,6 +1,6 @@
 (customizing_richtext_output)=
 
-# Customizing rich text output
+# Customizing richtext output
 In some cases, it might be necessary to customize the output of a [RichTextField](rich_text_field), or a `RichTextBlock` within a [StreamField](../topics/streamfield).
 
 This can be done through a simple [Django filter](https://docs.djangoproject.com/en/5.0/howto/custom-template-tags/).
@@ -10,7 +10,6 @@ This can be done through a simple [Django filter](https://docs.djangoproject.com
 This example shows how to add a class to all `<p>` tags in a RichTextField or a RichTextBlock.
 
 In your templatetag library file, add a new filter:
-
 
 ```python
 from bs4 import BeautifulSoup

--- a/docs/extending/customizing_richtext_output.md
+++ b/docs/extending/customizing_richtext_output.md
@@ -1,0 +1,63 @@
+(customizing_richtext_output)=
+
+# Customizing rich text output
+In some cases, it might be necessary to customize the output of a [RichTextField](rich_text_field), or a `RichTextBlock` within a [StreamField](../topics/streamfield).
+
+This can be done through a simple [Django filter](https://docs.djangoproject.com/en/5.0/howto/custom-template-tags/).
+
+## Add a class to HTML tags
+
+This example shows how to add a class to all `<p>` tags in a RichTextField or a RichTextBlock.
+
+In your templatetag library file, add a new filter:
+
+
+```python
+from bs4 import BeautifulSoup
+from django import template
+from django.utils.html import mark_safe
+from wagtail.rich_text import RichText
+
+register = template.Library()
+
+# [...]
+
+@register.filter
+def richtext_p_add_class(value, class_name: str):
+    """
+    Adds a CSS class to a Richtext-generated paragraph.
+
+    Intended to be used right after a `| richext` filter in case of a RichTextField
+    (not necessary for a RichTextBlock)
+    """
+
+    if not class_name:
+        return value
+
+    if isinstance(value, RichText):
+        # In case of a RichTextBlock, first render it
+        value = str(value)
+
+    soup = BeautifulSoup(value, "html.parser")
+
+    paragraphs = soup.find_all("p")
+
+    for p in paragraphs:
+        p["class"] = p.get("class", []) + [class_name]
+
+    return mark_safe(str(soup))
+```
+
+Now, in your templates, you can add the following (don't forget to load your templatetag library):
+
+For a RichTextField:
+
+```html+django
+{{ page.sample_richtext_fied | richtext | richtext_p_add_class:"new_class" }}
+```
+
+For a RichTextBlock:
+
+```html+django
+{{ value.sample_richtext_block | richtext_p_add_class:"new_class" }}
+```

--- a/docs/extending/index.md
+++ b/docs/extending/index.md
@@ -21,5 +21,6 @@ custom_image_filters
 extending_client_side
 rich_text_internals
 extending_draftail
+customizing_richtext_output
 custom_bulk_actions
 ```


### PR DESCRIPTION
New documentation page on how to solve an issue that took two people into a couple hour long rabbit hole of having to update every layer from a Wagtail model to the Draftail editor, when a simpler solution was possible.