### PR TITLE
Add new Puppeteer cache location to fix CircleCI ui_tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,16 +83,18 @@ jobs:
           paths:
             - .venv
       - restore_cache:
-          key: ui_tests-npm_integration-v1-{{ checksum "client/tests/integration/package-lock.json" }}
+          key: ui_tests-npm_integration-v2-{{ checksum "client/tests/integration/package-lock.json" }}
       # Only install if node_modules wasn’t cached.
       - run: |
           if [[ ! -e "client/tests/integration/node_modules" ]]; then
               npm --prefix ./client/tests/integration ci
           fi
       - save_cache:
-          key: ui_tests-npm_integration-v1-{{ checksum "client/tests/integration/package-lock.json" }}
+          key: ui_tests-npm_integration-v2-{{ checksum "client/tests/integration/package-lock.json" }}
           paths:
             - client/tests/integration/node_modules
+            # Also cache the global location where Puppeteer stores browsers.
+            - ~/.cache/puppeteer
       - run: pipenv run ./wagtail/test/manage.py migrate
       - run:
           command: pipenv run ./wagtail/test/manage.py runserver 0:8000

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,7 @@ jobs:
           paths:
             - client/tests/integration/node_modules
             # Also cache the global location where Puppeteer stores browsers.
+            # https://pptr.dev/guides/configuration/#changing-the-default-cache-directory
             - ~/.cache/puppeteer
       - run: pipenv run ./wagtail/test/manage.py migrate
       - run:


### PR DESCRIPTION
Follow-up to #12203. We have failures in CircleCI `ui_tests` jobs when loading dependencies from cache. First failing job: [53745](https://app.circleci.com/pipelines/github/wagtail/wagtail/19140/workflows/1c1850df-eb6c-47a8-a9df-a8a8feb5942b/jobs/53803). The error is:

```
> ./client/tests/integration/node_modules/.bin/jest --config ./client/tests/integration/jest.config.js --runInBand --reporters=default --reporters=jest-junit

[…]
Could not find Chrome (ver. 127.0.6533.88). This can occur if either
 1. you did not perform an installation before running the script (e.g. `npx puppeteer browsers install chrome`) or
 2. your cache path is incorrectly configured (which is: /home/circleci/.cache/puppeteer).
[…]
```

---

This is most likely due to Puppeteer’s [cacheDirectory](https://pptr.dev/guides/configuration/#changing-the-default-cache-directory) changing to be a global location, which isn’t cached by our CircleCI configuration.

As I’ve changed the cache key, the first build in this PR will succeed no matter what. A subsequent build success after restoration of dependencies from cache should be a reliable indication that the fix worked.