### PR TITLE
Bugfix: Closed opened files as a coding standard

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Changelog
  * Docs: Add the `wagtail start` command to the management commands reference page (Damilola Oladele)
  * Docs: Refine the project template page sections and document common issues encountered when creating custom templates (Damilola Oladele)
  * Docs: Refine page titles to better align with the documentation style guide (Srishti Jaiswal)
+ * Maintenance: Close open files when reading within utils/setup.py (Ataf Fazledin Ahamed)
 
 
 6.3 LTS (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -849,6 +849,7 @@
 * Srishti Jaiswal
 * Alessandro Chitarrini
 * Joel William
+* Ataf Fazledin Ahamed
 
 ## Translators
 

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -34,7 +34,7 @@ depth: 1
 
 ### Maintenance
 
- * ...
+ * Close open files when reading within utils/setup.py (Ataf Fazledin Ahamed)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/utils/setup.py
+++ b/wagtail/utils/setup.py
@@ -29,10 +29,10 @@ class assets_mixin:
         Writes the current Wagtail version number into package.json
         """
         path = os.path.join(".", "client", "package.json")
-        input_file = open(path)
 
         try:
-            package = json.loads(input_file.read().decode("utf-8"))
+            with open(path, "r") as f:
+                package = json.loads(f.read())
         except ValueError as e:
             print("Unable to read " + path + " " + e)  # noqa: T201
             raise SystemExit(1)


### PR DESCRIPTION
## Introduction

While triaging your project, I found several cases where files opened weren't closed. Since this goes against the Python coding standard, I made small fixes to close the files or used a context manager to read the contents of the file.

I found 3 places where this was happening:
- wagtail/utils/sendfile_streaming_backend.py
- wagtail/utils/setup.py
- wagtail/admin/tests/test_account_management.py

Among them, the 3rd one belonged to tests, as a result - I didn't bother to update it.


## Contribution
All contributions made in this PR follows [Developer Certificate of Origin](https://developercertificate.org)


## Comments
If you think such fixes aren't necessary for your project, and you'd like me to find some better bugs / code-to-fix, then please let me know. I'll be happy to contribute.