### PR TITLE
Set sensible defaults for InlinePanel heading and label

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
  * Add the ability to apply basic Page QuerySet optimizations to `specific()` sub-queries using `select_related` & `prefetch_related` (Andy Babic)
  * Increase `DATA_UPLOAD_MAX_NUMBER_FIELDS` in project template (Matt Westcott)
  * Stop invalid Site hostname records from breaking preview (Matt Westcott)
+ * Set sensible defaults for InlinePanel heading and label (Matt Westcott)
  * Fix: Improve handling of translations for bulk page action confirmation messages (Matt Westcott)
  * Fix: Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
  * Fix: Ensure manual edits to `StreamField` values do not throw an error (Stefan Hammer)

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -17,6 +17,7 @@ depth: 1
  * Add the ability to apply basic Page QuerySet optimizations to `specific()` sub-queries using `select_related` & `prefetch_related`, see [](../reference/pages/queryset_reference.md) (Andy Babic)
  * Increase `DATA_UPLOAD_MAX_NUMBER_FIELDS` in project template (Matt Westcott)
  * Stop invalid Site hostname records from breaking preview (Matt Westcott)
+ * Set sensible defaults for InlinePanel heading and label (Matt Westcott)
 
 ### Bug fixes
 

--- a/wagtail/admin/panels/inline_panel.py
+++ b/wagtail/admin/panels/inline_panel.py
@@ -150,7 +150,7 @@ class InlinePanel(Panel):
                     compare.ChildRelationComparison,
                     self.panel.db_field,
                     field_comparisons,
-                    label=self.label,
+                    label=self.heading,
                 )
             ]
 

--- a/wagtail/admin/panels/inline_panel.py
+++ b/wagtail/admin/panels/inline_panel.py
@@ -3,6 +3,7 @@ import functools
 from django import forms
 from django.forms.formsets import DELETION_FIELD_NAME, ORDERING_FIELD_NAME
 from django.utils.functional import cached_property
+from django.utils.text import capfirst
 
 from wagtail.admin import compare
 
@@ -26,7 +27,7 @@ class InlinePanel(Panel):
         super().__init__(*args, **kwargs)
         self.relation_name = relation_name
         self.panels = panels
-        self.heading = heading or label
+        self.heading = heading or label or capfirst(relation_name.replace("_", " "))
         self.label = label
         self.min_num = min_num
         self.max_num = max_num
@@ -77,6 +78,8 @@ class InlinePanel(Panel):
     def on_model_bound(self):
         manager = getattr(self.model, self.relation_name)
         self.db_field = manager.rel
+        if not self.label:
+            self.label = capfirst(self.db_field.related_model._meta.verbose_name)
 
     def classes(self):
         return super().classes() + ["w-panel--nested"]

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -167,7 +167,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             response,
             '<label class="w-field__label" for="id_speakers-__prefix__-last_name" id="id_speakers-__prefix__-last_name-label">',
         )
-        self.assertContains(response, "Add speakers")
+        self.assertContains(response, "Add speaker")
         self.assertContains(response, "Put the keynote speaker first")
 
         # Test MultiFieldPanel help text

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -1569,7 +1569,7 @@ class TestInlinePanelGetComparison(TestCase):
         self.request.user = user
 
     def test_get_comparison(self):
-        # Test whether the InlinePanel passes it's label in get_comparison
+        # Test whether the InlinePanel passes its heading as the label in get_comparison
 
         page = Page.objects.get(id=4).specific
         comparison = (
@@ -1580,7 +1580,7 @@ class TestInlinePanelGetComparison(TestCase):
 
         comparison = [comp(page, page) for comp in comparison]
         field_labels = [comp.field_label() for comp in comparison]
-        self.assertIn("Speakers", field_labels)
+        self.assertIn("Speaker lineup", field_labels)
 
 
 class TestInlinePanelRelatedModelPanelConfigChecks(TestCase):
@@ -2078,7 +2078,7 @@ class TestMultipleChooserPanelGetComparison(TestCase):
         parent_page.add_child(instance=self.page)
 
     def test_get_comparison(self):
-        # Test whether the InlinePanel passes it's label in get_comparison
+        # Test whether the MultipleChooserPanel passes its heading in get_comparison
 
         comparison = (
             self.page.get_edit_handler()

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -1523,6 +1523,13 @@ class TestInlinePanel(WagtailTestUtils, TestCase):
                 ),
             )
 
+    def test_get_heading_and_label_from_field(self):
+        panel = InlinePanel("social_links").bind_to_model(PersonPage)
+        # Heading is the plural term, derived from the relation's related_name
+        self.assertEqual(panel.heading, "Social links")
+        # Label is the singular term, derived from the related model's verbose_name
+        self.assertEqual(panel.label, "Social link")
+
 
 class TestNonOrderableInlinePanel(WagtailTestUtils, TestCase):
     fixtures = ["test.json"]

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -434,7 +434,7 @@ class EventPage(Page):
         FieldPanel("body"),
         InlinePanel(
             "speakers",
-            label="Speakers",
+            label="Speaker",
             heading="Speaker lineup",
             help_text="Put the keynote speaker first",
         ),
@@ -2359,7 +2359,9 @@ class ModelWithNullableParentalKey(models.Model):
 
 class GalleryPage(Page):
     content_panels = Page.content_panels + [
-        MultipleChooserPanel("gallery_images", chooser_field_name="image")
+        MultipleChooserPanel(
+            "gallery_images", heading="Gallery images", chooser_field_name="image"
+        )
     ]
 
 


### PR DESCRIPTION
InlinePanels have a `heading` attribute used as the overall heading for the list (which is usually a plural such as Speakers) and a `label` attribute used for list items (Speaker 1, Speaker 2...) and the 'Add' button (Add speaker). If `heading` is not supplied, it falls back on the label (which isn't ideal, given the singular/plural mismatch), but if neither is supplied, both are blank, which means that `label` is effectively a required argument to InlinePanel.

This PR improves this by setting sensible defaults derived from the relation name: the (plural) heading is a prettified and capitalised version of the relation name, and the (singular) label is the related model's verbose_name capitalised. The latter isn't always great (as it's often a developer-facing name like "Blog page person relation") but it's better than leaving it blank, and the developer still has the option of setting it explicitly.