### PR TITLE
Refactor documents views to use universal designs

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -20,21 +20,23 @@
     <form action="{{ action_url }}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %} data-edit-form>
         {% csrf_token %}
 
-        {% if panel %}
-            {{ panel.render_form_content }}
-        {% else %}
-            {% block hidden_fields %}
-                {% for field in form.hidden_fields %}{{ field }}{% endfor %}
-            {% endblock %}
-
-            <ul class="fields">
-                {% block visible_fields %}
-                    {% for field in form.visible_fields %}
-                        <li>{% formattedfield field %}</li>
-                    {% endfor %}
+        {% block fields %}
+            {% if panel %}
+                {{ panel.render_form_content }}
+            {% else %}
+                {% block hidden_fields %}
+                    {% for field in form.hidden_fields %}{{ field }}{% endfor %}
                 {% endblock %}
-            </ul>
-        {% endif %}
+
+                <ul class="fields">
+                    {% block visible_fields %}
+                        {% for field in form.visible_fields %}
+                            <li>{% formattedfield field %}</li>
+                        {% endfor %}
+                    {% endblock %}
+                </ul>
+            {% endif %}
+        {% endblock %}
 
         {% block actions %}
             <button type="submit" class="button">{{ submit_button_label }}</button>

--- a/wagtail/documents/admin_urls.py
+++ b/wagtail/documents/admin_urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
         name="index_results",
     ),
     path("add/", documents.CreateView.as_view(), name="add"),
-    path("edit/<int:document_id>/", documents.edit, name="edit"),
+    path("edit/<int:document_id>/", documents.EditView.as_view(), name="edit"),
     path("delete/<int:document_id>/", documents.DeleteView.as_view(), name="delete"),
     path("multiple/add/", multiple.AddView.as_view(), name="add_multiple"),
     path("multiple/<int:doc_id>/", multiple.EditView.as_view(), name="edit_multiple"),

--- a/wagtail/documents/admin_urls.py
+++ b/wagtail/documents/admin_urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
         documents.IndexView.as_view(results_only=True),
         name="index_results",
     ),
-    path("add/", documents.add, name="add"),
+    path("add/", documents.CreateView.as_view(), name="add"),
     path("edit/<int:document_id>/", documents.edit, name="edit"),
     path("delete/<int:document_id>/", documents.DeleteView.as_view(), name="delete"),
     path("multiple/add/", multiple.AddView.as_view(), name="add_multiple"),

--- a/wagtail/documents/templates/wagtaildocs/documents/add.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/add.html
@@ -1,12 +1,9 @@
-{% extends "wagtailadmin/base.html" %}
-{% load i18n %}
-{% load wagtailimages_tags wagtailadmin_tags %}
+{% extends "wagtailadmin/generic/form.html" %}
+{% load i18n wagtailadmin_tags %}
 {% block titletag %}{% trans "Add a document" %}{% endblock %}
 
 {% block extra_js %}
     {{ block.super }}
