### PR TITLE
Add explicit Sphinx configuration to .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,7 @@ python:
         - docs
 formats: all
 sphinx:
+  configuration: docs/conf.py
   fail_on_warning: True
 search:
   ranking:


### PR DESCRIPTION
From readthedocs:

We are announcing the deprecation of projects using Sphinx or MkDocs without an explicit configuration in their .readthedocs.yaml file. After January 20, 2025, Read the Docs will require explicit configuration for all Sphinx and MkDocs projects.

We used to automatically try to find the configuration file for your project, but in order to make builds more explicit and predictable, we are deprecating this behavior. This will also allows us to better support projects that don't use Sphinx or MkDocs in the near future.

What do I need to do?

If you're using Sphinx or MkDocs, ensure your .readthedocs.yaml file includes the appropriate configuration key. For example:

For Sphinx projects:

    version: 2
    sphinx:
      configuration: docs/conf.py

For MkDocs projects:

    version: 2
    mkdocs:
      configuration: mkdocs.yml

Note: If you're using build.commands, no changes are required.

Deprecation timeline

We will implement this change gradually:

* January 6, 2025: Builds will be temporarily disabled for 12 hours (00:01 PST to 11:59 PST)
* January 13, 2025: Builds will be temporarily disabled for 24 hours (00:01 PST to 23:59 PST)
* January 20, 2025: Final cutoff date - builds without explicit configuration will be permanently disabled
