### PR TITLE
Implement get_block_by_content_path on ImageBlock

### DIFF
--- a/wagtail/images/blocks.py
+++ b/wagtail/images/blocks.py
@@ -242,6 +242,14 @@ class ImageBlock(StructBlock):
     def render_basic(self, value, context=None):
         return self.child_blocks["image"].render_basic(value, context=context)
 
+    def get_block_by_content_path(self, value, path_elements):
+        if path_elements:
+            return super().get_block_by_content_path(
+                self._image_to_struct_value(value), path_elements
+            )
+        else:
+            return self.bind(value)
+
     class Meta:
         icon = "image"
         template = "wagtailimages/widgets/image.html"

--- a/wagtail/images/tests/test_blocks.py
+++ b/wagtail/images/tests/test_blocks.py
@@ -373,6 +373,37 @@ class TestImageBlock(TestImageChooserBlock):
         )
         self.assertIsNone(block.clean(value))
 
+    def test_get_block_by_content_path(self):
+        field = StreamPage._meta.get_field("body")
+        page = StreamPage(
+            body=field.stream_block.to_python(
+                [
+                    {
+                        "id": "123",
+                        "type": "image_with_alt",
+                        "value": {
+                            "image": self.image.id,
+                            "alt_text": "Sample alt text",
+                            "decorative": False,
+                        },
+                    },
+                ]
+            )
+        )
+        bound_block = field.get_block_by_content_path(page.body, ["123"])
+        self.assertEqual(bound_block.block.name, "image_with_alt")
+        self.assertIsInstance(bound_block.value, Image)
+        self.assertEqual(bound_block.value.id, self.image.id)
+
+        bound_block = field.get_block_by_content_path(page.body, ["123", "alt_text"])
+        self.assertEqual(bound_block.block.name, "alt_text")
+        self.assertEqual(bound_block.value, "Sample alt text")
+
+        bound_block = field.get_block_by_content_path(
+            page.body, ["123", "does_not_exist"]
+        )
+        self.assertIsNone(bound_block)
+
 
 class TestImageBlockComparison(TestCase):
     comparison_class = compare.StreamFieldComparison


### PR DESCRIPTION
Fixes #12688. Without this, commenting on a field of an ImageBlock will cause subsequent loads of the edit view to fail at the point that the comments validate that they are attached to a valid block path.
