### PR TITLE
Audit all uses of localized/unlocalized numbers in templates

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/bulk_actions/select_all_checkbox_input.html
+++ b/wagtail/admin/templates/wagtailadmin/bulk_actions/select_all_checkbox_input.html
@@ -1,2 +1,2 @@
-{% load i18n %}
-<input {% if parent %}data-bulk-action-parent-id="{{ parent }}"{% endif %} data-bulk-action-select-all-checkbox type="checkbox" aria-label="{{ _('Select all') }}"/>
+{% load i18n l10n %}
+<input {% if parent %}data-bulk-action-parent-id="{{ parent|unlocalize }}"{% endif %} data-bulk-action-select-all-checkbox type="checkbox" aria-label="{{ _('Select all') }}"/>

--- a/wagtail/admin/templates/wagtailadmin/chooser/_search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/_search_results.html
@@ -1,11 +1,13 @@
 {% load i18n wagtailadmin_tags %}
 
 <h2 role="alert">
-    {% blocktrans trimmed count counter=pages.paginator.count %}
-        There is {{ counter }} match
-    {% plural %}
-        There are {{ counter }} matches
-    {% endblocktrans %}
+    {% with counter_val=pages.paginator.count %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}
+            There is {{ counter }} match
+        {% plural %}
+            There are {{ counter }} matches
+        {% endblocktrans %}
+    {% endwith %}
 </h2>
 
 {% if pages %}

--- a/wagtail/admin/templates/wagtailadmin/generic/chooser/results.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/chooser/results.html
@@ -4,11 +4,13 @@
     {% if is_searching %}
         {% block search_results_count %}
             <h2 role="alert">
-                {% blocktrans trimmed count counter=results.paginator.count %}
-                    There is {{ counter }} match
-                {% plural %}
-                    There are {{ counter }} matches
-                {% endblocktrans %}
+                {% with result_count=results.paginator.count %}
+                    {% blocktrans trimmed with counter=result_count|intcomma count counter_val=result_count %}
+                        There is {{ counter }} match
+                    {% plural %}
+                        There are {{ counter }} matches
+                    {% endblocktrans %}
+                {% endwith %}
             </h2>
         {% endblock %}
     {% else %}

--- a/wagtail/admin/templates/wagtailadmin/generic/index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index_results.html
@@ -15,7 +15,7 @@
     {% elif is_searching or is_filtering %}
         <div class="nice-padding">
             <h2 role="alert">
-                {% blocktrans trimmed count counter=items_count %}
+                {% blocktrans trimmed with counter=items_count|intcomma count counter_val=items_count %}
                     There is {{ counter }} match
                 {% plural %}
                     There are {{ counter }} matches

--- a/wagtail/admin/templates/wagtailadmin/generic/inspect.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/inspect.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/generic/base.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load i18n wagtailadmin_tags l10n %}
 
 {% block main_content %}
     {% block fields_output %}
@@ -11,7 +11,7 @@
                         {% if field.component %}
                             {% component field.component %}
                         {% else %}
-                            {{ field.value }}
+                            {{ field.value|localize }}
                         {% endif %}
                     </dd>
                 {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_delete.html
@@ -1,7 +1,11 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans trimmed count counter=items|length %}Delete 1 page {% plural %}Delete {{ counter }} pages{% endblocktrans %}{% endblock %}
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}Delete 1 page {% plural %}Delete {{ counter }} pages{% endblocktrans %}
+    {% endwith %}
+{% endblock %}
 
 {% block header %}
     {% include "wagtailadmin/shared/header.html" with title=_("Delete") icon="doc-empty-inverse" %}
@@ -16,11 +20,13 @@
                     <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noreferrer">{{ page.item.get_admin_display_title }}</a>
                     {% if page.descendant_count %}
                         <p>
-                            {% blocktrans trimmed count counter=page.descendant_count %}
-                                This will also delete one more subpage.
-                            {% plural %}
-                                This will also delete {{ counter }} more subpages.
-                            {% endblocktrans %}
+                            {% with counter_val=page.descendant_count %}
+                                {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}
+                                    This will also delete one more subpage.
+                                {% plural %}
+                                    This will also delete {{ counter }} more subpages.
+                                {% endblocktrans %}
+                            {% endwith %}
                         </p>
                     {% endif %}
                 </li>

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_move.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_move.html
@@ -1,7 +1,10 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans trimmed count counter=items|length %}Move 1 page{% plural %}Move {{ counter }} pages{% endblocktrans %}
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}Move 1 page{% plural %}Move {{ counter }} pages{% endblocktrans %}
+    {% endwith %}
 {% endblock %}
 
 {% block header %}
@@ -17,11 +20,13 @@
                     <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noreferrer">{{ page.item.get_admin_display_title }}</a>
                     {% if not page.item.is_leaf %}
                         <p>
-                            {% blocktrans trimmed count counter=page.child_pages %}
-                                This page has one child page
-                            {% plural %}
-                                This page has {{ counter }} child pages
-                            {% endblocktrans %}
+                            {% with counter_val=page.child_pages %}
+                                {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}
+                                    This page has one child page
+                                {% plural %}
+                                    This page has {{ counter }} child pages
+                                {% endblocktrans %}
+                            {% endwith %}
                         </p>
                     {% endif %}
                 </li>

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_publish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_publish.html
@@ -1,7 +1,11 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans trimmed count counter=items|length %}Publish 1 page {% plural %}Publish {{ counter }} pages{% endblocktrans %}{% endblock %}
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}Publish 1 page {% plural %}Publish {{ counter }} pages{% endblocktrans %}
+    {% endwith %}
+{% endblock %}
 
 {% block header %}
     {% include "wagtailadmin/shared/header.html" with title=_("Publish") icon="doc-empty-inverse" %}
@@ -14,15 +18,17 @@
             {% for page in items %}
                 <li>
                     <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noreferrer">{{ page.item.get_admin_display_title }}</a>
-                    {% if page.draft_descendant_count %}
-                        <p>
-                            {% blocktrans trimmed count counter=page.draft_descendant_count %}
-                                This page has one unpublished subpage
-                            {% plural %}
-                                This page has {{ counter }} unpublished subpages
-                            {% endblocktrans %}
-                        </p>
-                    {% endif %}
+                    {% with draft_descendant_count=page.draft_descendant_count %}
+                        {% if draft_descendant_count %}
+                            <p>
+                                {% blocktrans trimmed with counter=draft_descendant_count|intcomma count counter_val=draft_descendant_count %}
+                                    This page has one unpublished subpage
+                                {% plural %}
+                                    This page has {{ counter }} unpublished subpages
+                                {% endblocktrans %}
+                            </p>
+                        {% endif %}
+                    {% endwith %}
                 </li>
             {% endfor %}
         </ul>

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_unpublish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_unpublish.html
@@ -1,7 +1,11 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans trimmed count counter=items|length %}Unpublish 1 page {% plural %}Unpublish {{ counter }} pages{% endblocktrans %}{% endblock %}
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}Unpublish 1 page {% plural %}Unpublish {{ counter }} pages{% endblocktrans %}
+    {% endwith %}
+{% endblock %}
 
 {% block header %}
     {% include "wagtailadmin/shared/header.html" with title=_("Unpublish") icon="doc-empty-inverse" %}
