### PR TITLE
Optimise page publishing

### DIFF
--- a/wagtail/actions/publish_revision.py
+++ b/wagtail/actions/publish_revision.py
@@ -94,9 +94,8 @@ class PublishRevisionAction:
         )
 
         if isinstance(self.object, WorkflowMixin):
-            workflow_state = self.object.current_workflow_state
-            if workflow_state and getattr(
-                settings, "WAGTAIL_WORKFLOW_CANCEL_ON_PUBLISH", True
+            if getattr(settings, "WAGTAIL_WORKFLOW_CANCEL_ON_PUBLISH", True) and (
+                workflow_state := self.object.current_workflow_state
             ):
                 workflow_state.cancel(user=self.user)
 

--- a/wagtail/actions/publish_revision.py
+++ b/wagtail/actions/publish_revision.py
@@ -118,7 +118,7 @@ class PublishRevisionAction:
             # And clear the approved_go_live_at of any other revisions
             object.revisions.exclude(id=revision.id).update(approved_go_live_at=None)
             # if we are updating a currently live object skip the rest
-            if object.live_revision:
+            if object.live_revision_id:
                 # Log scheduled publishing
                 if log_action:
                     self.log_scheduling_action()

--- a/wagtail/actions/publish_revision.py
+++ b/wagtail/actions/publish_revision.py
@@ -114,7 +114,7 @@ class PublishRevisionAction:
             object.has_unpublished_changes = True
             # Instead set the approved_go_live_at of this revision
             revision.approved_go_live_at = object.go_live_at
-            revision.save()
+            revision.save(update_fields=["approved_go_live_at"])
             # And clear the approved_go_live_at of any other revisions
             object.revisions.exclude(id=revision.id).update(approved_go_live_at=None)
             # if we are updating a currently live object skip the rest

--- a/wagtail/management/commands/publish_scheduled.py
+++ b/wagtail/management/commands/publish_scheduled.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
 
         if dryrun:
             self.stdout.write("\n---------------------------------")
-            if any(expired_objects):
+            if expired_objects:
                 self.stdout.write("Expired objects to be deactivated:")
                 self.stdout.write("Expiry datetime\t\tModel\t\tSlug\t\tName")
                 self.stdout.write("---------------\t\t-----\t\t----\t\t----")

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2714,7 +2714,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         # These should definitely never change between revisions
         obj.id = self.id
         obj.pk = self.pk
-        obj.content_type = self.content_type
+        obj.content_type_id = self.content_type_id
 
         # Override possibly-outdated tree parameter fields
         obj.path = self.path
@@ -2730,15 +2730,15 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         obj.draft_title = self.draft_title
         obj.live = self.live
         obj.has_unpublished_changes = self.has_unpublished_changes
-        obj.owner = self.owner
+        obj.owner_id = self.owner_id
         obj.locked = self.locked
-        obj.locked_by = self.locked_by
+        obj.locked_by_id = self.locked_by_id
         obj.locked_at = self.locked_at
-        obj.latest_revision = self.latest_revision
+        obj.latest_revision_id = self.latest_revision_id
         obj.latest_revision_created_at = self.latest_revision_created_at
         obj.first_published_at = self.first_published_at
         obj.translation_key = self.translation_key
-        obj.locale = self.locale
+        obj.locale_id = self.locale_id
         obj.alias_of_id = self.alias_of_id
         revision_comment_positions = dict(
             getattr(obj, COMMENTS_RELATION_NAME).values_list("id", "position")


### PR DESCRIPTION
This PR does some light-touch optimising of the `publish_scheduled` management command, which also impacts page publishing in general (since it's 99% the same code). 