### PR TITLE
Debounce autocomplete tags to boost performance by reducing redundant calls to database

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,7 +9,7 @@ Changelog
  * Increase `DATA_UPLOAD_MAX_NUMBER_FIELDS` in project template (Matt Westcott)
  * Stop invalid Site hostname records from breaking preview (Matt Westcott)
  * Set sensible defaults for InlinePanel heading and label (Matt Westcott)
- * Limit tags autocompletion to 10 items to avoid performance issues with large number of matching tags (Aayushman Singh)
+ * Limit tags autocompletion to 10 items and add delay to avoid performance issues with large number of matching tags (Aayushman Singh)
  * Add the ability to restrict what types of requests a Pages supports via `allowed_http_methods` (Andy Babic)
  * Fix: Improve handling of translations for bulk page action confirmation messages (Matt Westcott)
  * Fix: Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
@@ -64,6 +64,7 @@ Changelog
  * Maintenance: Test project template for warnings when run against Django pre-release versions (Sage Abdullah)
  * Maintenance: Refactor redirects create/delete views to use generic views (Sage Abdullah)
  * Maintenance: Add JSDoc description, adopt linting recommendations, and add more unit tests for `ModalWorkflow` (LB (Ben) Johnston)
+ * Maintenance: Add support for for a `delay` value in `TagController` to debounce async autocomplete tag fetch requests (Aayushman Singh)
 
 
 6.3.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/controllers/TagController.test.js
+++ b/client/src/controllers/TagController.test.js
@@ -1,9 +1,14 @@
 import $ from 'jquery';
 
+import { setImmediate } from 'timers';
 import { Application } from '@hotwired/stimulus';
 import { TagController } from './TagController';
 
 window.$ = $;
