### PR TITLE
Refactor search promotions views to extend generic views and template

### DIFF
--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -479,7 +479,7 @@ class CreateView(
             {
                 "url": "",
                 "label": _("New: %(model_name)s")
-                % {"model_name": capfirst(self.model._meta.verbose_name)},
+                % {"model_name": self.get_page_subtitle()},
             }
         )
         return self.breadcrumbs_items + items

--- a/wagtail/contrib/search_promotions/admin_urls.py
+++ b/wagtail/contrib/search_promotions/admin_urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     path("results/", views.IndexView.as_view(results_only=True), name="index_results"),
     path("add/", views.CreateView.as_view(), name="add"),
     path("<int:query_id>/", views.EditView.as_view(), name="edit"),
-    path("<int:query_id>/delete/", views.delete, name="delete"),
+    path("<int:query_id>/delete/", views.DeleteView.as_view(), name="delete"),
     path("queries/chooser/", views.chooser, name="chooser"),
     path(
         "queries/chooser/results/",

--- a/wagtail/contrib/search_promotions/admin_urls.py
+++ b/wagtail/contrib/search_promotions/admin_urls.py
@@ -7,7 +7,7 @@ app_name = "wagtailsearchpromotions"
 urlpatterns = [
     path("", views.IndexView.as_view(), name="index"),
     path("results/", views.IndexView.as_view(results_only=True), name="index_results"),
-    path("add/", views.add, name="add"),
+    path("add/", views.CreateView.as_view(), name="add"),
     path("<int:query_id>/", views.edit, name="edit"),
     path("<int:query_id>/delete/", views.delete, name="delete"),
     path("queries/chooser/", views.chooser, name="chooser"),

--- a/wagtail/contrib/search_promotions/admin_urls.py
+++ b/wagtail/contrib/search_promotions/admin_urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     path("", views.IndexView.as_view(), name="index"),
     path("results/", views.IndexView.as_view(results_only=True), name="index_results"),
     path("add/", views.CreateView.as_view(), name="add"),
-    path("<int:query_id>/", views.edit, name="edit"),
+    path("<int:query_id>/", views.EditView.as_view(), name="edit"),
     path("<int:query_id>/delete/", views.delete, name="delete"),
     path("queries/chooser/", views.chooser, name="chooser"),
     path(

--- a/wagtail/contrib/search_promotions/forms.py
+++ b/wagtail/contrib/search_promotions/forms.py
@@ -25,6 +25,49 @@ class SearchPromotionForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.fields["page"].widget = AdminPageChooser()
 
+    def clean(self):
+        cleaned_data = super().clean()
+
+        # Use the raw value instead of from form.cleaned_data so we don't
+        # consider an invalid field as empty. For example, leaving the
+        # page field empty and entering an invalid external_link_url
+        # shouldn't raise an error about needing to enter a page or URL,
+        # since the user *has* entered (or tried to enter) a URL.
+        page = self["page"].value()
+        external_link_url = self["external_link_url"].value()
+        external_link_text = self["external_link_text"].value()
+
+        # Must supply a page or external_link_url (but not both)
+        if page is None:
+            if external_link_url:
+                # if an external_link_url is supplied,
+                # then external_link_text is also required
+                if not external_link_text:
+                    self.add_error(
+                        "external_link_text",
+                        forms.ValidationError(
+                            _(
+                                "You must enter an external link text if you enter an external link URL."
+                            )
+                        ),
+                    )
+            else:
+                self.add_error(
+                    None,
+                    forms.ValidationError(
+                        _("You must recommend a page OR an external link.")
+                    ),
+                )
+        elif external_link_url:
+            self.add_error(
+                None,
+                forms.ValidationError(
+                    _("Please only select a page OR enter an external link.")
+                ),
+            )
+
+        return cleaned_data
+
     class Meta:
         model = SearchPromotion
         fields = (
@@ -73,31 +116,6 @@ class SearchPromotionsFormSet(SearchPromotionsFormSetBase):
         non_empty_forms = 0
         for i in range(0, self.total_form_count()):
             form = self.forms[i]
-
-            page = form.cleaned_data["page"]
-            external_link_url = form.cleaned_data["external_link_url"]
-            external_link_text = form.cleaned_data["external_link_text"]
-
-            # only a page or external_link_url can be supplied
-            if page is None:
-                if external_link_url:
-                    # if an external_link_url then external_link_text is also required
-                    if not external_link_text:
-                        raise forms.ValidationError(
-                            _(
-                                "You must enter an external link text if you enter an external link URL."
-                            )
-                        )
-                else:
-                    raise forms.ValidationError(
-                        _("You must recommend a page OR an external link.")
-                    )
-            else:
-                if external_link_url:
-                    raise forms.ValidationError(
-                        _("Please only select a page OR enter an external link.")
-                    )
-
             if self.can_delete and self._should_delete_form(form):
                 non_deleted_forms -= 1
             if not (form.instance.id is None and not form.has_changed()):

--- a/wagtail/contrib/search_promotions/forms.py
+++ b/wagtail/contrib/search_promotions/forms.py
@@ -6,7 +6,7 @@ from wagtail.admin.widgets import AdminPageChooser
 from wagtail.contrib.search_promotions.models import Query, SearchPromotion
 
 
-class QueryForm(forms.Form):
+class QueryForm(forms.ModelForm):
     query_string = forms.CharField(
         label=_("Search term(s)/phrase"),
         help_text=_(
@@ -16,6 +16,17 @@ class QueryForm(forms.Form):
         ),
         required=True,
     )
+
+    def clean(self):
+        # We allow using an existing query string on the CreateView, so we need
+        # to skip the unique validation on `query_string`. This can be done by
+        # overriding the `clean()` method without calling `super().clean()`:
+        # https://docs.djangoproject.com/en/stable/topics/forms/modelforms/#overriding-the-clean-method
+        pass
+
+    class Meta:
+        model = Query
+        fields = ["query_string"]
 
 
 class SearchPromotionForm(forms.ModelForm):

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
@@ -21,7 +21,7 @@
 
             <ul class="fields">
                 <li>
-                    {% include "wagtailsearchpromotions/queries/chooser_field.html" with field=query_form.query_string only %}
+                    {% include "wagtailsearchpromotions/queries/chooser_field.html" with field=form.query_string only %}
                 </li>
                 <li>
                     {% include "wagtailsearchpromotions/includes/searchpromotions_formset.html" with formset=searchpicks_formset only %}
@@ -44,7 +44,7 @@
         {% include "wagtailsearchpromotions/queries/chooser_field.js" only %}
 
         $(function() {
-            createQueryChooser('{{ query_form.query_string.auto_id }}');
+            createQueryChooser('{{ form.query_string.auto_id }}');
         });
     </script>
 {% endblock %}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
@@ -1,38 +1,28 @@
 {% extends "wagtailadmin/generic/form.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}{% trans "Add search promotion" %}{% endblock %}
-{% block content %}
-    {% trans "Add search pick" as add_str %}
-    {% include "wagtailadmin/shared/header.html" with title=add_str icon="pick" %}
 
-    <div class="nice-padding">
-        <div class="help-block help-info">
-            {% icon name='help' %}
-            {% blocktrans trimmed %}
-                <p>Promoted search results are a means of recommending specific pages or external links that might not organically come high up in search results. E.g recommending your primary donation page to a user searching with the less common term "<em>giving</em>".</p>
-            {% endblocktrans %}
+{% block before_form %}
+    <div class="help-block help-info w-form-width">
+        {% icon name='help' %}
+        {% blocktrans trimmed %}
+            <p>Promoted search results are a means of recommending specific pages or external links that might not organically come high up in search results. E.g recommending your primary donation page to a user searching with the less common term "<em>giving</em>".</p>
+        {% endblocktrans %}
 
-            {% blocktrans trimmed %}
-                <p>The "Search term(s)/phrase" field below must contain the full and exact search for which you wish to provide recommended results, <em>including</em> any misspellings/user error. To help, you can choose from search terms that have been popular with users of your site.</p>
-            {% endblocktrans %}
-        </div>
-        <form action="{% url 'wagtailsearchpromotions:add' %}" method="POST" novalidate>
-            {% csrf_token %}
-
-            <ul class="fields">
-                <li>
-                    {% include "wagtailsearchpromotions/queries/chooser_field.html" with field=form.query_string only %}
-                </li>
-                <li>
-                    {% include "wagtailsearchpromotions/includes/searchpromotions_formset.html" with formset=searchpicks_formset only %}
-                </li>
-            </ul>
-
-            {% block footer %}
-                {{ block.super }}
-            {% endblock %}
-        </form>
+        {% blocktrans trimmed %}
+            <p>The "Search term(s)/phrase" field below must contain the full and exact search for which you wish to provide recommended results, <em>including</em> any misspellings/user error. To help, you can choose from search terms that have been popular with users of your site.</p>
+        {% endblocktrans %}
     </div>
+{% endblock %}
+
+{% block form_content %}
+    <ul class="fields">
+        <li>
+            {% include "wagtailsearchpromotions/queries/chooser_field.html" with field=form.query_string only %}
+        </li>
+        <li>
+            {% include "wagtailsearchpromotions/includes/searchpromotions_formset.html" with formset=searchpicks_formset only %}
+        </li>
+    </ul>
 {% endblock %}
 
 {% block extra_js %}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/confirm_delete.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/confirm_delete.html
@@ -1,15 +1,6 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/confirm_delete.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans trimmed with query=query.query_string %}Delete {{ query }}{% endblocktrans %}{% endblock %}
-{% block content %}
-    {% trans "Delete" as delete_str %}
-    {% include "wagtailadmin/shared/header.html" with title=delete_str subtitle=query.query_string %}
-
-    <div class="nice-padding">
-        <p>{% trans "Are you sure you want to delete all promoted results for this search term?" %}</p>
-        <form action="{% url 'wagtailsearchpromotions:delete' query.id %}" method="POST">
-            {% csrf_token %}
-            <input type="submit" value="{% trans 'Yes, delete' %}" class="button serious" />
-        </form>
-    </div>
+{% block confirmation_message %}
+    <p>{% trans "Are you sure you want to delete all promoted results for this search term?" %}</p>
 {% endblock %}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/edit.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/edit.html
@@ -1,37 +1,14 @@
-{% extends "wagtailadmin/generic/form.html" %}
+{% extends "wagtailadmin/generic/edit.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}{% blocktrans trimmed with query=query.query_string %}Editing {{ query }}{% endblocktrans %}{% endblock %}
-{% block content %}
-    {% trans "Editing" as editing_str %}
-    {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=query.query_string icon="pick"  %}
-
-    <form action="{% url 'wagtailsearchpromotions:edit' query.id %}" method="POST" class="nice-padding" novalidate>
-        {% csrf_token %}
-
-        <ul class="fields">
-            <li>
-                {% include "wagtailsearchpromotions/queries/chooser_field.html" with field=query_form.query_string only %}
-            </li>
-            <li>
-                {% include "wagtailsearchpromotions/includes/searchpromotions_formset.html" with formset=searchpicks_formset only %}
-            </li>
-        </ul>
-
-        {% block footer %}
-            {{ block.super }}
-        {% endblock %}
-    </form>
-{% endblock %}
-
-{% block extra_actions %}
-    {% comment %}
-        The view hasn't extended from generic EditView, so we cannot use the new
-        header buttons in the breadcrumbs for the Delete button. Instead, we'll
-        add a Delete button to the footer actions.
-    {% endcomment %}
-    {% if can_delete %}
-        <a href="{{ delete_url }}" class="button">{{ delete_item_label }}</a>
-    {% endif %}
+{% block form_content %}
+    <ul class="fields">
+        <li>
+            {% include "wagtailsearchpromotions/queries/chooser_field.html" with field=form.query_string only %}
+        </li>
+        <li>
+            {% include "wagtailsearchpromotions/includes/searchpromotions_formset.html" with formset=searchpicks_formset only %}
+        </li>
+    </ul>
 {% endblock %}
 
 {% block extra_js %}
@@ -43,7 +20,7 @@
         {% include "wagtailsearchpromotions/queries/chooser_field.js" only %}
 
         $(function() {
-            createQueryChooser('{{ query_form.query_string.auto_id }}');
+            createQueryChooser('{{ form.query_string.auto_id }}');
         });
     </script>
 {% endblock %}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/index.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/index.html
@@ -1,2 +1,1 @@
 {% extends "wagtailadmin/generic/index.html" %}
-{% load i18n %}

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -599,26 +599,25 @@ class TestSearchPromotionsAddView(WagtailTestUtils, TestCase):
         # User should be given an error on the specific field in the form
         self.assertEqual(response.status_code, 200)
 
-        # This currently fails because of a bug in the formset handling
-        # self.assertFormError(
-        #     response.context["form"], "query_string", "This field is required."
-        # )
-        # # The formset should still contain the submitted data
-        # self.assertEqual(len(response.context["searchpicks_formset"].forms), 1)
-        # self.assertEqual(
-        #     response.context["searchpicks_formset"].forms[0].cleaned_data["page"].id,
-        #     1,
-        # )
-        # self.assertEqual(
-        #     response.context["searchpicks_formset"]
-        #     .forms[0]
-        #     .cleaned_data["description"],
-        #     "Hello",
-        # )
-        # # Should not raise an error anywhere else
-        # self.assertFormSetError(response.context["searchpicks_formset"], 0, "page", [])
-        # self.assertFormSetError(response.context["searchpicks_formset"], 0, None, [])
-        # self.assertFormSetError(response.context["searchpicks_formset"], None, None, [])
+        self.assertFormError(
+            response.context["form"], "query_string", "This field is required."
+        )
+        # The formset should still contain the submitted data
+        self.assertEqual(len(response.context["searchpicks_formset"].forms), 1)
+        self.assertEqual(
+            response.context["searchpicks_formset"].forms[0].cleaned_data["page"].id,
+            1,
+        )
+        self.assertEqual(
+            response.context["searchpicks_formset"]
+            .forms[0]
+            .cleaned_data["description"],
+            "Hello",
+        )
+        # Should not raise an error anywhere else
+        self.assertFormSetError(response.context["searchpicks_formset"], 0, "page", [])
+        self.assertFormSetError(response.context["searchpicks_formset"], 0, None, [])
+        self.assertFormSetError(response.context["searchpicks_formset"], None, None, [])
 
     def test_post_with_invalid_page(self):
         # Submit

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -805,6 +805,40 @@ class TestSearchPromotionsAddView(AdminTemplateTestUtils, WagtailTestUtils, Test
         self.assertFormSetError(response.context["searchpicks_formset"], 0, None, [])
         self.assertFormSetError(response.context["searchpicks_formset"], None, None, [])
 
+    def test_get_with_no_permission(self):
+        self.user.is_superuser = False
+        self.user.save()
+        # Only basic access_admin permission is given
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin",
+                codename="access_admin",
+            )
+        )
+
+        response = self.client.get(reverse("wagtailsearchpromotions:add"))
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse("wagtailadmin_home"))
+
+    def test_get_with_add_permission_only(self):
+        self.user.is_superuser = False
+        self.user.save()
+        # Only basic access_admin permission is given
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin",
+                codename="access_admin",
+            ),
+            Permission.objects.get(
+                content_type__app_label="wagtailsearchpromotions",
+                codename="add_searchpromotion",
+            ),
+        )
+
+        response = self.client.get(reverse("wagtailsearchpromotions:add"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailsearchpromotions/add.html")
+
 
 class TestSearchPromotionsEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def setUp(self):
@@ -1282,10 +1316,48 @@ class TestSearchPromotionsEditView(AdminTemplateTestUtils, WagtailTestUtils, Tes
         self.assertFormSetError(response.context["searchpicks_formset"], 1, None, [])
         self.assertFormSetError(response.context["searchpicks_formset"], None, None, [])
 
+    def test_get_with_no_permission(self):
+        self.user.is_superuser = False
+        self.user.save()
+        # Only basic access_admin permission is given
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin",
+                codename="access_admin",
+            )
+        )
+
+        response = self.client.get(
+            reverse("wagtailsearchpromotions:edit", args=(self.query.id,)),
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse("wagtailadmin_home"))
+
+    def test_get_with_edit_permission_only(self):
+        self.user.is_superuser = False
+        self.user.save()
+        # Only basic access_admin permission is given
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin",
+                codename="access_admin",
+            ),
+            Permission.objects.get(
+                content_type__app_label="wagtailsearchpromotions",
+                codename="change_searchpromotion",
+            ),
+        )
+
+        response = self.client.get(
+            reverse("wagtailsearchpromotions:edit", args=(self.query.id,)),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailsearchpromotions/edit.html")
+
 
 class TestSearchPromotionsDeleteView(WagtailTestUtils, TestCase):
     def setUp(self):
-        self.login()
+        self.user = self.login()
 
         # Create a search pick to delete
         self.query = Query.get("Hello")
@@ -1321,6 +1393,44 @@ class TestSearchPromotionsDeleteView(WagtailTestUtils, TestCase):
         self.assertFalse(
             SearchPromotion.objects.filter(id=self.search_pick.id).exists()
         )
+
+    def test_get_with_no_permission(self):
+        self.user.is_superuser = False
+        self.user.save()
+        # Only basic access_admin permission is given
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin",
+                codename="access_admin",
+            )
+        )
+
+        response = self.client.get(
+            reverse("wagtailsearchpromotions:delete", args=(self.query.id,)),
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse("wagtailadmin_home"))
+
+    def test_get_with_edit_permission_only(self):
+        self.user.is_superuser = False
+        self.user.save()
+        # Only basic access_admin permission is given
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin",
+                codename="access_admin",
+            ),
+            Permission.objects.get(
+                content_type__app_label="wagtailsearchpromotions",
+                codename="delete_searchpromotion",
+            ),
+        )
+
+        response = self.client.get(
+            reverse("wagtailsearchpromotions:delete", args=(self.query.id,)),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailsearchpromotions/confirm_delete.html")
 
 
 class TestGarbageCollectManagementCommand(TestCase):

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -21,6 +21,7 @@ from wagtail.contrib.search_promotions.templatetags.wagtailsearchpromotions_tags
 )
 from wagtail.log_actions import registry as log_registry
 from wagtail.test.utils import WagtailTestUtils
