### PR TITLE
Fix duplicate class attribute in image chooser

### DIFF
--- a/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
+++ b/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
@@ -2,5 +2,5 @@
 
 {% block chosen_icon %}
     {# Empty alt because the chosen item’s title is already displayed next to the image. #}
-    <img class="chooser__image" data-chooser-image alt="" class="show-transparency" decoding="async" height="{{ preview.height }}" src="{{ preview.url }}" width="{{ preview.width }}">
+    <img class="chooser__image show-transparency" data-chooser-image alt="" decoding="async" height="{{ preview.height }}" src="{{ preview.url }}" width="{{ preview.width }}">
 {% endblock chosen_icon %}


### PR DESCRIPTION
Class attribute is duplicated, resulting in `show-transparency` not being taken into account