### PR TITLE
Fix focal point data being localized

### DIFF
--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -51,10 +51,10 @@
                 <div
                     class="focal-point-chooser"
                     style="max-width: {{ rendition.width }}px; max-height: {{ rendition.height }}px;"
-                    data-focal-point-x="{{ image.focal_point_x|default_if_none:'' }}"
-                    data-focal-point-y="{{ image.focal_point_y|default_if_none:'' }}"
-                    data-focal-point-width="{{ image.focal_point_width|default_if_none:'' }}"
-                    data-focal-point-height="{{ image.focal_point_height|default_if_none:'' }}"
+                    data-focal-point-x="{{ image.focal_point_x|default_if_none:''|unlocalize }}"
+                    data-focal-point-y="{{ image.focal_point_y|default_if_none:''|unlocalize }}"
+                    data-focal-point-width="{{ image.focal_point_width|default_if_none:''|unlocalize }}"
+                    data-focal-point-height="{{ image.focal_point_height|default_if_none:''|unlocalize }}"
                     data-focal-input-label="{% trans 'Image focal point' %}"
                 >
                     <img {{ rendition.attrs }} decoding="async" data-original-width="{{ image.width|unlocalize }}" data-original-height="{{ image.height|unlocalize }}" class="show-transparency">

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1264,12 +1264,19 @@ class TestImageEditView(WagtailTestUtils, TestCase):
     def test_no_thousand_separators_in_focal_point_editor(self):
         large_image = Image.objects.create(
             title="Test image",
-            file=get_test_image_file(size=(1024, 768)),
+            file=get_test_image_file(size=(3840, 2160)),
+            focal_point_x=2048,
+            focal_point_y=1001,
+            focal_point_width=1009,
+            focal_point_height=1002,
         )
         response = self.client.get(
             reverse("wagtailimages:edit", args=(large_image.id,))
         )
-        self.assertContains(response, 'data-original-width="1024"')
+        self.assertContains(response, 'data-original-width="3840"')
+        self.assertContains(response, 'data-focal-point-x="2048"')
+        self.assertContains(response, 'data-focal-point-width="1009"')
+        self.assertContains(response, 'data-focal-point-height="1002"')
 
     @override_settings(WAGTAILIMAGES_IMAGE_MODEL="tests.CustomImage")
     def test_unique_together_validation_error(self):


### PR DESCRIPTION
When working with an instance where `USE_L10N` is `True`, focal point data over 1000 is being localized to `"1 000"` for example, leading to `focal-point-chooser.js` making math operation resulting in 0. The focal area is then not displayed correctly.

Fixed that by using `unlocalize` filter.