### PR TITLE
Ensure that creation of image/document choose permissions happens after access_admin permission exists

### DIFF
--- a/wagtail/documents/migrations/0011_add_choose_permissions.py
+++ b/wagtail/documents/migrations/0011_add_choose_permissions.py
@@ -80,6 +80,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("wagtaildocs", "0010_document_file_hash"),
+        ("wagtailadmin", "0001_create_admin_access_permissions"),
     ]
 
     operations = [

--- a/wagtail/images/migrations/0023_add_choose_permissions.py
+++ b/wagtail/images/migrations/0023_add_choose_permissions.py
@@ -80,6 +80,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("wagtailimages", "0022_uploadedimage"),
+        ("wagtailadmin", "0001_create_admin_access_permissions"),
     ]
 
     operations = [


### PR DESCRIPTION
As per https://github.com/wagtail/wagtail/issues/12581#issuecomment-2478798241.

Fixes #12581
