### PR TITLE
Bypass ALLOWED_HOSTS checks when resolving Site for request

### DIFF
--- a/wagtail/models/sites.py
+++ b/wagtail/models/sites.py
@@ -160,7 +160,8 @@ class Site(models.Model):
 
     @staticmethod
     def _find_for_request(request):
-        hostname = split_domain_port(request.get_host())[0]
+        # Use `_get_raw_host` to avoid ALLOWED_HOSTS checks
+        hostname = split_domain_port(request._get_raw_host())[0]
         port = request.get_port()
         site = None
         try:

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -326,6 +326,12 @@ class TestSiteRouting(TestCase):
                 Site.find_for_request(request), self.alternate_port_events_site
             )
 
+    def test_site_with_disallowed_host(self):
+        request = get_dummy_request()
+        request.META["HTTP_HOST"] = "disallowed:80"
+        with self.assertNumQueries(1):
+            self.assertEqual(Site.find_for_request(request), self.default_site)
+
 
 class TestRouting(TestCase):
     fixtures = ["test.json"]


### PR DESCRIPTION
When trying to find a site, we were previously running `ALLOWED_HOSTS` checks. This is usually unnecessary, and can cause issues when used with a dummy request.

An alternative implementation would be to validate a Site's hostname against `ALLOWED_HOSTS` at edit time, but that may lead to confusing errors for admin users, and may still require this validation bypass anyway to catch existing values.

The downside of this approach is it stops validating `ALLOWED_HOSTS`, which might not be intended. I'll do some more testing to confirm the checks are still being done _somewhere_.