### PR TITLE
Move file upload drop-zone hover class toggling

### DIFF
--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import * as StimulusModule from '@hotwired/stimulus';
 
 import { Icon, Portal } from '../..';
@@ -58,14 +57,3 @@ window.MultipleChooserPanel = MultipleChooserPanel;
  */
 window.URLify = (str, numChars = 255, allowUnicode = false) =>
   urlify(str, { numChars, allowUnicode });
-
-$(() => {
-  /* Dropzones */
-  $('.drop-zone')
-    .on('dragover', function onDragOver() {
-      $(this).addClass('hovered');
-    })
-    .on('dragleave dragend drop', function onDragLeave() {
-      $(this).removeClass('hovered');
-    });
-});

--- a/wagtail/documents/static_src/wagtaildocs/js/add-multiple.js
+++ b/wagtail/documents/static_src/wagtaildocs/js/add-multiple.js
@@ -4,6 +4,14 @@ $(function () {
     e.preventDefault();
   });
 
+  $('.drop-zone')
+    .on('dragover', function onDragOver() {
+      $(this).addClass('hovered');
+    })
+    .on('dragleave dragend drop', function onDragLeave() {
+      $(this).removeClass('hovered');
+    });
+
   $('#fileupload').fileupload({
     dataType: 'html',
     sequentialUploads: true,

--- a/wagtail/images/static_src/wagtailimages/js/add-multiple.js
+++ b/wagtail/images/static_src/wagtailimages/js/add-multiple.js
@@ -4,6 +4,14 @@ $(function () {
     e.preventDefault();
   });
 
+  $('.drop-zone')
+    .on('dragover', function onDragOver() {
+      $(this).addClass('hovered');
+    })
+    .on('dragleave dragend drop', function onDragLeave() {
+      $(this).removeClass('hovered');
+    });
+
   $('#fileupload').fileupload({
     dataType: 'html',
     sequentialUploads: true,


### PR DESCRIPTION
Move the jQuery logic for toggling hover classes to the `add-multiple` JS files.

- Ensures that unused code is not loaded for all admin pages & co-locates behavior for easier future refactoring or replacement of jQuery file upload.
- Gets us a step closer to merging `core.js` & `wagtailadmin.js`, plus it means we now do not need jQuery imported in these files.

Note: While this does add duplication of code, it's better aligned to our current approach for multiple uploads where we treat these as isolated modules for images/documents.

## Testing

In both the documents & images multiple upload, check the 'dotted' outline appears when hovering a file to be uploaded.

<img width="1625" alt="Screenshot 2024-10-30 at 8 26 46 AM" src="https://github.com/user-attachments/assets/ed62c8ba-7ace-4240-af17-6155a7547bcd">
