### PR TITLE
Enable breadcrumbs by default and remove `_show_breadcrumbs`

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/generic/confirm_unpublish.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/confirm_unpublish.html
@@ -1,31 +1,27 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}{% blocktrans trimmed with title=object_display_title %}Unpublish {{ title }}{% endblocktrans %}{% endblock %}
-{% block content %}
-    {% include "wagtailadmin/shared/header.html" with title=_("Unpublish") subtitle=object_display_title icon=header_icon %}
 
-    <div class="nice-padding">
-        {% if usage_url %}
-            {% include "wagtailadmin/shared/usage_summary.html" %}
-        {% endif %}
-        {% block confirmation_text %}
-            <p>
-                {% blocktrans trimmed with model_name=model_opts.verbose_name %}
-                    Are you sure you want to unpublish this {{ model_name }}?
-                {% endblocktrans %}
-            </p>
+{% block main_content %}
+    {% if usage_url %}
+        {% include "wagtailadmin/shared/usage_summary.html" %}
+    {% endif %}
+    {% block confirmation_text %}
+        <p>
+            {% blocktrans trimmed with model_name=model_opts.verbose_name %}
+                Are you sure you want to unpublish this {{ model_name }}?
+            {% endblocktrans %}
+        </p>
+    {% endblock %}
+
+    <form action="{{ unpublish_url }}" method="POST">
+        {% csrf_token %}
+
+        {% block form_content %}
         {% endblock %}
 
-        <form action="{{ unpublish_url }}" method="POST">
-            {% csrf_token %}
-
-            {% block form_content %}
-            {% endblock %}
-
-            <div>
-                <button class="button" type="submit">{% trans 'Yes, unpublish it' %}</button>
-                <a href="{{ next_url }}" class="button button-secondary">{% trans "No, don't unpublish" %}</a>
-            </div>
-        </form>
-    </div>
+        <div>
+            <button class="button" type="submit">{% trans 'Yes, unpublish it' %}</button>
+            <a href="{{ next_url }}" class="button button-secondary">{% trans "No, don't unpublish" %}</a>
+        </div>
+    </form>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/shared/revisions/confirm_unschedule.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/revisions/confirm_unschedule.html
@@ -1,20 +1,16 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans trimmed with title=object_display_title %}Unschedule Revision {{ revision.id }} for {{ title }}{% endblocktrans %}{% endblock %}
-{% block content %}
-    {% include "wagtailadmin/shared/header.html" with title=_("Unschedule") subtitle=subtitle icon=header_icon %}
 
-    <div class="nice-padding">
-        <p>{% trans "Are you sure you want to unschedule this revision?" %}</p>
-        <form action="{{ revisions_unschedule_url }}" method="POST">
-            {% csrf_token %}
-            <input type="hidden" name="next" value="{{ next }}">
-            <ul class="fields">
-                <li>
-                    <input type="submit" value="{% trans 'Yes, unschedule' %}" class="button">
-                    <a href="{{ next_url }}" class="button button-secondary">{% trans "No, don't unschedule" %}</a>
-                </li>
-            </ul>
-        </form>
-    </div>
+{% block main_content %}
+    <p>{% trans "Are you sure you want to unschedule this revision?" %}</p>
+    <form action="{{ revisions_unschedule_url }}" method="POST">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ next }}">
+        <ul class="fields">
+            <li>
+                <input type="submit" value="{% trans 'Yes, unschedule' %}" class="button">
+                <a href="{{ next_url }}" class="button button-secondary">{% trans "No, don't unschedule" %}</a>
+            </li>
+        </ul>
+    </form>
 {% endblock %}

--- a/wagtail/admin/views/collections.py
+++ b/wagtail/admin/views/collections.py
@@ -50,7 +50,6 @@ class Create(CreateView):
     edit_url_name = "wagtailadmin_collections:edit"
     index_url_name = "wagtailadmin_collections:index"
     header_icon = "folder-open-1"
-    _show_breadcrumbs = True
 
     def get_form(self, form_class=None):
         form = super().get_form(form_class)
@@ -80,7 +79,6 @@ class Edit(EditView):
     delete_url_name = "wagtailadmin_collections:delete"
     context_object_name = "collection"
     header_icon = "folder-open-1"
