### PR TITLE
Fix profile picture upload not working in account settings

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -22,7 +22,7 @@
         action="{{ action_url }}"
         method="POST"
         novalidate
-        {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}
+        {% if form_is_multipart or form.is_multipart %} enctype="multipart/form-data"{% endif %}
         data-edit-form
         data-controller="w-unsaved"
         data-action="w-unsaved#submit beforeunload@window->w-unsaved#confirm change->w-unsaved#check keyup->w-unsaved#check"

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -276,6 +276,9 @@ class TestAccountSection(WagtailTestUtils, TestCase, TestAccountSectionUtilsMixi
         # Form media should be included on the page
         self.assertContains(response, "vendor/colorpicker.js")
 
+        # Form should use the multipart/form-data encoding type
+        self.assertContains(response, 'enctype="multipart/form-data"')
+
         # Check if the default title exists
         self.assertContains(response, "Name and Email")
 

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -238,6 +238,7 @@ class AccountView(WagtailAdminTemplateMixin, TemplateView):
         context["panels_by_tab"] = self.get_panels_by_tab(panels)
         context["menu_items"] = self.get_menu_items()
         context["media"] = self.get_media(panels)
+        context["form_is_multipart"] = True
         context["user"] = self.request.user
         # Remove these when this view is refactored to a generic.EditView subclass.
         # Avoid defining new translatable strings.


### PR DESCRIPTION
Regression in fc05b3eb596589f4262db24db3c5b6835d594573.

This view does not use the generic `EditView` yet, and it uses a separate form for each panel, without a root-level edit handler panel that gives you a `form` that contains all the fields. Thus, there's no singular form instance to be included in the context data.

In that commit, the `<form>` markup is removed from the template so that we reuse the markup from `generic/form.html` instead (and get the goodies like unsaved changes warning config). Unfortunately, we lost the `enctype="multipart/form-data"` attribute because `if form.is_multipart` doesn't evaluate to `True`.

I suppose the most correct solution is to do something like `any(form.is_multipart() for form in panel_forms)`. However, the current view code doesn't make this straightforward to do. The easiest way to do it might be to do the logic in `get_media()` and storing the value to `self`, but that would add a side-effect to the method. Unless we don't care about calling `get_panels()` and `panel.get_form()` multiple times, another way to do it would be to refactor the methods and introduce cached properties like `panels` and `panel_forms`, but that's a few lines more than I'd like for a bugfix.

Looking at the original code before fc05b3eb596589f4262db24db3c5b6835d594573, it seems the template always used `enctype="multipart/form-data"` regardless. So I opted for a simpler fix of just passing `True` directly in the context data.