### PR TITLE
Preserve 'multiple' URL param (and others) when searching in page chooser

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ Changelog
  * Fix: Ensure the accessible labels and tooltips reflect the correct private/public status on the live link button within pages after changing the privacy (Ayaan Qadri)
  * Fix: Fix empty `th` (table heading) elements that are not compliant with accessibility standards (Jai Vignesh J)
  * Fix: Ensure `MultipleChooserPanel` using images or documents work when nested within an `InlinePanel` when no other choosers are in use within the model (Elhussein Almasri)
+ * Fix: Ensure `MultipleChooserPanel` works after doing a search in the page chooser modal (Matt Westcott)
  * Fix: Ensure new `ListBlock` instances get created with unique IDs in the admin client for accessibility and mini-map element references (Srishti Jaiswal)
  * Docs: Move the model reference page from reference/pages to the references section as it covers all Wagtail core models (Srishti Jaiswal)
  * Docs: Move the panels reference page from references/pages to the references section as panels are available for any model editing, merge panels API into this page (Srishti Jaiswal)

--- a/client/src/entrypoints/admin/page-chooser-modal.js
+++ b/client/src/entrypoints/admin/page-chooser-modal.js
@@ -69,6 +69,16 @@ const PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
       $(this).data('timer', wait);
     });
 
+    function updateMultipleChoiceSubmitEnabledState() {
+      // update the enabled state of the multiple choice submit button depending on whether
+      // any items have been selected
+      if ($('[data-multiple-choice-select]:checked', modal.body).length) {
+        $('[data-multiple-choice-submit]', modal.body).removeAttr('disabled');
+      } else {
+        $('[data-multiple-choice-submit]', modal.body).attr('disabled', true);
+      }
+    }
+
     /* Set up behaviour of choose-page links in the newly-loaded search results,
     to pass control back to the calling page */
     function ajaxifySearchResults() {
@@ -95,16 +105,11 @@ const PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         modal.loadUrl(this.href);
         return false;
       });
-    }
 
-    function updateMultipleChoiceSubmitEnabledState() {
-      // update the enabled state of the multiple choice submit button depending on whether
-      // any items have been selected
-      if ($('[data-multiple-choice-select]:checked', modal.body).length) {
-        $('[data-multiple-choice-submit]', modal.body).removeAttr('disabled');
-      } else {
-        $('[data-multiple-choice-submit]', modal.body).attr('disabled', true);
-      }
+      updateMultipleChoiceSubmitEnabledState();
+      $('[data-multiple-choice-select]', modal.body).on('change', () => {
+        updateMultipleChoiceSubmitEnabledState();
+      });
     }
 
     function ajaxifyBrowseResults() {

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -41,6 +41,7 @@ depth: 1
  * Ensure the accessible labels and tooltips reflect the correct private/public status on the live link button within pages after changing the privacy (Ayaan Qadri)
  * Fix empty `th` (table heading) elements that are not compliant with accessibility standards (Jai Vignesh J)
  * Ensure `MultipleChooserPanel` using images or documents work when nested within an `InlinePanel` when no other choosers are in use within the model (Elhussein Almasri)
+ * Ensure `MultipleChooserPanel` works after doing a search in the page chooser modal (Matt Westcott)
  * Ensure new `ListBlock` instances get created with unique IDs in the admin client for accessibility and mini-map element references (Srishti Jaiswal)
 
 ### Documentation

--- a/wagtail/admin/templates/wagtailadmin/chooser/browse.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/browse.html
@@ -5,7 +5,8 @@
     {% trans "Choose a page" as choose_str %}
 {% endif %}
 
-{% include "wagtailadmin/shared/header.html" with title=choose_str subtitle=page_type_names|join:", " search_url="wagtailadmin_choose_page_search" query_parameters="page_type="|add:page_type_string icon="doc-empty-inverse" search_disable_async=True %}
+{% querystring as search_query_params %}
+{% include "wagtailadmin/shared/header.html" with title=choose_str subtitle=page_type_names|join:", " search_url="wagtailadmin_choose_page_search" query_parameters=search_query_params icon="doc-empty-inverse" search_disable_async=True %}
 
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='internal' %}

--- a/wagtail/admin/templates/wagtailadmin/chooser/tables/parent_page_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/tables/parent_page_cell.html
@@ -1,7 +1,7 @@
 {% load wagtailadmin_tags %}
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
     {% if value %}
