### PR TITLE
Stop PopularTagsFilter from applying an IN clause when not filtering

### DIFF
--- a/wagtail/admin/filters.py
+++ b/wagtail/admin/filters.py
@@ -223,7 +223,7 @@ class PopularTagsFilter(django_filters.MultipleChoiceFilter):
 
     def filter(self, qs, value):
         filtered = super().filter(qs, value)
-        if not self.use_subquery:
+        if not self.use_subquery or not value:
             return filtered
 
         # Workaround for https://github.com/wagtail/wagtail/issues/6616


### PR DESCRIPTION
Fixes #12349
