### PR TITLE
Replaced twitter references in the docs with more appropriate alternatives

### DIFF
--- a/docs/advanced_topics/embeds.md
+++ b/docs/advanced_topics/embeds.md
@@ -3,7 +3,7 @@
 # Embedded content
 
 Wagtail supports generating embed code from URLs to content on external
-providers such as YouTube or Twitter. By default, Wagtail will fetch the embed
+providers such as YouTube or X. By default, Wagtail will fetch the embed
 code directly from the relevant provider's site using the oEmbed protocol.
 
 Wagtail has a built-in list of the most common providers and this list can be

--- a/docs/advanced_topics/third_party_tutorials.md
+++ b/docs/advanced_topics/third_party_tutorials.md
@@ -157,7 +157,7 @@ the latest Wagtail versions.
 -   [Wagtail-Multilingual: a simple project to demonstrate how multilingual is implemented](https://github.com/cristovao-alves/Wagtail-Multilingual) (31 January 2017)
 -   [Wagtail: 2 Steps for Adding Pages Outside of the CMS](https://www.caktusgroup.com/blog/2016/02/15/wagtail-2-steps-adding-pages-outside-cms/) (15 February 2016)
 -   [Deploying Wagtail to Heroku](https://wagtail.org/blog/deploying-wagtail-heroku/) (15 July 2015)
--   [Adding a Twitter Widget for Wagtail's new StreamField](https://jossingram.wordpress.com/2015/04/02/adding-a-twitter-widget-for-wagtails-new-streamfield/) (2 April 2015)
+-   [Adding a X Widget for Wagtail's new StreamField](https://jossingram.wordpress.com/2015/04/02/adding-a-x-widget-for-wagtails-new-streamfield/) (2 April 2015)
 -   [Working With Wagtail: Menus](https://learnwagtail.com/tutorials/how-to-create-a-custom-wagtail-menu-system/) (22 January 2015)
 -   [Upgrading Wagtail to use Django 1.7 locally using vagrant](https://jossingram.wordpress.com/2014/12/10/upgrading-wagtail-to-use-django-1-7-locally-using-vagrant/) (10 December 2014)
 -   [Wagtail redirect page. Can link to page, URL and document](https://gist.github.com/alej0varas/e7e334643ceab6e65744) (24 September 2014)
@@ -178,4 +178,4 @@ You can also find more resources from the community on [Awesome Wagtail](https:/
 ## Tip
 
 We are working on a collection of Wagtail tutorials and best practices.
-Please tweet [\@WagtailCMS](https://twitter.com/WagtailCMS) or [contact us directly](mailto:hello@wagtail.org) to share your Wagtail HOWTOs, development notes or site launches.
+Please tweet [\@WagtailCMS](https://x.com/WagtailCMS) or [contact us directly](mailto:hello@wagtail.org) to share your Wagtail HOWTOs, development notes or site launches.

--- a/docs/reference/contrib/settings.md
+++ b/docs/reference/contrib/settings.md
@@ -274,12 +274,12 @@ if you have to use multiple values from one model:
 
 ```html+jinja
 {% with generic_social_settings=settings("app_label.GenericSocialMediaSettings") %}
-    Follow us on Twitter at @{{ generic_social_settings.facebook }},
+    Follow us on X at @{{ generic_social_settings.facebook }},
     or Instagram at @{{ generic_social_settings.instagram }}.
 {% endwith %}
 
 {% with site_social_settings=settings("app_label.SiteSpecificSocialMediaSettings") %}
-    Follow us on Twitter at @{{ site_social_settings.facebook }},
+    Follow us on X at @{{ site_social_settings.facebook }},
     or Instagram at @{{ site_social_settings.instagram }}.
 {% endwith %}
 ```

--- a/docs/releases/2.14.1.rst
+++ b/docs/releases/2.14.1.rst
@@ -15,5 +15,5 @@ What's new
 Bug fixes
 ~~~~~~~~~
 
- * Prevent failure on Twitter embeds and others which return cache_age as a string (Matt Westcott)
+ * Prevent failure on X embeds and others which return cache_age as a string (Matt Westcott)
  * Fix Uncaught ReferenceError when editing links in Hallo (Cynthia Kiser)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -178,7 +178,7 @@ There are also many improvements to the documentation both under the hood and in
  * Add a `classnames` template tag to easily build up classes from variables provided to a template (Paarth Agarwal)
  * Clean up multiple eslint rules usage and configs to align better with the Wagtail coding guidelines (LB (Ben Johnston))
  * Make `ModelAdmin` `InspectView` footer actions consistent with other parts of the UI (Thibaud Colas)
- * Add support for Twitter and other text-only embeds in Draftail embed previews (Iman Syed, Paarth Agarwal)
+ * Add support for X and other text-only embeds in Draftail embed previews (Iman Syed, Paarth Agarwal)
  * Use new modal dialog component for privacy settings modal (Sage Abdullah)
  * Add `menu_item_name` to modify `MenuItem`'s name for `ModelAdmin` (Alexander Rogovskyy, Vu Pham)
  * Add an extra confirmation prompt when deleting pages with a large number of child pages, see [](wagtailadmin_unsafe_page_deletion_limit) (Jaspreet Singh)

--- a/docs/tutorial/create_footer_for_all_pages.md
+++ b/docs/tutorial/create_footer_for_all_pages.md
@@ -29,14 +29,14 @@ from wagtail.contrib.settings.models import (
 
 @register_setting
 class NavigationSettings(BaseGenericSetting):
-    twitter_url = models.URLField(verbose_name="Twitter URL", blank=True)
+    x_url = models.URLField(verbose_name="X URL", blank=True)
     github_url = models.URLField(verbose_name="GitHub URL", blank=True)
     mastodon_url = models.URLField(verbose_name="Mastodon URL", blank=True)
 
     panels = [
         MultiFieldPanel(
             [
-                FieldPanel("twitter_url"),
+                FieldPanel("x_url"),
                 FieldPanel("github_url"),
                 FieldPanel("mastodon_url"),
             ],
@@ -100,15 +100,15 @@ Create an `includes` folder in your `mysite/templates` folder. Then in your newl
 <footer>
     <p>Built with Wagtail</p>
 
-    {% with twitter_url=settings.base.NavigationSettings.twitter_url github_url=settings.base.NavigationSettings.github_url mastodon_url=settings.base.NavigationSettings.mastodon_url %}
-        {% if twitter_url or github_url or mastodon_url %}
+    {% with x_url=settings.base.NavigationSettings.x_url github_url=settings.base.NavigationSettings.github_url mastodon_url=settings.base.NavigationSettings.mastodon_url %}
+        {% if x_url or github_url or mastodon_url %}
             <p>
                 Follow me on:
                 {% if github_url %}
                     <a href="{{ github_url }}">GitHub</a>
                 {% endif %}
-                {% if twitter_url %}
-                    <a href="{{ twitter_url }}">Twitter</a>
+                {% if x_url %}
+                    <a href="{{ x_url }}">X</a>
                 {% endif %}
                 {% if mastodon_url %}
                     <a href="{{ mastodon_url }}">Mastodon</a>
@@ -302,15 +302,15 @@ Add your `footer_text` template to your footer by modifying your `mysite/templat
 <footer>
     <p>Built with Wagtail</p>
 
-    {% with twitter_url=settings.base.NavigationSettings.twitter_url github_url=settings.base.NavigationSettings.github_url mastodon_url=settings.base.NavigationSettings.mastodon_url %}
-        {% if twitter_url or github_url or mastodon_url %}
+    {% with x_url=settings.base.NavigationSettings.x_url github_url=settings.base.NavigationSettings.github_url mastodon_url=settings.base.NavigationSettings.mastodon_url %}
+        {% if x_url or github_url or mastodon_url %}
             <p>
                 Follow me on:
                 {% if github_url %}
                     <a href="{{ github_url }}">GitHub</a>
                 {% endif %}
-                {% if twitter_url %}
-                    <a href="{{ twitter_url }}">Twitter</a>
+                {% if x_url %}
+                    <a href="{{ x_url }}">X</a>
                 {% endif %}
                 {% if mastodon_url %}
                     <a href="{{ mastodon_url }}">Mastodon</a>


### PR DESCRIPTION
Fixed #12483
-  Replace Twitter references in the docs with X
- [X] Links pointing to Twitter/X
- [X] Text references mentioning Twitter
