### PR TITLE
Fix StreamValue._prefetch_blocks() to skip manually inserted items

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changelog
 
  * Fix: Improve handling of translations for bulk page action confirmation messages (Matt Westcott)
  * Fix: Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
+ * Fix: Ensure manual edits to `StreamField` values do not throw an error (Stefan Hammer)
  * Docs: Move the model reference page from reference/pages to the references section as it covers all Wagtail core models (Srishti Jaiswal)
  * Docs: Move the panels reference page from references/pages to the references section as panels are available for any model editing, merge panels API into this page (Srishti Jaiswal)
  * Docs: Move the tags documentation to standalone advanced topic, instead of being inside the reference/pages section (Srishti Jaiswal)

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -20,6 +20,7 @@ depth: 1
 
  * Improve handling of translations for bulk page action confirmation messages (Matt Westcott)
  * Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
+ * Ensure manual edits to `StreamField` values do not throw an error (Stefan Hammer)
 
 ### Documentation
 

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -710,7 +710,7 @@ class StreamValue(MutableSequence):
         raw_values = OrderedDict(
             (i, raw_item["value"])
             for i, raw_item in enumerate(self._raw_data)
-            if raw_item["type"] == type_name and self._bound_blocks[i] is None
+            if self._bound_blocks[i] is None and raw_item["type"] == type_name
         )
         # pass the raw block values to bulk_to_python as a list
         converted_values = child_block.bulk_to_python(raw_values.values())

--- a/wagtail/tests/test_streamfield.py
+++ b/wagtail/tests/test_streamfield.py
@@ -237,6 +237,24 @@ class TestStreamValueAccess(TestCase):
         self.assertEqual(fetched_body[1].block_type, "text")
         self.assertEqual(fetched_body[1].value, "bar")
 
+    def test_can_append_on_queried_instance(self):
+        # The test is analog to test_can_append(), but instead of working with the
+        # in-memory version from JSONStreamModel.objects.create(), we query a fresh
+        # instance from the db.
+        # It tests adding data to child blocks that
+        # have not yet been lazy loaded. This would previously crash.
+        self.json_body = JSONStreamModel.objects.get(pk=self.json_body.pk)
+        self.json_body.body.append(("text", "bar"))
+        self.json_body.save()
+
+        fetched_body = JSONStreamModel.objects.get(id=self.json_body.id).body
+        self.assertIsInstance(fetched_body, StreamValue)
+        self.assertEqual(len(fetched_body), 2)
+        self.assertEqual(fetched_body[0].block_type, "text")
+        self.assertEqual(fetched_body[0].value, "foo")
+        self.assertEqual(fetched_body[1].block_type, "text")
+        self.assertEqual(fetched_body[1].value, "bar")
+
     def test_complex_assignment(self):
         page = StreamPage(title="Test page", body=[])
         page.body = [


### PR DESCRIPTION
Fixes #12320

The existing tests only work with an in-memory instance. I've duplicated the `test_can_append()`-test and added a query for the test-object, which turned the test into a failing test. Then I've fixed the issue in `StreamValue` as described in https://github.com/wagtail/wagtail/issues/12320#issuecomment-2352386434 (**update:** I've now used a cleaner change, I think, by flipping the if-condition).