### PR TITLE
Refactor headings to follow Google Developer Style Guide

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Docs: Refine the adding reports page so that common (page/non-page) class references are at the top and the full page only example has correct heading nesting (Alessandro Chitarrini)
  * Docs: Add the `wagtail start` command to the management commands reference page (Damilola Oladele)
  * Docs: Refine the project template page sections and document common issues encountered when creating custom templates (Damilola Oladele)
+ * Docs: Refine page titles to better align with the documentation style guide (Srishti Jaiswal)
 
 
 6.3 LTS (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -1,6 +1,6 @@
 (api_v2_configuration)=
 
-# Wagtail API v2 Configuration Guide
+# Wagtail API v2 configuration guide
 
 This section of the docs will show you how to set up a public API for your
 Wagtail site.

--- a/docs/advanced_topics/api/v2/usage.md
+++ b/docs/advanced_topics/api/v2/usage.md
@@ -1,13 +1,13 @@
 (api_v2_usage)=
 
-# Wagtail API v2 Usage Guide
+# Wagtail API v2 usage guide
 
 The Wagtail API module exposes a public, read-only, JSON-formatted API which
 can be used by external clients (such as a mobile app) or the site's frontend.
 
 This document is intended for developers using the API exposed by Wagtail. For
 documentation on how to enable the API module in your Wagtail site, see
-[Wagtail API v2 Configuration Guide](/advanced_topics/api/v2/configuration)
+[Wagtail API v2 configuration guide](/advanced_topics/api/v2/configuration)
 
 Contents
 

--- a/docs/advanced_topics/customisation/index.md
+++ b/docs/advanced_topics/customisation/index.md
@@ -1,4 +1,4 @@
-# Customising Wagtail
+# Customizing Wagtail
 
 ```{toctree}
 ---

--- a/docs/advanced_topics/images/feature_detection.md
+++ b/docs/advanced_topics/images/feature_detection.md
@@ -1,6 +1,6 @@
 (image_feature_detection)=
 
-# Feature Detection
+# Feature detection
 
 Wagtail has the ability to automatically detect faces and features inside your images and crop the images to those features.
 

--- a/docs/advanced_topics/reference_index.md
+++ b/docs/advanced_topics/reference_index.md
@@ -1,6 +1,6 @@
 (managing_the_reference_index)=
 
-# Managing the Reference Index
+# Manage the reference index
 
 Wagtail maintains a reference index, which records references between objects whenever those objects are saved. The index allows Wagtail to efficiently report the usage of images, documents and snippets within pages, including within StreamField and rich text fields.
 

--- a/docs/deployment/under_the_hood.md
+++ b/docs/deployment/under_the_hood.md
@@ -1,4 +1,4 @@
-# Wagtail Deployment: Under the Hood
+# Deployment: Under the hood
 
 This doc provides a technical deep-dive into Wagtail hosting concepts. Most likely, you'll want to [choose a hosting provider](index.md) instead.
 

--- a/docs/extending/extending_draftail.md
+++ b/docs/extending/extending_draftail.md
@@ -1,6 +1,6 @@
 (extending_the_draftail_editor)=
 
-# Extending the Draftail Editor
+# Extending the Draftail editor
 
 Wagtail’s rich text editor is built with [Draftail](https://www.draftail.org/), which supports different types of extensions.
 

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -262,7 +262,7 @@ When introduced in Wagtail 4.1, the `ReferenceIndex` model recorded references a
 
 This change will remove the impact of the indexing on non-Wagtail apps and models.
 
-If you have models that still require reference indexing, and which are not registered as snippets or with ModelAdmin, you will need to explicitly register them within your app's `AppConfig.ready()` method. See [Reference Index](registering_a_model_for_indexing) for further details.
+If you have models that still require reference indexing, and which are not registered as snippets or with ModelAdmin, you will need to explicitly register them within your app's `AppConfig.ready()` method. See [Reference index](registering_a_model_for_indexing) for further details.
 
 The use of `wagtail_reference_index_ignore` to prevent indexing of models is unchanged, but in many cases it may no longer be necessary.
 

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -28,6 +28,7 @@ depth: 1
  * Refine the [](adding_reports) page so that common (page/non-page) class references are at the top and the full page only example has correct heading nesting (Alessandro Chitarrini)
  * Add the [`wagtail start`](wagtail_start) command to the management commands reference page (Damilola Oladele)
  * Refine the [](project_templates_reference) page sections and document common issues encountered when creating custom templates (Damilola Oladele)
+ * Refine page titles to better align with the documentation style guide (Srishti Jaiswal)
 
 ### Maintenance
 


### PR DESCRIPTION
Fixed #12466

~For now, I am marking this as a draft. It - still needs some work.~
- [x] I have a few queries. I am commenting all of them.
- [x] changed h1 (main) headers of doc files according to the google developer style guild .