### PR TITLE
Make the upgrade banner dismissible

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Add support for an image `description` field across all images, to better support accessible image descriptions (Chiemezuo Akujobi)
  * Prompt the user about unsaved changes when editing snippets (Sage Abdullah)
  * Implement incremental dashboard design enhancements (Albina Starykova, Ben Enright)
+ * Make dashboard upgrade banners dismissible (Sage Abdullah)
  * Add support for specifying different preview modes to the "View draft" URL for pages (Robin Varghese)
  * Add a new enhanced contrast admin theming option for the admin interface (Albina Starykova, Victoria Ottah)
  * Implement new designs for the footer actions dropdown with more contrast and larger text (Sage Abdullah)

--- a/client/src/controllers/DismissibleController.ts
+++ b/client/src/controllers/DismissibleController.ts
@@ -15,7 +15,7 @@ import { WAGTAIL_CONFIG } from '../config/wagtailConfig';
  * updateDismissibles(data, wagtailConfig);
  */
 export const updateDismissibles = (
-  data: Record<string, boolean>,
+  data: Record<string, boolean | string>,
 ): Promise<Response> =>
   fetch(WAGTAIL_CONFIG.ADMIN_URLS?.DISMISSIBLES, {
     method: 'PATCH',
@@ -59,10 +59,24 @@ export class DismissibleController extends Controller<HTMLElement> {
    * appropriate class and data attribute optimistically. Each dismissible
    * defines how it uses (or not) these indicators.
    */
-  toggle(): void {
-    if (!this.idValue) return;
+  toggle(event?: Event & { params?: { value?: boolean | string } }): void {
     this.element.classList.add(this.dismissedClass);
     this.dismissedValue = true;
-    updateDismissibles({ [this.idValue]: true });
+    this.patch(event);
+  }
+
+  /**
+   * Send a PATCH request to the server to update the dismissible state for the
+   * given ID and update value.
+   *
+   * @param event - The event that triggered the patch, with optional params.
+   * The param can technically be any value, but we currently only use booleans
+   * and strings.
+   */
+  patch(event?: Event & { params?: { value?: boolean | string } }): void {
+    if (!this.idValue) return;
+    updateDismissibles({
+      [this.idValue]: event?.params?.value ?? this.dismissedValue,
+    });
   }
 }

--- a/client/src/controllers/UpgradeController.test.js
+++ b/client/src/controllers/UpgradeController.test.js
@@ -10,12 +10,12 @@ describe('UpgradeController', () => {
   beforeEach(() => {
     document.body.innerHTML = `
     <div
-      class="panel w-hidden"
+      class="panel"
       id="panel"
       data-controller="w-upgrade"
       data-w-upgrade-current-version-value="${version}"
-      data-w-upgrade-hidden-class="w-hidden"
       data-w-upgrade-url-value="${url}"
+      hidden
     >
       <div class="help-block help-warning">
         Your version: <strong>${version}</strong>.
@@ -30,7 +30,7 @@ describe('UpgradeController', () => {
     application.stop();
   });
 
-  it('should keep the hidden class by default & then show a message when version is out of date', async () => {
+  it('should keep the hidden attribute by default & then show a message when version is out of date', async () => {
     const data = {
       version: '5.15.1',
       url: 'https://docs.wagtail.org/latest/url',
@@ -58,16 +58,12 @@ describe('UpgradeController', () => {
       { referrerPolicy: 'strict-origin-when-cross-origin' },
     );
 
-    expect(
-      document.getElementById('panel').classList.contains('w-hidden'),
-    ).toBe(true);
+    expect(document.getElementById('panel').hidden).toBe(true);
 
     await new Promise(requestAnimationFrame);
 
     // should remove the hidden class on success
-    expect(
-      document.getElementById('panel').classList.contains('w-hidden'),
-    ).toBe(false);
+    expect(document.getElementById('panel').hidden).toBe(false);
 
     // should update the latest version number in the text
     expect(document.getElementById('latest-version').textContent).toBe(
@@ -103,9 +99,7 @@ describe('UpgradeController', () => {
     // trigger next browser render cycle
     await Promise.resolve();
 
-    expect(
-      document.getElementById('panel').classList.contains('w-hidden'),
-    ).toBe(true);
+    expect(document.getElementById('panel').hidden).toBe(true);
   });
 
   it('should throw an error if the fetch fails', async () => {

--- a/client/src/controllers/UpgradeController.test.js
+++ b/client/src/controllers/UpgradeController.test.js
@@ -8,7 +8,7 @@ describe('UpgradeController', () => {
   const version = '2.3';
 
   beforeEach(() => {
-    document.body.innerHTML = `
+    document.body.innerHTML = /* html */ `
     <div
       class="panel"
       id="panel"
@@ -78,7 +78,7 @@ describe('UpgradeController', () => {
 
   it('should not show the message if the current version is up to date', async () => {
     const data = {
-      version: '5.15.1',
+      version: '2.3',
       url: 'https://docs.wagtail.org/latest/url',
       minorUrl: 'https://docs.wagtail.org/latest-minor/url',
       lts: {
@@ -99,6 +99,16 @@ describe('UpgradeController', () => {
     // trigger next browser render cycle
     await Promise.resolve();
 
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://releases.wagtail.org/mock.txt',
+      { referrerPolicy: 'strict-origin-when-cross-origin' },
+    );
+
+    expect(document.getElementById('panel').hidden).toBe(true);
+
+    await new Promise(requestAnimationFrame);
+
+    // should keep the hidden attribute
     expect(document.getElementById('panel').hidden).toBe(true);
   });
 

--- a/client/src/controllers/UpgradeController.ts
+++ b/client/src/controllers/UpgradeController.ts
@@ -20,7 +20,6 @@ import { VersionNumber, VersionDeltaType } from '../utils/version';
  * }
  */
 export class UpgradeController extends Controller<HTMLElement> {
-  static classes = ['hidden'];
   static targets = ['latestVersion', 'link'];
   static values = {
     currentVersion: String,
@@ -29,7 +28,6 @@ export class UpgradeController extends Controller<HTMLElement> {
   };
 
   declare currentVersionValue: string;
-  declare hiddenClass: string;
   declare latestVersionTarget: HTMLElement;
   declare linkTarget: HTMLElement;
   declare ltsOnlyValue: any;
@@ -87,7 +85,7 @@ export class UpgradeController extends Controller<HTMLElement> {
           if (this.linkTarget instanceof HTMLElement) {
             this.linkTarget.setAttribute('href', releaseNotesUrl || '');
           }
-          this.element.classList.remove(this.hiddenClass);
+          this.element.hidden = false;
         }
       })
       .catch((err) => {

--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -25,9 +25,9 @@ This release introduces a new block type [`ImageBlock`](streamfield_imageblock),
 
 ### Incremental dashboard enhancements
 
-The Wagtail dashboard design evolves towards providing more information and navigation features. Mobile support is much improved.
+The Wagtail dashboard design evolves towards providing more information and navigation features. Mobile support is much improved. Upgrade banners are now dismissible.
 
-This feature was developed by Albina Starykova based on designs by Ben Enright.
+This feature was developed by Albina Starykova and Sage Abdullah, based on designs by Ben Enright.
 
 ### Enhanced contrast admin theme
 

--- a/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html
+++ b/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html
@@ -1,10 +1,10 @@
 {% load i18n wagtailcore_tags wagtailadmin_tags %}
 {% wagtail_version as current_version %}
-<div class="w-panel-upgrade w-hidden w-flex w-mb-[-2rem] sm:w-mb-0 w-gap-5 w-items-center w-pl-slim-header w-pr-5 sm:w-px-[3.5rem] w-py-5 w-text-text-context w-bg-surface-info-panel w-border-b w-border-transparent"
+<div class="w-panel-upgrade w-flex w-mb-[-2rem] sm:w-mb-0 w-gap-5 w-items-center w-pl-slim-header w-pr-5 sm:w-px-[3.5rem] w-py-5 w-text-text-context w-bg-surface-info-panel w-border-b w-border-transparent"
      data-controller="w-upgrade"
      data-w-upgrade-current-version-value="{{ current_version }}"
      {% if lts_only %}data-w-upgrade-lts-only-value="true"{% endif %}
-     data-w-upgrade-hidden-class="w-hidden">
+     hidden>
     {% icon name='info-circle' classname='w-w-5 w-h-5 w-shrink-0 w-text-text-link-info w-ml-5 sm:w-ml-0' %}
     <div>
         <p class="w-mb-1"><strong>{% trans "Wagtail upgrade available" %}</strong></p>

--- a/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html
+++ b/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html
@@ -1,9 +1,11 @@
 {% load i18n wagtailcore_tags wagtailadmin_tags %}
 {% wagtail_version as current_version %}
 <div class="w-panel-upgrade w-flex w-mb-[-2rem] sm:w-mb-0 w-gap-5 w-items-center w-pl-slim-header w-pr-5 sm:w-px-[3.5rem] w-py-5 w-text-text-context w-bg-surface-info-panel w-border-b w-border-transparent"
-     data-controller="w-upgrade"
+     data-controller="w-upgrade w-dismissible"
      data-w-upgrade-current-version-value="{{ current_version }}"
      {% if lts_only %}data-w-upgrade-lts-only-value="true"{% endif %}
+     data-w-dismissible-id-value="{{ dismissible_id }}"
+     data-w-dismissible-dismissed-class="w-hidden"
      hidden>
     {% icon name='info-circle' classname='w-w-5 w-h-5 w-shrink-0 w-text-text-link-info w-ml-5 sm:w-ml-0' %}
     <div>
@@ -17,4 +19,21 @@
                class="w-text-text-link-info hover:w-text-text-link-info w-underline w-underline-offset-[3px]">{% trans "Read the release notes." %}</a>
         </p>
     </div>
+
+    <button
+        type="button"
+        data-action="w-dismissible#toggle"
+        {% if dismissible_value %}data-w-dismissible-value-param="{{ dismissible_value }}"{% endif %}
+        data-w-upgrade-target="dismiss"
+        class="w-ml-auto w-flex w-items-center w-justify-center w-bg-transparent w-rounded-full w-p-0 w-w-8 w-h-8
+               w-text-primary
+               w-border
+               w-border-transparent
+               hover:w-text-text-link-hover
+               more-contrast:w-border-border-interactive-more-contrast
+               hover:more-contrast:w-border-border-interactive-more-contrast-hover
+              "
+    >
+        {% icon name="cross" classname="w-w-4 w-h-4" %}
+    </button>
 </div>

--- a/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html
+++ b/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html
@@ -26,7 +26,7 @@
         {% if dismissible_value %}data-w-dismissible-value-param="{{ dismissible_value }}"{% endif %}
         data-w-upgrade-target="dismiss"
         class="w-ml-auto w-flex w-items-center w-justify-center w-bg-transparent w-rounded-full w-p-0 w-w-8 w-h-8
-               w-text-primary
+               w-text-current
                w-border
                w-border-transparent
                hover:w-text-text-link-hover

--- a/wagtail/admin/tests/test_upgrade_notification.py
+++ b/wagtail/admin/tests/test_upgrade_notification.py
@@ -1,12 +1,17 @@
 from django.test import RequestFactory, TestCase, override_settings
 
+from wagtail import __version__
 from wagtail.admin.views.home import UpgradeNotificationPanel
 from wagtail.test.utils import WagtailTestUtils
+from wagtail.users.models import UserProfile
 
 
 class TestUpgradeNotificationPanel(WagtailTestUtils, TestCase):
-    DATA_ATTRIBUTE_UPGRADE_CHECK = "data-w-upgrade"
-    DATA_ATTRIBUTE_UPGRADE_CHECK_LTS = "data-w-upgrade-lts-only"
+    ATTR_UPGRADE_CHECK_LTS = "data-w-upgrade-lts-only-value"
+    ATTR_CURRENT_VERSION = "data-w-upgrade-current-version-value"
+    ATTR_DISMISSIBLE_ID = "data-w-dismissible-id-value"
+    ATTR_LAST_DISMISSED_VALUE = "data-w-dismissible-value-param"
+    DISMISSIBLE_ID = "last_upgrade_check"
 
     @classmethod
     def setUpTestData(cls):
@@ -59,9 +64,21 @@ class TestUpgradeNotificationPanel(WagtailTestUtils, TestCase):
         parent_context = {"request": self.request}
 
         result = self.panel.render_html(parent_context)
-
-        self.assertIn(self.DATA_ATTRIBUTE_UPGRADE_CHECK, result)
-        self.assertNotIn(self.DATA_ATTRIBUTE_UPGRADE_CHECK_LTS, result)
+        soup = self.get_soup(result)
+        controller = soup.select_one("[data-controller]")
+        self.assertIsNotNone(controller)
+        self.assertEqual(
+            set(controller["data-controller"].split()),
+            {"w-upgrade", "w-dismissible"},
+        )
+        self.assertFalse(controller.get(self.ATTR_UPGRADE_CHECK_LTS))
+        self.assertEqual(
+            controller.get(self.ATTR_DISMISSIBLE_ID),
+            self.DISMISSIBLE_ID,
+        )
+        toggle = soup.select_one("[data-action='w-dismissible#toggle']")
+        self.assertIsNotNone(toggle)
+        self.assertIsNone(toggle.get(self.ATTR_LAST_DISMISSED_VALUE))
 
     @override_settings(WAGTAIL_ENABLE_UPDATE_CHECK=False)
     def test_render_html_setting_false(self):
@@ -72,22 +89,58 @@ class TestUpgradeNotificationPanel(WagtailTestUtils, TestCase):
 
         self.assertEqual(result, "")
 
-    @override_settings(WAGTAIL_ENABLE_UPDATE_CHECK="LTS")
-    def test_render_html_setting_LTS(self):
-        self.request.user = self.superuser
-        parent_context = {"request": self.request}
-
-        result = self.panel.render_html(parent_context)
-
-        self.assertIn(self.DATA_ATTRIBUTE_UPGRADE_CHECK, result)
-        self.assertIn(self.DATA_ATTRIBUTE_UPGRADE_CHECK_LTS, result)
-
-    @override_settings(WAGTAIL_ENABLE_UPDATE_CHECK="lts")
     def test_render_html_setting_lts(self):
         self.request.user = self.superuser
         parent_context = {"request": self.request}
+        setting_values = ["lts", "LTS"]
+        for value in setting_values:
+            with self.subTest(setting=value):
+                with override_settings(WAGTAIL_ENABLE_UPDATE_CHECK=value):
+                    result = self.panel.render_html(parent_context)
+
+                soup = self.get_soup(result)
+                controller = soup.select_one("[data-controller]")
+                self.assertIsNotNone(controller)
+                self.assertEqual(
+                    set(controller["data-controller"].split()),
+                    {"w-upgrade", "w-dismissible"},
+                )
+                self.assertEqual(
+                    controller.get(self.ATTR_UPGRADE_CHECK_LTS),
+                    "true",
+                )
+                self.assertEqual(
+                    controller.get(self.ATTR_DISMISSIBLE_ID),
+                    self.DISMISSIBLE_ID,
+                )
+                toggle = soup.select_one("[data-action='w-dismissible#toggle']")
+                self.assertIsNotNone(toggle)
+                self.assertIsNone(toggle.get(self.ATTR_LAST_DISMISSED_VALUE))
+
+    def test_render_html_dismissed_version(self):
+        profile = UserProfile.get_for_user(self.superuser)
+        profile.dismissibles.update({self.DISMISSIBLE_ID: "6.2.2"})
+        profile.save()
+        self.request.user = self.superuser
+        parent_context = {"request": self.request}
 
         result = self.panel.render_html(parent_context)
+        soup = self.get_soup(result)
 
-        self.assertIn(self.DATA_ATTRIBUTE_UPGRADE_CHECK, result)
-        self.assertIn(self.DATA_ATTRIBUTE_UPGRADE_CHECK_LTS, result)
+        controller = soup.select_one("[data-controller='w-upgrade w-dismissible']")
+        self.assertIsNotNone(controller)
+
+        self.assertEqual(
+            controller.get(self.ATTR_DISMISSIBLE_ID),
+            self.DISMISSIBLE_ID,
+        )
+        self.assertEqual(
+            controller.get(self.ATTR_CURRENT_VERSION),
+            __version__,
+        )
+        toggle = soup.select_one("[data-action='w-dismissible#toggle']")
+        self.assertIsNotNone(toggle)
+        self.assertEqual(
+            toggle.get(self.ATTR_LAST_DISMISSED_VALUE),
+            "6.2.2",
+        )

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -36,6 +36,7 @@ User = get_user_model()
 
 class UpgradeNotificationPanel(Component):
     template_name = "wagtailadmin/home/upgrade_notification.html"
+    dismissible_id = "last_upgrade_check"
 
     def get_upgrade_check_setting(self) -> Union[bool, str]:
         return getattr(settings, "WAGTAIL_ENABLE_UPDATE_CHECK", True)
@@ -46,8 +47,19 @@ class UpgradeNotificationPanel(Component):
             return True
         return False
 
+    def get_dismissible_value(self, user) -> str:
+        if profile := getattr(user, "wagtail_userprofile", None):
+            return profile.dismissibles.get(self.dismissible_id)
+        return None
+
     def get_context_data(self, parent_context: Mapping[str, Any]) -> Mapping[str, Any]:
-        return {"lts_only": self.upgrade_check_lts_only()}
+        return {
+            "lts_only": self.upgrade_check_lts_only(),
+            "dismissible_id": self.dismissible_id,
+            "dismissible_value": self.get_dismissible_value(
+                parent_context["request"].user
+            ),
+        }
 
     def render_html(self, parent_context: Mapping[str, Any] = None) -> str:
         if (


### PR DESCRIPTION
Remember the last dismissed version and use that as the basis for comparison to check whether we should show the upgrade banner or not. However, keep using the actual installed version to decide whether to show the minor release notes vs the patch release notes.

## Dismissal demo

https://github.com/user-attachments/assets/1d9a5b2c-0e09-42ea-a35e-4e887e2b3587

## Different themes

https://github.com/user-attachments/assets/942fe2b8-031e-4cac-b4e9-d7be1c8fd8cd

## Testing

To test, you can serve your own `latest.txt` on a local server (e.g. with `npx serve --cors`) and edit it to simulate new Wagtail versions coming out.

Then, either:
- change the URL in `UpgradeController`, or
- add e.g. `data-w-upgrade-url-value="http://localhost:9090/latest.txt"` in the HTML to point to your local URL.

To simulate the installed Wagtail version, you can either:
- edit the version in `wagtail/__init__.py`, or
- change the `current_version` context data in the upgrade panel's Python code, or
- hack the `data-w-upgrade-current-version-value` directly in the HTML

To clear out dismissibles, you can apply the following patch:

```diff
diff --git a/wagtail/admin/views/dismissibles.py b/wagtail/admin/views/dismissibles.py
index ade5129b32..ce41ba2a54 100644
--- a/wagtail/admin/views/dismissibles.py
+++ b/wagtail/admin/views/dismissibles.py
@@ -11,6 +11,8 @@ class DismissiblesView(View):
         # The UserProfile may not exist for the user, in which case return an empty object
         profile = getattr(request.user, "wagtail_userprofile", None)
         dismissibles = profile.dismissibles if profile else {}
+        profile.dismissibles = {}
+        profile.save()
         return JsonResponse(dismissibles)

     def patch(self, request, *args, **kwargs):
```

and just access http://localhost:8000/admin/dismissibles/