### PR TITLE
Update MySQL and add MariaDB to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,8 @@ concurrency:
 # - django 4.2, python 3.10, mysql:8.0
 # - django 4.2, python 3.11, mariadb:10.5
 # - django 5.0, python 3.11, sqlite, WAGTAIL_CHECK_TEMPLATE_NUMBER_FORMAT=1
-# - django 5.1, python 3.12, mysql:8.4, parallel, USE_EMAIL_USER_MODEL=yes, DISABLE_TIMEZONE=yes
-# - django 5.1, python 3.12, mariadb:11.4, USE_EMAIL_USER_MODEL=yes, DISABLE_TIMEZONE=yes
+# - django 5.1, python 3.12, mysql:8.4, parallel, USE_EMAIL_USER_MODEL=yes
+# - django 5.1, python 3.12, mariadb:11.4, USE_EMAIL_USER_MODEL=yes
 # - django 5.1, python 3.12, sqlite, parallel, USE_EMAIL_USER_MODEL=yes
 # - django 5.1, python 3.12, postgres:15, psycopg 3, parallel, DISABLE_TIMEZONE=yes
 # - django stable/5.1.x, python 3.11, postgres:15, psycopg 3 (allow failures)
@@ -174,14 +174,12 @@ jobs:
             mysql: 'mariadb:11.4'
             healthcmd: 'mariadb-admin ping'
             emailuser: emailuser
-            notz: notz
           - python: '3.12'
             django: 'Django>=5.1,<5.2'
             experimental: false
             parallel: '--parallel'
             mysql: 'mysql:8.4'
             emailuser: emailuser
