### PR TITLE
Fail tests if thousand separator is used in templates

### DIFF
--- a/wagtail/test/formats/en/formats.py
+++ b/wagtail/test/formats/en/formats.py
@@ -1,0 +1,9 @@
+from django.utils.functional import SimpleLazyObject
+
+
+def disallow_separator():
+    raise ValueError("Separator used!")
+
+
+THOUSAND_SEPARATOR = SimpleLazyObject(disallow_separator)
+NUMBER_GROUPING = (1,)

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -270,3 +270,6 @@ MESSAGE_TAGS = {
     message_constants.WARNING: "my-custom-tag",
     message_constants.ERROR: "my-custom-tag",
 }
+
+USE_THOUSAND_SEPARATOR = True
+FORMAT_MODULE_PATH = ["wagtail.test.formats"]


### PR DESCRIPTION
Experimenting based on https://github.com/wagtail/wagtail/pull/12244#discussion_r1725196615

Note that we currently also have
https://github.com/wagtail/wagtail/blob/a59a2d0585f9b2ee4ff94152a5de4c66b02819df/wagtail/admin/tests/formats/en/formats.py#L1

used in
https://github.com/wagtail/wagtail/blob/a59a2d0585f9b2ee4ff94152a5de4c66b02819df/wagtail/admin/tests/test_checks.py#L104-L142