### PR TITLE
Refactor images views to use universal designs

### DIFF
--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -978,7 +978,7 @@ class DeleteView(
 class InspectView(PermissionCheckedMixin, WagtailAdminTemplateMixin, TemplateView):
     any_permission_required = ["add", "change", "delete", "view"]
     template_name = "wagtailadmin/generic/inspect.html"
-    page_title = gettext_lazy("Inspecting")
+    page_title = gettext_lazy("Inspect")
     model = None
     index_url_name = None
     edit_url_name = None
@@ -1015,7 +1015,7 @@ class InspectView(PermissionCheckedMixin, WagtailAdminTemplateMixin, TemplateVie
         items.append(
             {
                 "url": "",
-                "label": _("Inspect"),
+                "label": self.get_page_title(),
                 "sublabel": object_str,
             }
         )

--- a/wagtail/images/admin_urls.py
+++ b/wagtail/images/admin_urls.py
@@ -6,7 +6,7 @@ app_name = "wagtailimages"
 urlpatterns = [
     path("", images.IndexView.as_view(), name="index"),
     path("results/", images.IndexView.as_view(results_only=True), name="index_results"),
-    path("<int:image_id>/", images.edit, name="edit"),
+    path("<int:image_id>/", images.EditView.as_view(), name="edit"),
     path("<int:image_id>/delete/", images.DeleteView.as_view(), name="delete"),
     path(
         "<int:image_id>/generate_url/",

--- a/wagtail/images/admin_urls.py
+++ b/wagtail/images/admin_urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
         name="generate_url",
     ),
     path("<int:image_id>/preview/<str:filter_spec>/", images.preview, name="preview"),
-    path("add/", images.add, name="add"),
+    path("add/", images.CreateView.as_view(), name="add"),
     path("usage/<int:image_id>/", images.UsageView.as_view(), name="image_usage"),
     path("multiple/add/", multiple.AddView.as_view(), name="add_multiple"),
     path("multiple/<int:image_id>/", multiple.EditView.as_view(), name="edit_multiple"),

--- a/wagtail/images/templates/wagtailimages/images/add.html
+++ b/wagtail/images/templates/wagtailimages/images/add.html
@@ -1,12 +1,9 @@
-{% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags wagtailadmin_tags %}
-{% load i18n %}
+{% extends "wagtailadmin/generic/form.html" %}
+{% load wagtailimages_tags wagtailadmin_tags i18n %}
 {% block titletag %}{% trans "Add an image" %}{% endblock %}
 
 {% block extra_js %}
     {{ block.super }}
-
-    {{ form.media.js }}
 
     <script>
         $(function() {
@@ -39,30 +36,15 @@
     </script>
 {% endblock %}
 
-{% block extra_css %}
-    {{ block.super }}
-    {{ form.media.css }}
-{% endblock %}
-
-{% block content %}
-    {% trans "Add image" as add_str %}
-    {% include "wagtailadmin/shared/header.html" with title=add_str icon="image" %}
-
-    <div class="nice-padding">
-        {% include "wagtailadmin/shared/non_field_errors.html" %}
-
-        <form action="{% url 'wagtailimages:add' %}" method="POST" enctype="multipart/form-data" novalidate>
-            {% csrf_token %}
-            <ul class="fields">
-                {% for field in form %}
-                    {% if field.is_hidden %}
-                        {{ field }}
-                    {% else %}
-                        <li>{% formattedfield field %}</li>
-                    {% endif %}
-                {% endfor %}
-                <li><input type="submit" value="{% trans 'Save' %}" class="button" /></li>
-            </ul>
-        </form>
-    </div>
+{% block actions %}
+    <button
+        type="submit"
+        class="button button-longrunning"
+        data-controller="w-progress"
+        data-action="w-progress#activate"
+        data-w-progress-active-value="{% trans 'Uploading…' %}"
+    >
+        {% icon name="spinner" %}
+        <em data-w-progress-target="label">{% trans 'Upload' %}</em>
+    </button>
 {% endblock %}

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -1,16 +1,8 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/edit.html" %}
 {% load wagtailimages_tags wagtailadmin_tags i18n l10n %}
-{% block titletag %}{% blocktrans trimmed with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
-{% block extra_css %}
-    {{ block.super }}
-
-    {{ form.media.css }}
-{% endblock %}
 
 {% block extra_js %}
     {{ block.super }}
-
-    {{ form.media.js }}
 
     <!-- Focal point chooser -->
     <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.ba-throttle-debounce.min.js' %}"></script>
@@ -18,15 +10,11 @@
     <script src="{% versioned_static 'wagtailimages/js/focal-point-chooser.js' %}"></script>
 {% endblock %}
 
-{% block content %}
-    {% trans "Editing" as editing_str %}
-    {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=image.title icon="image" %}
-    {% include "wagtailadmin/shared/non_field_errors.html" %}
-
+{% block main_content %}
     <form action="{% url 'wagtailimages:edit' image.id %}" method="POST" enctype="multipart/form-data" novalidate>
         {% csrf_token %}
         <input type="hidden" value="{{ next }}" name="next">
-        <div class="row row-flush nice-padding">
+        <div class="row row-flush">
             <div class="col6">
                 {% for field in form %}
                     {% if field.name == 'file' %}
@@ -39,8 +27,8 @@
                 {% endfor %}
                 <div class="w-hidden sm:w-block">
                     <input type="submit" value="{% trans 'Save' %}" class="button" />
-                    {% if user_can_delete %}
-                        <a href="{% url 'wagtailimages:delete' image.id %}{% if next %}?next={{ next|urlencode }}{% endif %}" class="button no">{% trans "Delete image" %}</a>
+                    {% if can_delete %}
+                        <a href="{{ delete_url }}{% if next %}?next={{ next|urlencode }}{% endif %}" class="button no">{% trans "Delete image" %}</a>
                     {% endif %}
                 </div>
             </div>
@@ -94,11 +82,11 @@
             </div>
         </div>
 
-        <div class="row row-flush nice-padding sm:!w-hidden">
+        <div class="row row-flush sm:!w-hidden">
             <div class="col5">
                 <input type="submit" value="{% trans 'Save' %}" class="button" />
-                {% if user_can_delete %}
-                    <a href="{% url 'wagtailimages:delete' image.id %}{% if next %}?next={{ next }}{% endif %}" class="button no">{% trans "Delete image" %}</a>
+                {% if can_delete %}
+                    <a href="{{ delete_url }}{% if next %}?next={{ next }}{% endif %}" class="button no">{% trans "Delete image" %}</a>
                 {% endif %}
             </div>
         </div>

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -10,85 +10,66 @@
     <script src="{% versioned_static 'wagtailimages/js/focal-point-chooser.js' %}"></script>
 {% endblock %}
 
-{% block main_content %}
-    <form action="{% url 'wagtailimages:edit' image.id %}" method="POST" enctype="multipart/form-data" novalidate>
-        {% csrf_token %}
-        <input type="hidden" value="{{ next }}" name="next">
-        <div class="row row-flush">
-            <div class="col6">
-                {% for field in form %}
-                    {% if field.name == 'file' %}
-                        {% include "wagtailimages/images/_file_field.html" %}
-                    {% elif field.is_hidden %}
-                        {{ field }}
-                    {% else %}
-                        {% formattedfield field %}
-                    {% endif %}
-                {% endfor %}
-                <div class="w-hidden sm:w-block">
-                    <input type="submit" value="{% trans 'Save' %}" class="button" />
-                    {% if can_delete %}
-                        <a href="{{ delete_url }}{% if next %}?next={{ next|urlencode }}{% endif %}" class="button no">{% trans "Delete image" %}</a>
-                    {% endif %}
-                </div>
+{% block fields %}
+    <div class="w-grid w-grid-cols-1 sm:w-grid-cols-2 w-gap-8">
+        <div>
+            <input type="hidden" value="{{ next }}" name="next">
+            {% for field in form %}
+                {% if field.name == 'file' %}
+                    {% include "wagtailimages/images/_file_field.html" %}
+                {% elif field.is_hidden %}
+                    {{ field }}
+                {% else %}
+                    {% formattedfield field %}
+                {% endif %}
+            {% endfor %}
+        </div>
+        <div>
+            {% image image max-800x600 as rendition %}
+
+            <div
+                class="focal-point-chooser"
+                style="max-width: {{ rendition.width|unlocalize }}px; max-height: {{ rendition.height|unlocalize }}px;"
+                data-focal-point-x="{{ image.focal_point_x|default_if_none:''|unlocalize }}"
+                data-focal-point-y="{{ image.focal_point_y|default_if_none:''|unlocalize }}"
+                data-focal-point-width="{{ image.focal_point_width|default_if_none:''|unlocalize }}"
+                data-focal-point-height="{{ image.focal_point_height|default_if_none:''|unlocalize }}"
+                data-focal-input-label="{% trans 'Image focal point' %}"
+            >
+                <img {{ rendition.attrs }} decoding="async" data-original-width="{{ image.width|unlocalize }}" data-original-height="{{ image.height|unlocalize }}" class="show-transparency">
+                <div class="current-focal-point-indicator{% if not image.has_focal_point %} hidden{% endif %}"></div>
             </div>
 
-            <div class="col6">
-                {% image image max-800x600 as rendition %}
+            {% if url_generator_url %}
+                <a href="{{ url_generator_url }}" class="button bicolor button--icon">{% icon name="link" wrapped=1 %}{% trans "URL Generator" %}</a>
+                <hr />
+            {% endif %}
 
-                <div
-                    class="focal-point-chooser"
-                    style="max-width: {{ rendition.width|unlocalize }}px; max-height: {{ rendition.height|unlocalize }}px;"
-                    data-focal-point-x="{{ image.focal_point_x|default_if_none:''|unlocalize }}"
-                    data-focal-point-y="{{ image.focal_point_y|default_if_none:''|unlocalize }}"
-                    data-focal-point-width="{{ image.focal_point_width|default_if_none:''|unlocalize }}"
-                    data-focal-point-height="{{ image.focal_point_height|default_if_none:''|unlocalize }}"
-                    data-focal-input-label="{% trans 'Image focal point' %}"
-                >
-                    <img {{ rendition.attrs }} decoding="async" data-original-width="{{ image.width|unlocalize }}" data-original-height="{{ image.height|unlocalize }}" class="show-transparency">
-                    <div class="current-focal-point-indicator{% if not image.has_focal_point %} hidden{% endif %}"></div>
+            <div class="w-grid md:w-grid-cols-3 w-gap-2">
+                <div class="w-col-span-2">
+                    <h2 class="w-label-3">{% trans "Focal point" %} <span class="w-font-normal">{% trans "(optional)" %}</span></h2>
+                    <p>{% trans "To define this image's most important region, drag a box over the image above." %} {% if image.has_focal_point %}({% trans "Current focal point shown" %}){% endif %}</p>
+
+                    <button class="button button-secondary no remove-focal-point" type="button">{% trans "Remove focal area" %}</button>
                 </div>
+                <div class="w-col-span-1">
+                    {% image image original as original_image %}
 
-                {% if url_generator_enabled %}
-                    <a href="{% url 'wagtailimages:url_generator' image.id %}" class="button bicolor button--icon">{% icon name="link" wrapped=1 %}{% trans "URL Generator" %}</a>
-                    <hr />
-                {% endif %}
+                    <dl>
+                        <dt>{% trans "Max dimensions" %}</dt>
+                        <dd>{{ original_image.width|unlocalize }}x{{ original_image.height|unlocalize }}</dd>
+                        <dt>{% trans "Filesize" %}</dt>
+                        <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
 
-                <div class="row">
-                    <div class="col8">
-                        <h2 class="w-label-3">{% trans "Focal point" %} <span class="w-font-normal">{% trans "(optional)" %}</span></h2>
-                        <p>{% trans "To define this image's most important region, drag a box over the image above." %} {% if image.has_focal_point %}({% trans "Current focal point shown" %}){% endif %}</p>
-
-                        <button class="button button-secondary no remove-focal-point" type="button">{% trans "Remove focal area" %}</button>
-                    </div>
-                    <div class="col4">
-                        {% image image original as original_image %}
-
-                        <dl>
-                            <dt>{% trans "Max dimensions" %}</dt>
-                            <dd>{{ original_image.width|unlocalize }}x{{ original_image.height|unlocalize }}</dd>
-                            <dt>{% trans "Filesize" %}</dt>
-                            <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
-
-                            <dt>{% trans "Usage" %}</dt>
-                            <dd>
-                                {% with image.get_usage.count as usage_count_val %}
-                                    <a href="{{ image.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
-                                {% endwith %}
-                            </dd>
-                        </dl>
-                    </div>
+                        <dt>{% trans "Usage" %}</dt>
+                        <dd>
+                            {% with image.get_usage.count as usage_count_val %}
+                                <a href="{{ image.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                            {% endwith %}
+                        </dd>
+                    </dl>
                 </div>
             </div>
         </div>
-
-        <div class="row row-flush sm:!w-hidden">
-            <div class="col5">
-                <input type="submit" value="{% trans 'Save' %}" class="button" />
-                {% if can_delete %}
-                    <a href="{{ delete_url }}{% if next %}?next={{ next }}{% endif %}" class="button no">{% trans "Delete image" %}</a>
-                {% endif %}
-            </div>
-        </div>
-    </form>
+    </div>
 {% endblock %}

--- a/wagtail/images/templates/wagtailimages/images/url_generator.html
+++ b/wagtail/images/templates/wagtailimages/images/url_generator.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block main_content %}
-    <div class="w-image-url-generator nice-padding" data-generator-url="{% url 'wagtailimages:generate_url' object.id '__filterspec__' %}">
+    <div class="w-image-url-generator w-mt-8" data-generator-url="{% url 'wagtailimages:generate_url' object.id '__filterspec__' %}">
         <form class="w-image-url-generator__form w-mb-5">
             {% include "wagtailadmin/shared/field.html" with field=form.filter_method %}
             {% field_row max_content=True %}

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -1,4 +1,4 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 {% load i18n %}
 {% load l10n %}
 {% load wagtailadmin_tags wagtailimages_tags %}
@@ -9,42 +9,37 @@
     {{ form_media.css }}
 {% endblock %}
 
-{% block content %}
-    {% trans "Add images" as add_str %}
-    {% include "wagtailadmin/shared/header.html" with title=add_str icon="image" %}
+{% block main_content %}
+    <div class="drop-zone w-mt-8">
+        <p>{% trans "Drag and drop images into this area to upload immediately." %}</p>
+        <p>{{ help_text }}</p>
 
-    <div class="nice-padding">
-        <div class="drop-zone">
-            <p>{% trans "Drag and drop images into this area to upload immediately." %}</p>
-            <p>{{ help_text }}</p>
-
-            <form action="{% url 'wagtailimages:add_multiple' %}" method="POST" enctype="multipart/form-data">
-                <div class="replace-file-input">
-                    <button class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}{% trans "Or choose from your computer" %}</button>
-                    <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtailimages:add_multiple' %}" multiple>
-                </div>
-                {% csrf_token %}
-                {% if collections %}
-                    {% trans "Add to collection:" as label_text %}
-                    {% rawformattedfield label_text=label_text id_for_label="id_addimage_collection" classname="w-mx-auto w-mt-4 w-grid w-justify-center" %}
-                        <select id="id_addimage_collection" name="collection">
-                            {% for pk, display_name in collections.get_indented_choices %}
-                                <option value="{{ pk|unlocalize }}"{% if pk|unlocalize == selected_collection_id %} selected{% endif %} >
-                                    {{ display_name }}
-                                </option>
-                            {% endfor %}
-                        </select>
-                    {% endrawformattedfield %}
-                {% endif %}
-            </form>
-        </div>
-
-        <div id="overall-progress" class="progress progress-secondary">
-            <div class="bar" style="width: 0%;">0%</div>
-        </div>
-
-        <ul id="upload-list" class="upload-list multiple"></ul>
+        <form action="{% url 'wagtailimages:add_multiple' %}" method="POST" enctype="multipart/form-data">
+            <div class="replace-file-input">
+                <button class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}{% trans "Or choose from your computer" %}</button>
+                <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtailimages:add_multiple' %}" multiple>
+            </div>
+            {% csrf_token %}
+            {% if collections %}
+                {% trans "Add to collection:" as label_text %}
+                {% rawformattedfield label_text=label_text id_for_label="id_addimage_collection" classname="w-mx-auto w-mt-4 w-grid w-justify-center" %}
+                    <select id="id_addimage_collection" name="collection">
+                        {% for pk, display_name in collections.get_indented_choices %}
+                            <option value="{{ pk|unlocalize }}"{% if pk|unlocalize == selected_collection_id %} selected{% endif %} >
+                                {{ display_name }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                {% endrawformattedfield %}
+            {% endif %}
+        </form>
     </div>
+
+    <div id="overall-progress" class="progress progress-secondary">
+        <div class="bar" style="width: 0%;">0%</div>
+    </div>
+
+    <ul id="upload-list" class="upload-list multiple"></ul>
 
     <template id="upload-list-item">
         <li class="row">

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -935,7 +935,7 @@ class TestImageAddViewWithLimitedCollectionPermissions(WagtailTestUtils, TestCas
         )
 
 
-class TestImageEditView(WagtailTestUtils, TestCase):
+class TestImageEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def setUp(self):
         self.user = self.login()
 
@@ -972,6 +972,14 @@ class TestImageEditView(WagtailTestUtils, TestCase):
         # (see TestImageEditViewWithCustomImageModel - this confirms that form media
         # definitions are being respected)
         self.assertNotContains(response, "wagtailadmin/js/draftail.js")
+
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {"url": reverse("wagtailimages:index"), "label": "Images"},
+                {"url": "", "label": "Test image"},
+            ],
+            response.content,
+        )
 
     def test_simple_with_collection_nesting(self):
         root_collection = Collection.get_first_root_node()

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -3373,7 +3373,7 @@ class TestMultipleImageUploaderWithCustomRequiredFields(WagtailTestUtils, TestCa
         self.assertTrue(response_json["success"])
 
 
-class TestURLGeneratorView(WagtailTestUtils, TestCase):
+class TestURLGeneratorView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def setUp(self):
         # Create an image for running tests on
         self.image = Image.objects.create(
@@ -3396,6 +3396,19 @@ class TestURLGeneratorView(WagtailTestUtils, TestCase):
         # Check response
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailimages/images/url_generator.html")
+        self.assertTemplateUsed(response, "wagtailadmin/generic/base.html")
+
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {"url": reverse("wagtailimages:index"), "label": "Images"},
+                {
+                    "url": reverse("wagtailimages:edit", args=(self.image.id,)),
+                    "label": "Test image",
+                },
+                {"url": "", "label": "Generate URL", "sublabel": "Test image"},
+            ],
+            response.content,
+        )
 
     def test_get_bad_permissions(self):
         """

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -15,6 +15,7 @@ from django.utils.encoding import force_str
 from django.utils.html import escape, escapejs
 from django.utils.http import RFC3986_SUBDELIMS, urlencode
 from django.utils.safestring import mark_safe
+from django.utils.text import capfirst
 from willow.optimizers.base import OptimizerBase
 from willow.registry import registry
 
@@ -35,6 +36,7 @@ from wagtail.test.testapp.models import (
     VariousOnDeleteModel,
 )
 from wagtail.test.utils import WagtailTestUtils
+from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 from wagtail.test.utils.timestamps import local_datetime
 
 from .utils import Image, get_test_image_file, get_test_image_file_svg
@@ -2336,7 +2338,7 @@ class TestImageChooserUploadViewWithLimitedPermissions(WagtailTestUtils, TestCas
         )
 
 
-class TestMultipleImageUploader(WagtailTestUtils, TestCase):
+class TestMultipleImageUploader(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     """
     This tests the multiple image upload views located in wagtailimages/views/multiple.py
     """
@@ -2365,6 +2367,17 @@ class TestMultipleImageUploader(WagtailTestUtils, TestCase):
         # (see TestMultipleImageUploaderWithCustomImageModel - this confirms that form media
         # definitions are being respected)
         self.assertNotContains(response, "wagtailadmin/js/draftail.js")
+
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {
+                    "url": reverse("wagtailimages:index"),
+                    "label": capfirst(self.image._meta.verbose_name_plural),
+                },
+                {"url": "", "label": "Add images"},
+            ],
+            response.content,
+        )
 
     @override_settings(WAGTAILIMAGES_MAX_UPLOAD_SIZE=1000)
     def test_add_max_file_size_context_variables(self):

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -515,7 +515,7 @@ class TestImageListingResultsView(WagtailTestUtils, TransactionTestCase):
         )
 
 
-class TestImageAddView(WagtailTestUtils, TestCase):
+class TestImageAddView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def setUp(self):
         self.login()
 
@@ -542,6 +542,14 @@ class TestImageAddView(WagtailTestUtils, TestCase):
 
         # draftail should NOT be a standard JS include on this page
         self.assertNotContains(response, "wagtailadmin/js/draftail.js")
+
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {"url": reverse("wagtailimages:index"), "label": "Images"},
+                {"url": "", "label": "New: Image"},
+            ],
+            response.content,
+        )
 
     def test_get_with_collections(self):
         root_collection = Collection.get_first_root_node()

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -209,8 +209,11 @@ class URLGeneratorView(generic.InspectView):
     model = get_image_model()
     pk_url_kwarg = "image_id"
     header_icon = "image"
-    page_title = "Generating URL"
+    page_title = gettext_lazy("Generate URL")
     template_name = "wagtailimages/images/url_generator.html"
+    index_url_name = "wagtailimages:index"
+    edit_url_name = "wagtailimages:edit"
+    _show_breadcrumbs = True
 
     def get_page_subtitle(self):
         return self.object.title

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -4,12 +4,10 @@ from tempfile import SpooledTemporaryFile
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.http import FileResponse, HttpResponse, JsonResponse
-from django.shortcuts import get_object_or_404, redirect
-from django.template.response import TemplateResponse
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.functional import cached_property
-from django.utils.http import urlencode
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, ngettext
 from django.views import View
@@ -125,84 +123,81 @@ class IndexView(generic.IndexView):
         return context
 
 
-@permission_checker.require("change")
-def edit(request, image_id):
-    Image = get_image_model()
-    ImageForm = get_image_form(Image)
+class EditView(generic.EditView):
+    permission_policy = permission_policy
+    pk_url_kwarg = "image_id"
+    error_message = gettext_lazy("The image could not be saved due to errors.")
+    template_name = "wagtailimages/images/edit.html"
+    index_url_name = "wagtailimages:index"
+    edit_url_name = "wagtailimages:edit"
+    delete_url_name = "wagtailimages:delete"
+    header_icon = "image"
+    context_object_name = "image"
+    _show_breadcrumbs = True
 
-    image = get_object_or_404(Image, id=image_id)
+    @cached_property
+    def model(self):
+        return get_image_model()
 
-    if not permission_policy.user_has_permission_for_instance(
-        request.user, "change", image
-    ):
-        raise PermissionDenied
+    def get_form_class(self):
+        return get_image_form(self.model)
 
-    next_url = get_valid_next_url_from_request(request)
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["user"] = self.request.user
+        return kwargs
 
-    if request.method == "POST":
-        form = ImageForm(request.POST, request.FILES, instance=image, user=request.user)
-        if form.is_valid():
-            form.save()
+    def get_object(self, queryset=None):
+        obj = super().get_object(queryset)
+        if not permission_policy.user_has_permission_for_instance(
+            self.request.user, "change", obj
+        ):
+            raise PermissionDenied
+        return obj
 
-            edit_url = reverse("wagtailimages:edit", args=(image.id,))
-            redirect_url = "wagtailimages:index"
-            if next_url:
-                edit_url = f"{edit_url}?{urlencode({'next': next_url})}"
-                redirect_url = next_url
+    def get_success_message(self):
+        return _("Image '%(image_title)s' updated.") % {
+            "image_title": self.object.title
+        }
 
-            messages.success(
-                request,
-                _("Image '%(image_title)s' updated.") % {"image_title": image.title},
-                buttons=[messages.button(edit_url, _("Edit again"))],
-            )
-            return redirect(redirect_url)
-        else:
-            messages.error(request, _("The image could not be saved due to errors."))
-    else:
-        form = ImageForm(instance=image, user=request.user)
+    @cached_property
+    def next_url(self):
+        return get_valid_next_url_from_request(self.request)
 
-    # Check if we should enable the frontend url generator
-    try:
-        reverse("wagtailimages_serve", args=("foo", "1", "bar"))
-        url_generator_enabled = True
-    except NoReverseMatch:
-        url_generator_enabled = False
+    def get_success_url(self):
+        return self.next_url or super().get_success_url()
 
-    if image.is_stored_locally():
-        # Give error if image file doesn't exist
-        if not os.path.isfile(image.file.path):
-            messages.error(
-                request,
-                _(
-                    "The source image file could not be found. Please change the source or delete the image."
-                )
-                % {"image_title": image.title},
-                buttons=[
-                    messages.button(
-                        reverse("wagtailimages:delete", args=(image.id,)), _("Delete")
+    def render_to_response(self, context, **response_kwargs):
+        if self.object.is_stored_locally():
+            # Give error if image file doesn't exist
+            if not os.path.isfile(self.object.file.path):
+                messages.error(
+                    self.request,
+                    _(
+                        "The source image file could not be found. Please change the source or delete the image."
                     )
-                ],
-            )
+                    % {"image_title": self.object.title},
+                    buttons=[messages.button(self.get_delete_url(), _("Delete"))],
+                )
 
-    try:
-        filesize = image.get_file_size()
-    except SourceImageIOError:
-        filesize = None
+        return super().render_to_response(context, **response_kwargs)
 
-    return TemplateResponse(
-        request,
-        "wagtailimages/images/edit.html",
-        {
-            "image": image,
-            "form": form,
-            "url_generator_enabled": url_generator_enabled,
-            "filesize": filesize,
-            "user_can_delete": permission_policy.user_has_permission_for_instance(
-                request.user, "delete", image
-            ),
-            "next": next_url,
-        },
-    )
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["next"] = self.next_url
+
+        try:
+            context["filesize"] = self.object.get_file_size()
+        except SourceImageIOError:
+            context["filesize"] = None
+
+        try:
+            reverse("wagtailimages_serve", args=("foo", "1", "bar"))
+            context["url_generator_enabled"] = True
+        except NoReverseMatch:
+            context["url_generator_enabled"] = False
+
+        return context
 
 
 class URLGeneratorView(generic.InspectView):

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -379,6 +379,11 @@ class UsageView(generic.UsageView):
     permission_policy = permission_policy
     permission_required = "change"
     header_icon = "image"
+    index_url_name = "wagtailimages:index"
+    edit_url_name = "wagtailimages:edit"
+
+    def get_base_object_queryset(self):
+        return super().get_base_object_queryset().select_related("uploaded_by_user")
 
     def user_has_permission(self, permission):
         return self.permission_policy.user_has_permission_for_instance(

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -131,8 +131,10 @@ class EditView(generic.EditView):
     index_url_name = "wagtailimages:index"
     edit_url_name = "wagtailimages:edit"
     delete_url_name = "wagtailimages:delete"
+    url_generator_url_name = "wagtailimages:url_generator"
     header_icon = "image"
     context_object_name = "image"
+    delete_item_label = gettext_lazy("Delete image")
     _show_breadcrumbs = True
 
     @cached_property
@@ -193,9 +195,11 @@ class EditView(generic.EditView):
 
         try:
             reverse("wagtailimages_serve", args=("foo", "1", "bar"))
-            context["url_generator_enabled"] = True
+            context["url_generator_url"] = reverse(
+                self.url_generator_url_name, args=(self.object.id,)
+            )
         except NoReverseMatch:
-            context["url_generator_enabled"] = False
+            context["url_generator_url"] = None
 
         return context
 

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -2,7 +2,10 @@ import os.path
 
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.text import capfirst
+from django.utils.translation import gettext_lazy
 
+from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
 from wagtail.admin.views.generic.multiple_upload import AddView as BaseAddView
 from wagtail.admin.views.generic.multiple_upload import (
     CreateFromUploadView as BaseCreateFromUploadView,
@@ -19,10 +22,14 @@ from wagtail.images.permissions import ImagesPermissionPolicyGetter, permission_
 from wagtail.images.utils import find_image_duplicates
 
 
-class AddView(BaseAddView):
+class AddView(WagtailAdminTemplateMixin, BaseAddView):
     permission_policy = ImagesPermissionPolicyGetter()
     template_name = "wagtailimages/multiple/add.html"
+    header_icon = "image"
+    page_title = gettext_lazy("Add images")
+    _show_breadcrumbs = True
 
+    index_url_name = "wagtailimages:index"
     edit_object_url_name = "wagtailimages:edit_multiple"
     delete_object_url_name = "wagtailimages:delete_multiple"
     edit_object_form_prefix = "image"
@@ -34,6 +41,15 @@ class AddView(BaseAddView):
     edit_upload_form_prefix = "uploaded-image"
     context_upload_name = "uploaded_image"
     context_upload_id_name = "uploaded_file_id"
+
+    def get_breadcrumbs_items(self):
+        return self.breadcrumbs_items + [
+            {
+                "url": reverse(self.index_url_name),
+                "label": capfirst(self.model._meta.verbose_name_plural),
+            },
+            {"url": "", "label": self.get_page_title()},
+        ]
 
     def get_model(self):
         return get_image_model()


### PR DESCRIPTION
Built on top of #12272.

Multiple upload view

<details><summary>Before/After</summary>

<img width="935" alt="image" src="https://github.com/user-attachments/assets/610840c1-339d-434f-beef-d7fc8fb6e48b">


<img width="913" alt="image" src="https://github.com/user-attachments/assets/07331fbd-4c79-45d2-af65-d5bfcf50874a">


</details> 

Edit view

<details><summary>Before/After</summary>

<img width="935" alt="image" src="https://github.com/user-attachments/assets/20d2f836-5ec3-4cc2-ba3f-329dacd7a106">


<img width="913" alt="image" src="https://github.com/user-attachments/assets/e97a27b0-27c7-4170-b5d6-9c4683231e69">

</details>

URL Generator view

<details><summary>Before/After</summary>

<img width="935" alt="image" src="https://github.com/user-attachments/assets/1e540add-7838-4608-b12e-b1e6ef28136d">

<img width="935" alt="image" src="https://github.com/user-attachments/assets/36051426-1b64-4438-a7d9-e44ac56e22bb">


</details> 

Single upload view (not really used anymore)

<details><summary>Before/After</summary>

<img width="935" alt="image" src="https://github.com/user-attachments/assets/50e4b9ee-f7f9-40a7-912a-a97072a64eee">


<img width="913" alt="image" src="https://github.com/user-attachments/assets/5e6ab0f4-5f07-4404-b71c-71706e57ec2a">

</details> 