### PR TITLE
Prevent redundant calls to `Site.find_for_request()` from `Page.get_url_parts()`

### DIFF
--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -912,7 +912,7 @@ class TestChooserExternalLinkWithNonRootServePath(TestChooserExternalLink):
                 "external-link-chooser-link_text": "about",
             }
         )
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(10):
             response = self.post(
                 {
                     "external-link-chooser-url": f"http://localhost/{self.prefix}about/",

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2136,15 +2136,16 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         if not possible_sites:
             return None
 
+        unique_site_ids = {values[0] for values in possible_sites}
         site_id, root_path, root_url, language_code = possible_sites[0]
 
-        site = Site.find_for_request(request)
-        if site:
-            for site_id, root_path, root_url, language_code in possible_sites:
-                if site_id == site.pk:
-                    break
-            else:
-                site_id, root_path, root_url, language_code = possible_sites[0]
+        if len(unique_site_ids) > 1 and request is not None:
+            site = Site.find_for_request(request)
+            if site:
+                for values in possible_sites:
+                    if values[0] == site.pk:
+                        site_id, root_path, root_url, language_code = values
+                        break
 
         use_wagtail_i18n = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2132,8 +2132,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         if not possible_sites:
             return None
 
-        # Because of the ordering applied by Site.get_site_root_paths(),
-        # the first item is best in the vast majority of cases
+        # Thanks to the ordering applied by Site.get_site_root_paths(),
+        # the first item is ideal in the vast majority of setups.
         site_id, root_path, root_url, language_code = possible_sites[0]
 
         unique_site_ids = {values[0] for values in possible_sites}


### PR DESCRIPTION
I noticed this issue whilst working on #12448 and thought it was worth a pulling out into it's own PR.

Essentially, when there's only a single site in the root path result, that means only one site is relevant, so calling `Site.find_for_request()` won't affect the result. This PR prevents these redundant calls.