@@ -15,13 +19,15 @@
                 <li>
                     <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noreferrer">{{ page.item.get_admin_display_title }}</a>
                     <p>
-                        {% if page.live_descendant_count %}
-                            {% blocktrans trimmed count counter=page.live_descendant_count %}
-                                This page has one subpage
-                            {% plural %}
-                                This page has {{ counter }} subpages
-                            {% endblocktrans %}
-                        {% endif %}
+                        {% with live_descendant_count=page.live_descendant_count %}
+                            {% if live_descendant_count %}
+                                {% blocktrans trimmed with counter=live_descendant_count|intcomma count counter_val=live_descendant_count %}
+                                    This page has one subpage
+                                {% plural %}
+                                    This page has {{ counter }} subpages
+                                {% endblocktrans %}
+                            {% endif %}
+                        {% endwith %}
                     </p>
                 </li>
             {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
@@ -12,7 +12,7 @@
                 {% trans 'Are you sure you want to delete this page?' %}
 
                 {% if descendant_count %}
-                    {% blocktrans trimmed count counter=descendant_count %}
+                    {% blocktrans trimmed with counter=descendant_count descendant_count=descendant_count|intcomma count counter=counter %}
                         Deleting this page will also delete {{ descendant_count }} child page.
                     {% plural %}
                         Deleting this page will also delete {{ descendant_count }} more child pages.
@@ -21,20 +21,20 @@
                     {% if translation_count %} {# has translations #}
                         {% if translation_descendant_count %} {# has translations with descendants #}
                             {% if translation_count == 1 %}
-                                {% blocktrans trimmed count counter=translation_descendant_count %}
+                                {% blocktrans trimmed with counter=translation_descendant_count translation_descendant_count=translation_descendant_count|intcomma count counter=counter %}
                                     It will also delete 1 translation and its combined {{ translation_descendant_count }} translated child page.
                                 {% plural %}
                                     It will also delete 1 translation and its combined {{ translation_descendant_count }} translated child pages.
                                 {% endblocktrans %}
                             {% else %}
-                                {% blocktrans trimmed count counter=translation_descendant_count %}
+                                {% blocktrans trimmed with counter=translation_descendant_count translation_count=translation_count|intcomma translation_descendant_count=translation_descendant_count|intcomma count counter=counter %}
                                     It will also delete {{ translation_count }} translations and their combined {{ translation_descendant_count }} translated child page.
                                 {% plural %}
                                     It will also delete {{ translation_count }} translations and their combined {{ translation_descendant_count }} translated child pages.
                                 {% endblocktrans %}
                             {% endif %}
                         {% else %}
-                            {% blocktrans trimmed count counter=translation_count %}
+                            {% blocktrans trimmed with counter=translation_count translation_count=translation_count|intcomma count counter=counter %}
                                 It will also delete {{ translation_count }} translation.
                             {% plural %}
                                 It will also delete {{ translation_count }} translations.
@@ -44,20 +44,20 @@
                 {% elif translation_count %} {# no descendants #}
                     {% if translation_descendant_count %} {# has translations with descendants #}
                         {% if translation_count == 1 %}
-                            {% blocktrans trimmed count counter=translation_descendant_count %}
+                            {% blocktrans trimmed with counter=translation_descendant_count translation_descendant_count=translation_descendant_count|intcomma count counter=counter %}
                                 Deleting this page will also delete 1 translation and its combined {{ translation_descendant_count }} translated child page.
                             {% plural %}
                                 Deleting this page will also delete 1 translation and its combined {{ translation_descendant_count }} translated child pages.
                             {% endblocktrans %}
                         {% else %}
-                            {% blocktrans trimmed count counter=translation_descendant_count %}
+                            {% blocktrans trimmed with counter=translation_descendant_count translation_count=translation_count|intcomma translation_descendant_count=translation_descendant_count|intcomma count counter=counter%}
                                 Deleting this page will also delete {{ translation_count }} translations and their combined {{ translation_descendant_count }} translated child page.
                             {% plural %}
                                 Deleting this page will also delete {{ translation_count }} translations and their combined {{ translation_descendant_count }} translated child pages.
                             {% endblocktrans %}
                         {% endif %}
                     {% else %}
-                        {% blocktrans trimmed count counter=translation_count %}
+                        {% blocktrans trimmed with counter=translation_count descendant_count=descendant_count|intcomma translation_count=translation_count|intcomma count counter=counter %}
                             Deleting this page will also delete {{ translation_count }} translation of this page.
                         {% plural %}
                             This will also delete {{ descendant_count }} more child pages.
@@ -71,7 +71,7 @@
                 {% csrf_token %}
                 {% if confirm_before_delete %}
                     <p id="id_confirm_site_name-warning" class="status-msg warning">
-                        {% blocktrans trimmed with total_pages=descendant_count|add:1 %}
+                        {% blocktrans trimmed with total_pages=descendant_count|add:1|intcomma %}
                             This action will delete total <b>{{ total_pages }}</b> pages.
                         {% endblocktrans %}
                     </p>

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_move.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_move.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% block titletag %}{% blocktrans trimmed with title=page_to_move.get_admin_display_title %}Move {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% include "wagtailadmin/shared/header.html" with title=_("Move") subtitle=page_to_move.get_admin_display_title icon="doc-empty-inverse" %}
@@ -12,7 +12,7 @@
                 {% blocktrans trimmed with title=destination.get_admin_display_title %}Are you sure you want to move this page and all of its children into '{{ title }}'?{% endblocktrans %}
             {% endif %}
             {% if translations_to_move_count %}
-                {% blocktrans trimmed count counter=translations_to_move_count %}
+                {% blocktrans trimmed with counter=translations_to_move_count translations_to_move_count=translations_to_move_count|intcomma count counter=counter %}
                     This will also move one translation of this page and its child pages
                 {% plural %}
                     This will also move {{ translations_to_move_count }} translations of this page and their child pages

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_unpublish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_unpublish.html
@@ -5,7 +5,7 @@
     <p>
         {% trans "Are you sure you want to unpublish this page?" %}
         {% if translation_count %}
-            {% blocktrans trimmed with translation_count=translation_count count counter=translation_count %}
+            {% blocktrans trimmed with counter=translation_count translation_count=translation_count|intcomma count counter=counter %}
                 This will also unpublish one translation of the page.
             {% plural %}
                 This will also unpublish all {{ translation_count }} translations of the page.
@@ -21,20 +21,20 @@
         {% fragment as text %}
             {% if translation_descendant_count %}
                 {% if translation_descendant_count == 1 %}
-                    {% blocktrans trimmed count counter=live_descendant_count %}
+                    {% blocktrans trimmed with counter=live_descendant_count live_descendant_count=live_descendant_count|intcomma count counter=counter %}
                         This page has one subpage and its translations have a combined one translated child page. Unpublish these too
                     {% plural %}
                         This page has {{ live_descendant_count }} child pages and its translations have a combined one translated child page. Unpublish these too
                     {% endblocktrans %}
                 {% else %}
-                    {% blocktrans trimmed count counter=live_descendant_count %}
+                    {% blocktrans trimmed with counter=live_descendant_count live_descendant_count=live_descendant_count|intcomma translation_descendant_count=translation_descendant_count|intcomma count counter=counter %}
                         This page has one child page and its translations have a combined {{ translation_descendant_count }} translated child pages. Unpublish these too
                     {% plural %}
                         This page has {{ live_descendant_count }} child pages and its translations have a combined {{ translation_descendant_count }} translated child pages. Unpublish these too
                     {% endblocktrans %}
                 {% endif %}
             {% else %}
-                {% blocktrans trimmed count counter=live_descendant_count %}
+                {% blocktrans trimmed with counter=live_descendant_count live_descendant_count=live_descendant_count|intcomma count counter=counter %}
                     This page has one subpage. Unpublish this too
                 {% plural %}
                     This page has {{ live_descendant_count }} subpages. Unpublish these too

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_ordering_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_ordering_cell.html
@@ -11,7 +11,7 @@
         <span class="w-sr-only">
             {% trans 'Drag' %}
             <span>
-                {% blocktranslate trimmed with index=row.index|add:1 total=table.row_count %}Item {{ index }} of {{ total }}{% endblocktranslate %}
+                {% blocktranslate trimmed with index=row.index|add:1|intcomma total=table.row_count|intcomma %}Item {{ index }} of {{ total }}{% endblocktranslate %}
             </span>
         </span>
     </button>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
@@ -4,7 +4,7 @@
 {% block after_label %}
     {% if result_scope == "whole_tree" %}
         {% if items_count %}
-            {% blocktranslate trimmed %}
+            {% blocktranslate trimmed with start_index=start_index|intcomma end_index=end_index|intcomma items_count=items_count|intcomma %}
                 {{ start_index }}-{{ end_index }} of {{ items_count }} across entire site.
             {% endblocktranslate %}
         {% else %}
@@ -17,7 +17,7 @@
         </a>
     {% elif result_scope == "parent" %}
         {% if items_count %}
-            {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}
+            {% blocktranslate trimmed with title=parent_page.get_admin_display_title start_index=start_index|intcomma end_index=end_index|intcomma items_count=items_count|intcomma %}
                 {{ start_index }}-{{ end_index }} of {{ items_count }} in '<span class="w-title-ellipsis">{{ title }}</span>'.
             {% endblocktranslate %}
         {% else %}
@@ -29,7 +29,7 @@
             {% translate "Search the whole site" %}
         </a>
     {% else %}
-        {% blocktranslate trimmed %}
+        {% blocktranslate trimmed with start_index=start_index|intcomma end_index=end_index|intcomma items_count=items_count|intcomma %}
             {{ start_index }}-{{ end_index }} of {{ items_count }}
         {% endblocktranslate %}
     {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_pagination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_pagination.html
@@ -1,17 +1,17 @@
-{% load i18n wagtailadmin_tags %}
+{% load i18n wagtailadmin_tags l10n %}
 
 {% comment %}
 Pagination for page listings. Used by the `{% paginate %}` template tag.
 {% endcomment %}
 
 <nav class="pagination" aria-label="{% trans 'Pagination' %}">
-    <p>{% blocktrans trimmed with page_number=page.number num_pages=paginator.num_pages %}
+    <p>{% blocktrans trimmed with page_number=page.number|intcomma num_pages=paginator.num_pages|intcomma %}
         Page {{ page_number }} of {{ num_pages }}.
     {% endblocktrans %}</p>
     <ul>
         <li class="prev">
             {% if page.has_previous %}
-                <a data-page="{{ page.previous_page_number }}" href="{{ base_url }}{% pagination_querystring page.previous_page_number page_key=page_key %}" class="{{ classname }}">
+                <a data-page="{{ page.previous_page_number|unlocalize }}" href="{{ base_url }}{% pagination_querystring page.previous_page_number page_key=page_key %}" class="{{ classname }}">
                     {% icon name="arrow-left" classname="default" %}
                     {% trans "Previous" %}
                 </a>
@@ -19,7 +19,7 @@ Pagination for page listings. Used by the `{% paginate %}` template tag.
         </li>
         <li class="next">
             {% if page.has_next %}
-                <a data-page="{{ page.next_page_number }}" href="{{ base_url }}{% pagination_querystring page.next_page_number page_key=page_key %}" class="{{ classname }}">
+                <a data-page="{{ page.next_page_number|unlocalize }}" href="{{ base_url }}{% pagination_querystring page.next_page_number page_key=page_key %}" class="{{ classname }}">
                     {% trans "Next" %}
                     {% icon name="arrow-right" classname="default" %}
                 </a>

--- a/wagtail/admin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/search_results.html
@@ -2,11 +2,13 @@
 <div class="nice-padding">
     {% if pages %}
         <h2 role="alert">
-            {% blocktrans trimmed count counter=all_pages.count %}
-                There is one matching page
-            {% plural %}
-                There are {{ counter }} matching pages
-            {% endblocktrans %}
+            {% with page_count=all_pages.count %}
+                {% blocktrans trimmed with counter=page_count|intcomma count counter_val=page_count %}
+                    There is one matching page
+                {% plural %}
+                    There are {{ counter }} matching pages
+                {% endblocktrans %}
+            {% endwith %}
         </h2>
 
         {% search_other %}
@@ -16,16 +18,16 @@
                 <h3 id="page-types-title" class="filter-title">{% trans "Page types" %}</h3>
                 <ul class="filter-options">
                     {% if not selected_content_type %}
-                        <li class="w-bg-border-furniture">{% trans "All" %} ({{ all_pages.count }})</li>
+                        <li class="w-bg-border-furniture">{% trans "All" %} ({{ all_pages.count|intcomma }})</li>
                     {% else %}
-                        <li><a href="{% url 'wagtailadmin_pages:search' %}?q={{ query_string|urlencode }}">{% trans "All" %} ({{ all_pages.count }})</a></li>
+                        <li><a href="{% url 'wagtailadmin_pages:search' %}?q={{ query_string|urlencode }}">{% trans "All" %} ({{ all_pages.count|intcomma }})</a></li>
                     {% endif %}
 
                     {% for content_type, count in content_types %}
                         {% if content_type == selected_content_type %}
-                            <li class="w-bg-border-furniture">{{ content_type.model_class.get_verbose_name }} ({{ count }})</li>
+                            <li class="w-bg-border-furniture">{{ content_type.model_class.get_verbose_name }} ({{ count|intcomma }})</li>
                         {% else %}
-                            <li><a href="{% url 'wagtailadmin_pages:search' %}?q={{ query_string|urlencode }}&amp;content_type={{ content_type.app_label }}.{{ content_type.model|lower }}">{{ content_type.model_class.get_verbose_name }} ({{ count }})</a></li>
+                            <li><a href="{% url 'wagtailadmin_pages:search' %}?q={{ query_string|urlencode }}&amp;content_type={{ content_type.app_label }}.{{ content_type.model|lower }}">{{ content_type.model_class.get_verbose_name }} ({{ count|intcomma }})</a></li>
                         {% endif %}
                     {% endfor %}
                 </ul>

--- a/wagtail/admin/templates/wagtailadmin/reports/listing/_list_page_types_usage.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/listing/_list_page_types_usage.html
@@ -42,9 +42,9 @@
                 </td>
                 <td class="count" valign="top">
                     {% if page_type.count > 0 %}
-                        <a href="{% url 'wagtailadmin_pages:type_use' content_type_app_name=page_type.app_label content_type_model_name=page_type.model %}">{{ page_type.count }}</a>
+                        <a href="{% url 'wagtailadmin_pages:type_use' content_type_app_name=page_type.app_label content_type_model_name=page_type.model %}">{{ page_type.count|intcomma }}</a>
                     {% else %}
-                        {{ page_type.count }}
+                        {{ page_type.count|intcomma }}
                     {% endif %}
                 </td>
                 <td class="last-edited-page" valign="top">

--- a/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
@@ -36,7 +36,7 @@
     <input type="checkbox" name="is_editing" value="1" data-w-session-target="unsavedChanges" hidden />
     {% if revision_id %}
         {# The ID of the latest revision that was known when this module was initially loaded #}
-        <input type="hidden" name="revision_id" value="{{ revision_id }}" />
+        <input type="hidden" name="revision_id" value="{{ revision_id|unlocalize }}" />
     {% endif %}
     <div id="w-editing-sessions">
         {% component sessions_list %}

--- a/wagtail/admin/templates/wagtailadmin/shared/forms/single_checkbox.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/forms/single_checkbox.html
@@ -1,5 +1,6 @@
 {# Render a single checkbox with text center-aligned. #}
+{% load l10n %}
 <label class="w-flex w-items-center {{ label_classname }}">
-    <input type="checkbox" name="{{ name }}"{% if value %} value="{{ value }}"{% endif %} {% if checked %}checked{% endif %} {% include "wagtailadmin/shared/attrs.html" with attrs=attrs %}>
+    <input type="checkbox" name="{{ name }}"{% if value %} value="{{ value|unlocalize }}"{% endif %} {% if checked %}checked{% endif %} {% include "wagtailadmin/shared/attrs.html" with attrs=attrs %}>
     {{ text }}
 </label>

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -9,7 +9,7 @@
 {% resolve_url linkurl as url_path %}
 
 <nav class="pagination" aria-label="{% trans 'Pagination' %}">
-    <p>{% blocktrans trimmed with page_num=items.number total_pages=items.paginator.num_pages %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed with page_num=items.number|intcomma total_pages=items.paginator.num_pages|intcomma %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}</p>
     <ul>
         <li class="prev">
             {% if items.has_previous %}

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panel_toggle.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panel_toggle.html
@@ -13,7 +13,7 @@
     {% icon name=toggle.icon_name classname=nav_icon_classes %}
     {% if toggle.has_counter %}
         <div data-side-panel-toggle-counter class="{{ nav_icon_counter_classes }} {{ toggle.counter_classname|default:'w-bg-surface-button-default'}}" {% if not count %}hidden{% endif %}>
-            {{ count }}
+            {{ count|intcomma }}
         </div>
     {% endif %}
 </button>

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/locale.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/locale.html
@@ -5,7 +5,7 @@
     {% trans 'Locale: ' as screen_reader_title_prefix %}
 
     {% if object.pk and translations %}
-        {% blocktrans trimmed asvar help_text %}
+        {% blocktrans trimmed with translations_total=translations_total|intcomma asvar help_text %}
             Available in {{ translations_total }} locales
         {% endblocktrans %}
     {% else %}

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/usage.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/usage.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 <div class="w-py-6 w-space-y-3">
     <section class="w-flex w-space-x-3">
         <div class="w-flex w-flex-1">
@@ -13,7 +13,7 @@
                 {% if usage_url_text %}
                     {{ usage_url_text }}
                 {% else %}
-                    {% blocktrans trimmed count usage_count=usage_count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}
+                    {% blocktrans trimmed with counter=usage_count usage_count=usage_count|intcomma count counter=counter %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}
                 {% endif %}
             </a>
         </div>

--- a/wagtail/admin/templates/wagtailadmin/shared/usage_summary.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/usage_summary.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% comment "text/markdown" %}
 This shared template is used to display the usage count for an object as a link
 to the object's usage page. It is used by the admin's delete and unpublish views.
@@ -11,7 +11,7 @@ Variables this template accepts:
 {% endcomment %}
 <p>
     <a href="{{ usage_url }}">
-        {% blocktrans trimmed with model_name=model_opts.verbose_name count usage_count=usage_count asvar usage_message %}
+        {% blocktrans trimmed with counter=usage_count model_name=model_opts.verbose_name usage_count=usage_count|intcomma count counter=counter asvar usage_message %}
             This {{ model_name }} is referenced {{ usage_count }} time.
         {% plural %}
             This {{ model_name }} is referenced {{ usage_count }} times.

--- a/wagtail/admin/templates/wagtailadmin/workflows/includes/task_usage_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/includes/task_usage_cell.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
     {% for workflow_task in value|slice:":5" %}
         <a href="{% url 'wagtailadmin_workflows:edit' workflow_task.workflow.pk %}">{{ workflow_task.workflow.name }}{% if not forloop.last %}, {% endif %}</a>
@@ -6,6 +6,8 @@
         {% trans "Not used" %}
     {% endfor %}
     {% if value|length > 5 %}
-        {% blocktrans trimmed count counter=value|length|add:-5 %}+{{ counter }} more{% plural %}+{{ counter }} more{% endblocktrans %}
+        {% with counter_val=value|length|add:-5 %}
+            {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}+{{ counter }} more{% plural %}+{{ counter }} more{% endblocktrans %}
+        {% endwith %}
     {% endif %}
 </td>

--- a/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_tasks_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_tasks_cell.html
@@ -1,17 +1,17 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
     <ul class="workflow-tasks">
         {% for task in tasks %}
             <a href="{% url 'wagtailadmin_workflows:edit_task' task.task_id %}">
-                <li class="workflow-tasks__task" data-controller="w-tooltip" data-w-tooltip-content-value="{% blocktrans trimmed with forloop.counter as step_number %}Step {{ step_number }}{% endblocktrans %}: {{ task.task.name }}">
-                    <div class="workflow-tasks__step">{% blocktrans trimmed with forloop.counter as step_number %}Step {{ step_number }}{% endblocktrans %}</div>
+                <li class="workflow-tasks__task" data-controller="w-tooltip" data-w-tooltip-content-value="{% blocktrans trimmed with forloop.counter|intcomma as step_number %}Step {{ step_number }}{% endblocktrans %}: {{ task.task.name }}">
+                    <div class="workflow-tasks__step">{% blocktrans trimmed with forloop.counter|intcomma as step_number %}Step {{ step_number }}{% endblocktrans %}</div>
                     <h4 class="workflow-tasks__name">{{ task.task.name }}</h4>
                 </li>
             </a>
         {% endfor %}
         {% if extra_count > 0 %}
             <li class="workflow-tasks__extra-tasks">
-                {% blocktrans trimmed count counter=extra_count %}+{{ counter }} more{% plural %}+{{ counter }} more{% endblocktrans %}
+                {% blocktrans trimmed with counter=extra_count|intcomma count counter_val=extra_count %}+{{ counter }} more{% plural %}+{{ counter }} more{% endblocktrans %}
             </li>
         {% endif %}
     </ul>

--- a/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_used_by_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_used_by_cell.html
@@ -1,13 +1,15 @@
 {% extends "wagtailadmin/tables/title_cell.html" %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% block title %}
     <a href="{{ link_url }}">
-        {% blocktrans trimmed count counter=instance.all_pages.count %}
-            1 page
-        {% plural %}
-            {{ counter }} pages
-        {% endblocktrans %}
+        {% with instance.all_pages.count as counter_val %}
+            {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}
+                1 page
+            {% plural %}
+                {{ counter }} pages
+            {% endblocktrans %}
+        {% endwith %}
     </a>
 {% endblock %}
 
@@ -15,11 +17,13 @@
     {# Only show snippet type count if there's a model with workflows enabled #}
     {% if workflow_enabled_models %}
         <div>
-            {% blocktrans trimmed count counter=instance.content_types %}
-                1 snippet type
-            {% plural %}
-                {{ counter }} snippet types
-            {% endblocktrans %}
+            {% with instance.content_types as counter_val %}
+                {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}
+                    1 snippet type
+                {% plural %}
+                    {{ counter }} snippet types
+                {% endblocktrans %}
+            {% endwith %}
         </div>
     {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/results.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/results.html
@@ -2,11 +2,13 @@
 {% if tasks %}
     {% if search_form.is_searching %}
         <h2 role="alert">
-            {% blocktrans trimmed count counter=tasks.paginator.count %}
-                There is {{ counter }} match
-            {% plural %}
-                There are {{ counter }} matches
-            {% endblocktrans %}
+            {% with counter_val=tasks.paginator.count %}
+                {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}
+                    There is {{ counter }} match
+                {% plural %}
+                    There are {{ counter }} matches
+                {% endblocktrans %}
+            {% endwith %}
         </h2>
     {% else %}
         <h2>{% trans "Tasks" %}</h2>

--- a/wagtail/admin/ui/tables/__init__.py
+++ b/wagtail/admin/ui/tables/__init__.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from django.contrib.admin.utils import quote
 from django.forms import MediaDefiningClass
 from django.template.loader import get_template
+from django.templatetags.l10n import unlocalize
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.text import capfirst
@@ -156,7 +157,10 @@ class Column(BaseColumn):
 
     def get_cell_context_data(self, instance, parent_context):
         context = super().get_cell_context_data(instance, parent_context)
-        context["value"] = self.get_value(instance)
+        value = self.get_value(instance)
+        if isinstance(value, int) and not isinstance(value, bool):
+            value = unlocalize(value)
+        context["value"] = value
         return context
 
 
@@ -271,6 +275,12 @@ class BooleanColumn(Column):
     """Represents a True/False/None value as a tick/cross/question icon"""
 
     cell_template_name = "wagtailadmin/tables/boolean_cell.html"
+
+    def get_value(self, instance):
+        value = super().get_value(instance)
+        if value is None:
+            return None
+        return bool(value)
 
 
 class LiveStatusTagColumn(StatusTagColumn):

--- a/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/generic/index_results.html" %}
-{% load i18n %}
+{% load i18n l10n %}
 {% block results %}
     <form class="w-overflow-auto" data-controller="w-bulk" data-w-bulk-action-inactive-class="w-invisible" action="{% url 'wagtailforms:delete_submissions' form_page.id %}" method="get">
         <input type="hidden" value="{{ next_url }}" name="next">
@@ -21,7 +21,7 @@
                 {% for row in data_rows %}
                     <tr>
                         <td>
-                            <input type="checkbox" name="selected-submissions" class="select-submission" value="{{ row.model_id }}" data-action="w-bulk#toggle" data-w-bulk-target="item" />
+                            <input type="checkbox" name="selected-submissions" class="select-submission" value="{{ row.model_id|unlocalize }}" data-action="w-bulk#toggle" data-w-bulk-target="item" />
                         </td>
                         {% for cell in row.fields %}
                             <td>

--- a/wagtail/contrib/forms/templates/wagtailforms/panels/form_responses_panel.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/panels/form_responses_panel.html
@@ -1,8 +1,8 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% trans "Total submissions" as total %}
 {% trans "Latest submission" as latest %}
 <p>
-    <span class="w-label-3">{{ total }}</span> <a href="{% url 'wagtailforms:list_submissions' self.instance.id %}">{{ submission_count }}</a>
+    <span class="w-label-3">{{ total }}</span> <a href="{% url 'wagtailforms:list_submissions' self.instance.id %}">{{ submission_count|intcomma }}</a>
 </p>
 <p>
     <span class="w-label-3">{{ latest }}</span> {{ last_submit_time }}

--- a/wagtail/contrib/redirects/templates/wagtailredirects/import_summary.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/import_summary.html
@@ -8,7 +8,7 @@
     <section id="summary" class="nice-padding">
         <p class="help-block help-warning">
             {% icon name='warning' %}
-            {% blocktrans trimmed with total=import_summary.total successes=import_summary.successes errors=import_summary.errors_count %}Found {{ total }} redirects, created {{ successes }} and found {{ errors }} errors.{% endblocktrans %}
+            {% blocktrans trimmed with total=import_summary.total|intcomma successes=import_summary.successes|intcomma errors=import_summary.errors_count|intcomma %}Found {{ total }} redirects, created {{ successes }} and found {{ errors }} errors.{% endblocktrans %}
         </p>
 
         <table class="listing">

--- a/wagtail/documents/templates/wagtaildocs/bulk_actions/confirm_bulk_add_tags.html
+++ b/wagtail/documents/templates/wagtaildocs/bulk_actions/confirm_bulk_add_tags.html
@@ -1,7 +1,11 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n %}
 {% load wagtailimages_tags wagtailadmin_tags %}
-{% block titletag %}{% blocktrans trimmed count counter=items|length %}Add tags to 1 document {% plural %}Add tags to {{ counter }} documents{% endblocktrans %}{% endblock %}
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}Add tags to 1 document {% plural %}Add tags to {{ counter }} documents{% endblocktrans %}
+    {% endwith %}
+{% endblock %}
 
 {% block header %}
     {% trans "Add tags to documents" as add_str %}

--- a/wagtail/documents/templates/wagtaildocs/bulk_actions/confirm_bulk_add_to_collection.html
+++ b/wagtail/documents/templates/wagtaildocs/bulk_actions/confirm_bulk_add_to_collection.html
@@ -1,7 +1,11 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n %}
 {% load wagtailimages_tags wagtailadmin_tags %}
-{% block titletag %}{% blocktrans trimmed count counter=items|length %}Add 1 document to new collection {% plural %}Add {{ counter }} documents to new collection{% endblocktrans %}{% endblock %}
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}Add 1 document to new collection {% plural %}Add {{ counter }} documents to new collection{% endblocktrans %}
+    {% endwith %}
+{% endblock %}
 
 {% block header %}
     {% trans "Add documents to collection" as add_str %}

--- a/wagtail/documents/templates/wagtaildocs/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/documents/templates/wagtaildocs/bulk_actions/confirm_bulk_delete.html
@@ -1,6 +1,10 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load wagtailadmin_tags i18n %}
-{% block titletag %}{% blocktrans trimmed count counter=items|length %}Delete 1 document {% plural %}Delete {{ counter }} documents{% endblocktrans %}{% endblock %}
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}Delete 1 document {% plural %}Delete {{ counter }} documents{% endblocktrans %}
+    {% endwith %}
+{% endblock %}
 
 {% block header %}
     {% trans "Delete documents" as del_str %}
@@ -18,10 +22,12 @@
         </p>
         <ul>
             {% for document in items %}
-                <li>
-                    <a href="{% url 'wagtaildocs:edit' document.item.id %}" target="_blank" rel="noreferrer">{{document.item.title}}</a>
-                    (<a href="{{ document.item.usage_url }}">{% blocktrans trimmed count usage_count=document.item.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>)
-                </li>
+                {% with usage_count_val=document.item.get_usage.count %}
+                    <li>
+                        <a href="{% url 'wagtaildocs:edit' document.item.id %}" target="_blank" rel="noreferrer">{{document.item.title}}</a>
+                        (<a href="{{ document.item.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>)
+                    </li>
+                {% endwith %}
             {% endfor %}
         </ul>
     {% endif %}

--- a/wagtail/documents/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/edit.html
@@ -53,7 +53,9 @@
 
                 <dt>{% trans "Usage" %}</dt>
                 <dd>
-                    <a href="{{ document.usage_url }}">{% blocktrans trimmed count usage_count=document.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                    {% with usage_count_val=document.get_usage.count %}
+                        <a href="{{ document.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                    {% endwith %}
                 </dd>
             </dl>
         </div>

--- a/wagtail/images/templates/wagtailimages/bulk_actions/confirm_bulk_add_tags.html
+++ b/wagtail/images/templates/wagtailimages/bulk_actions/confirm_bulk_add_tags.html
@@ -1,7 +1,11 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n %}
 {% load wagtailimages_tags wagtailadmin_tags %}
-{% block titletag %}{% blocktrans trimmed count counter=items|length %}Add tags to 1 image {% plural %}Add tags to {{ counter }} images{% endblocktrans %}{% endblock %}
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}Add tags to 1 image {% plural %}Add tags to {{ counter }} images{% endblocktrans %}
+    {% endwith %}
+{% endblock %}
 
 {% block header %}
     {% trans "Add tags to images" as add_str %}

--- a/wagtail/images/templates/wagtailimages/bulk_actions/confirm_bulk_add_to_collection.html
+++ b/wagtail/images/templates/wagtailimages/bulk_actions/confirm_bulk_add_to_collection.html
@@ -1,7 +1,11 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n %}
 {% load wagtailimages_tags wagtailadmin_tags %}
-{% block titletag %}{% blocktrans trimmed count counter=items|length %}Add 1 image to new collection {% plural %}Add {{ counter }} images to new collection{% endblocktrans %}{% endblock %}
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}Add 1 image to new collection {% plural %}Add {{ counter }} images to new collection{% endblocktrans %}
+    {% endwith %}
+{% endblock %}
 
 {% block header %}
     {% trans "Add images to collection" as add_str %}

