### PR TITLE
Ensure the copy page form only allows choosing valid parents only

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Limit tags autocompletion to 10 items and add delay to avoid performance issues with large number of matching tags (Aayushman Singh)
  * Add the ability to restrict what types of requests a Pages supports via `allowed_http_methods` (Andy Babic)
  * Allow plain strings in panel definitions as shorthand for `FieldPanel` / `InlinePanel` (Matt Westcott)
+ * Only allow selection of valid new parents within the copy Page view (Mauro Soche)
  * Fix: Improve handling of translations for bulk page action confirmation messages (Matt Westcott)
  * Fix: Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
  * Fix: Ensure manual edits to `StreamField` values do not throw an error (Stefan Hammer)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -859,6 +859,7 @@
 * Strapchay
 * Alex Fulcher
 * Harsh Dange
+* Mauro Soche
 
 ## Translators
 

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -21,6 +21,7 @@ depth: 1
  * Limit tags autocompletion to 10 items and add delay to avoid performance issues with large number of matching tags (Aayushman Singh)
  * Add the ability to restrict what types of requests a Pages supports via [`allowed_http_methods`](#wagtail.models.Page.allowed_http_methods) (Andy Babic)
  * Allow plain strings in panel definitions as shorthand for `FieldPanel` / `InlinePanel` (Matt Westcott)
+ * Only allow selection of valid new parents within the copy Page view (Mauro Soche)
 
 ### Bug fixes
 

--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -30,7 +30,11 @@ class CopyForm(forms.Form):
         self.fields["new_parent_page"] = forms.ModelChoiceField(
             initial=self.page.get_parent(),
             queryset=Page.objects.all(),
-            widget=widgets.AdminPageChooser(can_choose_root=True, user_perms="copy_to"),
+            widget=widgets.AdminPageChooser(
+                target_models=self.page.specific_class.allowed_parent_page_models(),
+                can_choose_root=True,
+                user_perms="copy_to",
+            ),
             label=_("New parent page"),
             help_text=_("This copy will be a child of this given parent page."),
         )


### PR DESCRIPTION
Ensure the Page chooser greys out the types of pages that do not follow the content hierarchy when trying to copy a page.

Fixes #11593

Rebase of #11604 (as the original branch was not `main`).
