### PR TITLE
Add an alternative form builder that uses StreamFields to define form fields

### DIFF
--- a/wagtail/contrib/forms/blocks.py
+++ b/wagtail/contrib/forms/blocks.py
@@ -1,0 +1,213 @@
+from django.utils.translation import gettext_lazy as _
+
+from wagtail import blocks
+
+
+class FormFieldBlock(blocks.StructBlock):
+    label = blocks.CharBlock(help_text=_("Text describing the field."))
+    help_text = blocks.CharBlock(
+        required=False,
+        help_text=_(
+            "Text displayed below the label used to add more information, like this one."
+        ),
+    )
+    required = blocks.BooleanBlock(
+        required=False,
+        help_text=_("If checked, this field must be filled to validate the form."),
+    )
+
+    class Meta:
+        form_classname = "field-block"
+
+
+class ChoiceBlock(blocks.StructBlock):
+    label = blocks.CharBlock(label=_("Label"))
+    initial = blocks.BooleanBlock(label=_("Selected"), required=False)
+
+    class Meta:
+        label = _("Choice")
+
+
+class SinglelineFormFieldBlock(FormFieldBlock):
+    initial = blocks.CharBlock(
+        label=_("Default value"),
+        required=False,
+        help_text=_("Text used to pre-fill the field."),
+    )
+    min_length = blocks.IntegerBlock(
+        help_text=_("Minimum amount of characters allowed in the field."),
+        default=0,
+    )
+    max_length = blocks.IntegerBlock(
+        help_text=_("Maximum amount of characters allowed in the field."),
+        default=255,
+    )
+
+    class Meta:
+        icon = "pilcrow"
+        label = _("Single line text")
+
+
+class MultilineFormFieldBlock(FormFieldBlock):
+    initial = blocks.TextBlock(
+        label=_("Default value"),
+        required=False,
+        help_text=_("Multi-line text used to pre-fill the text area."),
+    )
+    min_length = blocks.IntegerBlock(
+        help_text=_("Minimum amount of characters allowed in the text area."),
+        default=0,
+    )
+    max_length = blocks.IntegerBlock(
+        help_text=_("Maximum amount of characters allowed in the text area."),
+        default=1024,
+    )
+
+    class Meta:
+        icon = "pilcrow"
+        label = _("Multi-line text")
+
+
+class EmailFormFieldBlock(FormFieldBlock):
+    initial = blocks.EmailBlock(
+        label=_("Default value"),
+        required=False,
+        help_text=_("E-mail used to pre-fill the field."),
+    )
+
+    class Meta:
+        icon = "mail"
+        label = _("Email")
+
+
+class NumberFormFieldBlock(FormFieldBlock):
+    initial = blocks.DecimalBlock(
+        label=_("Default value"),
+        required=False,
+        help_text=_("Number used to pre-fill the field."),
+    )
+    min_value = blocks.IntegerBlock(
+        help_text=_("Minimum number allowed in the field."),
+        required=False,
+    )
+    max_value = blocks.IntegerBlock(
+        help_text=_("Maximum number allowed in the field."),
+        required=False,
+    )
+
+    class Meta:
+        icon = "decimal"
+        label = _("Number")
+
+
+class URLFormFieldBlock(FormFieldBlock):
+    initial = blocks.URLBlock(
+        label=_("Default value"),
+        required=False,
+        help_text=_("URL used to pre-fill the field."),
+    )
+
+    class Meta:
+        icon = "link-external"
+        label = _("URL")
+
+
+class CheckBoxFormFieldBlock(FormFieldBlock):
+    initial = blocks.BooleanBlock(
+        label=_("Checked"),
+        required=False,
+        help_text=_("If checked, the checkbox will be checked by default."),
+    )
+
+    class Meta:
+        icon = "tick-inverse"
+        label = _("Checkbox")
+
+
+class CheckBoxesFormFieldBlock(FormFieldBlock):
+    choices = blocks.ListBlock(
+        ChoiceBlock(
+            [("initial", blocks.BooleanBlock(label=_("Checked"), required=False))]
+        ),
+        label=_("Choices"),
+    )
+
+    class Meta:
+        icon = "tick-inverse"
+        label = _("Checkboxes")
+
+
+class DropDownFormFieldBlock(FormFieldBlock):
+    choices = blocks.ListBlock(ChoiceBlock(), label=_("Choices"))
+
+    class Meta:
+        icon = "list-ul"
+        label = _("Drop down")
+
+
+class MultiSelectFormFieldBlock(FormFieldBlock):
+    choices = blocks.ListBlock(ChoiceBlock(), label=_("Choices"))
+
+    class Meta:
+        icon = "list-ul"
+        label = _("Multiple select")
+
+
+class RadioFormFieldBlock(FormFieldBlock):
+    choices = blocks.ListBlock(ChoiceBlock(), label=_("Choices"))
+
+    class Meta:
+        icon = "radio-empty"
+        label = _("Radio buttons")
+
+
+class DateFormFieldBlock(FormFieldBlock):
+    initial = blocks.DateBlock(
+        label=_("Default value"),
+        required=False,
+        help_text=_("Date used to pre-fill the field."),
+    )
+
+    class Meta:
+        icon = "date"
+        label = _("Date")
+
+
+class DateTimeFormFieldBlock(FormFieldBlock):
+    initial = blocks.DateTimeBlock(
+        label=_("Default value"),
+        required=False,
+        help_text=_("Date/time used to pre-fill the field."),
+    )
+
+    class Meta:
+        icon = "time"
+        label = _("Date/time")
+
+
+class HiddenFormFieldBlock(FormFieldBlock):
+    initial = blocks.CharBlock(
+        label=_("Default value"),
+        required=False,
+        help_text=_("Text used to pre-fill the field."),
+    )
+
+    class Meta:
+        icon = "no-view"
+        label = _("Hidden field")
+
+
+class FormFieldsBlock(blocks.StreamBlock):
+    singleline = SinglelineFormFieldBlock()
+    multiline = MultilineFormFieldBlock()
+    email = EmailFormFieldBlock()
+    number = NumberFormFieldBlock()
+    url = URLFormFieldBlock()
+    checkbox = CheckBoxFormFieldBlock()
+    checkboxes = CheckBoxesFormFieldBlock()
+    dropdown = DropDownFormFieldBlock()
+    multiselect = MultiSelectFormFieldBlock()
+    radio = RadioFormFieldBlock()
+    date = DateFormFieldBlock()
+    datetime = DateTimeFormFieldBlock()
+    hidden = HiddenFormFieldBlock()

