### PR TITLE
Avoid masking AttributeErrors during StreamField block serialization

### DIFF
--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -567,10 +567,14 @@ class BlockWidget(forms.Widget):
         super().__init__(attrs=attrs)
         self.block_def = block_def
         self._js_context = None
+        self._block_json = None
 
     def _build_block_json(self):
-        self._js_context = JSContext()
-        self._block_json = json.dumps(self._js_context.pack(self.block_def))
+        try:
+            self._js_context = JSContext()
+            self._block_json = json.dumps(self._js_context.pack(self.block_def))
+        except Exception as e:  # noqa: BLE001
+            raise ValueError("Error while serializing block definition: %s" % e) from e
 
     @property
     def js_context(self):
@@ -581,7 +585,7 @@ class BlockWidget(forms.Widget):
 
     @property
     def block_json(self):
-        if self._js_context is None:
+        if self._block_json is None:
             self._build_block_json()
 
         return self._block_json

--- a/wagtail/snippets/blocks.py
+++ b/wagtail/snippets/blocks.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import cached_property
 
 from wagtail.blocks import ChooserBlock
@@ -23,8 +24,15 @@ class SnippetChooserBlock(ChooserBlock):
     def widget(self):
         from wagtail.snippets.widgets import AdminSnippetChooser
 
+        try:
+            icon = self.target_model.snippet_viewset.icon
+        except AttributeError as e:
+            raise ImproperlyConfigured(
+                f"Cannot use SnippetChooserBlock with non-snippet model {self.target_model}"
+            ) from e
+
         # Override the default icon with the icon for the target model
-        self.set_meta_options({"icon": self.target_model.snippet_viewset.icon})
+        self.set_meta_options({"icon": icon})
         return AdminSnippetChooser(self.target_model, icon=self.meta.icon)
 
     class Meta:

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -9,7 +9,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core import checks, management
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.handlers.wsgi import WSGIRequest
@@ -5344,6 +5344,11 @@ class TestSnippetChooserBlock(TestCase):
 
         # None should not yield any references
         self.assertListEqual(list(block.extract_references(None)), [])
+
+    def test_exception_on_non_snippet_model(self):
+        with self.assertRaises(ImproperlyConfigured):
+            block = SnippetChooserBlock(Locale)
+            block.widget
 
 
 class TestAdminSnippetChooserWidget(WagtailTestUtils, TestCase):


### PR DESCRIPTION
Ref #11702. Generally, the first call to `_build_block_json` happens when accessing the `media` property of the widget. Django wraps this in a try/except AttributeError to guard against the widget not defining a `media` property, so if an AttributeError occurs during the `JSContext.pack` operation, the error will be suppressed and the BlockWidget left in an invalid state where `_js_context` is defined but `_block_json` is not. Accessing `block_json` on the widget will then fail with `'BlockWidget' object has no attribute '_block_json'`.

Along with dealing with the masking of AttributeError in general, we also add an error check for SnippetChooserBlock being used on a non-Snippet model, which has been identified on #11702 as a common cause of this problem.