### PR TITLE
Github actions - mysql and mariadb healthchecks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,12 +167,10 @@ jobs:
             django: 'Django>=4.2,<4.3'
             experimental: false
             mysql: 'mariadb:10.5'
-            healthcmd: 'mariadb-admin ping'
           - python: '3.12'
             django: 'Django>=5.1,<5.2'
             experimental: false
             mysql: 'mariadb:11.4'
-            healthcmd: 'mariadb-admin ping'
             emailuser: emailuser
           - python: '3.12'
             django: 'Django>=5.1,<5.2'
@@ -188,9 +186,10 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: wagtail
+          HEALTH_CMD: ${{ startsWith(matrix.mysql, 'mariadb') && 'healthcheck.sh --connect --innodb_initialized' || 'mysqladmin --protocol=tcp ping' }}
         ports:
           - 3306:3306
-        options: --health-cmd="${{ matrix.healthcmd || 'mysqladmin ping' }}" --health-interval=10s --health-timeout=5s --health-retries=3 --cap-add=sys_nice
+        options: --health-cmd=$HEALTH_CMD --health-interval=10s --health-timeout=5s --health-retries=3 --cap-add=sys_nice
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,7 @@ Changelog
 ~~~~~~~~~~~~~~~~
 
  * Add formal support for Django 5.1 (Matt Westcott)
- * Formalize support for MariaDB (Sage Abdullah)
+ * Formalize support for MariaDB (Sage Abdullah, Daniel Black)
  * Redirect to the last viewed listing page after deleting form submissions (Matthias Brück)
  * Provide `getTextLabel` method on date / time StreamField blocks (Vaughn Dickson)
  * Purge frontend cache when modifying redirects (Jake Howard)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -830,6 +830,7 @@
 * Vaughn Dickson
 * Ansuman Shukla
 * Nayanshi Singh
+* Daniel Black
 
 ## Translators
 

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -17,7 +17,7 @@ This release adds formal support for Django 5.1.
 
 ### Other features
 
- * Formalize support for MariaDB (Sage Abdullah)
+ * Formalize support for MariaDB (Sage Abdullah, Daniel Black)
  * Redirect to the last viewed listing page after deleting form submissions (Matthias Brück)
  * Provide `getTextLabel` method on date / time StreamField blocks (Vaughn Dickson)
  * Purge frontend cache when modifying redirects (Jake Howard)


### PR DESCRIPTION
mysqladmin ping and mariadb-admin ping can return healthy during their initialization stage as by default these connect over unix socket.

Add --protocol=tcp to mysqladmin to report healthy when a TCP connection occurs. The initial startup uses --skip-networking.

MariaDB has a built-in healthcheck.sh in its container - https://mariadb.com/kb/en/using-healthcheck-sh-script/ .