### PR TITLE
Migrate privacy switch modal field hiding to the Stimulus `RulesController`

### DIFF
--- a/client/src/controllers/RulesController.stories.js
+++ b/client/src/controllers/RulesController.stories.js
@@ -79,4 +79,48 @@ const EnableTemplate = ({ debug = false }) => (
   </StimulusWrapper>
 );
 
+const ShowTemplate = ({ debug = false }) => (
+  <StimulusWrapper debug={debug} definitions={definitions}>
+    <form
+      method="get"
+      data-controller="w-rules"
+      // avoid accidental submissions with preventing submit
+      data-action="change->w-rules#resolve submit->w-rules#resolve:prevent"
+    >
+      <div className="w-field__wrapper">
+        <label className="w-field__label" htmlFor="drink">
+          Choose your favorite drink:
+          <div className="w-field w-field--choice_field w-field--select">
+            <div className="w-field__input">
+              <select className="w-min-w-full" name="drink">
+                <option value="">-------</option>
+                <option value="coffee">Coffee ☕</option>
+                <option value="tea">Tea 🍵</option>
+                <option value="milo">Milo 🍫</option>
+                <option value="other">Other ❓</option>
+              </select>
+            </div>
+          </div>
+        </label>
+      </div>
+      <div
+        className="w-field__wrapper"
+        data-w-rules-target="show"
+        data-w-rules='{"drink":"other"}'
+      >
+        <label className="w-field__label" htmlFor="other">
+          Other
+          <div className="w-field w-field--choice_field w-field--select">
+            <div className="w-field__input">
+              <input type="text" name="other" />
+            </div>
+          </div>
+        </label>
+      </div>
+    </form>
+  </StimulusWrapper>
+);
+
 export const Enable = EnableTemplate.bind({});
+
+export const Show = ShowTemplate.bind({});

--- a/client/src/controllers/RulesController.ts
+++ b/client/src/controllers/RulesController.ts
@@ -7,6 +7,7 @@ import { debounce } from '../utils/debounce';
 
 enum Effect {
   Enable = 'enable',
+  Show = 'show',
 }
 
 enum Match {
@@ -30,7 +31,7 @@ type FormControlElement =
 
 /**
  * Adds the ability for a controlled form element to conditionally
- * enable targeted elements based on the data from the controlled form
+ * enable or show targeted elements based on the data from the controlled form
  * along with a set of rules to match against that data.
  *
  * @example - Enable a button if a specific value is chosen
@@ -46,16 +47,32 @@ type FormControlElement =
  *   </button>
  * </form>
  * ```
+ *
+ * @example - Show an additional checkbox a value is chosen
+ * ```html
+ * <form data-controller="w-rules" data-action="change->w-rules#resolve">
+ *   <select name="fav-drink" required>
+ *     <option value="">Select a drink</option>
+ *     <option value="coffee">Coffee</option>
+ *     <option value="other">Other</option>
+ *   </select>
+ *   <input type="text" name="other-drink" data-w-rules-target="show" data-w-rules='{"fav-drink": ["other"]}'>
+ * </form>
+ * ```
  */
 export class RulesController extends Controller<
   HTMLFormElement | FormControlElement
 > {
-  static targets = ['enable'];
+  static targets = ['enable', 'show'];
 
   /** Targets will be enabled if the target's rule matches the scoped form data, otherwise will be disabled. */
   declare readonly enableTargets: FormControlElement[];
   /** True if there is at least one enable target, used to ensure rules do not run if not needed. */
   declare readonly hasEnableTarget: boolean;
+  /** Targets will be be set to `hidden=false` if the target's rule matches the scoped form data, otherwise will be hidden with `hidden=true`. */
+  declare readonly showTargets: HTMLElement[];
+  /** True if there is at least one show target, used to ensure rules do not run if not needed. */
+  declare readonly hasShowTarget: boolean;
 
   declare form;
   declare rulesCache: Record<
@@ -81,7 +98,7 @@ export class RulesController extends Controller<
    * rule attributes and the controlled element's form data.
    */
   resolve() {
-    if (!this.hasEnableTarget) return;
+    if (!this.hasEnableTarget && !this.hasShowTarget) return;
 
     const formData = new FormData(this.form);
 
@@ -112,6 +129,27 @@ export class RulesController extends Controller<
       if (event.defaultPrevented) return;
 
       target.disabled = !enable;
+    });
+
+    this.showTargets.forEach((target) => {
+      const effect = Effect.Show;
+      const { match, rules } = this.parseRules(target, effect);
+
+      const show =
+        match === Match.Any ? rules.some(checkFn) : rules.every(checkFn);
+
+      if (show === !target.hidden) return;
+
+      const event = this.dispatch('effect', {
+        bubbles: true,
+        cancelable: true,
+        detail: { effect, show },
+        target,
+      });
+
+      if (event.defaultPrevented) return;
+
+      target.hidden = !show;
     });
 
     this.dispatch('resolved', { bubbles: true, cancelable: false });
@@ -196,6 +234,14 @@ export class RulesController extends Controller<
   }
 
   enableTargetDisconnected() {
+    this.resolve();
+  }
+
+  showTargetConnected() {
+    this.resolve();
+  }
+
+  showTargetDisconnected() {
     this.resolve();
   }
 }

