### PR TITLE
Improve Documentation for Report Creation, Including Non-Page Models

### DIFF
--- a/docs/extending/adding_reports.md
+++ b/docs/extending/adding_reports.md
@@ -2,12 +2,16 @@
 
 # Adding reports
 
-Reports are views with listings of pages matching a specific query. They can also export these listings in spreadsheet format.
+Reports are views with listings of pages or any non-page model (such as snippets) matching a specific query. Reports can also export these listings in spreadsheet format.
 They are found in the _Reports_ submenu: by default, the _Locked pages_ report is provided, allowing an overview of locked pages on the site.
 
-It is possible to create your own custom reports in the Wagtail admin. Two base classes are provided:
-`wagtail.admin.views.reports.ReportView`, which provides basic listing and spreadsheet export functionality, and
-`wagtail.admin.views.reports.PageReportView`, which additionally provides a default set of fields suitable for page listings.
+It is possible to create your own custom reports in the Wagtail admin with two base classes provided:
+
+-  `wagtail.admin.views.reports.ReportView` - Provides the basic listing and spreadsheet export functionality without any pre-determined fields.
+-  `wagtail.admin.views.reports.PageReportView` - Extends the `ReportView` and provides a default set of fields suitable for page listings.
+
+## Example report for pages with unpublished changes
+
 For this example, we'll add a report which shows any pages with unpublished changes.
 We will register this view using the `unpublished_changes_report` name for the URL pattern.
 
@@ -15,12 +19,10 @@ We will register this view using the `unpublished_changes_report` name for the U
 # <project>/views.py
 from wagtail.admin.views.reports import PageReportView
 
-
 class UnpublishedChangesReportView(PageReportView):
     index_url_name = "unpublished_changes_report"
     index_results_url_name = "unpublished_changes_report_results"
 ```
-
 ## Defining your report
 
 The most important attributes and methods to customize to define your report are:

--- a/docs/extending/adding_reports.md
+++ b/docs/extending/adding_reports.md
@@ -39,7 +39,7 @@ class UnpublishedChangesReportView(PageReportView):
     index_url_name = "unpublished_changes_report"
     index_results_url_name = "unpublished_changes_report_results"
 ```
-## Defining your report
+### Defining your report
 
 The most important attributes and methods to customize to define your report are:
 
@@ -47,7 +47,7 @@ The most important attributes and methods to customize to define your report are
 .. method:: get_queryset(self)
 ```
 
-This retrieves the queryset of pages for your report. For our example:
+This retrieves the queryset of pages for your report, including both page models and non-page models.
 
 ```python
 # <project>/views.py
@@ -128,7 +128,7 @@ The name of the URL pattern registered for the results view (the report view wit
 
 ```
 
-## Spreadsheet exports
+### Spreadsheet exports
 
 ```{eval-rst}
 
@@ -175,7 +175,7 @@ preprocessing, set the preprocessing_function to ``None``.
 
 ```
 
-## Customizing templates
+### Customizing templates
 
 For this example \"pages with unpublished changes\" report, we'll add an extra column to the listing template, showing the last publication date for each page. To do this, we'll extend two templates: `wagtailadmin/reports/base_page_report_results.html`, and `wagtailadmin/reports/listing/_list_page_report.html`.
 
@@ -215,7 +215,7 @@ Extending `wagtailadmin/reports/base_page_report.html` was changed in favor of e
 
 Finally, we'll set `UnpublishedChangesReportView.results_template_name` to this new template: `'reports/unpublished_changes_report_results.html'`.
 
-## Adding a menu item and admin URL
+### Adding a menu item and admin URL
 
 To add a menu item for your new report to the _Reports_ submenu, you will need to use the `register_reports_menu_item` hook (see: [Register Reports Menu Item](register_reports_menu_item)). To add an admin url for the report, you will need to use the `register_admin_urls` hook (see: [Register Admin URLs](register_admin_urls)). This can be done as follows:
 
@@ -244,7 +244,7 @@ def register_unpublished_changes_report_url():
 
 Here, we use the `AdminOnlyMenuItem` class to ensure our report icon is only shown to superusers. To make the report visible to all users, you could replace this with `MenuItem`.
 
-## Setting up permission restriction
+### Setting up permission restriction
 
 Even with the menu item hidden, it would still be possible for any user to visit the report's URL directly, and so it is necessary to set up a permission restriction on the report view itself. This can be done by adding a `dispatch` method to the existing `UnpublishedChangesReportView` view:
 
@@ -257,7 +257,7 @@ Even with the menu item hidden, it would still be possible for any user to visit
         return super().dispatch(request, *args, **kwargs)
 ```
 
-## The full code
+### The full code
 
 ```python
 # <project>/views.py

--- a/docs/extending/adding_reports.md
+++ b/docs/extending/adding_reports.md
@@ -10,6 +10,22 @@ It is possible to create your own custom reports in the Wagtail admin with two b
 -  `wagtail.admin.views.reports.ReportView` - Provides the basic listing and spreadsheet export functionality without any pre-determined fields.
 -  `wagtail.admin.views.reports.PageReportView` - Extends the `ReportView` and provides a default set of fields suitable for page listings.
 
+## Reporting reference
+
+```{eval-rst}
+.. attribute:: template_name
+...
+.. attribute:: results_template_name
+...
+.. attribute:: page_title
+...
+.. attribute:: header_icon
+...
+.. attribute:: index_url_name
+...
+.. attribute:: index_results_url_name
+```
+
 ## Example report for pages with unpublished changes
 
 For this example, we'll add a report which shows any pages with unpublished changes.


### PR DESCRIPTION
**Problem:**

This PR addresses the lack of documentation for creating reports for snippets and non-page models in Wagtail. The existing documentation primarily focuses on generating reports for pages, leaving a gap for developers looking to implement reports for other model types.

**Issue Number:**

This PR fixes https://github.com/wagtail/wagtail/issues/12428.

**Changes Made:**

- Updated the introduction to clarify that reports can be created for both page and non-page models.
- Moved the reporting reference section to precede the example code for better organization.
- Improved the heading structure to differentiate between page-specific examples and general report information.

**Motivation:**

The aim of these changes is to assist developers in understanding how to create custom reports beyond just pages, facilitating a more versatile use of the Wagtail reporting system.

**Related Documentation:**

- Wagtail documentation on [adding reports](https://docs.wagtail.org/en/stable/extending/adding_reports.html)
- Reference to the GitHub issue for context and discussion.