-    _show_breadcrumbs = True
 
     def _user_may_move_collection(self, user, instance):
         """

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -41,9 +41,17 @@ class WagtailAdminTemplateMixin(TemplateResponseMixin, ContextMixin):
     page_title = ""
     page_subtitle = ""
     header_icon = ""
-    # Breadcrumbs are opt-in until we have a design that can be consistently applied
-    _show_breadcrumbs = False
+
     breadcrumbs_items = [{"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")}]
+    """
+    The base set of breadcrumbs items to be displayed on the page.
+    The property can be overridden by subclasses and viewsets to provide
+    custom base items, e.g. page tree breadcrumbs or add the "Snippets" item.
+
+    Views should copy and append to this list in :meth:`get_breadcrumbs_items()`
+    to define the path to the current view.
+    """
+
     template_name = "wagtailadmin/generic/base.html"
     header_buttons = []
     header_more_buttons = []
@@ -65,6 +73,12 @@ class WagtailAdminTemplateMixin(TemplateResponseMixin, ContextMixin):
         return self.header_icon
 
     def get_breadcrumbs_items(self):
+        """
+        Define the current path to the view by copying the base
+        :attr:`breadcrumbs_items` and appending the list.
+
+        If breadcrumbs are not required, return an empty list.
+        """
         return self.breadcrumbs_items
 
     def get_header_buttons(self):
@@ -92,14 +106,11 @@ class WagtailAdminTemplateMixin(TemplateResponseMixin, ContextMixin):
         context["page_title"] = self.get_page_title()
         context["page_subtitle"] = self.get_page_subtitle()
         context["header_icon"] = self.get_header_icon()
-
-        # Once all appropriate views use "wagtailadmin/generic/base.html" and
-        # the slim_header.html, _show_breadcrumbs can be removed
         context["header_title"] = self.get_header_title()
-        context["breadcrumbs_items"] = None
-        if self._show_breadcrumbs:
-            context["breadcrumbs_items"] = self.get_breadcrumbs_items()
-            context["header_buttons"] = self.get_header_buttons()
+
+        # Breadcrumbs are enabled by default.
+        context["breadcrumbs_items"] = self.get_breadcrumbs_items()
+        context["header_buttons"] = self.get_header_buttons()
         return context
 
     def get_template_names(self):
@@ -203,7 +214,6 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
     default_ordering = None
     filterset_class = None
     verbose_name_plural = None
-    _show_breadcrumbs = True
 
     def get_template_names(self):
         if self.results_only:

--- a/wagtail/admin/views/generic/history.py
+++ b/wagtail/admin/views/generic/history.py
@@ -415,7 +415,6 @@ class WorkflowHistoryDetailView(
     page_title = gettext_lazy("Workflow progress")
     header_icon = "list-ul"
     object_icon = "doc-empty-inverse"
-    _show_breadcrumbs = True
 
     @cached_property
     def index_url(self):

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -1290,6 +1290,7 @@ class UnpublishView(HookResponseMixin, WagtailAdminTemplateMixin, TemplateView):
     edit_url_name = None
     unpublish_url_name = None
     usage_url_name = None
+    page_title = gettext_lazy("Unpublish")
     success_message = gettext_lazy("'%(object)s' unpublished.")
     template_name = "wagtailadmin/generic/confirm_unpublish.html"
 
@@ -1310,12 +1311,15 @@ class UnpublishView(HookResponseMixin, WagtailAdminTemplateMixin, TemplateView):
     def get_usage(self):
         return ReferenceIndex.get_grouped_references_to(self.object)
 
+    def get_breadcrumbs_items(self):
+        return []
+
     def get_objects_to_unpublish(self):
         # Hook to allow child classes to have more objects to unpublish (e.g. page descendants)
         return [self.object]
 
-    def get_object_display_title(self):
-        return str(self.object)
+    def get_page_subtitle(self):
+        return get_latest_str(self.object)
 
     def get_success_message(self):
         if self.success_message is None:
@@ -1381,7 +1385,6 @@ class UnpublishView(HookResponseMixin, WagtailAdminTemplateMixin, TemplateView):
         context = super().get_context_data(**kwargs)
         context["model_opts"] = self.object._meta
         context["object"] = self.object
-        context["object_display_title"] = self.get_object_display_title()
         context["unpublish_url"] = self.get_unpublish_url()
         context["next_url"] = self.get_next_url()
         context["usage_url"] = self.get_usage_url()

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -1403,6 +1403,7 @@ class RevisionsUnscheduleView(WagtailAdminTemplateMixin, TemplateView):
         'Version %(revision_id)s of "%(object)s" unscheduled.'
     )
     template_name = "wagtailadmin/shared/revisions/confirm_unschedule.html"
+    page_title = gettext_lazy("Unschedule")
 
     def setup(self, request, pk, revision_id, *args, **kwargs):
         super().setup(request, *args, **kwargs)
@@ -1416,6 +1417,9 @@ class RevisionsUnscheduleView(WagtailAdminTemplateMixin, TemplateView):
             raise Http404
         return get_object_or_404(self.model, pk=unquote(str(self.pk)))
 
+    def get_breadcrumbs_items(self):
+        return []
+
     def get_revision(self):
         return get_object_or_404(self.object.revisions, id=self.revision_id)
 
@@ -1426,7 +1430,7 @@ class RevisionsUnscheduleView(WagtailAdminTemplateMixin, TemplateView):
         )
 
     def get_object_display_title(self):
-        return str(self.object)
+        return get_latest_str(self.object)
 
     def get_success_message(self):
         if self.success_message is None:
@@ -1456,10 +1460,13 @@ class RevisionsUnscheduleView(WagtailAdminTemplateMixin, TemplateView):
         return reverse(self.history_url_name, args=(quote(self.object.pk),))
 
     def get_page_subtitle(self):
-        return _('revision %(revision_id)s of "%(object)s"') % {
-            "revision_id": self.revision.id,
-            "object": self.get_object_display_title(),
-        }
+        return capfirst(
+            _('revision %(revision_id)s of "%(object)s"')
+            % {
+                "revision_id": self.revision.id,
+                "object": self.get_object_display_title(),
+            }
+        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -1467,8 +1474,6 @@ class RevisionsUnscheduleView(WagtailAdminTemplateMixin, TemplateView):
             {
                 "object": self.object,
                 "revision": self.revision,
-                "subtitle": self.get_page_subtitle(),
-                "object_display_title": self.get_object_display_title(),
                 "revisions_unschedule_url": self.get_revisions_unschedule_url(),
                 "next_url": self.get_next_url(),
             }

--- a/wagtail/admin/views/pages/utils.py
+++ b/wagtail/admin/views/pages/utils.py
@@ -50,7 +50,6 @@ class GenericPageBreadcrumbsMixin:
     item of the generic view's generated breadcrumbs items.
     """
 