--- a/wagtail/contrib/forms/blocks.py
+++ b/wagtail/contrib/forms/blocks.py
@@ -1,44 +1,77 @@
+from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 
 from wagtail import blocks
 
 
 class FormFieldBlock(blocks.StructBlock):
-    label = blocks.CharBlock(help_text=_("Text describing the field."))
-    help_text = blocks.CharBlock(
-        required=False,
-        help_text=_(
-            "Text displayed below the label used to add more information, like this one."
-        ),
+    label = blocks.CharBlock(
+        label=_("Label"),
+        help_text=_("Short text describing the field."),
+        form_classname="formbuilder-field-block-label",
     )
-    required = blocks.BooleanBlock(
+    help_text = blocks.CharBlock(
+        label=_("Help text"),
         required=False,
-        help_text=_("If checked, this field must be filled to validate the form."),
+        help_text=_("Text displayed below the label to add more information."),
     )
 
-    class Meta:
-        form_classname = "field-block"
+
+class RequiredBlock(blocks.BooleanBlock):
+    def __init__(self, condition=None):
+        super().__init__(
+            required=False,
+            help_text=format_lazy(
+                _("If checked, {condition} to validate the form."),
+                condition=condition or _("this field must be filled"),
+            ),
+            label=_("Required"),
+        )
 
 
 class ChoiceBlock(blocks.StructBlock):
-    label = blocks.CharBlock(label=_("Label"))
-    initial = blocks.BooleanBlock(label=_("Selected"), required=False)
+    label = blocks.CharBlock(
+        label=_("Label"),
+        form_classname="formbuilder-choice-label",
+    )
+    initial = blocks.BooleanBlock(
+        label=_("Selected"),
+        required=False,
+    )
 
     class Meta:
         label = _("Choice")
 
 
+class ChoicesList(blocks.ListBlock):
+    def __init__(self, child_block=None, **kwargs):
+        super().__init__(child_block or ChoiceBlock(), search_index=True, **kwargs)
+
+    label = _("Choices")
+    form_classname = "formbuilder-choices"
+
+
+def init_options(field_type):
+    return {
+        "label": _("Default value"),
+        "required": False,
+        "help_text": format_lazy(
+            _("{field_type} used to pre-fill the field."),
+            field_type=field_type,
+        ),
+    }
+
+
 class SinglelineFormFieldBlock(FormFieldBlock):
-    initial = blocks.CharBlock(
-        label=_("Default value"),
-        required=False,
-        help_text=_("Text used to pre-fill the field."),
-    )
+    required = RequiredBlock()
+    initial = blocks.CharBlock(**init_options(_("Single line text")))
     min_length = blocks.IntegerBlock(
+        label=_("Min length"),
         help_text=_("Minimum amount of characters allowed in the field."),
         default=0,
     )
     max_length = blocks.IntegerBlock(
+        label=_("Max length"),
         help_text=_("Maximum amount of characters allowed in the field."),
         default=255,
     )
@@ -46,51 +79,49 @@ class SinglelineFormFieldBlock(FormFieldBlock):
     class Meta:
         icon = "pilcrow"
         label = _("Single line text")
+        form_classname = "formbuilder-field-block formbuilder-field-block-singleline"
 
 
 class MultilineFormFieldBlock(FormFieldBlock):
-    initial = blocks.TextBlock(
-        label=_("Default value"),
-        required=False,
-        help_text=_("Multi-line text used to pre-fill the text area."),
-    )
+    required = RequiredBlock()
+    initial = blocks.TextBlock(**init_options(_("Multi-line text")))
     min_length = blocks.IntegerBlock(
-        help_text=_("Minimum amount of characters allowed in the text area."),
+        label=_("Min length"),
+        help_text=_("Minimum amount of characters allowed in the field."),
         default=0,
     )
     max_length = blocks.IntegerBlock(
-        help_text=_("Maximum amount of characters allowed in the text area."),
+        label=_("Max length"),
+        help_text=_("Maximum amount of characters allowed in the field."),
         default=1024,
     )
 
     class Meta:
         icon = "pilcrow"
         label = _("Multi-line text")
+        form_classname = "formbuilder-field-block formbuilder-field-block-multiline"
 
 
 class EmailFormFieldBlock(FormFieldBlock):
-    initial = blocks.EmailBlock(
-        label=_("Default value"),
-        required=False,
-        help_text=_("E-mail used to pre-fill the field."),
-    )
+    required = RequiredBlock()
+    initial = blocks.EmailBlock(**init_options(_("E-mail")))
 
     class Meta:
         icon = "mail"
-        label = _("Email")
+        label = _("E-mail")
+        form_classname = "formbuilder-field-block formbuilder-field-block-email"
 
 
 class NumberFormFieldBlock(FormFieldBlock):
-    initial = blocks.DecimalBlock(
-        label=_("Default value"),
-        required=False,
-        help_text=_("Number used to pre-fill the field."),
-    )
+    required = RequiredBlock()
+    initial = blocks.DecimalBlock(**init_options(_("Number")))
     min_value = blocks.IntegerBlock(
+        label=_("Min value"),
         help_text=_("Minimum number allowed in the field."),
         required=False,
     )
     max_value = blocks.IntegerBlock(
+        label=_("Max value"),
         help_text=_("Maximum number allowed in the field."),
         required=False,
     )
@@ -98,103 +129,105 @@ class NumberFormFieldBlock(FormFieldBlock):
     class Meta:
         icon = "decimal"
         label = _("Number")
+        form_classname = "formbuilder-field-block formbuilder-field-block-number"
 
 
 class URLFormFieldBlock(FormFieldBlock):
-    initial = blocks.URLBlock(
-        label=_("Default value"),
-        required=False,
-        help_text=_("URL used to pre-fill the field."),
-    )
+    required = RequiredBlock()
+    initial = blocks.URLBlock(**init_options(_("URL")))
 
     class Meta:
         icon = "link-external"
         label = _("URL")
+        form_classname = "formbuilder-field-block formbuilder-field-block-url"
 
 
 class CheckBoxFormFieldBlock(FormFieldBlock):
+    required = RequiredBlock(_("the box must be checked"))
     initial = blocks.BooleanBlock(
         label=_("Checked"),
         required=False,
-        help_text=_("If checked, the checkbox will be checked by default."),
+        help_text=_("If checked, the box will be checked by default."),
     )
 
     class Meta:
         icon = "tick-inverse"
         label = _("Checkbox")
+        form_classname = "formbuilder-field-block formbuilder-field-block-checkbox"
 
 
 class CheckBoxesFormFieldBlock(FormFieldBlock):
-    choices = blocks.ListBlock(
+    required = RequiredBlock(_("at least one box must be checked"))
+    choices = ChoicesList(
         ChoiceBlock(
             [("initial", blocks.BooleanBlock(label=_("Checked"), required=False))]
-        ),
-        label=_("Choices"),
+        )
     )
 
     class Meta:
         icon = "tick-inverse"
         label = _("Checkboxes")
+        form_classname = "formbuilder-field-block formbuilder-field-block-checkboxes"
 
 
 class DropDownFormFieldBlock(FormFieldBlock):
-    choices = blocks.ListBlock(ChoiceBlock(), label=_("Choices"))
+    required = RequiredBlock(_("an item must be selected"))
+    choices = ChoicesList()
 
     class Meta:
         icon = "list-ul"
         label = _("Drop down")
+        form_classname = "formbuilder-field-block formbuilder-field-block-dropdown"
 
 
 class MultiSelectFormFieldBlock(FormFieldBlock):
-    choices = blocks.ListBlock(ChoiceBlock(), label=_("Choices"))
+    required = RequiredBlock(_("at least one item must be selected"))
+    choices = ChoicesList()
 
     class Meta:
         icon = "list-ul"
         label = _("Multiple select")
+        form_classname = "formbuilder-field-block formbuilder-field-block-multiselect"
 
 
 class RadioFormFieldBlock(FormFieldBlock):
-    choices = blocks.ListBlock(ChoiceBlock(), label=_("Choices"))
+    required = RequiredBlock(_("an item must be selected"))
+    choices = ChoicesList()
 
     class Meta:
         icon = "radio-empty"
         label = _("Radio buttons")
+        form_classname = "formbuilder-field-block formbuilder-field-block-radio"
 
 
 class DateFormFieldBlock(FormFieldBlock):
-    initial = blocks.DateBlock(
-        label=_("Default value"),
-        required=False,
-        help_text=_("Date used to pre-fill the field."),
-    )
+    required = RequiredBlock()
+    initial = blocks.DateBlock(**init_options(_("Date")))
 
     class Meta:
         icon = "date"
         label = _("Date")
+        form_classname = "formbuilder-field-block formbuilder-field-block-date"
 
 
 class DateTimeFormFieldBlock(FormFieldBlock):
-    initial = blocks.DateTimeBlock(
-        label=_("Default value"),
-        required=False,
-        help_text=_("Date/time used to pre-fill the field."),
-    )
+    required = RequiredBlock()
+    initial = blocks.DateTimeBlock(**init_options(_("Date and time")))
 
     class Meta:
         icon = "time"
-        label = _("Date/time")
+        label = _("Date and time")
+        form_classname = "formbuilder-field-block formbuilder-field-block-datetime"
 
 
 class HiddenFormFieldBlock(FormFieldBlock):
-    initial = blocks.CharBlock(
-        label=_("Default value"),
-        required=False,
-        help_text=_("Text used to pre-fill the field."),
-    )
+    required = RequiredBlock()
+    initial = blocks.CharBlock(**init_options(_("Hidden text")))
 
     class Meta:
         icon = "no-view"
-        label = _("Hidden field")
+        label = _("Hidden text")
+        form_classname = "formbuilder-field-block formbuilder-field-block-hidden"
 
 
 class FormFieldsBlock(blocks.StreamBlock):
@@ -211,3 +244,6 @@ class FormFieldsBlock(blocks.StreamBlock):
     date = DateFormFieldBlock()
     datetime = DateTimeFormFieldBlock()
     hidden = HiddenFormFieldBlock()
+
+    class Meta:
+        form_classname = "formbuilder-fields-block"

--- a/wagtail/contrib/forms/forms.py
+++ b/wagtail/contrib/forms/forms.py
@@ -7,6 +7,8 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.forms import WagtailAdminPageForm
 
+from .utils import get_field_clean_name
+
 
 class BaseForm(django.forms.Form):
     def __init__(self, *args, **kwargs):
@@ -24,7 +26,8 @@ class FormBuilder:
 
     def create_singleline_field(self, field, options):
         # TODO: This is a default value - it may need to be changed
-        options["max_length"] = 255
+        if "max_length" not in options:
+            options["max_length"] = 255
         return django.forms.CharField(**options)
 
     def create_multiline_field(self, field, options):
@@ -158,6 +161,62 @@ class FormBuilder:
 
     def get_form_class(self):
         return type("WagtailForm", (BaseForm,), self.formfields)
+
+
+class StreamFieldFormBuilder(FormBuilder):
+    def create_dropdown_field(self, field_value, options):
+        options["choices"] = self.get_formatted_field_choices(field_value)
+        options["initial"] = self.get_formatted_field_initial(field_value)[0]
+        return super().create_dropdown_field(field_value, options)
+
+    def create_multiselect_field(self, field_value, options):
+        options["choices"] = self.get_formatted_field_choices(field_value)
+        options["initial"] = self.get_formatted_field_initial(field_value)
+        return super().create_multiselect_field(field_value, options)
+
+    def create_radio_field(self, field_value, options):
+        options["choices"] = self.get_formatted_field_choices(field_value)
+        options["initial"] = self.get_formatted_field_initial(field_value)[0]
+        return super().create_radio_field(field_value, options)
+
+    def create_checkboxes_field(self, field_value, options):
+        options["choices"] = self.get_formatted_field_choices(field_value)
+        options["initial"] = self.get_formatted_field_initial(field_value)
+        return super().create_checkboxes_field(field_value, options)
+
+    def get_formatted_field_choices(self, field_data):
+        return [
+            (
+                get_field_clean_name(choice["value"]["label"].strip()),
+                choice["value"]["label"],
+            )
+            for choice in field_data["choices"]
+        ]
+
+    def get_formatted_field_initial(self, field_data):
+        return [
+            choice["value"]["label"]
+            for choice in field_data["choices"]
+            if choice["value"]["initial"]
+        ]
+
+    @property
+    def formfields(self):
+        formfields = OrderedDict()
+
+        for field_data in self.fields.raw_data:
+            options = self.get_field_options(field_data)
+            create_field = self.get_create_field_function(field_data["type"])
+            clean_name = get_field_clean_name(field_data["value"]["label"])
+            formfields[clean_name] = create_field(field_data["value"], options)
+
+        return formfields
+
+    def get_field_options(self, field_data):
+        options = {**field_data["value"]}
+        if not getattr(settings, "WAGTAILFORMS_HELP_TEXT_ALLOW_HTML", False):
+            options["help_text"] = conditional_escape(options["help_text"])
+        return options
 
 
 class SelectDateForm(django.forms.Form):

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -14,7 +14,7 @@ from wagtail.api import APIField
 from wagtail.contrib.forms.utils import get_field_clean_name
 from wagtail.models import Orderable, Page
 
-from .forms import FormBuilder, WagtailAdminFormPageForm
+from .forms import FormBuilder, StreamFieldFormBuilder, WagtailAdminFormPageForm
 
 FORM_FIELD_CHOICES = (
     ("singleline", _("Single line text")),
@@ -305,6 +305,27 @@ class FormMixin:
         return context
 
 
+class StreamFieldFormMixin(FormMixin):
+    """A mixin that adds form builder functionality to the page."""
+
+    form_builder = StreamFieldFormBuilder
+
+    def get_form_fields(self):
+        return self.form_fields
+
+    def get_data_fields(self):
+        data_fields = [
+            ("submit_time", _("Submission date")),
+        ]
+
+        data_fields += [
+            (get_field_clean_name(data["value"]["label"]), data["value"]["label"])
+            for data in self.get_form_fields().raw_data
+        ]
+
+        return data_fields
+
+
 def validate_to_address(value):
     for address in value.split(","):
         validate_email(address.strip())
@@ -313,6 +334,11 @@ def validate_to_address(value):
 class AbstractForm(FormMixin, Page):
     """A Form Page. Pages implementing a form should inherit from it."""
 
+    class Meta:
+        abstract = True
+
+
+class AbstractStreamFieldForm(StreamFieldFormMixin, Page):
     class Meta:
         abstract = True
 
@@ -382,5 +408,10 @@ class AbstractEmailForm(EmailFormMixin, FormMixin, Page):
     A Form Page that sends email. Inherit from it if your form sends an email.
     """
 
+    class Meta:
+        abstract = True
+
+
+class AbstractEmailStreamFieldForm(EmailFormMixin, StreamFieldFormMixin, Page):
     class Meta:
         abstract = True


### PR DESCRIPTION
This PR introduces **StreamFieldFormBuilder**, an alternative form builder that uses a StreamField to define form fields, in order to improve user experience when building a form.

Because it's based on a distinct classes, this improvement doesn't break existing forms.

## Images

Field type selection:

![image](https://github.com/user-attachments/assets/06ba2c01-aec7-492e-b58c-3c26cda0aa5f)

Date/Time field with a DatePicker popup opened when setting its default value:

![image](https://github.com/user-attachments/assets/f938f3c5-f482-42b5-b092-89f4c2df4325)

Multiple select field with some choices:

![image](https://github.com/user-attachments/assets/6fc83c28-0aee-4450-8735-2603b75a1061)

## Features

- new fields are added with a more user-friendly selector with icons;
- a ListBlock is used to define choices label and default value, instead of a comma-separated list in a CharField.
- provide the right field type for each default value (ie. setting 'foo' as a default value for a number field is not possible);
- allow per-field options, such as `min_length`/`max_length` for CharField, and `min_value`/`max_value` for DecimalField, etc;

## Usage

- inherits your form page from `AbstractStreamFieldForm` instead `AbstractForm` (or `AbstractEmailStreamFieldForm` instead `AbstractEmailForm`);
- set the `form_fields` attribute in the FormPage class to a StreamField containing a FormFieldsBlock instead subclassing AbstractFormField with a parental key.

So the example provided in the docs becomes:

```py
from wagtail.fields import RichTextField, StreamField # <--
from wagtail.admin.panels import FieldPanel, FieldRowPanel, MultiFieldPanel
from wagtail.contrib.forms.panels import FormSubmissionsPanel
from wagtail.contrib.forms.blocks import FormFieldsBlock # <--
from wagtail.contrib.forms.models import AbstractEmailStreamFieldForm # <--


class FormPage(AbstractEmailStreamFieldForm):
    intro = RichTextField(blank=True)
    form_fields = StreamField(FormFieldsBlock()) # <--
    thank_you_text = RichTextField(blank=True)

    content_panels = [
        *AbstractEmailStreamFieldForm.content_panels, # <--
        FormSubmissionsPanel(),
        FieldPanel('intro'),
        FieldPanel('form_fields'), # <--
        FieldPanel('thank_you_text'),
        MultiFieldPanel([
            FieldRowPanel([
                FieldPanel('from_address', classname="col6"),
                FieldPanel('to_address', classname="col6"),
            ]),
            FieldPanel('subject'),
        ], "Email"),
    ]
```

## WIP

This PR is a work in progress and I wanted several feedbacks before to spend more time on this to:
- update translations;
- update tests;
- add docstrings and update user doc,
- add some CSS to put label field and initial check box inline, for `MultiSelectFormFieldBlock` and `CheckBoxesFormFieldBlock`;
- add some js to fill a dropdown with the user-defined labels (using telepath), for `DropDownFormFieldBlock` and `RadioFormFieldBlock`;
- add a utility function that converts AbstractForm-based forms to AbstractStreamFieldForm-based forms.