### PR TITLE
Change in twitter link reporting security issues

### DIFF
--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -13,7 +13,7 @@ The following organisations and individuals supported the [Wagtail's First Hatch
 -   [Taywa](https://www.taywa.ch/)
 -   [Rock Kitchen Harris](https://www.rkh.co.uk/)
 -   [The Motley Fool](https://www.fool.com/)
--   [R Strother Scott](https://twitter.com/rstrotherscott)
+-   [R Strother Scott](https://x.com/rstrotherscott)
 -   [Beyond Media](https://www.beyond.works/)
 
 The features below were developed thanks to the sponsorship of these organsations:

--- a/docs/advanced_topics/third_party_tutorials.md
+++ b/docs/advanced_topics/third_party_tutorials.md
@@ -151,7 +151,7 @@ the latest Wagtail versions.
 -   [Wagtail-Multilingual: a simple project to demonstrate how multilingual is implemented](https://github.com/cristovao-alves/Wagtail-Multilingual) (31 January 2017)
 -   [Wagtail: 2 Steps for Adding Pages Outside of the CMS](https://www.caktusgroup.com/blog/2016/02/15/wagtail-2-steps-adding-pages-outside-cms/) (15 February 2016)
 -   [Deploying Wagtail to Heroku](https://wagtail.org/blog/deploying-wagtail-heroku/) (15 July 2015)
--   [Adding a Twitter Widget for Wagtail's new StreamField](https://jossingram.wordpress.com/2015/04/02/adding-a-twitter-widget-for-wagtails-new-streamfield/) (2 April 2015)
+-   [Adding a  Widget for Wagtail's new StreamField](https://jossingram.wordpress.com/2015/04/02/adding-a-twitter-widget-for-wagtails-new-streamfield/) (2 April 2015)
 -   [Working With Wagtail: Menus](https://learnwagtail.com/tutorials/how-to-create-a-custom-wagtail-menu-system/) (22 January 2015)
 -   [Upgrading Wagtail to use Django 1.7 locally using vagrant](https://jossingram.wordpress.com/2014/12/10/upgrading-wagtail-to-use-django-1-7-locally-using-vagrant/) (10 December 2014)
 -   [Wagtail redirect page. Can link to page, URL and document](https://gist.github.com/alej0varas/e7e334643ceab6e65744) (24 September 2014)

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -53,7 +53,7 @@ On the day of disclosure, we will take the following steps:
    The commit messages for these patches will indicate that they are for security issues, but will not describe the issue in any detail; instead, they will warn of upcoming disclosure.
 2. Issue the relevant release(s), by placing new packages on [the Python Package Index](https://pypi.org/project/wagtail/), tagging the new release(s) in Wagtail's GitHub repository and updating Wagtail's [release notes](../releases/index).
 3. Publish a [security advisory](https://github.com/wagtail/wagtail/security/advisories?state=published) on Wagtail's GitHub repository. This describes the issue and its resolution in detail, pointing to the relevant patches and new releases, and crediting the reporter of the issue (if the reporter wishes to be publicly identified)
-4. Post a notice to the [Wagtail discussion board](https://github.com/wagtail/wagtail/discussions), [Slack workspace](https://wagtail.org/slack/) and Twitter feed ([\@WagtailCMS](https://twitter.com/wagtailcms)) that links to the security advisory.
+4. Post a notice to the [Wagtail discussion board](https://github.com/wagtail/wagtail/discussions), [Slack workspace](https://wagtail.org/slack/) and X feed ([\@WagtailCMS](https://x.com/wagtailcms)) that links to the security advisory.
 
 If a reported issue is believed to be particularly time-sensitive -- due to a known exploit in the wild, for example -- the time between advance notification and public disclosure may be shortened considerably.
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -28,4 +28,4 @@ If your bug report is a security issue, **do not** report it with an issue. Plea
 
 ## Torchbox
 
-Finally, if you have a query which isn't relevant for any of the above forums, feel free to contact the Wagtail team at Torchbox directly, on [hello@wagtail.org](mailto:hello@wagtail.org) or [@wagtailcms](https://twitter.com/wagtailcms).
+Finally, if you have a query which isn't relevant for any of the above forums, feel free to contact the Wagtail team at Torchbox directly, on [hello@wagtail.org](mailto:hello@wagtail.org) or [@wagtailcms](https://x.com/wagtailcms).


### PR DESCRIPTION
In the Report the security issues section the twitter link was not updated :
![Screenshot 2024-08-15 224248](https://github.com/user-attachments/assets/8ebe8fc2-5d15-4b08-89d5-2151f0e6bb07)

The updated link:

![Screenshot 2024-08-15 224314](https://github.com/user-attachments/assets/086f5ebd-feaf-4917-a69a-78409c04add3)
