### PR TITLE
Remove workaround and inline scripts for activating workflow actions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -60,6 +60,7 @@ Changelog
  * Maintenance: Replace `urlparse` with `urlsplit` to improve performance (Jake Howard)
  * Maintenance: Optimise embed finder lookups (Jake Howard)
  * Maintenance: Improve performance of initial admin loading by moving sprite hashing out of module import time (Jake Howard)
+ * Maintenance: Remove workaround and inline scripts for activating workflow actions (Sage Abdullah)
 
 
 6.1.3 (11.07.2024)

--- a/docs/extending/custom_tasks.md
+++ b/docs/extending/custom_tasks.md
@@ -1,3 +1,5 @@
+(custom_tasks)=
+
 # Adding new Task types
 
 The Workflow system allows users to create tasks, which represent stages of moderation.
@@ -124,6 +126,8 @@ class UserApprovalTask(Task):
 
     task_state_class = UserApprovalTaskState
 ```
+
+(custom_tasks_behavior)=
 
 ## Customising behaviour
 

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -391,3 +391,11 @@ If you need to completely customize the view's template, you can still override 
 If you override `template_name`, it is still necessary to set `results_template_name` to a template that extends `wagtailadmin/reports/base_report_results.html` (or `wagtailadmin/reports/base_page_report_results.html` for page reports), so the view can correctly update the listing and show the active filters as you apply or remove any filters.
 
 ## Upgrade considerations - changes to undocumented internals
+
+### Deprecation of `window.ActivateWorkflowActionsForDashboard` and `window.ActivateWorkflowActionsForEditView`
+
+The undocumented usage of the JavaScript `window.ActivateWorkflowActionsForDashboard` and `window.ActivateWorkflowActionsForEditView` functions will be removed in a future release.
+
+These functions are only used by Wagtail to initialize event listeners to workflow action buttons via inline scripts and are never intended to be used in custom code. The inline scripts have been removed in favour of initializing the event listeners directly in the included `workflow-action.js` script. As a result, the functions no longer need to be globally-accessible.
+
+Any custom workflow actions should be done using the [documented approach for customising the behavior of custom task types](custom_tasks_behavior), such as by overriding `Task.get_actions()`.

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -90,6 +90,7 @@ This feature was developed by Albina Starykova and sponsored by The Motley Fool.
  * Replace `urlparse` with `urlsplit` to improve performance (Jake Howard)
  * Optimise embed finder lookups (Jake Howard)
  * Improve performance of initial admin loading by moving sprite hashing out of module import time (Jake Howard)
+ * Remove workaround and inline scripts for activating workflow actions (Sage Abdullah)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -91,12 +91,6 @@
 
     <script src="{% versioned_static 'wagtailadmin/js/workflow-action.js' %}"></script>
     <script>
-        document.querySelectorAll('[data-controller="w-dropdown"]').forEach((e) => {
-            e.addEventListener(
-                'w-dropdown:shown',
-                () => ActivateWorkflowActionsForDashboard('{{ csrf_token|escapejs }}'),
-                { once: true },
-            );
-        });
+        document.addEventListener('DOMContentLoaded', () => ActivateWorkflowActionsForDashboard('{{ csrf_token|escapejs }}'));
     </script>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -44,7 +44,7 @@
                                 {% if actions %}
                                     <ul class="actions">
                                         <li>
-                                            {% dropdown toggle_icon="dots-horizontal" toggle_aria_label=_("Actions") hide_on_click=True %}
+                                            {% dropdown toggle_icon="dots-horizontal" toggle_aria_label=_("Actions") hide_on_click=True keep_mounted=True %}
                                                 {% for action_name, action_label, modal in actions %}
                                                     <button data-workflow-action-url="{% url state.workflow_action_url_name obj.pk|admin_urlquote action_name task_state.id %}" {% if modal %}data-launch-modal{% endif %}>{{ action_label }}</button>
                                                 {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -89,8 +89,5 @@
         </table>
     {% endpanel %}
 
-    <script src="{% versioned_static 'wagtailadmin/js/workflow-action.js' %}"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', () => ActivateWorkflowActionsForDashboard('{{ csrf_token|escapejs }}'));
-    </script>
+    <script src="{% versioned_static 'wagtailadmin/js/workflow-action.js' %}" data-activate="dashboard"></script>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
@@ -9,5 +9,4 @@
 <script src="{% versioned_static 'wagtailadmin/js/expanding-formset.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/preview-panel.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/privacy-switch.js' %}"></script>
-<script src="{% versioned_static 'wagtailadmin/js/workflow-action.js' %}"></script>
 {% hook_output 'insert_editor_js' %}

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
@@ -1,7 +1,7 @@
 {% load wagtailadmin_tags %}
 
 {% if show_menu %}
-    {% dropdown_button button=default_menu_item toggle_icon="arrow-up" %}
+    {% dropdown_button button=default_menu_item toggle_icon="arrow-up" keep_mounted=True %}
         {% for item in rendered_menu_items %}
             {{ item }}
         {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/shared/_workflow_init.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/_workflow_init.html
@@ -1,37 +1,9 @@
-<script>
-    $(function() {
-        ActivateWorkflowActionsForEditView('[data-edit-form]');
-
-        {% if publishing_will_cancel_workflow %}
-            /* Make user confirm before publishing the object if it will cancel an ongoing workflow */
-            let cancellationConfirmed = false;
-            $('[name=action-publish]').click((e) => {
-                if (!cancellationConfirmed) {
-                    e.stopImmediatePropagation();
-                    e.preventDefault();
-                    ModalWorkflow({
-                        'url': "{{ confirm_workflow_cancellation_url }}",
-                        'onload': {
-                            'confirm': function(modal, jsonData) {
-                                $('[data-confirm-cancellation]', modal.body).click((event) => {
-                                    cancellationConfirmed = true;
-                                    modal.close();
-                                    e.currentTarget.click();
-                                })
-                                $('[data-cancel-dialog]', modal.body).click((event) => {
-                                    modal.close();
-                                })
-                            },
-                            'no_confirmation_needed': function(modal, jsonData) {
-                                modal.close();
-                                cancellationConfirmed = true;
-                                e.currentTarget.click();
-                            }
-                        },
-                        'triggerElement': e.currentTarget,
-                    });
-                }
-            });
-        {% endif %}
-    });
+{% load wagtailadmin_tags %}
+<script
+    src="{% versioned_static 'wagtailadmin/js/workflow-action.js' %}"
+    data-activate="editor"
+    {% if publishing_will_cancel_workflow %}
+        data-confirm-cancellation-url="{{ confirm_workflow_cancellation_url }}"
+    {% endif %}
+>
 </script>

--- a/wagtail/admin/templates/wagtailadmin/shared/_workflow_init.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/_workflow_init.html
@@ -1,45 +1,37 @@
 <script>
     $(function() {
-        document.querySelectorAll('footer [data-controller="w-dropdown"]').forEach((e) => {
-            e.addEventListener(
-                'w-dropdown:shown',
-                () => {
-                    ActivateWorkflowActionsForEditView('[data-edit-form]');
+        ActivateWorkflowActionsForEditView('[data-edit-form]');
 
-                    {% if publishing_will_cancel_workflow %}
-                        /* Make user confirm before publishing the object if it will cancel an ongoing workflow */
-                        let cancellationConfirmed = false;
-                        $('[name=action-publish]').click((e) => {
-                            if (!cancellationConfirmed) {
-                                e.stopImmediatePropagation();
-                                e.preventDefault();
-                                ModalWorkflow({
-                                    'url': "{{ confirm_workflow_cancellation_url }}",
-                                    'onload': {
-                                        'confirm': function(modal, jsonData) {
-                                            $('[data-confirm-cancellation]', modal.body).click((event) => {
-                                                cancellationConfirmed = true;
-                                                modal.close();
-                                                e.currentTarget.click();
-                                            })
-                                            $('[data-cancel-dialog]', modal.body).click((event) => {
-                                                modal.close();
-                                            })
-                                        },
-                                        'no_confirmation_needed': function(modal, jsonData) {
-                                            modal.close();
-                                            cancellationConfirmed = true;
-                                            e.currentTarget.click();
-                                        }
-                                    },
-                                    'triggerElement': e.currentTarget,
-                                });
+        {% if publishing_will_cancel_workflow %}
+            /* Make user confirm before publishing the object if it will cancel an ongoing workflow */
+            let cancellationConfirmed = false;
+            $('[name=action-publish]').click((e) => {
+                if (!cancellationConfirmed) {
+                    e.stopImmediatePropagation();
+                    e.preventDefault();
+                    ModalWorkflow({
+                        'url': "{{ confirm_workflow_cancellation_url }}",
+                        'onload': {
+                            'confirm': function(modal, jsonData) {
+                                $('[data-confirm-cancellation]', modal.body).click((event) => {
+                                    cancellationConfirmed = true;
+                                    modal.close();
+                                    e.currentTarget.click();
+                                })
+                                $('[data-cancel-dialog]', modal.body).click((event) => {
+                                    modal.close();
+                                })
+                            },
+                            'no_confirmation_needed': function(modal, jsonData) {
+                                modal.close();
+                                cancellationConfirmed = true;
+                                e.currentTarget.click();
                             }
-                        });
-                    {% endif %}
-                },
-                { once: true }
-            )
-        });
+                        },
+                        'triggerElement': e.currentTarget,
+                    });
+                }
+            });
+        {% endif %}
     });
 </script>

--- a/wagtail/admin/templates/wagtailadmin/shared/dropdown/dropdown_button.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/dropdown/dropdown_button.html
@@ -8,6 +8,7 @@
     - `toggle_classname` (string?) - additional toggle classes
     - `classname` (string?) - additional component classes
     - `children` - Dropdown contents (`a` and `button` elements only)
+    - `keep_mounted` (boolean?) - Whether or not the dropdown should keep its DOM node mounted when hidden
 {% endcomment %}
 
 <div class="{% classnames 'w-dropdown-button' classname %}">
@@ -16,7 +17,7 @@
         {% fragment as toggle_classes %}{% classnames toggle_classname "button" %}{% endfragment %}
         {# Built with w-sr-only so there is no visible tooltip. #}
         {% fragment as toggle_label %}<span class="w-sr-only">{% trans "More actions" %}</span>{% endfragment %}
-        {% dropdown theme="dropdown-button" toggle_label=toggle_label toggle_classname=toggle_classes toggle_icon=toggle_icon|default:"arrow-down" toggle_tooltip_offset="[0, 0]" %}
+        {% dropdown theme="dropdown-button" toggle_label=toggle_label toggle_classname=toggle_classes toggle_icon=toggle_icon|default:"arrow-down" toggle_tooltip_offset="[0, 0]" keep_mounted=keep_mounted %}
             {{ children }}
         {% enddropdown %}
     {% endif %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/menu.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/menu.html
@@ -1,7 +1,7 @@
 {% load wagtailadmin_tags %}
 
 {% if show_menu %}
-    {% dropdown_button button=default_menu_item toggle_icon="arrow-up" %}
+    {% dropdown_button button=default_menu_item toggle_icon="arrow-up" keep_mounted=True %}
         {% for item in rendered_menu_items %}
             {{ item }}
         {% endfor %}


### PR DESCRIPTION
I recommend hiding whitespace changes when reviewing this PR.

Before #11456, we attach the event listeners for the workflow action buttons during page load using an inline script. After that PR, those event listeners broke because Tippy.js unmounts the dropdown content as soon as it initialises the dropdown (to be we remounted when the dropdown is open). As a result, we had to work around this by attaching the event listeners for those buttons via an event listener for the dropdown's `shown` event (https://github.com/wagtail/wagtail/pull/11514/files#r1462348870).

Now that we have the ability for the dropdown component to keep its content mounted in the DOM (as of a3cb4a6903d3b3a103c6096f77ec81c6eaccd082), we no longer need the workaround. This PR reverts the workaround changes.

With the upcoming work for #12081, we need to "implement a confirmation dialog to appear if the user tries to submit the form after conflicting edits have been identified":

<details><summary>Screenshot</summary>

<img width="914" alt="save confirmation dialog, asking the user whether they want to overwrite changes made by another user or whether they want to reload the page and lose any unsaved changes instead" src="https://github.com/wagtail/wagtail/assets/6379424/17d6d05a-6967-4a69-8c65-1f8a944d7d2f">

</details> 

"Save draft" isn't the only action that would trigger the confirmation dialog. Any other action that saves a new revision, e.g. "Publish" and workflow actions (submit, approve, etc.) also needs to trigger this confirmation.

If we don't use the "keep mounted" option and we don't revert the workaround, I imagine it's going to be hard for us to implement the confirmation dialog trigger for the buttons inside the dropdown. Hence, I made this PR.

In addition, the final commit refactors the activation code to not use inline scripts. Instead of attaching the `ActivateWorkflowActionsForDashboard` and `ActivateWorkflowActionsForEditView` functions to `window` and calling them from inline scripts, we can move the code to `workflow-action.js` itself, and let it call the appropriate function based on the data attributes given on the script. This commit is optional, but I think it's a nice cleanup to do in the meantime before we do any proper refactoring in the future.

## Testing

- On the dashboard, make sure the workflow actions for pages/snippets that are "awaiting your review" work correctly.
  - In particular, make sure the "Request changes" and "Approve with comment" buttons trigger a modal to enter a comment.
- On the editor, do the same for pages/snippets that are in a workflow. Ensure that the above workflow actions work correctly.
  - Additionally, if a page/snippet is in a workflow, clicking "Publish" should show a confirmation dialog saying that the workflow will be cancelled if the user continues with the publishing.
  - Also confirm that doing the above on Safari will not cause the button to hang indefinitely (to ensure the fix for #11420 isn't reverted).
  - If you set `WAGTAIL_WORKFLOW_CANCEL_ON_PUBLISH = False` in the settings file, then clicking "Publish" for a page/snippet that is in a workflow should not trigger the dialog and the publishing should continue anyway (with the workflow still in progress afterwards).