### PR TITLE
Add missing space to Swedish translation snippets

### DIFF
--- a/wagtail/snippets/locale/sv/LC_MESSAGES/django.po
+++ b/wagtail/snippets/locale/sv/LC_MESSAGES/django.po
@@ -87,8 +87,8 @@ msgstr "Radera"
 #, python-format
 msgid "Used %(usage_count)s time"
 msgid_plural "Used %(usage_count)s times"
-msgstr[0] "Använd %(usage_count)sgång"
-msgstr[1] "Använd %(usage_count)sgånger"
+msgstr[0] "Använd %(usage_count)s gång"
+msgstr[1] "Använd %(usage_count)s gånger"
 
 #, python-format
 msgid "Are you sure you want to delete this %(snippet_type_name)s?"


### PR DESCRIPTION
I noticed the missing spaces in our production evironment and thought I might as well fix them right away!