### PR TITLE
Update community guidelines link

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -46,6 +46,7 @@ Changelog
  * Docs: Update tutorial to reflect the move of the "Add child page" action to a top-level button in the header as a '+' icon (Clifford Gama)
  * Docs: Fix link to `HTTPMethod` in `Page.handle_options_request()` docs (Sage Abdullah)
  * Docs: Improve the Pages Theory page with added & more consistent section headings and admonitions to aid in readability (Clifford Gama)
+ * Docs: Fix non-functional link to the community guidelines in the Your first contribution page (Ankit Kumar)
  * Maintenance: Close open files when reading within utils/setup.py (Ataf Fazledin Ahamed)
  * Maintenance: Avoid redundant `ALLOWED_HOSTS` check in `Site.find_for_request` (Jake Howard)
  * Maintenance: Update `CloneController` to ensure that `added`/`cleared` events are not dispatched as cancelable (LB (Ben) Johnston)

--- a/docs/contributing/first_contribution_guide.md
+++ b/docs/contributing/first_contribution_guide.md
@@ -49,12 +49,12 @@ Below is a checklist. There are many like these you can copy for yourself as you
 
 Make an account on [Wagtail Slack](https://github.com/wagtail/wagtail/wiki/Slack) server, this is the way many of the community interact day to day. Introduce yourself on `#new-contributors` and join some of the other channels, remember to keep your intro short and be nice to others. After this, join [GitHub](https://github.com/) and set up your profile. It's really helpful to the community if your name can be added to your profiles in both communities and an image. It does not have to be your public name or a real image if you want to keep that private but please avoid it staying as the 'default avatar'.
 
-You may also want to join StackOverflow and [follow the Wagtail tag](https://stackoverflow.com/questions/tagged/wagtail), this way you can upvote great answers to questions you have or maybe consider contributing answers yourself.
+You may also want to join StackOverflow and [follow the Wagtail tag](https://stackoverflow.com/questions/tagged/wagtail), this way you can upvote great answers to questions you have or maybe consider contributing answers yourself. Before you dive in, take a moment to review the [community guidelines](https://github.com/wagtail/wagtail/blob/main/CODE_OF_CONDUCT.md) to get a grasp on the expectations for participation.
 
 #### Checklist
 
 ```markdown
--   [ ] Read the [community guidelines](https://github.com/wagtail/wagtail/blob/main/CODE_OF_CONDUCT.md)
+-   [ ] Read the community guidelines
 -   [ ] Join GitHub
 -   [ ] Add your preferred name and image to your GitHub profile
 -   [ ] Join Slack

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -62,6 +62,7 @@ depth: 1
  * Update tutorial to reflect the move of the "Add child page" action to a top-level button in the header as a '+' icon (Clifford Gama)
  * Fix link to `HTTPMethod` in `Page.handle_options_request()` docs (Sage Abdullah)
  * Improve [](pages_theory) with added & more consistent section headings and admonitions to aid in readability (Clifford Gama)
+ * Fix non-functional link to the community guidelines in the [Your first contribution](../contributing/first_contribution_guide.md) page (Ankit Kumar)
 
 ### Maintenance
 


### PR DESCRIPTION
This PR removes the non-functional community guidelines link and adds a new statement to guide readers to the correct guidelines.