### PR TITLE
Reduce unnecessary icon usages in the preview panel

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -67,6 +67,7 @@ Changelog
  * Maintenance: Add JSDoc description, adopt linting recommendations, and add more unit tests for `ModalWorkflow` (LB (Ben) Johnston)
  * Maintenance: Add support for for a `delay` value in `TagController` to debounce async autocomplete tag fetch requests (Aayushman Singh)
  * Maintenance: Add unit tests, Storybook stories & JSDoc items for the Stimulus `DrilldownController` (Srishti Jaiswal)
+ * Maintenance: Enhance sidebar preview performance by eliminating duplicate asset loads on preview error (Sage Abdullah)
 
 
 6.3.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/scss/components/_preview-panel.scss
+++ b/client/scss/components/_preview-panel.scss
@@ -198,5 +198,12 @@
     width: 0;
     height: 0;
     opacity: 0;
+
+    // Remove mask-image from radio inputs to avoid loading the default icon,
+    // use extra specificity to beat the default styles
+    &:is(input[type='radio'])::before {
+      content: none;
+      mask-image: none;
+    }
   }
 }

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -86,6 +86,7 @@ depth: 1
  * Add JSDoc description, adopt linting recommendations, and add more unit tests for `ModalWorkflow` (LB (Ben) Johnston)
  * Add support for for a `delay` value in `TagController` to debounce async autocomplete tag fetch requests (Aayushman Singh)
  * Add unit tests, Storybook stories & JSDoc items for the Stimulus `DrilldownController` (Srishti Jaiswal)
+ * Enhance sidebar preview performance by eliminating duplicate asset loads on preview error (Sage Abdullah)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/templates/wagtailadmin/generic/preview_error.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/preview_error.html
@@ -21,3 +21,6 @@
 {# Avoid loading all of Wagtail’s JavaScript for a fully static page. #}
 {% block js %}
 {% endblock %}
+
+{# Avoid loading Wagtail’s icons sprite. #}
+{% block icons_sprite %}{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -17,9 +17,11 @@
     {% sidebar_collapsed as sidebar_collapsed %}
     {% fragment as bodyclass %}{% block bodyclass %}{% endblock %}{% endfragment %}
     <body id="wagtail" class="{% classnames bodyclass sidebar_collapsed|yesno:"sidebar-collapsed," messages|yesno:"has-messages," %}" data-controller="w-init" data-w-init-ready-class="ready">
-        <div data-sprite></div>
+        {% block icons_sprite %}
+            <div data-sprite></div>
 
-        <script src="{% versioned_static 'wagtailadmin/js/icons.js' %}" data-icon-url="{% icon_sprite_url %}"></script>
+            <script src="{% versioned_static 'wagtailadmin/js/icons.js' %}" data-icon-url="{% icon_sprite_url %}"></script>
+        {% endblock %}
 
         <noscript class="capabilitymessage">
             {% blocktrans trimmed %}

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
 
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.views.pages.preview import PreviewOnEdit
 from wagtail.models import Page, Site
 from wagtail.test.testapp.models import (
@@ -159,6 +160,7 @@ class TestPreview(WagtailTestUtils, TestCase):
             '<h1 class="preview-error__title">Preview not available</h1>',
             html=True,
         )
+        self.assertNotContains(response, versioned_static("wagtailadmin/js/icons.js"))
 
     def test_preview_on_create_with_invalid_data(self):
         preview_url = reverse(
@@ -198,6 +200,7 @@ class TestPreview(WagtailTestUtils, TestCase):
             '<h1 class="preview-error__title">Preview not available</h1>',
             html=True,
         )
+        self.assertNotContains(response, versioned_static("wagtailadmin/js/icons.js"))
 
     def test_preview_on_create_with_m2m_field(self):
         preview_url = reverse(
@@ -418,6 +421,7 @@ class TestPreview(WagtailTestUtils, TestCase):
             '<h1 class="preview-error__title">Preview not available</h1>',
             html=True,
         )
+        self.assertNotContains(response, versioned_static("wagtailadmin/js/icons.js"))
 
     def test_preview_on_edit_clear_preview_data(self):
         preview_session_key = f"wagtail-preview-{self.event_page.id}"
@@ -453,6 +457,7 @@ class TestPreview(WagtailTestUtils, TestCase):
             '<h1 class="preview-error__title">Preview not available</h1>',
             html=True,
         )
+        self.assertNotContains(response, versioned_static("wagtailadmin/js/icons.js"))
 
     def test_preview_modes(self):
         preview_url = reverse(

--- a/wagtail/snippets/tests/test_preview.py
+++ b/wagtail/snippets/tests/test_preview.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
 
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.views.generic.preview import PreviewOnEdit
 from wagtail.test.testapp.models import (
     EventCategory,
@@ -59,6 +60,7 @@ class TestPreview(WagtailTestUtils, TestCase):
             '<h1 class="preview-error__title">Preview not available</h1>',
             html=True,
         )
+        self.assertNotContains(response, versioned_static("wagtailadmin/js/icons.js"))
 
     def test_preview_on_create_with_invalid_data(self):
         self.assertNotIn(self.session_key_prefix, self.client.session)
@@ -90,6 +92,7 @@ class TestPreview(WagtailTestUtils, TestCase):
             '<h1 class="preview-error__title">Preview not available</h1>',
             html=True,
         )
+        self.assertNotContains(response, versioned_static("wagtailadmin/js/icons.js"))
 
     def test_preview_on_create_with_m2m_field(self):
         response = self.client.post(self.preview_on_add_url, self.post_data)
@@ -229,6 +232,7 @@ class TestPreview(WagtailTestUtils, TestCase):
             '<h1 class="preview-error__title">Preview not available</h1>',
             html=True,
         )
+        self.assertNotContains(response, versioned_static("wagtailadmin/js/icons.js"))
 
     def test_preview_on_edit_clear_preview_data(self):
         # Set a fake preview session data for the page
@@ -259,6 +263,7 @@ class TestPreview(WagtailTestUtils, TestCase):
             '<h1 class="preview-error__title">Preview not available</h1>',
             html=True,
         )
+        self.assertNotContains(response, versioned_static("wagtailadmin/js/icons.js"))
 
     def test_preview_revision(self):
         snippet = MultiPreviewModesModel.objects.create(text="Multiple modes")


### PR DESCRIPTION
Per #12578.

- [x] Stop loading radio-full.svg for preview sizes
- [x] Skip loading the icons sprite in preview (error) template