### PR TITLE
Optimize sitemap

### DIFF
--- a/wagtail/contrib/sitemaps/sitemap_generator.py
+++ b/wagtail/contrib/sitemaps/sitemap_generator.py
@@ -1,4 +1,5 @@
 from django.contrib.sitemaps import Sitemap as DjangoSitemap
+from django.utils.functional import cached_property
 
 # Note: avoid importing models here. This module is imported from __init__.py
 # which causes it to be loaded early in startup if wagtail.contrib.sitemaps is
@@ -18,7 +19,8 @@ class Sitemap(DjangoSitemap):
         # (for backwards compatibility from before last_published_at was added)
         return obj.last_published_at or obj.latest_revision_created_at
 
-    def get_wagtail_site(self):
+    @cached_property
+    def wagtail_site(self):
         from wagtail.models import Site
 
         site = Site.find_for_request(self.request)
@@ -28,8 +30,7 @@ class Sitemap(DjangoSitemap):
 
     def items(self):
         return (
-            self.get_wagtail_site()
-            .root_page.get_descendants(inclusive=True)
+            self.wagtail_site.root_page.get_descendants(inclusive=True)
             .live()
             .public()
             .order_by("path")

--- a/wagtail/contrib/sitemaps/sitemap_generator.py
+++ b/wagtail/contrib/sitemaps/sitemap_generator.py
@@ -33,8 +33,7 @@ class Sitemap(DjangoSitemap):
             .live()
             .public()
             .order_by("path")
-            .defer_streamfields()
-            .specific()
+            .specific(defer=True)
         )
 
     def _urls(self, page, protocol, domain):

--- a/wagtail/contrib/sitemaps/tests.py
+++ b/wagtail/contrib/sitemaps/tests.py
@@ -106,7 +106,7 @@ class TestSitemapGenerator(TestCase):
         req_protocol = request.scheme
 
         sitemap = Sitemap()
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(15):
             urls = [
                 url["location"]
                 for url in sitemap.get_urls(1, django_site, req_protocol)
@@ -124,7 +124,7 @@ class TestSitemapGenerator(TestCase):
         # pre-seed find_for_request cache, so that it's not counted towards the query count
         Site.find_for_request(request)
 
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(12):
             urls = [
                 url["location"]
                 for url in sitemap.get_urls(1, django_site, req_protocol)
@@ -139,7 +139,7 @@ class TestSitemapGenerator(TestCase):
         req_protocol = request.scheme
 
         sitemap = Sitemap()
-        with self.assertNumQueries(19):
+        with self.assertNumQueries(17):
             urls = [
                 url["location"]
                 for url in sitemap.get_urls(1, django_site, req_protocol)
@@ -158,7 +158,7 @@ class TestSitemapGenerator(TestCase):
         # pre-seed find_for_request cache, so that it's not counted towards the query count
         Site.find_for_request(request)
 
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(14):
             urls = [
                 url["location"]
                 for url in sitemap.get_urls(1, django_site, req_protocol)


### PR DESCRIPTION
Fixes #1698 

This PR encompasses a few small optimisations:

- Use `.specific(defer=True)` when getting pages. This means there's no need to fetch the specific page models at all, removing the extra queries which comes with it.
- Use the DB to calculate the latest `lastmod`, rather than looping through all pages.
- Use a slightly simpler / faster way of determining the last modified date when looping through pages (copied from Django)
- Cache the Wagtail site on the view

The query drops in the tests is deceptive. These changes dropped them by 2 in the tests - the rest are from using a non-database cache.

With ~10000 pages (averaged over 10 requests using `gunicorn` and `oha`):

Before:

```
Slowest:      1.4849 secs
Fastest:      1.0741 secs
Average:      1.1292 secs
Requests/sec: 0.8856
```

35 DB queries

After:

```
Slowest:      1.8591 secs
Fastest:      1.4128 secs
Average:      1.4964 secs
Requests/sec: 0.6683
```

18 DB queries

--- 

I'm not sure why the updated version appears slower - although I think it's within the margin of error. It's running fewer queries, and `defer=True` should make the codepaths much simpler, too. The tests were run on `bakerydemo` and I suspect with more than just a single model the improvements may be greater still. 