### PR TITLE
Fix minimap toggle visibility

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ Changelog
  * Fix: Remove wrongly-added filters from redirects index (Matt Westcott)
  * Fix: Prevent popular tags filter from generating overly complex queries when not filtering (Matt Westcott)
  * Fix: Fix content path links in usage view to scroll to the correct element (Sage Abdullah)
+ * Fix: Always show the minimap toggle button (Albina Starykova)
  * Docs: Upgrade Sphinx to 7.3 (Matt Westcott)
  * Docs: Document how to customize date/time format settings (Vince Salvino)
  * Docs: Create a new documentation section for deployment and move fly.io deployment from the tutorial to this section (Vince Salvino)

--- a/client/src/components/Minimap/CollapseAll.scss
+++ b/client/src/components/Minimap/CollapseAll.scss
@@ -31,8 +31,8 @@
     position: absolute;
     top: $minimap-top-offset;
     inset-inline-end: 0;
-    margin-top: theme('spacing.3');
-    margin-inline-end: theme('spacing.3');
+    margin-top: theme('spacing.5');
+    margin-inline-end: theme('spacing.10');
 
     .side-panel-open & {
       inset-inline-end: var(--side-panel-width, 0);

--- a/client/src/components/Minimap/Minimap.scss
+++ b/client/src/components/Minimap/Minimap.scss
@@ -53,30 +53,10 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   background-color: theme('colors.surface-page');
   color: theme('colors.icon-primary');
   transform: rotate(180deg);
-  // Expand is available for keyboard users only.
-  opacity: 0;
-  pointer-events: none;
 
   @include media-breakpoint-up(sm) {
-    margin-top: theme('spacing.9');
+    margin-top: 18px;
     padding: theme('spacing.[1.5]');
-
-    *:focus {
-      opacity: 1;
-      pointer-events: auto;
-    }
-
-    // Ensure the toggle button is only visible when it has **focus-visible**.
-    // With fallback focus styles for browsers that lack focus-visible support.
-    *:focus:not(:focus-visible) {
-      opacity: 0;
-      pointer-events: none;
-    }
-
-    &:focus-visible {
-      opacity: 1;
-      pointer-events: auto;
-    }
   }
 
   .icon {
@@ -85,8 +65,6 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   }
 
   :where(.w-minimap--expanded) & {
-    opacity: 1;
-    pointer-events: auto;
     margin-top: theme('spacing.3');
     margin-inline-start: theme('spacing.3');
     padding: theme('spacing.3');

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -43,6 +43,7 @@ This release adds formal support for Django 5.1.
  * Remove wrongly-added filters from redirects index (Matt Westcott)
  * Prevent popular tags filter from generating overly complex queries when not filtering (Matt Westcott)
  * Fix content path links in usage view to scroll to the correct element (Sage Abdullah)
+ * Always show the minimap toggle button (Albina Starykova)
 
 ### Documentation
 


### PR DESCRIPTION
Addresses #12175 

Fixes `Minimap toggle` visibility in the initial state, and fine-tunes `CollapseAll` button positioning accordingly.

![image](https://github.com/user-attachments/assets/3ca8e0cd-db73-4dba-9887-a313e57445a1)

![image](https://github.com/user-attachments/assets/04dfc85d-0a3b-4d53-a54a-c68a66852634)

Tested in Chrome 126, Firefox 129, Safari 17



