### PR TITLE
Docs - Formatting / white-space clean up

### DIFF
--- a/docs/advanced_topics/accessibility_considerations.md
+++ b/docs/advanced_topics/accessibility_considerations.md
@@ -238,7 +238,7 @@ Some users, such as those with vestibular disorders, may prefer a more static ve
 
 ```css
 @media (prefers-reduced-motion) {
-  /* styles to apply if a user's device settings are set to reduced motion */
+    /* styles to apply if a user's device settings are set to reduced motion */
     /* for example, disable animations */
     * {
         animation: none !important;
@@ -248,7 +248,6 @@ Some users, such as those with vestibular disorders, may prefer a more static ve
 ```
 
 Note that `prefers-reduced-motion` is only applied for users who enabled this setting in their operating system or browser. This feature is supported by Chrome, Safari and Firefox. For more information on reduced motion, see the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).
-
 
 ## Accessibility resources
 

--- a/docs/advanced_topics/customisation/custom_page_listings.md
+++ b/docs/advanced_topics/customisation/custom_page_listings.md
@@ -1,4 +1,5 @@
 (custom_page_listings)=
+
 # Custom page listings
 
 Normally, editors navigate through the Wagtail admin interface by following the structure of the page tree. However, this can make it slow to locate a specific page for editing, especially on large sites where pages are organised into a deep hierarchy.

--- a/docs/advanced_topics/deploying.md
+++ b/docs/advanced_topics/deploying.md
@@ -52,15 +52,15 @@ If you would like to serve your images from a separate asset server or CDN, you 
 Document serving is controlled by the [WAGTAILDOCS_SERVE_METHOD](wagtaildocs_serve_method) method.
 When using `FileSystemStorage`, documents are stored in a `documents` subdirectory within your site's `MEDIA_ROOT`. In this case, `WAGTAILDOCS_SERVE_METHOD` defaults to `serve_view`, where Wagtail serves the document through a Django view that enforces privacy checks. This has the following implications:
 
