### PR TITLE
Documentation - Minor clean up (model reference + typo)

### DIFF
--- a/docs/extending/forms.md
+++ b/docs/extending/forms.md
@@ -77,4 +77,4 @@ A view performs the following steps to render a model form through the panels me
 -   An instance of the form class is created as per a normal Django form view.
 -   The view then calls `get_bound_panel` on the top-level panel, passing `instance`, `form` and `request` as keyword arguments. This returns a `BoundPanel` object, which follows [the template component API](/extending/template_components). Finally, the `BoundPanel` object (and its media definition) is rendered onto the template.
 
-New panel types can be defined by sub-classing `wagtail.admin.panels.Panel` - see [](panels_api).
+New panel types can be defined by subclassing `wagtail.admin.panels.Panel` - see [](panels_api).

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -1,10 +1,10 @@
 # Model reference
 
 ```{eval-rst}
-.. automodule:: wagtail.models
+.. module:: wagtail.models
 ```
 
-This document contains reference information for the model classes inside the `wagtailcore` module.
+This document contains reference information for the model classes inside the `wagtail.models` module.
 
 (page_model_ref)=
 


### PR DESCRIPTION
Remove the "wagtail.models is split into submodules for maintainability..." text from the core modules index and fix a small typo (inconsistent spelling).

 _Originally posted by @gasman in [#12435](https://github.com/wagtail/wagtail/issues/12435#issuecomment-2440283982)_

Note: I tried simply removing `automodule:: wagtail.models` from `docs/reference/models.md` but this caused a build error due to the module not being able to be referenced. `'get_specific' (try placing a "module" or "currentmodule" directive in the document, or giving an explicit module name) make: *** [Makefile:53: html] Error 2`


## Before

<img width="877" alt="Screenshot 2024-10-29 at 6 22 58 PM" src="https://github.com/user-attachments/assets/f244896f-f6b5-4762-b47c-14c2348eaf9e">

## After

<img width="863" alt="Screenshot 2024-10-29 at 6 23 06 PM" src="https://github.com/user-attachments/assets/75b054e9-f588-45b0-9190-d33121e83e59">
