### PR TITLE
Introducing Wagtail Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
     <a href="https://fosstodon.org/@wagtail">
         <img src="https://img.shields.io/mastodon/follow/109308882653647818?domain=https%3A%2F%2Ffosstodon.org&style=social" alt="Follow @wagtail@fosstodon.org">
     </a>
+    <a href="https://gurubase.io/g/wagtail">
+        <img src="https://img.shields.io/badge/Gurubase-Ask%20Wagtail%20Guru-006BFF" alt="Gurubase" />
+    </a>
 </p>
 
 Wagtail is an open source content management system built on Django, with a strong community and commercial support. It's focused on user experience, and offers precise control for designers and developers.


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [Wagtail Guru](https://gurubase.io/g/wagtail) has been manually added to Gurubase. Wagtail Guru uses the data from this repo and data from the [docs](https://docs.wagtail.org/) to answer questions by leveraging the LLM.

This PR introduces the "Wagtail Guru", showcasing that Wagtail now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "Wagtail Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the Wagtail documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable Wagtail Guru in Gurubase, just let us know that's totally fine.
