### PR TITLE
12094: Add missing getTextLabel implementation for BaseDateTimeWidget

### DIFF
--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -510,6 +510,12 @@ class BaseDateTimeWidget extends Widget {
         if (opts && opts.soft) return;
         element.focus();
       },
+      getTextLabel() {
+        if(this.getValue()) {
+          return this.getValue().toString();
+        }
+        return null;
+      },
       idForLabel: id,
     };
     widget.setState(initialState);

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -511,10 +511,8 @@ class BaseDateTimeWidget extends Widget {
         element.focus();
       },
       getTextLabel() {
-        if(this.getValue()) {
-          return this.getValue().toString();
-        }
-        return null;
+        if (!this.getValue()) return '';
+        return this.getValue();
       },
       idForLabel: id,
     };

--- a/client/src/entrypoints/admin/telepath/widgets.test.js
+++ b/client/src/entrypoints/admin/telepath/widgets.test.js
@@ -809,4 +809,8 @@ describe('telepath: wagtail.widgets.DateTimeInput', () => {
     boundWidget.focus();
     expect(document.activeElement).toBe(document.querySelector('input'));
   });
+
+  test('getTextLabel() returns the text of entered value', () => {
+    expect(boundWidget.getTextLabel()).toBe('2021-01-19 11:59');
+  });
 });


### PR DESCRIPTION
Add missing getTextLabel implementation for BaseDateTimeWidget, so the value is displayed if it is available instead of a JavaScript 'null'.

https://github.com/wagtail/wagtail/issues/12094