+
+jest.useFakeTimers();
+
+const flushPromises = () => new Promise(setImmediate);
 
 describe('TagController', () => {
   let application;
@@ -20,11 +25,22 @@ describe('TagController', () => {
   beforeAll(() => {
     application = Application.start();
     application.register('w-tag', TagController);
+    application.handleError = jest.fn();
   });
 
   beforeEach(() => {
     element = null;
     jest.clearAllMocks();
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve([]),
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await flushPromises();
+    jest.restoreAllMocks();
   });
 
   it('should attach the jQuery tagit to the controlled element', async () => {
@@ -43,11 +59,11 @@ describe('TagController', () => {
 
     expect(tagitMock).not.toHaveBeenCalled();
 
-    await new Promise(requestAnimationFrame);
+    await flushPromises();
 
     expect(tagitMock).toHaveBeenCalledWith({
       allowSpaces: true,
-      autocomplete: { source: '/admin/tag-autocomplete/' },
+      autocomplete: { source: expect.any(Function) },
       preprocessTag: expect.any(Function),
       tagLimit: 10,
     });
@@ -64,13 +80,222 @@ describe('TagController', () => {
     expect(preprocessTag("'long black'")).toEqual(`"'long black'"`);
     expect(preprocessTag('caffe latte')).toEqual(`"caffe latte"`);
 
-    // check the custom clear behaviour
+    // check the custom clear behavior
     document
       .getElementById('id_tags')
       .dispatchEvent(new CustomEvent('example:event'));
 
-    await new Promise(requestAnimationFrame);
+    await flushPromises();
 
     expect(tagitMock).toHaveBeenCalledWith('removeAll');
+  });
+
+  describe('autocomplete', () => {
+    let autocompleteSource;
+
+    beforeAll(async () => {
+      document.body.innerHTML = `
+      <form id="form">
+        <input
+          id="id_tags"
+          type="text"
+          name="tags"
+          data-controller="w-tag"
+          data-action="example:event->w-tag#clear"
+          data-w-tag-delay-value="300"
+          data-w-tag-options-value='${JSON.stringify({
+            allowSpaces: true,
+            tagLimit: 10,
+          })}'
+          data-w-tag-url-value="/admin/tag-autocomplete/"
+        >
+      </form>`;
+
+      await flushPromises();
+
+      // get last mock call
+      autocompleteSource =
+        tagitMock.mock.calls[tagitMock.mock.calls.length - 1][0].autocomplete
+          .source;
+    });
+
+    it('should handle a successful fetch response', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          json: () => Promise.resolve(['tag1', 'tag2', 'tag3']),
+        }),
+      );
+
+      expect(autocompleteSource).toBeInstanceOf(Function);
+
+      const result = await new Promise((resolve) => {
+        autocompleteSource({ term: 'tag' }, resolve);
+        jest.runAllTimers();
+      });
+
+      expect(result).toEqual(['tag1', 'tag2', 'tag3']);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/admin/tag-autocomplete/?term=tag'),
+        {
+          headers: { Accept: 'application/json' },
+          method: 'GET',
+          signal: expect.any(AbortSignal),
+        },
+      );
+    });
+
+    it('should handle empty term gracefully', async () => {
+      const result = await new Promise((resolve) => {
+        autocompleteSource({ term: '' }, resolve);
+        jest.runAllTimers();
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('should handle an empty fetch response', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          json: () => Promise.resolve([]),
+        }),
+      );
+
+      expect(autocompleteSource).toBeInstanceOf(Function);
+
+      const result = await new Promise((resolve) => {
+        autocompleteSource({ term: 'nonexistent' }, resolve);
+        jest.runAllTimers();
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost/admin/tag-autocomplete/?term=nonexistent',
+        expect.any(Object),
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle fetch errors gracefully', async () => {
+      global.fetch = jest.fn(() => Promise.reject(new Error('Fetch error')));
+
+      expect(application.handleError).not.toHaveBeenCalled();
+      expect(autocompleteSource).toBeInstanceOf(Function);
+
+      const result = await new Promise((resolve) => {
+        autocompleteSource({ term: 'error' }, resolve);
+        jest.runAllTimers();
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost/admin/tag-autocomplete/?term=error',
+        expect.any(Object),
+      );
+
+      // check we returned an empty array, even with an error
+      expect(result).toEqual([]);
+
+      // check the error gets handed to Stimulus
+      expect(application.handleError).toHaveBeenCalledWith(
+        new Error('Fetch error'),
+        'Network or API error during autocomplete request.',
+        { term: 'error', url: '/admin/tag-autocomplete/' },
+      );
+    });
+
+    it('should debounce requests to the tag endpoint', async () => {
+      // mocking a slow fetch
+      global.fetch = jest.fn(
+        () =>
+          new Promise((resolve) => {
+            window.setTimeout(resolve, 300);
+          }),
+      );
+
+      expect(autocompleteSource).toBeInstanceOf(Function);
+
+      const response = jest.fn();
+
+      // First request
+      autocompleteSource({ term: 'test1' }, response);
+      jest.advanceTimersByTime(100);
+
+      // Second request during debounce window
+      autocompleteSource({ term: 'test2' }, response);
+      jest.advanceTimersByTime(100);
+
+      // Third request during debounce window
+      autocompleteSource({ term: 'test3' }, response);
+      jest.advanceTimersByTime(50);
+
+      await jest.runAllTimersAsync();
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+
+      expect(fetch).toHaveBeenCalledWith(
+        // only the most recent request should be made
+        expect.stringContaining('/admin/tag-autocomplete/?term=test3'),
+        expect.any(Object),
+      );
+
+      expect(response).toHaveBeenCalledTimes(1);
+      expect(response).toHaveBeenCalledWith([]);
+    });
+
+    it('should allow new requests to to be made after the debounce window & abort in-flight', async () => {
+      // mock a slow fetch the first time but fast the second time
+      global.fetch = jest
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              window.setTimeout(
+                () =>
+                  resolve({ json: () => Promise.resolve(['slow IGNORED']) }),
+                600,
+              );
+            }),
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              window.setTimeout(
+                () => resolve({ json: () => Promise.resolve(['slow cooked']) }),
+                50,
+              );
+            }),
+        );
+
+      expect(autocompleteSource).toBeInstanceOf(Function);
+
+      const response = jest.fn();
+
+      // First request
+      autocompleteSource({ term: 's' }, response);
+      jest.advanceTimersByTime(300);
+
+      // Second request after previous debounce window
+      autocompleteSource({ term: 'slow' }, response);
+
+      await jest.runAllTimersAsync();
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+
+      expect(fetch).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('/admin/tag-autocomplete/?term=s'),
+        expect.any(Object),
+      );
+
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('/admin/tag-autocomplete/?term=slow'),
+        expect.any(Object),
+      );
+
+      expect(application.handleError).not.toHaveBeenCalled();
+
+      expect(response).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/client/src/controllers/TagController.ts
+++ b/client/src/controllers/TagController.ts
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 
 import { Controller } from '@hotwired/stimulus';
+import { debounce } from '../utils/debounce';
 
 declare global {
   interface JQuery {
@@ -15,25 +16,86 @@ declare global {
  *
  * @example
  * <input id="id_tags" type="text" name="tags" data-controller="w-tag" data-w-tag-url-value="/admin/tag-autocomplete/" />
+ *
+ * @example - with delay
+ * <input id="id_tags" type="text" name="tags" data-controller="w-tag" data-w-tag-delay-value="300" data-w-tag-url-value="/admin/tag-autocomplete/" />
  */
 export class TagController extends Controller {
   static values = {
+    delay: { type: Number, default: 0 },
     options: { default: {}, type: Object },
-    url: String,
+    url: { default: '', type: String },
   };
 
+  /** Options for tagit, see https://github.com/aehlke/tag-it#options */
   declare optionsValue: any;
-  declare urlValue: any;
+  /** URL for async tag autocomplete. */
+  declare urlValue: string;
+  /** Delay to use when debouncing the async tag autocomplete. */
+  declare delayValue: number;
+
+  private autocompleteAbort: AbortController | null = null;
+  private autocompleteLazy;
+
   tagit?: JQuery<HTMLElement>;
+
+  initialize() {
+    this.autocompleteLazy = debounce(
+      this.autocomplete.bind(this),
+      this.delayValue,
+    );
+  }
 
   connect() {
     const preprocessTag = this.cleanTag.bind(this);
 
+    const autocomplete = {
+      source: (request, response) => {
+        this.autocompleteLazy.cancel();
+        this.autocompleteLazy(request).then(response);
+      },
+    };
+
     $(this.element).tagit({
-      autocomplete: { source: this.urlValue },
+      autocomplete,
       preprocessTag,
       ...this.optionsValue,
     });
+  }
+
+  async autocomplete({ term }: { term: string }) {
+    if (this.autocompleteAbort) {
+      this.autocompleteAbort.abort();
+    }
+
+    this.autocompleteAbort = new AbortController();
+    const { signal } = this.autocompleteAbort;
+
+    try {
+      const url = new URL(this.urlValue, window.location.origin);
+      url.searchParams.set('term', term);
+
+      const fetchResponse = await fetch(url.toString(), {
+        headers: { Accept: 'application/json' },
+        method: 'GET',
+        signal,
+      });
+
+      const data = await fetchResponse.json();
+      return Array.isArray(data) ? data : [];
+    } catch (error) {
+      if (!(error instanceof DOMException && error.name === 'AbortError')) {
+        this.context.application.handleError(
+          error,
+          'Network or API error during autocomplete request.',
+          { term, url: this.urlValue },
+        );
+      }
+    } finally {
+      this.autocompleteAbort = null;
+    }
+
+    return [];
   }
 
   /**
@@ -49,5 +111,12 @@ export class TagController extends Controller {
    */
   clear() {
     $(this.element).tagit('removeAll');
+  }
+
+  disconnect() {
+    if (this.autocompleteAbort) {
+      this.autocompleteAbort.abort();
+      this.autocompleteAbort = null;
+    }
   }
 }

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -19,7 +19,7 @@ depth: 1
  * Increase `DATA_UPLOAD_MAX_NUMBER_FIELDS` in project template (Matt Westcott)
  * Stop invalid Site hostname records from breaking preview (Matt Westcott)
  * Set sensible defaults for InlinePanel heading and label (Matt Westcott)
- * Limit tags autocompletion to 10 items to avoid performance issues with large number of matching tags (Aayushman Singh)
+ * Limit tags autocompletion to 10 items and add delay to avoid performance issues with large number of matching tags (Aayushman Singh)
  * Add the ability to restrict what types of requests a Pages supports via [`allowed_http_methods`](#wagtail.models.Page.allowed_http_methods) (Andy Babic)
 
 ### Bug fixes
@@ -83,6 +83,7 @@ depth: 1
  * Test project template for warnings when run against Django pre-release versions (Sage Abdullah)
  * Refactor redirects create/delete views to use generic views (Sage Abdullah)
  * Add JSDoc description, adopt linting recommendations, and add more unit tests for `ModalWorkflow` (LB (Ben) Johnston)
+ * Add support for for a `delay` value in `TagController` to debounce async autocomplete tag fetch requests (Aayushman Singh)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/widgets/tags.py
+++ b/wagtail/admin/widgets/tags.py
@@ -48,6 +48,7 @@ class AdminTagWidget(TagWidget):
             help_text = _("Tags can only consist of a single word, no spaces allowed.")
 
         context["widget"]["help_text"] = help_text
+        context["widget"]["attrs"]["data-w-tag-delay-value"] = 200
         context["widget"]["attrs"]["data-w-tag-url-value"] = autocomplete_url
         context["widget"]["attrs"]["data-w-tag-options-value"] = json.dumps(
             {


### PR DESCRIPTION
Solves #12415. Adding simple server side results limiter to 10 and a debouncer for client side for now. 