--- a/client/src/controllers/RulesController.ts
+++ b/client/src/controllers/RulesController.ts
@@ -54,15 +54,14 @@ export class RulesController extends Controller<
   initialize() {
     this.rulesCache = {};
     this.resolve = debounce(this.resolve.bind(this), 50);
+    this.form = this.findForm();
+  }
 
+  findForm() {
     const element = this.element;
-    if (element instanceof HTMLFormElement) {
-      this.form = element;
-    } else if ('form' in element) {
-      this.form = element.form;
-    } else {
-      this.form = element.closest('form');
-    }
+    if (element instanceof HTMLFormElement) return element;
+    if ('form' in element) return element.form;
+    return element.closest('form');
   }
 
   /**

--- a/client/src/controllers/RulesController.ts
+++ b/client/src/controllers/RulesController.ts
@@ -5,6 +5,10 @@ import { Controller } from '@hotwired/stimulus';
 import { castArray } from '../utils/castArray';
 import { debounce } from '../utils/debounce';
 
+enum Effect {
+  Enable = 'enable',
+}
+
 /**
  * Form control elements that can support the `disabled` attribute.
  *
@@ -73,23 +77,25 @@ export class RulesController extends Controller<
 
     const formData = new FormData(this.form);
 
-    this.enableTargets.forEach((target) => {
-      const rules = this.parseRules(target);
+    const checkFn = ([fieldName, allowedValues]) => {
+      // Forms can have multiple values for the same field name
+      const values = formData.getAll(fieldName);
+      // Checkbox fields will NOT appear in FormData unless checked, support this when validValues are also empty
+      if (allowedValues.length === 0 && values.length === 0) return true;
+      return allowedValues.some((validValue) => values.includes(validValue));
+    };
 
-      const enable = rules.every(([fieldName, allowedValues]) => {
-        // Forms can have multiple values for the same field name
-        const values = formData.getAll(fieldName);
-        // Checkbox fields will NOT appear in FormData unless checked, support this when validValues are also empty
-        if (allowedValues.length === 0 && values.length === 0) return true;
-        return allowedValues.some((validValue) => values.includes(validValue));
-      });
+    this.enableTargets.forEach((target) => {
+      const effect = Effect.Enable;
+      const rules = this.parseRules(target, effect);
+      const enable = rules.every(checkFn);
 
       if (enable === !target.disabled) return;
 
       const event = this.dispatch('effect', {
         bubbles: true,
         cancelable: true,
-        detail: { effect: 'enable', enable },
+        detail: { effect, enable },
         target,
       });
 
@@ -103,17 +109,30 @@ export class RulesController extends Controller<
 
   /**
    * Finds & parses the rules for the provided target by the rules attribute,
-   * which is determined via the identifier (e.g. `data-w-rules`).
-   * Check the rules cache first, then parse the rules for caching if not found.
+   * which is determined via the identifier and the provided effect name,
+   * (e.g. `data-w-enable-rules`). falling back to the generic attribute
+   * if not found (e.g. `data-w-rules`).
+   *
+   * With the found rules, check the rules cache first,
+   * then parse the rules for caching if not found.
    *
    * When parsing the rule, assume an `Object.entries` format or convert an
    * object to this format. Then ensure each value is an array of strings
    * for consistent comparison to FormData values.
    */
