### PR TITLE
Correctly handle None values in ImageBlock.bulk_to_python

### DIFF
--- a/wagtail/images/blocks.py
+++ b/wagtail/images/blocks.py
@@ -148,10 +148,7 @@ class ImageBlock(StructBlock):
     def bulk_to_python(self, values):
         values = list(values)
 
-        if not values:
-            return []
-
-        if isinstance(values[0], int):
+        if any(isinstance(value, int) for value in values):
             # `values` is a list of image IDs (as we might encounter if an ImageChooserBlock has been
             # changed to an ImageBlock with no data migration)
             image_values = self.child_blocks["image"].bulk_to_python(values)
@@ -166,8 +163,8 @@ class ImageBlock(StructBlock):
             ]
 
         else:
-            # assume `values` is a list of dicts containing `image`, `decorative` and `alt_text` keys
-            # to be handled by the StructBlock superclass
+            # assume `values` is a (possibly empty) list of dicts containing
+            # `image`, `decorative` and `alt_text` keys to be handled by the StructBlock superclass
             struct_values = super().bulk_to_python(values)
 
         return [


### PR DESCRIPTION
Fixes #12514

A list such as `[None, 123]` (which might be received for an ImageBlock that was previously an `ImageChooserBlock(required=False)`) should result in `[None, <Image: id=123>]`.

Note that the code path for the "list of dicts" representation (where we hand off to `StructBlock.bulk_to_python`) does _not_ handle `None` values, as StructBlock has no concept of requiredness. However, `None` should never appear in this case, as these values are saved by ImageBlock itself, and it produces `{"image": None, "alt_text": None, "decorative": None}` as the database value for a non-required block with no image selected. Have added a further test to confirm this.