### PR TITLE
Hide sidebar panel overflow

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
  * Fix: Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
  * Fix: Ensure manual edits to `StreamField` values do not throw an error (Stefan Hammer)
  * Fix: Fix sub-menus within the main menu cannot be closed on mobile (Bojan Mihelac)
+ * Fix: Fix animation overflow transition when navigating through subpages in the sidebar page explorer (manu)
  * Docs: Move the model reference page from reference/pages to the references section as it covers all Wagtail core models (Srishti Jaiswal)
  * Docs: Move the panels reference page from references/pages to the references section as panels are available for any model editing, merge panels API into this page (Srishti Jaiswal)
  * Docs: Move the tags documentation to standalone advanced topic, instead of being inside the reference/pages section (Srishti Jaiswal)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -851,6 +851,7 @@
 * Joel William
 * Ataf Fazledin Ahamed
 * Ayaan Qadri
+* manu
 
 ## Translators
 

--- a/client/src/components/Sidebar/SidebarPanel.scss
+++ b/client/src/components/Sidebar/SidebarPanel.scss
@@ -13,6 +13,7 @@
   z-index: 400;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 
   @include media-breakpoint-up(sm) {
     z-index: var(--z-index);

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -23,6 +23,7 @@ depth: 1
  * Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
  * Ensure manual edits to `StreamField` values do not throw an error (Stefan Hammer)
  * Fix sub-menus within the main menu cannot be closed on mobile (Bojan Mihelac)
+ * Fix animation overflow transition when navigating through subpages in the sidebar page explorer (manu)
 
 ### Documentation
 


### PR DESCRIPTION
When you navigate the to a subpage in the sidebar, the animation is currently overflowing the panel. In my opinion this is not a designers intention, it shouldn't overflow, the focus should stay inside of the panel.

Before:

https://github.com/user-attachments/assets/e9b73b96-ebed-41f2-8104-d4e228c5b5f4

After:

https://github.com/user-attachments/assets/b23fa97a-5853-4d37-b94d-07309d2f3b46

The result looks aesthetically more pleasing. 

I've also checked if a11y is still given when I'm on a smaller screen, thus the sidebar panel children are still able to overflow vertically as expected. 

![image](https://github.com/user-attachments/assets/8b697381-c729-4a91-803f-a91f5d2044aa)