-  parseRules(target: Element) {
-    if (!target) return [];
-    const rulesRaw = target.getAttribute(`data-${this.identifier}`);
-    if (!rulesRaw) return [];
+  parseRules(target: Element, effect: Effect = Effect.Enable) {
+    const emptyRules = [];
+    if (!target) return emptyRules;
+
+    let attribute = `data-${this.identifier}-${effect}`;
+    let rulesRaw = target.getAttribute(attribute);
+
+    if (!rulesRaw) {
+      attribute = `data-${this.identifier}`;
+      rulesRaw = target.getAttribute(attribute);
+    }
+
+    if (!rulesRaw) return emptyRules;
 
     const cachedRule = this.rulesCache[rulesRaw];
     if (cachedRule) return cachedRule;
@@ -123,8 +142,11 @@ export class RulesController extends Controller<
     try {
       parsedRules = JSON.parse(rulesRaw);
     } catch (error) {
-      this.context.handleError(error, 'Unable to parse rule.');
-      return [];
+      this.context.handleError(
+        error,
+        `Unable to parse rule at the attribute '${attribute}'.`,
+      );
+      return emptyRules;
     }
 
     const rules = (

--- a/client/src/controllers/RulesController.ts
+++ b/client/src/controllers/RulesController.ts
@@ -101,14 +101,6 @@ export class RulesController extends Controller<
     this.dispatch('resolved', { bubbles: true, cancelable: false });
   }
 
-  enableTargetDisconnected() {
-    this.resolve();
-  }
-
-  enableTargetConnected() {
-    this.resolve();
-  }
-
   /**
    * Finds & parses the rules for the provided target by the rules attribute,
    * which is determined via the identifier (e.g. `data-w-rules`).
@@ -147,5 +139,15 @@ export class RulesController extends Controller<
     this.rulesCache[rulesRaw] = rules;
 
     return rules;
+  }
+
+  /* Target disconnection & reconnection */
+
+  enableTargetConnected() {
+    this.resolve();
+  }
+
+  enableTargetDisconnected() {
+    this.resolve();
   }
 }

--- a/client/src/controllers/RulesController.ts
+++ b/client/src/controllers/RulesController.ts
@@ -9,6 +9,11 @@ enum Effect {
   Enable = 'enable',
 }
 
+enum Match {
+  All = 'all', // Default
+  Any = 'any',
+}
+
 /**
  * Form control elements that can support the `disabled` attribute.
  *
@@ -53,7 +58,10 @@ export class RulesController extends Controller<
   declare readonly hasEnableTarget: boolean;
 
   declare form;
-  declare rulesCache: Record<string, [string, string[]][]>;
+  declare rulesCache: Record<
+    string,
+    { match: Match; rules: [string, string[]][] }
+  >;
 
   initialize() {
     this.rulesCache = {};
@@ -87,8 +95,10 @@ export class RulesController extends Controller<
 
     this.enableTargets.forEach((target) => {
       const effect = Effect.Enable;
-      const rules = this.parseRules(target, effect);
-      const enable = rules.every(checkFn);
+      const { match, rules } = this.parseRules(target, effect);
+
+      const enable =
+        match === Match.Any ? rules.some(checkFn) : rules.every(checkFn);
 
       if (enable === !target.disabled) return;
 
@@ -99,9 +109,9 @@ export class RulesController extends Controller<
         target,
       });
 
-      if (!event.defaultPrevented) {
-        target.disabled = !enable;
-      }
+      if (event.defaultPrevented) return;
+
+      target.disabled = !enable;
     });
 
     this.dispatch('resolved', { bubbles: true, cancelable: false });
@@ -121,7 +131,7 @@ export class RulesController extends Controller<
    * for consistent comparison to FormData values.
    */
   parseRules(target: Element, effect: Effect = Effect.Enable) {
-    const emptyRules = [];
+    const emptyRules = { match: Match.All, rules: [] };
     if (!target) return emptyRules;
 
     let attribute = `data-${this.identifier}-${effect}`;
@@ -158,9 +168,25 @@ export class RulesController extends Controller<
         castArray(validValues).map(String),
       ]) as [string, string[]][];
 
