### PR TITLE
Make draftail features wrap in case there is a lot of added features

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Changelog
  * Fix: Show the correct privacy status in the sidebar when creating a new page (Joel William)
  * Fix: Prevent generic model edit view from unquoting non-integer primary keys multiple times (Matt Westcott)
  * Fix: Ensure comments are functional when editing Page models with `read_only` `Fieldpanel`s in use (Strapchay)
+ * Fix: Ensure Draftail features wrap when a large amount of features are added (Bartosz Cieliński)
  * Docs: Move the model reference page from reference/pages to the references section as it covers all Wagtail core models (Srishti Jaiswal)
  * Docs: Move the panels reference page from references/pages to the references section as panels are available for any model editing, merge panels API into this page (Srishti Jaiswal)
  * Docs: Move the tags documentation to standalone advanced topic, instead of being inside the reference/pages section (Srishti Jaiswal)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -857,6 +857,7 @@
 * Clifford Gama
 * Noah van der Meer
 * Strapchay
+* Bartosz Cieliński
 
 ## Translators
 

--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -212,6 +212,7 @@ $draftail-editor-font-family: theme('fontFamily.sans');
 
 .Draftail-ToolbarGroup {
   display: flex;
+  flex-wrap: wrap;
 }
 
 .Draftail-ToolbarGroup::before {

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -38,6 +38,7 @@ depth: 1
  * Show the correct privacy status in the sidebar when creating a new page (Joel William)
  * Prevent generic model edit view from unquoting non-integer primary keys multiple times (Matt Westcott)
  * Ensure comments are functional when editing Page models with `read_only` `Fieldpanel`s in use (Strapchay)
+ * Ensure Draftail features wrap when a large amount of features are added (Bartosz Cieliński)
 
 ### Documentation
 


### PR DESCRIPTION
After upgrading to 6.3 our huge list of features stopped wrapping: 
![image](https://github.com/user-attachments/assets/142c4728-897e-4bc5-a24f-0963b2c691b0)
![image](https://github.com/user-attachments/assets/7b4f8cd3-b29e-4d6a-b8d3-1769f4954f32)
This makes it look alright again:
![image](https://github.com/user-attachments/assets/c42fee6b-1587-4f6f-bec3-9c185a7c7594)
![image](https://github.com/user-attachments/assets/8df86c7e-461d-4fb4-9044-945f6858604b)

