### PR TITLE
Populate ImageBlock alt text from default_alt_text when a new image is chosen

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Changelog
  * Use explicit label for defaulting to server language in account settings (Sage Abdullah)
  * Add support for specifying an operator on `Fuzzy` queries (Tom Usher)
  * Remove support for Safari 15 (Thibaud Colas)
+ * Populate the ImageBlock alt text from the image’s default alt text when selecting a new image (Matt Westcott)
  * Fix: Improve handling of translations for bulk page action confirmation messages (Matt Westcott)
  * Fix: Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
  * Fix: Ensure manual edits to `StreamField` values do not throw an error (Stefan Hammer)

--- a/client/src/components/ChooserWidget/ImageChooserWidget.js
+++ b/client/src/components/ChooserWidget/ImageChooserWidget.js
@@ -34,6 +34,9 @@ export class ImageChooser extends Chooser {
         width: this.previewImage.getAttribute('width'),
         height: this.previewImage.getAttribute('height'),
       };
+      state.default_alt_text = this.previewImage.getAttribute(
+        'data-default-alt-text',
+      );
     }
     return state;
   }
@@ -42,6 +45,10 @@ export class ImageChooser extends Chooser {
     super.renderState(newState);
     this.previewImage.setAttribute('src', newState.preview.url);
     this.previewImage.setAttribute('width', newState.preview.width);
+    this.previewImage.setAttribute(
+      'data-default-alt-text',
+      newState.default_alt_text,
+    );
   }
 }
 

--- a/client/src/components/ChooserWidget/index.js
+++ b/client/src/components/ChooserWidget/index.js
@@ -1,11 +1,13 @@
+import EventEmitter from 'events';
 import { ChooserModal } from '../../includes/chooserModal';
 
