### PR TITLE
Added simple check to Lexeme creation in the mysql backend

### DIFF
--- a/wagtail/search/backends/database/mysql/mysql.py
+++ b/wagtail/search/backends/database/mysql/mysql.py
@@ -344,7 +344,11 @@ class MySQLSearchQueryCompiler(BaseSearchQueryCompiler):
 
             lexemes = Lexeme(last_term, invert=invert, prefix=self.LAST_TERM_IS_PREFIX)
             for term in terms:
-                new_lexeme = Lexeme(term, invert=invert)
+                try:
+                    new_lexeme = Lexeme(term, invert=invert)
+                except ValueError:
+                    # Ignore terms that result in invalid lexemes
+                    continue
 
                 if query.operator == "and":
                     lexemes &= new_lexeme

--- a/wagtail/search/backends/database/mysql/query.py
+++ b/wagtail/search/backends/database/mysql/query.py
@@ -55,7 +55,9 @@ class Lexeme(LexemeCombinable, Value):
         
         # check if removal of non-word characters would result in an empty expression
         if not re.sub(r"\W+", "", self.value):
-            raise ValueError("Lexeme with this value would result in an empty expression")
+            raise ValueError(
+                "Lexeme with this value would result in an empty expression"
+            )
 
     def as_sql(self, compiler, connection):
         param = re.sub(

--- a/wagtail/search/backends/database/mysql/query.py
+++ b/wagtail/search/backends/database/mysql/query.py
@@ -52,7 +52,7 @@ class Lexeme(LexemeCombinable, Value):
         self.invert = invert
         self.weight = weight
         super().__init__(value, output_field=output_field)
-        
+
         # check if removal of non-word characters would result in an empty expression
         if not re.sub(r"\W+", "", self.value):
             raise ValueError(

--- a/wagtail/search/backends/database/mysql/query.py
+++ b/wagtail/search/backends/database/mysql/query.py
@@ -52,6 +52,10 @@ class Lexeme(LexemeCombinable, Value):
         self.invert = invert
         self.weight = weight
         super().__init__(value, output_field=output_field)
+        
+        # check if removal of non-word characters would result in an empty expression
+        if not re.sub(r"\W+", "", self.value):
+            raise ValueError("Lexeme with this value would result in an empty expression")
 
     def as_sql(self, compiler, connection):
         param = re.sub(

--- a/wagtail/search/tests/test_mysql_backend.py
+++ b/wagtail/search/tests/test_mysql_backend.py
@@ -68,6 +68,15 @@ class TestMySQLSearchBackend(BackendTests, TransactionTestCase):
             all_other_titles | {"JavaScript: The Definitive Guide"},
         )
 
+        # Tests multiple words with a special character in between surrounded by spaces so it becomes a separate word, which should be removed by the MySQL backend before the query is executed and therefore should not affect the results or break the query
+        results = self.backend.search(
+            ~PlainText("javascript & parts"), models.Book.objects.all()
+        )
+        self.assertSetEqual(
+            {r.title for r in results},
+            all_other_titles | {"JavaScript: The Definitive Guide"},
+        )
+
     @skip(
         "The MySQL backend doesn't support choosing individual fields for the search, only (body, title) or (autocomplete) fields may be searched."
     )


### PR DESCRIPTION
Our editors are sometimes searching company names in the wagtail admin search. Something like *company & co* and then get no results and I get many errors. 
Other people ran into the same issues using the mysql search backend (see #8094 and #8614).
I propose this simple fix to avoid adding terms to the search query that will evaluate to empty expressions. Anything that is just non-word characters will be ignored, when creating the Lexeme instance, by raising a ValueError that is later caught.
So this should fix #8094 and #8614.

Please let me know if there is anything to improve.
