### PR TITLE
Form pages listing fixes

### DIFF
--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -18,6 +18,7 @@ from wagtail.contrib.forms.tests.utils import (
     make_form_page,
     make_form_page_with_custom_submission,
 )
+from wagtail.contrib.forms.utils import get_form_types
 from wagtail.models import Locale, Page
 from wagtail.test.demosite.models import FormPage as FormPageDemo
 from wagtail.test.testapp.models import (
@@ -158,6 +159,7 @@ class TestFormsIndex(WagtailTestUtils, TestCase):
 
     def setUp(self):
         self.login(username="siteeditor", password="password")
+        get_form_types.cache_clear()
 
     @classmethod
     def setUpTestData(cls):

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -1,11 +1,11 @@
+from functools import lru_cache
+
 from django.contrib.contenttypes.models import ContentType
 
 from wagtail import hooks
 from wagtail.coreutils import safe_snake_case
 from wagtail.models import get_page_models
 from wagtail.permissions import page_permission_policy
-
-_FORM_CONTENT_TYPES = None
 
 
 def get_field_clean_name(label):
@@ -16,19 +16,13 @@ def get_field_clean_name(label):
     return safe_snake_case(label)
 
 
+@lru_cache(maxsize=None)
 def get_form_types():
-    global _FORM_CONTENT_TYPES
-    if _FORM_CONTENT_TYPES is None:
-        from wagtail.contrib.forms.models import FormMixin
+    from wagtail.contrib.forms.models import FormMixin
 
-        form_models = [
-            model for model in get_page_models() if issubclass(model, FormMixin)
-        ]
+    form_models = [model for model in get_page_models() if issubclass(model, FormMixin)]
 
-        _FORM_CONTENT_TYPES = list(
-            ContentType.objects.get_for_models(*form_models).values()
-        )
-    return _FORM_CONTENT_TYPES
+    return list(ContentType.objects.get_for_models(*form_models).values())
 
 
 def get_forms_for_user(user):


### PR DESCRIPTION
~~This doesn't include the switch to `TransactionTestCase` yet – will push that later. I'm just curious whether this has any effect.~~

Fixes test failures from #12324, and add a small cleanup to use `lru_cache` instead of a global variable.