### PR TITLE
Only override snippet chooser icon if it's different

### DIFF
--- a/wagtail/snippets/blocks.py
+++ b/wagtail/snippets/blocks.py
@@ -23,8 +23,10 @@ class SnippetChooserBlock(ChooserBlock):
     def widget(self):
         from wagtail.snippets.widgets import AdminSnippetChooser
 
-        # Override the default icon with the icon for the target model
-        self.set_meta_options({"icon": self.target_model.snippet_viewset.icon})
+        # Override the default icon with the icon for the target model (if defined)
+        if (icon := self.target_model.snippet_viewset.icon) != "snippet":
+            self.set_meta_options({"icon": icon})
+
         return AdminSnippetChooser(self.target_model, icon=self.meta.icon)
 
     class Meta:


### PR DESCRIPTION
This allows overriding the icon on a per-block basis.
