### PR TITLE
Improve search term reports

### DIFF
--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/search_terms_report_results.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/search_terms_report_results.html
@@ -1,1 +1,0 @@
-{% extends "wagtailadmin/reports/base_report_results.html" %}

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -989,7 +989,7 @@ class TestQueryHitsReportView(BaseReportViewTestCase):
             "wagtailsearchpromotions/search_terms_report_results.html",
         )
         self.assertBreadcrumbs(
-            [{"url": "", "label": "Search Terms"}],
+            [{"url": "", "label": "Search terms"}],
             response.content,
         )
 
@@ -997,7 +997,7 @@ class TestQueryHitsReportView(BaseReportViewTestCase):
 
         soup = self.get_soup(response.content)
         self.assertActiveFilterNotRendered(soup)
-        self.assertPageTitle(soup, "Search Terms - Wagtail")
+        self.assertPageTitle(soup, "Search terms - Wagtail")
 
     def test_get_with_no_permissions(self):
         self.user.is_superuser = False

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -998,7 +998,7 @@ class TestQueryHitsReportView(BaseReportViewTestCase):
         self.assertTemplateUsed(response, "wagtailadmin/reports/base_report.html")
         self.assertTemplateUsed(
             response,
-            "wagtailsearchpromotions/search_terms_report_results.html",
+            "wagtailadmin/reports/base_report_results.html",
         )
         self.assertBreadcrumbs(
             [{"url": "", "label": "Search terms"}],

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -1036,14 +1036,18 @@ class TestFilteredQueryHitsView(BaseReportViewTestCase):
 
     def setUp(self):
         self.user = self.login()
-        self.query_hit = Query.get("Found")
+        self.query_hit = Query.get("This will be found")
         self.query_hit.add_hit(timezone.now())
 
-    def test_filter_by_query_string(self):
-        response = self.get(params={"query_string": "Found"})
+    def test_search_by_query_string(self):
+        response = self.get(params={"q": "Found"})
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Found")
+        self.assertContains(response, "this will be found")
+        self.assertNotContains(response, "There are no results.")
+        self.assertActiveFilterNotRendered(self.get_soup(response.content))
 
-        response = self.get(params={"query_string": "Not found"})
+        response = self.get(params={"q": "Not found"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "There are no results.")
+        self.assertNotContains(response, "this will be found")
+        self.assertActiveFilterNotRendered(self.get_soup(response.content))

--- a/wagtail/contrib/search_promotions/views/reports.py
+++ b/wagtail/contrib/search_promotions/views/reports.py
@@ -1,21 +1,14 @@
 from django.utils.translation import gettext_lazy as _
-from django_filters import CharFilter, DateFromToRangeFilter
+from django_filters import DateFromToRangeFilter
 
 from wagtail.admin.auth import permission_denied
 from wagtail.admin.filters import DateRangePickerWidget, WagtailFilterSet
 from wagtail.admin.ui.tables import Column
 from wagtail.admin.views.reports import ReportView
 from wagtail.contrib.search_promotions.models import Query
-from wagtail.models import ContentType
 
 
 class SearchTermsReportFilterSet(WagtailFilterSet):
-    query_string = CharFilter(
-        label=_("Search term"),
-        field_name="query_string",
-        lookup_expr="icontains",
-    )
-
     created_at = DateFromToRangeFilter(
         label=_("Date"),
         field_name="daily_hits__date",
@@ -23,14 +16,16 @@ class SearchTermsReportFilterSet(WagtailFilterSet):
     )
 
     class Meta:
-        model = ContentType
-        fields = ["query_string", "created_at"]
+        model = Query
+        fields = []
 
 
 class SearchTermsReportView(ReportView):
     results_template_name = "wagtailsearchpromotions/search_terms_report_results.html"
     page_title = _("Search terms")
     header_icon = "search"
+    is_searchable = True
+    search_fields = ["query_string"]
     filterset_class = SearchTermsReportFilterSet
     index_url_name = "wagtailsearchpromotions:search_terms"
     index_results_url_name = "wagtailsearchpromotions:search_terms_results"
@@ -47,11 +42,13 @@ class SearchTermsReportView(ReportView):
         "_hits",
     ]
 
-    def get_queryset(self):
-        qs = Query.get_most_popular()
+    def get_filterset_kwargs(self):
+        kwargs = super().get_filterset_kwargs()
+        kwargs["queryset"] = self.get_base_queryset()
+        return kwargs
 
-        filterset = self.filterset_class(self.request.GET, queryset=qs)
-        return filterset.qs
+    def get_base_queryset(self):
+        return Query.get_most_popular()
 
     def dispatch(self, request, *args, **kwargs):
         if not self.request.user.is_superuser:

--- a/wagtail/contrib/search_promotions/views/reports.py
+++ b/wagtail/contrib/search_promotions/views/reports.py
@@ -1,4 +1,4 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django_filters import CharFilter, DateFromToRangeFilter
 
 from wagtail.admin.auth import permission_denied
@@ -29,7 +29,7 @@ class SearchTermsReportFilterSet(WagtailFilterSet):
 
 class SearchTermsReportView(ReportView):
     results_template_name = "wagtailsearchpromotions/search_terms_report_results.html"
-    page_title = _("Search Terms")
+    page_title = _("Search terms")
     header_icon = "search"
     filterset_class = SearchTermsReportFilterSet
     index_url_name = "wagtailsearchpromotions:search_terms"

--- a/wagtail/contrib/search_promotions/views/reports.py
+++ b/wagtail/contrib/search_promotions/views/reports.py
@@ -21,7 +21,6 @@ class SearchTermsReportFilterSet(WagtailFilterSet):
 
 
 class SearchTermsReportView(ReportView):
-    results_template_name = "wagtailsearchpromotions/search_terms_report_results.html"
     page_title = _("Search terms")
     header_icon = "search"
     is_searchable = True

--- a/wagtail/contrib/search_promotions/views/reports.py
+++ b/wagtail/contrib/search_promotions/views/reports.py
@@ -27,11 +27,12 @@ class SearchTermsReportView(ReportView):
     is_searchable = True
     search_fields = ["query_string"]
     filterset_class = SearchTermsReportFilterSet
+    default_ordering = "-_hits"
     index_url_name = "wagtailsearchpromotions:search_terms"
     index_results_url_name = "wagtailsearchpromotions:search_terms_results"
     columns = [
-        Column("query_string", label=_("Search term(s)")),
-        Column("_hits", label=_("Views")),
+        Column("query_string", label=_("Search term(s)"), sort_key="query_string"),
+        Column("_hits", label=_("Views"), sort_key="_hits"),
     ]
     export_headings = {
         "query_string": _("Search term(s)"),

--- a/wagtail/contrib/search_promotions/views/reports.py
+++ b/wagtail/contrib/search_promotions/views/reports.py
@@ -9,7 +9,7 @@ from wagtail.contrib.search_promotions.models import Query
 
 
 class SearchTermsReportFilterSet(WagtailFilterSet):
-    created_at = DateFromToRangeFilter(
+    hit_date = DateFromToRangeFilter(
         label=_("Date"),
         field_name="daily_hits__date",
         widget=DateRangePickerWidget,

--- a/wagtail/contrib/search_promotions/wagtail_hooks.py
+++ b/wagtail/contrib/search_promotions/wagtail_hooks.py
@@ -44,7 +44,7 @@ def register_search_picks_menu_item():
 @hooks.register("register_reports_menu_item")
 def register_query_search_report_menu_item():
     return AdminOnlyMenuItem(
-        _("Search Terms"),
+        _("Search terms"),
         reverse("wagtailsearchpromotions:search_terms"),
         name="search-terms",
         icon_name="search",


### PR DESCRIPTION
Improve #12341. The report is useful, but the implementation still had some rough edges. This PR improves it 🙂 

- Fix incorrect use of `gettext` instead of `gettext_lazy` for translatable strings at the class level
- Use search instead of a filter to find by `query_string`
- Improve the filterset definition for the view
  - Fix incorrect model set on the `Meta` class
  - Rename `created_at` to `hit_date` for the date filter
- Allow sorting by each column
- Add and improve tests
- Remove unnecessary `search_terms_report_results.html` template