### PR TITLE
Reinstate modal-workflow self.ajaxifyForm & add unit tests

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -60,6 +60,7 @@ Changelog
  * Maintenance: Migrate jQuery class toggling & drag/drop event handling within the multiple upload views to the Stimulus ZoneController usage (Ayaan Qadri)
  * Maintenance: Test project template for warnings when run against Django pre-release versions (Sage Abdullah)
  * Maintenance: Refactor redirects create/delete views to use generic views (Sage Abdullah)
+ * Maintenance: Add JSDoc description, adopt linting recommendations, and add more unit tests for `ModalWorkflow` (LB (Ben) Johnston)
 
 
 6.3.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/entrypoints/admin/__snapshots__/modal-workflow.test.js.snap
+++ b/client/src/entrypoints/admin/__snapshots__/modal-workflow.test.js.snap
@@ -45,6 +45,18 @@ HTMLCollection [
           >
             path/to/endpoint
           </div>
+          
+      
+          <form
+            action="/path/to/form/submit"
+            id="form"
+            method="post"
+          >
+            <input
+              name="key"
+              value="value"
+            />
+          </form>
         </div>
         
     

--- a/client/src/entrypoints/admin/modal-workflow.js
+++ b/client/src/entrypoints/admin/modal-workflow.js
@@ -91,15 +91,15 @@ function ModalWorkflow(opts) {
   };
 
   self.ajaxifyForm = function ajaxifyForm(formSelector) {
-    $(formSelector).each(() => {
+    $(formSelector).each(function ajaxifyFormInner() {
       const action = this.action;
       if (this.method.toLowerCase() === 'get') {
-        $(this).on('submit', () => {
+        $(this).on('submit', function handleSubmit() {
           self.loadUrl(action, $(this).serialize());
           return false;
         });
       } else {
-        $(this).on('submit', () => {
+        $(this).on('submit', function handleSubmit() {
           self.postForm(action, $(this).serialize());
           return false;
         });

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -79,6 +79,7 @@ depth: 1
  * Migrate jQuery class toggling & drag/drop event handling within the multiple upload views to the Stimulus ZoneController usage (Ayaan Qadri)
  * Test project template for warnings when run against Django pre-release versions (Sage Abdullah)
  * Refactor redirects create/delete views to use generic views (Sage Abdullah)
+ * Add JSDoc description, adopt linting recommendations, and add more unit tests for `ModalWorkflow` (LB (Ben) Johnston)
 
 
 ## Upgrade considerations - changes affecting all projects


### PR DESCRIPTION
- Fixes #12618
- Regression from #12380

<img width="1791" alt="Screenshot 2024-11-22 at 9 57 43 PM" src="https://github.com/user-attachments/assets/71a905b6-1e5d-4ffc-aea9-b1cd51c205e7">

Adds unit tests for this so we (I) can avoid breaking again in the future. Example screenshot of test failing on `main`.
<img width="876" alt="Screenshot 2024-11-22 at 9 59 46 PM" src="https://github.com/user-attachments/assets/6bc9a9a3-246b-4bac-82fd-815d264f3238">
