### PR TITLE
Fix column width overflow in document chooser for long filenames

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -50,6 +50,7 @@ ul.listing {
 
   td {
     vertical-align: middle;
+    word-break: break-word;
   }
 
   td.title {


### PR DESCRIPTION
This PR addresses issue [#12357](https://github.com/wagtail/wagtail/issues/12357), where long filenames without spaces cause the column widths of the document chooser table to stretch, making it difficult to read the document titles, especially on narrower browser windows.

### Steps to Reproduce: 
  1. Upload a document with a long filename (without spaces).
  2. Edit a page that uses the document chooser.
  3. Open the document chooser modal in a narrow browser window.
  4. Observe that the table columns are stretched due to long filenames.

### Before 
![Screenshot - 2024-10-03T224331 059](https://github.com/user-attachments/assets/d809b3a1-fed7-46e6-8a09-ec8d423c220a)

### After
![Screenshot - 2024-10-03T224536 953](https://github.com/user-attachments/assets/23708cfe-ba6d-476c-8412-d07a95e349ba)

