### PR TITLE
Don't show privacy status panel while creating a new page

### DIFF
--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -254,6 +254,7 @@ class PageStatusSidePanel(StatusSidePanel):
 
     def get_status_templates(self, context):
         templates = super().get_status_templates(context)
+        # only inject the privacy status if the page exists (not for create page views)
         if self.object.id:
             templates.insert(
                 -1, "wagtailadmin/shared/side_panels/includes/status/privacy.html"

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -254,9 +254,10 @@ class PageStatusSidePanel(StatusSidePanel):
 
     def get_status_templates(self, context):
         templates = super().get_status_templates(context)
-        templates.insert(
-            -1, "wagtailadmin/shared/side_panels/includes/status/privacy.html"
-        )
+        if self.object.id:
+            templates.insert(
+                -1, "wagtailadmin/shared/side_panels/includes/status/privacy.html"
+            )
         return templates
 
     def get_usage_context(self):


### PR DESCRIPTION
**Fixes #12277** 
**Note:** This is a quick fix, and is probably not the most optimal solution. Will come up with a better solution soon.
Thanks to @lb- 

Screenshots:

1. **Before**: 

![Screenshot From 2024-11-23 01-36-52](https://github.com/user-attachments/assets/174b0afd-429b-41fc-81d5-3fe53bceb661)

2. **After**:

![Screenshot From 2024-11-23 01-41-48](https://github.com/user-attachments/assets/2cbb0f82-c7bc-4c13-a668-25e72a1ae2b5)
