### PR TITLE
Fix child restriction admin form when ancestors page view restrictions exists (#4277)

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/page_privacy/ancestor_privacy.html
+++ b/wagtail/admin/templates/wagtailadmin/page_privacy/ancestor_privacy.html
@@ -1,3 +1,0 @@
-{% load i18n %}
-<p>{% trans "This page has been made private by a parent page." %}</p>
-<p>{% trans "You can edit the privacy settings on:" %} <a href="{% url 'wagtailadmin_pages:edit' page_with_restriction.id %}">{{ page_with_restriction.specific_deferred.get_admin_display_title }}</a></p>

--- a/wagtail/admin/tests/test_privacy.py
+++ b/wagtail/admin/tests/test_privacy.py
@@ -1,5 +1,3 @@
-import json
-
 from django.contrib.auth.models import Group
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -116,27 +114,15 @@ class TestSetPrivacyView(WagtailTestUtils, TestCase):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(
-            response, "wagtailadmin/page_privacy/ancestor_privacy.html"
-        )
-        self.assertContains(
-            response, "This page has been made private by a parent page."
-        )
-        self.assertEqual(
-            response.context["page_with_restriction"].specific, self.private_page
-        )
-        # Should render without any heading, as the dialog already has a heading
-        soup = self.get_soup(json.loads(response.content)["html"])
-        self.assertIsNone(soup.select_one("header"))
-        self.assertIsNone(soup.select_one("h1"))
-
-        # Should link to the edit page for the collection with the restriction
-        link = soup.select_one("a")
         parent_edit_url = reverse(
             "wagtailadmin_pages:edit",
             args=(self.private_page.pk,),
         )
-        self.assertEqual(link.get("href"), parent_edit_url)
+        html = response.json()["html"]
+        self.assertIn(
+            f'<span>Privacy is inherited from the ancestor page - <a href="{parent_edit_url }">Private page (simple page)</a></span>',
+            html,
+        )
 
     def test_set_password_restriction(self):
         """

--- a/wagtail/admin/views/page_privacy.py
+++ b/wagtail/admin/views/page_privacy.py
@@ -1,9 +1,14 @@
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.forms.pages import PageViewRestrictionForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.models import Page, PageViewRestriction
+from wagtail.models.view_restrictions import BaseViewRestriction
 
 
 def set_privacy(request, page_id):
@@ -12,18 +17,24 @@ def set_privacy(request, page_id):
     if not page_perms.can_set_view_restrictions():
         raise PermissionDenied
 
-    # fetch restriction records in depth order so that ancestors appear first
-    restrictions = page.get_view_restrictions().order_by("page__depth")
+    restrictions = page.get_view_restrictions().order_by("-page__depth")
     if restrictions:
-        restriction = restrictions[0]
-        restriction_exists_on_ancestor = restriction.page != page
+        if restrictions[0].page == page:
+            restriction = restrictions[0]
+            if len(restrictions) > 1:
+                restriction_on_ancestor = restrictions[1]
+            else:
+                restriction_on_ancestor = None
+        else:
+            restriction = None
+            restriction_on_ancestor = restrictions[0]
     else:
         restriction = None
-        restriction_exists_on_ancestor = False
+        restriction_on_ancestor = None
 
     if request.method == "POST":
         form = PageViewRestrictionForm(request.POST, instance=restriction)
-        if form.is_valid() and not restriction_exists_on_ancestor:
+        if form.is_valid():
             if form.cleaned_data["restriction_type"] == PageViewRestriction.NONE:
                 # remove any existing restriction
                 if restriction:
@@ -47,33 +58,44 @@ def set_privacy(request, page_id):
             )
 
     else:  # request is a GET
-        if not restriction_exists_on_ancestor:
-            if restriction:
-                form = PageViewRestrictionForm(instance=restriction)
-            else:
-                # no current view restrictions on this page
-                form = PageViewRestrictionForm(initial={"restriction_type": "none"})
+        if restriction:
+            form = PageViewRestrictionForm(instance=restriction)
 
-    if restriction_exists_on_ancestor:
-        # display a message indicating that there is a restriction at ancestor level -
-        # do not provide the form for setting up new restrictions
-        return render_modal_workflow(
-            request,
-            "wagtailadmin/page_privacy/ancestor_privacy.html",
-            None,
-            {
-                "page_with_restriction": restriction.page,
-            },
-        )
-    else:
-        # no restriction set at ancestor level - can set restrictions here
-        return render_modal_workflow(
-            request,
-            "wagtailadmin/page_privacy/set_privacy.html",
-            None,
-            {
-                "page": page,
-                "form": form,
-            },
-            json_data={"step": "set_privacy"},
-        )
+        else:
+            # no current view restrictions on this page
+            form = PageViewRestrictionForm(initial={"restriction_type": "none"})
+
+        if restriction_on_ancestor:
+            ancestor_page_link = format_html(
+                '<a href="{url}">{title}</a>',
+                url=reverse(
+                    "wagtailadmin_pages:edit", args=[restriction_on_ancestor.page_id]
+                ),
+                title=restriction_on_ancestor.page.specific_deferred.get_admin_display_title(),
+            )
+            inherit_from_parent_choice = (
+                BaseViewRestriction.NONE,
+                format_html(
+                    "<span>{}</span>",
+                    mark_safe(
+                        _(
+                            "Privacy is inherited from the ancestor page - %(ancestor_page)s"
+                        )
+                        % {"ancestor_page": ancestor_page_link}
+                    ),
+                ),
+            )
+            form.fields["restriction_type"].choices = [
+                inherit_from_parent_choice
+            ] + list(form.fields["restriction_type"].choices[1:])
+
+    return render_modal_workflow(
+        request,
+        "wagtailadmin/page_privacy/set_privacy.html",
+        None,
+        {
+            "page": page,
+            "form": form,
+        },
+        json_data={"step": "set_privacy"},
+    )


### PR DESCRIPTION
Fixes #4277.

This pull request modifies the behavior of the "Change Privacy" modal in scenarios where ancestor pages have set privacy, as follows:

1. The privacy setting for child pages now consistently displays as editable. Previously, it rendered the message "This page has been made private by a parent page" without offering the ability to edit privacy settings.
2. When an ancestor's page privacy is set, the label for the "none" option is updated to indicate the source of the page privacy, enhancing visibility for editors (image below).

![privacy-ancestor-page](https://github.com/user-attachments/assets/d462d3f3-e579-4939-b251-a86d9e902295)


PR is based on [documentation](https://docs.wagtail.org/en/stable/advanced_topics/privacy.html#id1l) and [comment](https://github.com/wagtail/wagtail/issues/4277#issuecomment-365283569):

> This sets a restriction on who is allowed to view the page and its sub-pages.

> Discovering this came about from a use case where we wanted to be able to set extra restrictions on child pages, so personally the implementation is correct, but the admin form is wrong. Changing it the other way round (making the implementation match the admin's reporting) would be a worse step, I think.