### PR TITLE
Frontend cache: Fix n+1 query issues when batch purging page urls

### DIFF
--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -480,14 +480,43 @@ class TestCachePurgingFunctions(TestCase):
             PURGED_URLS, {"http://localhost/events/", "http://localhost/events/past/"}
         )
 
+    def test_purge_page_from_cache_with_shared_site_cache_target(self):
+        site_cache_target = object()
+        page = EventIndex.objects.get(url_path="/home/events/")
+
+        # Ensure site root paths are already cached, which should result in
+        # zero additional queries being incurred by this test
+        page._get_relevant_site_root_paths(site_cache_target)
+
+        with self.assertNumQueries(0):
+            for _i in range(4):
+                purge_page_from_cache(page, site_cache_target=site_cache_target)
+                self.assertEqual(
+                    PURGED_URLS,
+                    {"http://localhost/events/", "http://localhost/events/past/"},
+                )
+                PURGED_URLS.clear()
+
     def test_purge_pages_from_cache(self):
         pages = list(Page.objects.all().type(EventPage))
-        # For each page, a query is made to fetch the specific instance,
-        # and another is made to fetch site root paths
         with self.captureOnCommitCallbacks(execute=True):
-            with self.assertNumQueries(len(pages) * 2):
+            with self.assertNumQueries(1):
                 purge_pages_from_cache(pages)
         self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)
+
+    def test_purge_pages_from_cache_with_shared_site_cache_target(self):
+        site_cache_target = object()
+        pages = list(Page.objects.all().type(EventPage))
+
+        # Ensure site root paths are already cached, which should result in
+        # zero additional queries being incurred by this test
+        pages[1]._get_relevant_site_root_paths(site_cache_target)
+
+        with self.assertNumQueries(0):
+            for _i in range(4):
+                purge_pages_from_cache(pages, site_cache_target=site_cache_target)
+                self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)
+                PURGED_URLS.clear()
 
     def test_purge_batch(self):
         with self.captureOnCommitCallbacks(execute=True):
@@ -509,13 +538,27 @@ class TestCachePurgingFunctions(TestCase):
     def test_purge_batch_with_multiple_pages(self):
         batch = PurgeBatch()
         pages = list(Page.objects.all().type(EventPage))
-        # For each page, a query is made to fetch the specific instance,
-        # and another is made to fetch site root paths
-        with self.assertNumQueries(len(pages) * 2):
+        with self.assertNumQueries(1):
             batch.add_pages(pages)
         batch.purge()
 
         self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)
+
+    def test_multiple_purge_batches_with_shared_site_cache_target(self):
+        site_cache_target = object()
+        pages = list(Page.objects.all().type(EventPage))
+
+        # Ensure site root paths are already cached, which should result in
+        # zero additional queries being incurred by this test
+        pages[1]._get_relevant_site_root_paths(site_cache_target)
+
+        with self.assertNumQueries(0):
+            for _i in range(4):
+                batch = PurgeBatch(site_cache_target=site_cache_target)
+                batch.add_pages(pages)
+                batch.purge()
+                self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)
+                PURGED_URLS.clear()
 
     @override_settings(
         WAGTAILFRONTENDCACHE={

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -18,7 +18,7 @@ from wagtail.contrib.frontend_cache.backends import (
 )
 from wagtail.contrib.frontend_cache.utils import get_backends
 from wagtail.models import Page
-from wagtail.test.testapp.models import EventIndex
+from wagtail.test.testapp.models import EventIndex, EventPage
 from wagtail.utils.deprecation import RemovedInWagtail70Warning
 
 from .utils import (
@@ -28,6 +28,16 @@ from .utils import (
     purge_url_from_cache,
     purge_urls_from_cache,
 )
+
+EVENTPAGE_URLS = {
+    "http://localhost/events/final-event/",
+    "http://localhost/events/christmas/",
+    "http://localhost/events/saint-patrick/",
+    "http://localhost/events/tentative-unpublished-event/",
+    "http://localhost/events/someone-elses-event/",
+    "http://localhost/events/tentative-unpublished-event/",
+    "http://localhost/secret-plans/steal-underpants/",
+}
 
 
 class TestBackendConfiguration(SimpleTestCase):
@@ -438,7 +448,12 @@ class MockCloudflareBackend(CloudflareBackend):
         "varnish": {
             "BACKEND": "wagtail.contrib.frontend_cache.tests.MockBackend",
         },
-    }
+    },
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        }
+    },
 )
 class TestCachePurgingFunctions(TestCase):
     fixtures = ["test.json"]
