### PR TITLE
Fix typo: remove reference to PublishingPanel as a method

### DIFF
--- a/docs/tutorial/create_footer_for_all_pages.md
+++ b/docs/tutorial/create_footer_for_all_pages.md
@@ -218,7 +218,7 @@ Since your `FooterText` model is a Wagtail snippet, you must manually add `Mixin
 
 `TranslatableMixin` is an abstract model you can add to any non-page Django model to make it translatable.
 
-Also, with Wagtail, you can set publishing schedules for changes you made to a Snippet. You can use the `PublishingPanel()` method to schedule `revisions` in your `FooterText`.
+Also, with Wagtail, you can set publishing schedules for changes you made to a Snippet. You can use a `PublishingPanel` to schedule revisions in your `FooterText`.
 
 The `__str__` method defines a human-readable string representation of an instance of the `FooterText` class. It returns the string "Footer text".
 


### PR DESCRIPTION
Corrects the following in docs:

>You can use the `PublishingPanel()` method to schedule `revisions` in your `FooterText`.

`PublishingPanel` is not a method.

Side note: I wasn't sure if I should remove the backticks on revisions here, or in a separate commit or PR, or if they are intentional. But I removed them as "revisions" here is not a piece of code, nor does it refer to a piece of code. Be happy to remove the change or make it a separate commit.
