### PR TITLE
Stop history view from breaking if a log entry's revision is missing

### DIFF
--- a/wagtail/admin/views/generic/history.py
+++ b/wagtail/admin/views/generic/history.py
@@ -165,6 +165,7 @@ class ActionColumn(Column):
 
         if (
             (url_name := self.url_names.get("revisions_unschedule"))
+            and instance.revision
             and instance.revision.approved_go_live_at
             and self.user_can_unschedule
         ):


### PR DESCRIPTION
As [reported on Slack](https://wagtailcms.slack.com/archives/C81FGJR2S/p1729234838263919) - if a revision corresponding to a log entry is missing (which may legitimately happen as a result of running the [purge_revisions](https://docs.wagtail.org/en/stable/reference/management_commands.html#purge-revisions) management command), the page history view errors out with `'NoneType' object has no attribute 'approved_go_live_at'`. This can be replicated on bakerydemo by bringing up a fresh database, running `./manage.py purge_revisions`, then visiting the history view for the homepage.

Fix this by adding a check for `instance.revision` before accessing `instance.revision.approved_go_live_at`.