### PR TITLE
Reduce usage of `SECRET_KEY` in version and icon hashes

### DIFF
--- a/wagtail/admin/icons.py
+++ b/wagtail/admin/icons.py
@@ -32,7 +32,7 @@ def get_icons():
 
 @lru_cache(maxsize=None)
 def get_icon_sprite_hash():
-    return hashlib.sha1(get_icons().encode()).hexdigest()
+    return hashlib.sha1(get_icons().encode()).hexdigest()[:8]
 
 
 def get_icon_sprite_url():

--- a/wagtail/admin/icons.py
+++ b/wagtail/admin/icons.py
@@ -3,7 +3,6 @@ import itertools
 import re
 from functools import lru_cache
 
-from django.conf import settings
 from django.template.loader import render_to_string
 from django.urls import reverse
 
@@ -33,10 +32,7 @@ def get_icons():
 
 @lru_cache(maxsize=None)
 def get_icon_sprite_hash():
-    # SECRET_KEY is used to prevent exposing the Wagtail version
-    return hashlib.sha1(
-        (get_icons() + settings.SECRET_KEY).encode("utf-8")
-    ).hexdigest()[:8]
+    return hashlib.sha1(get_icons().encode()).hexdigest()
 
 
 def get_icon_sprite_url():

--- a/wagtail/admin/staticfiles.py
+++ b/wagtail/admin/staticfiles.py
@@ -24,15 +24,19 @@ except AttributeError:
         use_version_strings = True
     else:
         # see if we're using a storage backend using hashed filenames
-        storage = storages[STATICFILES_STORAGE_ALIAS].__class__
-        use_version_strings = not issubclass(storage, HashedFilesMixin)
+        use_version_strings = not isinstance(
+            storages[STATICFILES_STORAGE_ALIAS], HashedFilesMixin
+        )
 
 
 if use_version_strings:
     # SECRET_KEY is used to prevent exposing the Wagtail version
-    VERSION_HASH = hashlib.sha1(
-        (__version__ + settings.SECRET_KEY).encode("utf-8")
-    ).hexdigest()[:8]
+    VERSION_HASH = hashlib.blake2b(
+        __version__.encode(),
+        salt=settings.SECRET_KEY.encode()[:16],
+        digest_size=4,
+        person=__name__.encode()[:16],
+    )
 else:
     VERSION_HASH = None
 

--- a/wagtail/admin/staticfiles.py
+++ b/wagtail/admin/staticfiles.py
@@ -30,13 +30,11 @@ except AttributeError:
 
 
 if use_version_strings:
-    # SECRET_KEY is used to prevent exposing the Wagtail version
-    VERSION_HASH = hashlib.blake2b(
-        __version__.encode(),
-        salt=settings.SECRET_KEY.encode()[:16],
-        digest_size=4,
-        person=__name__.encode()[:16],
-    )
+    # INSTALLED_APPS is used as a unique value to distinguish Wagtail apps
+    # and avoid exposing the Wagtail version directly
+    VERSION_HASH = hashlib.sha1(
+        "".join([__version__] + settings.INSTALLED_APPS).encode(),
+    ).hexdigest()[:8]
 else:
     VERSION_HASH = None
 

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -11,7 +11,7 @@ from django.test.utils import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 
-from wagtail.admin.staticfiles import versioned_static
+from wagtail.admin.staticfiles import VERSION_HASH, versioned_static
 from wagtail.admin.templatetags.wagtailadmin_tags import (
     avatar_url,
     i18n_enabled,
@@ -99,9 +99,12 @@ class TestNotificationStaticTemplateTag(SimpleTestCase):
 
 
 class TestVersionedStatic(SimpleTestCase):
+    def test_version_hash(self):
+        self.assertEqual(len(VERSION_HASH), 8)
+
     def test_versioned_static(self):
         result = versioned_static("wagtailadmin/js/core.js")
-        self.assertRegex(result, r"^/static/wagtailadmin/js/core.js\?v=(\w+)$")
+        self.assertRegex(result, r"^/static/wagtailadmin/js/core.js\?v=(\w{8})$")
 
     @mock.patch("wagtail.admin.staticfiles.static")
     def test_versioned_static_version_string(self, mock_static):


### PR DESCRIPTION
Following #11811, I realised we can do a little more to protect the secret key (it's far from unprotected now, but we can do better).

1. Don't use the secret key as a salt for the icons hash. We return the entire content, so the user can just hash the content themselves. 
2. Replace `SECRET_KEY` for `INSTALLED_APPS` as an installation-specific salt for the version hash. See [this comment](https://github.com/wagtail/wagtail/pull/12117#issuecomment-2220197439) for more.