### PR TITLE
Fix error in workflows listing with multiple snippets assigned on PostgreSQL

### DIFF
--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -163,6 +163,33 @@ class TestWorkflowsIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase)
         self.assertNotContains(response, "There are no enabled workflows.")
         self.assertContains(response, "test_workflow")
 
+    def test_multiple_snippets_assigned_to_workflow(self):
+        Workflow.objects.create(name="Nocontenttypes")
+        multi_ct_workflow = Workflow.objects.create(name="Multicontenttypes")
+        for model in [FullFeaturedSnippet, ModeratedModel]:
+            WorkflowContentType.objects.create(
+                workflow=multi_ct_workflow,
+                content_type=ContentType.objects.get_for_model(model),
+            )
+
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        soup = self.get_soup(response.content)
+        cells = [
+            text
+            for td in soup.select("td")
+            if (text := td.get_text(separator=" | ", strip=True))
+        ]
+        self.assertEqual(
+            cells,
+            [
+                "Multicontenttypes",
+                "0 pages | 2 snippet types",
+                "Nocontenttypes",
+                "0 pages | 0 snippet types",
+            ],
+        )
+
     def test_num_queries(self):
         self.create_workflows()
         self.get()

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -4,7 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
 from django.db import transaction
-from django.db.models import Count, OuterRef, Prefetch
+from django.db.models import Count, Prefetch
 from django.db.models.functions import Lower
 from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
@@ -43,7 +43,6 @@ from wagtail.models import (
     Task,
     TaskState,
     Workflow,
-    WorkflowContentType,
     WorkflowState,
     WorkflowTask,
 )
@@ -151,10 +150,7 @@ class Index(IndexView):
 
     def get_base_queryset(self):
         queryset = super().get_base_queryset()
-        content_types = WorkflowContentType.objects.filter(
-            workflow=OuterRef("pk")
-        ).values_list("pk", flat=True)
-        queryset = queryset.annotate(content_types=Count(content_types))
+        queryset = queryset.annotate(content_types=Count("workflow_content_types"))
         return queryset.prefetch_related(
             "workflow_pages",
             "workflow_pages__page",


### PR DESCRIPTION
Fixes #12364.

To test:


- Add `WorkflowMixin` to `FooterText` (no need to run migrations as there are no fields added)
- Go to Settings > Workflows and click on the "Moderators approval" workflow
- Assign the workflow to `FooterText` (in addition to `Person`)
- Go to Settings > Workflows again