### PR TITLE
Move publish, lock, and unlock permissions to the "Custom permissions" column

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -27,6 +27,7 @@ ul.listing {
 
   td,
   th {
+    text-align: start;
     padding: calc(1em * var(--w-density-factor)) 0.3em;
 
     @include media-breakpoint-up(sm) {
@@ -62,7 +63,6 @@ ul.listing {
 
     th {
       font-size: 0.9em;
-      text-align: start;
       font-weight: normal;
       white-space: nowrap;
     }
@@ -87,8 +87,8 @@ ul.listing {
   }
 
   &:has(
-      td:first-child input[type='checkbox'],
-      th:first-child input[type='checkbox']
+      td:first-child input[type='checkbox']:only-child,
+      th:first-child input[type='checkbox']:only-child
     ) {
     td:first-child,
     th:first-child {
@@ -97,6 +97,7 @@ ul.listing {
       width: theme('spacing.10');
       text-align: center;
 
+      // stylelint-disable-next-line selector-max-specificity
       input[type='checkbox'] {
         margin-inline-end: 0;
       }
@@ -574,8 +575,8 @@ table.listing {
     }
 
     &:has(
-        td:first-child input[type='checkbox'],
-        th:first-child input[type='checkbox']
+        td:first-child input[type='checkbox']:only-child,
+        th:first-child input[type='checkbox']:only-child
       ) {
       // Bulk actions, match the width of the header spacing up until
       // the page title (final breadcrumb item):
@@ -596,8 +597,8 @@ table.listing {
     // custom ordering is active, as the padding to match the breadcrumbs is
     // already handled by the first column.
     &:has(
-        td:first-child input[type='checkbox'],
-        th:first-child input[type='checkbox'],
+        td:first-child input[type='checkbox']:only-child,
+        th:first-child input[type='checkbox']:only-child,
         .ord
       ) {
       th:nth-child(2),
@@ -616,11 +617,12 @@ table.listing {
     // then apply the same 80px padding via the first column's left padding.
     &:not(.nice-padding &, .report &, .editor-view &):not(
         :has(
-            td:first-child input[type='checkbox'],
-            th:first-child input[type='checkbox'],
+            td:first-child input[type='checkbox']:only-child,
+            th:first-child input[type='checkbox']:only-child,
             .ord
           )
       ) {
+      // stylelint-disable-next-line selector-max-specificity
       th:first-child,
       td:first-child {
         padding-inline-start: theme('spacing.20');

--- a/client/src/controllers/BulkController.ts
+++ b/client/src/controllers/BulkController.ts
@@ -164,6 +164,10 @@ export class BulkController extends Controller<HTMLElement> {
       const lastClickedIndex = activeItems.findIndex(
         (item) => item === lastChanged,
       );
+
+      // The last clicked item is not in the current group, skip bulk toggling
+      if (lastClickedIndex === -1) return;
+
       const currentIndex = activeItems.findIndex(
         (item) => item === event?.target,
       );

--- a/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
@@ -51,7 +51,7 @@
                         {% if extra_perms_exist.custom %}
                             <td>
                                 {% if content_perms_dict.custom %}
-                                    <fieldset class="w-p-0">
+                                    <fieldset class="w-p-0 w-flex w-flex-col w-gap-1">
                                         <legend class="w-sr-only">{% trans "Custom permissions" %}</legend>
                                         {% for custom_perm in content_perms_dict.custom %}
                                             {% trans custom_perm.name as custom_perm_label %}

--- a/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
@@ -11,15 +11,6 @@
                 <col width="10%" />
                 <col width="10%" />
                 <col width="10%" />
-                {% if extra_perms_exist.publish %}
-                    <col width="10%" />
-                {% endif %}
-                {% if extra_perms_exist.lock %}
-                    <col width="10%" />
-                {% endif %}
-                {% if extra_perms_exist.unlock %}
-                    <col width="10%" />
-                {% endif %}
                 {% if extra_perms_exist.custom %}
                     <col width="25%" />
                 {% endif %}
@@ -30,15 +21,6 @@
                     <th>{% trans "Add" %}</th>
                     <th>{% trans "Change" %}</th>
                     <th>{% trans "Delete" %}</th>
-                    {% if extra_perms_exist.publish %}
-                        <th>{% trans "Publish" %}</th>
-                    {% endif %}
-                    {% if extra_perms_exist.lock %}
-                        <th>{% trans "Lock" %}</th>
-                    {% endif %}
-                    {% if extra_perms_exist.unlock %}
-                        <th>{% trans "Unlock" %}</th>
-                    {% endif %}
                     {% if extra_perms_exist.custom %}
                         <th>{% trans "Custom permissions" %}</th>
                     {% endif %}
@@ -66,30 +48,6 @@
                                 {{ content_perms_dict.delete.checkbox.tag }}
                             {% endif %}
                         </td>
-                        {% if extra_perms_exist.publish %}
-                            <td>
-                                {% if content_perms_dict.publish %}
-                                    <label for="{{ content_perms_dict.publish.checkbox.id_for_label }}" class="w-sr-only">{{ content_perms_dict.publish.perm.name }}</label>
-                                    {{ content_perms_dict.publish.checkbox.tag }}
-                                {% endif %}
-                            </td>
-                        {% endif %}
-                        {% if extra_perms_exist.lock %}
-                            <td>
-                                {% if content_perms_dict.lock %}
-                                    <label for="{{ content_perms_dict.lock.checkbox.id_for_label }}" class="w-sr-only">{{ content_perms_dict.lock.perm.name }}</label>
-                                    {{ content_perms_dict.lock.checkbox.tag }}
-                                {% endif %}
-                            </td>
-                        {% endif %}
-                        {% if extra_perms_exist.unlock %}
-                            <td>
-                                {% if content_perms_dict.unlock %}
-                                    <label for="{{ content_perms_dict.unlock.checkbox.id_for_label }}" class="w-sr-only">{{ content_perms_dict.unlock.perm.name }}</label>
-                                    {{ content_perms_dict.unlock.checkbox.tag }}
-                                {% endif %}
-                            </td>
-                        {% endif %}
                         {% if extra_perms_exist.custom %}
                             <td>
                                 {% if content_perms_dict.custom %}
@@ -124,24 +82,6 @@
                         <label for="toggle-all-delete" class="visuallyhidden">{% trans "Toggle all delete permissions" %}</label>
                         <input id="toggle-all-delete" type="checkbox" data-action="w-bulk#toggleAll" data-w-bulk-target="all" data-w-bulk-group-param="delete">
                     </td>
-                    {% if extra_perms_exist.publish %}
-                        <td>
-                            <label for="toggle-all-publish" class="visuallyhidden">{% trans "Toggle all publish permissions" %}</label>
-                            <input id="toggle-all-publish" type="checkbox" data-action="w-bulk#toggleAll" data-w-bulk-target="all" data-w-bulk-group-param="publish">
-                        </td>
-                    {% endif %}
-                    {% if extra_perms_exist.lock %}
-                        <td>
-                            <label for="toggle-all-lock" class="visuallyhidden">{% trans "Toggle all lock permissions" %}</label>
-                            <input id="toggle-all-lock" type="checkbox" data-action="w-bulk#toggleAll" data-w-bulk-target="all" data-w-bulk-group-param="lock">
-                        </td>
-                    {% endif %}
-                    {% if extra_perms_exist.unlock %}
-                        <td>
-                            <label for="toggle-all-unlock" class="visuallyhidden">{% trans "Toggle all unlock permissions" %}</label>
-                            <input id="toggle-all-unlock" type="checkbox" data-action="w-bulk#toggleAll" data-w-bulk-target="all" data-w-bulk-group-param="unlock">
-                        </td>
-                    {% endif %}
                     {% if extra_perms_exist.custom %}
                         <td>
                             <label for="toggle-all-custom" class="visuallyhidden">{% trans "Toggle all custom permissions" %}</label>

--- a/wagtail/users/templatetags/wagtailusers_tags.py
+++ b/wagtail/users/templatetags/wagtailusers_tags.py
@@ -76,7 +76,6 @@ def format_permissions(permission_bound_field):
             'add': checkbox,
             'change': checkbox,
             'delete': checkbox,
-            'publish': checkbox,  # only if the model extends DraftStateMixin
             'custom': list_of_checkboxes_for_custom_permissions
         },
     ]
@@ -112,13 +111,10 @@ def format_permissions(permission_bound_field):
 
     # Permissions that are known by Wagtail, to be shown under their own columns.
     # Other permissions will be shown under the "custom permissions" column.
-    main_permission_names = ["add", "change", "delete", "publish", "lock", "unlock"]
+    main_permission_names = ["add", "change", "delete"]
 
     # Only show the columns for these permissions if any of the model has them.
     extra_perms_exist = {
-        "publish": False,
-        "lock": False,
-        "unlock": False,
         "custom": False,
     }
     # Batch the permission query for all content types, then group by content type


### PR DESCRIPTION
!["Object permissions" section in the group permissions editor](https://github.com/user-attachments/assets/e662fe7d-d9a7-4c9a-9ee8-a793898bb690)



A few tidy-ups:

- 1st commit fixes #12196 and supersedes #11786.
- 2nd commit moves the permissions for the optional mixins to the 'custom' permissions.
  - This reverts some of the changes in 1f143cf8ca5b65c91a77cfb7aa625c82d10cc2f3 and 12c6c97a8b809bd2c761a2e1417ace884d0f239f.
  - I kept the `extra_perms_exist` dict despite it now only contains the `custom` key instead of reverting it back to a boolean flag like it was 1f143cf8ca5b65c91a77cfb7aa625c82d10cc2f3, to minimise the diff and in case we want to add other columns in the future.
- 3rd commit fixes an issue I encountered when you use the shift+click bulk toggling feature across columns.
  - To test, try clicking a checkbox in one column, then shift+click a checkbox in a different column (doesn't matter the row). Before this commit, you'll see an error in the browser console.
- 4th commit is just a small tweak to add a gap between multiple permissions in the same 'Custom permissions' cell.

There are definitely still some more room for improvements here, but without proper designs I think this is a worthwhile thing to do for now.