### PR TITLE
documentation correction - wagtailpagecache should not use quotes around cache name

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@ Changelog
  * Docs: Document usage of custom validation for admin form pages when using `AbstractEmailForm` or `AbstractForm` pages (John-Scott Atlakson, LB (Ben) Johnston)
  * Docs: Reword `BlogTagIndexPage` example for clarity (Clifford Gama)
  * Docs: Change title of blog index page in tutorial to avoid slug issues (Thibaud Colas)
+ * Docs: Fix `wagtailcache` and `wagtailpagecache` examples to not use quotes for the `fragment_name` (Shiv)
  * Maintenance: Close open files when reading within utils/setup.py (Ataf Fazledin Ahamed)
  * Maintenance: Avoid redundant `ALLOWED_HOSTS` check in `Site.find_for_request` (Jake Howard)
  * Maintenance: Update `CloneController` to ensure that `added`/`cleared` events are not dispatched as cancelable (LB (Ben) Johnston)
@@ -58,6 +59,7 @@ Changelog
  * Fix: Improve spacing of page / collection permissions table in Group settings (Sage Abdullah)
  * Docs: Reword `BlogTagIndexPage` example for clarity (Clifford Gama)
  * Docs: Change title of blog index page in tutorial to avoid slug issues (Thibaud Colas)
+ * Docs: Fix `wagtailcache` and `wagtailpagecache` examples to not use quotes for the `fragment_name` (Shiv)
 
 
 6.3 LTS (01.11.2024)

--- a/docs/releases/6.3.1.md
+++ b/docs/releases/6.3.1.md
@@ -23,3 +23,4 @@ depth: 1
 
  * Reword `BlogTagIndexPage` example for clarity and several other tweaks (Clifford Gama)
  * Change title of blog index page in tutorial to avoid slug issues (Thibaud Colas)
+ * Fix `wagtailcache` and `wagtailpagecache` examples to not use quotes for the `fragment_name` (Shiv)

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -52,6 +52,7 @@ depth: 1
  * Document usage of [Custom validation for admin form pages](form_builder_custom_admin_validation) when using `AbstractEmailForm` or `AbstractForm` pages (John-Scott Atlakson, LB (Ben) Johnston)
  * Reword `BlogTagIndexPage` example for clarity (Clifford Gama)
  * Change title of blog index page in tutorial to avoid slug issues (Thibaud Colas)
+ * Fix `wagtailcache` and `wagtailpagecache` examples to not use quotes for the `fragment_name` (Shiv)
 
 ### Maintenance
 

--- a/docs/topics/writing_templates.md
+++ b/docs/topics/writing_templates.md
@@ -342,7 +342,7 @@ The `{% wagtailcache %}` tag functions similarly to Django's `{% cache %}` tag, 
 ```html+django
 {% load wagtail_cache %}
 
-{% wagtailcache 500 "sidebar" %}
+{% wagtailcache 500 sidebar %}
     <!-- sidebar -->
 {% endwagtailcache %}
 ```
@@ -358,7 +358,7 @@ Much like `{% cache %}`, you can use [`make_template_fragment_key`](django.core.
 ```html+django
 {% load wagtail_cache %}
 
-{% wagtailpagecache 500 "hero" %}
+{% wagtailpagecache 500 hero %}
     <!-- hero -->
 {% endwagtailpagecache %}
 ```
@@ -368,7 +368,7 @@ This is identical to:
 ```html+django
 {% wagtail_site as current_site %}
 
-{% wagtailcache 500 "hero" page.cache_key current_site.id %}
+{% wagtailcache 500 hero page.cache_key current_site.id %}
     <!-- hero -->
 {% endwagtailcache %}
 ```


### PR DESCRIPTION
Issue #12541

This pull request addresses an issue in the documentation regarding the usage of the {% wagtailpagecache %} and {% wagtailcache %} template tags. The documentation currently suggests using double quotes around the cache name, which causes issues with cache invalidation when clearing the cache manually in Python.