### PR TITLE
Factor root_page.depth into ordering of site root paths

### DIFF
--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -912,7 +912,7 @@ class TestChooserExternalLinkWithNonRootServePath(TestChooserExternalLink):
                 "external-link-chooser-link_text": "about",
             }
         )
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(10):
             response = self.post(
                 {
                     "external-link-chooser-url": f"http://localhost/{self.prefix}about/",

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2136,15 +2136,16 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         if not possible_sites:
             return None
 
+        unique_site_ids = {values[0] for values in possible_sites}
         site_id, root_path, root_url, language_code = possible_sites[0]
 
-        site = Site.find_for_request(request)
-        if site:
-            for site_id, root_path, root_url, language_code in possible_sites:
-                if site_id == site.pk:
-                    break
-            else:
-                site_id, root_path, root_url, language_code = possible_sites[0]
+        if len(unique_site_ids) > 1 and request is not None:
+            site = Site.find_for_request(request)
+            if site:
+                for values in possible_sites:
+                    if values[0] == site.pk:
+                        site_id, root_path, root_url, language_code = values
+                        break
 
         use_wagtail_i18n = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
 

--- a/wagtail/models/sites.py
+++ b/wagtail/models/sites.py
@@ -225,7 +225,12 @@ class Site(models.Model):
 
             for site in Site.objects.select_related(
                 "root_page", "root_page__locale"
-            ).order_by("-root_page__url_path", "-is_default_site", "hostname"):
+            ).order_by(
+                "-root_page__url_path",
+                "-is_default_site",
+                "-root_page__depth",
+                "hostname",
+            ):
                 if getattr(settings, "WAGTAIL_I18N_ENABLED", False):
                     result.extend(
                         [


### PR DESCRIPTION
Complimentary / exploratory extension of #12454

The thinking is: This would result in a more meaningful order when the value is used by `Page._get_relevant_site_root_paths()` - one that should negate the need for a 'current site' as a tie-breaker in most circumstances (and in turn, reduce the reliance on `Site.find_for_request()` to improve accuracy in `Page.get_url_parts()`)

Since two `Site` objects cannot share the same `root_page`, if an individual page is found to belong to more than one site, the one with the higher `root_page__depth` value will be have a root page that is closer the page, which I think is a safe basis for it being weighted as more relevant.