### PR TITLE
Only call openpyxl at runtime

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -81,6 +81,7 @@ Changelog
  * Maintenance: Enhance the Stimulus `ZoneController` (`w-zone`) to support inactive class and a mechanism to switch the mode based on data within events (Ayaan Qadri)
  * Maintenance: Use the Stimulus `ZoneController` (`w-zone`) to remove ad-hoc jQuery for the privacy switch when toggling visibility of private/public elements (Ayaan Qadri)
  * Maintenance: Remove unused `is_active` & `active_menu_items` from `wagtail.admin.menu.MenuItem` (Srishti Jaiswal)
+ * Maintenance: Only call `openpyxl` at runtime to improve performance for projects that do not use `ReportView`, `SpreadsheetExportMixin` and `wagtail.contrib.redirects` (Sébastien Corbin)
 
 
 6.3.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -100,7 +100,7 @@ depth: 1
  * Enhance the Stimulus `ZoneController` (`w-zone`) to support inactive class and a mechanism to switch the mode based on data within events (Ayaan Qadri)
  * Use the Stimulus `ZoneController` (`w-zone`) to remove ad-hoc jQuery for the privacy switch when toggling visibility of private/public elements (Ayaan Qadri)
  * Remove unused `is_active` & `active_menu_items` from `wagtail.admin.menu.MenuItem` (Srishti Jaiswal)
-
+ * Only call `openpyxl` at runtime to improve performance for projects that do not use `ReportView`, `SpreadsheetExportMixin` and `wagtail.contrib.redirects` (Sébastien Corbin)
 
 ## Upgrade considerations - changes affecting all projects
 

--- a/wagtail/admin/views/mixins.py
+++ b/wagtail/admin/views/mixins.py
@@ -14,8 +14,6 @@ from django.utils.formats import get_format
 from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext as _
-from openpyxl import Workbook
-from openpyxl.cell import WriteOnlyCell
 
 from wagtail.admin.widgets.button import Button
 from wagtail.coreutils import multigetattr
@@ -208,6 +206,8 @@ class SpreadsheetExportMixin:
 
     def generate_xlsx_row(self, worksheet, row_dict, date_format=None):
         """Generate cells to append to the worksheet"""
+        from openpyxl.cell import WriteOnlyCell
+
         for field, value in row_dict.items():
             cell = WriteOnlyCell(
                 worksheet, self.preprocess_field_value(field, value, self.FORMAT_XLSX)
@@ -246,6 +246,8 @@ class SpreadsheetExportMixin:
 
     def write_xlsx(self, queryset, output):
         """Write an xlsx workbook from a queryset"""
+        from openpyxl import Workbook
+
         workbook = Workbook(write_only=True, iso_dates=True)
 
         worksheet = workbook.create_sheet(title="Sheet1")

--- a/wagtail/contrib/redirects/base_formats.py
+++ b/wagtail/contrib/redirects/base_formats.py
@@ -1,8 +1,6 @@
 import csv
 from io import BytesIO, StringIO
 
-import openpyxl
-
 
 class Dataset(list):
     def __init__(self, rows=(), headers=None):
@@ -66,6 +64,8 @@ class XLSX:
         """
         Create dataset from the first sheet of a xlsx workbook.
         """
+        import openpyxl
+
         workbook = openpyxl.load_workbook(BytesIO(data), read_only=True, data_only=True)
         sheet = workbook.worksheets[0]
         try:


### PR DESCRIPTION
After discussing the way to import openpyxl https://github.com/wagtail/wagtail/discussions/12125, here's a simple PR that just move openpyxl usages to local imports so that it will be called at runtime.

Projects that don't use `ReportView` (or `SpreadsheetExportMixin`) and `wagtail.contrib.redirects` will see a memory use decrease