### PR TITLE
Do not suggest using the custom user model's app config as the custom wagtail.users app config

### DIFF
--- a/docs/advanced_topics/customisation/custom_user_models.md
+++ b/docs/advanced_topics/customisation/custom_user_models.md
@@ -107,10 +107,10 @@ class UserViewSet(WagtailUserViewSet):
         return CustomUserCreationForm
 ```
 
-Then, configure the `wagtail.users` application to use the custom viewset, by setting up a custom `AppConfig` class. Within your custom `myapp` app directory, create `apps.py` (if it does not exist already) and add:
+Then, configure the `wagtail.users` application to use the custom viewset, by setting up a custom `AppConfig` class. Within your project folder (which will be the package containing the top-level settings and urls modules), create `apps.py` (if it does not exist already) and add:
 
 ```python
-# myapp/apps.py
+# myproject/apps.py
 from wagtail.users.apps import WagtailUsersAppConfig
 
 
@@ -123,7 +123,8 @@ Replace `wagtail.users` in `settings.INSTALLED_APPS` with the path to `CustomUse
 ```python
 INSTALLED_APPS = [
     ...,
-    "myapp.apps.CustomUsersAppConfig",
+    "myapp",  # an app that contains the custom user model
+    "myproject.apps.CustomUsersAppConfig",  # a custom app config for the wagtail.users app
     # "wagtail.users",
     ...,
 ]

--- a/docs/extending/customizing_group_views.md
+++ b/docs/extending/customizing_group_views.md
@@ -89,10 +89,10 @@ Add the field to the group 'edit'/'create' templates:
 {% endblock extra_fields %}
 ```
 
-Finally, we configure the `wagtail.users` application to use the custom viewset, by setting up a custom `AppConfig` class. Within your custom `myapp` app directory, create `apps.py` (if it does not exist already) and add:
+Finally, we configure the `wagtail.users` application to use the custom viewset, by setting up a custom `AppConfig` class. Within your project folder (which will be the package containing the top-level settings and urls modules), create `apps.py` (if it does not exist already) and add:
 
 ```python
-# myapp/apps.py
+# myproject/apps.py
 from wagtail.users.apps import WagtailUsersAppConfig
 
 
@@ -105,7 +105,7 @@ Replace `wagtail.users` in `settings.INSTALLED_APPS` with the path to `CustomUse
 ```python
 INSTALLED_APPS = [
     ...,
-    "myapp.apps.CustomUsersAppConfig",
+    "myproject.apps.CustomUsersAppConfig",
     # "wagtail.users",
     ...,
 ]


### PR DESCRIPTION
Found this while trying to reproduce #5961...

The doc changes in 449a48d7f9816fa17eda2ca258de41ed13df8e39, in particular the paragraphs about creating the custom `AppConfig` subclass for `wagtail.users`, were changed so that the `WagtailUsersAppConfig` subclass is created in an app's `apps.py`.

The docs say:

> Finally, we configure the `wagtail.users` application to use the custom viewset, by setting up a custom `AppConfig` class. Within your custom `myapp` app directory, create `apps.py` (if it does not exist already) and add:
>
> ```python
> # myapp/apps.py
> from wagtail.users.apps import WagtailUsersAppConfig
> 
> 
> class CustomUsersAppConfig(WagtailUsersAppConfig):
>     user_viewset = "myapp.viewsets.UserViewSet"
> ```

The docs also changed the name of the example `users` app (where the custom user model is defined) into `myapp`. Even though it says to "add" the custom `WagtailUsersAppConfig` subclass, some people (e.g. myself) may mistakenly assume that they could just replace/combine the existing `AppConfig` of their custom user model's app config with the `WagtailUsersAppConfig` subclass.

Doing so would mean the "models" module of the app that contains the custom user model will be used by Django in favour of the models module of the wagtail.users app, which contains the UserProfile model. As a result, the UserProfile model becomes mistakenly picked up by the wagtailcore app, creating a bogus migration when makemigrations is run.

We can either update the `myapp/apps.py` example to also include the original config class for `myapp` to demonstrate that the two `AppConfig`s should not be combined, but I decided to partially revert the doc changes in that commit so that we put the custom `WagtailUsersAppConfig` in an `apps.py` inside the project directory instead. I think this helps avoid the confusion, as we won't be interfering with the developer's apps.

I also updated the `INSTALLED_APPS` code example to clarify that both apps still need to be registered separately.