### PR TITLE
Remove note about database search not ordering by relevance

### DIFF
--- a/docs/topics/search/searching.md
+++ b/docs/topics/search/searching.md
@@ -128,7 +128,7 @@ The search operator specifies how the search should behave when the user has typ
 
 Both operators have benefits and drawbacks. The "or" operator will return many more results but will likely contain a lot of results that aren't relevant. The "and" operator only returns results that contain all search terms but requires the user to be more precise with their query.
 
-We recommend using the "or" operator when ordering by relevance and the "and" operator when ordering by anything else (note: the database backend doesn't currently support ordering by relevance).
+We recommend using the "or" operator when ordering by relevance and the "and" operator when ordering by anything else.
 
 Here's an example of using the `operator` keyword argument:
 


### PR DESCRIPTION
This text existed since Wagtail 1.x and is referring to the original database backend that just did substring matches (which is now the fallback backend), before we supported database-backed full-text search.
