### PR TITLE
Fix issues with `WagtailAdminFormPageForm.clean`

### DIFF
--- a/docs/reference/contrib/forms/customization.md
+++ b/docs/reference/contrib/forms/customization.md
@@ -825,3 +825,32 @@ class EmailFormPage(EmailFormMixin, FormMixin, BasePage):
     # ...
 
 ```
+
+(form_builder_custom_admin_validation)=
+
+## Custom validation for admin form pages
+
+By default, pages that inherit from `FormMixin` will validate that each field added by an editor has a unique `clean_name`.
+
+If you need to add custom validation, create a subclass of `WagtailAdminFormPageForm` and add your own `clean` definition and set the `base_form_class` on your `Page` model.
+
+```{note}
+Validation only applies when editors use the form builder to add fields in the Wagtail admin,
+not when the form is submitted by end users.
+```
+
+```python
+from wagtail.models import Page
+from wagtail.contrib.forms.models import FormMixin, WagtailAdminFormPageForm
+
+
+class CustomWagtailAdminFormPageForm(WagtailAdminFormPageForm):
+    def clean(self):
+        cleaned_data = super().clean()
+        # Insert custom validation here, see `WagtailAdminFormPageForm.clean` for an example
+        return cleaned_data
+
+
+class FormPage(AbstractForm):
+    base_form_class = CustomWagtailAdminFormPageForm
+```

--- a/wagtail/contrib/forms/forms.py
+++ b/wagtail/contrib/forms/forms.py
@@ -173,11 +173,12 @@ class SelectDateForm(django.forms.Form):
 
 class WagtailAdminFormPageForm(WagtailAdminPageForm):
     def clean(self):
-        super().clean()
+        cleaned_data = super().clean()
+        related_name = "form_fields"
 
         # Check for duplicate form fields by comparing their internal clean_names
         if "form_fields" in self.formsets:
-            forms = self.formsets["form_fields"].forms
+            forms = self.formsets[related_name].forms
             for form in forms:
                 form.is_valid()
 
@@ -193,7 +194,7 @@ class WagtailAdminFormPageForm(WagtailAdminPageForm):
             if duplicate_clean_name:
                 duplicate_form_field = next(
                     f
-                    for f in self.formsets["form_fields"].forms
+                    for f in self.formsets[related_name].forms
                     if f.instance.get_field_clean_name() == duplicate_clean_name
                 )
                 duplicate_form_field.add_error(
@@ -205,3 +206,5 @@ class WagtailAdminFormPageForm(WagtailAdminPageForm):
                         % {"label_name": duplicate_form_field.instance.label}
                     ),
                 )
+
+        return cleaned_data

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -1973,6 +1973,52 @@ class TestDuplicateFormFieldLabels(WagtailTestUtils, TestCase):
             text="There is another field with the label Test field, please change one of them.",
         )
 
+    def test_adding_duplicate_form_labels_with_custom_related_name(self):
+        """
+        Ensure duplicate field names are checked, even if a custom related_name is used.
+        ``FormPageWithCustomSubmission`` uses the related_name `custom_form_fields`.
+        """
+
+        post_data = {
+            "title": "Drink selection",
+            "content": "Some content",
+            "slug": "drink-selection",
+            "custom_form_fields-TOTAL_FORMS": "3",
+            "custom_form_fields-INITIAL_FORMS": "3",
+            "custom_form_fields-MIN_NUM_FORMS": "0",
+            "custom_form_fields-MAX_NUM_FORMS": "1000",
+            # Duplicate field labels
+            "custom_form_fields-0-id": "",
+            "custom_form_fields-0-label": "chocolate",
+            "custom_form_fields-0-field_type": "singleline",
+            "custom_form_fields-1-id": "",
+            "custom_form_fields-1-label": "chocolate",
+            "custom_form_fields-1-field_type": "singleline",
+            # Unique field label
+            "custom_form_fields-2-id": "",
+            "custom_form_fields-2-label": "coffee",
+            "custom_form_fields-2-field_type": "singleline",
+        }
+
+        response = self.client.post(
+            reverse(
+                "wagtailadmin_pages:add",
+                args=(
+                    "tests",
+                    "formpagewithcustomsubmission",
+                    self.root_page.id,
+                ),
+            ),
+            post_data,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(
+            response,
+            text="There is another field with the label chocolate, please change one of them.",
+        )
+
 
 class TestPreview(WagtailTestUtils, TestCase):
     post_data = {

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -2085,6 +2085,35 @@ class TestFormPageCreate(WagtailTestUtils, TestCase):
             response, reverse("wagtailadmin_pages:edit", args=(page.id,))
         )
 
+    def test_form_page_creation_error_with_custom_clean_method(self):
+        """
+        CustomFormPageSubmission uses a custom `base_form_class` with a clean method
+        that will raise a ValidationError if the from email contains 'example.com'.
+        """
+
+        post_data = {
+            "title": "Drink selection",
+            "slug": "drink-selection",
+            "from_address": "bad@example.com",
+        }
+
+        response = self.client.post(
+            reverse(
+                "wagtailadmin_pages:add",
+                args=("tests", "formpagewithcustomsubmission", self.root_page.id),
+            ),
+            post_data,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(
+            response, "The page could not be created due to validation errors"
+        )
+        self.assertContains(
+            response, "<li>Email cannot be from example.com</li>", count=1
+        )
+
 
 class TestFormPageEdit(WagtailTestUtils, TestCase):
     def setUp(self):


### PR DESCRIPTION
* Ensure `WagtailAdminFormPageForm.clean` is applied regardless of related name.
* Fix & document support for extending `WagtailAdminFormPageForm` for form page admin validation.

Rebase & added unit tests from #10375 - includes clean up of docs with refined wording and a change that has a more streamlined code diff.


## Details

- Dynamically detect the `related_name` of any form fields attached to the page so that validation is actually run for custom related_names.
- This also will apply validation even if there are multiple `AbstractFormField` subclasses related to the page.
- Return `cleaned_data` for more consistent subclassing.
- Updated documentation with an example of adding custom page validation for form fields.
- Add unit test to ensure that the documented usage of extending `WagtailAdminFormPageForm` works as expected.
- Add unit test to ensure that duplicate clean name validation correctly runs on FormPage models with a custom related name.

### Recommended release notes

 * --FIXES--
 * Ensure form builder supports custom admin form validation (John-Scott Atlakson, LB (Ben) Johnston)
 * Ensure form builder correctly checks for duplicate field names when using a custom related name (John-Scott Atlakson, LB (Ben) Johnston)
 * --DOCS--
 * Document usage of [Custom validation for admin form pages](form_builder_custom_admin_validation) when using `AbstractEmailForm` or `AbstractForm` pages (John-Scott Atlakson, LB (Ben) Johnston)
 * --UPGRADE CONSIDIERATIONS--
 * For any pages that exist (e.g. `AbstractEmailForm`, `AbstractForm`, `FormMixin`, `EmailFormMixin`) that have a form field related name of anything other than `related_fields`. If these pages have duplicate field names, these will now be flagged as an error on saving after upgrading. Previously, these duplicate fields would have not shown in the form page, but should be considered.


## How to test 

### A. Custom related name duplicate field validation

1. Create a new form page model that uses a custom related name, not just `form_fields` as the default documentation recommends.
3. Attempt to create a new page with that model that has two fields with the same name (e.g. `subject`), observe that you do NOT get an error as expected.

Observe page can be created with duplicate field names (subject).

![Screenshot 2024-10-28 at 6 39 33 PM](https://github.com/user-attachments/assets/b8e44f52-044b-4caf-9c99-fc556055897c)

Instead we should get this error
![Screenshot 2024-10-28 at 6 42 32 PM](https://github.com/user-attachments/assets/0eb7499a-936f-4a21-9369-4c484003955b)



```py

