### PR TITLE
Allow plain strings in panel definitions as shorthand for FieldPanel / InlinePanel

### DIFF
--- a/wagtail/admin/panels/group.py
+++ b/wagtail/admin/panels/group.py
@@ -71,7 +71,10 @@ class PanelGroup(Panel):
         return options
 
     def on_model_bound(self):
-        self.children = [child.bind_to_model(self.model) for child in self.children]
+        from .model_utils import expand_panel_list
+
+        child_panels = expand_panel_list(self.model, self.children)
+        self.children = [child.bind_to_model(self.model) for child in child_panels]
 
     @cached_property
     def child_identifiers(self):

--- a/wagtail/admin/panels/model_utils.py
+++ b/wagtail/admin/panels/model_utils.py
@@ -1,9 +1,12 @@
 import functools
 
+from django.core.exceptions import ImproperlyConfigured
+from django.db.models.fields.reverse_related import ManyToOneRel
 from django.forms.models import fields_for_model
 
 from wagtail.admin.forms.models import formfield_for_dbfield
 
+from .base import Panel
 from .field_panel import FieldPanel
 from .group import ObjectList
 
@@ -47,3 +50,31 @@ def get_edit_handler(model):
         panel = ObjectList(panels)
 
     return panel.bind_to_model(model)
+
+
+def expand_panel_list(model, panels):
+    """
+    Given a list which may be a mixture of Panel instances and strings (representing field/relation names),
+    expand it into a flat list of Panel instances
+    """
+    result = []
+    for panel in panels:
+        if isinstance(panel, Panel):
+            result.append(panel)
+
+        elif isinstance(panel, str):
+            field = model._meta.get_field(panel)
+            if isinstance(field, ManyToOneRel):
+                from .inline_panel import InlinePanel
+
+                result.append(InlinePanel(panel))
+            else:
+                result.append(FieldPanel(panel))
+
+        else:
+            raise ImproperlyConfigured(
+                "Invalid panel definition %r - expected Panel or string, got %r"
+                % (panel, type(panel))
+            )
+
+    return result

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -93,12 +93,7 @@ EVENT_AUDIENCE_CHOICES = (
 )
 
 
-COMMON_PANELS = (
-    FieldPanel("slug"),
-    FieldPanel("seo_title"),
-    FieldPanel("show_in_menus"),
-    FieldPanel("search_description"),
-)
+COMMON_PANELS = ("slug", "seo_title", "show_in_menus", "search_description")
 
 CUSTOM_PREVIEW_SIZES = [
     {
@@ -170,9 +165,9 @@ class CarouselItem(LinkFields):
     caption = models.CharField(max_length=255, blank=True)
 
     panels = [
-        FieldPanel("image"),
-        FieldPanel("embed_url"),
-        FieldPanel("caption"),
+        "image",
+        "embed_url",
+        "caption",
         MultiFieldPanel(LinkFields.panels, "Link"),
     ]
 
@@ -187,7 +182,7 @@ class RelatedLink(LinkFields):
     title = models.CharField(max_length=255, help_text="Link title")
 
     panels = [
-        FieldPanel("title"),
+        "title",
         MultiFieldPanel(LinkFields.panels, "Link"),
     ]
 
@@ -320,10 +315,7 @@ class EventPageSpeakerAward(TranslatableMixin, Orderable, models.Model):
     name = models.CharField("Award name", max_length=255)
     date_awarded = models.DateField(null=True, blank=True)
 
-    panels = [
-        FieldPanel("name"),
-        FieldPanel("date_awarded"),
-    ]
+    panels = ["name", "date_awarded"]
 
     class Meta(TranslatableMixin.Meta, Orderable.Meta):
         pass
@@ -351,9 +343,9 @@ class EventPageSpeaker(TranslatableMixin, Orderable, LinkFields, ClusterableMode
         return self.first_name + " " + self.last_name
 
     panels = [
-        FieldPanel("first_name"),
-        FieldPanel("last_name"),
-        FieldPanel("image"),
+        "first_name",
+        "last_name",
+        "image",
         MultiFieldPanel(LinkFields.panels, "Link"),
         InlinePanel("awards", label="Awards"),
     ]
@@ -422,16 +414,16 @@ class EventPage(Page):
 
     content_panels = [
         FieldPanel("title", classname="title"),
-        FieldPanel("date_from"),
-        FieldPanel("date_to"),
-        FieldPanel("time_from"),
-        FieldPanel("time_to"),
-        FieldPanel("location"),
+        "date_from",
+        "date_to",
+        "time_from",
+        "time_to",
+        "location",
         FieldPanel("audience", help_text="Who this event is for"),
-        FieldPanel("cost"),
-        FieldPanel("signup_link"),
+        "cost",
+        "signup_link",
         InlinePanel("carousel_items", label="Carousel items"),
-        FieldPanel("body"),
+        "body",
         InlinePanel(
             "speakers",
             label="Speaker",
@@ -439,7 +431,7 @@ class EventPage(Page):
             help_text="Put the keynote speaker first",
         ),
         InlinePanel("related_links", label="Related links"),
-        FieldPanel("categories"),
+        "categories",
         # InlinePanel related model uses `pk` not `id`
         InlinePanel("head_counts", label="Head Counts"),
     ]
@@ -2168,13 +2160,13 @@ class PersonPage(Page):
     content_panels = Page.content_panels + [
         MultiFieldPanel(
             [
-                FieldPanel("first_name"),
-                FieldPanel("last_name"),
+                "first_name",
+                "last_name",
             ],
             "Person",
         ),
-        InlinePanel("addresses", label="Address"),
-        InlinePanel("social_links", label="Social links"),
+        "addresses",
+        "social_links",
     ]
 
     class Meta:
@@ -2224,10 +2216,7 @@ class SocialLink(index.Indexed, ClusterableModel):
         to="tests.PersonPage", related_name="social_links", verbose_name="Person"
     )
 
-    panels = [
-        FieldPanel("url"),
-        FieldPanel("kind"),
-    ]
+    panels = ["url", "kind"]
 
     class Meta:
         verbose_name = "Social link"


### PR DESCRIPTION
A small-but-also-huge quality of life improvement when writing panel definitions - instead of writing

    content_panels = Page.content_panels + [
        FieldPanel("introduction"),
        FieldPanel("body"),
        FieldPanel("image"),
    ]

you can just write

    content_panels = Page.content_panels + ["introduction", "body", "image"]

and it will pick FieldPanel or InlinePanel depending on whether the name is a field or a one-to-many relation. You can of course continue to use longhand panel objects if you need to pass parameters or want to use MultiFieldPanel and the like.

Marking as "needs design decision", because if we want to go all in on this, there will be a lot of documentation to update :-)

Incorporates #12556 