### PR TITLE
Don't show notices about root / unroutable pages when searching or filtering in the page explorer

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/explorable_index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/explorable_index_results.html
@@ -2,51 +2,59 @@
 {% load wagtailadmin_tags i18n %}
 
 {% block before_results %}
-    {% if parent_page.is_root %}
-        <div class="nice-padding">
-            <div class="help-block help-info">
-                {% icon name='help' %}
-                {% if perms.wagtailcore.add_site %}
-                    {% url 'wagtailsites:index' as wagtailsites_index_url %}
-                    <p>
+    {% if not is_searching and not is_filtering %}
+        {% comment %}
+            Messages about any special implications / treatment of pages in the current section (e.g. they are unroutable
+            because no site is associated) are only shown if we are not searching or filtering. This is because search /
+            filter results include descendant pages, for which the message would not necessarily be accurate.
+        {% endcomment %}
+
+        {% if parent_page.is_root %}
+            <div class="nice-padding">
+                <div class="help-block help-info">
+                    {% icon name='help' %}
+                    {% if perms.wagtailcore.add_site %}
+                        {% url 'wagtailsites:index' as wagtailsites_index_url %}
+                        <p>
+                            {% blocktrans trimmed %}
+                                The root level is where you can add new sites to your Wagtail installation. Pages created here will not be accessible at any URL until they are associated with a site.
+                            {% endblocktrans %}
+                            {% if wagtailsites_index_url %}
+                                <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
+                            {% endif %}
+                        </p>
+                        <p>
+                            {% blocktrans trimmed %}
+                                If you just want to add pages to an existing site, create them as children of the homepage instead.
+                            {% endblocktrans %}
+                        </p>
+                    {% else %}
                         {% blocktrans trimmed %}
