### PR TITLE
Docs: Clarify file location, add missing imports

### DIFF
--- a/docs/topics/snippets/customizing.md
+++ b/docs/topics/snippets/customizing.md
@@ -44,7 +44,8 @@ class MemberFilterSet(WagtailFilterSet):
 And the following is the snippet's corresponding `SnippetViewSet` subclass:
 
 ```python
-from wagtail.admin.panels import FieldPanel
+# wagtail_hooks.py
+from wagtail.admin.panels import FieldPanel, ObjectList, TabbedInterface
 from wagtail.admin.ui.tables import UpdatedAtColumn
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet


### PR DESCRIPTION
_Please describe the problem you're fixing here. Include the issue number, if applicable._

* Some imports in the code block in the documentation page **Customizing admin views for snippets** were missing. 
* Additionally, the code block did not clarify its file location, unlike the code block above it.

This PR addresses these two issues by adding the missing imports and by clarifying the file location.