### PR TITLE
Controller/12511-Added Test and Storybook files for Stimulus DrilldownController

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -65,6 +65,7 @@ Changelog
  * Maintenance: Refactor redirects create/delete views to use generic views (Sage Abdullah)
  * Maintenance: Add JSDoc description, adopt linting recommendations, and add more unit tests for `ModalWorkflow` (LB (Ben) Johnston)
  * Maintenance: Add support for for a `delay` value in `TagController` to debounce async autocomplete tag fetch requests (Aayushman Singh)
+ * Maintenance: Add unit tests, Storybook stories & JSDoc items for the Stimulus `DrilldownController` (Srishti Jaiswal)
 
 
 6.3.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/controllers/DrilldownController.stories.js
+++ b/client/src/controllers/DrilldownController.stories.js
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import { StimulusWrapper } from '../../storybook/StimulusWrapper';
+import { DrilldownController } from './DrilldownController';
+
+export default {
+  title: 'Stimulus / DrilldownController',
+  argTypes: {
+    debug: {
+      control: 'boolean',
+      defaultValue: false,
+    },
+  },
+};
+
+const definitions = [
+  { identifier: 'w-drilldown', controllerConstructor: DrilldownController },
+];
+
+const sections = [
+  { label: 'Section 1', key: 0 },
+  { label: 'Section 2', key: 1 },
+  { label: 'Section 3', key: 2 },
+];
+
+const Template = ({ debug }) => (
+  <StimulusWrapper definitions={definitions} debug={debug}>
+    <section>
+      <div
+        id="filters-drilldown"
+        className="w-drilldown"
+        data-controller="w-drilldown"
+        data-w-drilldown-count-attr-value="data-w-active-filter-id"
+      >
+        <div className="w-drilldown__menu" data-w-drilldown-target="menu">
+          <h2>Show</h2>
+          {sections.map(({ label, key }) => (
+            <button
+              className="w-drilldown__toggle"
+              key={key}
+              type="button"
+              aria-expanded="false"
+              aria-controls={`drilldown-field-${key}`}
+              data-w-drilldown-target="toggle"
+              data-action="click->w-drilldown#open"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        {sections.map(({ label, key }) => (
+          <div
+            className="w-drilldown__submenu w-flex w-flex-col"
+            key={key}
+            id={`drilldown-field-${key}`}
+            hidden
+            tabIndex="-1"
+          >
+            <span>{label} contents</span>
+            <button
+              className="w-drilldown__back"
+              type="button"
+              data-action="click->w-drilldown#close"
+            >
+              Back
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  </StimulusWrapper>
+);
+
+export const Base = Template.bind({});

--- a/client/src/controllers/DrilldownController.test.js
+++ b/client/src/controllers/DrilldownController.test.js
@@ -1,0 +1,221 @@
+import { Application } from '@hotwired/stimulus';
+import { DrilldownController } from './DrilldownController';
+import { DropdownController } from './DropdownController';
+import { ActionController } from './ActionController';
+
+jest.useFakeTimers();
+
+describe('DrilldownController', () => {
+  const eventNames = [];
+
+  const events = {};
+  let application;
+  let errors = [];
+
+  const setup = async (
+    html = `
+    <section>
+      <div
+        id="filters-drilldown"
+        data-controller="w-drilldown"
+        data-action='${[
+          'w-swap:success@document->w-drilldown#updateCount',
+          'w-dropdown:hide->w-drilldown#delayedClose',
+          'w-dropdown:clickaway->w-drilldown#preventOutletClickaway',
+        ].join(' ')}'
+        data-w-drilldown-count-attr-value="data-w-active-filter-id"
+      >
+        <span data-w-drilldown-target="count"></span>
+        <button type="button">Show filters</button>
+        <div data-w-drilldown-target="menu" hidden>
+          <h2>Filter by</h2>
+          <button
+            id="drilldown-toggle"
+            type="button"
+            aria-expanded="false"
+            aria-controls="drilldown-field-0"
+            data-action="click->w-drilldown#open"
+            data-w-drilldown-target="toggle"
+          >
+            Field 1
+          </button>
+        </div>
+        <div id="drilldown-field-0" hidden tabIndex="-1">
+          <button type="button" data-action="click->w-drilldown#close">Back</button>
+        </div>
+      </div>
+      <button type="button" id="action-element" data-controller="w-action">Action</button>
+    </section>`,
+    identifier = 'w-drilldown',
+  ) => {
+    document.body.innerHTML = `<main>${html}</main>`;
+
+    application = new Application();
+    application.handleError = (error, message) => {
+      errors.push({ error, message });
+    };
+    application.register(identifier, DrilldownController);
+    application.register('w-action', ActionController);
+    application.register('w-dropdown', DropdownController);
+    application.start();
+
+    await jest.runAllTimersAsync();
+
+    return [
+      ...document.querySelectorAll(`[data-controller~="${identifier}"]`),
+    ].map((element) =>
+      application.getControllerForElementAndIdentifier(element, identifier),
+    );
+  };
+
+  beforeEach(async () => {
+    await setup();
+  });
+
+  afterEach(() => {
+    application?.stop && application.stop();
+    errors = [];
+    eventNames.forEach((name) => {
+      events[name] = [];
+    });
+  });
+
+  describe('Opening & closing', () => {
+    it('opens the submenu and sets active submenu value when toggle is clicked', async () => {
+      const toggleButton = document.getElementById('drilldown-toggle');
+      const submenu = document.getElementById('drilldown-field-0');
+
+      toggleButton.click();
+      await jest.runAllTimersAsync();
+
+      expect(toggleButton.getAttribute('aria-expanded')).toBe('true');
+      expect(submenu.hidden).toBeFalsy();
+    });
+
+    it('closes the submenu and clears active submenu value when close action is triggered', async () => {
+      const toggleButton = document.getElementById('drilldown-toggle');
+      const submenu = document.getElementById('drilldown-field-0');
+
+      toggleButton.click();
+      await jest.runAllTimersAsync();
+
+      expect(submenu.hidden).toBeFalsy();
+
+      const closeButton = document.querySelector(
+        '[data-action="click->w-drilldown#close"]',
+      );
+
+      closeButton.click();
+      await jest.runAllTimersAsync();
+
+      expect(toggleButton.getAttribute('aria-expanded')).toBe('false');
+      expect(submenu.hidden).toBeTruthy();
+    });
+
+    it('should close the menu when clicking outside the controlled area', async () => {
+      const otherTrigger = document.createElement('button');
+      otherTrigger.id = 'other-trigger';
+      otherTrigger.type = 'button';
+      otherTrigger.setAttribute('aria-controls', 'drilldown-field-0');
+      document.body.appendChild(otherTrigger);
+
+      const drilldownContainer = document.getElementById('filters-drilldown');
+      const toggleButton = document.getElementById('drilldown-toggle');
+      const submenu = document.getElementById('drilldown-field-0');
+
+      toggleButton.click();
+      await Promise.resolve();
+      expect(submenu.hidden).toBeFalsy();
+
+      let event = new CustomEvent('w-dropdown:clickaway', {
+        detail: { target: document.getElementById('other-trigger') },
+      });
+      event.preventDefault = jest.fn();
+      drilldownContainer.dispatchEvent(event);
+      await jest.runAllTimersAsync();
+
+      expect(event.preventDefault).toHaveBeenCalled();
+
+      event = new CustomEvent('w-dropdown:clickaway', {
+        detail: { target: document.getElementById('filters-drilldown') },
+      });
+      event.preventDefault = jest.fn();
+      drilldownContainer.dispatchEvent(event);
+      await jest.runAllTimersAsync();
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('should have the ability to be closed with a delay', async () => {
+      const drilldownContainer = document.getElementById('filters-drilldown');
+      const submenu = document.getElementById('drilldown-field-0');
+
+      document.getElementById('drilldown-toggle').click();
+      await Promise.resolve();
+      expect(submenu.hidden).toBe(false);
+
+      drilldownContainer.dispatchEvent(new Event('w-dropdown:hide'));
+      await jest.advanceTimersByTimeAsync(180);
+      expect(submenu.hidden).toBe(false);
+      await jest.advanceTimersByTimeAsync(20);
+      expect(submenu.hidden).toBe(true);
+    });
+  });
+
+  describe('Action outlet connection & disconnection', () => {
+    let actionElement;
+    let openMock;
+
+    beforeEach(() => {
+      actionElement = document.createElement('div');
+      actionElement.id = 'action-element';
+      document.body.appendChild(actionElement);
+
+      openMock = jest.fn();
+      actionElement.addEventListener('click', openMock);
+    });
+
+    it('should add an event listener on outlet connection', async () => {
+      actionElement.dispatchEvent(new Event('connection'));
+      actionElement.click();
+      expect(openMock).toHaveBeenCalled();
+    });
+
+    it('should remove event listener on outlet disconnection', async () => {
+      actionElement.dispatchEvent(new Event('connection'));
+
+      actionElement.click();
+      expect(openMock).toHaveBeenCalledTimes(1);
+
+      actionElement.removeEventListener('click', openMock);
+      actionElement.click();
+      expect(openMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Updating counts', () => {
+    beforeEach(async () => {
+      await setup(`<section>
+        <div id="filters-drilldown" data-controller="w-drilldown" data-w-drilldown-count-attr-value="data-w-active-filter-id" data-action="stimulus-reflex:success->w-drilldown#updateCount">
+          <span data-w-drilldown-target="count"></span>
+          <span data-w-drilldown-target="count" data-count-name="field-0"></span>
+          <div data-w-active-filter-id="field-0"></div>
+          <div data-w-active-filter-id="field-1"></div>
+          <div data-w-active-filter-id="field-0"></div>
+        </div>
+      </section>`);
+    });
+
+    it('updates the count target text and visibility based on data-w-active-filter-id', () => {
+      const countTargets = document.querySelectorAll(
+        '[data-w-drilldown-target="count"]',
+      );
+
+      expect(countTargets[0].textContent).toBe('3');
+      expect(countTargets[0].hidden).toBe(false);
+
+      expect(countTargets[1].textContent).toBe('2');
+      expect(countTargets[1].hidden).toBe(false);
+    });
+  });
+});

--- a/client/src/controllers/DrilldownController.ts
+++ b/client/src/controllers/DrilldownController.ts
@@ -1,10 +1,32 @@
 import { Controller } from '@hotwired/stimulus';
-import { ActionController } from './ActionController';
-import { DropdownController } from './DropdownController';
+
+import type { ActionController } from './ActionController';
+import type { DropdownController } from './DropdownController';
 
 /**
  * Drilldown menu interaction combined with URL-driven
  * state management for listing filters.
+ *
+ * @example
+ * ```html
+ * <section>
+ *   <div data-controller="w-drilldown" data-w-drilldown-count-attr-value="data-w-active-filter-id">
+ *     <div data-w-drilldown-target="menu">
+ *       <h2>Filter by</h2>
+ *       <button type="button" aria-expanded="false" aria-controls="drilldown-field-0" data-w-drilldown-target="toggle" data-action="click->w-drilldown#open">Field 1</button>
+ *       <button type="button" aria-expanded="false" aria-controls="drilldown-field-1" data-w-drilldown-target="toggle" data-action="click->w-drilldown#open">Field 2</button>
+ *     </div>
+ *     <div id="drilldown-field-0" hidden tabIndex="-1">
+ *       <p>...items for field 1</p>
+ *       <button type="button" data-action="click->w-drilldown#close">Back</button>
+ *     </div>
+ *     <div id="drilldown-field-1" hidden tabIndex="-1">
+ *       <p>...items for field 2</p>
+ *       <button type="button" data-action="click->w-drilldown#close">Back</button>
+ *     </div>
+ *   </div>
+ * </section>
+ * ```
  */
 export class DrilldownController extends Controller<HTMLElement> {
   static targets = ['count', 'menu', 'toggle'];
@@ -27,14 +49,22 @@ export class DrilldownController extends Controller<HTMLElement> {
     'w-dropdown',
   ];
 
+  /** Currently active submenu id. */
   declare activeSubmenuValue: string;
+  /** Attribute used to count items. */
   declare countAttrValue: string;
 
+  /** Targets for displaying item counts. */
   declare readonly countTargets: HTMLElement[];
+  /** Main menu target element. */
   declare readonly menuTarget: HTMLElement;
+  /** Targets for submenu toggle buttons. */
   declare readonly toggleTargets: HTMLButtonElement[];
+  /** Indicates if w-dropdown outlet is present. */
   declare readonly hasWDropdownOutlet: boolean;
+  /** Outlets for action controllers. */
   declare readonly wActionOutlets: ActionController[];
+  /** Outlet for the dropdown controller. */
   declare readonly wDropdownOutlet: DropdownController;
 
   countTargetConnected() {

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -84,6 +84,7 @@ depth: 1
  * Refactor redirects create/delete views to use generic views (Sage Abdullah)
  * Add JSDoc description, adopt linting recommendations, and add more unit tests for `ModalWorkflow` (LB (Ben) Johnston)
  * Add support for for a `delay` value in `TagController` to debounce async autocomplete tag fetch requests (Aayushman Singh)
+ * Add unit tests, Storybook stories & JSDoc items for the Stimulus `DrilldownController` (Srishti Jaiswal)
 
 
 ## Upgrade considerations - changes affecting all projects


### PR DESCRIPTION
fixed #12511

- [X] `Unit Test`: Added  test.js for the `DrilldownController`.
- [x] `Storybook Integration`: Added a Storybook file for the `DrilldownController`.
- [X] `Documentation Update`: Included an `@example` in the JSDoc for better clarity and usage guidance.
- [X] Updated the other controller imports in the file as `type` imports, as they are not used for any actual code.