### PR TITLE
Add support for specifying an operator on Fuzzy queries

### DIFF
--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -605,6 +605,10 @@ class Elasticsearch7SearchQueryCompiler(BaseSearchQueryCompiler):
             "query": query.query_string,
             "fuzziness": "AUTO",
         }
+
+        if query.operator != "or":
+            match_query["operator"] = query.operator
+
         if len(fields) == 1:
             if fields[0].boost != 1.0:
                 match_query["boost"] = fields[0].boost

--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -51,7 +51,7 @@ class Phrase(SearchQuery):
 
 class Fuzzy(SearchQuery):
     OPERATORS = ["and", "or"]
-    DEFAULT_OPERATOR = "and"
+    DEFAULT_OPERATOR = "or"
 
     def __init__(self, query_string: str, operator: str = DEFAULT_OPERATOR):
         self.query_string = query_string

--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -50,11 +50,17 @@ class Phrase(SearchQuery):
 
 
 class Fuzzy(SearchQuery):
-    def __init__(self, query_string: str):
+    OPERATORS = ["and", "or"]
+    DEFAULT_OPERATOR = "and"
+
+    def __init__(self, query_string: str, operator: str = DEFAULT_OPERATOR):
         self.query_string = query_string
+        self.operator = operator.lower()
+        if self.operator not in self.OPERATORS:
+            raise ValueError("`operator` must be either 'or' or 'and'.")
 
     def __repr__(self):
-        return f"<Fuzzy {repr(self.query_string)}>"
+        return f"<Fuzzy {repr(self.query_string)} operator={repr(self.operator)}>"
 
 
 class MatchAll(SearchQuery):

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -840,6 +840,27 @@ class TestElasticsearch7SearchQuery(TestCase):
         }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
+    def test_fuzzy_query_with_operator(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Fuzzy("Hello world", operator="and"),
+        )
+
+        # Check it
+        expected_result = {
+            "multi_match": {
+                "fields": [
+                    "_all_text",
+                    "_all_text_boost_2_0^2.0",
+                ],
+                "query": "Hello world",
+                "fuzziness": "AUTO",
+                "operator": "and",
+            }
+        }
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
     def test_year_filter(self):
         # Create a query
         query_compiler = self.query_compiler_class(


### PR DESCRIPTION
When using the `Fuzzy` query class (with an Elasticsearch backend), there is no way to override the operator used.

To emulate the behavior of either a `PlainText` query, or a standard query with `operator="and"` with fuzziness, you currently need to split the query manually and combine multiple `Fuzzy` query operations.

This PR adds supporting for overriding the `operator` on Fuzzy query types, e.g. `Fuzzy("foo bar", operator="and")`.

The default is set to `OR` so that:

```Page.search("foo bar")```

and

```Page.search(Fuzzy("foo bar"))```

have the same default operator.