### PR TITLE
Fix content metrics plugin to work on the main element before falling back to `body`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Changelog
  * Fix: Ensure that JS slugify function strips Unicode characters disallowed by Django slug validation (Atif Khan)
  * Fix: Do not show notices about root / unroutable pages when searching or filtering in the page explorer (Matt Westcott)
  * Fix: Resolve contrast issue for page deletion warning (Sanjeev Holla S)
+ * Fix: Make sure content metrics falls back to body element only when intended (Sage Abdullah)
  * Docs: Upgrade Sphinx to 7.3 (Matt Westcott)
  * Docs: Document how to customize date/time format settings (Vince Salvino)
  * Docs: Create a new documentation section for deployment and move fly.io deployment from the tutorial to this section (Vince Salvino)
@@ -49,6 +50,7 @@ Changelog
 
  * Fix: Fix various instances of `USE_THOUSAND_SEPARATOR` formatting numbers where formatting is invalid (Sébastien Corbin, Matt Westcott)
  * Fix: Fix broken link to user search (Shlomo Markowitz)
+ * Fix: Make sure content metrics falls back to body element only when intended (Sage Abdullah)
  * Docs: Clarify process for UserViewSet customisation (Sage Abdullah)
 
 

--- a/client/src/controllers/PreviewController.ts
+++ b/client/src/controllers/PreviewController.ts
@@ -22,7 +22,7 @@ const runContentChecks = async () => {
   axe.registerPlugin(wagtailPreviewPlugin);
 
   const contentMetrics = await getPreviewContentMetrics({
-    targetElement: 'main, [role="main"], body',
+    targetElement: 'main, [role="main"]',
   });
 
   // This requires Wagtail's preview plugin for axe to be registered in the

--- a/client/src/includes/contentMetrics.ts
+++ b/client/src/includes/contentMetrics.ts
@@ -61,7 +61,9 @@ export const contentMetricsPluginInstance = {
     options: ContentMetricsOptions,
     done: (metrics: ContentMetrics) => void,
   ) {
-    const main = document.querySelector<HTMLElement>(options.targetElement);
+    const main =
+      document.querySelector<HTMLElement>(options.targetElement) ||
+      document.body; // Fallback to the body only if the target element is not found
     const text = main?.innerText || '';
     const lang = document.documentElement.lang || 'en';
     const wordCount = getWordCount(lang, text);

--- a/docs/releases/6.2.2.md
+++ b/docs/releases/6.2.2.md
@@ -16,6 +16,7 @@ depth: 1
 
  * Fix various instances of `USE_THOUSAND_SEPARATOR` formatting numbers where formatting is invalid (Sébastien Corbin, Matt Westcott)
  * Fix broken link to user search (Shlomo Markowitz)
+ * Make sure content metrics falls back to body element only when intended (Sage Abdullah)
 
 
 ### Documentation

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -39,6 +39,7 @@ This release adds formal support for Django 5.1.
  * Ensure that JS slugify function strips Unicode characters disallowed by Django slug validation (Atif Khan)
  * Do not show notices about root / unroutable pages when searching or filtering in the page explorer (Matt Westcott)
  * Resolve contrast issue for page deletion warning (Sanjeev Holla S)
+ * Make sure content metrics falls back to body element only when intended (Sage Abdullah)
 
 ### Documentation
 


### PR DESCRIPTION
Testing with the Tracking Wild Yeast page on bakerydemo.

## Before: 613 words

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/601521b7-7fae-44f3-852f-aee1cf5f1fa1">

## After: 402 words

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/6d8cb6a3-3fbf-4c96-89d9-02e1253cc8e3">

## Manual testing

Highlighting everything inside the `<main>` element, copying, and pasting it into https://wordcounter.io gives me 391 words.

<img width="744" alt="image" src="https://github.com/user-attachments/assets/c6cfa92a-5b01-4fa3-a36b-ed8dee97d751">

