### PR TITLE
Allow deep contentpath for comments on fields other than StreamField

### DIFF
--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -4694,12 +4694,12 @@ class Comment(ClusterableModel):
             # comment applies to the field as a whole
             return True
 
-        if not isinstance(field, StreamField):
-            # only StreamField supports content paths that are deeper than one level
+        # e.g. StreamField supports content paths that are deeper than one level
+        if not hasattr(field, "get_block_by_content_path"):
             return False
 
-        stream_value = getattr(page, field_name)
-        block = field.get_block_by_content_path(stream_value, remainder)
+        field_value = getattr(page, field_name)
+        block = field.get_block_by_content_path(field_value, remainder)
         # content path is valid if this returns a BoundBlock rather than None
         return bool(block)
 


### PR DESCRIPTION
`Comment.has_valid_contentpath` ensures the contentpath of a saved comment matches a field on a Page.

https://github.com/wagtail/wagtail/blob/6857f6431a49ecf314b181583c99ff00cb91372e/wagtail/models/__init__.py#L4697-L4704

When dealing with custom model fields (for example based on `JSONField`), there's no way to handle deep comments in the form.

> If it looks like a duck, quacks like a duck, but needs batteries - you have the wrong abstraction
