### PR TITLE
Remove image_format_name_to_content_type function

### DIFF
--- a/wagtail/images/fields.py
+++ b/wagtail/images/fields.py
@@ -163,7 +163,7 @@ class WagtailImageField(ImageField):
             # Annotate the python representation of the FileField with the image
             # property so subclasses can reuse it for their own validation
             f.image = willow.Image.open(file)
-            f.content_type = image_format_name_to_content_type(f.image.format_name)
+            f.content_type = f.image.mime_type
 
         except Exception as exc:  # noqa: BLE001
             # Willow doesn't recognize it as an image.
@@ -181,31 +181,3 @@ class WagtailImageField(ImageField):
             self.check_image_pixel_size(f)
 
         return f
-
-
-def image_format_name_to_content_type(image_format_name):
-    """
-    Convert a Willow image format name to a content type.
-    TODO: Replace once https://github.com/wagtail/Willow/pull/102 and
-          a new Willow release is out
-    """
-    if image_format_name == "svg":
-        return "image/svg+xml"
-    elif image_format_name == "jpeg":
-        return "image/jpeg"
-    elif image_format_name == "png":
-        return "image/png"
-    elif image_format_name == "gif":
-        return "image/gif"
-    elif image_format_name == "bmp":
-        return "image/bmp"
-    elif image_format_name == "tiff":
-        return "image/tiff"
-    elif image_format_name == "webp":
-        return "image/webp"
-    elif image_format_name == "avif":
-        return "image/avif"
-    elif image_format_name == "ico":
-        return "image/x-icon"
-    else:
-        raise ValueError("Unknown image format name")


### PR DESCRIPTION
Fixes #12098

This was used in two places: in WagtailImageField.to_python (where it can be replaced with willow's mime_type as per the TODO note) and wagtail.images.models.Picture (where it's applied to a fixed list of image formats, so we can just specify the mime types directly in that list).
