### PR TITLE
Compact representation for StreamField migrations

### DIFF
--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -97,6 +97,17 @@ class Block(metaclass=BaseBlock):
 
         self.label = self.meta.label or ""
 
+    @classmethod
+    def construct_from_lookup(cls, lookup, *args, **kwargs):
+        """
+        See `wagtail.blocks.definition_lookup.BlockDefinitionLookup`.
+        Construct a block instance from the provided arguments, using the given BlockDefinitionLookup
+        object to perform any necessary lookups.
+        """
+        # In the base implementation, no lookups take place - args / kwargs are passed
+        # on to the constructor as-is
+        return cls(*args, **kwargs)
+
     def set_name(self, name):
         self.name = name
         if not self.meta.label:

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -376,7 +376,11 @@ class Block(metaclass=BaseBlock):
         """
         return False
 
-    def deconstruct(self):
+    @cached_property
+    def canonical_module_path(self):
+        """
+        Return the module path string that should be used to refer to this block in migrations.
+        """
         # adapted from django.utils.deconstruct.deconstructible
         module_name = self.__module__
         name = self.__class__.__name__
@@ -394,12 +398,13 @@ class Block(metaclass=BaseBlock):
         # if the module defines a DECONSTRUCT_ALIASES dictionary, see if the class has an entry in there;
         # if so, use that instead of the real path
         try:
-            path = module.DECONSTRUCT_ALIASES[self.__class__]
+            return module.DECONSTRUCT_ALIASES[self.__class__]
         except (AttributeError, KeyError):
-            path = f"{module_name}.{name}"
+            return f"{module_name}.{name}"
 
+    def deconstruct(self):
         return (
-            path,
+            self.canonical_module_path,
             self._constructor_args[0],
             self._constructor_args[1],
         )

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -420,6 +420,18 @@ class Block(metaclass=BaseBlock):
             self._constructor_args[1],
         )
 
+    def deconstruct_with_lookup(self, lookup):
+        """
+        Like `deconstruct`, but with a `wagtail.blocks.definition_lookup.BlockDefinitionLookupBuilder`
+        object available so that any block instances within the definition can be added to the lookup
+        table to obtain an ID (potentially shared with other matching block definitions, thus reducing
+        the overall definition size) to be used in place of the block. The resulting deconstructed form
+        returned here can then be restored into a block object using `Block.construct_from_lookup`.
+        """
+        # In the base implementation, no substitutions happen, so we ignore the lookup and just call
+        # deconstruct
+        return self.deconstruct()
+
     def __eq__(self, other):
         """
         Implement equality on block objects so that two blocks with matching definitions are considered

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -439,14 +439,9 @@ class Block(metaclass=BaseBlock):
         attributes identified in MUTABLE_META_ATTRIBUTES, so checking these along with the result of
         deconstruct (which captures the constructor arguments) is sufficient to identify (valid) differences.
 
