### PR TITLE
check_dead_providers.py added to return the list of bad requests endp…

### DIFF
--- a/wagtail/embeds/check_dead_providers.py
+++ b/wagtail/embeds/check_dead_providers.py
@@ -1,0 +1,75 @@
+import requests
+
+all_providers = [
+    {
+        "endpoint": "https://animoto.com/services/oembed",
+        "urls": [r"^https?://animoto\.com/play/.+$"],
+    },
+    {
+        "endpoint": "https://alpha-api.app.net/oembed",
+        "urls": [r"^https?://alpha\.app\.net/[^#?/]+/post/.+$", r"^https?://photos\.app\.net/[^#?/]+/.+$"],
+    },
+    {
+        "endpoint": "https://audioboom.com/publishing/oembed.{format}",
+        "urls": [r"^https?://audioboom\.com/boos/.+$", r"^https?://audioboom\.com/posts/.+$"],
+    },
+    {
+        "endpoint": "http://api.bambuser.com/oembed.{format}",
+        "urls": [r"^http://bambuser\.com/channel/[^#?/]+/broadcast/.+$", r"^http://bambuser\.com/channel/.+$", r"^http://bambuser\.com/v/.+$"],
+    },
+    {
+        "endpoint": "http://blip.tv/oembed/",
+        "urls": [r"^http://[-\w]+\.blip\.tv/.+$"],
+    },
+    {
+        "endpoint": "http://vzaar.com/api/videos/{1}.{format}",
+        "urls": [
+            r"^http://(?:www\.)?vzaar\.com/videos/([^#?/]+)(?:.+)?$",
+            r"^http://www\.vzaar\.tv/([^#?/]+)(?:.+)?$",
+            r"^http://vzaar\.tv/([^#?/]+)(?:.+)?$",
+            r"^http://vzaar\.me/([^#?/]+)(?:.+)?$",
+            r"^http://[-\w]+\.vzaar\.me/([^#?/]+)(?:.+)?$",
+        ],
+    },
+    {
+        "endpoint": "http://fast.wistia.com/oembed.{format}",
+        "urls": [r"^https?://([^/]+\.)?(wistia.com|wi.st)/(medias|embed)/.+$"],
+    },
+    {
+        "endpoint": "https://wordpress.tv/oembed/",
+        "urls": [r"^https?://wordpress\.tv/.+$"],
+    },
+    {
+        "endpoint": "https://video.yandex.ru/oembed.{format}",
+        "urls": [r"^https?://video\.yandex\.ru/users/[^#?/]+/view/.+$"],
+    },
+    {
+        "endpoint": "http://www.yfrog.com/api/oembed",
+        "urls": [r"^https?://(?:www\.)?yfrog\.com/.+$", r"^https?://(?:www\.)?yfrog\.us/.+$"],
+    },
+    
+]
+
+def check_providers(providers):
+    dead_providers = []
+
+    for provider in providers:
+        endpoint = provider['endpoint']
+        if '{format}' in endpoint:
+            endpoint = endpoint.replace("{format}", "json")
+        if '{1}' in endpoint:
+            endpoint = endpoint.replace("{1}", "1")
+        
+        try:
+            response = requests.get(endpoint, timeout=10)
+            if response.status_code != 200:
+                dead_providers.append(provider)
+        except requests.exceptions.RequestException:
+            dead_providers.append(provider)
+    
+    return dead_providers
+
+dead_providers = check_providers(all_providers)
+print("Providers with endpoints not opening or dead:")
+for provider in dead_providers:
+    print(provider)

--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -401,13 +401,7 @@ polleverywhere = {
     ],
 }
 
-qik = {
-    "endpoint": "http://qik.com/api/oembed.{format}",
-    "urls": [
-        r"^http://qik\.com/.+$",
-        r"^http://qik\.ly/.+$",
-    ],
-}
+
 
 
 rdio = {
@@ -423,14 +417,6 @@ reddit = {
     "endpoint": "https://www.reddit.com/oembed",
     "urls": [
         "^https?://(?:www\\.)?reddit\\.com/r/+[^#?/]+/comments/+[^#?/]+[^#?/].+$",
-    ],
-}
-
-
-revision3 = {
-    "endpoint": "http://revision3.com/api/oembed/",
-    "urls": [
-        r"^http://[-\w]+\.revision3\.com/.+$",
     ],
 }
 
@@ -738,10 +724,8 @@ all_providers = [
     pinterest,
     polldaddy,
     polleverywhere,
-    qik,
     rdio,
     reddit,
-    revision3,
     roomshare,
     sapo,
     screenr,


### PR DESCRIPTION
@tomkins
the check_dead_providers.py can identify the dead providers and then removed it from list,although i removed the get_embed('http://www.revision3.com/demo') 
and 
get_embed('http://qik.com/demo')

if only these two which need to be removed was a problem then i think there is no need for check_dead_providers.py.