-    this.rulesCache[rulesRaw] = rules;
+    const [, [match = Match.All] = []] =
+      rules.find(([key]) => key === '') || [];
 
-    return rules;
+    if (!Object.values(Match).includes(match as Match)) {
+      this.context.handleError(
+        new Error(`Invalid match value: '${match}'.`),
+        `Match value must be one of: '${Object.values(Match).join("', '")}'.`,
+      );
+      return emptyRules;
+    }
+
+    const newRules = {
+      match: match as Match,
+      rules: rules.filter(([key]) => key),
+    };
+
+    this.rulesCache[rulesRaw] = newRules;
+
+    return newRules;
   }
 
   /* Target disconnection & reconnection */

--- a/client/src/entrypoints/admin/privacy-switch.js
+++ b/client/src/entrypoints/admin/privacy-switch.js
@@ -4,50 +4,16 @@ import $ from 'jquery';
 
 $(() => {
   /* Interface to set permissions from the explorer / editor */
-  // eslint-disable-next-line func-names
-  $('[data-a11y-dialog-show="set-privacy"]').on('click', function () {
+  $('[data-a11y-dialog-show="set-privacy"]').on('click', function setPrivacy() {
     ModalWorkflow({
       dialogId: 'set-privacy',
       url: this.getAttribute('data-url'),
       onload: {
         set_privacy(modal) {
-          // eslint-disable-next-line func-names
-          $('form', modal.body).on('submit', function () {
+          $('form', modal.body).on('submit', function handleSubmit() {
             modal.postForm(this.action, $(this).serialize());
             return false;
           });
-
-          const restrictionTypePasswordField = $(
-            "input[name='restriction_type'][value='password']",
-            modal.body,
-          );
-          const restrictionTypeGroupsField = $(
-            "input[name='restriction_type'][value='groups']",
-            modal.body,
-          );
-          const passwordField = $('[name="password"]', modal.body).parents(
-            '[data-field-wrapper]',
-          );
-          const groupsFields = $('#groups-fields', modal.body);
-
-          function refreshFormFields() {
-            if (restrictionTypePasswordField.is(':checked')) {
-              passwordField.show();
-              groupsFields.hide();
-            } else if (restrictionTypeGroupsField.is(':checked')) {
-              passwordField.hide();
-              groupsFields.show();
-            } else {
-              passwordField.hide();
-              groupsFields.hide();
-            }
-          }
-          refreshFormFields();
-
-          $("input[name='restriction_type']", modal.body).on(
-            'change',
-            refreshFormFields,
-          );
         },
         set_privacy_done(modal, { is_public: isPublic }) {
           document.dispatchEvent(

--- a/wagtail/admin/templates/wagtailadmin/collection_privacy/set_privacy.html
+++ b/wagtail/admin/templates/wagtailadmin/collection_privacy/set_privacy.html
@@ -1,13 +1,15 @@
 {% load i18n wagtailadmin_tags %}
 
-<form action="{% url 'wagtailadmin_collections:set_privacy' collection.id %}" method="POST" novalidate>
+<form action="{% url 'wagtailadmin_collections:set_privacy' collection.id %}" method="POST" novalidate data-controller="w-rules" data-action="change->w-rules#resolve">
     {% csrf_token %}
     {% formattedfield field=form.restriction_type show_label=False %}
     {% if form.password is not None %}
-        {% formattedfield form.password %}
+        <div hidden data-w-rules-target="show" data-w-rules='{"restriction_type":"password"}'>
+            {% formattedfield form.password %}
+        </div>
     {% endif %}
-    <div id="groups-fields">
+    <div hidden data-w-rules-target="show" data-w-rules='{"restriction_type":"groups"}'>
         {% formattedfield form.groups %}
     </div>
-    <input type="submit" value="{% trans "Save" %}" class="button" />
+    <input type="submit" value='{% trans "Save" %}' class="button" />
 </form>

--- a/wagtail/admin/templates/wagtailadmin/page_privacy/set_privacy.html
+++ b/wagtail/admin/templates/wagtailadmin/page_privacy/set_privacy.html
@@ -1,13 +1,15 @@
 {% load i18n wagtailadmin_tags %}
 
-<form action="{% url 'wagtailadmin_pages:set_privacy' page.id %}" method="POST" novalidate>
+<form action="{% url 'wagtailadmin_pages:set_privacy' page.id %}" method="POST" novalidate data-controller="w-rules" data-action="change->w-rules#resolve">
     {% csrf_token %}
     {% formattedfield field=form.restriction_type show_label=False %}
     {% if form.password is not None %}
-        {% formattedfield form.password %}
+        <div hidden data-w-rules-target="show" data-w-rules='{"restriction_type": "password"}'>
+            {% formattedfield form.password %}
+        </div>
     {% endif %}
-    <div id="groups-fields">
+    <div hidden data-w-rules-target="show" data-w-rules='{"restriction_type": "groups"}'>
         {% formattedfield form.groups %}
     </div>
-    <input type="submit" value="{% trans "Save" %}" class="button" />
+    <input type="submit" value='{% trans "Save" %}' class="button" />
 </form>


### PR DESCRIPTION
## Summary

Adds the ability for `RulesController` to support targets that are shown dynamically based on field values within the same form.

Completes part 2 of #11045 (privacy switch jQuery migration) and incorporate some of the feedback from the initial implementation PR - https://github.com/wagtail/wagtail/pull/11202#discussion_r1863835969

## Details

1. Adds the ability to use `data-w-rules-enable`, falling back to `data-w-rules` for the rules value.
2. Adds the ability to determine if the rules should be applied when `all` fields match (the default) or `any` fields match, by providing data within the rules attribute's value.
  - Note: This is intentionally not using 'every'/'some' as we want a value that makes sense across the JS/Python divide while attempting to be intuitive and making room for future enhancements.
3. Cleans up the code a bit, moving the disconnect/reconnect to the end of the class & splitting out the `findForm` to a method.
4. Adds support for show targets, without trying to be too abstract in the implementation, we can further abstract repeated code out later if needed.
5. Incremental commits to be easier to review.
6. This will make it quite easy to do the final step, moving the filtered select over to the RulesController usage, some unit tests/storybook examples are based on this use case.

## Testing

<img width="1582" alt="Screenshot 2024-12-05" src="https://github.com/user-attachments/assets/4a688aa8-86f9-45fd-8d38-70148550955c">

1. Navigate to a collection and click the button to activate the privacy modal, within the modal validate that the field changes will correctly show/hide the password or group selection field. Also test the initial loading of the correctly shown elements based on the saved value.
7. Navigate to any page, open the status sidebar and click the change privacy button, perform a similar set of testing as above.
