### PR TITLE
Refactor `UnsavedController` to use `event.preventDefault()` to trigger browser confirmation dialog

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -281,6 +281,7 @@ Changelog
  * Maintenance: Remove jQuery usage in telepath widget classes (Matt Westcott)
  * Maintenance: Remove `xregexp` (IE11 polyfill) along with `window.XRegExp` global util (LB (Ben) Johnston)
  * Maintenance: Refactor the Django port of `urlify` to use TypeScript, officially deprecate `window.URLify` global util (LB (Ben) Johnston)
+ * Maintenance: Adopt the modern best practice for `beforeunload` usage in `UnsavedController` to trigger a leave page warning when edits have been made (Shubham Mukati, Sage Abdullah)
 
 
 6.0.6 (11.07.2024)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -241,6 +241,7 @@ Changelog
  * Fix: Use correct URL when redirecting back to page search results after an AJAX search (Sage Abdullah)
  * Fix: Reinstate missing static files in style guide (Sage Abdullah)
  * Fix: Provide `convert_mariadb_uuids` management command to assist with upgrading to Django 5.0+ on MariaDB (Matt Westcott)
+ * Fix: Ensure invalid submissions are marked as dirty edits on load to trigger UI and browser warnings for unsaved changes, restoring previous behavior from Wagtail 5.2 (Sage Abdullah)
  * Docs: Add contributing development documentation on how to work with a fork of Wagtail (Nix Asteri, Dan Braghis)
  * Docs: Make sure the settings panel is listed in tabbed interface examples (Tibor Leupold)
  * Docs: Update content and page names to their US spelling instead of UK spelling (Victoria Poromon)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -833,6 +833,7 @@
 * Daniel Black
 * Atif Khan
 * Sanjeev Holla S
+* Shubham Mukati
 
 ## Translators
 