class SecondaryFormField(AbstractFormField):
    page = ParentalKey("SecondFormPage", related_name="secondary_form_fields", on_delete=models.CASCADE)


class SecondFormPage(AbstractEmailForm):

    content_panels = AbstractEmailForm.content_panels + [
        InlinePanel("secondary_form_fields", heading="Form fields", label="Field"),
        MultiFieldPanel(
            [
                FieldRowPanel(
                    [
                        FieldPanel("from_address"),
                        FieldPanel("to_address"),
                    ]
                ),
                FieldPanel("subject"),
            ],
            "Email",
        ),
    ]
```


### B. Custom admin form validation

1. In bakerydemo, add custom validation to the existing contact us model (code below)
2. Check that you can correctly do some basic validation or at least print out the cleaned_data in the console.

Current error encountered

![Screenshot 2024-10-28 at 6 40 39 PM](https://github.com/user-attachments/assets/60307ecc-0efc-41d7-9b20-ada94ea44d59)

Instead we should be able to read the `cleaned_data`.

```
from wagtail.models import Page
from wagtail.contrib.forms.models import FormMixin, WagtailAdminFormPageForm


class CustomWagtailAdminFormPageForm(WagtailAdminFormPageForm):
    def clean(self):
        cleaned_data = super().clean()
        # print the output or attempt to read this, you will get an error on `main` but should get the form submission data with this PR
        print(cleaned_data["from_address"])
        return cleaned_data


class FormPage(AbstractEmailForm):
    image = models.ForeignKey(
        "wagtailimages.Image",
        null=True,
        blank=True,
        on_delete=models.SET_NULL,
        related_name="+",
    )
    body = StreamField(BaseStreamBlock(), use_json_field=True)
    thank_you_text = RichTextField(blank=True)

    base_form_class = CustomWagtailAdminFormPageForm ## add this line
    #...
```