### PR TITLE
Fix external-to-internal link converter detection when using non-root path for `wagtail_serve` view

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -205,6 +205,8 @@ WAGTAILADMIN_EXTERNAL_LINK_CONVERSION = 'exact'
 
 Customize Wagtail's behavior when an internal page url is entered in the external link chooser. Possible values for this setting are `'all'`, `'exact'`, `'confirm`, or `''`. The default, `'all'`, means that Wagtail will automatically convert submitted urls that exactly match page urls to the corresponding internal links. If the url is an inexact match - for example, the submitted url has query parameters - then Wagtail will confirm the conversion with the user. `'exact'` means that any inexact matches will be left as external urls, and the confirmation step will be skipped. `'confirm'` means that every link conversion will be confirmed with the user, even if the match is exact. `''` means that Wagtail will not attempt to convert any urls entered to internal page links.
 
+If the url is relative, Wagtail will not convert the link if there are more than one {class}`~wagtail.models.Site` instances. This is to avoid accidentally matching coincidentally named pages on different sites.
+
 (wagtail_date_time_formats)=
 
 ### `WAGTAIL_DATE_FORMAT`, `WAGTAIL_DATETIME_FORMAT`, `WAGTAIL_TIME_FORMAT`

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -912,7 +912,7 @@ class TestChooserExternalLinkWithNonRootServePath(TestChooserExternalLink):
                 "external-link-chooser-link_text": "about",
             }
         )
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(11):
             response = self.post(
                 {
                     "external-link-chooser-url": f"http://localhost/{self.prefix}about/",

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -904,12 +904,21 @@ class TestChooserExternalLinkWithNonRootServePath(TestChooserExternalLink):
         # take the serve path into account, but now it should be correctly
         # converted to an internal link (without needing confirmation as the
         # input URL will be an exact match to the page's full URL).
+
+        # Warm up the cache
         response = self.post(
             {
                 "external-link-chooser-url": f"http://localhost/{self.prefix}about/",
                 "external-link-chooser-link_text": "about",
             }
         )
+        with self.assertNumQueries(14):
+            response = self.post(
+                {
+                    "external-link-chooser-url": f"http://localhost/{self.prefix}about/",
+                    "external-link-chooser-link_text": "about",
+                }
+            )
         self.assertEqual(response.status_code, 200)
         response_json = json.loads(response.content.decode())
         self.assertEqual(response_json["step"], "external_link_chosen")

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -1,4 +1,5 @@
 import re
+from collections import defaultdict
 from urllib.parse import parse_qs, quote, urlencode, urlsplit
 
 from django.conf import settings
@@ -642,40 +643,45 @@ class ExternalLinkView(BaseLinkFormView):
             # Otherwise this could get very annoying accidentally matching coincidentally
             # named pages on different sites
 
+            possible_sites = defaultdict(list)
+
             if match_relative_paths:
-                possible_sites = []
                 for pk, path, url, language_code in sites:
-                    possible_sites.append((pk, url_without_query))
+                    possible_sites[pk].append(url_without_query)
 
                     # If the submitted URL is prefixed with the serve path,
                     # also consider it without the serve path so we can match
                     # the page using Page.route()
                     if serve_path and url_without_query.startswith(serve_path):
-                        possible_sites.append(
-                            (pk, url_without_query[len(serve_path) - 1 :])
+                        possible_sites[pk].append(
+                            url_without_query[len(serve_path) - 1 :]
                         )
             else:
-                possible_sites = []
                 for pk, path, url, language_code in sites:
                     if not submitted_url.startswith(url):
                         continue
-                    possible_sites.append((pk, url_without_query[len(url) :]))
+                    possible_sites[pk].append(url_without_query[len(url) :])
 
                     # If the submitted URL is prefixed with the serve path,
                     # also consider it without the serve path so we can match
                     # the page using Page.route()
                     if serve_path and url_without_query.startswith(url + serve_path):
-                        possible_sites.append(
-                            (pk, url_without_query[len(url) + len(serve_path) - 1 :])
+                        possible_sites[pk].append(
+                            url_without_query[len(url) + len(serve_path) - 1 :]
                         )
 
             # Loop over possible sites to identify a page match
-            for pk, url in possible_sites:
-                try:
-                    route = Site.objects.get(pk=pk).root_page.specific.route(
-                        request,
-                        [component for component in url.split("/") if component],
-                    )
+            for pk, possible_urls in possible_sites.items():
+                site = Site.objects.select_related("root_page").get(pk=pk)
+                root_page = site.root_page.specific
+                for url in possible_urls:
+                    try:
+                        route = root_page.route(
+                            request,
+                            [component for component in url.split("/") if component],
+                        )
+                    except Http404:
+                        continue
 
                     matched_page = route.page.specific
 
@@ -727,9 +733,6 @@ class ExternalLinkView(BaseLinkFormView):
                                 "internal": internal_data,
                             },
                         )
-
-                except Http404:
-                    continue
 
             # Otherwise, with no internal matches, fall back to an external url
             return self.render_chosen_response(result)

--- a/wagtail/test/urls_multilang_non_root.py
+++ b/wagtail/test/urls_multilang_non_root.py
@@ -8,4 +8,4 @@ urlpatterns = [
     path("admin/", include(wagtailadmin_urls)),
 ]
 
-urlpatterns += i18n_patterns(path("", include(wagtail_urls)))
+urlpatterns += i18n_patterns(path("site/", include(wagtail_urls)))


### PR DESCRIPTION
Fixes #11996.

There's a report that this used to work at some point before 4.0, but I'm pretty sure this has always been the case ever since the feature was introduced in #7376.

To test:

- Create a Wagtail project that uses a non-root path when including `wagtail_urls`, e.g. `path("the-ascent/", include(wagtail_urls)),`
- Update the `HomePage` model to have a `RichTextField`/`RichTextBlock`. I'm using this example (which includes some leftover I have for testing #12002)
  ```py
  from wagtail.documents.blocks import DocumentChooserBlock
  from wagtail.documents.models import AbstractDocument, Document
  from wagtail.blocks import RichTextBlock
  from wagtail.admin.panels import FieldPanel
  from wagtail.fields import RichTextField, StreamField
  from wagtail.models import Page
  
  
  class HomePage(Page):
      body = StreamField(
          block_types=[
              ("doc", DocumentChooserBlock()),
              ("text", RichTextBlock()),
          ],
          blank=True,
      )
      rich = RichTextField(blank=True, null=True)
      content_panels = Page.content_panels + [FieldPanel("body"), FieldPanel("rich")]
  
  
  class CustomDocument(AbstractDocument):
      my = RichTextField()
      admin_form_fields = ("my",) + Document.admin_form_fields
  ```
- Update the Site instance in Settings > Sites to use localhost with the port you are using for the server e.g. 8000
- Create a few pages, e.g.
  - "Credit cards" `credit-cards/`
  - "Best hotel credit cards" `credit-cards/best-hotel-credit-cards/`
- Create an external link and enter `/the-ascent/credit-cards/best-hotel-credit-cards/`
  - Before this PR, this link would not be detected as an internal link and thus will become an external link
  - After this PR, this link would be converted to an internal link to the "Best hotel credit cards" page.
    - This may not be obvious, set `WAGTAILADMIN_EXTERNAL_LINK_CONVERSION = "confirm"` in settings to make it more explicit
- Create another external link and enter `/credit-cards/best-hotel-credit-cards/`
  - Before this PR, this relative link is detected as an internal link
  - After this PR, this relative is still detected as an internal link
- Repeat the above cases with the full URL instead of relative links, e.g. `http://127.0.0.1:8000/the-ascent/credit-cards/best-hotel-credit-cards/` and `http://127.0.0.1:8000/credit-cards/best-hotel-credit-cards/`.
- If necessary, add another site in Settings > Site and ensure that the conversion works with the new site (although relative URL conversion will not work once you have more than one site).

I made a repo for my test project in case you find it helpful: https://github.com/laymonage/wagtail-11996-repro