### PR TITLE
Downgrade minimum version of Sphinx for Python 3.8 compatibility

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = --fail-on-warning -n -jauto
+SPHINXOPTS    = -W -n -jauto
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ testing_extras = [
 documentation_extras = [
     "pyenchant>=3.1.1,<4",
     "sphinxcontrib-spelling>=7,<8",
-    "Sphinx>=7.3",
+    "Sphinx>=7.0",
     "sphinx-autobuild>=0.6.0",
     "sphinx-wagtail-theme==6.3.0",
     "myst_parser==2.0.0",


### PR DESCRIPTION
In 5a8c33f34a36a038ab8cdaedddf19fe4d5750cf5 the minimum version was set to 7.3 to allow use of the long-form `--fail-on-warning` option, but this is not compatible with Python 3.8. Revert this to the original `-W` option and set 7.0 as the minimum version.