-    _show_breadcrumbs = True
     breadcrumbs_items_to_take = 1
 
     @cached_property

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -175,7 +175,6 @@ class Create(CreateView):
     index_url_name = "wagtailadmin_workflows:index"
     header_icon = "tasks"
     edit_handler = None
-    _show_breadcrumbs = True
 
     def get_edit_handler(self):
         if not self.edit_handler:
@@ -263,7 +262,6 @@ class Edit(EditView):
     header_more_buttons = []
     edit_handler = None
     MAX_PAGES = 5
-    _show_breadcrumbs = True
 
     def get_edit_handler(self):
         if not self.edit_handler:
@@ -641,7 +639,6 @@ class CreateTask(CreateView):
     edit_url_name = "wagtailadmin_workflows:edit_task"
     index_url_name = "wagtailadmin_workflows:task_index"
     header_icon = "thumbtack"
-    _show_breadcrumbs = True
 
     @cached_property
     def model(self):
@@ -704,7 +701,6 @@ class EditTask(EditView):
     enable_url_name = "wagtailadmin_workflows:enable_task"
     header_icon = "thumbtack"
     header_more_buttons = []
-    _show_breadcrumbs = True
 
     @cached_property
     def model(self):

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -63,9 +63,6 @@ class ModelViewSet(ViewSet):
     #: The view class to use for the inspect view; must be a subclass of ``wagtail.admin.views.generic.InspectView``.
     inspect_view_class = generic.InspectView
 
-    # Breadcrumbs can be turned off until we have a design that can be consistently applied
-    _show_breadcrumbs = True
-
     #: The prefix of template names to look for when rendering the admin views.
     template_prefix = ""
 
