### PR TITLE
Normalize StreamField.get_default to prevent creation forms from breaking

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Fix: Fix animation overflow transition when navigating through subpages in the sidebar page explorer (manu)
  * Fix: Ensure form builder supports custom admin form validation (John-Scott Atlakson, LB (Ben) Johnston)
  * Fix: Ensure form builder correctly checks for duplicate field names when using a custom related name (John-Scott Atlakson, LB (Ben) Johnston)
+ * Fix: Normalize `StreamField.get_default()` to prevent creation forms from breaking (Matt Westcott)
  * Docs: Move the model reference page from reference/pages to the references section as it covers all Wagtail core models (Srishti Jaiswal)
  * Docs: Move the panels reference page from references/pages to the references section as panels are available for any model editing, merge panels API into this page (Srishti Jaiswal)
  * Docs: Move the tags documentation to standalone advanced topic, instead of being inside the reference/pages section (Srishti Jaiswal)

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -28,6 +28,7 @@ depth: 1
  * Fix animation overflow transition when navigating through subpages in the sidebar page explorer (manu)
  * Ensure form builder supports custom admin form validation (John-Scott Atlakson, LB (Ben) Johnston)
  * Ensure form builder correctly checks for duplicate field names when using a custom related name (John-Scott Atlakson, LB (Ben) Johnston)
+ * Normalize `StreamField.get_default()` to prevent creation forms from breaking (Matt Westcott)
 
 ### Documentation
 

--- a/wagtail/fields.py
+++ b/wagtail/fields.py
@@ -239,6 +239,9 @@ class StreamField(models.Field):
         defaults.update(kwargs)
         return super().formfield(**defaults)
 
+    def get_default(self):
+        return self.stream_block.normalize(super().get_default())
+
     def value_to_string(self, obj):
         # This method is used for serialization using django.core.serializers,
         # which is used by dumpdata and loaddata for serializing model objects.

--- a/wagtail/tests/test_streamfield.py
+++ b/wagtail/tests/test_streamfield.py
@@ -297,6 +297,18 @@ class TestComplexDefault(TestCase):
         self.assertEqual(self.page.body[1].value[1].block_type, "author")
         self.assertEqual(self.page.body[1].value[1].value, "F. Scott Fitzgerald")
 
+    def test_creation_form_with_initial_instance(self):
+        form_class = ComplexDefaultStreamPage.get_edit_handler().get_form_class()
+        form = form_class(instance=self.page)
+        form_html = form.as_p()
+        self.assertIn("The Great Gatsby", form_html)
+
+    def test_creation_form_without_initial_instance(self):
+        form_class = ComplexDefaultStreamPage.get_edit_handler().get_form_class()
+        form = form_class()
+        form_html = form.as_p()
+        self.assertIn("The Great Gatsby", form_html)
+
 
 class TestStreamFieldRenderingBase(TestCase):
     model = JSONStreamModel


### PR DESCRIPTION
Fixes #12561

When a ModelForm is constructed without passing an `initial` instance, the result of `StreamField.get_default()` will become the default value of the form field without the intermediate step of being set on a model instance and read back (which would have the side effect of calling `normalize()`). Form rendering only works with normalized values (e.g. StreamValue rather than list-of-tuples for a StreamBlock), so the return value from `get_default()` needs to be normalized.
