### PR TITLE
Allow hook override of user profile avatar url in admin tags

### DIFF
--- a/docs/advanced_topics/customization/admin_templates.md
+++ b/docs/advanced_topics/customization/admin_templates.md
@@ -85,6 +85,12 @@ To replace the welcome message on the dashboard, create a template file `dashboa
 {% block branding_welcome %}Welcome to Frank's Site{% endblock %}
 ```
 
+(custom_user_profile_avatar)=
+
+## Custom user profile avatar
+
+To render a different `UserProfile` avatar with one coming from somewhere other than that model or from [gravatar](https://gravatar.com/), you can use the [`get_avatar_url`](#get_avatar_url) hook and resolve the avatar's image url as you see fit.
+
 (custom_user_interface_fonts)=
 
 ## Custom user interface fonts

--- a/docs/advanced_topics/customization/admin_templates.md
+++ b/docs/advanced_topics/customization/admin_templates.md
@@ -89,7 +89,17 @@ To replace the welcome message on the dashboard, create a template file `dashboa
 
 ## Custom user profile avatar
 
-To render a different `UserProfile` avatar with one coming from somewhere other than that model or from [gravatar](https://gravatar.com/), you can use the [`get_avatar_url`](#get_avatar_url) hook and resolve the avatar's image url as you see fit.
+To render a user avatar other than the one sourced from the `UserProfile` model or from [gravatar](https://gravatar.com/), you can use the [`get_avatar_url`](#get_avatar_url) hook and resolve the avatar's image url as you see fit.
+
+For example, you might have an avatar on a `Profile` model in your own application that is keyed to the `auth.User` model in the familiar pattern. In that case, you could register your hook as the in following example, and the Wagtail admin avatar will be replaced with your own `Profile` avatar accordingly.
+
+```python
+@hooks.register('get_avatar_url')
+def get_profile_avatar(user, size):
+    return user.profile.avatar
+```
+
+Additionally, you can use the default `size` parameter that is passed in to the hook if you need to attach it to a request or do any further processing on your image.
 
 (custom_user_interface_fonts)=
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -102,6 +102,28 @@ depth: 1
 ---
 ```
 
+## Appearance
+
+Hooks for modifying the display and appearance of basic CMS features and furniture.
+
+(get_avatar_url)=
+
+### `get_avatar_url`
+
+There is an existing `avatar` field on the Wagtail `UserProfile` model, which, although it cannot be altered on the model level, can be intercepted at the view level and made to point to some other image before it is rendered. Just define the hook and resolve the value to whatever image url you want to see taking the place of the `UserProfile` (or gravatar) image.
+
+For example, you might have an avatar on a `Profile` model in your own application that is keyed to the `auth.User` model in the familiar way. In that case, you could register your hook as:
+
+```python
+@hooks.register('get_avatar_url')
+def get_profile_avatar(user, size):
+    return user.profile.avatar
+```
+
+And the `UserProfile` avatar will be replaced with your own `Profile` avatar accordingly.
+
+Additionally, you can use the default `size` parameter that is passed in to the hook if you need to do any further processing before retrieving your url.
+
 ## Admin modules
 
 Hooks for building new areas of the admin interface (alongside pages, images, documents, and so on).

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -110,19 +110,21 @@ Hooks for modifying the display and appearance of basic CMS features and furnitu
 
 ### `get_avatar_url`
 
-There is an existing `avatar` field on the Wagtail `UserProfile` model, which, although it cannot be altered on the model level, can be intercepted at the view level and made to point to some other image before it is rendered. Just define the hook and resolve the value to whatever image url you want to see taking the place of the `UserProfile` (or gravatar) image.
-
-For example, you might have an avatar on a `Profile` model in your own application that is keyed to the `auth.User` model in the familiar way. In that case, you could register your hook as:
+Specify a custom user avatar to be displayed in the Wagtail admin. The callable passed to this hook should accept a `user` object and a `size` parameter that can be used in any resize or thumbnail processing you might need to do.
 
 ```python
+from datetime import datetime
+
 @hooks.register('get_avatar_url')
 def get_profile_avatar(user, size):
-    return user.profile.avatar
+    today = datetime.now()
+    is_christmas_day = today.month == 12 and today.day == 25
+
+    if is_christmas_day:
+      return '/static/images/santa.png'
+
+    return None
 ```
-
-And the `UserProfile` avatar will be replaced with your own `Profile` avatar accordingly.
-
-Additionally, you can use the default `size` parameter that is passed in to the hook if you need to do any further processing before retrieving your url.
 
 ## Admin modules
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -654,8 +654,19 @@ def avatar_url(user, size=50, gravatar_only=False):
     """
     A template tag that receives a user and size and return
     the appropriate avatar url for that user.
+
+    If the 'get_avatar_url' hook is defined, then that will intercept this
+    logic and point to whatever resource that function returns. In this way,
+    users can swap out the Wagtail UserProfile avatar for some other image or
+    field of their own choosing without needing to alter anything on the
+    existing models.
+
     Example usage: {% avatar_url request.user 50 %}
+
     """
+    for hook_fn in hooks.get_hooks("get_avatar_url"):
+        if url := hook_fn(user, size):
+            return url
 
     if (
         not gravatar_only

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -1,4 +1,5 @@
 import json
+import os
 import unittest
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
@@ -11,6 +12,7 @@ from django.test.utils import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 
+from wagtail import hooks
 from wagtail.admin.localization import get_js_translation_strings
 from wagtail.admin.staticfiles import VERSION_HASH, versioned_static
 from wagtail.admin.templatetags.wagtailadmin_tags import (
@@ -29,6 +31,67 @@ from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 from wagtail.users.models import UserProfile
 from wagtail.utils.deprecation import RemovedInWagtail70Warning
+
+
+class TestAvatarUrlInterceptTemplateTag(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.get_avatar_hook_mock = mock.MagicMock()
+        self.test_user = self.create_user(
+            username="testuser",
+            email="testuser@email.com",
+            password="password",
+        )
+
+    def tearDown(self):
+        self.get_avatar_hook_mock.reset_mock()
+
+    def test_get_avatar_url_hook_undefined(self):
+        url = avatar_url(self.test_user)
+        self.assertFalse(self.get_avatar_hook_mock.called)
+        self.assertIn("www.gravatar.com", url)
+
+    @mock.patch("wagtail.admin.templatetags.wagtailadmin_tags.hooks")
+    def test_get_avatar_url_empty_value(self, mock_hooks):
+        self.get_avatar_hook_mock.return_value = None
+        mock_hooks.get_hooks.return_value = [self.get_avatar_hook_mock]
+
+        with hooks.register_temporarily("get_avatar_url", self.get_avatar_hook_mock):
+            url = avatar_url(self.test_user)
+            self.assertEqual(
+                self.get_avatar_hook_mock.mock_calls,
+                [mock.call(self.test_user, 50)],
+            )
+            self.assertIn("www.gravatar.com", url)
+
+    @mock.patch("wagtail.admin.templatetags.wagtailadmin_tags.hooks")
+    def test_get_avatar_url(self, mock_hooks):
+        expected_url = "/some/avatar/fred.png"
+        self.get_avatar_hook_mock.return_value = expected_url
+        mock_hooks.get_hooks.return_value = [self.get_avatar_hook_mock]
+
+        with hooks.register_temporarily("get_avatar_url", self.get_avatar_hook_mock):
+            url = avatar_url(self.test_user)
+            self.assertEqual(
+                self.get_avatar_hook_mock.mock_calls,
+                [mock.call(self.test_user, 50)],
+            )
+            self.assertEqual(url, expected_url)
+
+    def test_get_avatar_url_registered_empty_value(self):
+        url = avatar_url(self.test_user)
+        self.assertIn("www.gravatar.com", url)
+
+    @mock.patch.dict(os.environ, {"AVATAR_INTERCEPT": "True"}, clear=True)
+    def test_get_avatar_url_registered(self):
+        avatar_intercept_url = "/some/avatar/fred.png"
+        test_user = self.create_user(
+            username="fred",
+            email="fred@email.com",
+            password="password",
+        )
+
+        url = avatar_url(test_user)
+        self.assertEqual(url, avatar_intercept_url)
 
 
 class TestAvatarTemplateTag(WagtailTestUtils, TestCase):

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -12,7 +12,6 @@ from django.test.utils import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 
-from wagtail import hooks
 from wagtail.admin.localization import get_js_translation_strings
 from wagtail.admin.staticfiles import VERSION_HASH, versioned_static
 from wagtail.admin.templatetags.wagtailadmin_tags import (
@@ -42,42 +41,7 @@ class TestAvatarUrlInterceptTemplateTag(WagtailTestUtils, TestCase):
             password="password",
         )
 
-    def tearDown(self):
-        self.get_avatar_hook_mock.reset_mock()
-
-    def test_get_avatar_url_hook_undefined(self):
-        url = avatar_url(self.test_user)
-        self.assertFalse(self.get_avatar_hook_mock.called)
-        self.assertIn("www.gravatar.com", url)
-
-    @mock.patch("wagtail.admin.templatetags.wagtailadmin_tags.hooks")
-    def test_get_avatar_url_empty_value(self, mock_hooks):
-        self.get_avatar_hook_mock.return_value = None
-        mock_hooks.get_hooks.return_value = [self.get_avatar_hook_mock]
-
-        with hooks.register_temporarily("get_avatar_url", self.get_avatar_hook_mock):
-            url = avatar_url(self.test_user)
-            self.assertEqual(
-                self.get_avatar_hook_mock.mock_calls,
-                [mock.call(self.test_user, 50)],
-            )
-            self.assertIn("www.gravatar.com", url)
-
-    @mock.patch("wagtail.admin.templatetags.wagtailadmin_tags.hooks")
-    def test_get_avatar_url(self, mock_hooks):
-        expected_url = "/some/avatar/fred.png"
-        self.get_avatar_hook_mock.return_value = expected_url
-        mock_hooks.get_hooks.return_value = [self.get_avatar_hook_mock]
-
-        with hooks.register_temporarily("get_avatar_url", self.get_avatar_hook_mock):
-            url = avatar_url(self.test_user)
-            self.assertEqual(
-                self.get_avatar_hook_mock.mock_calls,
-                [mock.call(self.test_user, 50)],
-            )
-            self.assertEqual(url, expected_url)
-
-    def test_get_avatar_url_registered_empty_value(self):
+    def test_get_avatar_url_undefined(self):
         url = avatar_url(self.test_user)
         self.assertIn("www.gravatar.com", url)
 

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -1,3 +1,5 @@
+import os
+
 from django import forms
 from django.http import HttpResponse
 from django.utils.safestring import mark_safe
@@ -432,3 +434,10 @@ def register_animated_advert_chooser_viewset():
 @hooks.register("register_admin_viewset")
 def register_event_page_listing_viewset():
     return event_page_listing_viewset
+
+
+@hooks.register("get_avatar_url")
+def register_avatar_intercept_url(user, size):
+    if os.environ.get("AVATAR_INTERCEPT"):
+        return "/some/avatar/fred.png"
+    return None


### PR DESCRIPTION
Resolves #12661 

- Add the 'get_avatar_url' hook.
- Unittest the 'get_avatar_url' hook.
- Update documentation.

@gasman 