### PR TITLE
Changing default value for Gravatar URL from ( mm -> mp )

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -87,6 +87,7 @@ Changelog
  * Maintenance: Use the Stimulus `ZoneController` (`w-zone`) to remove ad-hoc jQuery for the privacy switch when toggling visibility of private/public elements (Ayaan Qadri)
  * Maintenance: Remove unused `is_active` & `active_menu_items` from `wagtail.admin.menu.MenuItem` (Srishti Jaiswal)
  * Maintenance: Only call `openpyxl` at runtime to improve performance for projects that do not use `ReportView`, `SpreadsheetExportMixin` and `wagtail.contrib.redirects` (Sébastien Corbin)
+ * Maintenance: Adopt the update value `mp` instead of `mm` for 'mystery person' as the default Gravatar if no avatar found (Harsh Dange)
 
 
 6.3.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -858,6 +858,7 @@
 * Noah van der Meer
 * Strapchay
 * Alex Fulcher
+* Harsh Dange
 
 ## Translators
 

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -105,6 +105,7 @@ depth: 1
  * Use the Stimulus `ZoneController` (`w-zone`) to remove ad-hoc jQuery for the privacy switch when toggling visibility of private/public elements (Ayaan Qadri)
  * Remove unused `is_active` & `active_menu_items` from `wagtail.admin.menu.MenuItem` (Srishti Jaiswal)
  * Only call `openpyxl` at runtime to improve performance for projects that do not use `ReportView`, `SpreadsheetExportMixin` and `wagtail.contrib.redirects` (Sébastien Corbin)
+ * Adopt the update value `mp` instead of `mm` for 'mystery person' as the default Gravatar if no avatar found (Harsh Dange)
 
 ## Upgrade considerations - changes affecting all projects
 

--- a/wagtail/admin/tests/ui/test_sidebar.py
+++ b/wagtail/admin/tests/ui/test_sidebar.py
@@ -283,7 +283,7 @@ class TestAdaptMainMenuModule(WagtailTestUtils, DjangoTestCase):
                     ],
                     {
                         "name": user.first_name or user.get_username(),
-                        "avatarUrl": "//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=100&d=mm",
+                        "avatarUrl": "//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=100&d=mp",
                     },
                 ],
             },

--- a/wagtail/users/utils.py
+++ b/wagtail/users/utils.py
@@ -26,7 +26,7 @@ def user_can_delete_user(current_user, user_to_delete):
 
 
 def get_gravatar_url(email, size=50):
-    default = "mm"
+    default = "mp"
     size = (
         int(size) * 2
     )  # requested at retina size by default and scaled down at point of use with css


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/12658

### PR Title: Changing default value for Gravatar URL from ( mm -> mp )

### Description:
This PR addresses the following changes:
1. **Update the default Gravatar URL parameter value**:
   - Changed the default parameter value from `mm` to `mp` in the `get_gravatar_url` function in `wagtail/users/utils.py` at line 29.
   
2. **Fix the `avatarUrl` in `TestAdaptMainMenuModule` class**:
   - Updated the `avatarUrl` in `wagtail/admin/tests/ui/test_sidebar.py` to use the correct default parameter value `mp`.

### Changes:
- **wagtail/users/utils.py**:
  - Changed the default value for Gravatar URL from `mm` to `mp`.

- **wagtail/admin/tests/ui/test_sidebar.py**:
  - Updated the `avatarUrl` to use the correct default parameter value `mp`.

### Testing:
- Ensure that the Gravatar URL is correctly generated with the new default parameter value `mp`.
- Run the unit tests to verify that the changes do not introduce any regressions.