### PR TITLE
Fix oembed providers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -242,6 +242,8 @@ Changelog
  * Fix: Reinstate missing static files in style guide (Sage Abdullah)
  * Fix: Provide `convert_mariadb_uuids` management command to assist with upgrading to Django 5.0+ on MariaDB (Matt Westcott)
  * Fix: Ensure invalid submissions are marked as dirty edits on load to trigger UI and browser warnings for unsaved changes, restoring previous behavior from Wagtail 5.2 (Sage Abdullah)
+ * Fix: Update polldaddy oEmbed provider to use the crowdsignal URL (Matthew Scouten)
+ * Fix: Remove polleverywhere oEmbed provider as it this application longer supports oEmbed (Matthew Scouten)
  * Docs: Add contributing development documentation on how to work with a fork of Wagtail (Nix Asteri, Dan Braghis)
  * Docs: Make sure the settings panel is listed in tabbed interface examples (Tibor Leupold)
  * Docs: Update content and page names to their US spelling instead of UK spelling (Victoria Poromon)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -834,6 +834,7 @@
 * Atif Khan
 * Sanjeev Holla S
 * Shubham Mukati
+* Matthew Scouten
 
 ## Translators
 

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -47,6 +47,8 @@ This release adds formal support for Django 5.1.
  * Fix content path links in usage view to scroll to the correct element (Sage Abdullah)
  * Always show the minimap toggle button (Albina Starykova)
  * Ensure invalid submissions are marked as dirty edits on load to trigger UI and browser warnings for unsaved changes, restoring previous behavior from Wagtail 5.2 (Sage Abdullah)
+ * Update polldaddy oEmbed provider to use the crowdsignal URL (Matthew Scouten)
+ * Remove polleverywhere oEmbed provider as it this application longer supports oEmbed (Matthew Scouten)
 
 ### Documentation
 

--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -88,6 +88,14 @@ coub = {
     ],
 }
 
+crowdsignal = {
+    "endpoint": "https://api.crowdsignal.com/oembed",
+    "urls": [
+        r"^https?://(?:[-\w]+\.)?polldaddy\.com/.+$",
+        r"^https?://poll.fm/\d+$",
+    ],
+}
+
 crowd_ranking = {
     "endpoint": "http://crowdranking.com/api/oembed.{format}",
     "urls": [
@@ -383,23 +391,6 @@ pinterest = {
     ],
 }
 
-
-polldaddy = {
-    "endpoint": "https://polldaddy.com/oembed/",
-    "urls": [
-        r"^https?://(?:[-\w]+\.)?polldaddy\.com/.+$",
-    ],
-}
-
-
-polleverywhere = {
-    "endpoint": "https://www.polleverywhere.com/services/oembed/",
-    "urls": [
-        r"^https?://www\.polleverywhere\.com/polls/.+$",
-        r"^https?://www\.polleverywhere\.com/multiple_choice_polls/.+$",
-        r"^https?://www\.polleverywhere\.com/free_text_polls/.+$",
-    ],
-}
 
 qik = {
     "endpoint": "http://qik.com/api/oembed.{format}",
@@ -700,6 +691,7 @@ all_providers = [
     clikthrough,
     collegehumor,
     coub,
+    crowdsignal,
     crowd_ranking,
     dailymile,
     dailymotion,
@@ -736,8 +728,6 @@ all_providers = [
     opera,
     photobucket,
     pinterest,
-    polldaddy,
-    polleverywhere,
     qik,
     rdio,
     reddit,


### PR DESCRIPTION
Clean up two oembed providers that are out of date. 

Polleverywhere, as far as I can tell, no longer supports oembed. 

Polldaddy changed it's name to crowdsignal, and changed it's api for both polls and urls