### PR TITLE
Improve handling when a StructBlock has multiple error messages

### DIFF
--- a/client/src/components/StreamField/blocks/FieldBlock.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.js
@@ -55,7 +55,7 @@ export class FieldBlock {
       console.error(e);
       this.setError({
         messages: [
-          'This widget failed to render, please check the console for details',
+          'This widget failed to render, please check the console for details.',
         ],
       });
       return;

--- a/client/src/components/StreamField/blocks/FieldBlock.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.js
@@ -128,11 +128,10 @@ export class FieldBlock {
 
       const errorElement = document.createElement('p');
       errorElement.classList.add('error-message');
-      error.messages.forEach((message) => {
-        const messageItem = document.createElement('span');
-        messageItem.textContent = message;
-        errorElement.appendChild(messageItem);
-      });
+
+      const errorText = document.createTextNode(error.messages.join(' '));
+
+      errorElement.appendChild(errorText);
       errorContainer.appendChild(errorElement);
     } else {
       this.field.classList.remove('w-field--error');

--- a/client/src/components/StreamField/blocks/FieldBlock.test.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.test.js
@@ -166,8 +166,8 @@ describe('telepath: wagtail.blocks.FieldBlock', () => {
   test('setError() renders errors', () => {
     boundBlock.setError({
       messages: [
-        'Field must not contain the letter E',
-        'Field must contain a story about kittens',
+        'Field must not contain the letter E.',
+        'Field must contain a story about kittens.',
       ],
     });
     expect(document.body.innerHTML).toMatchSnapshot();

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -299,7 +299,7 @@ describe('telepath: wagtail.blocks.ListBlock', () => {
 
   test('setError passes error messages to children', () => {
     boundBlock.setError({
-      blockErrors: { 1: { messages: ['Not as good as the first one'] } },
+      blockErrors: { 1: { messages: ['Not as good as the first one.'] } },
     });
     expect(document.body.innerHTML).toMatchSnapshot();
   });

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -318,7 +318,7 @@ describe('telepath: wagtail.blocks.StreamBlock', () => {
       ],
       blockErrors: {
         /* block error */
-        1: { messages: ['Not as good as the first one'] },
+        1: { messages: ['Not as good as the first one.'] },
       },
     });
     expect(document.body.innerHTML).toMatchSnapshot();

--- a/client/src/components/StreamField/blocks/StructBlock.test.js
+++ b/client/src/components/StreamField/blocks/StructBlock.test.js
@@ -170,7 +170,7 @@ describe('telepath: wagtail.blocks.StructBlock', () => {
   test('setError passes error messages to children', () => {
     boundBlock.setError({
       blockErrors: {
-        size: { messages: ['This is too big'] },
+        size: { messages: ['This is too big.'] },
       },
     });
     expect(document.body.innerHTML).toMatchSnapshot();
@@ -178,7 +178,7 @@ describe('telepath: wagtail.blocks.StructBlock', () => {
 
   test('setError shows non-block errors', () => {
     boundBlock.setError({
-      messages: ['This is just generally wrong'],
+      messages: ['This is just generally wrong.'],
     });
     expect(document.body.innerHTML).toMatchSnapshot();
   });

--- a/client/src/components/StreamField/blocks/__snapshots__/FieldBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/FieldBlock.test.js.snap
@@ -5,7 +5,7 @@ exports[`telepath: wagtail.blocks.FieldBlock catches widget render errors it ren
         <div class="w-field w-field--char_field w-field--text_input w-field--error" data-field="">
           <div class="w-field__errors" id="the-prefix-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true"><use href="#icon-warning"></use></svg>
-          <p class="error-message"><span>This widget failed to render, please check the console for details</span></p></div>
+          <p class="error-message">This widget failed to render, please check the console for details.</p></div>
           <div class="w-field__help" id="the-prefix-helptext" data-field-help=""></div>
           <div class="w-field__input" data-field-input="">
             <div data-streamfield-widget=""></div>
@@ -33,7 +33,7 @@ exports[`telepath: wagtail.blocks.FieldBlock setError() renders errors 1`] = `
         <div class="w-field w-field--char_field w-field--text_input w-field--error" data-field="">
           <div class="w-field__errors" id="the-prefix-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true"><use href="#icon-warning"></use></svg>
-          <p class="error-message"><span>Field must not contain the letter E</span><span>Field must contain a story about kittens</span></p></div>
+          <p class="error-message">Field must not contain the letter E. Field must contain a story about kittens.</p></div>
           <div class="w-field__help" id="the-prefix-helptext" data-field-help=""><p class="help">drink <em>more</em> water</p></div>
           <div class="w-field__input" data-field-input="">
             <p name="the-prefix" id="the-prefix">The widget</p>

--- a/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
@@ -1075,7 +1075,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError passes error messages to ch
         <div class="w-field w-field--char_field w-field--admin_auto_height_text_input w-field--error" data-field="">
           <div class="w-field__errors" id="the-prefix-1-value-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true"><use href="#icon-warning"></use></svg>
-          <p class="error-message"><span>Not as good as the first one</span></p></div>
+          <p class="error-message">Not as good as the first one.</p></div>
           <div class="w-field__help" id="the-prefix-1-value-helptext" data-field-help=""></div>
           <div class="w-field__input" data-field-input="">
             <p name="the-prefix-1-value" id="the-prefix-1-value">The widget</p>

--- a/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
@@ -905,7 +905,7 @@ exports[`telepath: wagtail.blocks.StreamBlock setError renders error messages 1`
         <div class="w-field w-field--char_field w-field--admin_auto_height_text_input w-field--error" data-field="">
           <div class="w-field__errors" id="the-prefix-1-value-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true"><use href="#icon-warning"></use></svg>
-          <p class="error-message"><span>Not as good as the first one</span></p></div>
+          <p class="error-message">Not as good as the first one.</p></div>
           <div class="w-field__help" id="the-prefix-1-value-helptext" data-field-help=""></div>
           <div class="w-field__input" data-field-input="">
             <p name="the-prefix-1-value" id="the-prefix-1-value">Block B widget</p>

--- a/client/src/components/StreamField/blocks/__snapshots__/StructBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StructBlock.test.js.snap
@@ -64,7 +64,7 @@ exports[`telepath: wagtail.blocks.StructBlock setError passes error messages to 
         <div class="w-field w-field--choice_field w-field--select w-field--error" data-field="">
           <div class="w-field__errors" id="the-prefix-size-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true"><use href="#icon-warning"></use></svg>
-          <p class="error-message"><span>This is too big</span></p></div>
+          <p class="error-message">This is too big.</p></div>
           <div class="w-field__help" id="the-prefix-size-helptext" data-field-help=""></div>
           <div class="w-field__input" data-field-input="">
             <p name="the-prefix-size" id="the-prefix-size">Size widget</p>
@@ -75,7 +75,7 @@ exports[`telepath: wagtail.blocks.StructBlock setError passes error messages to 
 `;
 
 exports[`telepath: wagtail.blocks.StructBlock setError shows non-block errors 1`] = `
-"<div class="struct-block"><p class="help-block help-critical">This is just generally wrong</p>
+"<div class="struct-block"><p class="help-block help-critical">This is just generally wrong.</p>
         
           <div class="c-sf-help">
             <div class="help">

--- a/client/src/entrypoints/contrib/typed_table_block/__snapshots__/typed_table_block.test.js.snap
+++ b/client/src/entrypoints/contrib/typed_table_block/__snapshots__/typed_table_block.test.js.snap
@@ -158,7 +158,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError passe
         <div class="w-field w-field--char_field w-field--admin_auto_height_text_input w-field--error" data-field="">
           <div class="w-field__errors" id="mytable-cell-0-1-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true"><use href="#icon-warning"></use></svg>
-          <p class="error-message"><span>This is not enough cheese</span></p></div>
+          <p class="error-message">This is not enough cheese.</p></div>
           <div class="w-field__help" id="mytable-cell-0-1-helptext" data-field-help=""></div>
           <div class="w-field__input" data-field-input="">
             <p name="mytable-cell-0-1" id="mytable-cell-0-1">Block B widget</p>
@@ -213,7 +213,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError passe
 `;
 
 exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError shows non-block errors 1`] = `
-"<div class="typed-table-block "><p class="help-block help-critical">This is just generally wrong</p>
+"<div class="typed-table-block "><p class="help-block help-critical">This is just generally wrong.</p>
         <div class="w-field__wrapper" data-field-wrapper="">
           <label class="w-field__label" for="mytable-caption">
             Caption

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
@@ -211,7 +211,7 @@ describe('wagtail.contrib.typed_table_block.blocks.TypedTableBlock', () => {
     boundBlock.setError({
       blockErrors: {
         0: {
-          1: { messages: ['This is not enough cheese'] },
+          1: { messages: ['This is not enough cheese.'] },
         },
       },
     });
@@ -220,7 +220,7 @@ describe('wagtail.contrib.typed_table_block.blocks.TypedTableBlock', () => {
 
   test('setError shows non-block errors', () => {
     boundBlock.setError({
-      messages: ['This is just generally wrong'],
+      messages: ['This is just generally wrong.'],
     });
     expect(document.body.innerHTML).toMatchSnapshot();
   });


### PR DESCRIPTION
Fixes #12062 by:

1. Joining multiple error messages within `StructBlock`s with a space (to match what Django does).
2. Removing unnecessary `<span>`...`</span>` elements from error messages (they're not referenced or styled).
3. Adding full stops to test error messages to make spotting these issues easier.