### PR TITLE
Fix duplicated rich text input inside choosers

### DIFF
--- a/client/src/entrypoints/admin/draftail.js
+++ b/client/src/entrypoints/admin/draftail.js
@@ -11,52 +11,59 @@ import draftail, {
  * Entry point loaded when the Draftail editor is in use.
  */
 
-// Expose Draftail package as a global.
-window.Draftail = Draftail;
-// Expose module as a global.
-window.draftail = draftail;
+// This file is included and run when there's a DraftailRichTextArea widget in the response.
+// Normally this is only included once in the initial page load, but it may be included
+// more than once when there's an AJAX response that includes the widget, e.g. in choosers.
+// Ensure we only run the initialization code once.
+// https://github.com/wagtail/wagtail/issues/12002
+if (!window.Draftail || !window.draftail) {
+  // Expose Draftail package as a global.
+  window.Draftail = Draftail;
+  // Expose module as a global.
+  window.draftail = draftail;
 
-/** @deprecated RemovedInWagtail70 - Ensure that any third party packages that use global.chooserUrls can still append to this global object until support is removed. */
-window.chooserUrls = global.chooserUrls || {};
+  /** @deprecated RemovedInWagtail70 - Ensure that any third party packages that use global.chooserUrls can still append to this global object until support is removed. */
+  window.chooserUrls = global.chooserUrls || {};
 
-// Plugins for the built-in entities.
-const entityTypes = [
-  {
-    type: 'DOCUMENT',
-    source: draftail.DocumentModalWorkflowSource,
-    decorator: Document,
-  },
-  {
-    type: 'LINK',
-    source: draftail.LinkModalWorkflowSource,
-    decorator: Link,
-    onPaste: onPasteLink,
-  },
-  {
-    type: 'IMAGE',
-    source: draftail.ImageModalWorkflowSource,
-    block: ImageBlock,
-  },
-  {
-    type: 'EMBED',
-    source: draftail.EmbedModalWorkflowSource,
-    block: EmbedBlock,
-  },
-];
+  // Plugins for the built-in entities.
+  const entityTypes = [
+    {
+      type: 'DOCUMENT',
+      source: draftail.DocumentModalWorkflowSource,
+      decorator: Document,
+    },
+    {
+      type: 'LINK',
+      source: draftail.LinkModalWorkflowSource,
+      decorator: Link,
+      onPaste: onPasteLink,
+    },
+    {
+      type: 'IMAGE',
+      source: draftail.ImageModalWorkflowSource,
+      block: ImageBlock,
+    },
+    {
+      type: 'EMBED',
+      source: draftail.EmbedModalWorkflowSource,
+      block: EmbedBlock,
+    },
+  ];
 
-entityTypes.forEach((type) => draftail.registerPlugin(type, 'entityTypes'));
+  entityTypes.forEach((type) => draftail.registerPlugin(type, 'entityTypes'));
 
-/**
- * Initialize a Draftail editor on a given element when the w-draftail:init event is fired.
- */
-document.addEventListener('w-draftail:init', ({ detail = {}, target }) => {
-  const id = target.id;
+  /**
+   * Initialize a Draftail editor on a given element when the w-draftail:init event is fired.
+   */
+  document.addEventListener('w-draftail:init', ({ detail = {}, target }) => {
+    const id = target.id;
 
-  if (!id) {
-    // eslint-disable-next-line no-console
-    console.error('`w-draftail:init` event must have a target with an id.');
-    return;
-  }
+    if (!id) {
+      // eslint-disable-next-line no-console
+      console.error('`w-draftail:init` event must have a target with an id.');
+      return;
+    }
 
-  window.draftail.initEditor(`#${id}`, detail, document.currentScript);
-});
+    window.draftail.initEditor(`#${id}`, detail, document.currentScript);
+  });
+}


### PR DESCRIPTION
Fixes #12002. I recommend toggling whitespace when reviewing.

You can use [my project](https://github.com/laymonage/wagtail-11996-repro) to ease testing.

1. Install with current `main` branch, run migrations
2. Edit a page and add a document chooser block
3. Trigger the chooser a few times
4. Check the Upload tab of the chooser, the rich text field will show up multiple times (and it adds another one every time you open the chooser)
5. Switch to this PR branch
6. Repeat steps 2 and 3
7. The rich text field should only show up once in the Upload tab