### PR TITLE
Fix bug with ModelViewSet.get_menu_item(order=0) calls

### DIFF
--- a/wagtail/admin/menu.py
+++ b/wagtail/admin/menu.py
@@ -228,7 +228,7 @@ class WagtailMenuRegisterable:
             url=self.menu_url,
             name=self.menu_name,
             icon_name=self.menu_icon,
-            order=order or self.menu_order,
+            order=order if order is not None else self.menu_order,
         )
 
     @cached_property
@@ -286,7 +286,7 @@ class WagtailMenuRegisterableGroup(WagtailMenuRegisterable):
             menu=Menu(items=self.get_submenu_items()),
             name=self.menu_name,
             icon_name=self.menu_icon,
-            order=order or self.menu_order,
+            order=order if order is not None else self.menu_order,
         )
 
 


### PR DESCRIPTION
I just ran into a bit of a glitch while working on customising an admin menu where menu items constructed with `ModelViewSet.get_menu_item(order=0)` were being order by the class-level default of 8999, rather than 0. Turns out that `0` was being ignored because it's falsey, rather than the `get_menu_item` code checking `order is not None`.

Currently no tests because I couldn't find any existing tests that deal with menu item ordering and wouldn't be sure where best to put them. Happy to follow a suggestion here, but it's also a very small, safe-ish change... what could possibly go wrong? :sweat_smile: 
