### PR TITLE
Reuse WAGTAILIMAGES_EXTENSIONS when checking for alt text validity

### DIFF
--- a/client/src/includes/a11y-result.test.ts
+++ b/client/src/includes/a11y-result.test.ts
@@ -92,8 +92,9 @@ describe('addCustomChecks', () => {
 });
 
 // Options for checkImageAltText function
+// Permitted values are read from `get_allowed_image_extensions()`
 const options = {
-  pattern: '\\.(avif|gif|jpg|jpeg|png|svg|webp)$|_',
+  pattern: '\\.(avif|gif|jpg|jpeg|png|webp)$|_',
 };
 
 describe.each`

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -1,6 +1,8 @@
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 
+from wagtail.images.fields import get_allowed_image_extensions
+
 
 class BaseItem:
     template = "wagtailadmin/userbar/item_base.html"
@@ -84,7 +86,9 @@ class AccessibilityItem(BaseItem):
     axe_custom_checks = [
         {
             "id": "check-image-alt-text",
-            "options": {"pattern": "\\.(avif|gif|jpg|jpeg|png|svg|webp)$|_"},
+            "options": {
+                "pattern": f"\\.({'|'.join(get_allowed_image_extensions())})$|_"
+            },
         },
     ]
 


### PR DESCRIPTION
**What**

Reuse the image extensions returned from [get_allowed_image_extensions()](https://github.com/wagtail/wagtail/blob/fd9b1ca22b5ae1167d54a9c980f48c27792d4403/wagtail/images/fields.py#L14) when checking for alt text validity rather than defining a separate, hardcoded list of file extensions.

**Why**

1. Align the check with the project's permitted file types and, therefore, allow checking against custom image extensions.
2. Remove what feels like unnecessary duplication.