--- a/wagtail/images/templates/wagtailimages/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/images/templates/wagtailimages/bulk_actions/confirm_bulk_delete.html
@@ -1,6 +1,10 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load wagtailadmin_tags i18n %}
-{% block titletag %}{% blocktrans trimmed count counter=items|length %}Delete 1 image{% plural %}Delete {{ counter }} images{% endblocktrans %}{% endblock %}
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}Delete 1 image{% plural %}Delete {{ counter }} images{% endblocktrans %}
+    {% endwith %}
+{% endblock %}
 
 {% block header %}
     {% trans "Delete images" as del_str %}
@@ -18,10 +22,12 @@
         </p>
         <ul>
             {% for image in items %}
-                <li>
-                    <a href="{% url 'wagtailimages:edit' image.item.id %}" target="_blank" rel="noreferrer">{{image.item.title}}</a>
-                    (<a href="{{ image.item.usage_url }}">{% blocktrans trimmed count usage_count=image.item.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>)
-                </li>
+                {% with usage_count_val=image.item.get_usage.count %}
+                    <li>
+                        <a href="{% url 'wagtailimages:edit' image.item.id %}" target="_blank" rel="noreferrer">{{image.item.title}}</a>
+                        (<a href="{{ image.item.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>)
+                    </li>
+                {% endwith %}
             {% endfor %}
         </ul>
     {% endif %}

--- a/wagtail/images/templates/wagtailimages/images/_file_field.html
+++ b/wagtail/images/templates/wagtailimages/images/_file_field.html
@@ -1,8 +1,8 @@
-{% load i18n wagtailadmin_tags wagtailimages_tags %}
+{% load i18n wagtailadmin_tags wagtailimages_tags l10n %}
 {% rawformattedfield field=field %}
     {% image image original as original_image %}
 
-    <a href="{{ original_image.url }}">{% icon name="image" classname="default" %}{{ image.filename }}</a> ({{ original_image.width }}x{{ original_image.height}})<br /><br />
+    <a href="{{ original_image.url }}">{% icon name="image" classname="default" %}{{ image.filename }}</a> ({{ original_image.width|unlocalize }}x{{ original_image.height|unlocalize }})<br /><br />
 
     {% trans "Change image file:" %}
     {{ field }}

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -50,7 +50,7 @@
 
                 <div
                     class="focal-point-chooser"
-                    style="max-width: {{ rendition.width }}px; max-height: {{ rendition.height }}px;"
+                    style="max-width: {{ rendition.width|unlocalize }}px; max-height: {{ rendition.height|unlocalize }}px;"
                     data-focal-point-x="{{ image.focal_point_x|default_if_none:''|unlocalize }}"
                     data-focal-point-y="{{ image.focal_point_y|default_if_none:''|unlocalize }}"
                     data-focal-point-width="{{ image.focal_point_width|default_if_none:''|unlocalize }}"
@@ -78,13 +78,15 @@
 
                         <dl>
                             <dt>{% trans "Max dimensions" %}</dt>
-                            <dd>{{ original_image.width }}x{{ original_image.height }}</dd>
+                            <dd>{{ original_image.width|unlocalize }}x{{ original_image.height|unlocalize }}</dd>
                             <dt>{% trans "Filesize" %}</dt>
                             <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
 
                             <dt>{% trans "Usage" %}</dt>
                             <dd>
-                                <a href="{{ image.usage_url }}">{% blocktrans trimmed count usage_count=image.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                                {% with image.get_usage.count as usage_count_val %}
+                                    <a href="{{ image.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                                {% endwith %}
                             </dd>
                         </dl>
                     </div>

--- a/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
+++ b/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
@@ -1,6 +1,7 @@
 {% extends "wagtailadmin/widgets/chooser.html" %}
+{% load l10n %}
 
 {% block chosen_icon %}
     {# Empty alt because the chosen item’s title is already displayed next to the image. #}
-    <img class="chooser__image" data-chooser-image alt="" class="show-transparency" decoding="async" height="{{ preview.height }}" src="{{ preview.url }}" width="{{ preview.width }}">
+    <img class="chooser__image" data-chooser-image alt="" class="show-transparency" decoding="async" height="{{ preview.height|unlocalize }}" src="{{ preview.url }}" width="{{ preview.width|unlocalize }}">
 {% endblock chosen_icon %}

--- a/wagtail/images/tests/test_templatetags.py
+++ b/wagtail/images/tests/test_templatetags.py
@@ -12,6 +12,7 @@ from wagtail.images.tests.utils import (
 
 LIBRARIES = {
     "wagtailimages_tags": "wagtail.images.templatetags.wagtailimages_tags",
+    "l10n": "django.templatetags.l10n",
 }
 
 
@@ -123,7 +124,10 @@ class ImagesTestCase(TestCase):
         cls.engine = Engine(
             app_dirs=True,
             libraries=LIBRARIES,
-            builtins=[LIBRARIES["wagtailimages_tags"]],
+            builtins=[
+                LIBRARIES["wagtailimages_tags"],
+                LIBRARIES["l10n"],
+            ],
         )
 
     @classmethod
@@ -275,8 +279,8 @@ class SrcsetImageTagTestCase(ImagesTestCase):
     def test_srcset_image_assignment(self):
         template = (
             "{% srcset_image myimage width-{30,60} as bg %}"
-            "width: {{ bg.renditions.0.width }}, url: {{ bg.renditions.0.url }} "
-            "width: {{ bg.renditions.1.width }}, url: {{ bg.renditions.1.url }} "
+            "width: {{ bg.renditions.0.width|unlocalize }}, url: {{ bg.renditions.0.url }} "
+            "width: {{ bg.renditions.1.width|unlocalize }}, url: {{ bg.renditions.1.url }} "
         )
         rendered = self.render(template, {"myimage": self.image})
         expected = f"""
@@ -403,10 +407,10 @@ class PictureTagTestCase(ImagesTestCase):
     def test_picture_assignment(self):
         template = (
             "{% picture myimage width-{550,600} format-{jpeg,webp} as bg %}"
-            "width: {{ bg.formats.jpeg.0.width }}, url: {{ bg.formats.jpeg.0.url }} "
-            "width: {{ bg.formats.jpeg.1.width }}, url: {{ bg.formats.jpeg.1.url }} "
-            "width: {{ bg.formats.webp.0.width }}, url: {{ bg.formats.webp.0.url }} "
-            "width: {{ bg.formats.webp.1.width }}, url: {{ bg.formats.webp.1.url }} "
+            "width: {{ bg.formats.jpeg.0.width|unlocalize }}, url: {{ bg.formats.jpeg.0.url }} "
+            "width: {{ bg.formats.jpeg.1.width|unlocalize }}, url: {{ bg.formats.jpeg.1.url }} "
+            "width: {{ bg.formats.webp.0.width|unlocalize }}, url: {{ bg.formats.webp.0.url }} "
+            "width: {{ bg.formats.webp.1.width|unlocalize }}, url: {{ bg.formats.webp.1.url }} "
         )
         rendered = self.render(template, {"myimage": self.image})
         expected = f"""

--- a/wagtail/snippets/templates/wagtailsnippets/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/snippets/templates/wagtailsnippets/bulk_actions/confirm_bulk_delete.html
@@ -5,7 +5,7 @@
     {% if items|length == 1 %}
         {% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Delete {{ snippet_type_name }}{% endblocktrans %} - {{ items.0.item }}
     {% else %}
-        {{ items|length }} {{ model_opts.verbose_name_plural|capfirst }}
+        {{ items|length|intcomma }} {{ model_opts.verbose_name_plural|capfirst }}
     {% endif %}
 {% endblock %}
 
@@ -22,11 +22,13 @@
     {% if items %}
         {% if items|length == 1 %}
             <div class="usagecount">
-                <a href="{{ items.0.usage_url }}">{% blocktrans trimmed count usage_count=items.0.usage_count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                {% with usage_count_val=items.0.usage_count %}
+                    <a href="{{ items.0.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                {% endwith %}
             </div>
             <p>{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Are you sure you want to delete this {{ snippet_type_name }}?{% endblocktrans %}</p>
         {% else %}
-            <p>{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name_plural count=items|length %}Are you sure you want to delete {{ count }} {{ snippet_type_name }}?{% endblocktrans %}</p>
+            <p>{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name_plural count=items|length|intcomma %}Are you sure you want to delete {{ count }} {{ snippet_type_name }}?{% endblocktrans %}</p>
             <ul>
                 {% for snippet in items %}
                     <li>

--- a/wagtail/test/testapp/templates/tests/form_page_landing.html
+++ b/wagtail/test/testapp/templates/tests/form_page_landing.html
@@ -1,4 +1,5 @@
 {% extends "tests/base.html" %}
+{% load l10n %}
 
 {% block content %}
     <p>{{ greeting }}</p>
@@ -6,7 +7,7 @@
 
     <ul>
         {% for key, value in form_submission.get_data.items %}
-            <li>{{ key }}: {{ value }}</li>
+            <li>{{ key }}: {{ value|unlocalize }}</li>
         {% endfor %}
     </ul>
 {% endblock %}

--- a/wagtail/users/templates/wagtailusers/bulk_actions/confirm_bulk_assign_role.html
+++ b/wagtail/users/templates/wagtailusers/bulk_actions/confirm_bulk_assign_role.html
@@ -1,7 +1,11 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n wagtailusers_tags wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans trimmed count counter=items|length %}Assign role to 1 user {% plural %}Assign role to {{ counter }} users{% endblocktrans %}{% endblock %}
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}Assign role to 1 user {% plural %}Assign role to {{ counter }} users{% endblocktrans %}
+    {% endwith %}
+{% endblock %}
 
 {% block header %}
     {% trans "Assign role" as header_str %}

--- a/wagtail/users/templates/wagtailusers/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/users/templates/wagtailusers/bulk_actions/confirm_bulk_delete.html
@@ -1,7 +1,11 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n wagtailusers_tags wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans trimmed count counter=items|length %}Delete 1 user {% plural %}Delete {{ counter }} users{% endblocktrans %}{% endblock %}
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}Delete 1 user {% plural %}Delete {{ counter }} users{% endblocktrans %}
+    {% endwith %}
+{% endblock %}
 
 {% block header %}
     {% trans "Delete" as del_str %}

--- a/wagtail/users/templates/wagtailusers/bulk_actions/confirm_bulk_set_active_state.html
+++ b/wagtail/users/templates/wagtailusers/bulk_actions/confirm_bulk_set_active_state.html
@@ -1,7 +1,11 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n wagtailusers_tags wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans trimmed count counter=items|length %}Change active state for 1 user {% plural %}Change active state for {{ counter }} users{% endblocktrans %}{% endblock %}
+{% block titletag %}
+    {% with counter_val=items|length %}
+        {% blocktrans trimmed with counter=counter_val|intcomma count counter_val=counter_val %}Change active state for 1 user {% plural %}Change active state for {{ counter }} users{% endblocktrans %}
+    {% endwith %}
+{% endblock %}
 
 {% block header %}
     {% trans "Set active state" as header_str %}


### PR DESCRIPTION
Prompted by #12244, an attempt at dealing with the general issue as per https://github.com/wagtail/wagtail/pull/12244#discussion_r1725196615.

To identify all places where numbers are output directly onto templates, I made the following patch to the Django stable/5.0.x branch which raises an exception on any number that is output onto a template without first being passed through one of `|unlocalize`, `|intcomma`, `|localize` or `|filesize_number_format`:

```diff
diff --git a/django/contrib/humanize/templatetags/humanize.py b/django/contrib/humanize/templatetags/humanize.py
index 19000c185c..ca5f031e8a 100644
--- a/django/contrib/humanize/templatetags/humanize.py
+++ b/django/contrib/humanize/templatetags/humanize.py
@@ -74,7 +74,7 @@ def intcomma(value, use_l10n=True):
         except (TypeError, ValueError):
             return intcomma(value, False)
         else:
-            return number_format(value, use_l10n=True, force_grouping=True)
+            return number_format(value, use_l10n="explicit", force_grouping=True)
     result = str(value)
     match = re.match(r"-?\d+", result)
     if match:
diff --git a/django/template/defaultfilters.py b/django/template/defaultfilters.py
index b71c5555f0..9c6ff3ff6b 100644
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -920,7 +920,7 @@ def filesizeformat(bytes_):
         return avoid_wrapping(value)

     def filesize_number_format(value):
-        return formats.number_format(round(value, 1), 1)
+        return formats.number_format(round(value, 1), 1, use_l10n="explicit")

     KB = 1 << 10
     MB = 1 << 20
diff --git a/django/templatetags/l10n.py b/django/templatetags/l10n.py
index 93b0e18ebd..16e480d1c9 100644
--- a/django/templatetags/l10n.py
+++ b/django/templatetags/l10n.py
@@ -9,7 +9,7 @@ def localize(value):
     """
     Force a value to be rendered as a localized value.
     """
-    return str(formats.localize(value, use_l10n=True))
+    return str(formats.localize(value, use_l10n="explicit"))


 @register.filter(is_safe=False)
diff --git a/django/utils/numberformat.py b/django/utils/numberformat.py
index cf8b2d219c..acdceda956 100644
--- a/django/utils/numberformat.py
+++ b/django/utils/numberformat.py
@@ -1,6 +1,7 @@
 from decimal import Decimal

 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.safestring import mark_safe


@@ -29,6 +30,8 @@ def format(
         return mark_safe(number)
     if use_l10n is None:
         use_l10n = True
+    if use_l10n and use_l10n != "explicit":
+        raise ImproperlyConfigured("Localized number has been rendered")
     use_grouping = use_l10n and settings.USE_THOUSAND_SEPARATOR
     use_grouping = use_grouping or force_grouping
     use_grouping = use_grouping and grouping != 0

```

I then updated all template code accordingly, using `unlocalize` for numbers that need to be machine-readable, and `|intcomma` for most human-facing numbers, except for image dimensions ("1,024×768" looks odd) and places where a value's type is not known upfront (such as basic table cells and the 'inspect' view). This caught a handful of extra cases where `USE_THOUSAND_SEPARATOR` could have caused bugs, beyond the ones fixed by @SebCorbin in #12244.

The next task is to find a way to run our test suite in this configuration within our CI without having to patch the Django codebase - can we import and monkeypatch the relevant modules, or creatively abuse custom locale formats as @laymonage has done in #12249?