### PR TITLE
Purge frontend cache when modifying redirects

### DIFF
--- a/wagtail/contrib/frontend_cache/backends/azure.py
+++ b/wagtail/contrib/frontend_cache/backends/azure.py
@@ -100,7 +100,7 @@ class AzureBaseBackend(BaseBackend):
         return {
             "resource_group_name": self._resource_group_name,
             "custom_headers": self._custom_headers,
-            "content_paths": paths,
+            "content_paths": set(paths),
         }
 
     def _purge_content(self, paths):

--- a/wagtail/contrib/frontend_cache/backends/cloudfront.py
+++ b/wagtail/contrib/frontend_cache/backends/cloudfront.py
@@ -45,7 +45,7 @@ class CloudfrontBackend(BaseBackend):
                 self.hostnames = list(self.cloudfront_distribution_id.keys())
 
     def purge_batch(self, urls):
-        paths_by_distribution_id = defaultdict(list)
+        paths_by_distribution_id = defaultdict(set)
 
         for url in urls:
             url_parsed = urlparse(url)
@@ -69,7 +69,7 @@ class CloudfrontBackend(BaseBackend):
                 distribution_id = self.cloudfront_distribution_id
 
             if distribution_id:
-                paths_by_distribution_id[distribution_id].append(url_parsed.path)
+                paths_by_distribution_id[distribution_id].add(url_parsed.path)
 
         for distribution_id, paths in paths_by_distribution_id.items():
             self._create_invalidation(distribution_id, paths)

--- a/wagtail/contrib/frontend_cache/backends/dummy.py
+++ b/wagtail/contrib/frontend_cache/backends/dummy.py
@@ -1,0 +1,11 @@
+from .base import BaseBackend
+
+
+class DummyBackend(BaseBackend):
+    def __init__(self):
+        super().__init__()
+
+        self.urls = []
+
+    def purge(self, url) -> None:
+        self.urls.append(url)

--- a/wagtail/contrib/frontend_cache/utils.py
+++ b/wagtail/contrib/frontend_cache/utils.py
@@ -64,6 +64,15 @@ def purge_url_from_cache(url, backend_settings=None, backends=None):
 
 
 def purge_urls_from_cache(urls, backend_settings=None, backends=None):
+    if not urls:
+        return
+
+    backends = get_backends(backend_settings, backends)
+
+    # If no backends are configured, there's nothing to do
+    if not backends:
+        return
+
     # Convert each url to urls one for each managed language (WAGTAILFRONTENDCACHE_LANGUAGES setting).
     # The managed languages are common to all the defined backends.
     # This depends on settings.USE_I18N
@@ -104,8 +113,6 @@ def purge_urls_from_cache(urls, backend_settings=None, backends=None):
 
     for url in urls:
         urls_by_hostname[urlsplit(url).netloc].append(url)
