### PR TITLE
Added missing link to the Code of Conduct in the community guidelines…

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -843,6 +843,7 @@
 * Victoria Ottah
 * Bart Cieliński
 * alexkiro
+* Ankit Kumar
 
 ## Translators
 

--- a/docs/contributing/first_contribution_guide.md
+++ b/docs/contributing/first_contribution_guide.md
@@ -54,7 +54,7 @@ You may also want to join StackOverflow and [follow the Wagtail tag](https://sta
 #### Checklist
 
 ```markdown
--   [ ] Read the community guidelines
+-   [ ] Read the [community guidelines](https://github.com/wagtail/wagtail/blob/main/CODE_OF_CONDUCT.md)
 -   [ ] Join GitHub
 -   [ ] Add your preferred name and image to your GitHub profile
 -   [ ] Join Slack


### PR DESCRIPTION
Added a direct link to the Code of Conduct in the relevant markdown file to enhance clarity for users. This update ensures that readers can easily locate and reference the community guidelines, which were previously ambiguous.