@@ -136,7 +133,6 @@ class ModelViewSet(ViewSet):
                 "edit_url_name": self.get_url_name("edit"),
                 "delete_url_name": self.get_url_name("delete"),
                 "header_icon": self.icon,
-                "_show_breadcrumbs": self._show_breadcrumbs,
                 **kwargs,
             }
         )

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -31,7 +31,6 @@ class PageListingViewSet(ViewSet):
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(
             **{
-                "_show_breadcrumbs": True,
                 "header_icon": self.icon,
                 "model": self.model,
                 "index_url_name": self.get_url_name("index"),

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -145,7 +145,6 @@ class EditView(generic.EditView):
     pk_url_kwarg = "redirect_id"
     error_message = gettext_lazy("The redirect could not be saved due to errors.")
     header_icon = "redirect"
-    _show_breadcrumbs = True
 
     def get_success_message(self):
         return _("Redirect '%(redirect_title)s' updated.") % {
@@ -196,7 +195,6 @@ class CreateView(generic.CreateView):
     edit_url_name = "wagtailredirects:edit"
     error_message = gettext_lazy("The redirect could not be created due to errors.")
     header_icon = "redirect"
-    _show_breadcrumbs = True
 
     def get_success_message(self, instance):
         return _("Redirect '%(redirect_title)s' added.") % {

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -84,7 +84,6 @@ class EditView(generic.EditView):
     edit_url_name = "wagtailsettings:edit"
     error_message = gettext_lazy("The setting could not be saved due to errors.")
     permission_required = "change"
-    _show_breadcrumbs = True
 
     def setup(self, request, app_name, model_name, *args, **kwargs):
         self.app_name = app_name

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -162,7 +162,6 @@ class CreateView(generic.CreateView):
     error_message = gettext_lazy("The document could not be created due to errors.")
     template_name = "wagtaildocs/documents/add.html"
     header_icon = "doc-full-inverse"
-    _show_breadcrumbs = True
 
     @cached_property
     def model(self):
@@ -197,7 +196,6 @@ class EditView(generic.EditView):
     delete_url_name = "wagtaildocs:delete"
     header_icon = "doc-full-inverse"
     context_object_name = "document"
-    _show_breadcrumbs = True
 
     @cached_property
     def model(self):

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -25,7 +25,6 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
     template_name = "wagtaildocs/multiple/add.html"
     header_icon = "doc-full-inverse"
     page_title = gettext_lazy("Add documents")
-    _show_breadcrumbs = True
 
     index_url_name = "wagtaildocs:index"
     edit_object_url_name = "wagtaildocs:edit_multiple"

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -134,7 +134,6 @@ class EditView(generic.EditView):
     url_generator_url_name = "wagtailimages:url_generator"
     header_icon = "image"
     context_object_name = "image"
-    _show_breadcrumbs = True
 
     @cached_property
     def model(self):
@@ -212,7 +211,6 @@ class URLGeneratorView(generic.InspectView):
     template_name = "wagtailimages/images/url_generator.html"
     index_url_name = "wagtailimages:index"
     edit_url_name = "wagtailimages:edit"
-    _show_breadcrumbs = True
 
     def get_page_subtitle(self):
         return self.object.title
@@ -346,7 +344,6 @@ class CreateView(generic.CreateView):
     error_message = gettext_lazy("The image could not be created due to errors.")
     template_name = "wagtailimages/images/add.html"
     header_icon = "image"
-    _show_breadcrumbs = True
 
     @cached_property
     def model(self):

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -27,7 +27,6 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
     template_name = "wagtailimages/multiple/add.html"
     header_icon = "image"
     page_title = gettext_lazy("Add images")
-    _show_breadcrumbs = True
 
     index_url_name = "wagtailimages:index"
     edit_object_url_name = "wagtailimages:edit_multiple"


### PR DESCRIPTION
Hide whitespace when reviewing.

This enables breadcrumbs for all views that extend the `WagtailAdminTemplateMixin` class and the `wagtailadmin/generic/base.html` template.

For now, "confirmation" views (e.g. confirm delete, confirm unpublish, confirm unschedule) have the breadcrumbs disabled, as they are more like a confirmation step rather than a full view, and we might want to turn them into AJAX-loaded dialogs instead in the future.