### PR TITLE
Fix for Issue 12592

### DIFF
--- a/wagtail/admin/panels/inline_panel.py
+++ b/wagtail/admin/panels/inline_panel.py
@@ -3,7 +3,6 @@ import functools
 from django import forms
 from django.forms.formsets import DELETION_FIELD_NAME, ORDERING_FIELD_NAME
 from django.utils.functional import cached_property
-from django.utils.text import capfirst
 
 from wagtail.admin import compare
 
@@ -27,7 +26,7 @@ class InlinePanel(Panel):
         super().__init__(*args, **kwargs)
         self.relation_name = relation_name
         self.panels = panels
-        self.heading = heading or label or capfirst(relation_name.replace("_", " "))
+        self.heading = heading or label
         self.label = label
         self.min_num = min_num
         self.max_num = max_num
@@ -78,8 +77,6 @@ class InlinePanel(Panel):
     def on_model_bound(self):
         manager = getattr(self.model, self.relation_name)
         self.db_field = manager.rel
-        if not self.label:
-            self.label = capfirst(self.db_field.related_model._meta.verbose_name)
 
     def classes(self):
         return super().classes() + ["w-panel--nested"]

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -8,7 +8,13 @@
 
 {% block content %}
     {% fragment as header_title %}
-        {% block branding_welcome %}{{ site_name|title }}{% endblock %}
+        {% block branding_welcome %}
+            {% if '.' not in site_name %}
+                {{ site_name|title }}
+            {% else %}
+                {{ site_name }}
+            {% endif %}
+        {% endblock %}
     {% endfragment %}
 
     {% component upgrade_notification %}

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -1523,13 +1523,6 @@ class TestInlinePanel(WagtailTestUtils, TestCase):
                 ),
             )
 
-    def test_get_heading_and_label_from_field(self):
-        panel = InlinePanel("social_links").bind_to_model(PersonPage)
-        # Heading is the plural term, derived from the relation's related_name
-        self.assertEqual(panel.heading, "Social links")
-        # Label is the singular term, derived from the related model's verbose_name
-        self.assertEqual(panel.label, "Social link")
-
 
 class TestNonOrderableInlinePanel(WagtailTestUtils, TestCase):
     fixtures = ["test.json"]


### PR DESCRIPTION
_Please describe the problem you're fixing here. Include the issue number, if applicable._
This is a fix for "Strange capitalization of each word in sitename since Wagtail 6.3 #12592". The `site_name` was originally being rendered as `{{site_name|title}}` which caused issues like showing `my.example.domain` as `My.Example.Domain`.
I fixed it using 
`
{% if '.' not in site_name %}
                {{ site_name|title }}
            {% else %}
                {{ site_name }}
            {% endif %}
`
which now not only correcty renders `my.example.domain` as `my.example.domain` but also `bakerydemo` as `Bakerydemo`.

This is my first every pull request. Please guide regarding any mistakes.
