### PR TITLE
fix for "Strange capitalization of each word in sitename since Wagtail 6.3 #12592"

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -8,7 +8,13 @@
 
 {% block content %}
     {% fragment as header_title %}
-        {% block branding_welcome %}{{ site_name|title }}{% endblock %}
+        {% block branding_welcome %}
+            {% if '.' not in site_name %}
+                {{ site_name|title }}
+            {% else %}
+                {{ site_name }}
+            {% endif %}
+        {% endblock %}
     {% endfragment %}
 
     {% component upgrade_notification %}


### PR DESCRIPTION
_Please describe the problem you're fixing here. Include the issue number, if applicable._

Original Code:
`{% block branding_welcome %}{{ site_name|title }}{% endblock %}`
Rendering (Flawed):
faulty:  `my.example.domain`: `My.Example.Domain`
correct: `bakerydemo`: `Bakerydemo`

New Code:
`{% block branding_welcome %}
            {% if '.' not in site_name %}
                {{ site_name|title }}
            {% else %}
                {{ site_name }}
            {% endif %}
        {% endblock %}`
Rendering:
- [x] `my.example.domain`: `my.example.domain`
- [x] `bakerydemo`: `Bakerydemo`


