### PR TITLE
Fix font size for custom listing button styles

### DIFF
--- a/client/scss/components/_footer.scss
+++ b/client/scss/components/_footer.scss
@@ -116,7 +116,6 @@
 
 .actions .button {
   @apply w-leading-none w-inline-flex w-items-center;
-  font-size: theme('fontSize.16');
   font-weight: 600;
   padding: 0 theme('spacing.3');
   white-space: initial;
@@ -138,6 +137,7 @@
   }
 
   > .button {
+    font-size: theme('fontSize.16');
     flex-grow: 1;
   }
 }


### PR DESCRIPTION
Found while working on https://github.com/wagtail-nest/wagtail-modeladmin/pull/44.

One of the changes in 5c4f83df72551fcd04c8dd59e4d5adc744bebe72 accidentally affected custom top-level listing buttons. I didn't notice we already have the more specific `.actions .w-dropdown-button > .button` styles, otherwise I would've put it there.

<details><summary>Screenshots</summary>


## Before (with the regression)

<img width="824" alt="image" src="https://github.com/user-attachments/assets/9aa6134c-0a53-4250-b6ac-04561d6dccd3">

## After (same as before 5c4f83df72551fcd04c8dd59e4d5adc744bebe72)

<img width="824" alt="image" src="https://github.com/user-attachments/assets/ef84bbe4-ec54-4ea3-9d92-7484653f6ec4">


</details> 


## Testing

Add the following to `bakerydemo/base/wagtail_hooks.py`:

```py
from wagtail.admin import widgets as wagtailadmin_widgets


@hooks.register("register_page_listing_buttons")
def page_listing_buttons_new_signature(page, user, next_url=None):
    yield wagtailadmin_widgets.PageListingButton(
        "Custom button", "/custom-url", priority=10
    )

```

and open the page explorer.