### PR TITLE
Implement `for_instance` on `PageLogEntryManager`

### DIFF
--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -4521,6 +4521,9 @@ class PageLogEntryManager(BaseLogEntryManager):
 
         return PageLogEntry.objects.filter(q)
 
+    def for_instance(self, instance):
+        return self.filter(page=instance)
+
 
 class PageLogEntry(BaseLogEntry):
     page = models.ForeignKey(


### PR DESCRIPTION
(From a Slack #support query: https://wagtailcms.slack.com/archives/C81FGJR2S/p1719490591607189)

`BaseLogEntryManager` leaves `for_instance` unimplemented, and `ModelLogEntryManager` implements it but `PageLogEntryManager` doesn't. The `LogActionRegistry.get_logs_for_instance` method calls this, which means it fails on page models.

Currently this is only used on generic views, which aren't used by page models (unless they're also registered as a snippet, which isn't really a supported setup) but LogActionRegistry is supposed to work transparently across log models, so this is clearly a bug.