-        This was originally necessary as a workaround for https://code.djangoproject.com/ticket/24340
-        in Django <1.9; the deep_deconstruct function used to detect changes for migrations did not
-        recurse into the block lists, and left them as Block instances. This __eq__ method therefore
-        came into play when identifying changes within migrations.
-
-        As of Django >=1.9, this *probably* isn't required any more. However, it may be useful in
-        future as a way of identifying blocks that can be re-used within StreamField definitions
-        (https://github.com/wagtail/wagtail/issues/4298#issuecomment-367656028).
+        This was implemented as a workaround for a Django <1.9 bug and is quite possibly not used by Wagtail
+        any more, but has been retained as it provides a sensible definition of equality (and there's no
+        reason to break it).
         """
 
         if not isinstance(other, Block):

--- a/wagtail/blocks/definition_lookup.py
+++ b/wagtail/blocks/definition_lookup.py
@@ -1,0 +1,47 @@
+from importlib import import_module
+
+
+class BlockDefinitionLookup:
+    """
+    A utility for constructing StreamField Block objects in migrations, starting from
+    a compact representation that avoids repeating the same definition whenever a
+    block is re-used in multiple places over the block definition tree.
+
+    The underlying data is a list of block definitions, such as:
+    ```
+    [
+        ("wagtail.blocks.CharBlock", [], {"required": True}),
+        ("wagtail.blocks.RichTextBlock", [], {}),
+        ("wagtail.blocks.StreamBlock", [
+            [
+                ("heading", 0),
+                ("paragraph", 1),
+            ],
+        ], {}),
+    ]
+    ```
+
+    where each definition is a tuple of (module_path, args, kwargs) similar to that
+    returned by `deconstruct` - with the difference that any block objects appearing
+    in args / kwargs may be substituted with an index into the lookup table that
+    points to that block's definition. Any block class that wants to support such
+    substitutions should implement a static/class method
+    `construct_from_lookup(lookup, *args, **kwargs)`, where `lookup` is
+    the `BlockDefinitionLookup` instance. The method should return a block instance
+    constructed from the provided arguments (after performing any lookups).
+    """
+
+    def __init__(self, blocks):
+        self.blocks = blocks
+        self.block_classes = {}
+
+    def get_block(self, index):
+        path, args, kwargs = self.blocks[index]
+        try:
+            cls = self.block_classes[path]
+        except KeyError:
+            module_name, class_name = path.rsplit(".", 1)
+            module = import_module(module_name)
+            cls = self.block_classes[path] = getattr(module, class_name)
+
+        return cls.construct_from_lookup(self, *args, **kwargs)

--- a/wagtail/blocks/definition_lookup.py
+++ b/wagtail/blocks/definition_lookup.py
@@ -8,18 +8,18 @@ class BlockDefinitionLookup:
     a compact representation that avoids repeating the same definition whenever a
     block is re-used in multiple places over the block definition tree.
 
-    The underlying data is a list of block definitions, such as:
+    The underlying data is a dict of block definitions, such as:
     ```
-    [
-        ("wagtail.blocks.CharBlock", [], {"required": True}),
-        ("wagtail.blocks.RichTextBlock", [], {}),
-        ("wagtail.blocks.StreamBlock", [
+    {
+        0: ("wagtail.blocks.CharBlock", [], {"required": True}),
+        1: ("wagtail.blocks.RichTextBlock", [], {}),
+        2: ("wagtail.blocks.StreamBlock", [
             [
                 ("heading", 0),
                 ("paragraph", 1),
             ],
         ], {}),
-    ]
+    }
     ```
 
     where each definition is a tuple of (module_path, args, kwargs) similar to that
@@ -80,3 +80,6 @@ class BlockDefinitionLookupBuilder:
         self.blocks.append(deconstructed)
         block_indexes.append((index, deconstructed))
         return index
+
+    def get_lookup_as_dict(self):
+        return dict(enumerate(self.blocks))

--- a/wagtail/blocks/list_block.py
+++ b/wagtail/blocks/list_block.py
@@ -402,6 +402,12 @@ class ListBlock(Block):
         errors.extend(self.child_block.check(**kwargs))
         return errors
 
+    def deconstruct_with_lookup(self, lookup):
+        path, args, kwargs = super().deconstruct_with_lookup(lookup)
+        if isinstance(args[0], Block):
+            args = (lookup.add_block(args[0]),)
+        return path, args, kwargs
+
     class Meta:
         # No icon specified here, because that depends on the purpose that the
         # block is being used for. Feel encouraged to specify an icon in your

--- a/wagtail/blocks/list_block.py
+++ b/wagtail/blocks/list_block.py
@@ -151,6 +151,12 @@ class ListBlock(Block):
             # Default to a list consisting of one empty (i.e. default-valued) child item
             self.meta.default = [self.child_block.get_default()]
 
+    @classmethod
+    def construct_from_lookup(cls, lookup, child_block, **kwargs):
+        if isinstance(child_block, int):
+            child_block = lookup.get_block(child_block)
+        return cls(child_block, **kwargs)
+
     def value_from_datadict(self, data, files, prefix):
         count = int(data["%s-count" % prefix])
         child_blocks_with_indexes = []

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -441,6 +441,17 @@ class BaseStreamBlock(Block):
         kwargs = self._constructor_kwargs
         return (path, args, kwargs)
 
+    def deconstruct_with_lookup(self, lookup):
+        path = "wagtail.blocks.StreamBlock"
+        args = [
+            [
+                (name, lookup.add_block(block))
+                for name, block in self.child_blocks.items()
+            ]
+        ]
+        kwargs = self._constructor_kwargs
+        return (path, args, kwargs)
+
     def check(self, **kwargs):
         errors = super().check(**kwargs)
         for name, child_block in self.child_blocks.items():

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -89,6 +89,14 @@ class BaseStreamBlock(Block):
                 block.set_name(name)
                 self.child_blocks[name] = block
 
+    @classmethod
+    def construct_from_lookup(cls, lookup, child_blocks, **kwargs):
+        if child_blocks:
+            child_blocks = [
+                (name, lookup.get_block(index)) for name, index in child_blocks
+            ]
+        return cls(child_blocks, **kwargs)
+
     def empty_value(self, raw_text=None):
         return StreamValue(self, [], raw_text=raw_text)
 

--- a/wagtail/blocks/struct_block.py
+++ b/wagtail/blocks/struct_block.py
@@ -320,6 +320,17 @@ class BaseStructBlock(Block):
         kwargs = self._constructor_kwargs
         return (path, args, kwargs)
 
+    def deconstruct_with_lookup(self, lookup):
+        path = "wagtail.blocks.StructBlock"
+        args = [
+            [
+                (name, lookup.add_block(block))
+                for name, block in self.child_blocks.items()
+            ]
+        ]
+        kwargs = self._constructor_kwargs
+        return (path, args, kwargs)
+
     def check(self, **kwargs):
         errors = super().check(**kwargs)
         for name, child_block in self.child_blocks.items():

--- a/wagtail/blocks/struct_block.py
+++ b/wagtail/blocks/struct_block.py
@@ -119,6 +119,14 @@ class BaseStructBlock(Block):
                 block.set_name(name)
                 self.child_blocks[name] = block
 
+    @classmethod
+    def construct_from_lookup(cls, lookup, child_blocks, **kwargs):
+        if child_blocks:
+            child_blocks = [
+                (name, lookup.get_block(index)) for name, index in child_blocks
+            ]
+        return cls(child_blocks, **kwargs)
+
     def get_default(self):
         """
         Any default value passed in the constructor or self.meta is going to be a dict

--- a/wagtail/contrib/typed_table_block/blocks.py
+++ b/wagtail/contrib/typed_table_block/blocks.py
@@ -267,6 +267,17 @@ class BaseTypedTableBlock(Block):
         kwargs = self._constructor_kwargs
         return (path, args, kwargs)
 
+    def deconstruct_with_lookup(self, lookup):
+        path = "wagtail.contrib.typed_table_block.blocks.TypedTableBlock"
+        args = [
+            [
+                (name, lookup.add_block(block))
+                for name, block in self.child_blocks.items()
+            ]
+        ]
+        kwargs = self._constructor_kwargs
+        return (path, args, kwargs)
+
     def check(self, **kwargs):
         errors = super().check(**kwargs)
         for name, child_block in self.child_blocks.items():

--- a/wagtail/contrib/typed_table_block/blocks.py
+++ b/wagtail/contrib/typed_table_block/blocks.py
@@ -87,6 +87,14 @@ class BaseTypedTableBlock(Block):
                 block.set_name(name)
                 self.child_blocks[name] = block
 
+    @classmethod
+    def construct_from_lookup(cls, lookup, child_blocks, **kwargs):
+        if child_blocks:
+            child_blocks = [
+                (name, lookup.get_block(index)) for name, index in child_blocks
+            ]
+        return cls(child_blocks, **kwargs)
+
     def value_from_datadict(self, data, files, prefix):
         caption = data["%s-caption" % prefix]
 

--- a/wagtail/contrib/typed_table_block/tests.py
+++ b/wagtail/contrib/typed_table_block/tests.py
@@ -263,9 +263,9 @@ class TestTableBlock(TestCase):
 class TestBlockDefinitionLookup(TestCase):
     def test_block_lookup(self):
         lookup = BlockDefinitionLookup(
-            [
-                ("wagtail.blocks.CharBlock", [], {"required": True}),
-                (
+            {
+                0: ("wagtail.blocks.CharBlock", [], {"required": True}),
+                1: (
                     "wagtail.blocks.ChoiceBlock",
                     [],
                     {
@@ -276,7 +276,7 @@ class TestBlockDefinitionLookup(TestCase):
                         ]
                     },
                 ),
-                (
+                2: (
                     "wagtail.contrib.typed_table_block.blocks.TypedTableBlock",
                     [
                         [
@@ -286,7 +286,7 @@ class TestBlockDefinitionLookup(TestCase):
                     ],
                     {},
                 ),
-            ]
+            }
         )
         struct_block = lookup.get_block(2)
         self.assertIsInstance(struct_block, TypedTableBlock)

--- a/wagtail/contrib/typed_table_block/tests.py
+++ b/wagtail/contrib/typed_table_block/tests.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 
 from wagtail import blocks
 from wagtail.blocks.base import get_error_json_data
+from wagtail.blocks.definition_lookup import BlockDefinitionLookup
 from wagtail.blocks.struct_block import StructBlockValidationError
 from wagtail.contrib.typed_table_block.blocks import (
     TypedTable,
@@ -257,3 +258,40 @@ class TestTableBlock(TestCase):
                 "blockErrors": {1: {2: {"messages": ["This field is required."]}}},
             },
         )
+
+
+class TestBlockDefinitionLookup(TestCase):
+    def test_block_lookup(self):
+        lookup = BlockDefinitionLookup(
+            [
+                ("wagtail.blocks.CharBlock", [], {"required": True}),
+                (
+                    "wagtail.blocks.ChoiceBlock",
+                    [],
+                    {
+                        "choices": [
+                            ("be", "Belgium"),
+                            ("fr", "France"),
+                            ("nl", "Netherlands"),
+                        ]
+                    },
+                ),
+                (
+                    "wagtail.contrib.typed_table_block.blocks.TypedTableBlock",
+                    [
+                        [
+                            ("text", 0),
+                            ("country", 1),
+                        ],
+                    ],
+                    {},
+                ),
+            ]
+        )
+        struct_block = lookup.get_block(2)
+        self.assertIsInstance(struct_block, TypedTableBlock)
+        text_block = struct_block.child_blocks["text"]
+        self.assertIsInstance(text_block, blocks.CharBlock)
+        self.assertTrue(text_block.required)
+        country_block = struct_block.child_blocks["country"]
+        self.assertIsInstance(country_block, blocks.ChoiceBlock)

--- a/wagtail/fields.py
+++ b/wagtail/fields.py
@@ -96,7 +96,7 @@ class StreamField(models.Field):
             the top level block (as a block instance or class).
         :param use_json_field: Ignored, but retained for compatibility with historical migrations.
         :param block_lookup: Used in migrations to provide a more compact block definition -
-            see `wagtail.blocks.definition_lookup.BlockDefinitionLookup`. If passed, `block_types`
+            see ``wagtail.blocks.definition_lookup.BlockDefinitionLookup``. If passed, ``block_types``
             can contain integer indexes into this lookup table, in place of actual block instances.
         """
 

--- a/wagtail/fields.py
+++ b/wagtail/fields.py
@@ -171,7 +171,7 @@ class StreamField(models.Field):
             for name, block in self.stream_block.child_blocks.items()
         ]
         args = [block_types]
-        kwargs["block_lookup"] = lookup.blocks
+        kwargs["block_lookup"] = lookup.get_lookup_as_dict()
         return name, path, args, kwargs
 
     def to_python(self, value):

--- a/wagtail/fields.py
+++ b/wagtail/fields.py
@@ -8,7 +8,10 @@ from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 
 from wagtail.blocks import Block, BlockField, StreamBlock, StreamValue
-from wagtail.blocks.definition_lookup import BlockDefinitionLookup
+from wagtail.blocks.definition_lookup import (
+    BlockDefinitionLookup,
+    BlockDefinitionLookupBuilder,
+)
 from wagtail.rich_text import (
     RichTextMaxLengthValidator,
     extract_references_from_rich_text,
@@ -162,8 +165,13 @@ class StreamField(models.Field):
 
     def deconstruct(self):
         name, path, _, kwargs = super().deconstruct()
-        block_types = list(self.stream_block.child_blocks.items())
+        lookup = BlockDefinitionLookupBuilder()
+        block_types = [
+            (name, lookup.add_block(block))
+            for name, block in self.stream_block.child_blocks.items()
+        ]
         args = [block_types]
+        kwargs["block_lookup"] = lookup.blocks
         return name, path, args, kwargs
 
     def to_python(self, value):

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -5886,7 +5886,7 @@ class TestValidationErrorAsJsonData(TestCase):
 
 
 class TestBlockDefinitionLookup(TestCase):
-    def test_get_block_definition(self):
+    def test_simple_lookup(self):
         lookup = BlockDefinitionLookup(
             [
                 ("wagtail.blocks.CharBlock", [], {"required": True}),
@@ -5910,3 +5910,53 @@ class TestBlockDefinitionLookup(TestCase):
         self.assertIsNot(char_block, char_block_2)
         self.assertEqual(char_block.name, "title")
         self.assertEqual(char_block_2.name, "subtitle")
+
+    def test_structblock_lookup(self):
+        lookup = BlockDefinitionLookup(
+            [
+                ("wagtail.blocks.CharBlock", [], {"required": True}),
+                ("wagtail.blocks.RichTextBlock", [], {}),
+                (
+                    "wagtail.blocks.StructBlock",
+                    [
+                        [
+                            ("title", 0),
+                            ("description", 1),
+                        ],
+                    ],
+                    {},
+                ),
+            ]
+        )
+        struct_block = lookup.get_block(2)
+        self.assertIsInstance(struct_block, blocks.StructBlock)
+        title_block = struct_block.child_blocks["title"]
+        self.assertIsInstance(title_block, blocks.CharBlock)
+        self.assertTrue(title_block.required)
+        description_block = struct_block.child_blocks["description"]
+        self.assertIsInstance(description_block, blocks.RichTextBlock)
+
+    def test_streamblock_lookup(self):
+        lookup = BlockDefinitionLookup(
+            [
+                ("wagtail.blocks.CharBlock", [], {"required": True}),
+                ("wagtail.blocks.RichTextBlock", [], {}),
+                (
+                    "wagtail.blocks.StreamBlock",
+                    [
+                        [
+                            ("heading", 0),
+                            ("paragraph", 1),
+                        ],
+                    ],
+                    {},
+                ),
+            ]
+        )
+        stream_block = lookup.get_block(2)
+        self.assertIsInstance(stream_block, blocks.StreamBlock)
+        title_block = stream_block.child_blocks["heading"]
+        self.assertIsInstance(title_block, blocks.CharBlock)
+        self.assertTrue(title_block.required)
+        description_block = stream_block.child_blocks["paragraph"]
+        self.assertIsInstance(description_block, blocks.RichTextBlock)

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -5888,10 +5888,10 @@ class TestValidationErrorAsJsonData(TestCase):
 class TestBlockDefinitionLookup(TestCase):
     def test_simple_lookup(self):
         lookup = BlockDefinitionLookup(
-            [
-                ("wagtail.blocks.CharBlock", [], {"required": True}),
-                ("wagtail.blocks.RichTextBlock", [], {}),
-            ]
+            {
+                0: ("wagtail.blocks.CharBlock", [], {"required": True}),
+                1: ("wagtail.blocks.RichTextBlock", [], {}),
+            }
         )
         char_block = lookup.get_block(0)
         char_block.set_name("title")
@@ -5913,10 +5913,10 @@ class TestBlockDefinitionLookup(TestCase):
 
     def test_structblock_lookup(self):
         lookup = BlockDefinitionLookup(
-            [
-                ("wagtail.blocks.CharBlock", [], {"required": True}),
-                ("wagtail.blocks.RichTextBlock", [], {}),
-                (
+            {
+                0: ("wagtail.blocks.CharBlock", [], {"required": True}),
+                1: ("wagtail.blocks.RichTextBlock", [], {}),
+                2: (
                     "wagtail.blocks.StructBlock",
                     [
                         [
@@ -5926,7 +5926,7 @@ class TestBlockDefinitionLookup(TestCase):
                     ],
                     {},
                 ),
-            ]
+            }
         )
         struct_block = lookup.get_block(2)
         self.assertIsInstance(struct_block, blocks.StructBlock)
@@ -5938,10 +5938,10 @@ class TestBlockDefinitionLookup(TestCase):
 
     def test_streamblock_lookup(self):
         lookup = BlockDefinitionLookup(
-            [
-                ("wagtail.blocks.CharBlock", [], {"required": True}),
-                ("wagtail.blocks.RichTextBlock", [], {}),
-                (
+            {
+                0: ("wagtail.blocks.CharBlock", [], {"required": True}),
+                1: ("wagtail.blocks.RichTextBlock", [], {}),
+                2: (
                     "wagtail.blocks.StreamBlock",
                     [
                         [
@@ -5951,7 +5951,7 @@ class TestBlockDefinitionLookup(TestCase):
                     ],
                     {},
                 ),
-            ]
+            }
         )
         stream_block = lookup.get_block(2)
         self.assertIsInstance(stream_block, blocks.StreamBlock)
@@ -5963,10 +5963,10 @@ class TestBlockDefinitionLookup(TestCase):
 
     def test_listblock_lookup(self):
         lookup = BlockDefinitionLookup(
-            [
-                ("wagtail.blocks.CharBlock", [], {"required": True}),
-                ("wagtail.blocks.ListBlock", [0], {}),
-            ]
+            {
+                0: ("wagtail.blocks.CharBlock", [], {"required": True}),
+                1: ("wagtail.blocks.ListBlock", [0], {}),
+            }
         )
         list_block = lookup.get_block(1)
         self.assertIsInstance(list_block, blocks.ListBlock)
@@ -5977,9 +5977,9 @@ class TestBlockDefinitionLookup(TestCase):
         # Passing a class as the child block is still valid; this is not converted
         # to a reference
         lookup = BlockDefinitionLookup(
-            [
-                ("wagtail.blocks.ListBlock", [blocks.CharBlock], {}),
-            ]
+            {
+                0: ("wagtail.blocks.ListBlock", [blocks.CharBlock], {}),
+            }
         )
         list_block = lookup.get_block(0)
         self.assertIsInstance(list_block, blocks.ListBlock)

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -5960,3 +5960,28 @@ class TestBlockDefinitionLookup(TestCase):
         self.assertTrue(title_block.required)
         description_block = stream_block.child_blocks["paragraph"]
         self.assertIsInstance(description_block, blocks.RichTextBlock)
+
+    def test_listblock_lookup(self):
+        lookup = BlockDefinitionLookup(
+            [
+                ("wagtail.blocks.CharBlock", [], {"required": True}),
+                ("wagtail.blocks.ListBlock", [0], {}),
+            ]
+        )
+        list_block = lookup.get_block(1)
+        self.assertIsInstance(list_block, blocks.ListBlock)
+        list_item_block = list_block.child_block
+        self.assertIsInstance(list_item_block, blocks.CharBlock)
+        self.assertTrue(list_item_block.required)
+
+        # Passing a class as the child block is still valid; this is not converted
+        # to a reference
+        lookup = BlockDefinitionLookup(
+            [
+                ("wagtail.blocks.ListBlock", [blocks.CharBlock], {}),
+            ]
+        )
+        list_block = lookup.get_block(0)
+        self.assertIsInstance(list_block, blocks.ListBlock)
+        list_item_block = list_block.child_block
+        self.assertIsInstance(list_item_block, blocks.CharBlock)

--- a/wagtail/tests/test_streamfield.py
+++ b/wagtail/tests/test_streamfield.py
@@ -721,3 +721,104 @@ class TestGetBlockByContentPath(TestCase):
         self.assertEqual(bound_block.value, "Barnaby Rudge")
         bound_block = field.get_block_by_content_path(self.page.body, ["456", "999"])
         self.assertIsNone(bound_block)
+
+
+class TestConstructStreamFieldFromLookup(TestCase):
+    def test_construct_block_list_from_lookup(self):
+        field = StreamField(
+            [
+                ("heading", 0),
+                ("paragraph", 1),
+                ("button", 3),
+            ],
+            block_lookup=[
+                ("wagtail.blocks.CharBlock", [], {"required": True}),
+                ("wagtail.blocks.RichTextBlock", [], {}),
+                ("wagtail.blocks.PageChooserBlock", [], {}),
+                (
+                    "wagtail.blocks.StructBlock",
+                    [
+                        [
+                            ("page", 2),
+                            ("link_text", 0),
+                        ]
+                    ],
+                    {},
+                ),
+            ],
+        )
+        stream_block = field.stream_block
+        self.assertIsInstance(stream_block, blocks.StreamBlock)
+        self.assertEqual(len(stream_block.child_blocks), 3)
+
+        heading_block = stream_block.child_blocks["heading"]
+        self.assertIsInstance(heading_block, blocks.CharBlock)
+        self.assertTrue(heading_block.required)
+        self.assertEqual(heading_block.name, "heading")
+
+        paragraph_block = stream_block.child_blocks["paragraph"]
+        self.assertIsInstance(paragraph_block, blocks.RichTextBlock)
+        self.assertEqual(paragraph_block.name, "paragraph")
+
+        button_block = stream_block.child_blocks["button"]
+        self.assertIsInstance(button_block, blocks.StructBlock)
+        self.assertEqual(button_block.name, "button")
+        self.assertEqual(len(button_block.child_blocks), 2)
+        page_block = button_block.child_blocks["page"]
+        self.assertIsInstance(page_block, blocks.PageChooserBlock)
+        link_text_block = button_block.child_blocks["link_text"]
+        self.assertIsInstance(link_text_block, blocks.CharBlock)
+        self.assertEqual(link_text_block.name, "link_text")
+
+    def test_construct_top_level_block_from_lookup(self):
+        field = StreamField(
+            4,
+            block_lookup=[
+                ("wagtail.blocks.CharBlock", [], {"required": True}),
+                ("wagtail.blocks.RichTextBlock", [], {}),
+                ("wagtail.blocks.PageChooserBlock", [], {}),
+                (
+                    "wagtail.blocks.StructBlock",
+                    [
+                        [
+                            ("page", 2),
+                            ("link_text", 0),
+                        ]
+                    ],
+                    {},
+                ),
+                (
+                    "wagtail.blocks.StreamBlock",
+                    [
+                        [
+                            ("heading", 0),
+                            ("paragraph", 1),
+                            ("button", 3),
+                        ]
+                    ],
+                    {},
+                ),
+            ],
+        )
+        stream_block = field.stream_block
+        self.assertIsInstance(stream_block, blocks.StreamBlock)
+        self.assertEqual(len(stream_block.child_blocks), 3)
+
+        heading_block = stream_block.child_blocks["heading"]
+        self.assertIsInstance(heading_block, blocks.CharBlock)
+        self.assertTrue(heading_block.required)
+        self.assertEqual(heading_block.name, "heading")
+
+        paragraph_block = stream_block.child_blocks["paragraph"]
+        self.assertIsInstance(paragraph_block, blocks.RichTextBlock)
+        self.assertEqual(paragraph_block.name, "paragraph")
+
+        button_block = stream_block.child_blocks["button"]
+        self.assertIsInstance(button_block, blocks.StructBlock)
+        self.assertEqual(button_block.name, "button")
+        self.assertEqual(len(button_block.child_blocks), 2)
+        page_block = button_block.child_blocks["page"]
+        self.assertIsInstance(page_block, blocks.PageChooserBlock)
+        link_text_block = button_block.child_blocks["link_text"]
+        self.assertIsInstance(link_text_block, blocks.CharBlock)
+        self.assertEqual(link_text_block.name, "link_text")

--- a/wagtail/tests/test_streamfield.py
+++ b/wagtail/tests/test_streamfield.py
@@ -731,11 +731,11 @@ class TestConstructStreamFieldFromLookup(TestCase):
                 ("paragraph", 1),
                 ("button", 3),
             ],
-            block_lookup=[
-                ("wagtail.blocks.CharBlock", [], {"required": True}),
-                ("wagtail.blocks.RichTextBlock", [], {}),
-                ("wagtail.blocks.PageChooserBlock", [], {}),
-                (
+            block_lookup={
+                0: ("wagtail.blocks.CharBlock", [], {"required": True}),
+                1: ("wagtail.blocks.RichTextBlock", [], {}),
+                2: ("wagtail.blocks.PageChooserBlock", [], {}),
+                3: (
                     "wagtail.blocks.StructBlock",
                     [
                         [
@@ -745,7 +745,7 @@ class TestConstructStreamFieldFromLookup(TestCase):
                     ],
                     {},
                 ),
-            ],
+            },
         )
         stream_block = field.stream_block
         self.assertIsInstance(stream_block, blocks.StreamBlock)
@@ -773,11 +773,11 @@ class TestConstructStreamFieldFromLookup(TestCase):
     def test_construct_top_level_block_from_lookup(self):
         field = StreamField(
             4,
-            block_lookup=[
-                ("wagtail.blocks.CharBlock", [], {"required": True}),
-                ("wagtail.blocks.RichTextBlock", [], {}),
-                ("wagtail.blocks.PageChooserBlock", [], {}),
-                (
+            block_lookup={
+                0: ("wagtail.blocks.CharBlock", [], {"required": True}),
+                1: ("wagtail.blocks.RichTextBlock", [], {}),
+                2: ("wagtail.blocks.PageChooserBlock", [], {}),
+                3: (
                     "wagtail.blocks.StructBlock",
                     [
                         [
@@ -787,7 +787,7 @@ class TestConstructStreamFieldFromLookup(TestCase):
                     ],
                     {},
                 ),
-                (
+                4: (
                     "wagtail.blocks.StreamBlock",
                     [
                         [
@@ -798,7 +798,7 @@ class TestConstructStreamFieldFromLookup(TestCase):
                     ],
                     {},
                 ),
-            ],
+            },
         )
         stream_block = field.stream_block
         self.assertIsInstance(stream_block, blocks.StreamBlock)
@@ -857,11 +857,11 @@ class TestDeconstructStreamFieldWithLookup(TestCase):
             kwargs,
             {
                 "blank": True,
-                "block_lookup": [
-                    ("wagtail.blocks.CharBlock", (), {"required": True}),
-                    ("wagtail.blocks.RichTextBlock", (), {}),
-                    ("wagtail.blocks.PageChooserBlock", (), {}),
-                    (
+                "block_lookup": {
+                    0: ("wagtail.blocks.CharBlock", (), {"required": True}),
+                    1: ("wagtail.blocks.RichTextBlock", (), {}),
+                    2: ("wagtail.blocks.PageChooserBlock", (), {}),
+                    3: (
                         "wagtail.blocks.StructBlock",
                         [
                             [
@@ -871,6 +871,6 @@ class TestDeconstructStreamFieldWithLookup(TestCase):
                         ],
                         {},
                     ),
-                ],
+                },
             },
         )

--- a/wagtail/tests/test_streamfield.py
+++ b/wagtail/tests/test_streamfield.py
@@ -822,3 +822,55 @@ class TestConstructStreamFieldFromLookup(TestCase):
         link_text_block = button_block.child_blocks["link_text"]
         self.assertIsInstance(link_text_block, blocks.CharBlock)
         self.assertEqual(link_text_block.name, "link_text")
+
+
+class TestDeconstructStreamFieldWithLookup(TestCase):
+    def test_deconstruct(self):
+        class ButtonBlock(blocks.StructBlock):
+            page = blocks.PageChooserBlock()
+            link_text = blocks.CharBlock(required=True)
+
+        field = StreamField(
+            [
+                ("heading", blocks.CharBlock(required=True)),
+                ("paragraph", blocks.RichTextBlock()),
+                ("button", ButtonBlock()),
+            ],
+            blank=True,
+        )
+        field.set_attributes_from_name("body")
+
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(name, "body")
+        self.assertEqual(path, "wagtail.fields.StreamField")
+        self.assertEqual(
+            args,
+            [
+                [
+                    ("heading", 0),
+                    ("paragraph", 1),
+                    ("button", 3),
+                ]
+            ],
+        )
+        self.assertEqual(
+            kwargs,
+            {
+                "blank": True,
+                "block_lookup": [
+                    ("wagtail.blocks.CharBlock", (), {"required": True}),
+                    ("wagtail.blocks.RichTextBlock", (), {}),
+                    ("wagtail.blocks.PageChooserBlock", (), {}),
+                    (
+                        "wagtail.blocks.StructBlock",
+                        [
+                            [
+                                ("page", 2),
+                                ("link_text", 0),
+                            ]
+                        ],
+                        {},
+                    ),
+                ],
+            },
+        )


### PR DESCRIPTION
This PR introduces a new mechanism for deconstructing and constructing StreamField definitions, where the individual blocks are listed in a lookup table, and child blocks are stored as indexes into that lookup table. This means that duplicate occurrences of the same block definition can point to the same entry, greatly reducing migration sizes. Constructing the top-level block has also been moved to a `cached_property`, which hopefully also avoids the memory overhead from this happening when loading each migration (although I haven't dug into the migration runner to confirm this).

Fixes #4298

I tested against a new `wagtail start` project with home/models.py edited as below. The migration generated by `./manage.py makemigrations` is reduced from 591446 bytes / 7952 lines to 29158 bytes / 678 lines.

(Unfortunately it doesn't look like it's possible to share the lookup table across multiple StreamFields without major re-engineering of Django's migration builder, or else we could make even more dramatic reductions :-) )

```python
from django.db import models

from wagtail import blocks
from wagtail.admin.panels import FieldPanel
from wagtail.fields import StreamField
from wagtail.images.blocks import ImageChooserBlock
from wagtail.models import Page


class ColourChoiceBlock(blocks.ChoiceBlock):
    choices = [
        ('red', 'Red'),
        ('blue', 'Blue'),
        ('green', 'Green'),
        ('yellow', 'Yellow'),
    ]


class HeadingBlock(blocks.StructBlock):
    text = blocks.CharBlock(classname="full title", icon="title")
    level = blocks.ChoiceBlock(choices=[
        ('h2', 'H2'),
        ('h3', 'H3'),
        ('h4', 'H4'),
    ])
    colour = ColourChoiceBlock()


class ImageWithCaptionBlock(blocks.StructBlock):
    image = ImageChooserBlock()
    caption = blocks.CharBlock()
    background_colour = ColourChoiceBlock()
    alignment = blocks.ChoiceBlock(choices=[
        ('left', 'Left'),
        ('right', 'Right'),
    ])


class CallToActionBlock(blocks.StructBlock):
    text = blocks.CharBlock()
    button_text = blocks.CharBlock()
    button_link = blocks.PageChooserBlock()
    background_colour = ColourChoiceBlock()
    foreground_colour = ColourChoiceBlock()


class ContentStreamBlock(blocks.StreamBlock):
    heading = HeadingBlock()
    paragraph = blocks.RichTextBlock()
    image_with_caption = ImageWithCaptionBlock()
    carousel = blocks.ListBlock(blocks.StructBlock([
        ('image', ImageChooserBlock()),
        ('caption', blocks.CharBlock()),
    ]))
    call_to_action = CallToActionBlock()


class SingleColumnBlock(blocks.StructBlock):
    content = ContentStreamBlock()


class ColumnWithRightSidebarBlock(blocks.StructBlock):
    main_column = ContentStreamBlock()
    right_column = ContentStreamBlock()


class ColumnWithLeftSidebarBlock(blocks.StructBlock):
    left_column = ContentStreamBlock()
    main_column = ContentStreamBlock()


class ThreeColumnBlock(blocks.StructBlock):
    left_column = ContentStreamBlock()
    middle_column = ContentStreamBlock()
    right_column = ContentStreamBlock()


class LayoutStreamBlock(blocks.StreamBlock):
    single_column = SingleColumnBlock()
    column_with_right_sidebar = ColumnWithRightSidebarBlock()
    column_with_left_sidebar = ColumnWithLeftSidebarBlock()
    three_column = ThreeColumnBlock()


class HomePage(Page):
    body = StreamField(LayoutStreamBlock(), blank=True, max_num=3)

    content_panels = Page.content_panels + [
        FieldPanel('body'),
    ]


class BlogPage(Page):
    body = StreamField(LayoutStreamBlock(), blank=True)

    content_panels = Page.content_panels + [
        FieldPanel('body'),
    ]


class EventPage(Page):
    body = StreamField(LayoutStreamBlock(), blank=True)

    content_panels = Page.content_panels + [
        FieldPanel('body'),
    ]


class PublicationPage(Page):
    body = StreamField(LayoutStreamBlock(), blank=True)

    content_panels = Page.content_panels + [
        FieldPanel('body'),
    ]


class ResourcePage(Page):
    body = StreamField(LayoutStreamBlock(), blank=True)

    content_panels = Page.content_panels + [
        FieldPanel('body'),
    ]

```
