### PR TITLE
Fix misleading wording - clarify that get_site_root is created, not used

### DIFF
--- a/docs/tutorial/set_up_site_menu.md
+++ b/docs/tutorial/set_up_site_menu.md
@@ -21,7 +21,7 @@ def get_site_root(context):
     return Site.find_for_request(context["request"]).root_page
 ```
 
-In the preceding code, you used the `get_site_root` template tag to retrieve the root page of your site, which is your `HomePage` in this case.
+In the preceding code, you created the `get_site_root` template tag to retrieve the root page of your site, which is your `HomePage` in this case.
 
 Now, create `mysite/templates/includes/header.html` file and add the following to it:
 


### PR DESCRIPTION
The tag has been only just created and is yet to be used at this point in the tutorial.