-            notz: notz
     services:
       mysql:
         image: ${{ matrix.mysql || 'mysql:8.0' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,10 @@ concurrency:
 # Current configuration:
 # - django 4.2, python 3.9, postgres:12, psycopg 2, parallel
 # - django 4.2, python 3.10, mysql:8.0
+# - django 4.2, python 3.11, mariadb:10.5
 # - django 5.0, python 3.11, sqlite, WAGTAIL_CHECK_TEMPLATE_NUMBER_FORMAT=1
 # - django 5.1, python 3.12, mysql:8.4, parallel, USE_EMAIL_USER_MODEL=yes, DISABLE_TIMEZONE=yes
+# - django 5.1, python 3.12, mariadb:11.4, parallel, USE_EMAIL_USER_MODEL=yes, DISABLE_TIMEZONE=yes
 # - django 5.1, python 3.12, sqlite, parallel, USE_EMAIL_USER_MODEL=yes
 # - django 5.1, python 3.12, postgres:15, psycopg 3, parallel, DISABLE_TIMEZONE=yes
 # - django stable/5.1.x, python 3.11, postgres:15, psycopg 3 (allow failures)
@@ -161,6 +163,19 @@ jobs:
           - python: '3.10'
             django: 'Django>=4.2,<4.3'
             experimental: false
+          - python: '3.11'
+            django: 'Django>=4.2,<4.3'
+            experimental: false
+            mysql: 'mariadb:10.5'
+            healthcmd: 'mariadb-admin ping'
+          - python: '3.12'
+            django: 'Django>=5.1,<5.2'
+            experimental: false
+            parallel: '--parallel'
+            mysql: 'mariadb:11.4'
+            healthcmd: 'mariadb-admin ping'
+            emailuser: emailuser
+            notz: notz
           - python: '3.12'
             django: 'Django>=5.1,<5.2'
             experimental: false
@@ -172,12 +187,13 @@ jobs:
       mysql:
         image: ${{ matrix.mysql || 'mysql:8.0' }}
         env:
+          MARIADB_ROOT_PASSWORD: root
           MYSQL_ROOT_PASSWORD: root
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: wagtail
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 --cap-add=sys_nice
+        options: --health-cmd="${{ matrix.healthcmd || 'mysqladmin ping' }}" --health-interval=10s --health-timeout=5s --health-retries=3 --cap-add=sys_nice
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ concurrency:
 # - django 4.2, python 3.9, postgres:12, psycopg 2, parallel
 # - django 4.2, python 3.10, mysql:8.0
 # - django 5.0, python 3.11, sqlite, WAGTAIL_CHECK_TEMPLATE_NUMBER_FORMAT=1
-# - django 5.1, python 3.12, mysql:8.1, parallel
+# - django 5.1, python 3.12, mysql:8.4, parallel, USE_EMAIL_USER_MODEL=yes, DISABLE_TIMEZONE=yes
 # - django 5.1, python 3.12, sqlite, parallel, USE_EMAIL_USER_MODEL=yes
 # - django 5.1, python 3.12, postgres:15, psycopg 3, parallel, DISABLE_TIMEZONE=yes
 # - django stable/5.1.x, python 3.11, postgres:15, psycopg 3 (allow failures)
@@ -165,11 +165,14 @@ jobs:
             django: 'Django>=5.1,<5.2'
             experimental: false
             parallel: '--parallel'
-            mysql: 'mysql:8.1'
+            mysql: 'mysql:8.4'
+            emailuser: emailuser
+            notz: notz
     services:
       mysql:
         image: ${{ matrix.mysql || 'mysql:8.0' }}
         env:
+          MYSQL_ROOT_PASSWORD: root
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: wagtail
         ports:
@@ -197,6 +200,9 @@ jobs:
           DATABASE_ENGINE: django.db.backends.mysql
           DATABASE_HOST: '127.0.0.1'
           DATABASE_USER: root
+          DATABASE_PASSWORD: root
+          USE_EMAIL_USER_MODEL: ${{ matrix.emailuser }}
+          DISABLE_TIMEZONE: ${{ matrix.notz }}
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ concurrency:
 # - django 4.2, python 3.11, mariadb:10.5
 # - django 5.0, python 3.11, sqlite, WAGTAIL_CHECK_TEMPLATE_NUMBER_FORMAT=1
 # - django 5.1, python 3.12, mysql:8.4, parallel, USE_EMAIL_USER_MODEL=yes, DISABLE_TIMEZONE=yes
-# - django 5.1, python 3.12, mariadb:11.4, parallel, USE_EMAIL_USER_MODEL=yes, DISABLE_TIMEZONE=yes
+# - django 5.1, python 3.12, mariadb:11.4, USE_EMAIL_USER_MODEL=yes, DISABLE_TIMEZONE=yes
 # - django 5.1, python 3.12, sqlite, parallel, USE_EMAIL_USER_MODEL=yes
 # - django 5.1, python 3.12, postgres:15, psycopg 3, parallel, DISABLE_TIMEZONE=yes
 # - django stable/5.1.x, python 3.11, postgres:15, psycopg 3 (allow failures)
@@ -171,7 +171,6 @@ jobs:
           - python: '3.12'
             django: 'Django>=5.1,<5.2'
             experimental: false
-            parallel: '--parallel'
             mysql: 'mariadb:11.4'
             healthcmd: 'mariadb-admin ping'
             emailuser: emailuser


### PR DESCRIPTION
MySQL 8.1 has been EOL since 2023-10-25. Use the next LTS 8.4 (2032-04-30). Add `MYSQL_ROOT_PASSWORD` to ensure the root password is set. Also use email user model and disable timezone on the 8.4 strategy to ensure we test these configurations with MySQL as well.

https://endoflife.date/mysql

Add MariaDB (fixes #12304) to the test matrix. Use the 10.11 LTS (2028-02-16) and 11.4 LTS (2029-05-29). Also use the email user model and disable timezone for the 11.4
strategy.

https://endoflife.date/mariadb

Alternatively, we can also do "oldest LTS + latest version" strategy, which means using:
- `mysql:8.0`
- `mysql:latest` (9.0)
- `mariadb:10.5`
- `mariadb:latest` (11.5)