### PR TITLE
Extend streamblock js actions

### DIFF
--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -11,7 +11,7 @@ import {
 } from '../../../includes/panels';
 import { range } from '../../../utils/range';
 
-class ActionButton {
+export class ActionButton {
   constructor(sequenceChild) {
     this.sequenceChild = sequenceChild;
   }
@@ -63,7 +63,7 @@ class ActionButton {
   }
 }
 
-class MoveUpButton extends ActionButton {
+export class MoveUpButton extends ActionButton {
   enableEvent = 'enableMoveUp';
   disableEvent = 'disableMoveUp';
   initiallyDisabled = true;
@@ -75,7 +75,7 @@ class MoveUpButton extends ActionButton {
   }
 }
 
-class MoveDownButton extends ActionButton {
+export class MoveDownButton extends ActionButton {
   enableEvent = 'enableMoveDown';
   disableEvent = 'disableMoveDown';
   initiallyDisabled = true;
@@ -87,7 +87,7 @@ class MoveDownButton extends ActionButton {
   }
 }
 
-class DuplicateButton extends ActionButton {
+export class DuplicateButton extends ActionButton {
   enableEvent = 'enableDuplication';
   disableEvent = 'disableDuplication';
   icon = 'copy';
@@ -98,7 +98,7 @@ class DuplicateButton extends ActionButton {
   }
 }
 
-class DeleteButton extends ActionButton {
+export class DeleteButton extends ActionButton {
   icon = 'bin';
   labelIdentifier = 'DELETE';
 
@@ -196,10 +196,7 @@ export class BaseSequenceChild extends EventEmitter {
     this.deletedInput = dom.find(`input[name="${this.prefix}-deleted"]`);
     this.indexInput = dom.find(`input[name="${this.prefix}-order"]`);
 
-    this.addActionButton(new MoveUpButton(this));
-    this.addActionButton(new MoveDownButton(this));
-    this.addActionButton(new DuplicateButton(this));
-    this.addActionButton(new DeleteButton(this));
+    this.blockDef.setActions(this)
 
     const capabilities = new Map();
     capabilities.set('duplicate', {

--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -196,7 +196,7 @@ export class BaseSequenceChild extends EventEmitter {
     this.deletedInput = dom.find(`input[name="${this.prefix}-deleted"]`);
     this.indexInput = dom.find(`input[name="${this.prefix}-order"]`);
 
-    this.blockDef.setActions(this)
+    this.blockDef.setActions(this);
 
     const capabilities = new Map();
     capabilities.set('duplicate', {

--- a/client/src/components/StreamField/blocks/FieldBlock.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import { escapeHtml as h } from '../../../utils/text';
 import Icon from '../../Icon/Icon';
+import {DeleteButton, DuplicateButton, MoveDownButton, MoveUpButton} from "./BaseSequenceBlock";
 
 export class FieldBlock {
   constructor(
@@ -199,5 +200,12 @@ export class FieldBlockDefinition {
       initialError,
       parentCapabilities,
     );
+  }
+
+  setActions(base) {
+    base.addActionButton(new MoveUpButton(base));
+    base.addActionButton(new MoveDownButton(base));
+    base.addActionButton(new DuplicateButton(base));
+    base.addActionButton(new DeleteButton(base));
   }
 }

--- a/client/src/components/StreamField/blocks/FieldBlock.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.js
@@ -3,7 +3,12 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import { escapeHtml as h } from '../../../utils/text';
 import Icon from '../../Icon/Icon';
-import {DeleteButton, DuplicateButton, MoveDownButton, MoveUpButton} from "./BaseSequenceBlock";
+import {
+  DeleteButton,
+  DuplicateButton,
+  MoveDownButton,
+  MoveUpButton,
+} from './BaseSequenceBlock';
 
 export class FieldBlock {
   constructor(

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -4,7 +4,11 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   BaseSequenceBlock,
   BaseSequenceChild,
-  BaseInsertionControl, MoveUpButton, MoveDownButton, DuplicateButton, DeleteButton,
+  BaseInsertionControl,
+  MoveUpButton,
+  MoveDownButton,
+  DuplicateButton,
+  DeleteButton,
 } from './BaseSequenceBlock';
 import { escapeHtml as h } from '../../../utils/text';
 import { range } from '../../../utils/range';

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   BaseSequenceBlock,
   BaseSequenceChild,
-  BaseInsertionControl,
+  BaseInsertionControl, MoveUpButton, MoveDownButton, DuplicateButton, DeleteButton,
 } from './BaseSequenceBlock';
 import { escapeHtml as h } from '../../../utils/text';
 import { range } from '../../../utils/range';
@@ -295,5 +295,12 @@ export class ListBlockDefinition {
 
   render(placeholder, prefix, initialState, initialError) {
     return new ListBlock(this, placeholder, prefix, initialState, initialError);
+  }
+
+  setActions(base) {
+    base.addActionButton(new MoveUpButton(base));
+    base.addActionButton(new MoveDownButton(base));
+    base.addActionButton(new DuplicateButton(base));
+    base.addActionButton(new DeleteButton(base));
   }
 }

--- a/client/src/components/StreamField/blocks/StaticBlock.js
+++ b/client/src/components/StreamField/blocks/StaticBlock.js
@@ -1,4 +1,5 @@
 import { escapeHtml as h } from '../../../utils/text';
+import {DeleteButton, DuplicateButton, MoveDownButton, MoveUpButton} from "./BaseSequenceBlock";
 
 export class StaticBlock {
   constructor(blockDef, placeholder) {
@@ -40,5 +41,12 @@ export class StaticBlockDefinition {
 
   render(placeholder) {
     return new StaticBlock(this, placeholder);
+  }
+
+  setActions(base) {
+    base.addActionButton(new MoveUpButton(base));
+    base.addActionButton(new MoveDownButton(base));
+    base.addActionButton(new DuplicateButton(base));
+    base.addActionButton(new DeleteButton(base));
   }
 }

--- a/client/src/components/StreamField/blocks/StaticBlock.js
+++ b/client/src/components/StreamField/blocks/StaticBlock.js
@@ -1,5 +1,10 @@
 import { escapeHtml as h } from '../../../utils/text';
-import {DeleteButton, DuplicateButton, MoveDownButton, MoveUpButton} from "./BaseSequenceBlock";
+import {
+  DeleteButton,
+  DuplicateButton,
+  MoveDownButton,
+  MoveUpButton,
+} from './BaseSequenceBlock';
 
 export class StaticBlock {
   constructor(blockDef, placeholder) {

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -7,7 +7,11 @@ import tippy from 'tippy.js';
 import {
   BaseSequenceBlock,
   BaseSequenceChild,
-  BaseInsertionControl, MoveUpButton, MoveDownButton, DuplicateButton, DeleteButton,
+  BaseInsertionControl,
+  MoveUpButton,
+  MoveDownButton,
+  DuplicateButton,
+  DeleteButton,
 } from './BaseSequenceBlock';
 import { escapeHtml as h } from '../../../utils/text';
 import { hasOwn } from '../../../utils/hasOwn';

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -7,7 +7,7 @@ import tippy from 'tippy.js';
 import {
   BaseSequenceBlock,
   BaseSequenceChild,
-  BaseInsertionControl,
+  BaseInsertionControl, MoveUpButton, MoveDownButton, DuplicateButton, DeleteButton,
 } from './BaseSequenceBlock';
 import { escapeHtml as h } from '../../../utils/text';
 import { hasOwn } from '../../../utils/hasOwn';
@@ -451,5 +451,12 @@ export class StreamBlockDefinition {
       initialState,
       initialError,
     );
+  }
+
+  setActions(base) {
+    base.addActionButton(new MoveUpButton(base));
+    base.addActionButton(new MoveDownButton(base));
+    base.addActionButton(new DuplicateButton(base));
+    base.addActionButton(new DeleteButton(base));
   }
 }

--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -6,6 +6,7 @@ import {
   addErrorMessages,
   removeErrorMessages,
 } from '../../../includes/streamFieldErrors';
+import {DeleteButton, DuplicateButton, MoveDownButton, MoveUpButton} from "./BaseSequenceBlock";
 
 export class StructBlock {
   constructor(blockDef, placeholder, prefix, initialState, initialError) {
@@ -197,5 +198,12 @@ export class StructBlockDefinition {
       initialState,
       initialError,
     );
+  }
+
+  setActions(base) {
+    base.addActionButton(new MoveUpButton(base));
+    base.addActionButton(new MoveDownButton(base));
+    base.addActionButton(new DuplicateButton(base));
+    base.addActionButton(new DeleteButton(base));
   }
 }

--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -6,7 +6,12 @@ import {
   addErrorMessages,
   removeErrorMessages,
 } from '../../../includes/streamFieldErrors';
-import {DeleteButton, DuplicateButton, MoveDownButton, MoveUpButton} from "./BaseSequenceBlock";
+import {
+  DeleteButton,
+  DuplicateButton,
+  MoveDownButton,
+  MoveUpButton,
+} from './BaseSequenceBlock';
 
 export class StructBlock {
   constructor(blockDef, placeholder, prefix, initialState, initialError) {

--- a/client/src/entrypoints/admin/telepath/blocks.js
+++ b/client/src/entrypoints/admin/telepath/blocks.js
@@ -18,7 +18,7 @@ import {
   StreamBlock,
   StreamBlockDefinition,
 } from '../../../components/StreamField/blocks/StreamBlock';
-import {ActionButton} from "../../../components/StreamField/blocks/BaseSequenceBlock";
+import { ActionButton } from '../../../components/StreamField/blocks/BaseSequenceBlock';
 
 const wagtailStreamField = window.wagtailStreamField || {};
 

--- a/client/src/entrypoints/admin/telepath/blocks.js
+++ b/client/src/entrypoints/admin/telepath/blocks.js
@@ -18,6 +18,7 @@ import {
   StreamBlock,
   StreamBlockDefinition,
 } from '../../../components/StreamField/blocks/StreamBlock';
+import {ActionButton} from "../../../components/StreamField/blocks/BaseSequenceBlock";
 
 const wagtailStreamField = window.wagtailStreamField || {};
 
@@ -36,6 +37,8 @@ wagtailStreamField.blocks = {
 
   StreamBlock,
   StreamBlockDefinition,
+
+  ActionButton,
 };
 
 window.telepath.register('wagtail.blocks.FieldBlock', FieldBlockDefinition);

--- a/client/src/entrypoints/contrib/table_block/table.js
+++ b/client/src/entrypoints/contrib/table_block/table.js
@@ -4,6 +4,12 @@
 
 import $ from 'jquery';
 import { hasOwn } from '../../../utils/hasOwn';
+import {
+  DeleteButton,
+  DuplicateButton,
+  MoveDownButton,
+  MoveUpButton
+} from "../../../components/StreamField/blocks/BaseSequenceBlock";
 
 /**
  * Due to the limitations of Handsontable, the 'cell' elements do not accept keyboard focus.
@@ -307,6 +313,13 @@ class TableInput {
     };
     widget.setState(initialState);
     return widget;
+  }
+
+  setActions(base) {
+    base.addActionButton(new MoveUpButton(base));
+    base.addActionButton(new MoveDownButton(base));
+    base.addActionButton(new DuplicateButton(base));
+    base.addActionButton(new DeleteButton(base));
   }
 }
 window.telepath.register('wagtail.widgets.TableInput', TableInput);

--- a/client/src/entrypoints/contrib/table_block/table.js
+++ b/client/src/entrypoints/contrib/table_block/table.js
@@ -8,8 +8,8 @@ import {
   DeleteButton,
   DuplicateButton,
   MoveDownButton,
-  MoveUpButton
-} from "../../../components/StreamField/blocks/BaseSequenceBlock";
+  MoveUpButton,
+} from '../../../components/StreamField/blocks/BaseSequenceBlock';
 
 /**
  * Due to the limitations of Handsontable, the 'cell' elements do not accept keyboard focus.

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
@@ -7,6 +7,12 @@ import {
   addErrorMessages,
   removeErrorMessages,
 } from '../../../includes/streamFieldErrors';
+import {
+  DeleteButton,
+  DuplicateButton,
+  MoveDownButton,
+  MoveUpButton
+} from "../../../components/StreamField/blocks/BaseSequenceBlock";
 
 export class TypedTableBlock {
   constructor(blockDef, placeholder, prefix, initialState, initialError) {
@@ -602,6 +608,13 @@ export class TypedTableBlockDefinition {
       initialState,
       initialError,
     );
+  }
+
+  setActions(base) {
+    base.addActionButton(new MoveUpButton(base));
+    base.addActionButton(new MoveDownButton(base));
+    base.addActionButton(new DuplicateButton(base));
+    base.addActionButton(new DeleteButton(base));
   }
 }
 window.telepath.register(

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
@@ -11,8 +11,8 @@ import {
   DeleteButton,
   DuplicateButton,
   MoveDownButton,
-  MoveUpButton
-} from "../../../components/StreamField/blocks/BaseSequenceBlock";
+  MoveUpButton,
+} from '../../../components/StreamField/blocks/BaseSequenceBlock';
 
 export class TypedTableBlock {
   constructor(blockDef, placeholder, prefix, initialState, initialError) {

--- a/docs/advanced_topics/customisation/streamfield_blocks.md
+++ b/docs/advanced_topics/customisation/streamfield_blocks.md
@@ -214,7 +214,6 @@ class AddressBlockDefinition extends window.wagtailStreamField.blocks
     
     setActions(base) {
         super().setActions(base);
-        
     }
 }
 window.telepath.register('myapp.blocks.AddressBlock', AddressBlockDefinition);

--- a/docs/advanced_topics/customisation/streamfield_blocks.md
+++ b/docs/advanced_topics/customisation/streamfield_blocks.md
@@ -171,6 +171,55 @@ window.telepath.register('myapp.blocks.AddressBlock', AddressBlockDefinition);
 
 (custom_value_class_for_structblock)=
 
+### Adding new actions to a StructBlock
+
+```javascript
+class ResetButton extends window.wagtailStreamField.blocks.ActionButton {
+    icon = 'arrow-up';
+    labelIdentifier = 'MOVE_UP';
+    
+    onClick() {
+        this.sequenceChild.resetState();
+    }
+}
+
+class AddressBlockDefinition extends window.wagtailStreamField.blocks
+    .StructBlockDefinition {
+    render(placeholder, prefix, initialState, initialError) {
+        const block = super.render(
+            placeholder,
+            prefix,
+            initialState,
+            initialError,
+        );
+        
+        block.resetState = () => {
+            block.setState(initialState);
+        };
+
+        const stateField = document.getElementById(prefix + '-state');
+        const countryField = document.getElementById(prefix + '-country');
+        const updateStateInput = () => {
+            if (countryField.value == 'us') {
+                stateField.removeAttribute('disabled');
+            } else {
+                stateField.setAttribute('disabled', true);
+            }
+        };
+        updateStateInput();
+        countryField.addEventListener('change', updateStateInput);
+
+        return block;
+    }
+    
+    setActions(base) {
+        super().setActions(base);
+        
+    }
+}
+window.telepath.register('myapp.blocks.AddressBlock', AddressBlockDefinition);
+```
+
 ## Additional methods and properties on `StructBlock` values
 
 When rendering StreamField content on a template, StructBlock values are represented as `dict`-like objects where the keys correspond to the names of the child blocks. Specifically, these values are instances of the class `wagtail.blocks.StructValue`.


### PR DESCRIPTION
Add a way to extend actions for an StructBlock in javascript side. This allows for developers to add new capabilities to a block. Examples of possible integrations:

- Reset button to remove changes
- Copy button that would copy the state of object to clipboard
- Replace button that would change to an textarea allowing to paste state from clipboard
- Generate button to create content with faker or GenAI

My motivation is to enable to copy and pasting of blocks between snippets. This way I can keep to content highly structured, but still allow content creators to move content from one field to another. Rather than trying to find a global solution for content copy/pasting allowing hook to change buttons would allow me to try out what would work best.

Would proposed change be something that would work for Wagtail?