### PR TITLE
Fixed long filename wrapping issue in document chooser table

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -50,6 +50,7 @@ ul.listing {
 
   td {
     vertical-align: middle;
+    overflow-wrap:anywhere;
   }
 
   td.title {

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -50,7 +50,7 @@ ul.listing {
 
   td {
     vertical-align: middle;
-    overflow-wrap:anywhere;
+    overflow-wrap: anywhere;
   }
 
   td.title {


### PR DESCRIPTION
Refering to #12390 the deprecated code has been fixed with new preferred way as requested.. Works fine
