### PR TITLE
HEIC / HEIF image support

### DIFF
--- a/docs/advanced_topics/images/image_file_formats.md
+++ b/docs/advanced_topics/images/image_file_formats.md
@@ -25,10 +25,11 @@ image formats and let the browser choose the one it prefers. For example:
 </picture>
 ```
 
+(customising_output_formats)=
 ### Customising output formats
 
 By default, all `avif`, `bmp` and `webp` images are converted to the `png` format
-when no image output format is given.
+when no image output format is given, and `heic` images are converted to `jpeg`.
 
 The default conversion mapping can be changed by setting the
 `WAGTAILIMAGES_FORMAT_CONVERSIONS` to a dictionary, which maps the input type

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -566,3 +566,15 @@ If a user navigates directly to the URL of the SVG file embedded scripts may be 
 -   setting `Content-Disposition: attachment` will cause the file to be downloaded rather than being immediately rendered in the browser, meaning scripts will not be executed (note: this will not prevent scripts from running if a user downloads and subsequently opens the SVG file in their browser).
 
 The steps required to set headers for specific responses will vary, depending on how your Wagtail application is deployed.
+
+(heic_heif_images)=
+
+## HEIC / HEIF images
+
+`.heic` images are not widely supported on the web, but may be encountered when exporting images from Apple devices. Wagtail does not allow upload of these by default, but this can be enabled by adding "heic" to `WAGTAILIMAGES_EXTENSIONS`:
+
+```python
+WAGTAILIMAGES_EXTENSIONS = ["gif", "jpg", "jpeg", "png", "webp", "heic"]
+```
+
+These images will be automatically converted to JPEG format when rendered (see [](customising_output_formats)).

--- a/wagtail/images/image_operations.py
+++ b/wagtail/images/image_operations.py
@@ -409,7 +409,7 @@ class WebPQualityOperation(FilterOperation):
 
 
 class FormatOperation(FilterOperation):
-    supported_formats = ["jpeg", "png", "gif", "webp", "avif", "ico"]
+    supported_formats = ["jpeg", "png", "gif", "webp", "avif", "ico", "heic"]
 
     def construct(self, format, *options):
         self.format = format

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1071,12 +1071,12 @@ class Filter:
                     "output-format-options" in env
                     and "lossless" in env["output-format-options"]
                 ):
-                    return willow.save_as_heif(output, lossless=True)
+                    return willow.save_as_heic(output, lossless=True)
                 elif "heic-quality" in env:
                     quality = env["heic-quality"]
                 else:
                     quality = getattr(settings, "WAGTAILIMAGES_HEIC_QUALITY", 80)
-                return willow.save_as_heif(output, quality=quality)
+                return willow.save_as_heic(output, quality=quality)
             elif output_format == "svg":
                 return willow.save_as_svg(output)
             elif output_format == "ico":

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -62,6 +62,7 @@ IMAGE_FORMAT_EXTENSIONS = {
     "webp": ".webp",
     "svg": ".svg",
     "ico": ".ico",
+    "heic": ".heic",
 }
 
 
@@ -998,11 +999,12 @@ class Filter:
                 # Developer specified an output format
                 output_format = env["output-format"]
             else:
-                # Convert bmp and webp to png by default
+                # Convert avif, bmp and webp to png, and heic to jpg, by default
                 default_conversions = {
                     "avif": "png",
                     "bmp": "png",
                     "webp": "png",
+                    "heic": "jpeg",
                 }
 
                 # Convert unanimated GIFs to PNG as well
@@ -1061,6 +1063,20 @@ class Filter:
                 else:
                     quality = getattr(settings, "WAGTAILIMAGES_AVIF_QUALITY", 80)
                 return willow.save_as_avif(output, quality=quality)
+            elif output_format == "heic":
+                # Allow changing of HEIC compression quality. Safari is the only browser that supports HEIC,
+                # so there is little value in outputting it - for that reason, we make it work if someone
+                # explicitly requests it, but these settings are not documented.
+                if (
+                    "output-format-options" in env
+                    and "lossless" in env["output-format-options"]
+                ):
+                    return willow.save_as_heif(output, lossless=True)
+                elif "heic-quality" in env:
+                    quality = env["heic-quality"]
+                else:
+                    quality = getattr(settings, "WAGTAILIMAGES_HEIC_QUALITY", 80)
+                return willow.save_as_heif(output, quality=quality)
             elif output_format == "svg":
                 return willow.save_as_svg(output)
             elif output_format == "ico":

--- a/wagtail/images/tests/test_image_operations.py
+++ b/wagtail/images/tests/test_image_operations.py
@@ -719,6 +719,29 @@ class TestFormatFilter(TestCase):
         # quality=80 is default for the Willow and PIL libraries
         save.assert_called_with(f, "WEBP", quality=80, lossless=True)
 
+    def test_heic(self):
+        fil = Filter(spec="width-400|format-heic")
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+        out = fil.run(image, BytesIO())
+
+        self.assertEqual(out.format_name, "heic")
+
+    def test_heic_lossless(self):
+        fil = Filter(spec="width-400|format-heic-lossless")
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+
+        f = BytesIO()
+        with patch("PIL.Image.Image.save") as save:
+            fil.run(image, f)
+
+        save.assert_called_with(f, "HEIF", quality=-1, chroma=444)
+
     def test_invalid(self):
         fil = Filter(spec="width-400|format-foo")
         image = Image.objects.create(


### PR DESCRIPTION
Prompted by https://stackoverflow.com/questions/79039140/wagtail-heic-image-upload...

.heic images are sometimes encountered when working with Apple devices (e.g. when exporting photos via Airdrop), but are not widely supported on the web (only by Safari). However, since we have the `WAGTAILIMAGES_FORMAT_CONVERSIONS` mechanism to handle converting them to something better, and we install Willow with `heif` support as standard (as required for AVIF), this is a nice quick win...

Given that .heic seems to be used predominantly for photos, I've set it up to convert to JPEG rather than PNG as per other conversions. In principle it's also possible to output to .heic using `{% image ... format-heic %}`, and consequently there's a new `WAGTAILIMAGES_HEIC_QUALITY` setting, but given the questionable use-case for this I've chosen not to document this.

A minor quirk is that Django adds `accept="image/*"` to ImageField file upload fields as standard, and Chrome (+ possibly other browsers) unintuitively, but sensibly, doesn't consider `image/heic` to match that - so we have to explicitly add that as a special case.

Incorporates #12382.