### PR TITLE
Add translatable model copy for translation done signal

### DIFF
--- a/docs/reference/signals.md
+++ b/docs/reference/signals.md
@@ -197,8 +197,10 @@ This signal is emitted from a `TaskState` when a page's task is canceled.
 
 ## copy_for_translation_done
 
-This signal is emitted from a `CopyPageForTranslationAction` when a page is being copied to a new locale (translated).
+This signal is emitted from `CopyForTranslationAction` or `CopyPageForTranslationAction` when a translatable model or page is copied to a new locale (translated).
 
--   `sender` - `CopyPageForTranslationAction`
--   `source_obj` - The source page
--   `target_obj` - The copy of the source page in the new locale
+A translatable model is a model that implements the [TranslatableMixin](wagtail.models.TranslatableMixin).
+
+-   `sender` - `CopyForTranslationAction` or `CopyPageForTranslationAction`
+-   `source_obj` - The source object
+-   `target_obj` - The copy of the source object in the new locale

--- a/wagtail/actions/copy_for_translation.py
+++ b/wagtail/actions/copy_for_translation.py
@@ -242,4 +242,10 @@ class CopyForTranslationAction:
             self.object, self.locale, self.exclude_fields
         )
 
+        copy_for_translation_done.send(
+            sender=self.__class__,
+            source_obj=self.object,
+            target_obj=translated_object,
+        )
+
         return translated_object


### PR DESCRIPTION
In https://github.com/wagtail/wagtail/pull/12033 _copy for translation done_ signal for _pages_ is introduced.

However, this signal should also fire when any translatable model is translated.
A translatable model is a model that implements the TranslatableMixin.

CC @ArnarTumi 