### PR TITLE
Add a `deactivate` method to ProgressController

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Changelog
  * Adopt more compact representation for StreamField definitions in migrations (Matt Westcott)
  * Implement a new design for locale labels in listings (Albina Starykova)
  * Add alt text validation rule in the accessibility checker (Albina Starykova)
+ * Add a `deactivate()` method to `ProgressController` (Alex Morega)
  * Fix: Make `WAGTAILIMAGES_CHOOSER_PAGE_SIZE` setting functional again (Rohit Sharma)
  * Fix: Enable `richtext` template tag to convert lazy translation values (Benjamin Bach)
  * Fix: Ensure permission labels on group permissions page are translated where available (Matt Westcott)

--- a/client/src/controllers/ProgressController.ts
+++ b/client/src/controllers/ProgressController.ts
@@ -72,6 +72,14 @@ export class ProgressController extends Controller<HTMLButtonElement> {
     });
   }
 
+  deactivate() {
+    this.loadingValue = false;
+
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+  }
+
   loadingValueChanged(isLoading: boolean) {
     const activeClass = this.hasActiveClass
       ? this.activeClass
@@ -103,8 +111,6 @@ export class ProgressController extends Controller<HTMLButtonElement> {
   }
 
   disconnect(): void {
-    if (this.timer) {
-      clearTimeout(this.timer);
-    }
+    this.deactivate();
   }
 }

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -30,6 +30,7 @@ This feature was implemented by Albina Starykova, with support from the Wagtail 
  * Remove reduced opacity for draft page title in listings (Inju Michorius)
  * Adopt more compact representation for StreamField definitions in migrations (Matt Westcott)
  * Implement a new design for locale labels in listings (Albina Starykova)
+ * Add a `deactivate()` method to `ProgressController` (Alex Morega)
 
 
 ### Bug fixes


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/12057. This creates a non-hacky way for users of the `w-progress` controller to stop the loading state, and restore the button to the original, clickable state.