### PR TITLE
Enable breadcrumbs in revisions compare view

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/generic/revisions/compare.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/revisions/compare.html
@@ -1,84 +1,71 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 {% load i18n wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans trimmed with title=page_subtitle %}Comparing {{ title }}{% endblocktrans %}{% endblock %}
+{% block main_content %}
+    <table class="listing w-mt-8">
+        <col width="15%" />
+        <col />
 
-{% block content %}
-    {% include "wagtailadmin/shared/header.html" with title=_("Comparing") subtitle=page_subtitle icon=header_icon %}
+        <thead>
+            <tr>
+                <th>{% trans "Fields" %}</th>
+                <th>{% trans "Changes" %}</th>
+            </tr>
+        </thead>
 
-    <div class="nice-padding">
-
-        <p>
-            <a href="{{ history_url }}" class="button button-small">{{ history_label|capfirst }}</a>
-            <a href="{{ edit_url }}" class="button button-small button-secondary">{{ edit_label|capfirst }}</a>
-        </p>
-
-
-        <table class="listing">
-            <col width="15%" />
-            <col />
-
-            <thead>
+        <tbody>
+            {% for comp in comparison %}
                 <tr>
-                    <th>{% trans "Fields" %}</th>
-                    <th>{% trans "Changes" %}</th>
+                    <td class="title" valign="top">
+                        <div class="title-wrapper">{{ comp.field_label }}:</div>
+                    </td>
+                    <td class="comparison{% if not comp.is_field %} no-padding{% endif %}">
+                        {% if comp.is_field %}
+                            {{ comp.htmldiff }}
+                        {% elif comp.is_child_relation %}
+                            {% for child_comp in comp.get_child_comparisons %}
+                                <div class="comparison__child-object {% if child_comp.is_addition %}addition{% elif child_comp.is_deletion %}deletion{% endif %}">
+                                    {% with child_comp.get_position_change as move %}
+                                        {% if move %}
+                                            <div class="help-block help-info">
+                                                {% icon name='help' %}
+                                                <p>
+                                                    {% if move > 0 %}
+                                                        {% blocktrans trimmed count counter=move %}
+                                                            Moved down 1 place.
+                                                        {% plural %}
+                                                            Moved down {{ counter }} places.
+                                                        {% endblocktrans %}
+                                                    {% elif move < 0 %}
+                                                        {% blocktrans trimmed count counter=move|abs %}
+                                                            Moved up 1 place.
+                                                        {% plural %}
+                                                            Moved up {{ counter }} places.
+                                                        {% endblocktrans %}
+                                                    {% endif %}
+                                                </p>
+                                            </div>
+                                        {% endif %}
+                                    {% endwith %}
+
+                                    <dl class="comparison__list">
+                                        {% for field_comp in child_comp.get_field_comparisons %}
+                                            <dt>{{ field_comp.field_label }}</dt>
+                                            <dd>{{ field_comp.htmldiff }}</dd>
+                                        {% endfor %}
+                                    </dl>
+                                </div>
+                            {% endfor %}
+                        {% endif %}
+                    </td>
                 </tr>
-            </thead>
-
-            <tbody>
-                {% for comp in comparison %}
-                    <tr>
-                        <td class="title" valign="top">
-                            <div class="title-wrapper">{{ comp.field_label }}:</div>
-                        </td>
-                        <td class="comparison{% if not comp.is_field %} no-padding{% endif %}">
-                            {% if comp.is_field %}
-                                {{ comp.htmldiff }}
-                            {% elif comp.is_child_relation %}
-                                {% for child_comp in comp.get_child_comparisons %}
-                                    <div class="comparison__child-object {% if child_comp.is_addition %}addition{% elif child_comp.is_deletion %}deletion{% endif %}">
-                                        {% with child_comp.get_position_change as move %}
-                                            {% if move %}
-                                                <div class="help-block help-info">
-                                                    {% icon name='help' %}
-                                                    <p>
-                                                        {% if move > 0 %}
-                                                            {% blocktrans trimmed count counter=move %}
-                                                                Moved down 1 place.
-                                                            {% plural %}
-                                                                Moved down {{ counter }} places.
-                                                            {% endblocktrans %}
-                                                        {% elif move < 0 %}
-                                                            {% blocktrans trimmed count counter=move|abs %}
-                                                                Moved up 1 place.
-                                                            {% plural %}
-                                                                Moved up {{ counter }} places.
-                                                            {% endblocktrans %}
-                                                        {% endif %}
-                                                    </p>
-                                                </div>
-                                            {% endif %}
-                                        {% endwith %}
-
-                                        <dl class="comparison__list">
-                                            {% for field_comp in child_comp.get_field_comparisons %}
-                                                <dt>{{ field_comp.field_label }}</dt>
-                                                <dd>{{ field_comp.htmldiff }}</dd>
-                                            {% endfor %}
-                                        </dl>
-                                    </div>
-                                {% endfor %}
-                            {% endif %}
-                        </td>
-                    </tr>
-                {% empty %}
-                    <tr>
-                        <td colspan="2" class="no-results-message">
-                            <p>{% trans "There are no differences between these two versions" %}</p>
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+            {% empty %}
+                <tr>
+                    <td colspan="2" class="no-results-message">
+                        <p>{% trans "There are no differences between these two versions" %}</p>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 {% endblock %}

