### PR TITLE
Fix no-index directive for Sphinx 7.4.7

### DIFF
--- a/docs/reference/pages/panels.md
+++ b/docs/reference/pages/panels.md
@@ -11,7 +11,7 @@ Here are some built-in panel types that you can use in your panel definitions. T
 
 ```{eval-rst}
 .. module:: wagtail.admin.panels
-   :noindex:
+   :no-index:
 ```
 
 (field_panel)=
@@ -300,7 +300,7 @@ The `MultipleChooserPanel` definition on `BlogPage` would be:
 
 ```{eval-rst}
 .. module:: wagtail.admin.panels
-   :noindex:
+   :no-index:
 
 .. autoclass:: TitleFieldPanel
 


### PR DESCRIPTION
Documentation builds are currently failing on Sphinx 7.4.7 (released two days ago) with the warnings:
```
/Users/matthew/Development/tbx/wagtail/devscript/wagtail/docs/reference/pages/panels.md:13: WARNING: duplicate object description of wagtail.admin.panels, other instance in reference/panel_api, use :no-index: for one of them
/Users/matthew/Development/tbx/wagtail/devscript/wagtail/docs/reference/pages/panels.md:302: WARNING: duplicate object description of wagtail.admin.panels, other instance in reference/pages/panels, use :no-index: for one of them
```

~(To silence both warnings it's necessary to change `noindex` to `no-index` and add the extra indent, and I'm not sure why...)~ no, the indent was a red herring - changing to `no-index` didn't fix it on my first attempt because there are two instances of it, and apparently I didn't run `make clean` before retrying...