### PR TITLE
Add method to set default privacy option

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Allow a custom image rendition model to define its unique constraint with `models.UniqueConstraint` instead of `unique_together` (Oliver Parker, Cynthia Kiser, Sage Abdullah)
  * Default to the `standard` tokenizer on Elasticsearch, to correctly handle numbers as tokens (Matt Westcott)
  * Add color-scheme meta tag to Wagtail admin (Ashish Nagmoti)
+ * Add the ability to set the default privacy restriction for new pages using `get_default_privacy_setting` (Shlomo Markowitz)
  * Fix: Take preferred language into account for translatable strings in client-side code (Bernhard Bliem, Sage Abdullah)
  * Fix: Do not show the content type column as sortable when searching pages (Srishti Jaiswal, Sage Abdullah)
  * Fix: Support simple subqueries for `in` and `exact` lookup on Elasticsearch (Sage Abdullah)

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -190,6 +190,38 @@ See also [django-treebeard](inv:treebeard:std:doc#index)'s [node API](inv:treebe
 
     .. automethod:: find_for_request
 
+    .. method:: get_default_privacy_setting(request)
+
+        Set the default privacy setting for the page.
+
+        The method must return a dictionary with at least a 'type' key. The value must be one of the following values from :class:`~wagtail.models.PageViewRestriction`'s :attr:`~wagtail.models.PageViewRestriction.restriction_type`:
+
+        - ``BaseViewRestriction.NONE``: The page is public and can be accessed by anyone. (default) - '{"type": BaseViewRestriction.NONE}'
+
+        - ``BaseViewRestriction.LOGIN``: The page is private and can only be accessed by authenticated users. - '{"type": BaseViewRestriction.LOGIN}'
+
+        - ``BaseViewRestriction.PASSWORD``: The page is private and can only be accessed by users with a shared password. (requires additional ``password`` key in the dictionary) - '{"type": BaseViewRestriction.PASSWORD, "password": "P@ssw0rd123!"}'
+
+        - ``BaseViewRestriction.GROUPS``: The page is private and can only be accessed by users in specific groups. (requires additional ``groups`` key with list of Group objects) - '{"type": BaseViewRestriction.GROUPS, "groups": [moderators, editors]}'
+
+        Example
+
+        .. code-block:: python
+
+            class BreadsIndexPage(Page):
+                #...
+
+                def get_default_privacy_setting(request):
+                    from wagtail.models import BaseViewRestriction
+                    # if the editor has the foo.add_bar permission set the default to groups with the moderators and editors group checked
+                    if request.user.has_perm("foo.add_bar"):
+                        moderators = Group.objects.filter(name="Moderators").first()
+                        editors = Group.objects.filter(name="Editors").first()
+                        return {"type": BaseViewRestriction.GROUPS, "groups": [moderators,editors]}
+                    else:
+                        return {"type": BaseViewRestriction.NONE}
+
+
     .. autoattribute:: context_object_name
 
         Custom name for page instance in page's ``Context``.

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -19,6 +19,7 @@ depth: 1
  * Allow a custom image rendition model to define its unique constraint with `models.UniqueConstraint` instead of `unique_together` (Oliver Parker, Cynthia Kiser, Sage Abdullah)
  * Default to the `standard` tokenizer on Elasticsearch, to correctly handle numbers as tokens (Matt Westcott)
  * Add color-scheme meta tag to Wagtail admin (Ashish Nagmoti)
+ * Add the ability to set the [default privacy restriction for new pages](set_default_page_privacy) using `get_default_privacy_setting` (Shlomo Markowitz)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/privacy.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/privacy.html
@@ -2,8 +2,7 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block content %}
-    {% if page.id %}{% test_page_is_public page as is_public %}{% else %}{% test_page_is_public parent_page as is_public %}{% endif %}
-
+    {% if page.id %}{% test_page_is_public page as is_public %}{% endif %}
     {# The swap between public and private text is done using JS inside of privacy-switch.js when the response from the modal comes back #}
     <div
         class="{% if not is_public %}w-hidden{% endif %}"

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -1429,6 +1429,10 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         except self.specific_class.DoesNotExist:
             return None
 
+    def get_default_privacy_setting(self, request: HttpRequest):
+        """Set the default privacy setting for a page."""
+        return {"type": BaseViewRestriction.NONE}
+
     @classmethod
     def clean_subpage_models(cls):
         """


### PR DESCRIPTION
fixes #3708 

Usage

The default option can be different based on the user or request if desired.

```python
class newPage(Page):
    ...
    def get_default_privacy_setting(self,request):
          # privacy setting options ['public',"logged_in", "shared_password", "user_groups"]

          # set default to group
          from django.contrib.auth.models import Group
          moderators = Group.objects.filter(name="Moderators").first()
          editors = Group.objects.filter(name="Editors").first()
          return {'type':'user_groups','groups':[moderators,editors]}

          # set default to shared password
          return {'type':'shared_password',"password":"default password"}

          # set default to login
          return {'type':'logged_in'}
     
          # set default to public (default)
          return {'type':'public'}
```