### PR TITLE
Use correct connection when searching

### DIFF
--- a/wagtail/search/backends/database/sqlite/sqlite.py
+++ b/wagtail/search/backends/database/sqlite/sqlite.py
@@ -1,7 +1,12 @@
 from collections import OrderedDict
 from functools import reduce
 
-from django.db import DEFAULT_DB_ALIAS, NotSupportedError, connections, transaction
+from django.db import (
+    NotSupportedError,
+    connections,
+    router,
+    transaction,
+)
 from django.db.models import Avg, Count, F, Manager, Q, TextField
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.functions import Cast, Length
@@ -145,17 +150,22 @@ class ObjectIndexer:
 
 
 class Index:
-    def __init__(self, backend, db_alias=None):
+    def __init__(self, backend):
         self.backend = backend
         self.name = self.backend.index_name
-        self.db_alias = DEFAULT_DB_ALIAS if db_alias is None else db_alias
-        self.connection = connections[self.db_alias]
-        if self.connection.vendor != "sqlite":
+
+        self.read_connection = connections[router.db_for_read(IndexEntry)]
+        self.write_connection = connections[router.db_for_write(IndexEntry)]
+
+        if (
+            self.read_connection.vendor != "sqlite"
+            or self.write_connection.vendor != "sqlite"
+        ):
             raise NotSupportedError(
-                "You must select a SQLite database " "to use the SQLite search backend."
+                "You must select a SQLite database to use the SQLite search backend."
             )
 
-        self.entries = IndexEntry._default_manager.using(self.db_alias)
+        self.entries = IndexEntry._default_manager.all()
 
     def add_model(self, model):
         pass
@@ -165,7 +175,7 @@ class Index:
 
     def _refresh_title_norms(self, full=False):
         """
-        Refreshes the value of the title_norm field.
+        Refreshes the value of the title_noqrm field.
 
         This needs to be set to 'lavg/ld' where:
          - lavg is the average length of titles in all documents (also in terms)
@@ -195,11 +205,9 @@ class Index:
         ).update(title_norm=lavg / F("title_length"))
 
     def delete_stale_model_entries(self, model):
-        existing_pks = (
-            model._default_manager.using(self.db_alias)
-            .annotate(object_id=Cast("pk", TextField()))
-            .values("object_id")
-        )
+        existing_pks = model._default_manager.annotate(
+            object_id=Cast("pk", TextField())
+        ).values("object_id")
         content_types_pks = get_descendants_content_types_pks(model)
         stale_entries = self.entries.filter(
             content_type_id__in=content_types_pks
@@ -270,7 +278,7 @@ class Index:
             update_method(content_type_pk, indexers)
 
     def delete_item(self, item):
-        item.index_entries.all()._raw_delete(using=self.db_alias)
+        item.index_entries.all()._raw_delete(using=self.write_connection.alias)
 
     def __str__(self):
         return self.name
@@ -291,7 +299,7 @@ class SQLiteSearchRebuilder:
 class SQLiteSearchAtomicRebuilder(SQLiteSearchRebuilder):
     def __init__(self, index):
         super().__init__(index)
-        self.transaction = transaction.atomic(using=index.db_alias)
+        self.transaction = transaction.atomic(using=index.write_connection.alias)
         self.transaction_opened = False
 
     def start(self):
@@ -673,11 +681,11 @@ class SQLiteSearchBackend(BaseSearchBackend):
         if params.get("ATOMIC_REBUILD", False):
             self.rebuilder_class = self.atomic_rebuilder_class
 
-    def get_index_for_model(self, model, db_alias=None):
-        return Index(self, db_alias)
+    def get_index_for_model(self, model):
+        return Index(self)
 
     def get_index_for_object(self, obj):
-        return self.get_index_for_model(obj._meta.model, obj._state.db)
+        return self.get_index_for_model(obj._meta.model)
 
     def reset_index(self):
         for connection in [


### PR DESCRIPTION
This PR fixes 2 issues with the DB backends' connection handling, which helps towards https://github.com/wagtail/wagtail/issues/11237.

First, the index was using `obj._state.db`, where `obj` is the instance being indexed (such as `Page`). If the index itself lived in a different DB (as defined by Django's database router), it would attempt to insert into the wrong database. This might just result in the database using the less ideal (like the primary rather than a read-replica), or could be a database where the index tables don't exist at all.

Secondly, similar to the above, the same connection was being used for both reads and writes. Instead, separate connections are used for reads and writes as needed, allowing the database router to be used correctly.

_Please describe the problem you're fixing here. Include the issue number, if applicable._
