### PR TITLE
Modified max-width

### DIFF
--- a/client/scss/components/forms/_input-text.scss
+++ b/client/scss/components/forms/_input-text.scss
@@ -44,6 +44,6 @@ textarea {
 .w-field--date_time_field,
 .w-field--time_field {
   input {
-    width: auto;
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
Fixes #12299

The input field was overflowing its parent wrapper which made the design asymmetrical. To fix this, I changed "width: auto" to "max-width: 100%;".