### PR TITLE
Remove unnecessary filters from redirects index

### DIFF
--- a/wagtail/contrib/redirects/filters.py
+++ b/wagtail/contrib/redirects/filters.py
@@ -1,27 +1,13 @@
 import django_filters
 from django import forms
-from django.db.models import QuerySet
 from django.utils.translation import gettext as _
 
 from wagtail.admin.filters import WagtailFilterSet
 from wagtail.contrib.redirects.models import Redirect
-from wagtail.models import Page, Site
-
-
-def get_redirect_pages_queryset(request) -> QuerySet[Page]:
-    redirect_page_pks = (
-        Redirect.objects.filter(redirect_page__isnull=False)
-        .order_by()
-        .values_list("redirect_page", flat=True)
-        .distinct()
-    )
-    return Page.objects.filter(pk__in=redirect_page_pks)
+from wagtail.models import Site
 
 
 class RedirectsReportFilterSet(WagtailFilterSet):
-    redirect_page = django_filters.ModelChoiceFilter(
-        field_name="redirect_page", queryset=get_redirect_pages_queryset
-    )
     is_permanent = django_filters.ChoiceFilter(
         label=_("Type"),
         method="filter_type",
@@ -44,4 +30,4 @@ class RedirectsReportFilterSet(WagtailFilterSet):
 
     class Meta:
         model = Redirect
-        exclude = []
+        fields = ["is_permanent", "site"]

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -774,23 +774,6 @@ class TestRedirectsIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase)
 
         self.assertEqual(len(csv_data), 10)
 
-    def test_redirect_page_filter_only_includes_relevant_pages(self):
-        """
-        The redirect_page filter should only include pages referenced by Redirect objects.
-        """
-        response = self.get()
-        request = response.context["request"]
-        qs = response.context["filters"].filters["redirect_page"].queryset(request)
-        self.assertQuerySetEqual(qs, Page.objects.none())
-
-        page = Page.objects.get(id=2)
-        models.Redirect.add_redirect("/to-page", page, False)
-
-        response = self.get()
-        request = response.context["request"]
-        qs = response.context["filters"].filters["redirect_page"].queryset(request)
-        self.assertQuerySetEqual(qs, Page.objects.filter(pk=2))
-
 
 @override_settings(
     WAGTAILFRONTENDCACHE={


### PR DESCRIPTION
Fixes #12330

The filters "Redirect from", "Redirect to a page", "Target page route", "Redirect to any URL", "Automatically created" and "Created at" were introduced when `exclude = []` was set on the filter class in https://github.com/wagtail/wagtail/pull/8851/files#diff-a1afb82083d526ca8eee0f70b714bea11910ca7b12b8efe8acdcb3b8fc6c0519, and there's good reason to believe that this change was unintentional - there's no acknowledgement of it in the PR comments, the "Created at" filter is essentially non-functional since it filters on an exact timestamp rather than a date range, and the labels have not been changed from the verbose_name field defaults (which are somewhat confusing when used outside the context of the create/edit form).

The "Redirect to a page" filter in particular is causing issues on large sites as this dropdown can legitimately run to many thousands of entries and exceed web server resource limits.

Thus, roll back this filter set to its previous state of just `is_permanent` and `site`. If a user needs to find all redirects pointing to a given page, searching on the page title will generally be sufficient.
