### PR TITLE
StaticBlock renders empty in templates

### DIFF
--- a/wagtail/blocks/static_block.py
+++ b/wagtail/blocks/static_block.py
@@ -33,6 +33,9 @@ class StaticBlock(Block):
     def normalize(self, value):
         return None
 
+    def render_basic(self, value, context=None):
+        return ""
+
     class Meta:
         admin_text = None
         default = None

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -5015,6 +5015,11 @@ class TestStaticBlock(unittest.TestCase):
         result = block.render(None)
         self.assertEqual(result, "<p>PostsStaticBlock template</p>")
 
+    def test_render_without_template(self):
+        block = blocks.StaticBlock()
+        result = block.render(None)
+        self.assertEqual(result, "")
+
     def test_serialize(self):
         block = blocks.StaticBlock()
         result = block.get_prep_value(None)


### PR DESCRIPTION
StaticBlocks are used to render blocks that are always the same. They can also be used to create logical partitions in content. If that useage does not require a template, it will render the string "None" in the template. Here is a suggestion to always render an empty string when a template is not configured on the block.

Here is an example of a StaticBlock without a template:
![Screenshot 2024-10-18 at 10 44 09](https://github.com/user-attachments/assets/bc01512f-961e-48c4-b74d-c44783a12191)

And this is how it renders by default in the front end:
![Screenshot 2024-10-18 at 10 44 19](https://github.com/user-attachments/assets/f440bc0c-db36-4b85-a98d-26fde16c628c)

This PR gets rid of that 'None' value in the template if no block template is supplied.
