### PR TITLE
View draft - support different preview modes #6574

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Changelog
  * Add support for an image `description` field across all images, to better support accessible image descriptions (Chiemezuo Akujobi)
  * Prompt the user about unsaved changes when editing snippets (Sage Abdullah)
  * Implement incremental dashboard design enhancements (Albina Starykova)
+ * Add support for specifying different preview modes to the "View draft" URL for pages (Robin Varghese)
  * Fix: Prevent page type business rules from blocking reordering of pages (Andy Babic, Sage Abdullah)
  * Fix: Improve layout of object permissions table (Sage Abdullah)
  * Fix: Fix typo in aria-label attribute of page explorer navigation link (Sébastien Corbin)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -839,6 +839,7 @@
 * rahulsamant37
 * Gabriel Getzie
 * Rohit Singh
+* Robin Varghese
 
 ## Translators
 

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -42,6 +42,7 @@ This feature was developed by Albina Starykova based on designs by Ben Enright.
  * Fire `copy_for_translation_done` signal when copying translatable models as well as pages (Coen van der Kamp)
  * Add support for an image `description` field across all images, to better support accessible image descriptions (Chiemezuo Akujobi)
  * Prompt the user about unsaved changes when editing snippets (Sage Abdullah)
+ * Add support for specifying different preview modes to the "View draft" URL for pages (Robin Varghese)
 
 ### Bug fixes
 

--- a/wagtail/admin/views/pages/preview.py
+++ b/wagtail/admin/views/pages/preview.py
@@ -14,7 +14,7 @@ def view_draft(request, page_id):
         raise PermissionDenied
 
     try:
-        preview_mode = page.default_preview_mode
+        preview_mode = request.GET.get("mode", page.default_preview_mode)
     except IndexError:
         raise PermissionDenied
 

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -195,7 +195,11 @@ class SimplePage(Page):
 
 
 class MultiPreviewModesPage(Page):
-    template = "tests/simple_page.html"
+    preview_templates = {
+        "original": "tests/simple_page.html",
+        "alt#1": "tests/simple_page_alt.html",
+    }
+    template = preview_templates["original"]
 
     @property
     def preview_modes(self):
@@ -206,8 +210,8 @@ class MultiPreviewModesPage(Page):
         return "alt#1"
 
     def get_preview_template(self, request, mode_name):
-        if mode_name == "alt#1":
-            return "tests/simple_page_alt.html"
+        if mode_name in self.preview_templates:
+            return self.preview_templates[mode_name]
         return super().get_preview_template(request, mode_name)
 
 


### PR DESCRIPTION
Fixes #6574 

## manual testing instructions

- visit a page with a url `mode` and ensure the correct template is loaded
  - ex. http://localhost:8000/admin/pages/69/view_draft/?mode=landing
- visit a contact page without preview mode url argument
  - ex. http://localhost:8000/admin/pages/69/view_draft/
- 