-
-    {{ form.media.js }}
 
     <script>
         $(function() {
@@ -39,40 +36,15 @@
     </script>
 {% endblock %}
 
-{% block extra_css %}
-    {{ block.super }}
-    {{ form.media.css }}
-{% endblock %}
-
-{% block content %}
-    {% trans "Add document" as add_str %}
-    {% include "wagtailadmin/shared/header.html" with title=add_str icon="doc-full-inverse" %}
-
-    <div class="nice-padding">
-        {% include "wagtailadmin/shared/non_field_errors.html" %}
-        <form action="{% url 'wagtaildocs:add' %}" method="POST" enctype="multipart/form-data" novalidate>
-            {% csrf_token %}
-            <ul class="fields">
-                {% for field in form %}
-                    {% if field.is_hidden %}
-                        {{ field }}
-                    {% else %}
-                        <li>{% formattedfield field %}</li>
-                    {% endif %}
-                {% endfor %}
-                <li>
-                    <button
-                        type="submit"
-                        class="button button-longrunning"
-                        data-controller="w-progress"
-                        data-action="w-progress#activate"
-                        data-w-progress-active-value="{% trans 'Uploading…' %}"
-                    >
-                        {% icon name="spinner" %}
-                        <em data-w-progress-target="label">{% trans 'Upload' %}</em>
-                    </button>
-                </li>
-            </ul>
-        </form>
-    </div>
+{% block actions %}
+    <button
+        type="submit"
+        class="button button-longrunning"
+        data-controller="w-progress"
+        data-action="w-progress#activate"
+        data-w-progress-active-value="{% trans 'Uploading…' %}"
+    >
+        {% icon name="spinner" %}
+        <em data-w-progress-target="label">{% trans 'Upload' %}</em>
+    </button>
 {% endblock %}

--- a/wagtail/documents/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/edit.html
@@ -1,25 +1,8 @@
-{% extends "wagtailadmin/base.html" %}
-{% load i18n %}
-{% load wagtailimages_tags wagtailadmin_tags %}
-{% block titletag %}{% blocktrans trimmed with title=document.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
+{% extends "wagtailadmin/generic/edit.html" %}
+{% load i18n wagtailadmin_tags %}
 
-{% block extra_js %}
-    {{ block.super }}
-
-    {{ form.media.js }}
-{% endblock %}
-
-{% block extra_css %}
-    {{ block.super }}
-    {{ form.media.css }}
-{% endblock %}
-
-{% block content %}
-    {% trans "Editing" as editing_str %}
-    {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=document.title icon="doc-full-inverse" %}
-    {% include "wagtailadmin/shared/non_field_errors.html" %}
-
-    <div class="row row-flush nice-padding">
+{% block main_content %}
+    <div class="row row-flush">
 
         <div class="col10">
             <form action="{% url 'wagtaildocs:edit' document.id %}" method="POST" enctype="multipart/form-data" novalidate>
@@ -37,8 +20,8 @@
                     {% endfor %}
                     <li>
                         <input type="submit" value="{% trans 'Save' %}" class="button" />
-                        {% if user_can_delete %}
-                            <a href="{% url 'wagtaildocs:delete' document.id %}{% if next %}?next={{ next|urlencode }}{% endif %}" class="button no">{% trans "Delete document" %}</a>
+                        {% if can_delete %}
+                            <a href="{{ delete_url }}{% if next %}?next={{ next|urlencode }}{% endif %}" class="button no">{% trans "Delete document" %}</a>
                         {% endif %}
                     </li>
                 </ul>

--- a/wagtail/documents/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/edit.html
@@ -1,46 +1,33 @@
 {% extends "wagtailadmin/generic/edit.html" %}
 {% load i18n wagtailadmin_tags %}
 
-{% block main_content %}
-    <div class="row row-flush">
-
-        <div class="col10">
-            <form action="{% url 'wagtaildocs:edit' document.id %}" method="POST" enctype="multipart/form-data" novalidate>
-                {% csrf_token %}
-                <input type="hidden" value="{{ next }}" name="next">
-                <ul class="fields">
-                    {% for field in form %}
-                        {% if field.name == 'file' %}
-                            <li>{% include "wagtaildocs/documents/_file_field.html" %}</li>
-                        {% elif field.is_hidden %}
-                            {{ field }}
-                        {% else %}
-                            <li>{% formattedfield field %}</li>
-                        {% endif %}
-                    {% endfor %}
-                    <li>
-                        <input type="submit" value="{% trans 'Save' %}" class="button" />
-                        {% if can_delete %}
-                            <a href="{{ delete_url }}{% if next %}?next={{ next|urlencode }}{% endif %}" class="button no">{% trans "Delete document" %}</a>
-                        {% endif %}
-                    </li>
-                </ul>
-            </form>
-        </div>
-        <div class="col2">
-            <dl>
-                {% if document.file %}
-                    <dt>{% trans "Filesize" %}</dt>
-                    <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
+{% block fields %}
+    <div class="w-grid w-grid-cols-1 sm:w-grid-cols-6 w-gap-8">
+        <div class="sm:w-col-span-5">
+            <input type="hidden" value="{{ next }}" name="next">
+            {% for field in form %}
+                {% if field.name == 'file' %}
+                    {% include "wagtaildocs/documents/_file_field.html" %}
+                {% elif field.is_hidden %}
+                    {{ field }}
+                {% else %}
+                    {% formattedfield field %}
                 {% endif %}
-
-                <dt>{% trans "Usage" %}</dt>
-                <dd>
-                    {% with usage_count_val=document.get_usage.count %}
-                        <a href="{{ document.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
-                    {% endwith %}
-                </dd>
-            </dl>
+            {% endfor %}
         </div>
+
+        <dl>
+            {% if document.file %}
+                <dt>{% trans "Filesize" %}</dt>
+                <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
+            {% endif %}
+
+            <dt>{% trans "Usage" %}</dt>
+            <dd>
+                {% with usage_count_val=document.get_usage.count %}
+                    <a href="{{ document.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                {% endwith %}
+            </dd>
+        </dl>
     </div>
 {% endblock %}

--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -82,7 +82,6 @@
     <script>
         window.fileupload_opts = {
             max_title_length: {{ max_title_length|stringformat:"s"|default:"null" }}, //numeric format
-            simple_upload_url: "{% url 'wagtaildocs:add' %}"
         }
     </script>
 {% endblock %}

--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -1,4 +1,4 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 {% load i18n %}
 {% load l10n %}
 {% load wagtailadmin_tags %}
@@ -9,42 +9,37 @@
     {{ form_media.css }}
 {% endblock %}
 
-{% block content %}
-    {% trans "Add documents" as add_str %}
-    {% include "wagtailadmin/shared/header.html" with title=add_str icon="doc-full-inverse" %}
+{% block main_content %}
+    <div class="drop-zone w-mt-8">
+        <p>{% trans "Drag and drop documents into this area to upload immediately." %}</p>
+        <p>{{ help_text }}</p>
 
-    <div class="nice-padding">
-        <div class="drop-zone">
-            <p>{% trans "Drag and drop documents into this area to upload immediately." %}</p>
-            <p>{{ help_text }}</p>
-
-            <form action="{% url 'wagtaildocs:add_multiple' %}" method="POST" enctype="multipart/form-data">
-                <div class="replace-file-input">
-                    <button class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}{% trans "Or choose from your computer" %}</button>
-                    <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtaildocs:add_multiple' %}" multiple>
-                </div>
-                {% csrf_token %}
-                {% if collections %}
-                    {% trans "Add to collection:" as label_text %}
-                    {% rawformattedfield label_text=label_text id_for_label="id_adddocument_collection" classname="w-mx-auto w-mt-4 w-grid w-justify-center"  %}
-                        <select id="id_adddocument_collection" name="collection">
-                            {% for pk, display_name in collections.get_indented_choices %}
-                                <option value="{{ pk|unlocalize }}"{% if pk|unlocalize == selected_collection_id %} selected{% endif %}>
-                                    {{ display_name }}
-                                </option>
-                            {% endfor %}
-                        </select>
-                    {% endrawformattedfield %}
-                {% endif %}
-            </form>
-        </div>
-
-        <div id="overall-progress" class="progress progress-secondary">
-            <div class="bar" style="width: 0%;">0%</div>
-        </div>
-
-        <ul id="upload-list" class="upload-list multiple"></ul>
+        <form action="{% url 'wagtaildocs:add_multiple' %}" method="POST" enctype="multipart/form-data">
+            <div class="replace-file-input">
+                <button class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}{% trans "Or choose from your computer" %}</button>
+                <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtaildocs:add_multiple' %}" multiple>
+            </div>
+            {% csrf_token %}
+            {% if collections %}
+                {% trans "Add to collection:" as label_text %}
+                {% rawformattedfield label_text=label_text id_for_label="id_adddocument_collection" classname="w-mx-auto w-mt-4 w-grid w-justify-center"  %}
+                    <select id="id_adddocument_collection" name="collection">
+                        {% for pk, display_name in collections.get_indented_choices %}
+                            <option value="{{ pk|unlocalize }}"{% if pk|unlocalize == selected_collection_id %} selected{% endif %}>
+                                {{ display_name }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                {% endrawformattedfield %}
+            {% endif %}
+        </form>
     </div>
+
+    <div id="overall-progress" class="progress progress-secondary">
+        <div class="bar" style="width: 0%;">0%</div>
+    </div>
+
+    <ul id="upload-list" class="upload-list multiple"></ul>
 
     <template id="upload-list-item">
         <li class="row">

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -9,6 +9,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.html import escape
 from django.utils.http import urlencode
+from django.utils.text import capfirst
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.documents import get_document_model, models
@@ -1025,7 +1026,7 @@ class TestDocumentDeleteView(WagtailTestUtils, TestCase):
         self.assertContains(response, "This document is referenced 0 times")
 
 
-class TestMultipleDocumentUploader(WagtailTestUtils, TestCase):
+class TestMultipleDocumentUploader(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     """
     This tests the multiple document upload views located in wagtaildocs/views/multiple.py
     """
@@ -1063,6 +1064,17 @@ class TestMultipleDocumentUploader(WagtailTestUtils, TestCase):
         # Check response
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtaildocs/multiple/add.html")
+
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {
+                    "url": reverse("wagtaildocs:index"),
+                    "label": capfirst(self.doc._meta.verbose_name_plural),
+                },
+                {"url": "", "label": "Add documents"},
+            ],
+            response.content,
+        )
 
         # no collection chooser when only one collection exists
         self.assertNotContains(response, "id_adddocument_collection")

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -28,6 +28,7 @@ from wagtail.test.testapp.models import (
     VariousOnDeleteModel,
 )
 from wagtail.test.utils import WagtailTestUtils
+from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 
 
 class TestDocumentIndexView(WagtailTestUtils, TestCase):
@@ -2052,7 +2053,7 @@ class TestUsageCount(WagtailTestUtils, TestCase):
         self.assertContains(response, "Used 0 times")
 
 
-class TestGetUsage(WagtailTestUtils, TestCase):
+class TestGetUsage(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     fixtures = ["test.json"]
 
     def setUp(self):
@@ -2086,6 +2087,24 @@ class TestGetUsage(WagtailTestUtils, TestCase):
         self.assertContains(response, "Christmas")
         self.assertContains(response, '<table class="listing">')
         self.assertContains(response, "<td>Event page</td>", html=True)
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {
+                    "url": reverse("wagtaildocs:index"),
+                    "label": "Documents",
+                },
+                {
+                    "url": reverse("wagtaildocs:edit", args=(1,)),
+                    "label": "test document",
+                },
+                {
+                    "url": "",
+                    "label": "Usage",
+                    "sublabel": "test document",
+                },
+            ],
+            response.content,
+        )
 
     def test_usage_page_no_usage(self):
         response = self.client.get(reverse("wagtaildocs:document_usage", args=(1,)))

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -627,7 +627,7 @@ class TestDocumentAddViewWithLimitedCollectionPermissions(WagtailTestUtils, Test
         )
 
 
