### PR TITLE
Change 'Publish' button label to 'Schedule to publish' if go-live schedule is set

### DIFF
--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -87,6 +87,8 @@ class PublishMenuItem(ActionMenuItem):
 
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)
+        page = context.get("page")
+        context["is_scheduled"] = page and page.go_live_at
         context["is_revision"] = context["view"] == "revisions_revert"
         return context
 

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/publish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/publish.html
@@ -6,9 +6,9 @@
     class="button button-longrunning"
     data-controller="w-progress"
     data-action="w-progress#activate"
-    data-w-progress-active-value="{% trans 'Publishing…' %}"
+    data-w-progress-active-value="{% if is_scheduled %}{% trans 'Scheduling…' %}{% else %}{% trans 'Publishing…' %}{% endif %}"
 >
     {% if icon_name %}{% icon name=icon_name classname="button-longrunning__icon" %}{% endif %}
     {% icon name="spinner" %}
-    <em data-w-progress-target="label">{% if is_revision %}{% trans 'Publish this version' %}{% else %}{{ label }}{% endif %}</em>
+    <em data-w-progress-target="label">{% if is_scheduled %}{% trans "Schedule to publish" %}{% elif is_revision %}{% trans 'Publish this version' %}{% else %}{{ label }}{% endif %}</em>
 </button>

--- a/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
@@ -8,7 +8,7 @@
     {% page_permissions instance as page_perms %}
     {% trans 'Choose when this page should go live and/or expire' as schedule_publishing_dialog_subtitle %}
     {% if page_perms.can_publish %}
-        {% trans 'This publishing schedule will only take effect after you select the "Publish" option' as message_heading %}
+        {% trans 'This publishing schedule will only take effect after you select the "Schedule to publish" option' as message_heading %}
     {% else %}
         {% trans "Anyone with editing permissions can create schedules" as message_heading %}
         {% trans "But only those with publishing permissions can make them effective." as message_description %}

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/workflow.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/workflow.html
@@ -143,7 +143,7 @@
                                 <div><span class="w-text-grey-600">{% trans 'Expiry:' %}</span> {{ scheduled_expire_at }}</div>
                             {% endif %}
                             {% if draft_go_live_at or draft_expire_at %}
-                                <div class="w-label-3 w-text-primary">{% trans 'Once published:' %}</div>
+                                <div class="w-label-3 w-text-primary">{% trans 'Once scheduled:' %}</div>
                                 {% if draft_go_live_at %}
                                     <div><span class="w-text-grey-600">{% trans 'Go-live:' %}</span> {{ draft_go_live_at }}</div>
                                 {% endif %}

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -615,10 +615,10 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             ).exists()
         )
 
-        # Should show the draft go_live_at and expire_at under the "Once published" label
+        # Should show the draft go_live_at and expire_at under the "Once scheduled" label
         self.assertContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
             count=1,
         )
@@ -639,7 +639,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
 
         self.assertContains(
             response,
-            'This publishing schedule will only take effect after you select the "Publish" option',
+            'This publishing schedule will only take effect after you select the "Schedule to publish" option',
         )
 
     def test_edit_post_scheduled_custom_timezone(self):
@@ -692,11 +692,11 @@ class TestPageEdit(WagtailTestUtils, TestCase):
                 ).exists()
             )
 
-        # Should show the draft go_live_at under the "Once published" label
+        # Should show the draft go_live_at under the "Once scheduled" label
         # and should be in the user's timezone
         self.assertContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
             count=1,
         )
@@ -719,7 +719,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
 
         self.assertContains(
             response,
-            'This publishing schedule will only take effect after you select the "Publish" option',
+            'This publishing schedule will only take effect after you select the "Schedule to publish" option',
         )
 
     def test_schedule_panel_without_publish_permission(self):
@@ -848,10 +848,10 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         # No new revision should have been created
         self.assertEqual(child_page_new.latest_revision_id, latest_revision.pk)
 
-        # Should not show the draft go_live_at and expire_at under the "Once published" label
+        # Should not show the draft go_live_at and expire_at under the "Once scheduled" label
         self.assertNotContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
         )
         self.assertNotContains(
@@ -1037,10 +1037,10 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             reverse("wagtailadmin_pages:edit", args=(self.child_page.id,)), post_data
         )
 
