### PR TITLE
Adding updated tutorial link requested by Divio to Third-Party Tutorials

### DIFF
--- a/docs/advanced_topics/third_party_tutorials.md
+++ b/docs/advanced_topics/third_party_tutorials.md
@@ -6,6 +6,7 @@ from third-party developers. Some of the older links may not apply to
 the latest Wagtail versions.
 ```
 
+-   [Deploying Wagtail on Divio](https://docs.divio.com/en/latest/introduction/wagtail/) (~June 2024)
 -   [Upgrading Wagtail (from 2.5 to 6.0)](https://learnwagtail.com/blog/category/upgrading-wagtail/) (18 April 2024)
 -   [Using Wagtail Form Templates in Software Development Projects](https://devcodef1.com/news/1211030/wagtail-form-templates-in-sd-projects) (9 April 2024)
 -   [Build an Intuitive Link StructBlock in Wagtail: Simplifying Link Management for Content Editors](https://enzedonline.com/en/tech-blog/build-an-intuitive-link-structblock-in-wagtail-simplifying-link-management-for-content-editors/) (9 March 2024)


### PR DESCRIPTION
 Divio requested that we include the updated version date for their quickstart guide in the Third-Party Tutorials links. This should be a small and straightforward update, but please let me know if there are any questions.
