### PR TITLE
Added keyboard shortcut for main menu

### DIFF
--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -193,6 +193,9 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = ({
         }
         type="button"
         ref={mobileNavToggleRef}
+        data-controller="w-kbd"
+        data-w-kbd-key-value="mod+["
+        data-w-kbd-scope-value="global"
       >
         {visibleOnMobile ? <Icon name="cross" /> : <Icon name="bars" />}
       </button>
@@ -233,6 +236,9 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = ({
                 hover:opacity-100
                 more-contrast:w-border-border-interactive-more-contrast-dark-bg
                 hover:more-contrast:w-border-border-interactive-more-contrast-dark-bg-hover`}
+              data-controller="w-kbd"
+              data-w-kbd-key-value="mod+["
+              data-w-kbd-scope-value="global"
             >
               <Icon
                 name="expand-right"

--- a/client/src/components/Sidebar/__snapshots__/Sidebar.test.js.snap
+++ b/client/src/components/Sidebar/__snapshots__/Sidebar.test.js.snap
@@ -6,6 +6,9 @@ exports[`Sidebar should render with the minimum required props 1`] = `
     aria-expanded="false"
     aria-label="Toggle sidebar"
     className="button sidebar-nav-toggle"
+    data-controller="w-kbd"
+    data-w-kbd-key-value="mod+["
+    data-w-kbd-scope-value="global"
     onClick={[Function]}
     type="button"
   >
@@ -38,6 +41,9 @@ exports[`Sidebar should render with the minimum required props 1`] = `
                 hover:opacity-100
                 more-contrast:w-border-border-interactive-more-contrast-dark-bg
                 hover:more-contrast:w-border-border-interactive-more-contrast-dark-bg-hover"
+          data-controller="w-kbd"
+          data-w-kbd-key-value="mod+["
+          data-w-kbd-scope-value="global"
           onClick={[Function]}
           type="button"
         >

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1380,6 +1380,7 @@ def keyboard_shortcuts_dialog(context):
             ("actions-model", _("Actions")): [
                 (_("Save changes"), f"{modifier} + s"),
                 (_("Preview"), f"{modifier} + p"),
+                (_("Main menu"), f"{modifier} + ["),
             ],
             ("rich-text-content", _("Text content")): [
                 (_("Insert or edit a link"), f"{modifier} + k")


### PR DESCRIPTION
Added a new wagtail keyboard shortcut for Main menu with reference to this discussion: https://github.com/wagtail/wagtail/discussions/12050

Keyboard shortcut dialog after new change:

![Screenshot from 2024-12-12 16-57-03](https://github.com/user-attachments/assets/abd01877-d5f5-47a4-bcca-56ff5fde414f)

Unit test case status for javascript:

![Screenshot from 2024-12-12 17-31-22](https://github.com/user-attachments/assets/c3ad4be4-e409-4f76-a3b2-56df918950e2)

Let me know if I need to add a unit test for these changes, All existing test cases for keyboard shortcuts are passing.
