### PR TITLE
Documentation: Configure API to use the DRF's TokenAuthentication

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,6 +38,7 @@ Changelog
  * Docs: Clarify process for UserViewSet customization (Sage Abdullah)
  * Docs: Correct `WAGTAIL_WORKFLOW_REQUIRE_REAPPROVAL_ON_EDIT` documentation to state that it defaults to `False` (Matt Westcott)
  * Docs: Add an example of customizing a default accessibility check (Cynthia Kiser)
+ * Docs: Demonstrate access protection with `TokenAuthentication` in the Wagtail API v2 Configuration Guide (Krzysztof Jeziorny)
  * Maintenance: Removed support for Python 3.8 (Matt Westcott)
  * Maintenance: Drop pytz dependency in favour of `zoneinfo.available_timezones` (Sage Abdullah)
  * Maintenance: Relax django-taggit dependency to allow 6.0 (Matt Westcott)

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -309,8 +309,32 @@ class CustomPagesAPIViewSet(PagesAPIViewSet):
 api_router.register_endpoint("pages", CustomPagesAPIViewSet)
 ```
 
-Don't forget to add `rest_framework.authtoken` to your `INSTALLED_APPS` section in the settings and run the needed migrations. This way, your API endpoint will be accessible only with the Authorization header containing the generated `Token: exampletoken123xyz`.
+Extend settings with
 
+```python
+# settings.py
+
+INSTALLED_APPS = [
+    ...
+
+    'rest_framework.authtoken',
+
+    ...
+]
+
+...
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication"
+    ],
+}
+```
+
+
+Don't forget to run the needed migrations. 
+
+Your API endpoint will be accessible only with the Authorization header containing the generated `Token: exampletoken123xyz`.
 Note: If you use `TokenAuthentication` in production you must ensure that your API is only available over `https`.
 
 ## Additional settings

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -331,10 +331,9 @@ REST_FRAMEWORK = {
 }
 ```
 
+Don't forget to run the app's migrations.
 
-Don't forget to run the app's migrations. 
-
-Your API endpoint will be accessible only with the Authorization header containing the generated `Token exampleSecretToken123xyz`. 
+Your API endpoint will be accessible only with the Authorization header containing the generated `Token exampleSecretToken123xyz`.
 Tokens can be generated in the Django admin under Auth Token or using the `manage.py` command `drf_create_token`.
 
 Note: If you use `TokenAuthentication` in production you must ensure that your API is only available over `https`.

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -292,7 +292,7 @@ For cases where the source image set may contain SVGs, the `ImageRenditionField`
 
 ### Authentication
 
-To protect the access to your API, you can implement an [authentication](https://www.django-rest-framework.org/api-guide/authentication/) method provided by the Django Rest Framework, for example the [Token Authentication](https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication):
+To protect the access to your API, you can implement an [authentication](https://www.django-rest-framework.org/api-guide/authentication/) method provided by the Django REST Framework, for example the [Token Authentication](https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication):
 
 ```python
 # api.py
@@ -332,9 +332,11 @@ REST_FRAMEWORK = {
 ```
 
 
-Don't forget to run the needed migrations. 
+Don't forget to run the app's migrations. 
 
-Your API endpoint will be accessible only with the Authorization header containing the generated `Token: exampletoken123xyz`.
+Your API endpoint will be accessible only with the Authorization header containing the generated `Token exampleSecretToken123xyz`. 
+Tokens can be generated in the Django admin under Auth Token or using the `manage.py` command `drf_create_token`.
+
 Note: If you use `TokenAuthentication` in production you must ensure that your API is only available over `https`.
 
 ## Additional settings

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -290,6 +290,29 @@ a URL to the image if your media files are properly configured.
 
 For cases where the source image set may contain SVGs, the `ImageRenditionField` constructor takes a `preserve_svg` argument. The behavior of `ImageRenditionField` when `preserve_svg` is `True` is as described for the `image` template tag's `preserve-svg` argument (see the documentation on [](svg_images)).
 
+### Authentication
+
+To protect the access to your API, you can implement an [authentication](https://www.django-rest-framework.org/api-guide/authentication/) method provided by the Django Rest Framework, for example the [Token Authentication](https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication):
+
+```python
+# api.py
+
+from rest_framework.permissions import IsAuthenticated
+
+# ...
+
+class CustomPagesAPIViewSet(PagesAPIViewSet):
+    name = "pages"
+    permission_classes = (IsAuthenticated,)
+
+
+api_router.register_endpoint("pages", CustomPagesAPIViewSet)
+```
+
+Don't forget to add `rest_framework.authtoken` to your `INSTALLED_APPS` section in the settings and run the needed migrations. This way, your API endpoint will be accessible only with the Authorization header containing the generated `Token: exampletoken123xyz`.
+
+Note: If you use `TokenAuthentication` in production you must ensure that your API is only available over `https`.
+
 ## Additional settings
 
 ### `WAGTAILAPI_BASE_URL`

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -59,6 +59,7 @@ This release adds formal support for Django 5.1.
  * Clarify process for [UserViewSet customization](custom_userviewset) (Sage Abdullah)
  * Correct `WAGTAIL_WORKFLOW_REQUIRE_REAPPROVAL_ON_EDIT` documentation to state that it defaults to `False` (Matt Westcott)
  * Add an example of customizing a default accessibility check (Cynthia Kiser)
+ * Demonstrate access protection with `TokenAuthentication` in the [Wagtail API v2 Configuration Guide](/advanced_topics/api/v2/configuration) (Krzysztof Jeziorny)
 
 
 ### Maintenance


### PR DESCRIPTION
A tutorial part how to implement the DRF's `TokenAuthentication` for API access protection.

Having to research the method myself I propose to extend the documentation with an example how to implement the `TokenAuthentication` from the Django REST Framework.