### PR TITLE
Removed unused method and test from menu.py and tests.py

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -78,6 +78,7 @@ Changelog
  * Maintenance: Migrate the conditional enabling of fields in the image URL builder view away from ad-hoc jQuery to use the `RulesController` (`w-rules`) approach (LB (Ben) Johnston)
  * Maintenance: Enhance the Stimulus `ZoneController` (`w-zone`) to support inactive class and a mechanism to switch the mode based on data within events (Ayaan Qadri)
  * Maintenance: Use the Stimulus `ZoneController` (`w-zone`) to remove ad-hoc jQuery for the privacy switch when toggling visibility of private/public elements (Ayaan Qadri)
+ * Maintenance: Remove unused `is_active` & `active_menu_items` from `wagtail.admin.menu.MenuItem` (Srishti Jaiswal)
 
 
 6.3.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -97,6 +97,7 @@ depth: 1
  * Migrate the conditional enabling of fields in the image URL builder view away from ad-hoc jQuery to use the `RulesController` (`w-rules`) approach (LB (Ben) Johnston)
  * Enhance the Stimulus `ZoneController` (`w-zone`) to support inactive class and a mechanism to switch the mode based on data within events (Ayaan Qadri)
  * Use the Stimulus `ZoneController` (`w-zone`) to remove ad-hoc jQuery for the privacy switch when toggling visibility of private/public elements (Ayaan Qadri)
+ * Remove unused `is_active` & `active_menu_items` from `wagtail.admin.menu.MenuItem` (Srishti Jaiswal)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/menu.py
+++ b/wagtail/admin/menu.py
@@ -43,9 +43,6 @@ class MenuItem(metaclass=MediaDefiningClass):
         """
         return True
 
-    def is_active(self, request):
-        return request.path.startswith(str(self.url))
-
     def render_component(self, request):
         return LinkMenuItemComponent(
             self.name,
@@ -121,13 +118,6 @@ class Menu:
 
         return items
 
-    def active_menu_items(self, request):
-        return [
-            item
-            for item in self.menu_items_for_request(request)
-            if item.is_active(request)
-        ]
-
     @property
     def media(self):
         media = Media()
@@ -153,9 +143,6 @@ class SubmenuMenuItem(MenuItem):
     def is_shown(self, request):
         # show the submenu if one or more of its children is shown
         return bool(self.menu.menu_items_for_request(request))
-
-    def is_active(self, request):
-        return bool(self.menu.active_menu_items(request))
 
     def render_component(self, request):
         return SubMenuItemComponent(

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -401,10 +401,6 @@ class TestMenuItem(WagtailTestUtils, TestCase):
         response = self.client.get(reverse("wagtailadmin_home"))
         self.request = response.wsgi_request
 
-    def test_menuitem_reverse_lazy_url_pass(self):
-        menuitem = MenuItem(_("Test"), reverse_lazy("wagtailadmin_home"))
-        self.assertIs(menuitem.is_active(self.request), True)
-
     def test_menuitem_with_classname(self):
         menuitem = MenuItem(
             _("Test"),


### PR DESCRIPTION
Fixes #11433 

This PR removes unused methods related to menu item activity handling in the Wagtail admin menu:
```
wagtail.admin.menu.MenuItem.is_active
wagtail.admin.menu.Menu.active_menu_items
wagtail.admin.menu.SubmenuMenuItem.is_active
```
These methods are no longer utilized in the codebase and have been superseded by JavaScript-based handling of active menu items. Specifically, the `sidebar-menu-item--active` class, responsible for theming active menu items via CSS, is now exclusively managed by JavaScript.

Cleaned up the related test from `wgatail.admin.tests.tests.py` : `wagtail.admin.tests.tests.TestMenuItem.test_menuitem_reverse_lazy_url_pass`

- [X]  I ran the full test suite to confirm there were no regressions.
- [X]  I manually verified that the admin menu is functioning as expected.
- [X]  Screenshots of the functioning menu after the changes are included for review.

**Before removing the methods:**

https://github.com/user-attachments/assets/0644f8ce-cf27-412a-92bf-405c6746004a

**After removing the methods:**

https://github.com/user-attachments/assets/9b4c7a4c-67bf-4260-82a2-a974c605697b

**After removing the test, all tests passed :**
![Screenshot 2024-12-01 111639](https://github.com/user-attachments/assets/42556ed4-450b-41a3-ad16-a5d84e77545a)