-        # Should show the go_live_at and expire_at without the "Once published" label
+        # Should show the go_live_at and expire_at without the "Once scheduled" label
         self.assertNotContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
         )
         self.assertContains(
@@ -1201,10 +1201,10 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             reverse("wagtailadmin_pages:edit", args=(self.child_page.id,)), post_data
         )
 
-        # Should show the go_live_at and expire_at without the "Once published" label
+        # Should show the go_live_at and expire_at without the "Once scheduled" label
         self.assertNotContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
         )
         self.assertContains(
@@ -1384,10 +1384,10 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             count=1,
         )
 
-        # Should also show the draft go_live_at and expire_at under the "Once published" label
+        # Should also show the draft go_live_at and expire_at under the "Once scheduled" label
         self.assertContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
             count=1,
         )
@@ -1478,10 +1478,10 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             html=True,
         )
 
-        # Should show the go_live_at and expire_at without the "Once published" label
+        # Should show the go_live_at and expire_at without the "Once scheduled" label
         self.assertNotContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
         )
         self.assertContains(
@@ -1582,10 +1582,10 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             count=1,
         )
 
-        # Should show the go_live_at and expire_at without the "Once published" label
+        # Should show the go_live_at and expire_at without the "Once scheduled" label
         self.assertNotContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
         )
         self.assertContains(

--- a/wagtail/snippets/action_menu.py
+++ b/wagtail/snippets/action_menu.py
@@ -50,6 +50,13 @@ class ActionMenuItem(Component):
         context = parent_context.copy()
         url = self.get_url(parent_context)
 
+        instance = parent_context.get("instance")
+        is_scheduled = (
+            parent_context.get("draftstate_enabled")
+            and instance
+            and instance.go_live_at
+        )
+
         context.update(
             {
                 "label": self.label,
@@ -58,6 +65,7 @@ class ActionMenuItem(Component):
                 "classname": self.classname,
                 "icon_name": self.icon_name,
                 "request": parent_context["request"],
+                "is_scheduled": is_scheduled,
                 "is_revision": parent_context["view"] == "revisions_revert",
             }
         )

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/publish.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/publish.html
@@ -4,13 +4,11 @@
     name="{{ name }}"
     value="{{ name }}"
     class="button action-save button-longrunning"
-    data-controller="w-progress w-kbd"
+    data-controller="w-progress"
     data-action="w-progress#activate"
-    data-w-kbd-key-value="mod+s"
-    data-w-kbd-scope-value="global"
-    data-w-progress-active-value="{% trans 'Publishing…' %}"
+    data-w-progress-active-value="{% if is_scheduled %}{% trans 'Scheduling…' %}{% else %}{% trans 'Publishing…' %}{% endif %}"
 >
     {% icon name=icon_name classname="button-longrunning__icon" %}
     {% icon name="spinner" %}
-    <em data-w-progress-target="label">{% if is_revision %}{% trans 'Publish this version' %}{% else %}{% trans 'Publish' %}{% endif %}</em>
+    <em data-w-progress-target="label">{% if is_scheduled %}{% trans "Schedule to publish" %}{% elif is_revision %}{% trans 'Publish this version' %}{% else %}{% trans 'Publish' %}{% endif %}</em>
 </button>

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -1242,7 +1242,7 @@ class TestCreateDraftStateSnippet(WagtailTestUtils, TestCase):
         # The publish button should have name="action-publish"
         self.assertContains(
             response,
-            '<button\n    type="submit"\n    name="action-publish"\n    value="action-publish"\n    class="button action-save button-longrunning"\n    data-controller="w-progress w-kbd"\n    data-action="w-progress#activate"\n    data-w-kbd-key-value="mod+s"\n',
+            '<button\n    type="submit"\n    name="action-publish"\n    value="action-publish"\n    class="button action-save button-longrunning"\n    data-controller="w-progress"\n    data-action="w-progress#activate"\n',
         )
         # The status side panel should be rendered so that the
         # publishing schedule can be configured
@@ -2181,7 +2181,7 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         # The publish button should have name="action-publish"
         self.assertContains(
             response,
-            '<button\n    type="submit"\n    name="action-publish"\n    value="action-publish"\n    class="button action-save button-longrunning"\n    data-controller="w-progress w-kbd"\n    data-action="w-progress#activate"\n    data-w-kbd-key-value="mod+s"\n',
+            '<button\n    type="submit"\n    name="action-publish"\n    value="action-publish"\n    class="button action-save button-longrunning"\n    data-controller="w-progress"\n    data-action="w-progress#activate"\n',
         )
 
         # The status side panel should show "No publishing schedule set" info
@@ -2752,10 +2752,10 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         # Get the edit page again
         response = self.get()
 
-        # Should show the draft go_live_at and expire_at under the "Once published" label
+        # Should show the draft go_live_at and expire_at under the "Once scheduled" label
         self.assertContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
             count=1,
         )
