### PR TITLE
Ensure cloudfront purges are called with lists

### DIFF
--- a/wagtail/contrib/frontend_cache/backends/cloudfront.py
+++ b/wagtail/contrib/frontend_cache/backends/cloudfront.py
@@ -72,7 +72,7 @@ class CloudfrontBackend(BaseBackend):
                 paths_by_distribution_id[distribution_id].add(url_parsed.path)
 
         for distribution_id, paths in paths_by_distribution_id.items():
-            self._create_invalidation(distribution_id, paths)
+            self._create_invalidation(distribution_id, list(paths))
 
     def purge(self, url):
         self.purge_batch([url])

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -360,7 +360,7 @@ class TestBackendConfiguration(SimpleTestCase):
             backends.get("cloudfront").purge("http://torchbox.com/blog/")
 
         _create_invalidation.assert_called_once_with(
-            "frontend", {"/home/events/christmas/"}
+            "frontend", ["/home/events/christmas/"]
         )
 
         self.assertTrue(


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/12538

It seems `botocore` doesn't like invalidating with a `set`. The source for `botocore` is hard to navigate, so it's hard to tell when this changed or see about adding `set` support, so instead just cast to a `list`.