### PR TITLE
Mark `js_translation_strings` template tag for deprecation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -51,6 +51,7 @@ Changelog
  * Maintenance: Ensure the side panel's show event is dispatched after any hide events (Sage Abdullah)
  * Maintenance: Migrate preview-panel JavaScript to Stimulus & TypeScript, add full unit testing (Sage Abdullah)
  * Maintenance: Move `wagtailConfig` values from inline scripts to the `wagtail_config` template tag (LB (Ben) Johnston, Sage Abdullah)
+ * Maintenance: Deprecate the `{% locales %}` and `{% js_translation_strings %}` template tags (LB (Ben) Johnston, Sage Abdullah)
 
 
 6.2.2 (24.09.2024)

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -73,6 +73,7 @@ This release adds formal support for Django 5.1.
  * Ensure the side panel's show event is dispatched after any hide events (Sage Abdullah)
  * Migrate preview-panel JavaScript to Stimulus & TypeScript, add full unit testing (Sage Abdullah)
  * Move `wagtailConfig` values from inline scripts to the `wagtail_config` template tag (LB (Ben) Johnston, Sage Abdullah)
+ * Deprecate the `{% locales %}` and `{% js_translation_strings %}` template tags (LB (Ben) Johnston, Sage Abdullah)
 
 
 ## Upgrade considerations - changes affecting all projects
@@ -98,3 +99,9 @@ To disable the automatic preview update feature, set [`WAGTAIL_AUTO_UPDATE_PREVI
 The undocumented `locales` template tag will be removed in a future release.
 
 If access to JSON locales within JavaScript is needed, use `window.wagtailConfig.LOCALES` instead.
+
+### Deprecation of the `{% js_translation_strings %}` template tag
+
+The undocumented `js_translation_strings` template tag will be removed in a future release.
+
+If access to JSON translation strings within JavaScript is needed, use `window.wagtailConfig.STRINGS` instead.

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -684,6 +684,10 @@ def admin_theme_classname(context):
 
 @register.simple_tag
 def js_translation_strings():
+    warn(
+        "The `js_translation_strings` template tag will be removed in a future release.",
+        category=RemovedInWagtail70Warning,
+    )
     return mark_safe(json.dumps(get_js_translation_strings()))
 
 

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -11,6 +11,7 @@ from django.test.utils import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 
+from wagtail.admin.localization import get_js_translation_strings
 from wagtail.admin.staticfiles import VERSION_HASH, versioned_static
 from wagtail.admin.templatetags.wagtailadmin_tags import (
     avatar_url,
@@ -27,6 +28,7 @@ from wagtail.models import Locale, Page
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 from wagtail.users.models import UserProfile
+from wagtail.utils.deprecation import RemovedInWagtail70Warning
 
 
 class TestAvatarTemplateTag(WagtailTestUtils, TestCase):
@@ -378,7 +380,12 @@ class TestInternationalisationTags(TestCase):
             self.assertTrue(i18n_enabled())
 
     def test_locales(self):
-        locales_output = locales_tag()
+        with self.assertWarnsMessage(
+            RemovedInWagtail70Warning,
+            "The `locales` template tag will be removed in a future release.",
+        ):
+            locales_output = locales_tag()
+
         self.assertIsInstance(locales_output, str)
         self.assertEqual(
             json.loads(locales_output),
@@ -400,6 +407,20 @@ class TestInternationalisationTags(TestCase):
         # check with an invalid id
         with self.assertNumQueries(0):
             self.assertIsNone(locale_label_from_id(self.locale_ids[-1] + 100), None)
+
+    def test_js_translation_strings(self):
+        template = """
+            {% load wagtailadmin_tags %}
+            {% js_translation_strings %}
+        """
+
+        expected = json.dumps(get_js_translation_strings())
+
+        with self.assertWarnsMessage(
+            RemovedInWagtail70Warning,
+            "The `js_translation_strings` template tag will be removed in a future release.",
+        ):
+            self.assertHTMLEqual(expected, Template(template).render(Context()))
 
 
 class ComponentTest(SimpleTestCase):


### PR DESCRIPTION
- `js_translation_strings` is no longer used by Wagtail admin code
- It was historically used for generating the JS config strings within templates, we now do this in Python and expose as JSON via the `wagtail_config` template tag
- Add a warning for deprecation so that we can remove this unused template tag in the next major version of Wagtail
- See https://github.com/wagtail/wagtail/issues/9771#issuecomment-2375235298 for context
