### PR TITLE
implemented functionality for shortcut key for link entity tooltip render using ctrl + k

### DIFF
--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
@@ -876,7 +876,7 @@ function CommentableEditor({
 
               if(commandTriggeredInLinkEntity){
                 const currentParent = window.getSelection()?.focusNode?.parentElement?.closest('[data-draftail-trigger]')
-                //trigger mouseEvent to Activate tooltip
+                // trigger mouseEvent to Activate tooltip
                 const mouseUpEvent = new MouseEvent('mouseup', {bubbles: true, cancelable: true });
                 currentParent?.dispatchEvent(mouseUpEvent);
 

--- a/client/src/components/Draftail/decorators/TooltipEntity.js
+++ b/client/src/components/Draftail/decorators/TooltipEntity.js
@@ -17,6 +17,8 @@ export const shortenLabel = (label) => {
   return shortened;
 };
 
+const ENTER_KEY_CODE = 13
+
 class TooltipEntity extends Component {
   constructor(props) {
     super(props);
@@ -111,6 +113,14 @@ class TooltipEntity extends Component {
                   target="_blank"
                   rel="noreferrer"
                   className="Tooltip__link"
+                  onKeyDown={(e)=>{
+                    e.preventDefault()
+                    e.stopPropagation()
+                    if(e?.keyCode === ENTER_KEY_CODE){
+                      window.open(url, "_blank", "noopener,noreferrer")
+                      this.closeTooltip()
+                    };
+                  }}
                 >
                   {shortenLabel(label)}
                 </a>
@@ -119,6 +129,8 @@ class TooltipEntity extends Component {
               <button
                 className="button button-small Tooltip__button"
                 onClick={this.onEdit}
+                onKeyDown={(e)=>{
+                  if(e?.keyCode === ENTER_KEY_CODE)this.onEdit(e)}}
               >
                 Edit
               </button>
@@ -126,6 +138,8 @@ class TooltipEntity extends Component {
               <button
                 className="button button-small button-secondary no Tooltip__button"
                 onClick={this.onRemove}
+                onKeyDown={(e)=>{
+                  if(e?.keyCode === ENTER_KEY_CODE) this.onRemove(e)}}
               >
                 Remove
               </button>

--- a/client/src/components/Draftail/decorators/__snapshots__/TooltipEntity.test.js.snap
+++ b/client/src/components/Draftail/decorators/__snapshots__/TooltipEntity.test.js.snap
@@ -55,6 +55,7 @@ exports[`TooltipEntity #openTooltip 1`] = `
       <a
         className="Tooltip__link"
         href="https://www.example.com/"
+        onKeyDown={[Function]}
         rel="noreferrer"
         target="_blank"
         title="https://www.example.com/"
@@ -64,12 +65,14 @@ exports[`TooltipEntity #openTooltip 1`] = `
       <button
         className="button button-small Tooltip__button"
         onClick={[Function]}
+        onKeyDown={[Function]}
       >
         Edit
       </button>
       <button
         className="button button-small button-secondary no Tooltip__button"
         onClick={[Function]}
+        onKeyDown={[Function]}
       >
         Remove
       </button>

--- a/client/src/components/Portal/Portal.tsx
+++ b/client/src/components/Portal/Portal.tsx
@@ -63,6 +63,7 @@ class Portal extends Component<{
       if(event?.ctrlKey && event?.keyCode === this.K_KEY_CODE) return true
       if([this.CONTROL_KEY_CODE, this.K_KEY_CODE, this.ENTER_KEY_CODE].includes(event?.keyCode)) return true
     }
+    return false
   }
 
   componentDidMount() {

--- a/client/src/components/Portal/Portal.tsx
+++ b/client/src/components/Portal/Portal.tsx
@@ -33,6 +33,9 @@ class Portal extends Component<{
   };
 
   portal: HTMLElement;
+  CONTROL_KEY_CODE: Number = 17;
+  K_KEY_CODE: Number = 75
+  ENTER_KEY_CODE: Number = 13
 
   constructor(props) {
     super(props);
@@ -43,11 +46,22 @@ class Portal extends Component<{
   }
 
   onCloseEvent(event: MouseEvent) {
-    const { onClose } = this.props;
-    const target = event.target as Element;
+    const isLinkTooltipKeyTriggerEvent = this.checkTooltipKeyTrigerEvent(event);
 
-    if (!this.portal.contains(target)) {
-      onClose();
+    if(!isLinkTooltipKeyTriggerEvent){
+      const { onClose } = this.props;
+      const target = event.target as Element;
+
+      if (!this.portal.contains(target)) {
+        onClose();
+      }
+    }
+  }
+
+  checkTooltipKeyTrigerEvent(event: MouseEvent | KeyboardEvent){
+    if(event instanceof KeyboardEvent){
+      if(event?.ctrlKey && event?.keyCode === this.K_KEY_CODE) return true
+      if([this.CONTROL_KEY_CODE, this.K_KEY_CODE, this.ENTER_KEY_CODE].includes(event?.keyCode)) return true
     }
   }
 

--- a/client/src/components/Portal/Portal.tsx
+++ b/client/src/components/Portal/Portal.tsx
@@ -46,7 +46,7 @@ class Portal extends Component<{
   }
 
   onCloseEvent(event: MouseEvent) {
-    const isLinkTooltipKeyTriggerEvent = this.checkTooltipKeyTrigerEvent(event);
+    const isLinkTooltipKeyTriggerEvent = this.checkTooltipKeyTriggerEvent(event);
 
     if(!isLinkTooltipKeyTriggerEvent){
       const { onClose } = this.props;
@@ -58,7 +58,7 @@ class Portal extends Component<{
     }
   }
 
-  checkTooltipKeyTrigerEvent(event: MouseEvent | KeyboardEvent){
+  checkTooltipKeyTriggerEvent(event: MouseEvent | KeyboardEvent){
     if(event instanceof KeyboardEvent){
       if(event?.ctrlKey && event?.keyCode === this.K_KEY_CODE) return true
       if([this.CONTROL_KEY_CODE, this.K_KEY_CODE, this.ENTER_KEY_CODE].includes(event?.keyCode)) return true

--- a/client/src/components/Portal/Portal.tsx
+++ b/client/src/components/Portal/Portal.tsx
@@ -33,9 +33,9 @@ class Portal extends Component<{
   };
 
   portal: HTMLElement;
-  CONTROL_KEY_CODE: Number = 17;
-  K_KEY_CODE: Number = 75
-  ENTER_KEY_CODE: Number = 13
+  CONTROL_KEY_CODE: number = 17;
+  K_KEY_CODE: number = 75
+  ENTER_KEY_CODE: number = 13
 
   constructor(props) {
     super(props);


### PR DESCRIPTION
Fixes #11627

The pull request implements the shortcut key functionality when `ctrl + k` is pressed on a link entity in the editor. This also allows all actions on the tooltip to be triggered from keyboard navigation.

