### PR TITLE
Fix image preview when Willow optimizers are enabled

### DIFF
--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import urllib
+from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth.models import Group, Permission
@@ -14,6 +15,8 @@ from django.utils.encoding import force_str
 from django.utils.html import escape, escapejs
 from django.utils.http import RFC3986_SUBDELIMS, urlencode
 from django.utils.safestring import mark_safe
+from willow.optimizers.base import OptimizerBase
+from willow.registry import registry
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.images import get_image_model
@@ -3530,6 +3533,35 @@ class TestPreviewView(WagtailTestUtils, TestCase):
         response = self.client.get(
             reverse("wagtailimages:preview", args=(self.image.id, "fill-800x600"))
         )
+
+        # Check response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "image/png")
+
+    def test_preview_with_optimizer(self):
+        """
+        Test that preview works with optimizers
+
+        Willow optimizers require
+        """
+
+        class DummyOptimizer(OptimizerBase):
+            library_name = "dummy"
+            image_format = "png"
+
+            @classmethod
+            def check_library(cls):
+                return True
+
+            @classmethod
+            def process(cls, file_path: str):
+                pass
+
+        # Get the image
+        with patch.object(registry, "_registered_optimizers", [DummyOptimizer]):
+            response = self.client.get(
+                reverse("wagtailimages:preview", args=(self.image.id, "fill-800x600"))
+            )
 
         # Check response
         self.assertEqual(response.status_code, 200)

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -1,9 +1,9 @@
 import os
-from io import BytesIO
+from tempfile import SpooledTemporaryFile
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.http import HttpResponse, JsonResponse
+from django.http import FileResponse, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -293,10 +293,10 @@ def preview(request, image_id, filter_spec):
 
     try:
         # Temporary image needs to be an instance that Willow can run optimizers on
-        temp_image = BytesIO()
+        temp_image = SpooledTemporaryFile(max_size=settings.FILE_UPLOAD_MAX_MEMORY_SIZE)
         image = Filter(spec=filter_spec).run(image, temp_image)
         temp_image.seek(0)
-        response = HttpResponse(temp_image)
+        response = FileResponse(temp_image)
         response["Content-Type"] = "image/" + image.format_name
         return response
     except InvalidFilterSpecError:

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -1,4 +1,5 @@
 import os
+from io import BytesIO
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
@@ -291,8 +292,11 @@ def preview(request, image_id, filter_spec):
     image = get_object_or_404(get_image_model(), id=image_id)
 
     try:
-        response = HttpResponse()
-        image = Filter(spec=filter_spec).run(image, response)
+        # Temporary image needs to be an instance that Willow can run optimizers on
+        temp_image = BytesIO()
+        image = Filter(spec=filter_spec).run(image, temp_image)
+        temp_image.seek(0)
+        response = HttpResponse(temp_image)
         response["Content-Type"] = "image/" + image.format_name
         return response
     except InvalidFilterSpecError:


### PR DESCRIPTION
Avoids wagtail/Willow#147

Follow the steps to reproduce - should be the exact same for testing.

I've gone for fixing the preview as the goal for this one. One potential alternative could be that `Filter.run` has an `optimize=True` parameter, which could then be disabled for previews.

~However as the run method has typing to say that output is BytesIO (which doesn't match HttpResponse) - I've gone for switching it.~