### PR TITLE
Remove all `eslint-disable no-undef` & use `global` comments

### DIFF
--- a/client/src/components/ChooserWidget/DocumentChooserWidget.js
+++ b/client/src/components/ChooserWidget/DocumentChooserWidget.js
@@ -1,13 +1,13 @@
+/* global DocumentChooserModal */
+
 import { Chooser, ChooserFactory } from '.';
 
 export class DocumentChooser extends Chooser {
-  // eslint-disable-next-line no-undef
   chooserModalClass = DocumentChooserModal;
 }
 window.DocumentChooser = DocumentChooser;
 
 export class DocumentChooserFactory extends ChooserFactory {
   widgetClass = DocumentChooser;
-  // eslint-disable-next-line no-undef
   chooserModalClass = DocumentChooserModal;
 }

--- a/client/src/components/ChooserWidget/ImageChooserWidget.js
+++ b/client/src/components/ChooserWidget/ImageChooserWidget.js
@@ -1,7 +1,8 @@
+/* global ImageChooserModal */
+
 import { Chooser, ChooserFactory } from '.';
 
 export class ImageChooser extends Chooser {
-  // eslint-disable-next-line no-undef
   chooserModalClass = ImageChooserModal;
 
   initHTMLElements(id) {
@@ -37,6 +38,5 @@ export class ImageChooser extends Chooser {
 
 export class ImageChooserFactory extends ChooserFactory {
   widgetClass = ImageChooser;
-  // eslint-disable-next-line no-undef
   chooserModalClass = ImageChooserModal;
 }

--- a/client/src/components/ChooserWidget/PageChooserWidget.js
+++ b/client/src/components/ChooserWidget/PageChooserWidget.js
@@ -1,7 +1,8 @@
+/* global PageChooserModal */
+
 import { Chooser, ChooserFactory } from '.';
 
 export class PageChooser extends Chooser {
-  // eslint-disable-next-line no-undef
   chooserModalClass = PageChooserModal;
 
   titleStateKey = 'adminTitle';
@@ -44,7 +45,6 @@ export class PageChooser extends Chooser {
 
 export class PageChooserFactory extends ChooserFactory {
   widgetClass = PageChooser;
-  // eslint-disable-next-line no-undef
   chooserModalClass = PageChooserModal;
 
   getModalOptions() {

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -1,4 +1,5 @@
-/* eslint-disable no-underscore-dangle */
+/* global $ */
+
 import { v4 as uuidv4 } from 'uuid';
 
 import {
@@ -12,8 +13,6 @@ import {
   addErrorMessages,
   removeErrorMessages,
 } from '../../../includes/streamFieldErrors';
-
-/* global $ */
 
 class ListChild extends BaseSequenceChild {
   /*
@@ -219,6 +218,7 @@ export class ListBlock extends BaseSequenceBlock {
   }
 
   insert(value, index, opts) {
+    // eslint-disable-next-line no-underscore-dangle
     return this._insert(
       this.blockDef.childBlockDef,
       value,

--- a/client/src/entrypoints/admin/privacy-switch.js
+++ b/client/src/entrypoints/admin/privacy-switch.js
@@ -1,10 +1,11 @@
+/* global ModalWorkflow */
+
 import $ from 'jquery';
 
 $(() => {
   /* Interface to set permissions from the explorer / editor */
   // eslint-disable-next-line func-names
   $('[data-a11y-dialog-show="set-privacy"]').on('click', function () {
-    // eslint-disable-next-line no-undef
     ModalWorkflow({
       dialogId: 'set-privacy',
       url: this.getAttribute('data-url'),

--- a/client/src/entrypoints/admin/task-chooser.js
+++ b/client/src/entrypoints/admin/task-chooser.js
@@ -1,3 +1,5 @@
+/* global ModalWorkflow TASK_CHOOSER_MODAL_ONLOAD_HANDLERS */
+
 import $ from 'jquery';
 
 function createTaskChooser(id) {
@@ -7,10 +9,8 @@ function createTaskChooser(id) {
   const editAction = chooserElement.find('[data-chooser-edit-link]');
 
   $('[data-chooser-action-choose]', chooserElement).on('click', () => {
-    // eslint-disable-next-line no-undef
     ModalWorkflow({
       url: chooserElement.data('chooserUrl'),
-      // eslint-disable-next-line no-undef
       onload: TASK_CHOOSER_MODAL_ONLOAD_HANDLERS,
       responses: {
         taskChosen(data) {

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -1,3 +1,5 @@
+/* global draftail */
+
 import { gettext } from '../../../utils/gettext';
 import { runInlineScripts } from '../../../utils/runInlineScripts';
 
@@ -324,7 +326,6 @@ class BoundDraftailWidget {
     this.capabilities = new Map(parentCapabilities);
     this.options = options;
 
-    // eslint-disable-next-line no-undef
     const [, setOptions] = draftail.initEditor(
       '#' + this.input.id,
       this.getFullOptions(),

--- a/client/src/entrypoints/admin/workflow-action.js
+++ b/client/src/entrypoints/admin/workflow-action.js
@@ -1,3 +1,5 @@
+/* global ModalWorkflow */
+
 import $ from 'jquery';
 import { WAGTAIL_CONFIG } from '../../config/wagtailConfig';
 
@@ -26,7 +28,6 @@ function ActivateWorkflowActionsForDashboard() {
         e.preventDefault();
 
         if ('launchModal' in buttonElement.dataset) {
-          // eslint-disable-next-line no-undef
           ModalWorkflow({
             url: buttonElement.dataset.workflowActionUrl,
             onload: {
@@ -83,7 +84,6 @@ function ActivateWorkflowActionsForEditView(formSelector) {
           e.stopPropagation();
 
           // open the modal at the given URL
-          // eslint-disable-next-line no-undef
           ModalWorkflow({
             url: buttonElement.dataset.workflowActionModalUrl,
             onload: {

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -1,3 +1,5 @@
+/* global ModalWorkflow */
+
 import $ from 'jquery';
 import { initTabs } from './tabs';
 import { gettext } from '../utils/gettext';
@@ -356,7 +358,6 @@ class ChooserModal {
   }
 
   open(opts, callback) {
-    // eslint-disable-next-line no-undef
     ModalWorkflow({
       url: this.getURL(opts || {}),
       urlParams: this.getURLParams(opts || {}),

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotions_formset.js
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotions_formset.js
@@ -1,5 +1,6 @@
+/* global InlinePanel */
+
 $(function () {
-  // eslint-disable-next-line no-undef
   var panel = new InlinePanel({
     formsetPrefix: 'id_{{ formset.prefix }}',
     emptyChildFormPrefix: '{{ formset.empty_form.prefix }}',


### PR DESCRIPTION
Remove all eslint-disable no-undef & use global comments

Recommendation is to either declare globals in config or in a `/* global ` comment

See https://eslint.org/docs/latest/rules/no-undef#rule-details

While we are still not clear on the future of replacing some of these globals, I thought it might be nice to do a small clean up anyway.