### PR TITLE
Add missing backticks on {% image %} in heading

### DIFF
--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -230,7 +230,7 @@ Wagtail does not allow deforming or stretching images. Image dimension ratios wi
 
 Wagtail provides two shortcuts to give greater control over the `img` element:
 
-### 1. Adding attributes to the {% image %} tag
+### 1. Adding attributes to the `{% image %}` tag
 
 Extra attributes can be specified with the syntax `attribute="value"`:
 


### PR DESCRIPTION
Initially opened this to rename "img tag" to "img element" in the heading preceding the one changed in PR now, but then I realised `<img>` is indeed an HTML tag 😅  (from the context I'd been thinking Django template tag, which it isn't). Mentioning that here because I'm thinking maybe we may want to include the angular brackets on `img` in that heading.

Anyway, I removed that commit and have repurposed the PR for the other small change. (Feel free to close PR if it's too small to consider as a single change.)