### PR TITLE
Allow page types to easily restrict what type of requests they respond to

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
  * Stop invalid Site hostname records from breaking preview (Matt Westcott)
  * Set sensible defaults for InlinePanel heading and label (Matt Westcott)
  * Limit tags autocompletion to 10 items to avoid performance issues with large number of matching tags (Aayushman Singh)
+ * Add the ability to restrict what types of requests a Pages supports via `allowed_http_methods` (Andy Babic)
  * Fix: Improve handling of translations for bulk page action confirmation messages (Matt Westcott)
  * Fix: Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
  * Fix: Ensure manual edits to `StreamField` values do not throw an error (Stefan Hammer)

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -200,6 +200,28 @@ See also [django-treebeard](inv:treebeard:std:doc#index)'s [node API](inv:treebe
 
     .. automethod:: get_admin_display_title
 
+    .. autoattribute:: allowed_http_methods
+
+        When customizing this attribute, developers are encouraged to use values from Python's built-in ``http.HTTPMethod`` enum in the list, as it is more robust, and makes use of values that already exist in memory. For example:
+
+        .. code-block:: python
+
+            from http import HTTPMethod
+
+            class MyPage(Page):
+                allowed_http_methods = [HTTPMethod.GET, HTTPMethod.OPTIONS]
+
+        The ``http.HTTPMethod`` enum wasn't added until Python 3.11, so if your project uses an older version of Python, you can use uppercase strings instead. For example:
+
+        .. code-block:: python
+
+            class MyPage(Page):
+                allowed_http_methods = ["GET", "OPTIONS"]
+
+    .. automethod:: check_request_method
+
+    .. automethod:: handle_options_request
+
     .. autoattribute:: preview_modes
 
     .. autoattribute:: default_preview_mode

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -19,6 +19,7 @@ depth: 1
  * Stop invalid Site hostname records from breaking preview (Matt Westcott)
  * Set sensible defaults for InlinePanel heading and label (Matt Westcott)
  * Limit tags autocompletion to 10 items to avoid performance issues with large number of matching tags (Aayushman Singh)
+ * Add the ability to restrict what types of requests a Pages supports via [`allowed_http_methods`](#wagtail.models.Page.allowed_http_methods) (Andy Babic)
 
 ### Bug fixes
 

--- a/wagtail/compat.py
+++ b/wagtail/compat.py
@@ -11,3 +11,19 @@ except ValueError:
     raise ImproperlyConfigured(
         "AUTH_USER_MODEL must be of the form" " 'app_label.model_name'"
     )
+
+
+try:
+    from http import HTTPMethod
+except ImportError:
+    # For Python < 3.11
+    from enum import Enum
+
+    class HTTPMethod(Enum):
+        GET = "GET"
+        HEAD = "HEAD"
+        OPTIONS = "OPTIONS"
+        POST = "POST"
+        PUT = "PUT"
+        DELETE = "DELETE"
+        PATCH = "PATCH"

--- a/wagtail/contrib/routable_page/models.py
+++ b/wagtail/contrib/routable_page/models.py
@@ -1,6 +1,6 @@
 import logging
-from http import HTTPMethod
 from functools import partial
+from http import HTTPMethod
 
 from django.core.checks import Warning
 from django.http import Http404

--- a/wagtail/contrib/routable_page/models.py
+++ b/wagtail/contrib/routable_page/models.py
@@ -1,6 +1,5 @@
 import logging
 from functools import partial
-from http import HTTPMethod
 
 from django.core.checks import Warning
 from django.http import Http404
@@ -171,10 +170,6 @@ class RoutablePageMixin:
             kwargs = {}
         if view is None:
             return super().serve(request, *args, **kwargs)
-
-        self.check_http_method(request, *args, **kwargs)
-        if request.method == HTTPMethod.OPTIONS:
-            return self.handle_options_request(request, *args, **kwargs)
         return view(request, *args, **kwargs)
 
     def render(self, request, *args, template=None, context_overrides=None, **kwargs):

--- a/wagtail/contrib/routable_page/models.py
+++ b/wagtail/contrib/routable_page/models.py
@@ -1,4 +1,5 @@
 import logging
+from http import HTTPMethod
 from functools import partial
 
 from django.core.checks import Warning
@@ -170,6 +171,10 @@ class RoutablePageMixin:
             kwargs = {}
         if view is None:
             return super().serve(request, *args, **kwargs)
+
+        self.check_http_method(request, *args, **kwargs)
+        if request.method == HTTPMethod.OPTIONS:
+            return self.handle_options_request(request, *args, **kwargs)
         return view(request, *args, **kwargs)
 
     def render(self, request, *args, template=None, context_overrides=None, **kwargs):

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -49,7 +49,7 @@ from django.utils import timezone
 from django.utils import translation as translation
 from django.utils.cache import patch_cache_control
 from django.utils.encoding import force_bytes, force_str
-from django.utils.functional import Promise, cached_property, classproperty
+from django.utils.functional import Promise, cached_property
 from django.utils.module_loading import import_string
 from django.utils.text import capfirst, slugify
 from django.utils.translation import gettext_lazy as _

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -462,9 +462,9 @@ class RevisionMixin(models.Model):
             if not previous_revision:
                 log(
                     instance=self,
-                    action=(
-                        log_action if isinstance(log_action, str) else "wagtail.edit"
-                    ),
+                    action=log_action
+                    if isinstance(log_action, str)
+                    else "wagtail.edit",
                     user=user,
                     revision=revision,
                     content_changed=changed,
@@ -472,9 +472,9 @@ class RevisionMixin(models.Model):
             else:
                 log(
                     instance=self,
-                    action=(
-                        log_action if isinstance(log_action, str) else "wagtail.revert"
-                    ),
+                    action=log_action
+                    if isinstance(log_action, str)
+                    else "wagtail.revert",
                     user=user,
                     data={
                         "revision": {
@@ -1904,9 +1904,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             if not previous_revision:
                 log(
                     instance=self,
-                    action=(
-                        log_action if isinstance(log_action, str) else "wagtail.edit"
-                    ),
+                    action=log_action
+                    if isinstance(log_action, str)
+                    else "wagtail.edit",
                     user=user,
                     revision=revision,
                     content_changed=changed,
@@ -1914,9 +1914,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             else:
                 log(
                     instance=self,
-                    action=(
-                        log_action if isinstance(log_action, str) else "wagtail.revert"
-                    ),
+                    action=log_action
+                    if isinstance(log_action, str)
+                    else "wagtail.revert",
                     user=user,
                     data={
                         "revision": {
@@ -3071,9 +3071,9 @@ class Revision(models.Model):
                     "revision": {
                         "id": self.id,
                         "created": ensure_utc(self.created_at),
-                        "go_live_at": (
-                            ensure_utc(object.go_live_at) if object.go_live_at else None
-                        ),
+                        "go_live_at": ensure_utc(object.go_live_at)
+                        if object.go_live_at
+                        else None,
                         "has_live_version": object.live,
                     }
                 },
@@ -3522,11 +3522,9 @@ class PageViewRestriction(BaseViewRestriction):
         if specific_instance:
             log(
                 instance=specific_instance,
-                action=(
-                    "wagtail.view_restriction.create"
-                    if is_new
-                    else "wagtail.view_restriction.edit"
-                ),
+                action="wagtail.view_restriction.create"
+                if is_new
+                else "wagtail.view_restriction.edit",
                 user=user,
                 data={
                     "restriction": {
@@ -3876,11 +3874,9 @@ class AbstractWorkflow(ClusterableModel):
                     "title": self.name,
                     "status": state.status,
                     "next": next_task_data,
-                    "task_state_id": (
-                        state.current_task_state.id
-                        if state.current_task_state
-                        else None
-                    ),
+                    "task_state_id": state.current_task_state.id
+                    if state.current_task_state
+                    else None,
                 }
             },
             revision=obj.get_latest_revision(),

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2129,7 +2129,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             self.get_context(request, *args, **kwargs),
         )
 
-    def check_http_method(self, request, *args, **kwargs):
+    def check_request_method(self, request, *args, **kwargs):
         if request.method not in self.allowed_http_methods:
             logger.warning(
                 "Method Not Allowed (%s): %s",

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -15,7 +15,6 @@ import functools
 import logging
 import posixpath
 import uuid
-from http import HTTPMethod
 from io import StringIO
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
@@ -70,6 +69,7 @@ from wagtail.actions.publish_page_revision import PublishPageRevisionAction
 from wagtail.actions.publish_revision import PublishRevisionAction
 from wagtail.actions.unpublish import UnpublishAction
 from wagtail.actions.unpublish_page import UnpublishPageAction
+from wagtail.compat import HTTPMethod
 from wagtail.coreutils import (
     WAGTAIL_APPEND_SLASH,
     camelcase_to_underscore,
@@ -462,9 +462,9 @@ class RevisionMixin(models.Model):
             if not previous_revision:
                 log(
                     instance=self,
-                    action=log_action
-                    if isinstance(log_action, str)
-                    else "wagtail.edit",
+                    action=(
+                        log_action if isinstance(log_action, str) else "wagtail.edit"
+                    ),
                     user=user,
                     revision=revision,
                     content_changed=changed,
@@ -472,9 +472,9 @@ class RevisionMixin(models.Model):
             else:
                 log(
                     instance=self,
-                    action=log_action
-                    if isinstance(log_action, str)
-                    else "wagtail.revert",
+                    action=(
+                        log_action if isinstance(log_action, str) else "wagtail.revert"
+                    ),
                     user=user,
                     data={
                         "revision": {
@@ -1904,9 +1904,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             if not previous_revision:
                 log(
                     instance=self,
-                    action=log_action
-                    if isinstance(log_action, str)
-                    else "wagtail.edit",
+                    action=(
+                        log_action if isinstance(log_action, str) else "wagtail.edit"
+                    ),
                     user=user,
                     revision=revision,
                     content_changed=changed,
@@ -1914,9 +1914,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             else:
                 log(
                     instance=self,
-                    action=log_action
-                    if isinstance(log_action, str)
-                    else "wagtail.revert",
+                    action=(
+                        log_action if isinstance(log_action, str) else "wagtail.revert"
+                    ),
                     user=user,
                     data={
                         "revision": {
@@ -2122,10 +2122,6 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
     def serve(self, request, *args, **kwargs):
         request.is_preview = False
-
-        self.check_http_method(request, *args, **kwargs)
-        if request.method == HTTPMethod.OPTIONS:
-            return self.handle_options_request(request, *args, **kwargs)
 
         return TemplateResponse(
             request,
@@ -3075,9 +3071,9 @@ class Revision(models.Model):
                     "revision": {
                         "id": self.id,
                         "created": ensure_utc(self.created_at),
-                        "go_live_at": ensure_utc(object.go_live_at)
-                        if object.go_live_at
-                        else None,
+                        "go_live_at": (
+                            ensure_utc(object.go_live_at) if object.go_live_at else None
+                        ),
                         "has_live_version": object.live,
                     }
                 },
@@ -3526,9 +3522,11 @@ class PageViewRestriction(BaseViewRestriction):
         if specific_instance:
             log(
                 instance=specific_instance,
-                action="wagtail.view_restriction.create"
-                if is_new
-                else "wagtail.view_restriction.edit",
+                action=(
+                    "wagtail.view_restriction.create"
+                    if is_new
+                    else "wagtail.view_restriction.edit"
+                ),
                 user=user,
                 data={
                     "restriction": {
@@ -3878,9 +3876,11 @@ class AbstractWorkflow(ClusterableModel):
                     "title": self.name,
                     "status": state.status,
                     "next": next_task_data,
-                    "task_state_id": state.current_task_state.id
-                    if state.current_task_state
-                    else None,
+                    "task_state_id": (
+                        state.current_task_state.id
+                        if state.current_task_state
+                        else None
+                    ),
                 }
             },
             revision=obj.get_latest_revision(),

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2148,9 +2148,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             return HttpResponseNotAllowed(allowed_methods)
 
     def handle_options_request(self, request, *args, **kwargs):
-        return HttpResponse(
-            headers={"Allow": ", ".join(self.allowed_http_method_names())}
-        )
+        response = HttpResponse()
+        response["Allow"] = ", ".join(self.allowed_http_method_names())
+        return response
 
     def is_navigable(self):
         """

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2141,7 +2141,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                 request.path,
                 extra={"status_code": 405, "request": request},
             )
-            return HttpResponseNotAllowed(sorted(self.allowed_http_methods_upper))
+            return HttpResponseNotAllowed(self.allowed_http_methods)
 
     def handle_options_request(self, request, *args, **kwargs):
         response = HttpResponse()

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2148,9 +2148,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             return HttpResponseNotAllowed(allowed_methods)
 
     def handle_options_request(self, request, *args, **kwargs):
-        response = HttpResponse()
-        response.headers["Allow"] = ", ".join(self.allowed_http_methods)
-        return response
+        return HttpResponse(
+            headers={"Allow": ", ".join(self.allowed_http_method_names())}
+        )
 
     def is_navigable(self):
         """

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -1466,7 +1466,10 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
     @classmethod
     def allowed_http_method_names(cls):
-        return [str(method) for method in cls.allowed_http_methods]
+        return [
+            method.value if hasattr(method, "value") else method
+            for method in cls.allowed_http_methods
+        ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -1464,6 +1464,10 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         if result is not None:
             return result[0]
 
+    @classmethod
+    def allowed_http_method_names(cls):
+        return [str(method) for method in cls.allowed_http_methods]
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not self.id:
@@ -2130,14 +2134,15 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         )
 
     def check_request_method(self, request, *args, **kwargs):
-        if request.method not in self.allowed_http_methods:
+        allowed_methods = self.allowed_http_method_names()
+        if request.method not in allowed_methods:
             logger.warning(
                 "Method Not Allowed (%s): %s",
                 request.method,
                 request.path,
                 extra={"status_code": 405, "request": request},
             )
-            return HttpResponseNotAllowed(self.allowed_http_methods)
+            return HttpResponseNotAllowed(allowed_methods)
 
     def handle_options_request(self, request, *args, **kwargs):
         response = HttpResponse()

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -526,6 +526,7 @@ class EventSitemap(Sitemap):
 class EventIndex(Page):
     intro = RichTextField(blank=True, max_length=50)
     ajax_template = "tests/includes/event_listing.html"
+    allowed_http_methods = ["get", "options"]
 
     def get_events(self):
         return self.get_children().live().type(EventPage)

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -527,7 +527,9 @@ class EventSitemap(Sitemap):
 class EventIndex(Page):
     intro = RichTextField(blank=True, max_length=50)
     ajax_template = "tests/includes/event_listing.html"
-    allowed_http_methods = [HTTPMethod.GET, HTTPMethod.OPTIONS]
+
+    # NOTE: Using a mix of enum and string values to test handling of both
+    allowed_http_methods = [HTTPMethod.GET, "OPTIONS"]
 
     def get_events(self):
         return self.get_children().live().type(EventPage)

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -44,6 +44,7 @@ from wagtail.blocks import (
     StreamBlock,
     StructBlock,
 )
+from wagtail.compat import HTTPMethod
 from wagtail.contrib.forms.forms import FormBuilder, WagtailAdminFormPageForm
 from wagtail.contrib.forms.models import (
     FORM_FIELD_CHOICES,
@@ -526,7 +527,7 @@ class EventSitemap(Sitemap):
 class EventIndex(Page):
     intro = RichTextField(blank=True, max_length=50)
     ajax_template = "tests/includes/event_listing.html"
-    allowed_http_methods = ["get", "options"]
+    allowed_http_methods = [HTTPMethod.GET, HTTPMethod.OPTIONS]
 
     def get_events(self):
         return self.get_children().live().type(EventPage)

--- a/wagtail/tests/test_page_allowed_http_methods.py
+++ b/wagtail/tests/test_page_allowed_http_methods.py
@@ -1,0 +1,32 @@
+from django.test import TestCase
+
+from wagtail.models import Page, Site
+from wagtail.test.testapp.models import EventIndex
+
+
+class AllowedHttpMethodsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        site = Site.objects.select_related("root_page").get(is_default_site=True)
+        cls.page = Page(title="Page", slug="page")
+        site.root_page.add_child(instance=cls.page)
+        cls.event_index_page = EventIndex(title="Event index", slug="event-index")
+        site.root_page.add_child(instance=cls.event_index_page)
+
+    def test_options_request_for_default_page(self):
+        response = self.client.options(self.page.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response["Allow"], "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT"
+        )
+
+    def test_options_request_for_restricted_page(self):
+        response = self.client.options(self.event_index_page.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Allow"], "GET, OPTIONS")
+
+    def test_invalid_request_method_for_restricted_page(self):
+        response = self.client.post(self.event_index_page.url)
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response["Allow"], "GET, OPTIONS")

--- a/wagtail/tests/test_page_allowed_http_methods.py
+++ b/wagtail/tests/test_page_allowed_http_methods.py
@@ -18,15 +18,15 @@ class AllowedHttpMethodsTestCase(TestCase):
         response = self.client.options(self.page.url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response["Allow"], "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT"
+            response.headers["Allow"], "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT"
         )
 
     def test_options_request_for_restricted_page(self):
         response = self.client.options(self.event_index_page.url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response["Allow"], "GET, OPTIONS")
+        self.assertEqual(response.headers["Allow"], "GET, OPTIONS")
 
     def test_invalid_request_method_for_restricted_page(self):
         response = self.client.post(self.event_index_page.url)
         self.assertEqual(response.status_code, 405)
-        self.assertEqual(response["Allow"], "GET, OPTIONS")
+        self.assertEqual(response.headers["Allow"], "GET, OPTIONS")

--- a/wagtail/tests/test_page_allowed_http_methods.py
+++ b/wagtail/tests/test_page_allowed_http_methods.py
@@ -18,15 +18,15 @@ class AllowedHttpMethodsTestCase(TestCase):
         response = self.client.options(self.page.url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.headers["Allow"], "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT"
+            response["Allow"], "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT"
         )
 
     def test_options_request_for_restricted_page(self):
         response = self.client.options(self.event_index_page.url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.headers["Allow"], "GET, OPTIONS")
+        self.assertEqual(response["Allow"], "GET, OPTIONS")
 
     def test_invalid_request_method_for_restricted_page(self):
         response = self.client.post(self.event_index_page.url)
         self.assertEqual(response.status_code, 405)
-        self.assertEqual(response.headers["Allow"], "GET, OPTIONS")
+        self.assertEqual(response["Allow"], "GET, OPTIONS")

--- a/wagtail/wagtail_hooks.py
+++ b/wagtail/wagtail_hooks.py
@@ -296,27 +296,23 @@ def register_core_log_actions(actions):
                                 log_entry.data["revision"]["created"],
                             )
                         ),
-                        "go_live_at": (
-                            render_timestamp(
-                                parse_datetime_localized(
-                                    log_entry.data["revision"]["go_live_at"],
-                                )
+                        "go_live_at": render_timestamp(
+                            parse_datetime_localized(
+                                log_entry.data["revision"]["go_live_at"],
                             )
-                            if log_entry.data["revision"]["go_live_at"]
-                            else None
-                        ),
+                        )
+                        if log_entry.data["revision"]["go_live_at"]
+                        else None,
                     }
                 else:
                     return _("Page unscheduled for publishing at %(go_live_at)s") % {
-                        "go_live_at": (
-                            render_timestamp(
-                                parse_datetime_localized(
-                                    log_entry.data["revision"]["go_live_at"],
-                                )
+                        "go_live_at": render_timestamp(
+                            parse_datetime_localized(
+                                log_entry.data["revision"]["go_live_at"],
                             )
-                            if log_entry.data["revision"]["go_live_at"]
-                            else None
-                        ),
+                        )
+                        if log_entry.data["revision"]["go_live_at"]
+                        else None,
                     }
             except KeyError:
                 return _("Page unscheduled from publishing")

--- a/wagtail/wagtail_hooks.py
+++ b/wagtail/wagtail_hooks.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.contrib.auth.views import redirect_to_login
 from django.db import models
-from django.http import HttpRequest, HttpResponse
 from django.urls import reverse
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
@@ -552,14 +551,3 @@ def register_workflow_log_actions(actions):
                 }
             except (KeyError, TypeError):
                 return _("Workflow cancelled")
-
-
-@hooks.register("before_serve_page", order=0)
-def serve_options_response(page: Page, request: HttpRequest, *args, **kwargs):
-    """Handle responding to requests for the OPTIONS HTTP verb."""
-    if request.method == "OPTIONS" and "options" in page.allowed_http_methods_lower:
-        response = HttpResponse()
-        response.headers["Allow"] = ", ".join(sorted(page.allowed_http_methods_upper))
-        response.headers["Content-Length"] = "0"
-        return response
-    return None

--- a/wagtail/wagtail_hooks.py
+++ b/wagtail/wagtail_hooks.py
@@ -566,7 +566,9 @@ def register_workflow_log_actions(actions):
 @hooks.register("before_serve_page", order=0)
 def handle_options_request(page: Page, request: "HttpRequest", *args, **kwargs):
     """Handle responding to requests for the OPTIONS HTTP verb."""
-    page.check_http_method(request, *args, **kwargs)
+    check_response = page.check_request_method(request, *args, **kwargs)
+    if check_response is not None:
+        return check_response
     if request.method == HTTPMethod.OPTIONS:
         return page.handle_options_request(request, *args, **kwargs)
     return None

--- a/wagtail/wagtail_hooks.py
+++ b/wagtail/wagtail_hooks.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.contrib.auth.views import redirect_to_login
 from django.db import models
+from django.http import HttpRequest, HttpResponse
 from django.urls import reverse
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
@@ -551,3 +552,14 @@ def register_workflow_log_actions(actions):
                 }
             except (KeyError, TypeError):
                 return _("Workflow cancelled")
+
+
+@hooks.register("before_serve_page", order=0)
+def serve_options_response(page: Page, request: HttpRequest, *args, **kwargs):
+    """Handle responding to requests for the OPTIONS HTTP verb."""
+    if request.method == "OPTIONS" and "options" in page.allowed_http_methods_lower:
+        response = HttpResponse()
+        response.headers["Allow"] = ", ".join(sorted(page.allowed_http_methods_upper))
+        response.headers["Content-Length"] = "0"
+        return response
+    return None

--- a/wagtail/wagtail_hooks.py
+++ b/wagtail/wagtail_hooks.py
@@ -560,11 +560,15 @@ def register_workflow_log_actions(actions):
 
 
 @hooks.register("before_serve_page", order=0)
-def handle_options_request(page: Page, request: "HttpRequest", *args, **kwargs):
-    """Handle responding to requests for the OPTIONS HTTP verb."""
+def check_request_method(page: Page, request: "HttpRequest", *args, **kwargs):
+    """
+    Before serving, check the request method is permitted by the page,
+    and use the page object's :meth:``wagtail.models.Page.handle_options_request``
+    method to generate a response if the OPTIONS HTTP verb is used.
+    """
     check_response = page.check_request_method(request, *args, **kwargs)
     if check_response is not None:
         return check_response
-    if request.method == HTTPMethod.OPTIONS:
+    if request.method == HTTPMethod.OPTIONS.value:
         return page.handle_options_request(request, *args, **kwargs)
     return None


### PR DESCRIPTION
The main benefit of these changes is to prevent unwanted cache-bypassing on projects by only permitting GET requests for most pages (POST, PUT and DELETE requests are widely known to bypass edge caching and can put unnecessary strain on servers). From a theoretical perspective, it's also fitting to bring pages a little more in-line with Django views, as both are essentially HTTP response generators, and as such, it makes sense for them to have similar controls.