### PR TITLE
Avoid importing custom user models at load time in wagtail.admin.models

### DIFF
--- a/wagtail/admin/models.py
+++ b/wagtail/admin/models.py
@@ -1,4 +1,4 @@
-from django.contrib.auth import get_user_model
+from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -76,7 +76,7 @@ def popular_tags_for_model(model, count=10):
 
 class EditingSession(models.Model):
     user = models.ForeignKey(
-        get_user_model(),
+        settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
         related_name="editing_sessions",
     )

--- a/wagtail/test/customuser/models.py
+++ b/wagtail/test/customuser/models.py
@@ -5,11 +5,14 @@ from django.contrib.auth.models import (
 )
 from django.db import models
 
-# make sure we can import wagtail.admin.auth here without triggering a circular import
-# (which is easily done because it's dealing with django.contrib.auth views which depend
-# on the user model)
+# Custom user models are a common source of circular import errors, since the user model is often
+# referenced in Wagtail core code that we may want to import here. To prevent this, Wagtail should
+# avoid importing the user model at load time.
+# wagtail.admin.auth and wagtail.admin.views.generic are imported here as these have been
+# previously identified as sources of circular imports.
 from wagtail.admin.auth import permission_denied  # noqa: F401
 from wagtail.admin.panels import FieldPanel
+from wagtail.admin.views.generic import chooser as chooser_views  # noqa: F401
 
 from .fields import ConvertedValueField
 


### PR DESCRIPTION
As per https://docs.djangoproject.com/en/5.0/topics/auth/customizing/#referencing-the-user-model , module-level code such as ForeignKey definitions should use `AUTH_USER_MODEL` rather than `get_user_model()`.

Probably fixes #12228 (unconfirmed)
