### PR TITLE
Suppress unknown files warning when building the ePub docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,6 +83,15 @@ nitpick_ignore = [
     ("py:class", "wagtail.blocks.stream_block.BaseStreamBlock"),
 ]
 
+# We have .txt and .ico files in the static directory that trigger unknown mime
+# type warnings when building the epub and are ignored by the builder. For the
+# table markup files, they are already rendered in the output. Other files are
+# not relevant to the epub. Suppress the warnings so we don't have to explicitly
+# list the files in `epub_exclude_files`.
+suppress_warnings = [
+    "epub.unknown_project_files",
+]
+
 if not on_rtd:
     extensions.append("sphinxcontrib.spelling")
 


### PR DESCRIPTION
As per https://github.com/wagtail/wagtail/pull/12502#discussion_r1822733154.

Will merge soon so our RTD build is fixed. There are errors in the generated ePub, but the changes are more involved so I'll open a separate PR for those.