--- a/client/src/controllers/ActionController.test.js
+++ b/client/src/controllers/ActionController.test.js
@@ -27,11 +27,7 @@ describe('ActionController', () => {
         reload: {
           configurable: true,
           value: jest.fn().mockImplementation(() => {
-            const event = new Event('beforeunload');
-            Object.defineProperty(event, 'returnValue', {
-              value: null,
-              writable: true,
-            });
+            const event = new Event('beforeunload', { cancelable: true });
             window.dispatchEvent(event);
           }),
         },
@@ -156,9 +152,8 @@ describe('ActionController', () => {
       expect(beforeUnloadHandler).toHaveBeenCalledTimes(1);
 
       const event = beforeUnloadHandler.mock.lastCall[0];
-      // These mean the browser confirmation dialog was not shown
+      // This means the browser confirmation dialog was not shown
       expect(event.defaultPrevented).toBe(false);
-      expect(event.returnValue).toBeNull();
 
       window.removeEventListener('beforeunload', beforeUnloadHandler);
     });
@@ -168,7 +163,7 @@ describe('ActionController', () => {
       <form
         data-controller="w-unsaved"
         data-action="beforeunload@window->w-unsaved#confirm"
-        data-w-unsaved-confirmation-value="You have unsaved changes!"
+        data-w-unsaved-confirmation-value="true"
       >
       </form>
       <button
@@ -197,7 +192,7 @@ describe('ActionController', () => {
 
       const event = beforeUnloadHandler.mock.lastCall[0];
       // This means the browser confirmation dialog was shown
-      expect(event.returnValue).toBe('You have unsaved changes!');
+      expect(event.defaultPrevented).toBe(true);
       window.removeEventListener('beforeunload', beforeUnloadHandler);
     });
   });
@@ -208,7 +203,7 @@ describe('ActionController', () => {
       <form
         data-controller="w-unsaved"
         data-action="beforeunload@window->w-unsaved#confirm"
-        data-w-unsaved-confirmation-value="You have unsaved changes!"
+        data-w-unsaved-confirmation-value="true"
       >
       </form>
       <button
@@ -239,9 +234,8 @@ describe('ActionController', () => {
       expect(beforeUnloadHandler).toHaveBeenCalledTimes(1);
 
       const beforeUnloadEvent = beforeUnloadHandler.mock.lastCall[0];
-      // If the browser confirmation was shown, these would be truthy
+      // If the browser confirmation was shown, this would be true
       expect(beforeUnloadEvent.defaultPrevented).toBe(false);
-      expect(beforeUnloadEvent.returnValue).toBeNull();
 
       expect(confirmHandler).toHaveBeenCalledTimes(1);
       const confirmEvent = confirmHandler.mock.lastCall[0];

--- a/client/src/controllers/UnsavedController.test.js
+++ b/client/src/controllers/UnsavedController.test.js
@@ -10,6 +10,7 @@ describe('UnsavedController', () => {
     'w-unsaved:clear',
     'w-unsaved:ready',
     'w-unsaved:confirm',
+    'w-unsaved:watch-edits',
   ];
 
   const events = {};
@@ -241,6 +242,18 @@ describe('UnsavedController', () => {
         </form>
       </section>`);
 
+      // Should immediately set the form as having edits
+      const form = document.querySelector('form');
+      expect(form.dataset.wUnsavedHasEditsValue).toEqual('true');
+
+      // Should dispatch an add event with the type of edits
+      // so that the user can be warned
+      expect(events['w-unsaved:add']).toHaveLength(1);
+      expect(events['w-unsaved:add'][0]).toHaveProperty('detail.type', 'edits');
+
+      // Should not dispatch a watch-edits event
+      expect(events['w-unsaved:watch-edits']).toHaveLength(0);
+
       const result = await mockBrowserClose();
 
       expect(result).toEqual(true);
@@ -260,6 +273,18 @@ describe('UnsavedController', () => {
           <button>Submit</submit>
         </form>
       </section>`);
+
+      // Should immediately set the form as having edits
+      const form = document.querySelector('form');
+      expect(form.dataset.wUnsavedHasEditsValue).toEqual('true');
+
+      // Should dispatch an add event with the type of edits
+      // so that the user can be warned
+      expect(events['w-unsaved:add']).toHaveLength(1);
+      expect(events['w-unsaved:add'][0]).toHaveProperty('detail.type', 'edits');
+
+      // Should not dispatch a watch-edits event
+      expect(events['w-unsaved:watch-edits']).toHaveLength(0);
 
       const result = await mockBrowserClose();
 

--- a/client/src/controllers/UnsavedController.ts
+++ b/client/src/controllers/UnsavedController.ts
@@ -111,7 +111,13 @@ export class UnsavedController extends Controller<HTMLFormElement> {
     const watch = this.watchValue;
 
     if (watch.includes('comments')) this.watchComments(durations);
-    if (watch.includes('edits')) this.watchEdits(durations);
+
+    if (this.forceValue) {
+      // Do not watch for edits and assume the form is dirty
+      this.hasEditsValue = true;
+    } else if (watch.includes('edits')) {
+      this.watchEdits(durations);
+    }
 
     this.dispatch('ready', { cancelable: false });
   }
@@ -155,11 +161,6 @@ export class UnsavedController extends Controller<HTMLFormElement> {
 
     this.runningCheck = debounce(
       () => {
-        if (this.forceValue) {
-          this.hasEditsValue = true;
-          return;
-        }
-
         if (!this.initialFormData) {
           this.hasEditsValue = false;
           return;
@@ -188,7 +189,7 @@ export class UnsavedController extends Controller<HTMLFormElement> {
   confirm(event: BeforeUnloadEvent) {
     if (!this.confirmationValue) return;
 
-    if (this.forceValue || this.hasCommentsValue || this.hasEditsValue) {
+    if (this.hasCommentsValue || this.hasEditsValue) {
       // Dispatch a `confirm` event that is cancelable to allow for custom handling
       // instead of the browser's default confirmation dialog.
       const confirmEvent = this.dispatch('confirm', { cancelable: true });

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -46,6 +46,7 @@ This release adds formal support for Django 5.1.
  * Prevent popular tags filter from generating overly complex queries when not filtering (Matt Westcott)
  * Fix content path links in usage view to scroll to the correct element (Sage Abdullah)
  * Always show the minimap toggle button (Albina Starykova)
+ * Ensure invalid submissions are marked as dirty edits on load to trigger UI and browser warnings for unsaved changes, restoring previous behavior from Wagtail 5.2 (Sage Abdullah)
 
 ### Documentation
 

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -75,6 +75,7 @@ This release adds formal support for Django 5.1.
  * Migrate preview-panel JavaScript to Stimulus & TypeScript, add full unit testing (Sage Abdullah)
  * Move `wagtailConfig` values from inline scripts to the `wagtail_config` template tag (LB (Ben) Johnston, Sage Abdullah)
  * Deprecate the `{% locales %}` and `{% js_translation_strings %}` template tags (LB (Ben) Johnston, Sage Abdullah)
+ * Adopt the modern best practice for `beforeunload` usage in `UnsavedController` to trigger a leave page warning when edits have been made (Shubham Mukati, Sage Abdullah)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -18,7 +18,7 @@
         data-controller="w-init w-unsaved"
         data-action="w-unsaved#submit beforeunload@window->w-unsaved#confirm change->w-unsaved#check keyup->w-unsaved#check"
         data-w-init-event-value="{% if comments_enabled %}w-comments:init{% endif %}"
-        data-w-unsaved-confirmation-value="{{ _("This page has unsaved changes.") }}"
+        data-w-unsaved-confirmation-value="true"
         data-w-unsaved-force-value="{% if has_unsaved_changes %}true{% else %}false{% endif %}"
         data-w-unsaved-watch-value="edits{% if comments_enabled %} comments{% endif %}"
     >

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -22,7 +22,7 @@
             data-controller="w-init w-unsaved"
             data-action="w-unsaved#submit beforeunload@window->w-unsaved#confirm change->w-unsaved#check keyup->w-unsaved#check"
             data-w-init-event-value="{% if comments_enabled %}w-comments:init{% endif %}"
-            data-w-unsaved-confirmation-value="{{ _("This page has unsaved changes.") }}"
+            data-w-unsaved-confirmation-value="true"
             data-w-unsaved-force-value="{% if has_unsaved_changes %}true{% else %}false{% endif %}"
             data-w-unsaved-watch-value="edits{% if comments_enabled %} comments{% endif %}"
         >


### PR DESCRIPTION
## Part 1

The first commit fixes #12132 supersedes #12139. See issue for more details.

Per https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event

> best practice is to trigger the dialog by invoking `preventDefault()` on the event object, while also setting `returnValue` to support legacy cases.

We don't need to support legacy cases, as our supported browsers all support the `preventDefault()` approach.

See also:
https://caniuse.com/mdn-api_window_beforeunload_event_preventdefault_activation

## Part 2

The second commit fixes #12355.
