### PR TITLE
Docs - Small cleanup (typos)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -743,7 +743,6 @@
 * Sandro Rodrigues
 * Brian Mugo
 * Panagiotis H.M. Issaris
-* Damilola Oladele
 * Olumide Micheal
 * Chiemezuo Akujobi
 * Krish Soni

--- a/docs/reference/panels.md
+++ b/docs/reference/panels.md
@@ -314,7 +314,7 @@ The `MultipleChooserPanel` definition on `BlogPage` would be:
 
 ## Panel customization
 
-By adding extra parameters to your panel/field definitions, you can control much of how your fields will display in the Wagtail page editing interface. Wagtail's page editing interface takes much of its behavior from Django's admin, so you may find many options for customisation covered there.
+By adding extra parameters to your panel/field definitions, you can control much of how your fields will display in the Wagtail page editing interface. Wagtail's page editing interface takes much of its behavior from Django's admin, so you may find many options for customization covered there.
 (See [Django model field reference](inv:django#ref/models/fields)).
 
 (customising_panel_icons)=

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -291,7 +291,7 @@ You can also place the `WagtailUsersAppConfig` subclass inside the same `apps.py
 
 For more details, see [](custom_userviewset).
 
-## Upgrade considerations - changes affecting Wagtail customisations
+## Upgrade considerations - changes affecting Wagtail customizations
 
 ### Changes to report views with the new Universal Listings UI
 

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -36,6 +36,6 @@ depth: 1
 
 ## Upgrade considerations - deprecation of old functionality
 
-## Upgrade considerations - changes affecting Wagtail customisations
+## Upgrade considerations - changes affecting Wagtail customizations
 
 ## Upgrade considerations - changes to undocumented internals

--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -496,7 +496,7 @@ In this example, the variable `is_happening_today` will be made available within
 
 All block types, not just `StructBlock`, support the `template` property. However, for blocks that handle basic Python data types, such as `CharBlock` and `IntegerBlock`, there are some limitations on where the template will take effect. For further details, see [](boundblocks_and_values).
 
-## Customisations
+## Customizations
 
 All block types implement a common API for rendering their front-end and form representations, and storing and retrieving values to and from the database. By subclassing the various block classes and overriding these methods, all kinds of customizations are possible, from modifying the layout of StructBlock form fields to implementing completely new ways of combining blocks. For further details, see [](custom_streamfield_blocks).
 


### PR DESCRIPTION
- Fix a few US/UK spelling items (inc. in 6.4 release notes scaffold)
- Remove duplicate contributors entry from a2c9e9ab2cf3e4f0808c340f8df94882de82b5f3

See original entry https://github.com/wagtail/wagtail/blob/b9e13077bb5ac9962cc69627a0a49042832f3ebd/CONTRIBUTORS.md?plain=1#L634 from 09a225730aedc7298902979a0a4bf210a03969fe