### PR TITLE
Use correct `ACTIVE_CONTENT_LOCALE` name in wagtailConfig stubs

### DIFF
--- a/client/src/config/wagtailConfig.test.js
+++ b/client/src/config/wagtailConfig.test.js
@@ -22,7 +22,7 @@ describe('wagtailConfig', () => {
     it('exists', () => {
       expect(WAGTAIL_CONFIG).toEqual(
         expect.objectContaining({
-          ACTIVE_LOCALE: expect.any(String),
+          ACTIVE_CONTENT_LOCALE: expect.any(String),
           LOCALES: expect.any(Array),
         }),
       );

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -35,7 +35,7 @@ const wagtailConfig = {
       display_name: 'French',
     },
   ],
-  ACTIVE_LOCALE: 'en',
+  ACTIVE_CONTENT_LOCALE: 'en',
 };
 
 const configScript = Object.assign(document.createElement('script'), {


### PR DESCRIPTION
- Fix up from #11166

See source config usage here:

https://github.com/wagtail/wagtail/blob/3d5c20863cd895a337c3b08345d1ab0c4cff966f/wagtail/admin/templatetags/wagtailadmin_tags.py#L967