### PR TITLE
Fix long name issue in document chooser table cell

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -50,6 +50,7 @@ ul.listing {
 
   td {
     vertical-align: middle;
+    overflow-wrap: anywhere;
   }
 
   td.title {


### PR DESCRIPTION
This PR addresses #12357 When there are long filenames (without spaces) for documents, the column widths of the table in the document chooser are stretched (especially when the browser width is narrow) so it is difficult to read the document title.

This solution is following #12390 suggested 

Before:
![image](https://github.com/user-attachments/assets/522cc84a-58d1-45e0-8984-45970bf87826)
Fixed:
![image](https://github.com/user-attachments/assets/c7acbd06-1507-47a1-8b53-7c720c739e4d)