+from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 
 
 class TestSearchPromotions(TestCase):
@@ -175,7 +176,7 @@ class TestGetSearchPromotionsTemplateTag(TestCase):
         self.assertEqual(search_picks, [])
 
 
-class TestSearchPromotionsIndexView(WagtailTestUtils, TestCase):
+class TestSearchPromotionsIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def setUp(self):
         self.user = self.login()
 
@@ -183,6 +184,10 @@ class TestSearchPromotionsIndexView(WagtailTestUtils, TestCase):
         response = self.client.get(reverse("wagtailsearchpromotions:index"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailsearchpromotions/index.html")
+        self.assertBreadcrumbsItemsRendered(
+            [{"url": "", "label": "Promoted search results"}],
+            response.content,
+        )
 
     def test_search(self):
         response = self.client.get(
@@ -463,7 +468,7 @@ class TestSearchPromotionsIndexView(WagtailTestUtils, TestCase):
         self.assertIsNone(soup.select_one(f'a[href="{add_url}"]'))
 
 
-class TestSearchPromotionsAddView(WagtailTestUtils, TestCase):
+class TestSearchPromotionsAddView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def setUp(self):
         self.user = self.login()
 
@@ -471,6 +476,16 @@ class TestSearchPromotionsAddView(WagtailTestUtils, TestCase):
         response = self.client.get(reverse("wagtailsearchpromotions:add"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailsearchpromotions/add.html")
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {
+                    "url": reverse("wagtailsearchpromotions:index"),
+                    "label": "Promoted search results",
+                },
+                {"url": "", "label": "New: Promoted search result"},
+            ],
+            response.content,
+        )
 
     def test_post(self):
         # Submit

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -19,6 +19,7 @@ from wagtail.contrib.search_promotions.models import (
 from wagtail.contrib.search_promotions.templatetags.wagtailsearchpromotions_tags import (
     get_search_promotions,
 )
+from wagtail.log_actions import registry as log_registry
 from wagtail.test.utils import WagtailTestUtils
 
 
@@ -492,13 +493,12 @@ class TestSearchPromotionsAddView(WagtailTestUtils, TestCase):
         self.assertTrue(Query.get("test").editors_picks.filter(page_id=1).exists())
 
         # Ensure that only one log entry was created for the search pick
-        # This currently fails because the code incorrectly logs it twice
-        # search_picks = list(Query.get("test").editors_picks.all())
-        # self.assertEqual(len(search_picks), 1)
-        # self.assertTrue(search_picks[0].page_id, 1)
-        # logs = log_registry.get_logs_for_instance(search_picks[0])
-        # self.assertEqual(len(logs), 1)
-        # self.assertEqual(logs[0].action, "wagtail.create")
+        search_picks = list(Query.get("test").editors_picks.all())
+        self.assertEqual(len(search_picks), 1)
+        self.assertTrue(search_picks[0].page_id, 1)
+        logs = log_registry.get_logs_for_instance(search_picks[0])
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(logs[0].action, "wagtail.create")
 
     def test_with_multiple_picks(self):
         # Submit
@@ -534,12 +534,11 @@ class TestSearchPromotionsAddView(WagtailTestUtils, TestCase):
         self.assertEqual(search_picks[1].description, "The landing page")
 
         # Ensure that only one log entry was created for each search pick
-        # This currently fails because the code incorrectly logs it twice
-        # for search_pick in search_picks:
-        #     logs = log_registry.get_logs_for_instance(search_pick)
-        #     self.assertEqual(len(logs), 1)
-        #     self.assertEqual(logs[0].action, "wagtail.create")
-        #     self.assertEqual(logs[0].user, self.user)
+        for search_pick in search_picks:
+            logs = log_registry.get_logs_for_instance(search_pick)
+            self.assertEqual(len(logs), 1)
+            self.assertEqual(logs[0].action, "wagtail.create")
+            self.assertEqual(logs[0].user, self.user)
 
     def test_post_with_existing_query_string(self):
         # Create an existing query with search picks

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -583,6 +583,44 @@ class TestSearchPromotionsAddView(WagtailTestUtils, TestCase):
             },
         )
 
+    def test_post_with_invalid_query_string(self):
+        # Submit
+        post_data = {
+            "query_string": "",
+            "editors_picks-TOTAL_FORMS": 1,
+            "editors_picks-INITIAL_FORMS": 0,
+            "editors_picks-MAX_NUM_FORMS": 1000,
+            "editors_picks-0-DELETE": "",
+            "editors_picks-0-ORDER": 0,
+            "editors_picks-0-page": 1,
+            "editors_picks-0-description": "Hello",
+        }
+        response = self.client.post(reverse("wagtailsearchpromotions:add"), post_data)
+
+        # User should be given an error on the specific field in the form
+        self.assertEqual(response.status_code, 200)
+
+        # This currently fails because of a bug in the formset handling
+        # self.assertFormError(
+        #     response.context["form"], "query_string", "This field is required."
+        # )
+        # # The formset should still contain the submitted data
+        # self.assertEqual(len(response.context["searchpicks_formset"].forms), 1)
+        # self.assertEqual(
+        #     response.context["searchpicks_formset"].forms[0].cleaned_data["page"].id,
+        #     1,
+        # )
+        # self.assertEqual(
+        #     response.context["searchpicks_formset"]
+        #     .forms[0]
+        #     .cleaned_data["description"],
+        #     "Hello",
+        # )
+        # # Should not raise an error anywhere else
+        # self.assertFormSetError(response.context["searchpicks_formset"], 0, "page", [])
+        # self.assertFormSetError(response.context["searchpicks_formset"], 0, None, [])
+        # self.assertFormSetError(response.context["searchpicks_formset"], None, None, [])
+
     def test_post_with_invalid_page(self):
         # Submit
         post_data = {

--- a/wagtail/contrib/search_promotions/views/settings.py
+++ b/wagtail/contrib/search_promotions/views/settings.py
@@ -126,6 +126,7 @@ def save_searchpicks(query, new_query, searchpicks_formset):
 
 
 class CreateView(generic.CreateView):
+    model = Query
     permission_policy = ModelPermissionPolicy(SearchPromotion)
     index_url_name = "wagtailsearchpromotions:index"
     edit_url_name = "wagtailsearchpromotions:edit"
@@ -134,6 +135,9 @@ class CreateView(generic.CreateView):
     success_message = gettext_lazy("Editor's picks for '%(query)s' created.")
     error_message = gettext_lazy("Recommendations have not been created due to errors")
     template_name = "wagtailsearchpromotions/add.html"
+    header_icon = "pick"
+    page_subtitle = gettext_lazy("Promoted search result")
+    _show_breadcrumbs = True
 
     def get_success_message(self, instance):
         return self.success_message % {"query": instance}
@@ -143,6 +147,11 @@ class CreateView(generic.CreateView):
             # formset level error (e.g. no forms submitted)
             return " ".join(error for error in formset_errors)
         return super().get_error_message()
+
+    def get_breadcrumbs_items(self):
+        breadcrumbs = super().get_breadcrumbs_items()
+        breadcrumbs[-2]["label"] = _("Promoted search results")
+        return breadcrumbs
 
     def form_valid(self, form):
         self.form = form

--- a/wagtail/contrib/search_promotions/views/settings.py
+++ b/wagtail/contrib/search_promotions/views/settings.py
@@ -152,8 +152,6 @@ class CreateView(generic.CreateView):
         )
 
         if save_searchpicks(self.object, self.object, self.searchpicks_formset):
-            for search_pick in self.searchpicks_formset.new_objects:
-                log(search_pick, "wagtail.create")
             messages.success(
                 self.request,
                 self.get_success_message(self.object),

--- a/wagtail/contrib/search_promotions/views/settings.py
+++ b/wagtail/contrib/search_promotions/views/settings.py
@@ -30,7 +30,7 @@ class IndexView(generic.IndexView):
     template_name = "wagtailsearchpromotions/index.html"
     results_template_name = "wagtailsearchpromotions/index_results.html"
     context_object_name = "queries"
-    page_title = gettext_lazy("Search Terms")
+    page_title = gettext_lazy("Promoted search results")
     header_icon = "pick"
     paginate_by = 20
     permission_policy = ModelPermissionPolicy(SearchPromotion)
@@ -78,7 +78,7 @@ class IndexView(generic.IndexView):
 
     def get_breadcrumbs_items(self):
         breadcrumbs = super().get_breadcrumbs_items()
-        breadcrumbs[-1]["label"] = _("Promoted search results")
+        breadcrumbs[-1]["label"] = self.get_page_title()
         return breadcrumbs
 
 
@@ -149,7 +149,7 @@ class CreateView(generic.CreateView):
 
     def get_breadcrumbs_items(self):
         breadcrumbs = super().get_breadcrumbs_items()
-        breadcrumbs[-2]["label"] = _("Promoted search results")
+        breadcrumbs[-2]["label"] = IndexView.page_title
         return breadcrumbs
 
     def form_valid(self, form):
@@ -208,7 +208,7 @@ class EditView(generic.EditView):
 
     def get_breadcrumbs_items(self):
         breadcrumbs = super().get_breadcrumbs_items()
-        breadcrumbs[-2]["label"] = _("Promoted search results")
+        breadcrumbs[-2]["label"] = IndexView.page_title
         return breadcrumbs
 
     def form_valid(self, form):


### PR DESCRIPTION
Fixes #12613. Part of #8365. Supersedes #11731.

Note: when merging, please also credit Rohit Sharma as the author of the original PR.

A bit bigger than I thought as there are a lot of issues in the current code...

## CreateView

<details><summary>Screenshots</summary>

### Before

<img width="946" alt="image" src="https://github.com/user-attachments/assets/46c1d370-5151-486f-b391-8a0a13fcff1a">


### After

<img width="946" alt="image" src="https://github.com/user-attachments/assets/bd0bb638-c0d1-4cb0-bd2b-1eb5e95d25c5">



</details> 



## EditView

<details><summary>Screenshots</summary>

### Before

<img width="946" alt="image" src="https://github.com/user-attachments/assets/c617bbdd-d7df-4302-b780-ee0f9bab2f4c">


### After

<img width="946" alt="image" src="https://github.com/user-attachments/assets/88d2591f-3974-4e2f-86f2-789e72e4966e">



</details> 

## DeleteView

<details><summary>Screenshots</summary>

### Before

<img width="482" alt="image" src="https://github.com/user-attachments/assets/ba0e52a1-075c-48a9-8aa2-cb8fcf920f8e">


### After

<img width="482" alt="image" src="https://github.com/user-attachments/assets/dc5496f3-634a-455b-a161-0327c5c06766">




</details> 