@@ -2867,10 +2867,10 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         # No new revision should have been created
         self.assertEqual(self.test_snippet.latest_revision_id, latest_revision.pk)
 
-        # Should not show the draft go_live_at and expire_at under the "Once published" label
+        # Should not show the draft go_live_at and expire_at under the "Once scheduled" label
         self.assertNotContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
         )
         self.assertNotContains(
@@ -2975,10 +2975,10 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
 
         response = self.get()
 
-        # Should show the go_live_at and expire_at without the "Once published" label
+        # Should show the go_live_at and expire_at without the "Once scheduled" label
         self.assertNotContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
         )
         self.assertContains(
@@ -3118,10 +3118,10 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
 
         response = self.get()
 
-        # Should show the go_live_at and expire_at without the "Once published" label
+        # Should show the go_live_at and expire_at without the "Once scheduled" label
         self.assertNotContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
         )
         self.assertContains(
@@ -3292,10 +3292,10 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
             count=1,
         )
 
-        # Should also show the draft go_live_at and expire_at under the "Once published" label
+        # Should also show the draft go_live_at and expire_at under the "Once scheduled" label
         self.assertContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
             count=1,
         )
@@ -3389,10 +3389,10 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
             html=True,
         )
 
-        # Should show the go_live_at and expire_at without the "Once published" label
+        # Should show the go_live_at and expire_at without the "Once scheduled" label
         self.assertNotContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
         )
         self.assertContains(
@@ -3488,10 +3488,10 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
             count=1,
         )
 
-        # Should show the go_live_at and expire_at without the "Once published" label
+        # Should show the go_live_at and expire_at without the "Once scheduled" label
         self.assertNotContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
         )
         self.assertContains(
@@ -3544,10 +3544,10 @@ class TestScheduledForPublishLock(BaseTestSnippetEditView):
 
         response = self.get()
 
-        # Should show the go_live_at without the "Once published" label
+        # Should show the go_live_at without the "Once scheduled" label
         self.assertNotContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
         )
 
@@ -3611,10 +3611,10 @@ class TestScheduledForPublishLock(BaseTestSnippetEditView):
 
         response = self.get()
 
-        # Should show the go_live_at without the "Once published" label
+        # Should show the go_live_at without the "Once scheduled" label
         self.assertNotContains(
             response,
-            '<div class="w-label-3 w-text-primary">Once published:</div>',
+            '<div class="w-label-3 w-text-primary">Once scheduled:</div>',
             html=True,
         )
 


### PR DESCRIPTION
I thought this might improve the clarity of how the feature works...

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/6783bda7-5880-49da-9c93-2e6d21cf4126">

I was hoping to address this in #12400, but it turns out we didn't touch the code for the existing page and snippets action menu items that much. We also didn't get to refactor them to be unified, which led to me opening #12422.

We have to duplicate the code between pages and snippets until #12422 is fixed.

I also noticed that for some reason a5f426b3f5c4e17697a5b188483036e9d125e232 added the Ctrl+S attributes to the publish button for snippets too 😨
Fortunately it seems the "Save draft" option takes priority though...

Note that this only works for edit views. For create views, the model instance isn't passed to the action menu item, so we can't check for the `go_live_at` value without further refactoring. Even if that weren't an issue, the scheduling dialog will do a full-page save when you click "Save schedule", so you'll immediately be in the edit view unless the page has validation errors.