@@ -459,17 +474,20 @@ class TestCachePurgingFunctions(TestCase):
     def test_purge_page_from_cache(self):
         with self.captureOnCommitCallbacks(execute=True):
             page = EventIndex.objects.get(url_path="/home/events/")
+        with self.assertNumQueries(1):
             purge_page_from_cache(page)
         self.assertEqual(
             PURGED_URLS, {"http://localhost/events/", "http://localhost/events/past/"}
         )
 
     def test_purge_pages_from_cache(self):
+        pages = list(Page.objects.all().type(EventPage))
+        # For each page, a query is made to fetch the specific instance,
+        # and another is made to fetch site root paths
         with self.captureOnCommitCallbacks(execute=True):
-            purge_pages_from_cache(EventIndex.objects.all())
-        self.assertEqual(
-            PURGED_URLS, {"http://localhost/events/", "http://localhost/events/past/"}
-        )
+            with self.assertNumQueries(len(pages) * 2):
+                purge_pages_from_cache(pages)
+        self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)
 
     def test_purge_batch(self):
         with self.captureOnCommitCallbacks(execute=True):
@@ -487,6 +505,17 @@ class TestCachePurgingFunctions(TestCase):
                 "http://localhost/foo",
             },
         )
+
+    def test_purge_batch_with_multiple_pages(self):
+        batch = PurgeBatch()
+        pages = list(Page.objects.all().type(EventPage))
+        # For each page, a query is made to fetch the specific instance,
+        # and another is made to fetch site root paths
+        with self.assertNumQueries(len(pages) * 2):
+            batch.add_pages(pages)
+        batch.purge()
+
+        self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)
 
     @override_settings(
         WAGTAILFRONTENDCACHE={

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -480,7 +480,7 @@ class TestCachePurgingFunctions(TestCase):
             PURGED_URLS, {"http://localhost/events/", "http://localhost/events/past/"}
         )
 
-    def test_purge_page_from_cache_with_shared_site_cache_target(self):
+    def test_purge_page_from_cache_with_shared_cache_object(self):
         page = EventIndex.objects.get(url_path="/home/events/")
 
         # Ensure site root paths are already cached, which should result in
@@ -489,7 +489,7 @@ class TestCachePurgingFunctions(TestCase):
 
         with self.assertNumQueries(0):
             for _i in range(4):
-                purge_page_from_cache(page, site_cache_target=page)
+                purge_page_from_cache(page, cache_object=page)
                 self.assertEqual(
                     PURGED_URLS,
                     {"http://localhost/events/", "http://localhost/events/past/"},
@@ -503,7 +503,7 @@ class TestCachePurgingFunctions(TestCase):
                 purge_pages_from_cache(pages)
         self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)
 
-    def test_purge_pages_from_cache_with_shared_site_cache_target(self):
+    def test_purge_pages_from_cache_with_shared_cache_object(self):
         pages = list(Page.objects.all().type(EventPage))
 
         # Ensure site root paths are already cached, which should result in
@@ -512,7 +512,7 @@ class TestCachePurgingFunctions(TestCase):
 
         with self.assertNumQueries(0):
             for _i in range(4):
-                purge_pages_from_cache(pages, site_cache_target=pages[0])
+                purge_pages_from_cache(pages, cache_object=pages[0])
                 self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)
                 PURGED_URLS.clear()
 
@@ -542,7 +542,7 @@ class TestCachePurgingFunctions(TestCase):
 
         self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)
 
-    def test_multiple_purge_batches_with_shared_site_cache_target(self):
+    def test_multiple_purge_batches_with_shared_cache_object(self):
         pages = list(Page.objects.all().type(EventPage))
 
         # Ensure site root paths are already cached, which should result in
@@ -551,7 +551,7 @@ class TestCachePurgingFunctions(TestCase):
 
         with self.assertNumQueries(0):
             for _i in range(4):
-                batch = PurgeBatch(site_cache_target=pages[0])
+                batch = PurgeBatch(cache_object=pages[0])
                 batch.add_pages(pages)
                 batch.purge()
                 self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -476,10 +476,10 @@ class TestCachePurgingFunctions(TestCase):
         with self.captureOnCommitCallbacks(execute=True):
             with self.assertNumQueries(1):
                 purge_page_from_cache(page)
-            self.assertEqual(
-                PURGED_URLS,
-                {"http://localhost/events/", "http://localhost/events/past/"},
-            )
+        self.assertEqual(
+            PURGED_URLS,
+            {"http://localhost/events/", "http://localhost/events/past/"},
+        )
 
     def test_purge_page_from_cache_with_shared_cache_object(self):
         page = EventIndex.objects.get(url_path="/home/events/")
