### PR TITLE
Skip codecov task if no token is defined

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -367,6 +367,8 @@ jobs:
       - test-postgres-elasticsearch7
       - test-sqlite-opensearch2
     runs-on: ubuntu-latest
+    env:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -405,6 +407,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        if: ${{ env.codecov_token != '' || (github.repository == 'wagtail/wagtail' && github.event_name == 'pull_request') }}
         with:
           fail_ci_if_error: true
           flags: backend


### PR DESCRIPTION
#12276 updated the Github CI configuration to fail if the codecov upload fails.

I have Github CI running on my personal Wagtail fork (can't remember if I had to do something to enable that, or if it's automatic for everyone given the presence of the config in the repo...) and I don't have the CODECOV_TOKEN secret defined, so this causes CI to fail for me. Tweak the config to skip this task if CODECOV_TOKEN is not defined.

(if you're wondering, the shuffle into an env variable is required because [you can't access secrets within `if` clauses](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-using-secrets) for some reason...)