### PR TITLE
Rename tutorial blog index page to reduce the likelihood of slug issues

### DIFF
--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -344,7 +344,7 @@ Now that this is complete, here is how you can create a page from the Wagtail [a
 2.  In the Wagtail [admin interface](https://guide.wagtail.org/en-latest/concepts/wagtail-interfaces/#admin-interface), go to Pages, then click Home.
 3.  Add a child page to the Home page by clicking **...** at the top of the screen and selecting the option **Add child page**.
 4.  Choose **Blog index page** from the list of the page types.
-5.  Use "Our Blog" as your page title, make sure it has the slug "blog" on the Promote tab, and publish it.
+5.  Use "Blog" as your page title, make sure it has the slug "blog" on the Promote tab, and publish it.
 
 You can now access the URL, <http://127.0.0.1:8000/blog> on your site. Note how the slug from the Promote tab defines the page URL.
 
@@ -415,7 +415,7 @@ URL of the blog this post is a part of.
 Now, go to your [admin interface](https://guide.wagtail.org/en-latest/concepts/wagtail-interfaces/#admin-interface) and create a few blog posts as children of `BlogIndexPage` by following these steps:
 
 1.  Click **Pages** from the Wagtail [Sidebar](https://guide.wagtail.org/en-latest/how-to-guides/find-your-way-around/#the-sidebar), and then click **Home**
-2.  Hover on **Our blog** and click **Add child page**.
+2.  Hover on **Blog** and click **Add child page**.
 
 ![Page listing for Home page with the "Add Child Page" button highlighted in red](../_static/images/tutorial/tutorial_4a.png)
 
@@ -442,7 +442,7 @@ Publish each blog post when you are done editing.
 Congratulations! You now have the beginnings of a working blog. If you go to
 <http://127.0.0.1:8000/blog> in your browser, you can see all the posts that you created by following the preceding steps:
 
-![Basic "Our blog" page with three blogs listed, with their title, content](../_static/images/tutorial/tutorial_7.png)
+![Basic blog index page with three blogs listed, with their title, content](../_static/images/tutorial/tutorial_7.png)
 
 Titles should link to post pages, and a link back to the blog's homepage should appear in the footer of each post page.
 
@@ -502,10 +502,10 @@ For more information, see [Page QuerySet reference](../reference/pages/queryset_
 
 ### Overriding Context
 
-With a keen eye, you may have noticed problems with the `Our blog` page:
+With a keen eye, you may have noticed problems with the blog index page:
 
-1.  `Our blog` orders posts in chronological order. Generally blogs display content in _reverse_ chronological order.
-2.  `Our blog` displays all content. You want to make sure that it displays only _published_ content.
+1.  Posts are in chronological order. Generally blogs display content in _reverse_ chronological order.
+2.  Posts drafts are visible. You want to make sure that it displays only _published_ content.
 
 To accomplish these, you need to do more than grab the index
 page's children in the template. Instead, you want to modify the
@@ -924,7 +924,7 @@ Wagtail ecosystem, so that you can give it a title and URL in the
 admin, and so that you can manipulate its contents by returning
 a QuerySet from its `get_context()` method.
 
-Migrate this by running `python manage.py makemigrations` and then `python manage.py migrate`. After migrating the new changes, create a new `BlogTagIndexPage` in the admin interface. To create the `BlogTagIndexPage`, follow the same process you followed in creating the `BlogIndexPage` and give it the slug "tags" on the Promote tab. This means the `BlogTagIndexPage` is a child of the home page and parallel to `Our Blog` in the admin interface.
+Migrate this by running `python manage.py makemigrations` and then `python manage.py migrate`. After migrating the new changes, create a new `BlogTagIndexPage` in the admin interface. To create the `BlogTagIndexPage`, follow the same process you followed in creating the `BlogIndexPage` and give it the slug "tags" on the Promote tab. This means the `BlogTagIndexPage` is a child of the home page and parallel to `Blog` in the admin interface.
 
 Access `/tags` and Django will tell you what you probably already knew.
 You need to create the template, `blog/templates/blog/blog_tag_index_page.html` and add the following content to it:


### PR DESCRIPTION
See [recent Slack discussion](https://wagtailcms.slack.com/archives/C014L7KJH3N/p1731630356768909). I’m sure it’s a common issue that people create their blog index page without realising its slug doesn’t match what we have listed in our tutorial, due to slug being auto-filled based on the page title.

We can change the page title to the simpler "Blog", which addresses this possible point of friction, and is a very realistic title for a blog index page in any case.

---

For further references to the index page, I tried to switch some of them to use other ways than the page title, for clarity.