### PR TITLE
userbar render function should not call context processor(s) #12410

### DIFF
--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -9,9 +9,7 @@ class BaseItem:
         return {"self": self, "request": request}
 
     def render(self, request):
-        return render_to_string(
-            self.template, self.get_context_data(request), request=request
-        )
+        return render_to_string(self.template, self.get_context_data(request))
 
 
 class AdminItem(BaseItem):


### PR DESCRIPTION
This PR fixes issue #12410.

## Explanation

Here is `BaseItem` class that is used as base class for generating userbar items. 
```
class BaseItem:
    template = "wagtailadmin/userbar/item_base.html"

    def get_context_data(self, request):
        return {"self": self, "request": request}

    def render(self, request):
        return render_to_string(
            self.template, self.get_context_data(request), request=request
        )
```

`render` function of BaseItem class uses `django.template.loader.render_to_string` to render userbar item template. This function accepts context and request as optional arguments and when request is passed it calls context processor.

From code I can see that `request` is also passed in `context` so there is no need to pass it twice. Removing it as argument should not cause any harm. As a plus it won't call context processor.

if you wonder why `context processor` is called when request is passed check django code:

1. `render_to_string` - calls `django.template.backend.django.Template.render`
2. `render` calls `django.template.context.make_context`
3. and when request is passed to `make_context`  it uses `RequestContext` class which iterates through all processors and builds context for template.


