### PR TITLE
Add explicit path to Sphinx configuration in `.readthedocs.yml`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,7 @@ python:
         - docs
 formats: all
 sphinx:
+  configuration: docs/conf.py
   fail_on_warning: True
 search:
   ranking:


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

https://github.com/readthedocs/readthedocs.org/issues/10637