### PR TITLE
Add Wagtail settings to custom user models documentation

### DIFF
--- a/docs/advanced_topics/customization/custom_user_models.md
+++ b/docs/advanced_topics/customization/custom_user_models.md
@@ -91,6 +91,14 @@ in the default templates. There is a `fields` block that allows appending
 fields to the end or beginning of the existing fields or to allow all the fields to
 be redefined.
 
+Add the Wagtail settings to your project to reference the user form additions:
+
+```python
+WAGTAIL_USER_EDIT_FORM = 'users.forms.CustomUserEditForm'
+WAGTAIL_USER_CREATION_FORM = 'users.forms.CustomUserCreationForm'
+WAGTAIL_USER_CUSTOM_FIELDS = ['country', 'status']
+```
+
 (custom_userviewset)=
 
 ## Creating a custom `UserViewSet`


### PR DESCRIPTION
Creating a custom user model following the documentation for the stable release did not work without adding the Wagtail settings for the custom user edit/creation form from the documentation for version 6.1.3. 

Without the settings, the result from the placeholder was None.