-export class Chooser {
+export class Chooser extends EventEmitter {
   chooserModalClass = ChooserModal;
   titleStateKey = 'title'; // key used in the 'state' dictionary to hold the human-readable title
   editUrlStateKey = 'edit_url'; // key used in the 'state' dictionary to hold the URL of the edit page
 
   constructor(id, opts = {}) {
+    super();
     this.opts = opts;
     this.initHTMLElements(id);
     this.state = this.getStateFromHTML();
@@ -83,6 +85,7 @@ export class Chooser {
 
   setStateFromModalData(data) {
     this.setState(data);
+    this.emit('chosen', data);
   }
 
   clear() {

--- a/client/src/entrypoints/images/image-block.js
+++ b/client/src/entrypoints/images/image-block.js
@@ -15,6 +15,11 @@ class ImageBlockDefinition extends window.wagtailStreamField.blocks
     updateStateInput();
     isDecorativeField.addEventListener('change', updateStateInput);
 
+    const imageChooserWidget = block.childBlocks.image.widget;
+    imageChooserWidget.on('chosen', (data) => {
+      altTextField.value = data.default_alt_text;
+    });
+
     return block;
   }
 }

--- a/client/src/entrypoints/images/image-block.js
+++ b/client/src/entrypoints/images/image-block.js
@@ -16,8 +16,15 @@ class ImageBlockDefinition extends window.wagtailStreamField.blocks
     isDecorativeField.addEventListener('change', updateStateInput);
 
     const imageChooserWidget = block.childBlocks.image.widget;
+    let lastDefaultAltText = initialState?.image?.default_alt_text || '';
     imageChooserWidget.on('chosen', (data) => {
-      altTextField.value = data.default_alt_text;
+      /* If the alt text field has not been changed from the previous image's default alt text
+      (or the empty string, if there was no previous image), replace it with the new image's
+      default alt text */
+      if (altTextField.value === lastDefaultAltText) {
+        altTextField.value = data.default_alt_text;
+      }
+      lastDefaultAltText = data.default_alt_text;
     });
 
     return block;

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -47,6 +47,7 @@ This feature was developed by Jake Howard.
  * Use explicit label for defaulting to server language in account settings (Sage Abdullah)
  * Add support for specifying an operator on `Fuzzy` queries (Tom Usher)
  * Remove support for Safari 15 (Thibaud Colas)
+ * Populate the ImageBlock alt text from the image’s default alt text when selecting a new image (Matt Westcott)
 
 ### Bug fixes
 

--- a/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
+++ b/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
@@ -3,5 +3,5 @@
 
 {% block chosen_icon %}
     {# Empty alt because the chosen item’s title is already displayed next to the image. #}
-    <img class="chooser__image show-transparency" data-chooser-image alt="" decoding="async" height="{{ preview.height|unlocalize }}" src="{{ preview.url }}" width="{{ preview.width|unlocalize }}">
+    <img class="chooser__image show-transparency" data-chooser-image alt="" data-default-alt-text="{{ default_alt_text }}" decoding="async" height="{{ preview.height|unlocalize }}" src="{{ preview.url }}" width="{{ preview.width|unlocalize }}">
 {% endblock chosen_icon %}

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1876,6 +1876,7 @@ class TestImageChooserChosenView(WagtailTestUtils, TestCase):
         self.image = Image.objects.create(
             title="Test image",
             file=get_test_image_file(),
+            description="Test description",
         )
 
     def get(self, params={}):
@@ -1890,6 +1891,12 @@ class TestImageChooserChosenView(WagtailTestUtils, TestCase):
         response_json = json.loads(response.content.decode())
         self.assertEqual(response_json["step"], "chosen")
         self.assertEqual(response_json["result"]["title"], "Test image")
+        self.assertEqual(
+            set(response_json["result"]["preview"].keys()), {"url", "width", "height"}
+        )
+        self.assertEqual(
+            response_json["result"]["default_alt_text"], "Test description"
+        )
 
     def test_with_multiple_flag(self):
         # if 'multiple' is passed as a URL param, the result should be returned as a single-item list
@@ -1900,6 +1907,13 @@ class TestImageChooserChosenView(WagtailTestUtils, TestCase):
         self.assertEqual(response_json["step"], "chosen")
         self.assertEqual(len(response_json["result"]), 1)
         self.assertEqual(response_json["result"][0]["title"], "Test image")
+        self.assertEqual(
+            set(response_json["result"][0]["preview"].keys()),
+            {"url", "width", "height"},
+        )
+        self.assertEqual(
+            response_json["result"][0]["default_alt_text"], "Test description"
+        )
 
 
 class TestImageChooserChosenMultipleView(WagtailTestUtils, TestCase):
@@ -1910,15 +1924,18 @@ class TestImageChooserChosenMultipleView(WagtailTestUtils, TestCase):
         self.image1 = Image.objects.create(
             title="Test image",
             file=get_test_image_file(),
+            description="Test description",
         )
         self.image2 = Image.objects.create(
             title="Another test image",
             file=get_test_image_file(),
+            description="Another test description",
         )
 
         self.image3 = Image.objects.create(
             title="Unchosen test image",
             file=get_test_image_file(),
+            description="Unchosen test description",
         )
 
     def get(self, params={}):
@@ -1940,6 +1957,8 @@ class TestImageChooserChosenMultipleView(WagtailTestUtils, TestCase):
         self.assertEqual(len(response_json["result"]), 2)
         titles = {item["title"] for item in response_json["result"]}
         self.assertEqual(titles, {"Test image", "Another test image"})
+        alt_texts = {item["default_alt_text"] for item in response_json["result"]}
+        self.assertEqual(alt_texts, {"Test description", "Another test description"})
 
 
 class TestImageChooserSelectFormatView(WagtailTestUtils, TestCase):

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -43,6 +43,7 @@ class ImageChosenResponseMixin(ChosenResponseMixin):
             "width": preview_image.width,
             "height": preview_image.height,
         }
+        response_data["default_alt_text"] = image.default_alt_text
         return response_data
 
 

--- a/wagtail/images/widgets.py
+++ b/wagtail/images/widgets.py
@@ -31,11 +31,13 @@ class AdminImageChooser(BaseChooser):
             "width": preview_image.width,
             "height": preview_image.height,
         }
+        data["default_alt_text"] = instance.default_alt_text
         return data
 
     def get_context(self, name, value_data, attrs):
         context = super().get_context(name, value_data, attrs)
         context["preview"] = value_data.get("preview", {})
+        context["default_alt_text"] = value_data.get("default_alt_text", "")
         return context
 
     @property


### PR DESCRIPTION
Fixes #12660

Add `default_alt_text` to the dictionary of data returned from the image chooser modal and handled by the `AdminImageChooser` widget (on both the server and client side), and add a `chosen` event to the base Chooser widget class.

Use this to prepopulate the alt text field of ImageBlock when a new image is chosen (but avoid doing so if the field has already been explicitly edited to something other than the previous image's default, so that we're not replacing a contextual alt text string with a generic one).