### PR TITLE
Refactor settings `EditView` to make better use of generic `EditView`

### DIFF
--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/generic/edit.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 
 {% block before_form %}
     {% if site_switcher %}
@@ -10,8 +10,4 @@
             {{ site_switcher.site }}
         </form>
     {% endif %}
-{% endblock %}
-
-{% block form_content %}
-    {{ edit_handler.render_form_content }}
 {% endblock %}

--- a/wagtail/contrib/settings/tests/generic/test_admin.py
+++ b/wagtail/contrib/settings/tests/generic/test_admin.py
@@ -233,11 +233,8 @@ class TestGenericSettingEditView(BaseTestGenericSettingView):
     def test_register_with_icon(self):
         edit_url = reverse("wagtailsettings:edit", args=("tests", "IconGenericSetting"))
         edit_response = self.client.get(edit_url, follow=True)
-
-        self.assertContains(
-            edit_response,
-            """<svg class="icon icon-icon-setting-tag w-header__glyph" aria-hidden="true"><use href="#icon-icon-setting-tag"></use></svg>""",
-        )
+        soup = self.get_soup(edit_response.content)
+        self.assertIsNotNone(soup.select_one("h2 svg use[href='#icon-tag']"))
 
     def test_edit_invalid(self):
         response = self.post(post_data={"foo": "bar"})

--- a/wagtail/contrib/settings/tests/generic/test_register.py
+++ b/wagtail/contrib/settings/tests/generic/test_register.py
@@ -21,4 +21,4 @@ class GenericSettingRegisterTestCase(WagtailTestUtils, TestCase):
 
     def test_icon(self):
         admin = self.client.get(reverse("wagtailadmin_home"))
-        self.assertContains(admin, "icon-setting-tag")
+        self.assertContains(admin, '"tag"')

--- a/wagtail/contrib/settings/tests/site_specific/test_admin.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_admin.py
@@ -230,11 +230,8 @@ class TestSiteSettingEditView(BaseTestSiteSettingView):
     def test_register_with_icon(self):
         edit_url = reverse("wagtailsettings:edit", args=("tests", "IconGenericSetting"))
         edit_response = self.client.get(edit_url, follow=True)
-
-        self.assertContains(
-            edit_response,
-            """<svg class="icon icon-icon-setting-tag w-header__glyph" aria-hidden="true"><use href="#icon-icon-setting-tag"></use></svg>""",
-        )
+        soup = self.get_soup(edit_response.content)
+        self.assertIsNotNone(soup.select_one("h2 svg use[href='#icon-tag']"))
 
     def test_edit_invalid(self):
         response = self.post(post_data={"foo": "bar"})

--- a/wagtail/contrib/settings/tests/site_specific/test_register.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_register.py
@@ -21,4 +21,4 @@ class TestRegister(WagtailTestUtils, TestCase):
 
     def test_icon(self):
         admin = self.client.get(reverse("wagtailadmin_home"))
-        self.assertContains(admin, "icon-setting-tag")
+        self.assertContains(admin, '"tag"')

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -1839,12 +1839,12 @@ class ImportantPagesGenericSetting(BaseGenericSetting):
         verbose_name_plural = _("Important pages settings")
 
 
-@register_setting(icon="icon-setting-tag")
+@register_setting(icon="tag")
 class IconSiteSetting(BaseSiteSetting):
     pass
 
 
-@register_setting(icon="icon-setting-tag")
+@register_setting(icon="tag")
 class IconGenericSetting(BaseGenericSetting):
     pass
 


### PR DESCRIPTION
## Site settings

<details><summary>Screenshots</summary>

### Before

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/37c6a64a-0221-4284-9ced-5d39f4dc1d64">


### After

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/0df64f4e-4278-451e-ad04-26daeeec7d41">


</details> 

## Generic settings

<details><summary>Screenshots</summary>

### Before

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/b008c0c3-b645-4b1c-adf8-cf3af4af6600">


### After

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/9cadf24d-e321-4a58-a601-caa69852f1f1">



</details> 