### PR TITLE
Refactor `ImageBlock.bulk_to_python` to handle more cases of bad data

### DIFF
--- a/wagtail/images/tests/test_blocks.py
+++ b/wagtail/images/tests/test_blocks.py
@@ -253,6 +253,11 @@ class TestImageBlock(TestImageChooserBlock):
         result = block.bulk_to_python([])
         self.assertEqual(result, [])
 
+    def test_bulk_to_python_with_list_of_none(self):
+        block = ImageBlock(required=False)
+        result = block.bulk_to_python([None])
+        self.assertEqual(result, [None])
+
     def test_bulk_to_python_with_list_of_ints(self):
         block = ImageBlock(required=False)
         result = block.bulk_to_python([None, self.image.id, self.image.id])


### PR DESCRIPTION
Specifically, cases where an ImageChooserBlock to ImageBlock migration results in `[None]` as a value.

ref: https://github.com/wagtail/wagtail/issues/12514

---

We were still seeing the same crash referenced in #12514 on Wagtail.org with the fixes from #12517 applied.

In the process, we (@cnk @vossisboss) decided to refactor this logic a bit more.