### PR TITLE
Fix typo in 6.2 release notes and changelog

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,7 +20,7 @@ Changelog
  * Allow custom permission policies on snippets to prevent superusers from creating or editing them (Sage Abdullah)
  * Do not link to edit view from listing views if user has no permission to edit (Sage Abdullah)
  * Allow access to snippets and other model viewsets to users with "View" permission (Sage Abdullah)
- * Skip `ChooseParentView` if only one possible valid parent page availale (Matthias Brück)
+ * Skip `ChooseParentView` if only one possible valid parent page available (Matthias Brück)
  * Add `copy_for_translation_done` signal when a page is copied for translation (Arnar Tumi Þorsteinsson)
  * Remove reduced opacity for draft page title in listings (Inju Michorius)
  * Adopt more compact representation for StreamField definitions in migrations (Matt Westcott)

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -48,7 +48,7 @@ StreamField definitions within migrations are now represented in a more compact 
  * Allow custom permission policies on snippets to prevent superusers from creating or editing them (Sage Abdullah)
  * Do not link to edit view from listing views if user has no permission to edit (Sage Abdullah)
  * Allow access to snippets and other model viewsets to users with "View" permission (Sage Abdullah)
- * Skip `ChooseParentView` if only one possible valid parent page availale (Matthias Brück)
+ * Skip `ChooseParentView` if only one possible valid parent page available (Matthias Brück)
  * Add `copy_for_translation_done` signal when a page is copied for translation (Arnar Tumi Þorsteinsson)
  * Remove reduced opacity for draft page title in listings (Inju Michorius)
  * Implement a new design for locale labels in listings (Albina Starykova)

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -48,7 +48,7 @@ StreamField definitions within migrations are now represented in a more compact 
  * Allow custom permission policies on snippets to prevent superusers from creating or editing them (Sage Abdullah)
  * Do not link to edit view from listing views if user has no permission to edit (Sage Abdullah)
  * Allow access to snippets and other model viewsets to users with "View" permission (Sage Abdullah)
- * Skip `ChooseParentView` if only one possible valid parent page available (Matthias Brück)
+ * Skip `ChooseParentView` if only one possible valid parent page is available (Matthias Brück)
  * Add `copy_for_translation_done` signal when a page is copied for translation (Arnar Tumi Þorsteinsson)
  * Remove reduced opacity for draft page title in listings (Inju Michorius)
  * Implement a new design for locale labels in listings (Albina Starykova)


### PR DESCRIPTION
No issue.

Simply fixes a typo s/availale/available/g and a small grammar change in the Wagtail 6.2 release notes and changelog.
