### PR TITLE
Added aria-expanded attribute to add new column button

### DIFF
--- a/client/src/entrypoints/contrib/typed_table_block/__snapshots__/typed_table_block.test.js.snap
+++ b/client/src/entrypoints/contrib/typed_table_block/__snapshots__/typed_table_block.test.js.snap
@@ -24,16 +24,16 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock it renders cor
         <div class="typed-table-block__wrapper">
           <table>
             <thead>
-              <tr><th aria-hidden="true"></th><th><input type="hidden" name="mytable-column-0-type" value="test_block_a"><input type="hidden" name="mytable-column-0-order" value="0"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" title="Insert column">
+              <tr><th aria-hidden="true"></th><th><input type="hidden" name="mytable-column-0-type" value="test_block_a"><input type="hidden" name="mytable-column-0-order" value="0"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" aria-expanded="false" title="Insert column">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
       </button><input type="text" name="mytable-column-0-heading" class="column-heading" placeholder="Column heading"><button type="button" class="button button-secondary button-small button--icon text-replace no delete-column" aria-label="Delete column" title="Delete column">
         <svg class="icon icon-bin icon" aria-hidden="true"><use href="#icon-bin"></use></svg>
-      </button></th><th><input type="hidden" name="mytable-column-1-type" value="test_block_b"><input type="hidden" name="mytable-column-1-order" value="1"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" title="Insert column">
+      </button></th><th><input type="hidden" name="mytable-column-1-type" value="test_block_b"><input type="hidden" name="mytable-column-1-order" value="1"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" aria-expanded="false" title="Insert column">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
       </button><input type="text" name="mytable-column-1-heading" class="column-heading" placeholder="Column heading"><button type="button" class="button button-secondary button-small button--icon text-replace no delete-column" aria-label="Delete column" title="Delete column">
         <svg class="icon icon-bin icon" aria-hidden="true"><use href="#icon-bin"></use></svg>
       </button></th><th class="control-cell">
-                  <button type="button" class="button button-small button-secondary append-column button--icon text-replace white" data-append-column="" aria-label="Add column" title="Add column"><svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
+                  <button type="button" class="button button-small button-secondary append-column button--icon text-replace white" aria-expanded="false" data-append-column="" aria-label="Add column" title="Add column"><svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
                 </th></tr>
             </thead>
             <tbody><tr><td class="control-cell"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-row" aria-label="Insert row" title="Insert row">
@@ -130,16 +130,16 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError passe
         <div class="typed-table-block__wrapper">
           <table>
             <thead>
-              <tr><th aria-hidden="true"></th><th><input type="hidden" name="mytable-column-0-type" value="test_block_a"><input type="hidden" name="mytable-column-0-order" value="0"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" title="Insert column">
+              <tr><th aria-hidden="true"></th><th><input type="hidden" name="mytable-column-0-type" value="test_block_a"><input type="hidden" name="mytable-column-0-order" value="0"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" aria-expanded="false" title="Insert column">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
       </button><input type="text" name="mytable-column-0-heading" class="column-heading" placeholder="Column heading"><button type="button" class="button button-secondary button-small button--icon text-replace no delete-column" aria-label="Delete column" title="Delete column">
         <svg class="icon icon-bin icon" aria-hidden="true"><use href="#icon-bin"></use></svg>
-      </button></th><th><input type="hidden" name="mytable-column-1-type" value="test_block_b"><input type="hidden" name="mytable-column-1-order" value="1"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" title="Insert column">
+      </button></th><th><input type="hidden" name="mytable-column-1-type" value="test_block_b"><input type="hidden" name="mytable-column-1-order" value="1"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" aria-expanded="false" title="Insert column">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
       </button><input type="text" name="mytable-column-1-heading" class="column-heading" placeholder="Column heading"><button type="button" class="button button-secondary button-small button--icon text-replace no delete-column" aria-label="Delete column" title="Delete column">
         <svg class="icon icon-bin icon" aria-hidden="true"><use href="#icon-bin"></use></svg>
       </button></th><th class="control-cell">
