### PR TITLE
Remove multi-line icon comments

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -55,6 +55,7 @@ Changelog
  * Maintenance: Migrate preview-panel JavaScript to Stimulus & TypeScript, add full unit testing (Sage Abdullah)
  * Maintenance: Move `wagtailConfig` values from inline scripts to the `wagtail_config` template tag (LB (Ben) Johnston, Sage Abdullah)
  * Maintenance: Deprecate the `{% locales %}` and `{% js_translation_strings %}` template tags (LB (Ben) Johnston, Sage Abdullah)
+ * Maintenance: Ensure multi-line comments are cleaned from custom icons in addition to just single line comments (Jake Howard)
 
 
 6.2.2 (24.09.2024)

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -81,6 +81,7 @@ This release adds formal support for Django 5.1.
  * Move `wagtailConfig` values from inline scripts to the `wagtail_config` template tag (LB (Ben) Johnston, Sage Abdullah)
  * Deprecate the `{% locales %}` and `{% js_translation_strings %}` template tags (LB (Ben) Johnston, Sage Abdullah)
  * Adopt the modern best practice for `beforeunload` usage in `UnsavedController` to trigger a leave page warning when edits have been made (Shubham Mukati, Sage Abdullah)
+ * Ensure multi-line comments are cleaned from custom icons in addition to just single line comments (Jake Howard)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/icons.py
+++ b/wagtail/admin/icons.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 
 from wagtail import hooks
 
-icon_comment_pattern = re.compile(r"<!--.*?-->")
+icon_comment_pattern = re.compile(r"<!--.*?-->", re.DOTALL)
 
 
 @lru_cache(maxsize=None)

--- a/wagtail/admin/tests/test_icon_sprite.py
+++ b/wagtail/admin/tests/test_icon_sprite.py
@@ -11,6 +11,10 @@ class TestIconSpriteView(SimpleTestCase):
         )
         self.assertEqual(response.wsgi_request.GET["h"], get_icon_sprite_hash())
 
+    def test_no_comments(self):
+        response = self.client.get(get_icon_sprite_url())
+        self.assertNotContains(response, "<!--")
+
 
 class TestIconSpriteHash(SimpleTestCase):
     def test_hash(self):


### PR DESCRIPTION
This doesn't affect Wagtail's, but could reduce the size of 3rd-party icons.
