### PR TITLE
Properly handle pasting of multiple tags in a tag field in the admin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~~~~~
 
 * Set `FieldPanel(required_on_save=True)` for `AbstractFormField`'s `field_type` field (Alex Tomkins)
+* Handle pasting of multiple tags separated by newlines or commas (Matthias Brück)
 
 
 7.4 LTS (05.05.2026)

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -15,6 +15,7 @@ depth: 1
 ### Other features
 
  * Set `FieldPanel(required_on_save=True)` for `AbstractFormField`'s `field_type` field (Alex Tomkins)
+ * Handle pasting of multiple tags separated by newlines or commas (Matthias Brück)
 
 ### Bug fixes
 

--- a/wagtail/admin/static_src/wagtailadmin/js/vendor/tag-it.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/vendor/tag-it.js
@@ -224,6 +224,20 @@
             }
 
             // Events.
+
+            // Start Wagtail custom patch
+            // Handle pasting of multiple tags.
+            this.tagInput.on('paste', function (event) {
+                var pastedText = event.originalEvent.clipboardData.getData('text');
+                var tags = pastedText.split(/[\n,]+/);
+
+                if (tags.length > 1) {
+                    event.preventDefault();
+                    tags.forEach((tag) => that.createTag(tag));
+                }
+            });
+            // End Wagtail custom patch
+
             this.tagInput
                 .on('keydown', function(event) {
                     // Backspace is not detected within a keypress, so it must use keydown.
@@ -541,4 +555,3 @@
 
     });
 })(jQuery);
-


### PR DESCRIPTION
This tries to properly handle the pasting of multiple tags into a tag field. The pasted string is split by comma and displayed properly as single tags. 

The solution comes an issue in the tag-it library: https://github.com/aehlke/tag-it/issues/139#issuecomment-203447998

fixes #5357 