### PR TITLE
implemented fix for commenting not working on pages with read_only field panels

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Changelog
  * Fix: Ensure Cloudfront cache invalidation is called with a list, for compatibility with current botocore versions (Jake Howard)
  * Fix: Show the correct privacy status in the sidebar when creating a new page (Joel William)
  * Fix: Prevent generic model edit view from unquoting non-integer primary keys multiple times (Matt Westcott)
+ * Fix: Ensure comments are functional when editing Page models with `read_only` `Fieldpanel`s in use (Strapchay)
  * Docs: Move the model reference page from reference/pages to the references section as it covers all Wagtail core models (Srishti Jaiswal)
  * Docs: Move the panels reference page from references/pages to the references section as panels are available for any model editing, merge panels API into this page (Srishti Jaiswal)
  * Docs: Move the tags documentation to standalone advanced topic, instead of being inside the reference/pages section (Srishti Jaiswal)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -856,6 +856,7 @@
 * Steven Steinwand
 * Clifford Gama
 * Noah van der Meer
+* Strapchay
 
 ## Translators
 

--- a/client/src/entrypoints/admin/comments.js
+++ b/client/src/entrypoints/admin/comments.js
@@ -19,7 +19,7 @@ window.comments = (() => {
 
   function getContentPath(fieldNode) {
     // Return the total contentpath for an element as a string, in the form field.streamfield_uid.block...
-    if (fieldNode.closest('[data-contentpath-disabled]')) {
+    if (!fieldNode || fieldNode.closest('[data-contentpath-disabled]')) {
       return '';
     }
     let element = fieldNode.closest('[data-contentpath]');

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -37,6 +37,7 @@ depth: 1
  * Ensure Cloudfront cache invalidation is called with a list, for compatibility with current botocore versions (Jake Howard)
  * Show the correct privacy status in the sidebar when creating a new page (Joel William)
  * Prevent generic model edit view from unquoting non-integer primary keys multiple times (Matt Westcott)
+ * Ensure comments are functional when editing Page models with `read_only` `Fieldpanel`s in use (Strapchay)
 
 ### Documentation
 


### PR DESCRIPTION
Fixes #11838 

The pull request fixes the issue of commenting not working when any of the fields on a page has  been set on read_only 