-* **You should block direct access to the `documents` subdirectory of `MEDIA_ROOT` within your web server configuration.** This prevents users from bypassing [collection privacy settings](https://guide.wagtail.org/en-latest/how-to-guides/manage-collections/#privacy-settings) by accessing documents at their direct URL.
-* Documents are served as downloads rather than displayed in the browser (unless specified explicitly via [](wagtaildocs_inline_content_types)) - this ensures that if the document is a type that can contain scripts (such as HTML or SVG), the browser is prevented from executing them.
-* However, since the document is served through the Django application server, this may consume more server resources than serving the document directly from the web server.
+-   **You should block direct access to the `documents` subdirectory of `MEDIA_ROOT` within your web server configuration.** This prevents users from bypassing [collection privacy settings](https://guide.wagtail.org/en-latest/how-to-guides/manage-collections/#privacy-settings) by accessing documents at their direct URL.
+-   Documents are served as downloads rather than displayed in the browser (unless specified explicitly via [](wagtaildocs_inline_content_types)) - this ensures that if the document is a type that can contain scripts (such as HTML or SVG), the browser is prevented from executing them.
+-   However, since the document is served through the Django application server, this may consume more server resources than serving the document directly from the web server.
 
 The alternative serve methods `'direct'` and `'redirect'` work by serving the documents directly from `MEDIA_ROOT`. This means it is not possible to block direct access to the `documents` subdirectory, and so users may bypass permission checks by accessing the direct URL. Also, in the case that users with access to the Wagtail admin are not fully trusted, you will need to take additional steps to prevent the execution of scripts in documents:
 
-* The `WAGTAILDOCS_EXTENSIONS` setting may be used to restrict uploaded documents to an "allow list" of safe types.
-* The web server can be configured to return a `Content-Security-Policy: default-src 'none'` header for files within the `documents` subdirectory, which will prevent the execution of scripts in those files.
-* The web server can be configured to return a `Content-Disposition: attachment` header for files within the `documents` subdirectory, which will force the browser to download the file rather than displaying it inline.
+-   The `WAGTAILDOCS_EXTENSIONS` setting may be used to restrict uploaded documents to an "allow list" of safe types.
+-   The web server can be configured to return a `Content-Security-Policy: default-src 'none'` header for files within the `documents` subdirectory, which will prevent the execution of scripts in those files.
+-   The web server can be configured to return a `Content-Disposition: attachment` header for files within the `documents` subdirectory, which will force the browser to download the file rather than displaying it inline.
 
 If a remote ("cloud") storage backend is used, the serve method will default to `'redirect'` and the document will be served directly from the cloud storage file url. In this case, users may be able to bypass permission checks, and scripts within documents may be executed (depending on the cloud storage service's configuration). However, the impact of cross-site scripting attacks is reduced, as the document is served from a different domain to the main site.
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -410,8 +410,9 @@ Return a QuerySet of `Permission` objects to be shown in the Groups administrati
 Add buttons to the user list.
 
 This hook takes two parameters:
--  `user`: The user object to generate the button for
--  `request_user`: The currently logged-in user
+
+-   `user`: The user object to generate the button for
+-   `request_user`: The currently logged-in user
 
 This example will add a simple button to the listing if the currently logged-in user is a superuser:
 

--- a/docs/reference/management_commands.md
+++ b/docs/reference/management_commands.md
@@ -162,7 +162,7 @@ This does not remove unused rendition images, this can be done by clearing the f
 
 Options:
 
--  `--purge-only` :
+-   `--purge-only` :
     This argument will purge all image renditions without regenerating them. They will be regenerated when next requested.
 
 (convert_mariadb_uuids)=

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -340,7 +340,7 @@ See also [django-treebeard](https://django-treebeard.readthedocs.io/en/latest/in
             class BreadPage(Page):
                 ...
 
-                # default 
+                # default
                 private_page_options = ['password', 'groups', 'login']
 
                 # disable shared password

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -408,7 +408,6 @@ class CustomNonPageReportView(ReportView):
 {% endblock %}
 ```
 
-
 If you need to completely customize the view's template, you can still override the `template_name` attribute on the view class. Note that both `ReportView` and `PageReportView` now use the `wagtailadmin/reports/base_report.html` template, which now extends the `wagtailadmin/generic/listing.html` template. The `wagtailadmin/reports/base_page_report.html` template is now unused and should be replaced with `wagtailadmin/reports/base_report.html`.
 
 If you override `template_name`, it is still necessary to set `results_template_name` to a template that extends `wagtailadmin/reports/base_report_results.html` (or `wagtailadmin/reports/base_page_report_results.html` for page reports), so the view can correctly update the listing and show the active filters as you apply or remove any filters.

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -65,8 +65,8 @@ The syntax for `srcset_image` is the same as `image`, with two exceptions:
 {% srcset_image [image] [resize-rule-with-brace-expansion] sizes="[my source sizes]" %}
 ```
 
-- The resize rule should be provided with multiple sizes in a brace-expansion pattern, like `width-{200,400}`. This will generate the `srcset` attribute, with as many URLs as there are sizes defined in the resize rule, and one width descriptor per URL. The first provided size will always be used as the `src` attribute, and define the image’s width and height attributes, as a fallback.
-- The [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes) attribute is essential. This tells the browser how large the image will be displayed on the page, so that it can select the most appropriate image to load.
+-   The resize rule should be provided with multiple sizes in a brace-expansion pattern, like `width-{200,400}`. This will generate the `srcset` attribute, with as many URLs as there are sizes defined in the resize rule, and one width descriptor per URL. The first provided size will always be used as the `src` attribute, and define the image’s width and height attributes, as a fallback.
+-   The [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes) attribute is essential. This tells the browser how large the image will be displayed on the page, so that it can select the most appropriate image to load.
 
 Here is an example of `srcset_image` in action, generating a `srcset` attribute:
 

--- a/docs/tutorial/deployment.md
+++ b/docs/tutorial/deployment.md
@@ -215,11 +215,11 @@ If you successfully install flyctl but get an error saying "`fly` is not recogni
 8. Create your Fly.io project by running `fly launch`. Then press `y` to configure the settings.
 9. You will be taken to an admin screen on fly.io. Fill out the fields as follows:
 
-| Field                                                     | Instruction                                                                          |
-|-----------------------------------------------------------|--------------------------------------------------------------------------------------|
-| Choose a region for deployment                            | Select the region closest to the _AWS_S3_REGION_NAME_ in your _env.production_ file. |
-| CPU & Memory                                              | VM Size - shared-cpu-1x  VM Memory - 512 MB                                          |
-| Database                                                  | Fly Postgres - choose smallest option                                                |
+| Field                          | Instruction                                                                          |
+| ------------------------------ | ------------------------------------------------------------------------------------ |
+| Choose a region for deployment | Select the region closest to the _AWS_S3_REGION_NAME_ in your _env.production_ file. |
+| CPU & Memory                   | VM Size - shared-cpu-1x VM Memory - 512 MB                                           |
+| Database                       | Fly Postgres - choose smallest option                                                |
 
 click confirm **Confirm settings**
 
@@ -231,10 +231,10 @@ it's recommended to create a new database with the launch of the app through the
 
 10. Back in your terminal, answer the resulting prompt questions as follows:
 
-| Question                                                | Instruction                                                                                                                              |
-| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Overwrite ".../.dockerignore"?                          | Enter _y_                                                                                                                                |
-| Overwrite ".../Dockerfile"?                             | Enter _y_                                                                                                                                |
+| Question                       | Instruction |
+| ------------------------------ | ----------- |
+| Overwrite ".../.dockerignore"? | Enter _y_   |
+| Overwrite ".../Dockerfile"?    | Enter _y_   |
 
 The `fly launch` command creates two new files, `Dockerfile` and `fly.toml`, in your project directory.
 


### PR DESCRIPTION
Just a minor clean up of white-space / Markdown formatting in the documentation.

Remove additional line breaks, add missing line breaks, use the Markdown formatting for lists.