### PR TITLE
Fix max_num, display selection counter and enable bulk removal of selections for multipleChooserPanel!

### DIFF
--- a/client/src/components/ChooserWidget/index.js
+++ b/client/src/components/ChooserWidget/index.js
@@ -207,6 +207,7 @@ export class ChooserFactory {
       this.modal = new this.chooserModalClass(this.opts.modalUrl);
     }
     const options = { ...this.getModalOptions(), ...customOptions };
+    console.log('chooser open modal', options);
     this.modal.open(options, callback);
   }
 

--- a/client/src/components/MultipleChooserPanel/index.js
+++ b/client/src/components/MultipleChooserPanel/index.js
@@ -14,7 +14,29 @@ export class MultipleChooserPanel extends InlinePanel {
     const openModalButton = document.getElementById(
       `${opts.formsetPrefix}-OPEN_MODAL`,
     );
+    console.log('THIS THING ON???', opts, openModalButton);
+
     openModalButton.addEventListener('click', () => {
+      // console.log('OPEN MODAL BUTTON CLICKED', { ...opts });
+      // need to get the TOTAL_FORMS, INITIAL_FORMS, and MAX_NUM_FORMS from the formset
+
+      const maxForms = opts.maxForms;
+      const totalForms = Number(
+        document.getElementById(`${opts.formsetPrefix}-TOTAL_FORMS`)?.value ||
+          0,
+      );
+      // const maxMultiple = maxForms ? maxForms - totalForms : true;
+
+      console.log(
+        'OPEN MODAL BUTTON CLICKED',
+        { ...opts },
+        {
+          maxForms,
+          totalForms,
+          // maxMultiple,
+        },
+      );
+
       this.chooserWidgetFactory.openModal(
         (result) => {
           result.forEach((item) => {
@@ -25,10 +47,17 @@ export class MultipleChooserPanel extends InlinePanel {
             const chooserFieldId = `${formPrefix}-${opts.chooserFieldName}`;
             const chooserWidget =
               this.chooserWidgetFactory.getById(chooserFieldId);
+            // THIS RUNS AFTER SELECTION!!@##!@
+            console.log('multi-chooser-panel', {
+              item,
+              chooserWidget,
+              opts,
+              count: this.getChildCount(),
+            });
             chooserWidget.setStateFromModalData(item);
           });
         },
-        { multiple: true },
+        { available: maxForms - totalForms, multiple: maxForms },
       );
     });
   }

--- a/client/src/controllers/BulkController.ts
+++ b/client/src/controllers/BulkController.ts
@@ -21,8 +21,8 @@ type ToggleAllOptions = ToggleOptions & {
  *     <input type="checkbox" data-action="w-bulk#toggle" data-w-bulk-target="item">
  *     <input type="checkbox" data-action="w-bulk#toggle" data-w-bulk-target="item">
  *   </div>
- *   <button data-action="w-bulk#toggleAll" data-w-bulk-force-param="false">Clear all</button>
- *   <button data-action="w-bulk#toggleAll" data-w-bulk-force-param="true">Select all</button>
+ *   <button type="button" data-action="w-bulk#toggleAll" data-w-bulk-force-param="false">Clear all</button>
+ *   <button type="button" data-action="w-bulk#toggleAll" data-w-bulk-force-param="true">Select all</button>
  * </div>
  *
  * @example - Showing and hiding an actions container

--- a/client/src/controllers/CountController.test.js
+++ b/client/src/controllers/CountController.test.js
@@ -10,7 +10,7 @@ describe('CountController', () => {
 
       document.body.innerHTML = `
   <section>
-    <div id="element" data-controller="w-count" data-action="recount@document->w-count#count">
+    <div id="element" data-controller="w-count" data-action="recount@document->w-count#count" data-w-count-container-value="body">
       <span id="total" data-w-count-target="total"></span>
       <span id="label" data-w-count-target="label"></span>
     </div>
@@ -78,6 +78,50 @@ describe('CountController', () => {
       await Promise.resolve();
 
       expect(document.getElementById('label').innerHTML).toEqual('4 items');
+    });
+  });
+
+  describe('finding elements with the controlled element', () => {
+    beforeAll(() => {
+      application?.stop();
+
+      document.body.innerHTML = `
+    <section>
+      <form
+        data-controller="w-count"
+        data-action="change->w-count#count"
+        data-w-count-active-class="active"
+        data-w-count-find-value="*:checked"
+        data-w-count-min-value="1"
+      >
+        <input type="checkbox" name="opt" value="A" />
+        <input type="checkbox" name="opt" value="B" checked="" />
+        <input type="checkbox" name="opt" value="C" checked="" />
+      </form>
+    </section>`;
+
+      application = Application.start();
+      application.register('w-count', CountController);
+    });
+
+    it('should count the items if present & set the class', async () => {
+      expect(document.querySelector('form').classList.contains('active')).toBe(
+        true,
+      );
+    });
+
+    it('should remove the class when count is less than or equal to min value', async () => {
+      document.querySelector('input[value="B"]').removeAttribute('checked');
+
+      document
+        .querySelector('form')
+        .dispatchEvent(new CustomEvent('change', { bubbles: true }));
+
+      await Promise.resolve();
+
+      expect(document.querySelector('form').classList.contains('active')).toBe(
+        false,
+      );
     });
   });
 

--- a/client/src/controllers/CountController.ts
+++ b/client/src/controllers/CountController.ts
@@ -5,35 +5,51 @@ const DEFAULT_ERROR_SELECTOR = '.error-message,.help-critical';
 
 /**
  * Adds the ability for a controlled element to update the total count
- * of selected elements within the provided container selector, defaults
- * to `body.`
+ * of selected elements (via the `find` selector) within the provided
+ * container (via a selector or defaulting to the controlled element).
  *
- * @example
- * <div data-controller="w-count">
- *  <span data-w-count-target="label"></span>
- *  <span class="error-message">An error</span>
- * </div>
+ * @example - Finding all error messages within the body
+ * ```html
+ * <section>
+ *   <div data-controller="w-count" data-w-count-container-value="body">
+ *    <span data-w-count-target="label"></span>
+ *    <span class="error-message">An error</span>
+ *   </div>
+ *   <div class="error-message">Another error</div>
+ * </section>
+ * ```
+ *
+ * @example - Change a class when the total is above the provided minimum in the controlled element
+ * ```html
+ * <form data-controller="w-count" data-w-count-min-value="1" data-w-count-active-class="active" data-w-count-find-value="*:checked">
+ *   <input type="checkbox" name="opt" value="A" />
+ *   <input type="checkbox" name="opt" value="B" checked="" />
+ *   <input type="checkbox" name="opt" value="C" checked="" />
+ * </form>
+ * ```
  */
 export class CountController extends Controller<HTMLFormElement> {
   static classes = ['active'];
+
   static targets = ['label', 'total'];
+
   static values = {
-    container: { default: 'body', type: String },
+    container: { default: '', type: String },
     find: { default: DEFAULT_ERROR_SELECTOR, type: String },
     labels: { default: [], type: Array },
     min: { default: 0, type: Number },
     total: { default: 0, type: Number },
   };
 
-  /** selector string, used to determine the container/s to search through */
+  /** Selector string, used to determine the container/s to search through. If not provided will use the controller's element. */
   declare containerValue: string;
-  /** selector string, used to find the elements to count within the container */
+  /** Selector string, used to find the elements to count within the container. */
   declare findValue: string;
-  /** override pluralisation strings, e.g. `data-w-count-labels-value='["One item","Many items"]'` */
+  /** Override pluralisation strings, e.g. `data-w-count-labels-value='["One item","Many items"]'`. */
   declare labelsValue: string[];
-  /** minimum value, anything equal or below will trigger blank labels in the UI */
+  /** Minimum value, anything equal or below will trigger blank labels in the UI. */
   declare minValue: number;
-  /** total current count of found elements */
+  /** Total current count of found elements. */
   declare totalValue: number;
 
   declare readonly activeClass: string;
@@ -48,9 +64,13 @@ export class CountController extends Controller<HTMLFormElement> {
   }
 
   count() {
-    this.totalValue = [
-      ...document.querySelectorAll(this.containerValue || 'body'),
-    ]
+    const containerSelector = this.containerValue;
+
+    const containers = containerSelector
+      ? [...document.querySelectorAll(containerSelector)]
+      : [this.element];
+
+    this.totalValue = containers
       .map((element) => element.querySelectorAll(this.findValue).length)
       .reduce((total, subTotal) => total + subTotal, 0);
 

--- a/client/src/entrypoints/admin/modal-workflow.js
+++ b/client/src/entrypoints/admin/modal-workflow.js
@@ -1,29 +1,29 @@
-/* A framework for modal popups that are loaded via AJAX, allowing navigation to other
-subpages to happen within the lightbox, and returning a response to the calling page,
-possibly after several navigation steps
-*/
-
 import $ from 'jquery';
 
 import { noop } from '../../utils/noop';
 import { gettext } from '../../utils/gettext';
 
-/* eslint-disable */
+/**
+ * ModalWorkflow - A framework for modal popups that are loaded via AJAX.
+ *
+ * @description
+ * Allows navigation to other subpages to happen within the modal.
+ * Supports returning a response to the calling page, which may happen after several navigation steps.
+ *
+ * @param {object} opts
+ * @param {string} opts.url - A URL to the view that will be loaded into the dialog.
+ *   If not provided and `dialogId` is given, the dialog component's `data-url` attribute is used instead.
+ * @param {string=} opts.dialogId - The id of the dialog component to use instead of the Bootstrap modal.
+ * @param {Object.<string, function>=} opts.responses - A object of callbacks to be called when the modal content calls `modal.respond(callbackName, params)`
+ * @param {Object.<string, function>=} opts.onload - A object of callbacks to be called when loading a step of the workflow.
+ *   The 'step' field in the response identifies the callback to call, passing it the
+ *   modal object and response data as arguments.
+ * @param {HTMLElement=} opts.triggerElement - Element that triggered the modal.
+ *   It will be disabled while the modal is shown.
+ *   If not provided, defaults to `document.activeElement` (which may not work as expected in Safari).
+ * @returns {object}
+ */
 function ModalWorkflow(opts) {
-  /* options passed in 'opts':
-    'url' (required): URL to the view that will be loaded into the dialog.
-      If not provided and dialogId is given, the dialog component's data-url attribute is used instead.
-    'dialogId' (optional): the id of the dialog component to use instead of the Bootstrap modal
-    'responses' (optional): dict of callbacks to be called when the modal content
-      calls modal.respond(callbackName, params)
-    'onload' (optional): dict of callbacks to be called when loading a step of the workflow.
-      The 'step' field in the response identifies the callback to call, passing it the
-      modal object and response data as arguments
-    'triggerElement' (optional): element that triggered the modal.
-      It will be disabled while the modal is shown.
-      If not provided, defaults to `document.activeElement` (which may not work as expected in Safari).
-  */
-
   const self = {};
   const responseCallbacks = opts.responses || {};
   const errorCallback = opts.onError || noop;
@@ -73,7 +73,7 @@ function ModalWorkflow(opts) {
     });
 
     // add listener - once modal is fully hidden (closed & css transitions end) - re-focus on trigger and remove from DOM
-    self.container.on('hidden.bs.modal', function () {
+    self.container.on('hidden.bs.modal', () => {
       self.triggerElement.focus();
       self.container.remove();
     });
@@ -82,24 +82,24 @@ function ModalWorkflow(opts) {
     self.body = self.container.find('.modal-body');
   }
 
-  self.loadUrl = function (url, urlParams) {
+  self.loadUrl = function loadUrl(url, urlParams) {
     $.get(url, urlParams, self.loadResponseText, 'text').fail(errorCallback);
   };
 
-  self.postForm = function (url, formData) {
+  self.postForm = function postForm(url, formData) {
     $.post(url, formData, self.loadResponseText, 'text').fail(errorCallback);
   };
 
-  self.ajaxifyForm = function (formSelector) {
-    $(formSelector).each(function () {
+  self.ajaxifyForm = function ajaxifyForm(formSelector) {
+    $(formSelector).each(() => {
       const action = this.action;
       if (this.method.toLowerCase() === 'get') {
-        $(this).on('submit', function () {
+        $(this).on('submit', () => {
           self.loadUrl(action, $(this).serialize());
           return false;
         });
       } else {
-        $(this).on('submit', function () {
+        $(this).on('submit', () => {
           self.postForm(action, $(this).serialize());
           return false;
         });
@@ -107,12 +107,12 @@ function ModalWorkflow(opts) {
     });
   };
 
-  self.loadResponseText = function (responseText) {
+  self.loadResponseText = function loadResponseText(responseText) {
     const response = JSON.parse(responseText);
     self.loadBody(response);
   };
 
-  self.loadBody = function (response) {
+  self.loadBody = function loadBody(response) {
     if (response.html) {
       // if response contains an 'html' item, replace modal body with it
       if (useDialog) {
@@ -130,14 +130,14 @@ function ModalWorkflow(opts) {
     }
   };
 
-  self.respond = function (responseType) {
+  self.respond = function handleResponse(responseType) {
     if (responseType in responseCallbacks) {
-      const args = Array.prototype.slice.call(arguments, 1);
+      const args = Array.prototype.slice.call(arguments, 1); // eslint-disable-line prefer-rest-params
       responseCallbacks[responseType].apply(self, args);
     }
   };
 
-  self.close = function () {
+  self.close = function handleClose() {
     if (useDialog) {
       self.dialog.dispatchEvent(new CustomEvent('w-dialog:hide'));
     } else {
@@ -149,4 +149,5 @@ function ModalWorkflow(opts) {
 
   return self;
 }
+
 window.ModalWorkflow = ModalWorkflow;

--- a/client/src/entrypoints/admin/modal-workflow.js
+++ b/client/src/entrypoints/admin/modal-workflow.js
@@ -29,6 +29,8 @@ function ModalWorkflow(opts) {
   const errorCallback = opts.onError || noop;
   const useDialog = !!opts.dialogId;
 
+  console.info('ModalWorkflow', opts);
+
   if (useDialog) {
     self.dialog = document.getElementById(opts.dialogId);
     self.url = opts.url || self.dialog.dataset.url;

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -347,7 +347,9 @@ class ChooserModal {
   getURLParams(opts) {
     const urlParams = {};
     if (opts.multiple) {
-      urlParams.multiple = 1;
+      // allow passing of maximum multiple selection, falling back to a large number if any other truthy value is passed
+      urlParams.multiple =
+        typeof opts.multiple === 'number' ? opts.multiple : 9999;
     }
     if (opts.linkedFieldFilters) {
       Object.assign(urlParams, opts.linkedFieldFilters);
@@ -356,6 +358,7 @@ class ChooserModal {
   }
 
   open(opts, callback) {
+    console.log('chooserModal open', opts);
     // eslint-disable-next-line no-undef
     ModalWorkflow({
       url: this.getURL(opts || {}),

--- a/wagtail/admin/templates/wagtailadmin/chooser/browse.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/browse.html
@@ -22,7 +22,12 @@
     {% endif %}
 
     {% if is_multiple_choice %}
-        <form action="{% url 'wagtailadmin_choose_page_chosen_multiple' %}" method="GET" data-multiple-choice-form>
+        <form
+            action="{% url 'wagtailadmin_choose_page_chosen_multiple' %}"
+            method="GET"
+            data-controller="w-bulk"
+            data-multiple-choice-form
+        >
 
             <div class="page-results">
                 {% include 'wagtailadmin/chooser/_browse_results.html' %}

--- a/wagtail/admin/templates/wagtailadmin/chooser/tables/page_checkbox_select_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/tables/page_checkbox_select_cell.html
@@ -1,4 +1,4 @@
 {% load i18n l10n %}
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
-    <input type="checkbox" id="chooser-modal-select-{{ value|unlocalize }}" data-multiple-choice-select name="id" value="{{ value|unlocalize }}" {% if not instance.can_choose %}disabled{% endif %} title="{% blocktrans trimmed with title=instance %}Select {{ title }}{% endblocktrans %}">
+    <input type="checkbox" id="chooser-modal-select-{{ value|unlocalize }}" name="id" value="{{ value|unlocalize }}" {% if not instance.can_choose %}disabled{% endif %} title="{% blocktrans trimmed with title=instance %}Select {{ title }}{% endblocktrans %}"  data-multiple-choice-select data-action="w-bulk#toggle" data-w-bulk-target="item">
 </td>

--- a/wagtail/admin/templates/wagtailadmin/generic/chooser/checkbox_select_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/chooser/checkbox_select_cell.html
@@ -1,4 +1,4 @@
 {% load i18n l10n %}
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
-    <input type="checkbox" id="chooser-modal-select-{{ value|unlocalize }}" data-multiple-choice-select name="id" value="{{ value|unlocalize }}" title="{% blocktrans trimmed with title=instance %}Select {{ title }}{% endblocktrans %}">
+    <input type="checkbox" id="chooser-modal-select-{{ value|unlocalize }}" name="id" value="{{ value|unlocalize }}" title="{% blocktrans trimmed with title=instance %}Select {{ title }}{% endblocktrans %}"  data-multiple-choice-select data-action="w-bulk#toggle" data-w-bulk-target="item">
 </td>

--- a/wagtail/admin/templates/wagtailadmin/generic/chooser/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/chooser/chooser.html
@@ -31,6 +31,7 @@
             {% block filter_form %}
                 {% if filter_form.fields %}
                     <form data-chooser-modal-search action="{{ results_url }}" method="GET" novalidate>
+                        {% comment %} HERE {% endcomment %}
                         {% for field in filter_form.hidden_fields %}{{ field }}{% endfor %}
 
                         {% if filter_form.visible_fields %}

--- a/wagtail/admin/templates/wagtailadmin/generic/chooser/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/chooser/chooser.html
@@ -45,13 +45,40 @@
             {% endblock %}
 
             {% if is_multiple_choice %}
-                <form action="{{ chosen_multiple_url }}" method="GET" data-multiple-choice-form>
+                <form
+                    action="{{ chosen_multiple_url }}"
+                    method="GET"
+                    data-controller="w-bulk"
+                    data-multiple-choice-form
+                >
+                    <div class="help-block help-info">
+                        {% icon name='help' %}
+                        {% comment %} get number correctly passed into translations, maybe just use trans {% endcomment %}
+                        <p>
+                            {% blocktrans with max=3 %}This is {{ max }} by {{ max }}{% endblocktrans %}
+                            {% blocktrans trimmed %}
+                            <p>An overall total of <data value="3">three</data> items can be selected.</p>
+                            <p>Select up to <data value="2">two</data> additional items from the choices below.</p>
+                            {% endblocktrans %}
+                        </p>
+                    </div>
 
                     <div id="search-results" class="listing">
                         {% include view.results_template_name %}
                     </div>
 
-                    <input type="submit" data-multiple-choice-submit value="{% trans 'Confirm selection' %}" class="button" />
+                    <input class="button" type="submit" data-multiple-choice-submit value="{% trans 'Confirm selection' %}" />
+                    <button class="button button-secondary" type="button" data-action="w-bulk#toggleAll" data-w-bulk-force-param="false">{% trans 'Clear selection' %}</button>
+
+                    <div class="help-block help-warning">
+                        {% icon name='warning' %}
+                        {% comment %} make this show only when over the threshold {% endcomment %}
+                        <p>
+                            {% blocktrans trimmed %}
+                            <p>Too many items selected, these will not be applied upon confirming selection.</p>
+                            {% endblocktrans %}
+                        </p>
+                    </div>
                 </form>
             {% else %}
                 <div id="search-results" class="listing">

--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -1,6 +1,6 @@
 import re
 import urllib.parse
-
+from pprint import pprint
 from django.conf import settings
 from django.contrib.admin.utils import quote, unquote
 from django.core.exceptions import (
@@ -203,6 +203,7 @@ class BaseChooseView(
 
     @cached_property
     def is_multiple_choice(self):
+        # add a maximum param?
         return self.request.GET.get("multiple")
 
     @property
@@ -267,6 +268,10 @@ class BaseChooseView(
         # For result pagination links, we need a version of results_url with parameters removed,
         # so that the pagination include can append its own parameters via the {% querystring %} template tag
         results_pagination_url = re.sub(r"\?.*$", "", results_url)
+
+        print("chooser", pprint(vars(self)))
+        print("chooser:context", context)
+        # I want to get the maximum number of items that can be selected
 
         context.update(
             {

--- a/wagtail/images/templates/wagtailimages/chooser/results.html
+++ b/wagtail/images/templates/wagtailimages/chooser/results.html
@@ -11,7 +11,7 @@
                     <label title="Select {% if collections %}{{ image.collection.name }} » {% endif %}{{ image.title }}">
                         <div class="image">{% image image max-165x165 class="show-transparency" %}</div>
                         <h3>
-                            <input type="checkbox" data-multiple-choice-select name="id" value="{{ image.id }}" title="{% blocktrans trimmed with title=image.title %}Select {{ title }}{% endblocktrans %}">
+                            <input type="checkbox" name="id" value="{{ image.id }}" title="{% blocktrans trimmed with title=image.title %}Select {{ title }}{% endblocktrans %}" data-multiple-choice-select data-action="w-bulk#toggle" data-w-bulk-target="item">
                             {{ image.title|ellipsistrim:60 }}
                         </h3>
                     </label>


### PR DESCRIPTION
Fixes #11561

This PR based on this PR #11738 and these [commits](https://github.com/lb-/wagtail/commits/wip/11561-multiple-chooser-panel-ideas/) from @lb-!
The implementation of this PR based on https://github.com/wagtail/wagtail/pull/11738#issuecomment-2326058293:
> then there are two issues:
> 
> * the submitted or previous forms count as I said, and find a solution to this issue, just by calculating it and attached it as an attribute to **openModalButton** (Not Recommended as @ gasman mentioned in my other PR), the second solution is to send it ( count of previous forms) to the server side. as I did in my other PR.
> * we will need to modify **w-count**, or make another logic as it does not count the dynamic selection, the count of it is always zero in this case as I test it

This PR solves this issue by:
- if the user doesn't pass **max_num** then message that contains a counter for max_ num, selected items, and remaining items.
- but if the user exceeds the **max_num** then a warning with over maximum items.
- Additionally, This PR enables a bulk removal of multiple selections by adding a button to clear the current selection. 
- Additionally, This PR allows **w-count** controller to work on dynamic elements.

as show below:

![record](https://github.com/user-attachments/assets/e619927d-10a7-4e79-b000-940e2c14b94e)