-                            The root level is where you can add new sites to your Wagtail installation. Pages created here will not be accessible at any URL until they are associated with a site.
+                            Pages created here will not be accessible at any URL. To add pages to an existing site, create them as children of the homepage.
+                        {% endblocktrans %}
+                    {% endif %}
+                </div>
+            </div>
+            {# get_url_parts will return None is the page has no site #}
+        {% elif not parent_page.get_url_parts %}
+            <div class="nice-padding">
+                <div class="help-block help-warning">
+                    {% icon name='warning' %}
+                    {% if perms.wagtailcore.add_site %}
+                        {% url 'wagtailsites:index' as wagtailsites_index_url %}
+                        {% blocktrans trimmed %}
+                            There is no site set up for this location. Pages created here will not be accessible at any URL until a site is associated with this location.
                         {% endblocktrans %}
                         {% if wagtailsites_index_url %}
                             <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
                         {% endif %}
-                    </p>
-                    <p>
+                    {% else %}
                         {% blocktrans trimmed %}
-                            If you just want to add pages to an existing site, create them as children of the homepage instead.
+                            There is no site record for this location. Pages created here will not be accessible at any URL.
                         {% endblocktrans %}
-                    </p>
-                {% else %}
-                    {% blocktrans trimmed %}
-                        Pages created here will not be accessible at any URL. To add pages to an existing site, create them as children of the homepage.
-                    {% endblocktrans %}
-                {% endif %}
-            </div>
-        </div>
-        {# get_url_parts will return None is the page has no site #}
-    {% elif not parent_page.get_url_parts %}
-        <div class="nice-padding">
-            <div class="help-block help-warning">
-                {% icon name='warning' %}
-                {% if perms.wagtailcore.add_site %}
-                    {% url 'wagtailsites:index' as wagtailsites_index_url %}
-                    {% blocktrans trimmed %}
-                        There is no site set up for this location. Pages created here will not be accessible at any URL until a site is associated with this location.
-                    {% endblocktrans %}
-                    {% if wagtailsites_index_url %}
-                        <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
                     {% endif %}
-                {% else %}
-                    {% blocktrans trimmed %}
-                        There is no site record for this location. Pages created here will not be accessible at any URL.
-                    {% endblocktrans %}
-                {% endif %}
+                </div>
             </div>
-        </div>
+        {% endif %}
     {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/explorable_index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/explorable_index_results.html
@@ -1,0 +1,52 @@
+{% extends "wagtailadmin/pages/index_results.html" %}
+{% load wagtailadmin_tags i18n %}
+
+{% block before_results %}
+    {% if parent_page.is_root %}
+        <div class="nice-padding">
+            <div class="help-block help-info">
+                {% icon name='help' %}
+                {% if perms.wagtailcore.add_site %}
+                    {% url 'wagtailsites:index' as wagtailsites_index_url %}
+                    <p>
+                        {% blocktrans trimmed %}
+                            The root level is where you can add new sites to your Wagtail installation. Pages created here will not be accessible at any URL until they are associated with a site.
+                        {% endblocktrans %}
+                        {% if wagtailsites_index_url %}
+                            <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
+                        {% endif %}
+                    </p>
+                    <p>
+                        {% blocktrans trimmed %}
+                            If you just want to add pages to an existing site, create them as children of the homepage instead.
+                        {% endblocktrans %}
+                    </p>
+                {% else %}
+                    {% blocktrans trimmed %}
+                        Pages created here will not be accessible at any URL. To add pages to an existing site, create them as children of the homepage.
+                    {% endblocktrans %}
+                {% endif %}
+            </div>
+        </div>
+        {# get_url_parts will return None is the page has no site #}
+    {% elif not parent_page.get_url_parts %}
+        <div class="nice-padding">
+            <div class="help-block help-warning">
+                {% icon name='warning' %}
+                {% if perms.wagtailcore.add_site %}
+                    {% url 'wagtailsites:index' as wagtailsites_index_url %}
+                    {% blocktrans trimmed %}
+                        There is no site set up for this location. Pages created here will not be accessible at any URL until a site is associated with this location.
+                    {% endblocktrans %}
+                    {% if wagtailsites_index_url %}
+                        <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
+                    {% endif %}
+                {% else %}
+                    {% blocktrans trimmed %}
+                        There is no site record for this location. Pages created here will not be accessible at any URL.
+                    {% endblocktrans %}
+                {% endif %}
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index_results.html
@@ -1,4 +1,4 @@
-{% load wagtailadmin_tags i18n %}
+{% load wagtailadmin_tags %}
 
 {% if view.active_filters %}
     {% include "wagtailadmin/shared/active_filters.html" with active_filters=view.active_filters %}
@@ -13,55 +13,7 @@
 <form id="page-reorder-form">
     {% csrf_token %}
 
-    {% if parent_page %}
-        {% if parent_page.is_root %}
-            <div class="nice-padding">
-                <div class="help-block help-info">
-                    {% icon name='help' %}
-                    {% if perms.wagtailcore.add_site %}
-                        {% url 'wagtailsites:index' as wagtailsites_index_url %}
-                        <p>
-                            {% blocktrans trimmed %}
-                                The root level is where you can add new sites to your Wagtail installation. Pages created here will not be accessible at any URL until they are associated with a site.
-                            {% endblocktrans %}
-                            {% if wagtailsites_index_url %}
-                                <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
-                            {% endif %}
-                        </p>
-                        <p>
-                            {% blocktrans trimmed %}
-                                If you just want to add pages to an existing site, create them as children of the homepage instead.
-                            {% endblocktrans %}
-                        </p>
-                    {% else %}
-                        {% blocktrans trimmed %}
-                            Pages created here will not be accessible at any URL. To add pages to an existing site, create them as children of the homepage.
-                        {% endblocktrans %}
-                    {% endif %}
-                </div>
-            </div>
-            {# get_url_parts will return None is the page has no site #}
-        {% elif not parent_page.get_url_parts %}
-            <div class="nice-padding">
-                <div class="help-block help-warning">
-                    {% icon name='warning' %}
-                    {% if perms.wagtailcore.add_site %}
-                        {% url 'wagtailsites:index' as wagtailsites_index_url %}
-                        {% blocktrans trimmed %}
-                            There is no site set up for this location. Pages created here will not be accessible at any URL until a site is associated with this location.
-                        {% endblocktrans %}
-                        {% if wagtailsites_index_url %}
-                            <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
-                        {% endif %}
-                    {% else %}
-                        {% blocktrans trimmed %}
-                            There is no site record for this location. Pages created here will not be accessible at any URL.
-                        {% endblocktrans %}
-                    {% endif %}
-                </div>
-            </div>
-        {% endif %}
-    {% endif %}
+    {% block before_results %}{% endblock %}
 
     {% component table %}
 

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -932,6 +932,25 @@ class TestPageExplorerSignposting(WagtailTestUtils, TestCase):
             response, """<a href="/admin/sites/">Configure a site now.</a>"""
         )
 
+    def test_searching_at_root(self):
+        self.login(username="superuser", password="password")
+
+        # Message about root level should not show when searching or filtering
+        response = self.client.get(reverse("wagtailadmin_explore_root"), {"q": "hello"})
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            "The root level is where you can add new sites to your Wagtail installation.",
+        )
+        response = self.client.get(
+            reverse("wagtailadmin_explore_root"), {"has_child_pages": "true"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            "The root level is where you can add new sites to your Wagtail installation.",
+        )
+
     def test_admin_at_non_site_page(self):
         self.login(username="superuser", password="password")
         response = self.client.get(
@@ -949,6 +968,29 @@ class TestPageExplorerSignposting(WagtailTestUtils, TestCase):
         )
         self.assertContains(
             response, """<a href="/admin/sites/">Configure a site now.</a>"""
+        )
+
+    def test_searching_at_non_site_page(self):
+        self.login(username="superuser", password="password")
+
+        # Message about unroutable pages should not show when searching or filtering
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=(self.no_site_page.id,)),
+            {"q": "hello"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            "There is no site set up for this location.",
+        )
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=(self.no_site_page.id,)),
+            {"has_child_pages": "true"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            "There is no site set up for this location.",
         )
 
     def test_admin_at_site_page(self):

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -304,6 +304,7 @@ class ExplorableIndexView(IndexView):
     """
 
     template_name = "wagtailadmin/pages/explorable_index.html"
+    results_template_name = "wagtailadmin/pages/explorable_index_results.html"
     index_url_name = "wagtailadmin_explore"
     index_results_url_name = "wagtailadmin_explore_results"
     page_title = _("Exploring")


### PR DESCRIPTION
The messages "The root level is where you can add new sites to your Wagtail installation" and "There is no site set up for this location" are currently shown in the page explorer even when searching or filtering, which is misleading because in these views we show descendant pages for which the message may not be accurate. Fix this behaviour so that we only show the messages for a plain unfiltered view of a section.