-class TestDocumentEditView(WagtailTestUtils, TestCase):
+class TestDocumentEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def setUp(self):
         self.user = self.login()
 
@@ -685,6 +685,14 @@ class TestDocumentEditView(WagtailTestUtils, TestCase):
         # (see TestDocumentEditViewWithCustomDocumentModel - this confirms that form media
         # definitions are being respected)
         self.assertNotContains(response, "wagtailadmin/js/draftail.js")
+
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {"url": reverse("wagtaildocs:index"), "label": "Documents"},
+                {"url": "", "label": "Test document"},
+            ],
+            response.content,
+        )
 
         url_finder = AdminURLFinder(self.user)
         expected_url = "/admin/documents/edit/%d/" % self.document.id

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -405,7 +405,7 @@ class TestDocumentIndexResultsView(WagtailTestUtils, TransactionTestCase):
         self.assertContains(response, "<td>Root</td>", html=True)
 
 
-class TestDocumentAddView(WagtailTestUtils, TestCase):
+class TestDocumentAddView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def setUp(self):
         self.login()
 
@@ -426,6 +426,14 @@ class TestDocumentAddView(WagtailTestUtils, TestCase):
 
         # draftail should NOT be a standard JS include on this page
         self.assertNotContains(response, "wagtailadmin/js/draftail.js")
