### PR TITLE
Fix for privacy status for new child page by adding parent page's privacy info

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Fix: Prevent out-of-order migrations from skipping creation of image/document choose permissions (Matt Westcott)
  * Fix: Use correct connections on multi-database setups in database search backends (Jake Howard)
  * Fix: Ensure Cloudfront cache invalidation is called with a list, for compatibility with current botocore versions (Jake Howard)
+ * Fix: Show the correct privacy status in the sidebar when creating a new page (Joel William)
  * Docs: Move the model reference page from reference/pages to the references section as it covers all Wagtail core models (Srishti Jaiswal)
  * Docs: Move the panels reference page from references/pages to the references section as panels are available for any model editing, merge panels API into this page (Srishti Jaiswal)
  * Docs: Move the tags documentation to standalone advanced topic, instead of being inside the reference/pages section (Srishti Jaiswal)

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -35,6 +35,7 @@ depth: 1
  * Prevent out-of-order migrations from skipping creation of image/document choose permissions (Matt Westcott)
  * Use correct connections on multi-database setups in database search backends (Jake Howard)
  * Ensure Cloudfront cache invalidation is called with a list, for compatibility with current botocore versions (Jake Howard)
+ * Show the correct privacy status in the sidebar when creating a new page (Joel William)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/privacy.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/privacy.html
@@ -2,7 +2,7 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block content %}
-    {% test_page_is_public page as is_public %}
+    {% if page.id %}{% test_page_is_public page as is_public %}{% else %}{% test_page_is_public parent_page as is_public %}{% endif %}
 
     {# The swap between public and private text is done using JS inside of privacy-switch.js when the response from the modal comes back #}
     <div class="{% if not is_public %}w-hidden{% endif %}" data-privacy-sidebar-public>

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -241,6 +241,7 @@ class StatusSidePanel(BaseSidePanel):
 
 class PageStatusSidePanel(StatusSidePanel):
     def __init__(self, *args, **kwargs):
+        self.parent_page = kwargs.pop("parent_page", None)
         super().__init__(*args, **kwargs)
         if self.object.pk:
             self.usage_url = reverse("wagtailadmin_pages:usage", args=(self.object.pk,))
@@ -271,6 +272,9 @@ class PageStatusSidePanel(StatusSidePanel):
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)
         page = self.object
+
+        if self.parent_page:
+            context["parent_page"] = self.parent_page
 
         if page.id:
             context.update(

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -358,6 +358,7 @@ class CreateView(WagtailAdminTemplateMixin, HookResponseMixin, View):
                 show_schedule_publishing_toggle=self.form.show_schedule_publishing_toggle,
                 locale=self.locale,
                 translations=self.translations,
+                parent_page=self.parent_page,
             ),
         ]
         if self.page.is_previewable():

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -868,6 +868,7 @@ class EditView(WagtailAdminTemplateMixin, HookResponseMixin, View):
                 scheduled_object=self.scheduled_page,
                 locale=self.locale,
                 translations=self.translations,
+                parent_page=self.page.get_parent(),
             ),
         ]
         if self.page.is_previewable():


### PR DESCRIPTION
**Fixes #12277** 

This is an optimal fix when compared to #12621
Thanks to @lb- @Stormheg 

Before: 

![Screenshot From 2024-11-23 12-32-16](https://github.com/user-attachments/assets/60062cde-c94f-4d36-a830-57b1d686d940)
Using '**About**' page from bakery demo, changing it to private page.

![Screenshot From 2024-11-23 12-32-27](https://github.com/user-attachments/assets/4d69d316-7723-4a3b-878c-bdd5e66472d5)
Creating a new child page. Here it does not inherit the parent page's privacy status and shows 'Visible to all' instead of showing 'private'.

![Screenshot From 2024-11-23 12-32-52](https://github.com/user-attachments/assets/f86048ae-cac9-4c98-99bc-8bb2edf5a9e3)
On publishing the child page and editing it, it inherits the parent page's privacy status. (I haven't found any issue with the edit view page though, still passed parent_page to it.)

After:

![Screenshot From 2024-11-23 13-52-29](https://github.com/user-attachments/assets/dad9c5e5-54f3-40e8-8ed3-5068aeab9e5b)
Using '**About**' page from bakery demo, changing it to private page.

![Screenshot From 2024-11-23 13-52-39](https://github.com/user-attachments/assets/1730dd73-fc47-4761-aa6b-47b1418862e7)
Creating a new child page. It inherits the parent page's privacy status and shows 'Private'.

![Screenshot From 2024-11-23 13-52-55](https://github.com/user-attachments/assets/61a5635b-944e-43f3-92e3-fdc4aa357932)
On publishing the child page and editing it, it inherits the parent page's privacy status.




