### PR TITLE
Improve page listings performance

### DIFF
--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -1284,7 +1284,7 @@ class TestInWorkflowStatus(WagtailTestUtils, TestCase):
         # Warm up cache
         self.client.get(self.url)
 
-        with self.assertNumQueries(47):
+        with self.assertNumQueries(44):
             response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)

--- a/wagtail/contrib/simple_translation/tests/test_views.py
+++ b/wagtail/contrib/simple_translation/tests/test_views.py
@@ -476,7 +476,7 @@ class TestPageListing(WagtailTestUtils, TestCase):
     def test_translate_button_displayed(self):
         url = reverse("wagtailadmin_explore", args=(self.en_homepage.pk,))
         response = self.client.get(url)
-        with self.assertNumQueries(50):
+        with self.assertNumQueries(40):
             response = self.client.get(url)
 
         soup = self.get_soup(response.content)

--- a/wagtail/contrib/simple_translation/tests/test_views.py
+++ b/wagtail/contrib/simple_translation/tests/test_views.py
@@ -33,6 +33,7 @@ from wagtail.test.utils import TestCase, WagtailTestUtils
         ("fr", "French"),
         ("de", "German"),
     ],
+    WAGTAIL_I18N_ENABLED=True,
 )
 class TestSubmitTranslationView(WagtailTestUtils, TestCase):
     def setUp(self):
@@ -118,6 +119,7 @@ class TestSubmitTranslationView(WagtailTestUtils, TestCase):
         ("fr", "French"),
         ("de", "German"),
     ],
+    WAGTAIL_I18N_ENABLED=True,
 )
 class TestSubmitPageTranslationView(WagtailTestUtils, TestCase):
     def setUp(self):
@@ -222,6 +224,7 @@ class TestSubmitPageTranslationView(WagtailTestUtils, TestCase):
         ("fr", "French"),
         ("de", "German"),
     ],
+    WAGTAIL_I18N_ENABLED=True,
 )
 class TestSubmitSnippetTranslationView(WagtailTestUtils, TestCase):
     def setUp(self):
@@ -401,6 +404,7 @@ class TestSubmitSnippetTranslationWithDraftState(WagtailTestUtils, TestCase):
         ("de", "German"),
     ],
     WAGTAILSIMPLETRANSLATION_SYNC_PAGE_TREE=True,
+    WAGTAIL_I18N_ENABLED=True,
 )
 class TestPageTreeSync(WagtailTestUtils, TestCase):
     def setUp(self):
@@ -438,3 +442,50 @@ class TestPageTreeSync(WagtailTestUtils, TestCase):
 
         self.assertFalse(en_blog_index.has_translation(self.fr_locale))
         self.assertFalse(en_blog_index.has_translation(self.de_locale))
+
+
+@override_settings(
+    LANGUAGES=[
+        ("en", "English"),
+        ("fr", "French"),
+        ("de", "German"),
+    ],
+    WAGTAIL_CONTENT_LANGUAGES=[
+        ("en", "English"),
+        ("fr", "French"),
+        ("de", "German"),
+    ],
+    WAGTAIL_I18N_ENABLED=True,
+)
+class TestPageListing(WagtailTestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.en_locale = Locale.objects.first()
+        cls.fr_locale = Locale.objects.create(language_code="fr")
+        cls.de_locale = Locale.objects.create(language_code="de")
+
+        cls.en_homepage = Page.objects.get(depth=2)
+        cls.pages = []
+        for i in range(10):
+            instance = TestPage(title=f"Foo {i}", slug=f"foo-{i}")
+            cls.pages.append(cls.en_homepage.add_child(instance=instance))
+
+    def setUp(self):
+        self.user = self.login()
+
+    def test_translate_button_displayed(self):
+        url = reverse("wagtailadmin_explore", args=(self.en_homepage.pk,))
+        response = self.client.get(url)
+        with self.assertNumQueries(50):
+            response = self.client.get(url)
+
+        soup = self.get_soup(response.content)
+        page = self.pages[0]
+        translate_url = reverse(
+            "simple_translation:submit_page_translation",
+            args=[page.id],
+        )
+        translate_button = soup.select_one(f'a[href="{translate_url}"]')
+        self.assertIsNotNone(translate_button)
+        self.assertEqual(translate_button.text.strip(), "Translate")
+        self.assertIsNotNone(translate_button.select_one("svg.icon-globe"))

--- a/wagtail/contrib/simple_translation/wagtail_hooks.py
+++ b/wagtail/contrib/simple_translation/wagtail_hooks.py
@@ -58,7 +58,9 @@ def page_listing_more_buttons(page, user, next_url=None):
 
         if has_locale_to_translate_to:
             url = reverse("simple_translation:submit_page_translation", args=[page.id])
-            yield wagtailadmin_widgets.Button(_("Translate"), url, priority=60)
+            yield wagtailadmin_widgets.Button(
+                _("Translate"), url, icon_name="globe", priority=60
+            )
 
 
 @hooks.register("register_page_header_buttons")

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -642,7 +642,7 @@ class DraftStateMixin(models.Model):
 
     def get_lock(self):
         # Scheduled publishing lock should take precedence over other locks
-        if self.scheduled_revision:
+        if self.approved_schedule:
             return ScheduledForPublishLock(self)
         return super().get_lock()
 

--- a/wagtail/query.py
+++ b/wagtail/query.py
@@ -12,6 +12,7 @@ from django.db.models.functions import Cast, Length, Substr
 from django.db.models.query import BaseIterable, ModelIterable
 from treebeard.mp_tree import MP_NodeQuerySet
 
+from wagtail.models.i18n import Locale
 from wagtail.models.sites import Site
 from wagtail.search.queryset import SearchableQuerySetMixin
 
@@ -504,6 +505,17 @@ class PageQuerySet(SearchableQuerySetMixin, SpecificQuerySetMixin, TreeQuerySet)
             _is_site_root=Exists(
                 Site.objects.filter(
                     root_page__translation_key=OuterRef("translation_key")
+                )
+            )
+        )
+
+    def annotate_has_untranslated_locale(self):
+        return self.annotate(
+            _has_untranslated_locale=Exists(
+                Locale.objects.exclude(
+                    id__in=self.model.objects.filter(
+                        translation_key=OuterRef(OuterRef("translation_key"))
+                    ).values("locale_id")
                 )
             )
         )


### PR DESCRIPTION
This eliminates a few duplicated and N+1 queries on the page listings. I'm doing this because I'd like to reuse the page `IndexView` code to rebuild a few areas in the admin, such as:
- [workflow usage listing](https://static-wagtail-v6-2.netlify.app/admin/workflows/usage/1/)
- [page type usage listing](https://static-wagtail-v6-2.netlify.app/admin/pages/usage/base/standardpage/)

There are still more optimisations that can be made, but for the explorable listings the main offender is that we pass `self.parent_page.get_latest_revision_as_object()` to the status side panel.

https://github.com/wagtail/wagtail/blob/72b965cd94726e9fa0ceb64f10ef7ef88476fb2c/wagtail/admin/views/pages/listing.py#L503

This will reload the instance using the revision data, which unfortunately will undo any performance optimisation we make when fetching the parent page (e.g. foreign keys in `select_related` will be refetched individually again). I'm skipping that part for now as it seems a bit riskier.