+
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {"url": reverse("wagtaildocs:index"), "label": "Documents"},
+                {"url": "", "label": "New: Document"},
+            ],
+            response.content,
+        )
 
     def test_get_with_collections(self):
         root_collection = Collection.get_first_root_node()

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -307,6 +307,8 @@ class UsageView(generic.UsageView):
     permission_policy = permission_policy
     permission_required = "change"
     header_icon = "doc-full-inverse"
+    index_url_name = "wagtaildocs:index"
+    edit_url_name = "wagtaildocs:edit"
 
     def user_has_permission(self, permission):
         return self.permission_policy.user_has_permission_for_instance(

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -4,6 +4,7 @@ from django.contrib.admin.utils import quote
 from django.core.exceptions import PermissionDenied
 from django.http.response import HttpResponse as HttpResponse
 from django.utils.functional import cached_property
+from django.utils.http import urlencode
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, ngettext
 
@@ -196,6 +197,7 @@ class EditView(generic.EditView):
     delete_url_name = "wagtaildocs:delete"
     header_icon = "doc-full-inverse"
     context_object_name = "document"
+    delete_item_label = gettext_lazy("Delete document")
     _show_breadcrumbs = True
 
     @cached_property
@@ -229,6 +231,12 @@ class EditView(generic.EditView):
 
     def get_success_url(self):
         return self.next_url or super().get_success_url()
+
+    def get_delete_url(self):
+        delete_url = super().get_delete_url()
+        if self.next_url:
+            delete_url += "?" + urlencode({"next": self.next_url})
+        return delete_url
 
     def render_to_response(self, context, **response_kwargs):
         if self.object.is_stored_locally():

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -1,5 +1,10 @@
 import os.path
 
+from django.urls import reverse
+from django.utils.text import capfirst
+from django.utils.translation import gettext_lazy
+
+from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
 from wagtail.admin.views.generic.multiple_upload import AddView as BaseAddView
 from wagtail.admin.views.generic.multiple_upload import (
     CreateFromUploadView as BaseCreateFromUploadView,
@@ -15,10 +20,14 @@ from ..forms import get_document_form, get_document_multi_form
 from ..permissions import permission_policy
 
 
-class AddView(BaseAddView):
+class AddView(WagtailAdminTemplateMixin, BaseAddView):
     permission_policy = permission_policy
     template_name = "wagtaildocs/multiple/add.html"
+    header_icon = "doc-full-inverse"
+    page_title = gettext_lazy("Add documents")
+    _show_breadcrumbs = True
 
+    index_url_name = "wagtaildocs:index"
     edit_object_url_name = "wagtaildocs:edit_multiple"
     delete_object_url_name = "wagtaildocs:delete_multiple"
     edit_object_form_prefix = "doc"
@@ -30,6 +39,15 @@ class AddView(BaseAddView):
     edit_upload_form_prefix = "uploaded-document"
     context_upload_name = "uploaded_document"
     context_upload_id_name = "uploaded_file_id"
+
+    def get_breadcrumbs_items(self):
+        return self.breadcrumbs_items + [
+            {
+                "url": reverse(self.index_url_name),
+                "label": capfirst(self.model._meta.verbose_name_plural),
+            },
+            {"url": "", "label": self.get_page_title()},
+        ]
 
     def get_model(self):
         return get_document_model()

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -96,7 +96,6 @@
 
     <script>
         window.fileupload_opts = {
-            simple_upload_url: "{% url 'wagtailimages:add' %}",
             accepted_file_types: /\.({{ allowed_extensions|join:"|" }})$/i, //must be regex
             max_file_size: {{ max_filesize|stringformat:"s"|default:"null" }}, //numeric format
             max_title_length: {{ max_title_length|stringformat:"s"|default:"null" }}, //numeric format


### PR DESCRIPTION
Multiple upload view

<details><summary>Before/After</summary>

<img width="913" alt="image" src="https://github.com/user-attachments/assets/b2ac8542-f9bc-4e6b-b2ba-c71a4984b2c5">

<img width="913" alt="image" src="https://github.com/user-attachments/assets/95d9f65d-cbe2-45b5-b9fb-f9dd9ea04f89">

</details> 

Edit view

<details><summary>Before/After</summary>

<img width="913" alt="image" src="https://github.com/user-attachments/assets/18497be0-08c9-43b3-bea0-0c8b8d400f5c">

<img width="913" alt="image" src="https://github.com/user-attachments/assets/5225c882-e4cc-41f6-b946-47d832f949c1">

</details> 

Single upload view (not really used anymore)

<details><summary>Before/After</summary>

<img width="913" alt="image" src="https://github.com/user-attachments/assets/1dfdc9bc-4352-4203-afeb-f1b7d0cd376a">

<img width="913" alt="image" src="https://github.com/user-attachments/assets/be89b298-6cf5-4276-ac8b-d2c214b7a66e">

</details> 