### PR TITLE
Fix: Updated can_handle method to check for AbstractGroupApprovalTask in mail.py file

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -56,6 +56,7 @@ Changelog
  * Fix: Fix datetime fields overflowing its parent wrapper in listing filters (Rohit Singh)
  * Fix: Prevent multiple URLs from being combined into one when pasting links into a rich text input (Thibaud Colas)
  * Fix: Improve layout of report listing tables (Sage Abdullah)
+ * Fix: Fix regression from creation of `AbstractGroupApprovalTask` to ensure `can_handle` checks for the abstract class correctly (Sumana Sree Angajala)
  * Docs: Upgrade Sphinx to 7.3 (Matt Westcott)
  * Docs: Document how to customize date/time format settings (Vince Salvino)
  * Docs: Create a new documentation section for deployment and move fly.io deployment from the tutorial to this section (Vince Salvino)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -846,6 +846,7 @@
 * Ankit Kumar
 * Frank Yiu
 * Shaurya Panchal
+* Sumana Sree Angajala
 
 ## Translators
 

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -112,6 +112,7 @@ This feature was developed by Bart Cieliński, alexkiro, and Sage Abdullah.
  * Fix datetime fields overflowing its parent wrapper in listing filters (Rohit Singh)
  * Prevent multiple URLs from being combined into one when pasting links into a rich text input (Thibaud Colas)
  * Improve layout of report listing tables (Sage Abdullah)
+ * Fix regression from creation of `AbstractGroupApprovalTask` to ensure `can_handle` checks for the abstract class correctly (Sumana Sree Angajala)
 
 ### Documentation
 

--- a/wagtail/admin/mail.py
+++ b/wagtail/admin/mail.py
@@ -8,7 +8,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import override
 
 from wagtail.coreutils import camelcase_to_underscore
-from wagtail.models import GroupApprovalTask, Page, TaskState, WorkflowState
+from wagtail.models import AbstractGroupApprovalTask, Page, TaskState, WorkflowState
 from wagtail.users.models import UserProfile
 
 logger = logging.getLogger("wagtail.admin")
@@ -367,7 +367,7 @@ class BaseGroupApprovalTaskStateEmailNotifier(EmailNotificationMixin, Notifier):
 
     def can_handle(self, instance, **kwargs):
         if super().can_handle(instance, **kwargs) and isinstance(
-            instance.task.specific, GroupApprovalTask
+            instance.task.specific, AbstractGroupApprovalTask
         ):
             return True
         return False


### PR DESCRIPTION
This PR fixes issue #12328 by updating the `BaseGroupApprovalTaskStateEmailNotifier` to check for `AbstractGroupApprovalTask` instances. This allows custom tasks derived from `AbstractGroupApprovalTask` to be handled correctly.

**Changes:**
- Imported `AbstractGroupApprovalTask` from `wagtail.models`.
- Updated the `can_handle` method to check for `AbstractGroupApprovalTask` instead of `GroupApprovalTask`.
