### PR TITLE
Replace X links with Mastodon

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
         <img src="https://img.shields.io/pypi/dm/wagtail?logo=Downloads" alt="Monthly downloads" />
     </a>
     <a href="https://fosstodon.org/@wagtail">
-        <img src="https://img.shields.io/mastodon/follow/109316228974672802?domain=https%3A%2F%2Ffosstodon.org&style=social" alt="Follow @wagtail@fosstodon.org">
+        <img src="https://img.shields.io/mastodon/follow/109308882653647818?domain=https%3A%2F%2Ffosstodon.org&style=social" alt="Follow @wagtail@fosstodon.org">
     </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
     <a href="https://pypi.python.org/pypi/wagtail/">
         <img src="https://img.shields.io/pypi/dm/wagtail?logo=Downloads" alt="Monthly downloads" />
     </a>
-    <a href="https://x.com/WagtailCMS">
-        <img src="https://img.shields.io/twitter/follow/WagtailCMS?style=social&logo=twitter" alt="follow on X">
+    <a href="https://fosstodon.org/@wagtail">
+        <img src="https://img.shields.io/mastodon/follow/109316228974672802?domain=https%3A%2F%2Ffosstodon.org&style=social" alt="Follow @wagtail@fosstodon.org">
     </a>
 </p>
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -28,4 +28,4 @@ If your bug report is a security issue, **do not** report it with an issue. Plea
 
 ## Torchbox
 
-Finally, if you have a query which isn't relevant for any of the above forums, feel free to contact the Wagtail team at Torchbox directly, on [hello@wagtail.org](mailto:hello@wagtail.org) or [@wagtailcms](https://x.com/wagtailcms).
+Finally, if you have a query which isn't relevant for any of the above forums, feel free to contact the Wagtail team at Torchbox directly, on [hello@wagtail.org](mailto:hello@wagtail.org) or [@wagtail@fosstodon.org](https://fosstodon.org/@wagtail).


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/12459

---
The Mastodon icon link is broken, probably because we're using the wrong ID value.