-        <a href="{% url 'wagtailadmin_choose_page_child' value.id %}" class="navigate-parent">{{ value.get_admin_display_title }}</a>
+        <a href="{% url 'wagtailadmin_choose_page_child' value.id %}{% querystring p=None q=None %}" class="navigate-parent">{{ value.get_admin_display_title }}</a>
         {% if show_locale_labels %}{% status value.locale.get_display_name classname="w-status--label" %}{% endif %}
     {% endif %}
 </td>

--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -11,7 +11,7 @@
     - `search_results_url` - URL to be used for async requests to search results, if not provided, the form's action URL will be used
     - `search_target` - A selector string to be used as the target for the search results to be swapped into. Defaults to '#listing-results'
     - `search_disable_async` - If True, the default header async search functionality will not be used
-    - `query_parameters` - a query string (without the '?') to be placed after the search URL
+    - `query_parameters` - a query string (with or without the '?') to be placed after the search URL
     - `icon` - name of an icon to place against the title
     - `merged` - if true, add the classname 'w-header--merged'
     - `action_url` - if present, display an 'action' button. This is the URL to be used as the link URL for the button
@@ -42,7 +42,7 @@
             {% if search_url %}
                 <form
                     class="col search-form"
-                    action="{% url search_url %}{% if query_parameters %}?{{ query_parameters }}{% endif %}"
+                    action="{% url search_url %}{% if query_parameters %}{% if query_parameters.0 != '?' %}?{% endif %}{{ query_parameters }}{% endif %}"
                     method="get"
                     novalidate
                     role="search"

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -65,11 +65,19 @@ class TestChooserBrowse(WagtailTestUtils, TestCase):
 
         checkbox_value = str(self.child_page.id)
         decoded_content = response.content.decode()
+        response_json = json.loads(decoded_content)
+        self.assertEqual(response_json["step"], "browse")
+        response_html = response_json["html"]
 
-        self.assertIn(f'value=\\"{checkbox_value}\\"', decoded_content)
+        self.assertIn(f'value="{checkbox_value}"', response_html)
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/chooser/browse.html")
+
+        soup = self.get_soup(response_html)
+        search_url = soup.find("form", role="search")["action"]
+        search_query_params = parse_qs(urlsplit(search_url).query)
+        self.assertEqual(search_query_params["multiple"], ["1"])
 
     @override_settings(USE_THOUSAND_SEPARATOR=False)
     def test_multiple_chooser_view_without_thousand_separator(self):

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -371,11 +371,21 @@ class TestChooserSearch(WagtailTestUtils, TransactionTestCase):
         return self.client.get(reverse("wagtailadmin_choose_page_search"), params or {})
 
     def test_simple(self):
-        response = self.get({"q": "foobarbaz"})
+        response = self.get({"q": "foobarbaz", "allow_external_link": "true"})
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/chooser/_search_results.html")
         self.assertContains(response, "There is 1 match")
         self.assertContains(response, "foobarbaz")
+
+        # parent page link should preserve the allow_external_link parameter
+        expected_url = (
+            reverse("wagtailadmin_choose_page_child", args=[self.root_page.id])
+            + "?allow_external_link=true"
+        )
+        self.assertContains(
+            response,
+            f'<a href="{expected_url}" class="navigate-parent">{self.root_page.title}</a>',
+        )
 
     def test_partial_match(self):
         response = self.get({"q": "fooba"})

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -408,7 +408,11 @@ class SearchView(View):
     @property
     def columns(self):
         cols = [
-            PageTitleColumn("title", label=_("Title")),
+            PageTitleColumn(
+                "title",
+                label=_("Title"),
+                is_multiple_choice=self.is_multiple_choice,
+            ),
             ParentPageColumn("parent", label=_("Parent")),
             DateColumn(
                 "updated",


### PR DESCRIPTION
Fixes #11955, supersedes #12037

Several bugs fixed here:

* The search bar's action URL needs to preserve all URL parameters from the initial opening of the modal, not just `page_types` - this includes `multiple` (so that we don't drop back to single-select mode after a search) but also others that influence the results, such as `user_perms` (without this, the parent page chooser in the "move page" view will let you choose pages in search results that are greyed out while in browse mode) as well as `allow_external_links` and friends (which are not used directly by the search results view, but need to be passed on through the parent page link so that we don't lose the top navigation when we return to browse mode).
* `ajaxifySearchResults` was not attaching the event handler to the checkboxes for enabling/disabling the "confirm selection" button, so it was never being enabled
* The parent page link in the search results was not preserving any URL params - it needs to preserve all except the search query `q` and page number `p`.