### PR TITLE
Move images and documents `get_usage().count()` call to view code

### DIFF
--- a/wagtail/documents/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/edit.html
@@ -24,9 +24,7 @@
 
             <dt>{% trans "Usage" %}</dt>
             <dd>
-                {% with usage_count_val=document.get_usage.count %}
-                    <a href="{{ document.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
-                {% endwith %}
+                <a href="{{ document.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
             </dd>
         </dl>
     </div>

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -253,6 +253,7 @@ class EditView(generic.EditView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["usage_count_val"] = self.object.get_usage().count()
         context["filesize"] = self.object.get_file_size()
         context["next"] = self.next_url
         return context

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -63,9 +63,7 @@
 
                         <dt>{% trans "Usage" %}</dt>
                         <dd>
-                            {% with image.get_usage.count as usage_count_val %}
-                                <a href="{{ image.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
-                            {% endwith %}
+                            <a href="{{ image.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
                         </dd>
                     </dl>
                 </div>

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -186,6 +186,7 @@ class EditView(generic.EditView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["next"] = self.next_url
+        context["usage_count_val"] = self.object.get_usage().count()
 
         try:
             context["filesize"] = self.object.get_file_size()


### PR DESCRIPTION
The `get_usage()` method returns a `ReferenceGroups` instance that defines a `__getitem__` method.

https://github.com/wagtail/wagtail/blob/9889bddcb8823369f7a26c6b6f4a3eb6784d5985/wagtail/models/reference_index.py#L75-L76

Accessing `get_usage().count()` from the template via `image.get_usage.count` means that Django tries to access the count via `["count"]`, which calls `__getitem__` and fails when it tries to do `list(self)["count"]`, then continues by using `getattr(reference_groups, "count")` before finally calling the count method. As per [its template context resolution logic](https://github.com/django/django/blob/5f4252ecd6ce19cbf6d8bb9a3b4cca6a32eb40c2/django/template/base.py#L870-L945).

We have seen reports where the `blocktranslate` tag fails because the `usage_count_val` is not a number. We haven't got a reproducible example, but this would ensure we call the `count()` method directly – which _should_ always return a number as we get it from `QuerySet.count()`. Unless it can return something else somehow 🤔 

https://github.com/wagtail/wagtail/blob/9889bddcb8823369f7a26c6b6f4a3eb6784d5985/wagtail/models/reference_index.py#L54-L73


Slack reports:
- https://wagtailcms.slack.com/archives/C81FGJR2S/p1734001325701359
- https://wagtailcms.slack.com/archives/C81FGJR2S/p1731092379778579