-
-    backends = get_backends(backend_settings, backends)
 
     for hostname, urls in urls_by_hostname.items():
         backends_for_hostname = {
@@ -150,14 +157,14 @@ class PurgeBatch:
     """Represents a list of URLs to be purged in a single request"""
 
     def __init__(self, urls=None):
-        self.urls = []
+        self.urls = set()
 
         if urls is not None:
             self.add_urls(urls)
 
     def add_url(self, url):
         """Adds a single URL"""
-        self.urls.append(url)
+        self.urls.add(url)
 
     def add_urls(self, urls):
         """
@@ -166,7 +173,7 @@ class PurgeBatch:
         This is equivalent to running ``.add_url(url)`` on each URL
         individually
         """
-        self.urls.extend(urls)
+        self.urls.update(urls)
 
     def add_page(self, page):
         """

--- a/wagtail/contrib/redirects/models.py
+++ b/wagtail/contrib/redirects/models.py
@@ -5,7 +5,7 @@ from django.urls import Resolver404
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
-from wagtail.models import Page
+from wagtail.models import Page, Site
 
 
 class Redirect(models.Model):
@@ -79,6 +79,21 @@ class Redirect(models.Model):
         elif self.redirect_link:
             return self.redirect_link
         return None
+
+    def old_links(self, site_root_paths=None):
+        """
+        Determine the old URLs which this redirect might handle.
+
+        :param site_root_paths: Pre-calculated root paths (obtained from `Site.get_site_root_paths`)
+        :return: List of old links
+        """
+        if self.site_id is not None:
+            return {self.site.root_url + self.old_path}
+
+        if site_root_paths is None:
+            site_root_paths = Site.get_site_root_paths()
+
+        return {root_paths.root_url + self.old_path for root_paths in site_root_paths}
 
     def get_is_permanent_display(self):
         if self.is_permanent:

--- a/wagtail/contrib/redirects/signal_handlers.py
+++ b/wagtail/contrib/redirects/signal_handlers.py
@@ -1,9 +1,11 @@
 import logging
 from typing import Iterable, Set, Tuple
 
+from django.apps import apps
 from django.conf import settings
 from django.db.models import Q
 
+from wagtail.contrib.frontend_cache.utils import PurgeBatch
 from wagtail.coreutils import BatchCreator, get_dummy_request
 from wagtail.models import Page, Site
 
@@ -26,6 +28,19 @@ class BatchRedirectCreator(BatchCreator):
         for item in self.items:
             clashes_q |= Q(old_path=item.old_path, site_id=item.site_id)
         Redirect.objects.filter(automatically_created=True).filter(clashes_q).delete()
+
+    def post_process(self):
+        if not apps.is_installed("wagtail.contrib.frontend_cache"):
+            return
+
+        batch = PurgeBatch()
+
+        site_root_paths = Site.get_site_root_paths()
+
+        for redirect in self.items:
+            batch.add_urls(redirect.old_links(site_root_paths))
+
+        batch.purge()
 
 
 def autocreate_redirects_on_slug_change(

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from openpyxl.reader.excel import load_workbook
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
+from wagtail.contrib.frontend_cache.tests import PURGED_URLS
 from wagtail.contrib.redirects import models
 from wagtail.log_actions import registry as log_registry
 from wagtail.models import Page, Site
@@ -793,11 +794,19 @@ class TestRedirectsIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase)
         self.assertQuerySetEqual(qs, Page.objects.filter(pk=2))
 
 
+@override_settings(
+    WAGTAILFRONTENDCACHE={
+        "dummy": {
+            "BACKEND": "wagtail.contrib.frontend_cache.tests.MockBackend",
+        },
+    },
+)
 class TestRedirectsAddView(WagtailTestUtils, TestCase):
     fixtures = ["test.json"]
 
     def setUp(self):
         self.login()
+        PURGED_URLS.clear()
 
     def get(self, params={}):
         return self.client.get(reverse("wagtailredirects:add"), params)
@@ -834,6 +843,8 @@ class TestRedirectsAddView(WagtailTestUtils, TestCase):
         log_entry = log_registry.get_logs_for_instance(redirect).first()
         self.assertEqual(log_entry.action, "wagtail.create")
 
+        self.assertEqual(PURGED_URLS, {"http://localhost/test"})
+
     def test_add_with_site(self):
         localhost = Site.objects.get(hostname="localhost")
         response = self.post(
@@ -854,6 +865,8 @@ class TestRedirectsAddView(WagtailTestUtils, TestCase):
         self.assertEqual(redirects.first().redirect_link, "http://www.test.com/")
         self.assertEqual(redirects.first().site, localhost)
 
+        self.assertEqual(PURGED_URLS, {"http://localhost/test"})
+
     def test_add_validation_error(self):
         response = self.post(
             {
@@ -866,6 +879,7 @@ class TestRedirectsAddView(WagtailTestUtils, TestCase):
 
         # Should not redirect to index
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(PURGED_URLS, set())
 
     def test_cannot_add_duplicate_with_no_site(self):
         models.Redirect.objects.create(
@@ -882,6 +896,7 @@ class TestRedirectsAddView(WagtailTestUtils, TestCase):
 
         # Should not redirect to index
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(PURGED_URLS, set())
 
     def test_cannot_add_duplicate_on_same_site(self):
         localhost = Site.objects.get(hostname="localhost")
@@ -899,6 +914,7 @@ class TestRedirectsAddView(WagtailTestUtils, TestCase):
 
         # Should not redirect to index
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(PURGED_URLS, set())
 
     def test_can_reuse_path_on_other_site(self):
         localhost = Site.objects.get(hostname="localhost")
@@ -926,6 +942,8 @@ class TestRedirectsAddView(WagtailTestUtils, TestCase):
         redirects = models.Redirect.objects.filter(redirect_link="http://www.test.com/")
         self.assertEqual(redirects.count(), 1)
 
+        self.assertEqual(PURGED_URLS, redirects.get().old_links())
+
     def test_add_long_redirect(self):
         response = self.post(
             {
@@ -948,7 +966,16 @@ class TestRedirectsAddView(WagtailTestUtils, TestCase):
         )
         self.assertIsNone(redirects.first().site)
 
+        self.assertEqual(PURGED_URLS, redirects.get().old_links())
 
+
+@override_settings(
+    WAGTAILFRONTENDCACHE={
+        "dummy": {
+            "BACKEND": "wagtail.contrib.frontend_cache.tests.MockBackend",
+        },
+    },
+)
 class TestRedirectsEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def setUp(self):
         # Create a redirect to edit
@@ -959,6 +986,8 @@ class TestRedirectsEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
 
         # Login
         self.user = self.login()
+
+        PURGED_URLS.clear()
 
     def get(self, params={}, redirect_id=None):
         return self.client.get(
@@ -1012,6 +1041,8 @@ class TestRedirectsEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         )
         self.assertIsNone(redirects.first().site)
 
+        self.assertEqual(PURGED_URLS, {"http://localhost/test"})
+
     def test_edit_with_site(self):
         localhost = Site.objects.get(hostname="localhost")
 
@@ -1034,6 +1065,7 @@ class TestRedirectsEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
             redirects.first().redirect_link, "http://www.test.com/ive-been-edited"
         )
         self.assertEqual(redirects.first().site, localhost)
+        self.assertEqual(PURGED_URLS, {"http://localhost/test"})
 
     def test_edit_validation_error(self):
         response = self.post(
@@ -1047,6 +1079,7 @@ class TestRedirectsEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
 
         # Should not redirect to index
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(PURGED_URLS, set())
 
     def test_edit_duplicate(self):
         models.Redirect.objects.create(
@@ -1063,6 +1096,7 @@ class TestRedirectsEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
 
         # Should not redirect to index
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(PURGED_URLS, set())
 
     def test_get_with_no_permission(self, redirect_id=None):
         self.user.is_superuser = False
@@ -1098,6 +1132,13 @@ class TestRedirectsEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailredirects/edit.html")
 
 
+@override_settings(
+    WAGTAILFRONTENDCACHE={
+        "dummy": {
+            "BACKEND": "wagtail.contrib.frontend_cache.tests.MockBackend",
+        },
+    },
+)
 class TestRedirectsDeleteView(WagtailTestUtils, TestCase):
     def setUp(self):
         # Create a redirect to edit
@@ -1108,6 +1149,8 @@ class TestRedirectsDeleteView(WagtailTestUtils, TestCase):
 
         # Login
         self.login()
+
+        PURGED_URLS.clear()
 
     def get(self, params={}, redirect_id=None):
         return self.client.get(
@@ -1137,3 +1180,5 @@ class TestRedirectsDeleteView(WagtailTestUtils, TestCase):
         # Check that the redirect was deleted
         redirects = models.Redirect.objects.filter(old_path="/test")
         self.assertEqual(redirects.count(), 0)
+
+        self.assertEqual(PURGED_URLS, {"http://localhost/test"})

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -18,6 +18,7 @@ from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.ui.tables import Column, StatusTagColumn, TitleColumn
 from wagtail.admin.views import generic
 from wagtail.admin.widgets.button import Button
+from wagtail.contrib.frontend_cache.utils import PurgeBatch, purge_urls_from_cache
 from wagtail.contrib.redirects import models
 from wagtail.contrib.redirects.filters import RedirectsReportFilterSet
 from wagtail.contrib.redirects.forms import (
@@ -36,6 +37,7 @@ from wagtail.contrib.redirects.utils import (
     write_to_file_storage,
 )
 from wagtail.log_actions import log
+from wagtail.models import Site
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 
@@ -154,6 +156,20 @@ class EditView(generic.EditView):
             "redirect_title": self.object.title
         }
 
+    def save_instance(self):
+        purger = PurgeBatch()
+
+        root_paths = Site.get_site_root_paths()
+        purger.add_urls(self.object.old_links(root_paths))
+
+        instance = super().save_instance()
+
+        purger.add_urls(self.object.old_links(root_paths))
+
+        purger.purge()
+
+        return instance
+
 
 @permission_checker.require("delete")
 def delete(request, redirect_id):
@@ -168,6 +184,9 @@ def delete(request, redirect_id):
         with transaction.atomic():
             log(instance=theredirect, action="wagtail.delete")
             theredirect.delete()
+
+        purge_urls_from_cache(theredirect.old_links())
+
         messages.success(
             request,
             _("Redirect '%(redirect_title)s' deleted.")
@@ -192,6 +211,8 @@ def add(request):
             with transaction.atomic():
                 theredirect = form.save()
                 log(instance=theredirect, action="wagtail.create")
+
+            purge_urls_from_cache(theredirect.old_links())
 
             messages.success(
                 request,


### PR DESCRIPTION
When creating or modifying redirects, it's possible their source URL(s) are still cached by frontend caching, meaning the URL won't apply instantly.

This PR purges the "old" URL(s) of a redirect when modified. For site-agnostic redirects, assume all sites need purging.

The new tests reuse the existing `MockBackend` for testing. Because the backend instance doesn't persist, it's difficult to obtain the purged URLs.