### PR TITLE
Default URL param value for Gravatar URL have been deprecated (`mm` -> `mp`)

### DIFF
--- a/wagtail/users/utils.py
+++ b/wagtail/users/utils.py
@@ -26,7 +26,7 @@ def user_can_delete_user(current_user, user_to_delete):
 
 
 def get_gravatar_url(email, size=50):
-    default = "mm"
+    default = "mp"
     size = (
         int(size) * 2
     )  # requested at retina size by default and scaled down at point of use with css


### PR DESCRIPTION
Fixes #12658

Update the default Gravatar URL parameter value from 'mm' to 'mp'.

* Change the `default` parameter value from "mm" to "mp" in the `get_gravatar_url` function in `wagtail/users/utils.py` at line 29.

