### PR TITLE
Fix Sub-menus within the main menu cannot be closed on mobile (#10747)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
  * Fix: Improve handling of translations for bulk page action confirmation messages (Matt Westcott)
  * Fix: Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
  * Fix: Ensure manual edits to `StreamField` values do not throw an error (Stefan Hammer)
+ * Fix: Fix sub-menus within the main menu cannot be closed on mobile (Bojan Mihelac)
  * Docs: Move the model reference page from reference/pages to the references section as it covers all Wagtail core models (Srishti Jaiswal)
  * Docs: Move the panels reference page from references/pages to the references section as panels are available for any model editing, merge panels API into this page (Srishti Jaiswal)
  * Docs: Move the tags documentation to standalone advanced topic, instead of being inside the reference/pages section (Srishti Jaiswal)

--- a/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../PageExplorer/actions';
 import { SidebarPanel } from '../SidebarPanel';
 import { SIDEBAR_TRANSITION_DURATION } from '../Sidebar';
+import SubMenuCloseButton from './SubMenuCloseButton';
 
 export const PageExplorerMenuItem: React.FunctionComponent<
   MenuItemProps<PageExplorerMenuItemDefinition>
@@ -97,6 +98,7 @@ export const PageExplorerMenuItem: React.FunctionComponent<
           depth={depth}
           widthPx={485}
         >
+          <SubMenuCloseButton isVisible={isVisible} dispatch={dispatch} />
           {store.current && (
             <Provider store={store.current}>
               <PageExplorer

--- a/client/src/components/Sidebar/menu/SubMenuCloseButton.tsx
+++ b/client/src/components/Sidebar/menu/SubMenuCloseButton.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+
+import Icon from '../../Icon/Icon';
+import { gettext } from '../../../utils/gettext';
+import { MenuAction } from '../modules/MainMenu';
+
+interface SubMenuCloseButtonProps {
+  isVisible: boolean;
+  dispatch(action: MenuAction): void;
+}
+
+export default function SubMenuCloseButton({
+  isVisible,
+  dispatch,
+}: SubMenuCloseButtonProps) {
+  if (!isVisible) {
+    return null;
+  }
+  return createPortal(
+    <button
+      type="button"
+      onClick={() =>
+        dispatch({
+          type: 'set-navigation-path',
+          path: '',
+        })
+      }
+      className="button sidebar-close-menu-button"
+      aria-label={gettext('Close')}
+    >
+      <Icon name="cross" className="w-w-[15px] w-h-4" />
+    </button>,
+    document.body,
+  );
+}

--- a/client/src/components/Sidebar/menu/SubMenuItem.scss
+++ b/client/src/components/Sidebar/menu/SubMenuItem.scss
@@ -96,3 +96,7 @@
     }
   }
 }
+
+.sidebar-close-menu-button {
+  @apply w-grid sm:w-hidden w-place-items-center w-text-text-label-menus-default w-p-0 w-z-sidebar-toggle w-border-transparent w-fixed w-bg-surface-menus w-top-0 w-left-0 w-h-slim-header w-w-slim-header w-rounded-none hover:w-bg-surface-menu-item-active hover:w-text-text-label-menus-active;
+}

--- a/client/src/components/Sidebar/menu/SubMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/SubMenuItem.tsx
@@ -8,6 +8,7 @@ import { SidebarPanel } from '../SidebarPanel';
 import { SIDEBAR_TRANSITION_DURATION } from '../Sidebar';
 import { MenuItemDefinition, MenuItemProps } from './MenuItem';
 import { gettext } from '../../../utils/gettext';
+import SubMenuCloseButton from './SubMenuCloseButton';
 
 interface SubMenuItemProps extends MenuItemProps<SubMenuItemDefinition> {
   slim: boolean;
@@ -130,6 +131,7 @@ export const SubMenuItem: React.FunctionComponent<SubMenuItemProps> = ({
       </Tippy>
       <SidebarPanel isVisible={isVisible} isOpen={isOpen} depth={depth}>
         <div className="sidebar-sub-menu-panel">
+          <SubMenuCloseButton isVisible={isVisible} dispatch={dispatch} />
           <h2
             id={`wagtail-sidebar-submenu${path.split('.').join('-')}-title`}
             className={`${item.classNames} w-h4`}

--- a/client/src/components/Sidebar/menu/__snapshots__/PageExplorererMenuItem.test.js.snap
+++ b/client/src/components/Sidebar/menu/__snapshots__/PageExplorererMenuItem.test.js.snap
@@ -35,6 +35,9 @@ exports[`PageExplorerMenuItem should render with the minimum required props 1`] 
       isVisible={false}
       widthPx={485}
     >
+      <SubMenuCloseButton
+        isVisible={false}
+      />
       <Provider
         store={
           {

--- a/client/src/components/Sidebar/menu/__snapshots__/SubMenuItem.test.js.snap
+++ b/client/src/components/Sidebar/menu/__snapshots__/SubMenuItem.test.js.snap
@@ -32,6 +32,9 @@ exports[`SubMenuItem should render with the minimum required props 1`] = `
     <div
       className="sidebar-sub-menu-panel"
     >
+      <SubMenuCloseButton
+        isVisible={false}
+      />
       <h2
         className=" w-h4"
         id="wagtail-sidebar-submenu-reports-title"

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -22,6 +22,7 @@ depth: 1
  * Improve handling of translations for bulk page action confirmation messages (Matt Westcott)
  * Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
  * Ensure manual edits to `StreamField` values do not throw an error (Stefan Hammer)
+ * Fix sub-menus within the main menu cannot be closed on mobile (Bojan Mihelac)
 
 ### Documentation
 


### PR DESCRIPTION
Here is an attempt to fix [issue #10747](https://github.com/wagtail/wagtail/issues/10747) on GitHub.

The SubMenuCloseButton is a component displayed in submenus (such as the page explorer and submenus) which closes the submenu panel when clicked. It looks and is positioned similarly to the "Toggle sidebar" button.

Since the "Toggle sidebar" button has a higher z-index than the submenu panel, the SubMenuCloseButton is added to document.body using createPortal.

Quick demo:

[submenu-close-button-on-mobile.webm](https://github.com/wagtail/wagtail/assets/13813/e81959e8-b8d9-4cd6-b885-29fb2e81ae68)

I would like to verify that this solution is acceptable before updating tests or checking for accessibility considerations.