@@ -494,10 +494,10 @@ class TestCachePurgingFunctions(TestCase):
             with self.assertNumQueries(0):
                 purge_page_from_cache(page, cache_object=page)
 
-            self.assertEqual(
-                PURGED_URLS,
-                {"http://localhost/events/", "http://localhost/events/past/"},
-            )
+        self.assertEqual(
+            PURGED_URLS,
+            {"http://localhost/events/", "http://localhost/events/past/"},
+        )
 
     def test_purge_pages_from_cache(self):
         pages = list(Page.objects.all().type(EventPage))

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -481,16 +481,15 @@ class TestCachePurgingFunctions(TestCase):
         )
 
     def test_purge_page_from_cache_with_shared_site_cache_target(self):
-        site_cache_target = object()
         page = EventIndex.objects.get(url_path="/home/events/")
 
         # Ensure site root paths are already cached, which should result in
         # zero additional queries being incurred by this test
-        page._get_relevant_site_root_paths(site_cache_target)
+        page._get_relevant_site_root_paths()
 
         with self.assertNumQueries(0):
             for _i in range(4):
-                purge_page_from_cache(page, site_cache_target=site_cache_target)
+                purge_page_from_cache(page, site_cache_target=page)
                 self.assertEqual(
                     PURGED_URLS,
                     {"http://localhost/events/", "http://localhost/events/past/"},
@@ -505,16 +504,15 @@ class TestCachePurgingFunctions(TestCase):
         self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)
 
     def test_purge_pages_from_cache_with_shared_site_cache_target(self):
-        site_cache_target = object()
         pages = list(Page.objects.all().type(EventPage))
 
         # Ensure site root paths are already cached, which should result in
         # zero additional queries being incurred by this test
-        pages[1]._get_relevant_site_root_paths(site_cache_target)
+        pages[0]._get_relevant_site_root_paths()
 
         with self.assertNumQueries(0):
             for _i in range(4):
-                purge_pages_from_cache(pages, site_cache_target=site_cache_target)
+                purge_pages_from_cache(pages, site_cache_target=pages[0])
                 self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)
                 PURGED_URLS.clear()
 
@@ -545,16 +543,15 @@ class TestCachePurgingFunctions(TestCase):
         self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)
 
     def test_multiple_purge_batches_with_shared_site_cache_target(self):
-        site_cache_target = object()
         pages = list(Page.objects.all().type(EventPage))
 
         # Ensure site root paths are already cached, which should result in
         # zero additional queries being incurred by this test
-        pages[1]._get_relevant_site_root_paths(site_cache_target)
+        pages[0]._get_relevant_site_root_paths()
 
         with self.assertNumQueries(0):
             for _i in range(4):
-                batch = PurgeBatch(site_cache_target=site_cache_target)
+                batch = PurgeBatch(site_cache_target=pages[0])
                 batch.add_pages(pages)
                 batch.purge()
                 self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -475,6 +475,8 @@ class TestCachePurgingFunctions(TestCase):
         page = EventIndex.objects.get(url_path="/home/events/")
         with self.captureOnCommitCallbacks(execute=True):
             with self.assertNumQueries(1):
