### PR TITLE
Improve spacing of page permissions table in Group settings

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_formset.html
+++ b/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_formset.html
@@ -17,9 +17,9 @@
     <table class="listing">
         <col />
         {% for i in formset.permission_types %}
-            <col width="15%" />
+            <col width="5%" />
         {% endfor %}
-        <col />
+        <col width="10%" />
         <thead>
             <tr>
                 <th>{% trans "Collection" %}</th>

--- a/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_formset.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_formset.html
@@ -16,9 +16,9 @@
     <table class="listing">
         <col />
         {% for i in formset.permission_types %}
-            <col width="15%" />
+            <col width="5%" />
         {% endfor %}
-        <col />
+        <col width="10%" />
         <thead>
             <tr>
                 <th>{% trans "Page" %}</th>


### PR DESCRIPTION
Small interim fix for #12584.

![Image](https://github.com/user-attachments/assets/8607d5c4-3363-4d37-b716-85d2c64e4991)


I think we ought to rewrite our table styles at some point. These tables use `.listing`, which they shouldn't, but the essential styling of our tables rely on that class. Now that the main listing views use universal listings, the best course might be to write new styles for tables and make the builtin ones use them. Then, we deprecate the old styles in case people still use it, to be removed in the next major release. It's probably not going to be an easy task, though. We'll also need to rethink how we might replace our `width` attribute usage on the `col` elements as it's actually deprecated.