-                  <button type="button" class="button button-small button-secondary append-column button--icon text-replace white" data-append-column="" aria-label="Add column" title="Add column"><svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
+                  <button type="button" class="button button-small button-secondary append-column button--icon text-replace white" aria-expanded="false" data-append-column="" aria-label="Add column" title="Add column"><svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
                 </th></tr>
             </thead>
             <tbody><tr><td class="control-cell"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-row" aria-label="Insert row" title="Insert row">
@@ -236,16 +236,16 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError shows
         <div class="typed-table-block__wrapper">
           <table>
             <thead>
-              <tr><th aria-hidden="true"></th><th><input type="hidden" name="mytable-column-0-type" value="test_block_a"><input type="hidden" name="mytable-column-0-order" value="0"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" title="Insert column">
+              <tr><th aria-hidden="true"></th><th><input type="hidden" name="mytable-column-0-type" value="test_block_a"><input type="hidden" name="mytable-column-0-order" value="0"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" aria-expanded="false" title="Insert column">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
       </button><input type="text" name="mytable-column-0-heading" class="column-heading" placeholder="Column heading"><button type="button" class="button button-secondary button-small button--icon text-replace no delete-column" aria-label="Delete column" title="Delete column">
         <svg class="icon icon-bin icon" aria-hidden="true"><use href="#icon-bin"></use></svg>
-      </button></th><th><input type="hidden" name="mytable-column-1-type" value="test_block_b"><input type="hidden" name="mytable-column-1-order" value="1"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" title="Insert column">
+      </button></th><th><input type="hidden" name="mytable-column-1-type" value="test_block_b"><input type="hidden" name="mytable-column-1-order" value="1"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-column" aria-label="Insert column" aria-expanded="false" title="Insert column">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
       </button><input type="text" name="mytable-column-1-heading" class="column-heading" placeholder="Column heading"><button type="button" class="button button-secondary button-small button--icon text-replace no delete-column" aria-label="Delete column" title="Delete column">
         <svg class="icon icon-bin icon" aria-hidden="true"><use href="#icon-bin"></use></svg>
       </button></th><th class="control-cell">
-                  <button type="button" class="button button-small button-secondary append-column button--icon text-replace white" data-append-column="" aria-label="Add column" title="Add column"><svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
+                  <button type="button" class="button button-small button-secondary append-column button--icon text-replace white" aria-expanded="false" data-append-column="" aria-label="Add column" title="Add column"><svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
                 </th></tr>
             </thead>
             <tbody><tr><td class="control-cell"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-row" aria-label="Insert row" title="Insert row">

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
@@ -78,7 +78,7 @@ export class TypedTableBlock {
               <tr>
                 <th aria-hidden="true"></th>
                 <th class="control-cell">
-                  <button type="button" class="button button-small button-secondary append-column" data-append-column>
+                  <button type="button" class="button button-small button-secondary append-column" aria-expanded="false" data-append-column>
                     ${h(strings.ADD_COLUMN)}
                   </button>
                 </th>
@@ -148,12 +148,12 @@ export class TypedTableBlock {
       ).text(childBlockDef.meta.label);
       columnTypeButton.on('click', () => {
         if (this.addColumnCallback) this.addColumnCallback(childBlockDef);
-        this.hideAddColumnMenu();
+        this.hideAddColumnMenu(this.addColumnMenuTrigger);
       });
       const li = $('<li></li>').append(columnTypeButton);
       this.addColumnMenu.append(li);
     });