+                # Because no cache object is provided, a query is needed to
+                # fetch site root paths in order to derive page urls
                 purge_page_from_cache(page)
         self.assertEqual(
             PURGED_URLS,
@@ -504,7 +506,7 @@ class TestCachePurgingFunctions(TestCase):
         with self.captureOnCommitCallbacks(execute=True):
             with self.assertNumQueries(1):
                 # Because no cache object is provided, a query is needed to
-                # identify the site root paths
+                # fetch site root paths in order to derive page urls
                 purge_pages_from_cache(pages)
         self.assertEqual(PURGED_URLS, EVENTPAGE_URLS)
 
@@ -530,8 +532,8 @@ class TestCachePurgingFunctions(TestCase):
         page = EventIndex.objects.get(url_path="/home/events/")
         batch = PurgeBatch()
 
-        # Because the batch has no cache object, adding a page will
-        # result in a query to fetch the site root paths
+        # Because no cache object is provided, a query is needed to
+        # fetch site root paths in order to derive page urls
         with self.assertNumQueries(1):
             batch.add_page(page)
 
@@ -553,8 +555,8 @@ class TestCachePurgingFunctions(TestCase):
         pages = list(Page.objects.all().type(EventPage))
         batch = PurgeBatch()
 
-        # Because the batch has no cache object, adding pages will
-        # result in a query to fetch the site root paths
+        # Because the batch has no cache object, a query is needed to
+        # fetch site root paths in order to derive page urls
         with self.assertNumQueries(1):
             batch.add_pages(pages)
 

--- a/wagtail/contrib/frontend_cache/utils.py
+++ b/wagtail/contrib/frontend_cache/utils.py
@@ -128,7 +128,7 @@ def purge_page_from_cache(
     :type backend_settings: dict, optional
     :param backends: Optional list of strings referencing specific backends from ``settings.WAGTAILFRONTENDCACHE`` or provided as ``backend_settings``. Can be used to limit purge operations to specific backends.
     :type backends: list, optional
-    :param site_cache_target: Optional, but strongly recommended for improved performance. An object to be passed to URL-related methods, to allow cached site root path data to be reused.
+    :param site_cache_target: Optional, but strongly recommended when making a series of requests to this method. An object to be passed to URL-related methods, allowing cached site root path data to be reused across multiple requests.
     :type site_cache_target: object, optional
 
     This function retrieves all cached URLs for the given page and purges them from the configured

--- a/wagtail/contrib/frontend_cache/utils.py
+++ b/wagtail/contrib/frontend_cache/utils.py
@@ -55,44 +55,136 @@ def get_backends(backend_settings=None, backends=None):
 
 
 def purge_url_from_cache(url, backend_settings=None, backends=None):
+    """
+    Purge a single URL from the frontend cache.
+
+    :param url: The URL to purge from the cache.
+    :type url: str
+    :param backend_settings: Optional custom backend settings to use instead of those defined in ``settings.WAGTAILFRONTENDCACHE``.
+    :type backend_settings: dict, optional
+    :param backends: Optional list of strings referencing specific backends from ``settings.WAGTAILFRONTENDCACHE`` or provided as ``backend_settings``. Can be used to limit purge operations to specific backends.
+    :type backends: list, optional
+
+    This function purges a single URL from the configured frontend cache backends. It's useful
+    when you need to invalidate the cache for a specific URL.
+
+    If no custom backends or settings are provided, it will use the default configuration
+    from ``settings.WAGTAILFRONTENDCACHE``.
+
+    NOTE: This function also handles internationalization, creating language-specific URLs if
+    ``WAGTAILFRONTENDCACHE_LANGUAGES`` is set and ``USE_I18N`` is ``True``.
+    """
     purge_urls_from_cache([url], backend_settings=backend_settings, backends=backends)
 
 
 def purge_urls_from_cache(urls, backend_settings=None, backends=None):
+    """
+    Purge multiple URLs from the frontend cache.
+
+    :param urls: An iterable of URLs to purge from the cache.
+    :type urls: iterable of str
+    :param backend_settings: Optional custom backend settings to use instead of those defined in ``settings.WAGTAILFRONTENDCACHE``.
+    :type backend_settings: dict, optional
+    :param backends: Optional list of strings referencing specific backends from ``settings.WAGTAILFRONTENDCACHE`` or provided as ``backend_settings``. Can be used to limit purge operations to specific backends.
+    :type backends: list, optional
+
+    This function purges multiple URLs from the configured frontend cache backends. It's useful
+    when you need to invalidate the cache for multiple URLs at once.
+
+    If no custom backends or settings are provided, it will use the default configuration
+    from ``settings.WAGTAILFRONTENDCACHE``.
+
+    NOTE: This function also handles internationalization, creating language-specific URLs if
+    ``WAGTAILFRONTENDCACHE_LANGUAGES`` is set and ``USE_I18N`` is ``True``.
+    """
     from .tasks import purge_urls_from_cache_task
+
+    if not urls:
+        return
 
     purge_urls_from_cache_task.enqueue(list(urls), backend_settings, backends)
 
 
-def _get_page_cached_urls(page):
-    page_url = page.full_url
+def _get_page_cached_urls(page, site_cache_target=None):
+    page_url = page.get_full_url(site_cache_target)
     if page_url is None:  # nothing to be done if the page has no routable URL
         return []
 
-    return [page_url + path.lstrip("/") for path in page.specific.get_cached_paths()]
+    return [
+        page_url + path.lstrip("/")
+        for path in page.specific_deferred.get_cached_paths()
+    ]
 
 
-def purge_page_from_cache(page, backend_settings=None, backends=None):
-    purge_pages_from_cache([page], backend_settings=backend_settings, backends=backends)
+def purge_page_from_cache(
+    page, backend_settings=None, backends=None, *, site_cache_target=None
+):
+    """
+    Purge a single page from the frontend cache.
+
+    :param page: The page to purge from the cache.
+    :type page: Page
+    :param backend_settings: Optional custom backend settings to use instead of those defined in ``settings.WAGTAILFRONTENDCACHE``.
+    :type backend_settings: dict, optional
+    :param backends: Optional list of strings referencing specific backends from ``settings.WAGTAILFRONTENDCACHE`` or provided as ``backend_settings``. Can be used to limit purge operations to specific backends.
+    :type backends: list, optional
+    :param site_cache_target: Optional, but strongly recommended for improved performance. An object to be passed to URL-related methods, to allow cached site root path data to be reused.
+    :type site_cache_target: object, optional
+
+    This function retrieves all cached URLs for the given page and purges them from the configured
+    backends. It's useful when you need to invalidate the cache for a specific page,
+    for example after the page has been updated.
+
+    If no custom backends or settings are provided, it will use the default configuration
+    from ``settings.WAGTAILFRONTENDCACHE``.
+
+    The `site_cache_target` parameter can be any kind of object that supports arbitrary attribute
+    assignment, such as a Python object or Django Model instance.
+    """
+    urls = _get_page_cached_urls(page, site_cache_target)
+    purge_urls_from_cache(urls, backend_settings, backends)
 
 
-def purge_pages_from_cache(pages, backend_settings=None, backends=None):
-    urls = []
-    for page in pages:
-        urls.extend(_get_page_cached_urls(page))
+def purge_pages_from_cache(
+    pages, backend_settings=None, backends=None, *, site_cache_target=None
+):
+    """
+    Purge multiple pages from the frontend cache.
 
-    if urls:
-        purge_urls_from_cache(urls, backend_settings, backends)
+    :param pages: An iterable of pages to purge from the cache.
+    :type pages: iterable of Page
+    :param backend_settings: Optional custom backend settings to use instead of those defined in ``settings.WAGTAILFRONTENDCACHE``.
+    :type backend_settings: dict, optional
+    :param backends: Optional list of strings matching keys from ``settings.WAGTAILFRONTENDCACHE`` or provided as ``backend_settings``. Can be used to limit purge operations to specific backends.
+    :type backends: list, optional
+    :param site_cache_target: Optional object to be passed to URL-related methods, to allow cached site root path data to be reused across multiple requests to this method. If not provided, the ``PurgeBatch`` object created by this method will be used instead.
+    :type site_cache_target: object, optional
+
+    This function retrieves all cached URLs for the given pages and purges them from the configured
+    backends. It's useful when you need to invalidate the cache for multiple pages at once,
+    for example after a bulk update operation.
+
+    If no custom backends or settings are provided, it will use the default configuration
+    from ``settings.WAGTAILFRONTENDCACHE``.
+
+    The `site_cache_target` parameter can be any kind of object that supports arbitrary attribute
+    assignment, such as a Python object or Django Model instance.
+    """
+    batch = PurgeBatch(site_cache_target=site_cache_target)
+    batch.add_pages(pages)
+    batch.purge(backend_settings, backends)
 
 
 class PurgeBatch:
     """Represents a list of URLs to be purged in a single request"""
 
-    def __init__(self, urls=None):
+    def __init__(self, urls=None, *, site_cache_target=None):
         self.urls = set()
 
         if urls is not None:
             self.add_urls(urls)
+
+        self.site_cache_target = site_cache_target
 
     def add_url(self, url):
         """Adds a single URL"""
@@ -114,7 +206,7 @@ class PurgeBatch:
         This combines the page's full URL with each path that is returned by
         the page's `.get_cached_paths` method
         """
-        self.add_urls(_get_page_cached_urls(page))
+        self.add_urls(_get_page_cached_urls(page, self.site_cache_target or self))
 
     def add_pages(self, pages):
         """


### PR DESCRIPTION
Stumbled across this whilst testing performance for #11978, and figured it would be best resolved with a separate PR:

It transpires that we've never fully tested the performance of batch-purging pages from the front-end cache. As highlighted by the initial commit (9fd689f2762abb30968851b4f4b351adbdb7d583), all of the current methods supplied by wagtail make an additional query for each individual page being purged, because we're not providing anything that can be used to cache the 'site root paths' query initiated by `Page.get_full_url()`. We also call the `specific` property on each individual page in order to access `get_cached_paths()` - making this an **n+2** problem if you happen to pass vanilla `Page` objects to the various util methods.

This PR aims to resolve these issues by:
- Updating batch purge options to provide an object of some kind to `get_full_url()`, that can be used to cache site root path data on
- Using `.specific_deferred` instead of `.specific` to access the `get_cached_paths()` method for each page
- Use `assertNumQueries` as a basic benchmark in tests, making future decisions that hurt performance less likely