--- a/wagtail/admin/views/pages/revisions.py
+++ b/wagtail/admin/views/pages/revisions.py
@@ -8,7 +8,6 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
-from django.utils.translation import gettext_lazy
 
 from wagtail.admin import messages
 from wagtail.admin.action_menu import PageActionMenu
@@ -25,6 +24,7 @@ from wagtail.admin.views.generic.models import (
     RevisionsUnscheduleView,
 )
 from wagtail.admin.views.generic.preview import PreviewRevision
+from wagtail.admin.views.pages.utils import GenericPageBreadcrumbsMixin
 from wagtail.models import Page
 from wagtail.utils.timestamps import render_timestamp
 
@@ -163,12 +163,11 @@ class RevisionsView(PreviewRevision):
         return page
 
 
-class RevisionsCompare(RevisionsCompareView):
-    history_label = gettext_lazy("Page history")
-    edit_label = gettext_lazy("Edit this page")
+class RevisionsCompare(GenericPageBreadcrumbsMixin, RevisionsCompareView):
     history_url_name = "wagtailadmin_pages:history"
     edit_url_name = "wagtailadmin_pages:edit"
     header_icon = "doc-empty-inverse"
+    breadcrumbs_items_to_take = 2
 
     @method_decorator(user_passes_test(user_has_any_page_permission))
     def dispatch(self, request, *args, **kwargs):

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -4870,7 +4870,7 @@ class TestSnippetRevisions(WagtailTestUtils, TestCase):
         self.assertEqual(self.snippet.live_revision, self.snippet.latest_revision)
 
 
-class TestCompareRevisions(WagtailTestUtils, TestCase):
+class TestCompareRevisions(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     # Actual tests for the comparison classes can be found in test_compare.py
 
     def setUp(self):
@@ -4907,6 +4907,32 @@ class TestCompareRevisions(WagtailTestUtils, TestCase):
             '<span class="deletion">Initial revision</span><span class="addition">First edit</span>',
             html=True,
         )
+
+        index_url = reverse("wagtailsnippets_tests_revisablemodel:list", args=[])
+        edit_url = reverse(
+            "wagtailsnippets_tests_revisablemodel:edit",
+            args=(self.snippet.id,),
+        )
+        history_url = reverse(
+            "wagtailsnippets_tests_revisablemodel:history",
+            args=(self.snippet.id,),
+        )
+
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {"url": reverse("wagtailsnippets:index"), "label": "Snippets"},
+                {"url": index_url, "label": "Revisable models"},
+                {"url": edit_url, "label": str(self.snippet)},
+                {"url": history_url, "label": "History"},
+                {"url": "", "label": "Compare", "sublabel": str(self.snippet)},
+            ],
+            response.content,
+        )
+
+        soup = self.get_soup(response.content)
+        edit_button = soup.select_one(f"a.w-header-button[href='{edit_url}']")
+        self.assertIsNotNone(edit_button)
+        self.assertEqual(edit_button.text.strip(), "Edit")
 
     def test_compare_revisions_earliest(self):
         response = self.get("earliest", self.edit_revision.pk)

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -95,7 +95,7 @@ class TestCustomIcon(BaseSnippetViewSetTests):
             (
                 "revisions_compare",
                 [pk, self.revision_1.id, self.revision_2.id],
-                "header.html",
+                "headers/slim_header.html",
             ),
             ("revisions_unschedule", [pk, self.revision_2.id], "header.html"),
         ]

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -358,18 +358,6 @@ class PreviewRevisionView(PermissionCheckedMixin, PreviewRevision):
 class RevisionsCompareView(PermissionCheckedMixin, generic.RevisionsCompareView):
     permission_required = "change"
 
-    @property
-    def edit_label(self):
-        return _("Edit this %(model_name)s") % {
-            "model_name": self.model._meta.verbose_name
-        }
-
-    @property
-    def history_label(self):
-        return _("%(model_name)s history") % {
-            "model_name": self.model._meta.verbose_name
-        }
-
 
 class UnpublishView(PermissionCheckedMixin, generic.UnpublishView):
     permission_required = "publish"


### PR DESCRIPTION
Disable whitespace when reviewing.

## Pages

<details><summary>Screenshots</summary>


### Before

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/c95d8f29-b1a4-43ea-bf0d-630f7c367c91">


### After

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/1517ad61-8e10-46c3-9f40-f1ee23db61ef">

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/0e51c2ef-7760-43a2-8e48-09de1e23ce49">


</details> 


## Snippets

<details><summary>Screenshots</summary>


### Before

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/a00b0908-1772-4986-a20c-1b3bb54915f0">

### After

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/82c9510b-6e55-4ec8-8468-408f0186b54b">

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/b88331b3-89fb-4787-8dc7-6331f92bf8f2">


</details> 
