### PR TITLE
[UI]: Changed class from warning to failure for confirm site name mes…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Fix: Fix broken link to user search (Shlomo Markowitz)
  * Fix: Ensure that JS slugify function strips Unicode characters disallowed by Django slug validation (Atif Khan)
  * Fix: Do not show notices about root / unroutable pages when searching or filtering in the page explorer (Matt Westcott)
+ * Fix: Resolve contrast issue for page deletion warning (Sanjeev Holla S)
  * Docs: Upgrade Sphinx to 7.3 (Matt Westcott)
  * Docs: Document how to customize date/time format settings (Vince Salvino)
  * Docs: Create a new documentation section for deployment and move fly.io deployment from the tutorial to this section (Vince Salvino)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -832,6 +832,7 @@
 * Nayanshi Singh
 * Daniel Black
 * Atif Khan
+* Sanjeev Holla S
 
 ## Translators
 

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -37,6 +37,7 @@ This release adds formal support for Django 5.1.
  * Fix broken link to user search (Shlomo Markowitz)
  * Ensure that JS slugify function strips Unicode characters disallowed by Django slug validation (Atif Khan)
  * Do not show notices about root / unroutable pages when searching or filtering in the page explorer (Matt Westcott)
+ * Resolve contrast issue for page deletion warning (Sanjeev Holla S)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
@@ -70,7 +70,7 @@
             <form action="{% url 'wagtailadmin_pages:delete' page.id %}" method="POST">
                 {% csrf_token %}
                 {% if confirm_before_delete %}
-                    <p id="id_confirm_site_name-warning" class="status-msg warning">
+                    <p id="id_confirm_site_name-warning" class="status-msg failure">
                         {% blocktrans trimmed with total_pages=descendant_count|add:1|intcomma %}
                             This action will delete total <b>{{ total_pages }}</b> pages.
                         {% endblocktrans %}


### PR DESCRIPTION
…sage.

Fixes #12232

When deleting a page that triggers the [WAGTAILADMIN_UNSAFE_PAGE_DELETION_LIMIT](https://docs.wagtail.org/en/stable/reference/settings.html#wagtailadmin-unsafe-page-deletion-limit), the orange warning text fails the contrast checks. 

So I have changed the class of the message text from `warning` to `failure` which imrpoves the contrast.

## Before
![image](https://github.com/user-attachments/assets/6bc2bfb9-dbe3-4e72-a90b-5f59123c4f09)

## Now
![image](https://github.com/user-attachments/assets/f7b62e97-aad1-48cd-8212-a85c35d2fc77)
