### PR TITLE
Lower docs search ranking for release notes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,3 +12,7 @@ python:
 formats: all
 sphinx:
   fail_on_warning: True
+search:
+  ranking:
+    releases/*: -1
+    releases/upgrading.html: 0


### PR DESCRIPTION
Except for the 'upgrading' section, as it's still generally useful. (Let me know if we don't want to make that exception.)

I think this should be backported to `stable/6.3.x`, so that we can improve the search results on the stable docs. Right now it's not great, as described in #12545.

See also the docs for this config on RTD: https://docs.readthedocs.io/en/stable/config-file/v2.html#search-ranking. The value is an integer that goes from `-10` to `10`, with 0 being the default.