### PR TITLE
Use built-in venv instead of pipenv in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,32 +4,33 @@ jobs:
   backend:
     docker:
       - image: cimg/python:3.12
-    environment:
-      PIPENV_VENV_IN_PROJECT: true
     steps:
       - checkout
       - restore_cache:
-          key: pipenv-v3-{{ checksum "setup.py" }}
+          key: &venv-cache venv-v1-{{ checksum "setup.py" }}
       # Only install if .venv wasn’t cached.
       - run: |
           if [[ ! -e ".venv" ]]; then
-              pipenv install -e .[testing,docs]
+              python -m venv .venv
+              source .venv/bin/activate
+              python -m pip install -e .[testing,docs]
           fi
+          echo "source $(pwd)/.venv/bin/activate" >> $BASH_ENV
       - save_cache:
-          key: pipenv-v3-{{ checksum "setup.py" }}
+          key: *venv-cache
           paths:
             - .venv
-      - run: pipenv run ruff check .
-      - run: pipenv run ruff format --check .
-      - run: pipenv run semgrep --config .semgrep.yml --error .
-      - run: git ls-files '*.html' | xargs pipenv run djhtml --check
-      - run: pipenv run curlylint --parse-only wagtail
-      - run: pipenv run doc8 docs
+      - run: ruff check .
+      - run: ruff format --check .
+      - run: semgrep --config .semgrep.yml --error .
+      - run: git ls-files '*.html' | xargs djhtml --check
+      - run: curlylint --parse-only wagtail
+      - run: doc8 docs
       - run:
           name: Run tests
           command: |
             export PYTHONUNBUFFERED=1
-            WAGTAIL_CHECK_TEMPLATE_NUMBER_FORMAT=1 pipenv run python -u runtests.py --parallel=2
+            WAGTAIL_CHECK_TEMPLATE_NUMBER_FORMAT=1 python -u runtests.py --parallel=2
 
   frontend:
     docker:
@@ -64,45 +65,47 @@ jobs:
     docker:
       - image: cimg/python:3.12-browsers
     environment:
-      PIPENV_VENV_IN_PROJECT: true
       DJANGO_SETTINGS_MODULE: wagtail.test.settings_ui
-      DJANGO_DEBUG: true
+      DJANGO_DEBUG: 'true'
     steps:
       - checkout
       - attach_workspace:
           at: ~/project
       - restore_cache:
-          key: ui_tests-pipenv-v3-{{ checksum "setup.py" }}
+          key: &ui_tests-venv-cache ui_tests-venv-v1-{{ checksum "setup.py" }}
       # Only install if .venv wasn’t cached.
       - run: |
           if [[ ! -e ".venv" ]]; then
-              pipenv install -e .[testing]
+              python -m venv .venv
+              source .venv/bin/activate
+              python -m pip install -e .[testing]
           fi
+          echo "source $(pwd)/.venv/bin/activate" >> $BASH_ENV
       - save_cache:
-          key: ui_tests-pipenv-v3-{{ checksum "setup.py" }}
+          key: *ui_tests-venv-cache
           paths:
             - .venv
       - restore_cache:
-          key: ui_tests-npm_integration-v3-{{ checksum "client/tests/integration/package-lock.json" }}
+          key: &ui_tests-npm-cache ui_tests-npm_integration-v3-{{ checksum "client/tests/integration/package-lock.json" }}
       # Only install if node_modules wasn’t cached.
       - run: |
           if [[ ! -e "client/tests/integration/node_modules" ]]; then
               npm --prefix ./client/tests/integration ci
           fi
       - save_cache:
-          key: ui_tests-npm_integration-v3-{{ checksum "client/tests/integration/package-lock.json" }}
+          key: *ui_tests-npm-cache
           paths:
             - client/tests/integration/node_modules
             # Also cache the global location where Puppeteer stores browsers.
             # https://pptr.dev/guides/configuration/#changing-the-default-cache-directory
             - ~/.cache/puppeteer
-      - run: pipenv run ./wagtail/test/manage.py migrate
+      - run: ./wagtail/test/manage.py migrate
       - run:
-          command: pipenv run ./wagtail/test/manage.py runserver 0:8000
+          command: ./wagtail/test/manage.py runserver 0:8000
           background: true
-      - run: pipenv run ./wagtail/test/manage.py createcachetable
+      - run: ./wagtail/test/manage.py createcachetable
       - run:
-          command: pipenv run ./wagtail/test/manage.py createsuperuser --noinput
+          command: ./wagtail/test/manage.py createsuperuser --noinput
           environment:
             DJANGO_SUPERUSER_EMAIL: admin@example.com
             DJANGO_SUPERUSER_USERNAME: admin
@@ -112,9 +115,9 @@ jobs:
           environment:
             JEST_JUNIT_OUTPUT_DIR: reports/jest
       - run:
-          command: pipenv run ./wagtail/test/manage.py collectstatic --noinput
+          command: ./wagtail/test/manage.py collectstatic --noinput
           environment:
-            DJANGO_DEBUG: false
+            DJANGO_DEBUG: 'false'
             STATICFILES_STORAGE: manifest
       - store_test_results:
           path: ./reports/jest


### PR DESCRIPTION
I'm not sure exactly why our current CircleCI setup fails on PRs – and only PRs, not on `main`. It's clearly something to do with the cache, as seen in #12302 and a199096af3b4a16244d8b181707a190c28c32e88 – but for some reason it only happens with `semgrep`, and other tools like `ruff` works just fine.

It's uncertain whether `pipenv` is the cause of the CI failures, but perhaps semgrep doesn't like being run through `pipenv run`. The official example in CircleCI docs uses the built-in `venv` module, so let's try that: https://circleci.com/docs/caching/#caching-libraries

If this works, it's hard to know for sure whether using `venv` indeed fixes it, or whether it's because we update the cache key. To know the answer, we just wait and see if this keeps working indefinitely.

Also update the yml to use aliases for the keys so we only specify it once for each key, to avoid updating it in separate lines.