### PR TITLE
changed width to 100%

### DIFF
--- a/client/scss/components/forms/_input-text.scss
+++ b/client/scss/components/forms/_input-text.scss
@@ -44,6 +44,6 @@ textarea {
 .w-field--date_time_field,
 .w-field--time_field {
   input {
-    width: auto;
+    width: 100%;
   }
 }


### PR DESCRIPTION
#12299 
issue - ViewSet filter date picker missing margin 

FIX:
changed max-width to 100% so that it wont over flow the parent wrappers 