-    this.addColumnMenuBaseElement = null; // the element the add-column menu is attached to
+    this.addColumnMenuTrigger = null; // the element the add-column menu is attached to
 
     this.appendColumnButton.on('click', () => {
       this.toggleAddColumnMenu(this.appendColumnButton, (chosenBlockDef) => {
@@ -173,23 +173,26 @@ export class TypedTableBlock {
     }
   }
 
-  showAddColumnMenu(baseElement, callback) {
-    this.addColumnMenuBaseElement = baseElement;
-    baseElement.after(this.addColumnMenu);
+  showAddColumnMenu(triggeredElement, callback) {
+    this.addColumnMenuTrigger?.attr('aria-expanded', 'false');
+    this.addColumnMenuTrigger = triggeredElement;
+    triggeredElement.after(this.addColumnMenu);
+    triggeredElement.attr('aria-expanded', 'true');
     this.addColumnMenu.show();
     this.addColumnCallback = callback;
   }
 
-  hideAddColumnMenu() {
+  hideAddColumnMenu(triggeredElement) {
+    triggeredElement.attr('aria-expanded', 'false');
     this.addColumnMenu.hide();
-    this.addColumnMenuBaseElement = null;
+    this.addColumnMenuTrigger = null;
   }
 
-  toggleAddColumnMenu(baseElement, callback) {
-    if (this.addColumnMenuBaseElement === baseElement) {
-      this.hideAddColumnMenu();
+  toggleAddColumnMenu(triggeredElement, callback) {
+    if (this.addColumnMenuTrigger === triggeredElement) {
+      this.hideAddColumnMenu(triggeredElement);
     } else {
-      this.showAddColumnMenu(baseElement, callback);
+      this.showAddColumnMenu(triggeredElement, callback);
     }
   }
 
@@ -271,10 +274,13 @@ export class TypedTableBlock {
     const prependColumnButton = $(`<button type="button"
       class="button button-secondary button-small button--icon text-replace prepend-column"
       aria-label="${h(this.blockDef.meta.strings.INSERT_COLUMN)}"
+      aria-expanded="false"
       title="${h(this.blockDef.meta.strings.INSERT_COLUMN)}">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
       </button>`);
+
     $(newHeaderCell).append(prependColumnButton);
+
     prependColumnButton.on('click', () => {
       this.toggleAddColumnMenu(prependColumnButton, (chosenBlockDef) => {
         this.insertColumn(column.position, chosenBlockDef, {
@@ -331,6 +337,7 @@ export class TypedTableBlock {
       .attr('aria-label', this.blockDef.meta.strings.ADD_COLUMN)
       .addClass('button--icon text-replace white')
       .attr('aria-label', this.blockDef.meta.strings.ADD_COLUMN)
+      .attr('aria-expanded', 'false')
       .attr('title', this.blockDef.meta.strings.ADD_COLUMN);
 
     if (opts && opts.addInitialRow && this.tbody.children.length === 0) {


### PR DESCRIPTION
_Please describe the problem you're fixing here. Include the issue number, if applicable._

Refine of #7668 PR (+ requested changes of the PR by @gasman)

## Screenshots (Unit test and manual tests)
<details>
<summary>Normal</summary>

> When fresh reload (should be false - ✔️):

![image](https://github.com/user-attachments/assets/04d72ec9-bddd-495e-ba55-527bcc25d803)

> On click  (should be true - ✔️):

![image](https://github.com/user-attachments/assets/ddfc96e4-80d6-460f-9655-d3cbde3855d8)

> When aria-expanded="true" and reload (should back to false - ✔️) :

![image](https://github.com/user-attachments/assets/58fbc17b-e220-436d-8128-9c2ec13d850e)

</details>

<details>
<summary>Edge cases</summary>

> Adding column (both button should be false - ✔️)

![image](https://github.com/user-attachments/assets/9af3d73d-1483-4bd0-a421-6e7481366d87)

> when aria-expaned is true for one button and swtiching to another button should make false to current and true to where it switched -  ✔️

https://github.com/user-attachments/assets/090700de-62bf-4e90-9d50-ba2ecff340aa
</details>
<details>
<summary>All unit test for JS passing</summary>

![image](https://github.com/user-attachments/assets/8f6edb84-f554-493c-8a4d-7f15f73cae3b)

(updated snapshot)
</details>