### PR TITLE
Migrate away from deprecated sass @import to @use module system

### DIFF
--- a/client/scss/_settings.scss
+++ b/client/scss/_settings.scss
@@ -1,1 +1,1 @@
-@import 'settings/variables';
+@forward 'settings/variables';

--- a/client/scss/_tools.scss
+++ b/client/scss/_tools.scss
@@ -3,8 +3,8 @@ These are functions and mixins.
 No CSS should be produced by these files.
 */
 
-@import 'tools/functions.breakpoints';
+@forward 'tools/mixins.general';
+@forward 'tools/mixins.grid';
+@forward 'tools/mixins.guide-line';
+@forward 'tools/functions.breakpoints';
 @import 'tools/mixins.breakpoints';
-@import 'tools/mixins.general';
-@import 'tools/mixins.grid';
-@import 'tools/mixins.guide-line';

--- a/client/scss/_tools.scss
+++ b/client/scss/_tools.scss
@@ -6,5 +6,9 @@ No CSS should be produced by these files.
 @forward 'tools/mixins.general';
 @forward 'tools/mixins.grid';
 @forward 'tools/mixins.guide-line';
-@forward 'tools/functions.breakpoints';
+
+
+
+// stylelint-disable no-invalid-position-at-import-rule
+@import 'tools/functions.breakpoints';
 @import 'tools/mixins.breakpoints';

--- a/client/scss/components/_a11y-result.scss
+++ b/client/scss/components/_a11y-result.scss
@@ -1,5 +1,8 @@
+@use '../tools' as mixin;
+@use '../../src/components/CommentApp/main.scss' as main-mixin;
+
 .w-a11y-result__row {
-  @include box;
+  @include main-mixin.box;
   padding: theme('spacing.4');
   display: flex;
   justify-content: space-between;
@@ -9,7 +12,7 @@
     display: block;
   }
 
-  @include more-contrast() {
+  @include mixin.more-contrast() {
     border-color: theme('colors.border-furniture-more-contrast');
   }
 }

--- a/client/scss/components/_avatar.scss
+++ b/client/scss/components/_avatar.scss
@@ -1,3 +1,5 @@
+@use '../tools' as mixin;
+
 // user avatars
 .avatar {
   border-radius: 100%;
@@ -32,7 +34,7 @@
     width: 60px;
     height: 60px;
 
-    @include media-breakpoint-up(sm) {
+    @include mixin.media-breakpoint-up(sm) {
       width: 80px;
       height: 80px;
     }

--- a/client/scss/components/_breadcrumbs.scss
+++ b/client/scss/components/_breadcrumbs.scss
@@ -1,3 +1,5 @@
+@use '../tools' as mixin;
+
 .w-breadcrumbs:not(.editor-view .w-breadcrumbs) {
   @apply sm:w-py-2.5;
 
@@ -7,7 +9,7 @@
       font-size: theme('fontSize.18');
       font-weight: theme('fontWeight.extrabold');
 
-      @include media-breakpoint-up(md) {
+      @include mixin.media-breakpoint-up(md) {
         font-size: theme('fontSize.22');
       }
     }

--- a/client/scss/components/_bulk_actions.scss
+++ b/client/scss/components/_bulk_actions.scss
@@ -1,3 +1,5 @@
+@use '../tools' as mixin;
+
 .bulk-actions-filter-checkbox {
   .table-headers & {
     > div {
@@ -19,7 +21,7 @@
 
 .bulk-actions-choices {
   &.footer {
-    @include transition(transform 0.1s ease 0.1s);
+    @include mixin.transition(transform 0.1s ease 0.1s);
 
     &.hidden {
       transform: translateY(200px);
@@ -45,7 +47,7 @@
     }
 
     .bulk-actions-buttons {
-      @include unlistimmediate();
+      @include mixin.unlistimmediate();
       display: flex;
       gap: theme('spacing.4');
       border-inline-start: 1px solid theme('colors.icon-secondary');

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -3,6 +3,8 @@
 // Core button styles
 
 @use 'sass:color';
+@use '../tools' as mixin;
+@use '../settings' as variable;
 
 .button {
   border-radius: theme('borderRadius.sm');
@@ -16,7 +18,7 @@
   display: inline-block;
   background-color: theme('colors.surface-button-default');
   border: 1px solid theme('colors.surface-button-default');
-  outline-offset: $focus-outline-width;
+  outline-offset: variable.$focus-outline-width;
   color: theme('colors.text-button');
   text-decoration: none;
   white-space: nowrap;
@@ -41,7 +43,7 @@
 
   &.button--icon {
     .icon {
-      @include svg-icon();
+      @include mixin.svg-icon();
     }
   }
 
@@ -108,7 +110,7 @@
 
     &.button--icon {
       .icon {
-        @include svg-icon();
+        @include mixin.svg-icon();
       }
     }
 
@@ -145,7 +147,7 @@
       }
 
       &.button--icon .icon {
-        @include svg-icon(0.9rem);
+        @include mixin.svg-icon(0.9rem);
         padding: 0.25em;
       }
 
@@ -186,7 +188,7 @@
     }
 
     svg.icon-spinner {
-      @include transition(all 0.3s ease);
+      @include mixin.transition(all 0.3s ease);
       display: none;
     }
   }
@@ -196,7 +198,7 @@
     align-items: center;
 
     svg.icon-spinner {
-      @include svg-icon();
+      @include mixin.svg-icon();
       display: inline-block;
       opacity: 0.8;
       padding: 0;
@@ -263,7 +265,7 @@
       }
 
       .icon {
-        @include svg-icon(1rem, middle);
+        @include mixin.svg-icon(1rem, middle);
 
         font-size: initial;
         padding: 0.5em;
@@ -279,7 +281,7 @@
       }
     }
 
-    @include media-breakpoint-up(sm) {
+    @include mixin.media-breakpoint-up(sm) {
       &.icon {
         &.button-small {
           width: 1.75em;
@@ -291,7 +293,7 @@
 
   // Larger viewport width adjustments
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     font-size: theme('fontSize.14');
     padding: 0 1.4em;
     height: 3em;
@@ -321,7 +323,7 @@
 }
 
 .w-header-button {
-  @include more-contrast-interactive();
+  @include mixin.more-contrast-interactive();
   display: flex;
   align-items: center;
   justify-content: center;

--- a/client/scss/components/_chooser.scss
+++ b/client/scss/components/_chooser.scss
@@ -1,4 +1,5 @@
 @use 'sass:math';
+@use '../tools' as mixin;
 
 $preview-size: 2.625rem; // 42px
 
@@ -15,7 +16,7 @@ $preview-size: 2.625rem; // 42px
 // Very subdued button style specifically for choosers, as there can be a lot of
 // chooser fields left unused on a page editing form.
 .button.chooser__choose-button {
-  @include more-contrast-interactive();
+  @include mixin.more-contrast-interactive();
   @apply w-label-3;
   display: flex;
   align-items: center;
@@ -24,7 +25,7 @@ $preview-size: 2.625rem; // 42px
   padding: theme('spacing.[1.5]');
 
   .icon {
-    @include svg-icon(theme('spacing.4'), initial);
+    @include mixin.svg-icon(theme('spacing.4'), initial);
     color: inherit;
     margin-inline-end: 5px;
   }

--- a/client/scss/components/_dialog.scss
+++ b/client/scss/components/_dialog.scss
@@ -1,3 +1,5 @@
+@use '../tools' as mixin;
+
 .w-dialog {
   --w-dialog-close-icon-color: theme('colors.icon-primary');
 
@@ -35,7 +37,7 @@
     border-radius: theme('borderRadius.md');
     animation: theme('animation.fade-in');
 
-    @include media-breakpoint-up(sm) {
+    @include mixin.media-breakpoint-up(sm) {
       width: 600px;
     }
     @media (forced-colors: active) {
@@ -69,11 +71,11 @@
     max-height: calc(100vh - 180px);
     min-height: min(100vh - 180px, 320px);
 
-    @include media-breakpoint-up(sm) {
+    @include mixin.media-breakpoint-up(sm) {
       padding: theme('spacing.12');
     }
 
-    @include media-breakpoint-up(md) {
+    @include mixin.media-breakpoint-up(md) {
       padding-inline-start: theme('spacing.20');
       padding-inline-end: theme('spacing.20');
     }
@@ -89,7 +91,7 @@
     transform: translateY(theme('spacing.2'));
     inset-inline-start: calc(0 - theme('spacing.10'));
 
-    @include media-breakpoint-up(md) {
+    @include mixin.media-breakpoint-up(md) {
       display: block;
     }
   }

--- a/client/scss/components/_dropdown-button.scss
+++ b/client/scss/components/_dropdown-button.scss
@@ -2,6 +2,9 @@
 $separator: 1px solid theme('colors.white-15');
 $radius: theme('borderRadius.sm');
 
+@use '../tools' as mixin;
+@use '../settings' as variable;
+
 .w-dropdown-button {
   // Cosmetic details based on live tooltip placement,
   // implemented CSS-only by using Tippy.js `data-placement` and `:has`.
@@ -63,12 +66,12 @@ $radius: theme('borderRadius.sm');
   border-start-end-radius: 0;
   border-end-start-radius: var(--primary-button-radius-bottom);
   border-end-end-radius: 0;
-  min-height: $text-input-height;
+  min-height: variable.$text-input-height;
 }
 
 .w-dropdown-button .button.w-dropdown__toggle {
   width: theme('spacing.8');
-  height: $text-input-height;
+  height: variable.$text-input-height;
   padding: 0 theme('spacing.2');
   background-color: theme('colors.surface-button-default');
   color: theme('colors.text-button');
@@ -89,9 +92,9 @@ $radius: theme('borderRadius.sm');
 
 // Use a generic selector to support all types of links / buttons.
 .w-dropdown-button .w-dropdown__content :is(a, button) {
-  @include show-focus-outline-inside();
+  @include mixin.show-focus-outline-inside();
   height: auto;
-  min-height: $text-input-height;
+  min-height: variable.$text-input-height;
   margin: 0;
   white-space: normal;
   border-radius: 0;

--- a/client/scss/components/_filters.scss
+++ b/client/scss/components/_filters.scss
@@ -1,9 +1,11 @@
+@use '../tools' as mixin;
+
 .filterable {
   display: grid;
   grid-template-columns: 1fr minmax(theme('spacing.48'), theme('spacing.64'));
   grid-column-gap: theme('spacing.12');
 
-  @include media-breakpoint-down(md) {
+  @include mixin.media-breakpoint-down(md) {
     grid-template-columns: auto;
   }
 }
@@ -19,13 +21,13 @@
     margin-bottom: theme('spacing.3');
   }
 
-  @include media-breakpoint-down(md) {
+  @include mixin.media-breakpoint-down(md) {
     grid-row: 1;
   }
 }
 
 .w-filter-button {
-  @include more-contrast-interactive();
+  @include mixin.more-contrast-interactive();
   position: relative;
   width: theme('spacing.10');
   height: theme('spacing.10');
@@ -47,5 +49,5 @@
 
 .w-active-filters {
   @apply w-m-0 w-py-4 w-bg-surface-header w-border-b w-border-border-furniture w-flex w-flex-wrap w-list-none w-gap-2;
-  @include nice-padding;
+  @include mixin.nice-padding;
 }

--- a/client/scss/components/_footer.scss
+++ b/client/scss/components/_footer.scss
@@ -1,17 +1,19 @@
 @use 'sass:math';
+@use '../tools' as mixin;
+@use '../settings' as variable;
 
 .footer {
-  @include transition(bottom 0.5s ease 1s);
-  @include row();
-  margin-top: $mobile-nice-padding;
-  margin-inline-start: $mobile-nice-padding;
-  margin-inline-end: $mobile-nice-padding;
+  @include mixin.transition(bottom 0.5s ease 1s);
+  @include mixin.row();
+  margin-top: variable.$mobile-nice-padding;
+  margin-inline-start: variable.$mobile-nice-padding;
+  margin-inline-end: variable.$mobile-nice-padding;
   z-index: 20;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     margin-top: 0;
-    margin-inline-start: calc(#{$desktop-nice-padding} - 0.75em);
-    margin-inline-end: $desktop-nice-padding;
+    margin-inline-start: calc(#{variable.$desktop-nice-padding} - 0.75em);
+    margin-inline-end: variable.$desktop-nice-padding;
     width: auto;
     position: fixed;
     bottom: 0;
@@ -34,7 +36,7 @@
   transition: transform 1s;
   padding: theme('spacing.1');
 
-  @include media-breakpoint-down(xs) {
+  @include mixin.media-breakpoint-down(xs) {
     width: 100%;
 
     &:not(:first-child) {
@@ -42,7 +44,7 @@
     }
   }
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     padding: theme('spacing.[2.5]');
     margin-inline-end: 0;
 
@@ -54,7 +56,7 @@
   &.footer__container--hidden {
     transform: translateY(100%);
 
-    @include media-breakpoint-down(xs) {
+    @include mixin.media-breakpoint-down(xs) {
       display: none;
     }
   }
@@ -71,7 +73,7 @@
     margin: 0;
   }
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     margin-inline-end: theme('spacing[1.5]');
     align-items: center;
   }
@@ -81,7 +83,7 @@
 .footer .actions {
   width: 100%;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     width: theme('spacing.64');
   }
 
@@ -98,11 +100,11 @@
       // - set height responsively
       // - add a margin when there is a .button sibling
       // Unset these styles in favor of a fixed height and the grid gap
-      height: $text-input-height;
+      height: variable.$text-input-height;
       margin-inline-start: initial;
     }
 
-    @include media-breakpoint-up(sm) {
+    @include mixin.media-breakpoint-up(sm) {
       min-width: theme('spacing.80');
       width: max-content;
 

--- a/client/scss/components/_form-side.scss
+++ b/client/scss/components/_form-side.scss
@@ -1,6 +1,8 @@
 @use 'sass:color';
 @use 'sass:map';
 @use 'sass:math';
+@use '../tools' as mixin;
+@use '../../src/components/CommentApp/main.scss' as main-mixin;
 
 .side-panel-open {
   @apply w-overflow-y-hidden sm:w-overflow-y-auto;
@@ -41,7 +43,7 @@
   z-index: calc(theme('zIndex.header') - 10);
   width: var(--side-panel-width, 100%);
 
-  @include media-breakpoint-up(md) {
+  @include mixin.media-breakpoint-up(md) {
     width: var(--side-panel-width, theme('width.[1/3]'));
   }
 
@@ -83,13 +85,13 @@
     }
 
     &:focus-within:has(:focus-visible) {
-      @include focus-outline;
+      @include main-mixin.focus-outline;
     }
 
     @supports not selector(:focus-visible) {
       &:focus-within {
         /* Fallback for browsers without :focus-visible support */
-        @include focus-outline;
+        @include main-mixin.focus-outline;
       }
     }
   }

--- a/client/scss/components/_grid.legacy.scss
+++ b/client/scss/components/_grid.legacy.scss
@@ -1,14 +1,17 @@
+@use '../tools' as mixin;
+@use '../settings' as variable;
+
 .wrapper {
-  @include clearfix();
+  @include mixin.clearfix();
   @apply w-transition-sidebar;
   height: 100vh;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     transform: none;
-    padding-inline-start: $menu-width;
+    padding-inline-start: variable.$menu-width;
 
     .sidebar-collapsed & {
-      padding-inline-start: $menu-width-slim;
+      padding-inline-start: variable.$menu-width-slim;
     }
   }
 }
@@ -22,7 +25,7 @@
   // For mobile viewports, expect a sticky header over two rows.
   scroll-padding-top: calc(theme('spacing.slim-header') * 2 + $gap);
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     scroll-padding-top: calc(theme('spacing.slim-header') + $gap);
   }
 }
@@ -38,18 +41,18 @@
 }
 
 .content {
-  @include row();
+  @include mixin.row();
   background: theme('colors.surface-page');
   border-top: 0 solid transparent; // this top border provides space for the floating logo to toggle the menu
   min-height: 100%;
   position: relative; // yuk. necessary for positions for jquery ui widgets
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     padding-bottom: 4em;
   }
 }
 
-@include media-breakpoint-up(sm) {
+@include mixin.media-breakpoint-up(sm) {
   .content {
     border-top: 0;
     padding-top: 0;
@@ -57,63 +60,63 @@
 }
 
 .row {
-  @include clearfix();
+  @include mixin.clearfix();
 }
 
-@include media-breakpoint-up(sm) {
+@include mixin.media-breakpoint-up(sm) {
   .col1 {
-    @include column(1);
+    @include mixin.column(1);
   }
 
   .col2 {
-    @include column(2);
+    @include mixin.column(2);
   }
 
   .col3 {
-    @include column(3);
+    @include mixin.column(3);
   }
 
   .col4 {
-    @include column(4);
+    @include mixin.column(4);
   }
 
   .col5 {
-    @include column(5);
+    @include mixin.column(5);
   }
 
   .col6 {
-    @include column(6);
+    @include mixin.column(6);
   }
 
   .col7 {
-    @include column(7);
+    @include mixin.column(7);
   }
 
   .col8 {
-    @include column(8);
+    @include mixin.column(8);
   }
 
   .col9 {
-    @include column(9);
+    @include mixin.column(9);
   }
 
   .col10 {
-    @include column(10);
+    @include mixin.column(10);
   }
 
   .col11 {
-    @include column(11);
+    @include mixin.column(11);
   }
 
   .col12 {
-    @include column(12);
+    @include mixin.column(12);
   }
 
   .row {
-    @include row();
+    @include mixin.row();
   }
 
   .row-flush {
-    @include row-flush();
+    @include mixin.row-flush();
   }
 }

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -1,5 +1,7 @@
 @use 'sass:math';
 @use 'sass:color';
+@use '../tools' as mixin;
+@use '../settings' as variable;
 
 .w-header {
   @apply w-text-text-label;
@@ -45,7 +47,7 @@
   }
 
   &.w-header--merged .w-breadcrumbs {
-    padding-inline-start: $mobile-nav-indent;
+    padding-inline-start: variable.$mobile-nav-indent;
   }
 
   .col {
@@ -101,11 +103,11 @@
   }
 }
 
-@include media-breakpoint-up(sm) {
+@include mixin.media-breakpoint-up(sm) {
   .w-header {
     .row {
-      padding-inline-start: $desktop-nice-padding;
-      padding-inline-end: $desktop-nice-padding;
+      padding-inline-start: variable.$desktop-nice-padding;
+      padding-inline-end: variable.$desktop-nice-padding;
       padding-top: theme('spacing.10');
     }
 
@@ -133,7 +135,7 @@
     }
 
     .col3 {
-      @include column(3);
+      @include mixin.column(3);
     }
 
     .col3.actionbutton {
@@ -141,17 +143,17 @@
     }
 
     .col6 {
-      @include column(6);
+      @include mixin.column(6);
     }
 
     .col9 {
-      @include column(9);
+      @include mixin.column(9);
     }
   }
 }
 
 .w-slim-header {
-  @include more-contrast() {
+  @include mixin.more-contrast() {
     border-color: theme('colors.border-furniture-more-contrast');
   }
 

--- a/client/scss/components/_help-block.scss
+++ b/client/scss/components/_help-block.scss
@@ -1,5 +1,6 @@
 @use 'sass:color';
 @use 'sass:map';
+@use '../tools' as mixin;
 // Help text formatters
 .help-block {
   padding: 1em;
@@ -36,7 +37,7 @@
   position: relative;
 
   .icon {
-    @include svg-icon(1rem);
+    @include mixin.svg-icon(1rem);
     position: absolute;
     inset-inline-start: 1.125rem;
     top: 0.8125rem;

--- a/client/scss/components/_icons.scss
+++ b/client/scss/components/_icons.scss
@@ -1,4 +1,6 @@
 @use 'sass:string';
+@use '../tools' as mixin;
+@use '../settings' as variable;
 
 // Set SVG icons to use the current text color in the location they appear as
 // their default fill color. Can be overridden for a specific icon by either
@@ -25,7 +27,7 @@ $icons-after: ('arrow-down', 'arrow-up');
 @each $icon in $icons-after {
   .icon-#{$icon}-after::after {
     content: '';
-    mask-image: url('#{$images-root}icons/#{$icon}.svg');
+    mask-image: url('#{variable.$images-root}icons/#{$icon}.svg');
     width: 1em;
     height: 1em;
     display: inline-block;
@@ -51,7 +53,7 @@ use[href='#icon-spinner'] {
   overflow: hidden;
 
   .icon {
-    @include svg-icon(1rem, middle);
+    @include mixin.svg-icon(1rem, middle);
   }
 }
 
@@ -68,15 +70,15 @@ use[href='#icon-spinner'] {
 // stylelint-disable-next-line no-duplicate-selectors
 .icon {
   &.initial {
-    @include svg-icon(1em, $position: initial);
+    @include mixin.svg-icon(1em, $position: initial);
   }
 
   &.default {
-    @include svg-icon(1.5em);
+    @include mixin.svg-icon(1.5em);
   }
 
   &.middle {
-    @include svg-icon(1.5em, $position: middle);
+    @include mixin.svg-icon(1.5em, $position: middle);
   }
 
   &--flipped {

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -1,7 +1,9 @@
+@use '../tools' as mixin;
+
 /* stylelint-disable selector-max-combinators */
 // General listings, like for pages, images or snippets
 ul.listing {
-  @include unlist();
+  @include mixin.unlist();
 }
 
 .listing {
@@ -30,7 +32,7 @@ ul.listing {
     text-align: start;
     padding: calc(1em * var(--w-density-factor)) 0.3em;
 
-    @include media-breakpoint-up(sm) {
+    @include mixin.media-breakpoint-up(sm) {
       padding: calc(1em * var(--w-density-factor)) 1em;
     }
 
@@ -43,7 +45,7 @@ ul.listing {
   th {
     padding: 0.6em 0.3em;
 
-    @include media-breakpoint-up(sm) {
+    @include mixin.media-breakpoint-up(sm) {
       padding: 0.6em 1em;
     }
   }
@@ -150,7 +152,7 @@ ul.listing {
     }
 
     tbody .title a {
-      @include transition(none);
+      @include mixin.transition(none);
       display: block;
     }
 
@@ -363,7 +365,7 @@ ul.listing {
   }
 
   &.images img {
-    @include transition(border-color 0.2s ease);
+    @include mixin.transition(border-color 0.2s ease);
     border: 3px solid theme('colors.surface-page');
   }
 
@@ -413,7 +415,7 @@ ul.listing {
       float: inline-end;
     }
 
-    @include media-breakpoint-down(md) {
+    @include mixin.media-breakpoint-down(md) {
       display: grid;
 
       tr {
@@ -461,7 +463,7 @@ table.listing {
 
 // Use consistent spacing to the left and right of the header.
 .page-explorer .w-slim-header {
-  @include media-breakpoint-up(md) {
+  @include mixin.media-breakpoint-up(md) {
     padding-inline-end: theme('spacing.6');
   }
 }
@@ -483,7 +485,7 @@ table.listing {
   }
 
   ul {
-    @include unlist();
+    @include mixin.unlist();
     margin-top: -1.7em;
   }
 
@@ -508,7 +510,7 @@ table.listing {
 
 // listing filters
 .listing-filter {
-  @include clearfix();
+  @include mixin.clearfix();
   background-color: theme('colors.surface-header');
   border-width: 1px 0;
   margin: 3em 0;
@@ -523,8 +525,8 @@ table.listing {
 }
 
 .filter-options {
-  @include unlist();
-  @include clearfix();
+  @include mixin.unlist();
+  @include mixin.clearfix();
   overflow: hidden;
 
   li {
@@ -542,7 +544,7 @@ table.listing {
   }
 }
 
-@include media-breakpoint-up(sm) {
+@include mixin.media-breakpoint-up(sm) {
   .listing {
     &.horiz {
       display: grid;
@@ -723,12 +725,12 @@ table.listing {
 .listing {
   .children,
   .no-children {
-    @include transition(background-color 0.2s ease);
+    @include mixin.transition(background-color 0.2s ease);
   }
 
   .children a,
   .no-children a {
-    @include transition(all 0.2s ease);
+    @include mixin.transition(all 0.2s ease);
   }
 }
 
@@ -752,11 +754,11 @@ table.listing {
   text-overflow: ellipsis;
   white-space: nowrap;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     max-width: 30ch;
   }
 
-  @include media-breakpoint-up(md) {
+  @include mixin.media-breakpoint-up(md) {
     max-width: none;
   }
 }

--- a/client/scss/components/_loading-mask.scss
+++ b/client/scss/components/_loading-mask.scss
@@ -1,4 +1,5 @@
 @use 'sass:map';
+@use '../settings' as variable;
 // Loading mask: overlays a certain area with a loading spinner and a faded out cover to prevent interaction
 .loading-mask {
   &.loading {
@@ -28,7 +29,7 @@
       inset-inline-start: 50%;
       top: 50%;
       animation: spin-wag 0.5s infinite linear;
-      mask-image: url('#{$images-root}icons/spinner.svg');
+      mask-image: url('#{variable.$images-root}icons/spinner.svg');
       mask-repeat: no-repeat;
       z-index: 2;
       background: theme('colors.surface-button-default');

--- a/client/scss/components/_messages.scss
+++ b/client/scss/components/_messages.scss
@@ -1,3 +1,5 @@
+@use '../tools' as mixin;
+
 // Messages are specific to Django's 'Messaging' system which adds messages into the session,
 // for display on the next page visited. These appear as an animated banner at the top of the page.
 // For inline help text, see typography.scss
@@ -10,7 +12,7 @@
   }
 
   > ul {
-    @include unlistimmediate();
+    @include mixin.unlistimmediate();
     position: relative;
     top: -100px;
     opacity: 0;
@@ -23,7 +25,7 @@
   }
 
   > ul > li:before {
-    @include font-smoothing;
+    @include mixin.font-smoothing;
     margin-inline-end: 0.5em;
     font-size: 1.5em;
     vertical-align: middle;
@@ -59,7 +61,7 @@
     background-color: theme('colors.warning.100');
     color: theme('colors.grey.600');
 
-    @include more-contrast() {
+    @include mixin.more-contrast() {
       background-color: theme('colors.warning.75');
     }
   }
@@ -94,7 +96,7 @@
   top: 0;
 }
 
-@include media-breakpoint-up(sm) {
+@include mixin.media-breakpoint-up(sm) {
   .messages > ul > li {
     padding-inline-start: 1.6em;
     padding-inline-end: 3em;

--- a/client/scss/components/_modals.scss
+++ b/client/scss/components/_modals.scss
@@ -1,7 +1,9 @@
 $zindex-modal-background: 500;
 
+@use '../tools' as mixin;
+
 .fade {
-  @include transition(opacity 0.15s linear);
+  @include mixin.transition(opacity 0.15s linear);
   opacity: 0;
 
   &.in {
@@ -127,7 +129,7 @@ $zindex-modal-background: 500;
   }
 }
 
-@include media-breakpoint-up(sm) {
+@include mixin.media-breakpoint-up(sm) {
   .modal-dialog {
     margin-inline-end: theme('spacing.20');
     margin-inline-start: theme('spacing.20');
@@ -141,7 +143,7 @@ $zindex-modal-background: 500;
   }
 }
 
-@include media-breakpoint-up(xl) {
+@include mixin.media-breakpoint-up(xl) {
   .modal-dialog {
     margin-inline-end: auto;
     margin-inline-start: auto;

--- a/client/scss/components/_panel.scss
+++ b/client/scss/components/_panel.scss
@@ -1,13 +1,16 @@
 $header-icon-size: theme('spacing.4');
 $header-button-size: theme('spacing.6');
 
+@use '../tools' as mixin;
+@use '../settings' as variable;
+
 .w-panel {
   --header-gap: 0;
   margin-bottom: calc(
     theme('spacing.5') + theme('spacing.5') * var(--w-density-factor)
   );
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     --header-gap: theme('spacing.4');
   }
 
@@ -25,9 +28,9 @@ $header-button-size: theme('spacing.6');
   display: flex;
   align-items: center;
   margin-bottom: theme('spacing.[0.5]');
-  margin-inline-start: calc(-1 * #{$mobile-nice-padding});
+  margin-inline-start: calc(-1 * #{variable.$mobile-nice-padding});
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     margin-inline-start: calc(
       -1 * ((2 * $header-button-size) + var(--header-gap))
     );
@@ -48,7 +51,7 @@ $header-button-size: theme('spacing.6');
     cursor: pointer;
   }
 
-  @include media-breakpoint-up(md) {
+  @include mixin.media-breakpoint-up(md) {
     padding-inline-end: theme('spacing.5');
   }
 }
@@ -60,8 +63,8 @@ $header-button-size: theme('spacing.6');
 .w-panel__anchor,
 .w-panel__toggle,
 .w-panel__controls .button.button--icon {
-  @include show-focus-outline-inside();
-  @include more-contrast-interactive();
+  @include mixin.show-focus-outline-inside();
+  @include mixin.more-contrast-interactive();
   display: inline-grid;
   justify-content: center;
   align-content: center;
@@ -105,7 +108,7 @@ $header-button-size: theme('spacing.6');
 
 // The suffix anchor is intended for small viewports only.
 .w-panel__anchor--suffix {
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     display: none;
   }
 }
@@ -114,7 +117,7 @@ $header-button-size: theme('spacing.6');
 .w-panel__anchor--prefix {
   display: none;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     display: inline-grid;
   }
 }
@@ -152,14 +155,14 @@ $header-button-size: theme('spacing.6');
   margin-inline-end: calc(-1 * theme('spacing.8'));
   margin-inline-start: 0;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     margin: calc(-1 * theme('spacing.4'));
     margin-inline-start: 0;
   }
 }
 
 .w-panel__wrapper {
-  @include max-form-width();
+  @include mixin.max-form-width();
 }
 
 .w-panel--dashboard {
@@ -174,7 +177,7 @@ $header-button-size: theme('spacing.6');
     padding: theme('spacing.5');
     margin-inline-start: 0;
 
-    @include media-breakpoint-up(sm) {
+    @include mixin.media-breakpoint-up(sm) {
       margin-inline-start: calc(-1 * theme('spacing.5'));
     }
   }

--- a/client/scss/components/_preview-panel.scss
+++ b/client/scss/components/_preview-panel.scss
@@ -1,3 +1,6 @@
+@use '../tools' as mixin;
+@use '../../src/components/CommentApp/main.scss' as main-mixin;
+
 .w-preview {
   --w-preview-background-color: var(--w-color-white);
   --preview-width-ratio: min(
@@ -61,7 +64,7 @@
     margin-bottom: 1rem;
     padding-inline: 1rem;
 
-    @include more-contrast() {
+    @include mixin.more-contrast() {
       border-color: theme('colors.border-furniture-more-contrast');
     }
   }
@@ -84,19 +87,19 @@
     }
 
     &:focus-within:has(:focus-visible) {
-      @include focus-outline;
+      @include main-mixin.focus-outline;
     }
 
     .icon {
-      @include svg-icon(1rem);
+      @include mixin.svg-icon(1rem);
 
       &.icon-tablet-alt,
       &.icon-desktop {
-        @include svg-icon(1.25rem);
+        @include mixin.svg-icon(1.25rem);
       }
 
       &.icon-link-external {
-        @include svg-icon(0.9rem);
+        @include mixin.svg-icon(0.9rem);
       }
     }
   }

--- a/client/scss/components/_progressbar.scss
+++ b/client/scss/components/_progressbar.scss
@@ -1,3 +1,5 @@
+@use '../tools' as mixin;
+
 .progress {
   border-radius: 1.2em;
   background-color: theme('colors.surface-button-hover');
@@ -5,12 +7,12 @@
   opacity: 0;
 
   &.active {
-    @include transition(opacity 0.3s ease);
+    @include mixin.transition(opacity 0.3s ease);
     opacity: 1;
   }
 
   .bar {
-    @include transition(width 0.3s ease);
+    @include mixin.transition(width 0.3s ease);
     border-radius: 1.5em;
     overflow: hidden;
     text-align: end;

--- a/client/scss/components/_status-tag.scss
+++ b/client/scss/components/_status-tag.scss
@@ -1,4 +1,5 @@
 @use 'sass:color';
+@use '../settings' as variable;
 
 .w-status {
   border-radius: 2px;
@@ -15,7 +16,7 @@
   font-size: 0.8em;
   margin: 0 0.5em 0.5em;
   background: theme('colors.surface-page')
-    url('#{$images-root}bg-dark-diag.svg');
+    url('#{variable.$images-root}bg-dark-diag.svg');
 
   &.w-status--primary {
     color: theme('colors.text-meta');

--- a/client/scss/components/_summary.scss
+++ b/client/scss/components/_summary.scss
@@ -1,10 +1,12 @@
+@use '../tools' as mixin;
+
 .w-summary {
   color: theme('colors.text-link-default');
   margin-bottom: theme('spacing.3');
   padding-top: theme('spacing.1');
 
   .w-summary__list {
-    @include unlist();
+    @include mixin.unlist();
 
     display: flex;
     flex-wrap: wrap;
@@ -21,7 +23,7 @@
   }
 
   .icon {
-    @include svg-icon(1.375rem);
+    @include mixin.svg-icon(1.375rem);
     color: theme('colors.icon-primary');
   }
 

--- a/client/scss/components/_tag.scss
+++ b/client/scss/components/_tag.scss
@@ -1,4 +1,7 @@
 @use 'sass:map';
+@use '../tools' as mixin;
+@use '../settings' as variable;
+
 // free tagging tags from taggit
 .tag {
   border-radius: 2px;
@@ -15,7 +18,7 @@
     padding-inline-end: 0.5rem;
     width: 16px;
     height: 16px;
-    mask-image: url('#{$images-root}icons/tag.svg');
+    mask-image: url('#{variable.$images-root}icons/tag.svg');
     mask-repeat: no-repeat;
     transform: translateY(3px);
   }
@@ -37,8 +40,8 @@ a.tag:hover {
 
 .tagfilter {
   legend {
-    @include media-breakpoint-up(sm) {
-      @include column(2);
+    @include mixin.media-breakpoint-up(sm) {
+      @include mixin.column(2);
       padding-inline-start: 0;
     }
 

--- a/client/scss/components/_userbar.scss
+++ b/client/scss/components/_userbar.scss
@@ -1,6 +1,7 @@
 @use 'sass:map';
 @use 'sass:math';
 @use 'sass:string';
+@use '../tools' as mixin;
 
 // =============================================================================
 // Variables
@@ -54,7 +55,7 @@ $positions: (
   height: auto;
 
   &-icon {
-    @include svg-icon(2em);
+    @include mixin.svg-icon(2em);
   }
 }
 
@@ -185,7 +186,7 @@ $positions: (
     }
 
     &-icon {
-      @include svg-icon(1em, middle);
+      @include mixin.svg-icon(1em, middle);
       margin-inline-end: 0.5em;
       fill: currentColor;
       opacity: 0.4;

--- a/client/scss/components/_workflow-timeline.scss
+++ b/client/scss/components/_workflow-timeline.scss
@@ -1,10 +1,12 @@
+@use '../tools' as mixin;
+
 .workflow-timeline {
   @apply w-label-3;
   padding: 0;
   margin-top: theme('spacing.8');
   margin-bottom: theme('spacing.3');
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     margin-top: theme('spacing.10');
     margin-bottom: theme('spacing.10');
   }
@@ -67,7 +69,7 @@
   }
 
   &__footer-link {
-    @include transition(color 0.15s ease);
+    @include mixin.transition(color 0.15s ease);
     font-size: theme('fontSize.14');
     color: theme('colors.text-link-default');
     text-decoration: none;

--- a/client/scss/components/browser-message.scss
+++ b/client/scss/components/browser-message.scss
@@ -1,4 +1,6 @@
-@include media-breakpoint-up(sm) {
+@use '../tools' as mixin;
+
+@include mixin.media-breakpoint-up(sm) {
   .browsermessage {
     margin: 0 0 0 -150px;
   }

--- a/client/scss/components/forms/_drop-zone.scss
+++ b/client/scss/components/forms/_drop-zone.scss
@@ -1,8 +1,10 @@
+@use '../../settings' as variable;
+
 // file drop zones
 .drop-zone {
   border-radius: 5px;
   border: 2px dashed theme('colors.border-furniture');
-  padding: $mobile-nice-padding;
+  padding: variable.$mobile-nice-padding;
   background-color: theme('colors.surface-header');
   margin-bottom: 1em;
   text-align: center;

--- a/client/scss/components/forms/_error-message.scss
+++ b/client/scss/components/forms/_error-message.scss
@@ -1,4 +1,5 @@
 @use 'sass:map';
+@use '../../settings' as variable;
 
 .error-message {
   border: 1px solid transparent; // ensure visible separation in Windows High Contrast mode
@@ -13,7 +14,7 @@
     width: 1em;
     height: 1em;
     vertical-align: -10%;
-    mask-image: url('#{$images-root}icons/warning.svg');
+    mask-image: url('#{variable.$images-root}icons/warning.svg');
     background-color: currentColor;
   }
 }

--- a/client/scss/components/forms/_field-comment-control.scss
+++ b/client/scss/components/forms/_field-comment-control.scss
@@ -2,10 +2,12 @@
 $icon-size: theme('spacing.4');
 $button-padding: theme('spacing.2');
 
+@use '../../tools' as mixin;
+
 .w-field__comment-button {
   $root: &;
 
-  @include transition(opacity 0.2s ease);
+  @include mixin.transition(opacity 0.2s ease);
   position: absolute;
   color: theme('colors.text-button-outline-default');
   background: none;

--- a/client/scss/components/forms/_field-row.scss
+++ b/client/scss/components/forms/_field-row.scss
@@ -1,11 +1,13 @@
+@use '../../tools' as mixin;
+
 .w-field-row {
-  @include max-form-width();
+  @include mixin.max-form-width();
   gap: theme('spacing.5');
   // For mobile viewports, we attempt to display all items in the row side by side even if not at the desired size.
   display: flex;
   flex-wrap: wrap;
 
-  @include media-breakpoint-up(md) {
+  @include mixin.media-breakpoint-up(md) {
     display: grid;
     grid-auto-flow: column;
     // All columns will be the same size.
@@ -38,7 +40,7 @@
 
 // Each column will be as wide as its widest member.
 .w-field-row--max-content {
-  @include media-breakpoint-up(md) {
+  @include mixin.media-breakpoint-up(md) {
     grid-auto-columns: minmax(min-content, max-content);
   }
 }

--- a/client/scss/components/forms/_field-textoutput.scss
+++ b/client/scss/components/forms/_field-textoutput.scss
@@ -1,4 +1,6 @@
 @use 'sass:map';
+@use '../../settings' as variable;
+@use './input-base' as input-mixin;
 
 /**
  * A container for rendering human-readable field values in forms in a way
@@ -6,12 +8,12 @@
  */
 
 .w-field__textoutput {
-  @include input-base();
+  @include input-mixin.input-base();
   @apply w-body-text-large;
   background-color: theme('colors.surface-field-inactive');
   width: 100%;
   padding: theme('spacing.[1.5]') theme('spacing.5');
-  min-height: $text-input-height;
+  min-height: variable.$text-input-height;
   position: relative;
   overflow: hidden;
   overflow-wrap: break-word;

--- a/client/scss/components/forms/_field.scss
+++ b/client/scss/components/forms/_field.scss
@@ -1,4 +1,6 @@
 @use 'sass:map';
+@use '../../tools' as mixin;
+@use '../../settings' as variable;
 
 /**
  * The field component handles form fields’ layout and ancillary elements such as error messages and help text.
@@ -45,11 +47,11 @@
 }
 
 .w-field__wrapper {
-  @include max-form-width();
+  @include mixin.max-form-width();
   // This is primarily helpful to add margins between fields, but fields can often
   // be wrapped into groups (for example a row), so it’s safer to add a margin regardless
   // of what the next element is.
-  margin-bottom: $form-field-spacing;
+  margin-bottom: variable.$form-field-spacing;
 
   // Inside of listing tables we don't need margins because the table row will handle them.
   table.listing td & {
@@ -68,7 +70,7 @@
 
 .w-field__icon {
   $size: theme('spacing.4');
-  $offset: calc($text-input-height / 2 - $size / 2);
+  $offset: calc(variable.$text-input-height / 2 - $size / 2);
   width: $size;
   height: $size;
   color: theme('colors.icon-primary');
@@ -80,6 +82,6 @@
 
   + input {
     // Allows for a nice square around the icon.
-    padding-inline-start: $text-input-height;
+    padding-inline-start: variable.$text-input-height;
   }
 }

--- a/client/scss/components/forms/_form-width.scss
+++ b/client/scss/components/forms/_form-width.scss
@@ -1,8 +1,11 @@
+@use '../../tools' as mixin;
+@use '../../settings' as variable;
+
 .w-form-width {
-  @include max-form-width();
+  @include mixin.max-form-width();
 }
 
-@include media-breakpoint-up(md) {
+@include mixin.media-breakpoint-up(md) {
   .minimap-open {
     .w-form-width {
       max-width: theme('width.[4/5]');
@@ -32,7 +35,7 @@
 
 .fields {
   // Apply the desired form width for legacy `fields` container.
-  max-width: $max-form-width;
+  max-width: variable.$max-form-width;
 
   // Remove any spacing in legacy fields markup.
   > li {

--- a/client/scss/components/forms/_input-base.scss
+++ b/client/scss/components/forms/_input-base.scss
@@ -1,9 +1,11 @@
+@use '../../tools' as mixin;
+
 /**
  * Field styles reusable across **all** fields, including:
  * Text input, textarea, checkbox, radio, select, etc.
  */
 @mixin input-base() {
-  @include more-contrast-interactive();
+  @include mixin.more-contrast-interactive();
   appearance: none;
   border-radius: theme('borderRadius.DEFAULT');
   color: theme('colors.text-context');

--- a/client/scss/components/forms/_input-text.scss
+++ b/client/scss/components/forms/_input-text.scss
@@ -1,3 +1,6 @@
+@use '../../settings' as variable;
+@use './input-base' as input-mixin;
+
 // All HTML5 input types, with irrelevant ones commented out.
 // input[type="button"],
 // input[type="checkbox"],
@@ -22,11 +25,11 @@ input[type="time"],
 input[type="url"],
 input[type="week"],
 textarea {
-  @include input-base();
+  @include input-mixin.input-base();
   @apply w-body-text-large;
   width: 100%;
   padding: theme('spacing.[1.5]') theme('spacing.5');
-  min-height: $text-input-height;
+  min-height: variable.$text-input-height;
 }
 
 // Multiline text fields have larger top-bottom padding.

--- a/client/scss/components/forms/_nested-panel.scss
+++ b/client/scss/components/forms/_nested-panel.scss
@@ -1,6 +1,10 @@
+@use '../../tools' as mixin;
+@use '../../settings' as variable;
+
 $header-icon-size: theme('spacing.4');
 $icon-center-offset: 2px;
-$guide-line-bottom-margin: calc($form-field-spacing / 3);
+$guide-line-bottom-margin: calc(variable.$form-field-spacing / 3);
+
 
 /**
  * Panel styles shared between StreamField and InlinePanel,
@@ -11,20 +15,20 @@ $guide-line-bottom-margin: calc($form-field-spacing / 3);
 
 // Styles for the top-level panel, and any panel within.
 .w-panel--nested {
-  --nesting-indent: #{$nested-field-indent-sm};
+  --nesting-indent: #{variable.$nested-field-indent-sm};
 
-  @include media-breakpoint-up(sm) {
-    --nesting-indent: #{$nested-field-indent};
+  @include mixin.media-breakpoint-up(sm) {
+    --nesting-indent: #{variable.$nested-field-indent};
   }
 
   .w-panel__content {
-    @include guide-line-vertical();
+    @include mixin.guide-line-vertical();
     // Center the vertical line.
     margin-inline-start: calc(-1 * var(--nesting-indent));
     padding-inline-start: var(--nesting-indent);
     margin-bottom: $guide-line-bottom-margin;
 
-    @include media-breakpoint-up(sm) {
+    @include mixin.media-breakpoint-up(sm) {
       // Extra pixels for better alignment with center of icon.
       margin-inline-start: calc(
         -1 * var(--nesting-indent) + $icon-center-offset
@@ -40,7 +44,7 @@ $guide-line-bottom-margin: calc($form-field-spacing / 3);
   .w-field__wrapper {
     // Reduced field spacing for nested panels.
     // Using both padding and margin so the field guide line extends below.
-    padding-bottom: calc($form-field-spacing / 2);
+    padding-bottom: calc(variable.$form-field-spacing / 2);
     margin-bottom: $guide-line-bottom-margin;
   }
 }
@@ -48,13 +52,13 @@ $guide-line-bottom-margin: calc($form-field-spacing / 3);
 // Styles for nested panels at the top level only.
 .w-panel--nested:not(.w-panel .w-panel) {
   > .w-panel__content {
-    @include guide-line-vertical-stop();
+    @include mixin.guide-line-vertical-stop();
   }
 }
 
 // Styles for nested panels excluding the top level.
 .w-panel--nested .w-panel {
-  @include guide-line-nested();
+  @include mixin.guide-line-nested();
   margin-inline-start: var(--nesting-indent);
   margin-bottom: 0;
 
@@ -72,7 +76,7 @@ $guide-line-bottom-margin: calc($form-field-spacing / 3);
       calc(var(--w-direction-factor) * -1 * var(--nesting-indent))
     );
 
-    @include media-breakpoint-up(sm) {
+    @include mixin.media-breakpoint-up(sm) {
       transform: translateX(
         calc(var(--w-direction-factor) * theme('spacing.1'))
       );
@@ -80,7 +84,7 @@ $guide-line-bottom-margin: calc($form-field-spacing / 3);
   }
 
   .w-panel__divider {
-    @include guide-line-horizontal();
+    @include mixin.guide-line-horizontal();
     // Slightly nicer text alignment.
     margin-top: 1px;
   }

--- a/client/scss/components/forms/_radio-checkbox.scss
+++ b/client/scss/components/forms/_radio-checkbox.scss
@@ -1,4 +1,6 @@
 @use 'sass:math';
+@use '../../settings' as variable;
+@use './input-base' as input-mixin;
 
 // 24px input widget size.
 $size: 1.5rem;
@@ -9,7 +11,7 @@ $radio-checkbox-label-gap: theme('spacing.[2.5]');
 
 // Both input types are very similar in appearance and layout.
 @mixin radio-checkbox-base() {
-  @include input-base();
+  @include input-mixin.input-base();
   display: inline-block;
   position: relative;
   height: $size;
@@ -43,7 +45,7 @@ input[type='radio'] {
   border-radius: theme('borderRadius.full');
 
   &:checked::before {
-    mask-image: url('#{$images-root}icons/radio-full.svg');
+    mask-image: url('#{variable.$images-root}icons/radio-full.svg');
   }
 }
 
@@ -54,6 +56,6 @@ input[type='checkbox'] {
   vertical-align: bottom;
 
   &:checked::before {
-    mask-image: url('#{$images-root}icons/check.svg');
+    mask-image: url('#{variable.$images-root}icons/check.svg');
   }
 }

--- a/client/scss/components/forms/_required-mark.scss
+++ b/client/scss/components/forms/_required-mark.scss
@@ -1,8 +1,10 @@
+@use '../../tools' as mixin;
+
 .w-required-mark {
   color: theme('colors.text-error');
   margin-inline-start: 0.25ch;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     margin-inline-start: 0.5ch;
   }
 }

--- a/client/scss/components/forms/_select.scss
+++ b/client/scss/components/forms/_select.scss
@@ -1,7 +1,9 @@
 @use 'sass:map';
 @use 'sass:math';
+@use '../../settings' as variable;
+@use './input-base' as input-mixin;
 
-$select-size: $text-input-height;
+$select-size: variable.$text-input-height;
 $chevron-size: 0.375rem;
 $chevron-offset: math.div($select-size - $chevron-size, 2);
 
@@ -36,7 +38,7 @@ $chevron-offset: math.div($select-size - $chevron-size, 2);
 }
 
 select {
-  @include input-base();
+  @include input-mixin.input-base();
   @include select-arrow();
   @apply w-body-text-large;
   // Firefox workaround – Set a large line height (but smaller than min height) so the field’s text has enough top padding.

--- a/client/scss/components/forms/_tagit.scss
+++ b/client/scss/components/forms/_tagit.scss
@@ -1,5 +1,7 @@
+@use './input-base' as input-mixin;
+
 .tagit {
-  @include input-base();
+  @include input-mixin.input-base();
 
   input[type='text'] {
     min-height: 0;

--- a/client/scss/core.scss
+++ b/client/scss/core.scss
@@ -48,7 +48,7 @@ These are functions and mixins.
 * No CSS should be produced by these files.
 */
 
-@import 'tools';
+@use 'tools' as mixin;
 
 /* GENERIC
 This is for resets and other rules that affect large collections of bare elements.
@@ -59,15 +59,11 @@ This is for resets and other rules that affect large collections of bare element
 These are base styles for bare HTML elements.
 * Changes to them should be very rare.
 */
+@use 'elements/elements';
+@use 'elements/typography';
+@use 'elements/forms';
 
-// These inject Tailwind's base, component and utility styles and any styles registered by plugins of each layer.
-// Unused styles created within tailwinds layers won't be compiled into the compiled stylesheet
-// https://tailwindcss.com/docs/adding-custom-styles#using-css-and-layer
-@tailwind base;
-@tailwind components;
-@import 'elements/elements';
-@import 'elements/typography';
-@import 'elements/forms';
+
 
 /* COMPONENTS
 These are classes for components.
@@ -76,81 +72,81 @@ These are classes for components.
   which is the preferred pattern over housing them in the scss folder.
 */
 
-@import '../src/components/Transition/Transition';
-@import '../src/components/LoadingSpinner/LoadingSpinner';
-@import '../src/components/PublicationStatus/PublicationStatus';
-@import '../src/components/ComboBox/ComboBox';
-@import '../src/components/PageExplorer/PageExplorer';
-@import '../src/components/CommentApp/main';
+@use '../src/components/Transition/Transition';
+@use '../src/components/LoadingSpinner/LoadingSpinner';
+@use '../src/components/PublicationStatus/PublicationStatus';
+@use '../src/components/ComboBox/ComboBox';
+@use '../src/components/PageExplorer/PageExplorer';
+@use '../src/components/CommentApp/main';
 
-@import 'components/avatar';
-@import 'components/icons';
-@import 'components/forms/input-base';
-@import 'components/forms/input-text';
-@import 'components/forms/radio-checkbox';
-@import 'components/forms/select';
-@import 'components/forms/tagit';
-@import 'components/forms/radio-checkbox-multiple';
-@import 'components/forms/error-message';
-@import 'components/forms/required-mark';
-@import 'components/forms/help';
-@import 'components/forms/drop-zone';
-@import 'components/forms/daterange';
-@import 'components/forms/file';
-@import 'components/forms/publishing';
-@import 'components/forms/switch';
-@import 'components/forms/title';
-@import 'components/forms/field';
-@import 'components/forms/field-row';
-@import 'components/forms/field-comment-control';
-@import 'components/forms/field-textoutput';
-@import 'components/forms/form-width';
-@import 'components/forms/nested-panel';
-@import 'components/tabs';
-@import 'components/panel';
-@import 'components/dialog';
-@import 'components/dismissible';
-@import 'components/drilldown';
-@import 'components/dropdown';
-@import 'components/dropdown-button';
-@import 'components/help-block';
-@import 'components/button';
-@import 'components/keyboard-shortcuts';
-@import 'components/modals';
-@import 'components/chooser';
-@import 'components/tag';
-@import 'components/listing';
-@import 'components/filters';
-@import 'components/messages';
-@import 'components/messages.capability';
-@import 'components/messages.status';
-@import 'components/header';
-@import 'components/progressbar';
-@import 'components/summary';
-@import 'components/whats-new';
-@import 'components/grid.legacy';
-@import 'components/footer';
-@import 'components/loading-mask';
-@import 'components/human-readable-date';
-@import 'components/link.legacy';
-@import 'components/indicator';
-@import 'components/status-tag';
-@import 'components/skiplink';
-@import 'components/workflow-tasks';
-@import 'components/workflow-timeline';
-@import 'components/bulk_actions';
-@import 'components/preview-panel';
-@import 'components/preview-error';
-@import 'components/form-side';
-@import 'components/a11y-result';
-@import 'components/userbar';
-@import 'components/breadcrumbs';
-@import 'components/pill';
-@import 'components/ping';
-@import 'components/editing-sessions';
+@use 'components/avatar';
+@use 'components/icons';
+@use 'components/forms/input-base';
+@use 'components/forms/input-text';
+@use 'components/forms/radio-checkbox';
+@use 'components/forms/select';
+@use 'components/forms/tagit' as form-tagit;
+@use 'components/forms/radio-checkbox-multiple';
+@use 'components/forms/error-message';
+@use 'components/forms/required-mark';
+@use 'components/forms/help';
+@use 'components/forms/drop-zone';
+@use 'components/forms/daterange';
+@use 'components/forms/file';
+@use 'components/forms/publishing';
+@use 'components/forms/switch';
+@use 'components/forms/title';
+@use 'components/forms/field';
+@use 'components/forms/field-row';
+@use 'components/forms/field-comment-control';
+@use 'components/forms/field-textoutput';
+@use 'components/forms/form-width';
+@use 'components/forms/nested-panel';
+@use 'components/tabs';
+@use 'components/panel';
+@use 'components/dialog';
+@use 'components/dismissible';
+@use 'components/drilldown';
+@use 'components/dropdown';
+@use 'components/dropdown-button';
+@use 'components/help-block';
+@use 'components/button';
+@use 'components/keyboard-shortcuts';
+@use 'components/modals';
+@use 'components/chooser';
+@use 'components/tag';
+@use 'components/listing';
+@use 'components/filters';
+@use 'components/messages';
+@use 'components/messages.capability' as messages-capability;
+@use 'components/messages.status' as messages-status;
+@use 'components/header';
+@use 'components/progressbar';
+@use 'components/summary';
+@use 'components/whats-new';
+@use 'components/grid.legacy';
+@use 'components/footer';
+@use 'components/loading-mask';
+@use 'components/human-readable-date';
+@use 'components/link.legacy';
+@use 'components/indicator';
+@use 'components/status-tag';
+@use 'components/skiplink';
+@use 'components/workflow-tasks';
+@use 'components/workflow-timeline';
+@use 'components/bulk_actions';
+@use 'components/preview-panel';
+@use 'components/preview-error';
+@use 'components/form-side';
+@use 'components/a11y-result';
+@use 'components/userbar';
+@use 'components/breadcrumbs';
+@use 'components/pill';
+@use 'components/ping';
+@use 'components/editing-sessions';
 
-@import '../src/components/Sidebar/Sidebar';
-@import '../src/components/Minimap/Minimap';
+@use '../src/components/Sidebar/Sidebar';
+@use '../src/components/Minimap/Minimap';
 
 /* OVERRIDES
 These are classes that provide overrides.
@@ -158,29 +154,36 @@ These are classes that provide overrides.
 */
 
 // VENDOR: overrides of vendor styles.
-@import 'overrides/vendor.datetimepicker';
-@import 'overrides/vendor.handsontable';
-@import 'overrides/vendor.tagit';
-@import 'overrides/vendor.tippy';
+@use 'overrides/vendor.datetimepicker' as vendor-datetimepicker;
+@use 'overrides/vendor.handsontable' as vendor-handsontable;
+@use 'overrides/vendor.tagit' as vendor-tagit;
+@use 'overrides/vendor.tippy' as vendor-tippy;
 
 // UTILITIES: classes that do one simple thing.
-@import 'overrides/utilities.focus';
+@use 'overrides/utilities.focus' as utilities-focus;
 
 // Legacy utilities
-@import 'overrides/utilities.legacy';
-
-// TAILWIND: This is at the bottom so it can take precedence over other css classes
-@tailwind utilities;
+@use 'overrides/utilities.legacy' as utilities-legacy;
 
 /* Legacy layout-specific styles. Do not add new styles here. */
 
-@import 'layouts/404';
-@import 'layouts/compare-revisions';
-@import 'layouts/login';
-@import 'layouts/account';
-@import 'layouts/workflow-progress';
-@import 'layouts/report';
-@import 'layouts/add-multiple';
-@import 'layouts/chooser-duplicate-upload';
-@import 'layouts/focal-point-chooser';
-@import 'layouts/redirects';
+@use 'layouts/404' as layout-404;
+@use 'layouts/compare-revisions';
+@use 'layouts/login';
+@use 'layouts/account';
+@use 'layouts/workflow-progress';
+@use 'layouts/report';
+@use 'layouts/add-multiple';
+@use 'layouts/chooser-duplicate-upload';
+@use 'layouts/focal-point-chooser';
+@use 'layouts/redirects';
+
+// These inject Tailwind's base, component and utility styles and any styles registered by plugins of each layer.
+// Unused styles created within tailwinds layers won't be compiled into the compiled stylesheet
+// https://tailwindcss.com/docs/adding-custom-styles#using-css-and-layer
+
+@tailwind base;
+@tailwind components;
+
+// TAILWIND: This is at the bottom so it can take precedence over other css classes
+@tailwind utilities;

--- a/client/scss/core.scss
+++ b/client/scss/core.scss
@@ -41,7 +41,7 @@ These are variables, maps, and fonts.
 * No CSS should be produced by these files
 */
 
-@import 'settings';
+@use 'settings' as variable;
 
 /* TOOLS
 These are functions and mixins.

--- a/client/scss/elements/_forms.scss
+++ b/client/scss/elements/_forms.scss
@@ -1,4 +1,5 @@
 @use 'sass:map';
+@use '../tools' as mixin;
 // Legacy form reset styles. Avoid adding any new styles here.
 form {
   // Historically, Wagtail forms rendered all fields as list items.
@@ -28,7 +29,7 @@ input[type='button'],
 button {
   padding: 0 1em;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     &.button-small {
       height: 2em;
     }

--- a/client/scss/layouts/_404.scss
+++ b/client/scss/layouts/_404.scss
@@ -1,3 +1,5 @@
+@use '../tools' as mixin;
+
 .page404__bg {
   position: fixed;
   top: 0;
@@ -54,7 +56,7 @@ a.button.page404__button {
 }
 
 // MOBILE CHANGES:
-@include media-breakpoint-down(xs) {
+@include mixin.media-breakpoint-down(xs) {
   .page404__text-container {
     width: 400px;
   }

--- a/client/scss/layouts/_compare-revisions.scss
+++ b/client/scss/layouts/_compare-revisions.scss
@@ -3,13 +3,15 @@ $color-addition-light: var(--color-addition-light);
 $color-deletion-dark: var(--color-deletion-dark);
 $color-deletion-light: var(--color-deletion-light);
 
+@use '../tools' as mixin;
+
 .comparison {
   --color-addition-dark: #a6f3a6;
   --color-addition-light: #ebffeb;
   --color-deletion-dark: #f8cbcb;
   --color-deletion-light: #ffebeb;
 
-  @include dark-theme() {
+  @include mixin.dark-theme() {
     --color-addition-dark: #033a16;
     --color-addition-light: #045720;
     --color-deletion-dark: #67060c;

--- a/client/scss/layouts/_focal-point-chooser.scss
+++ b/client/scss/layouts/_focal-point-chooser.scss
@@ -1,9 +1,11 @@
+@use '../tools' as mixin;
+
 .focal-point-chooser {
   position: relative;
   margin-bottom: 20px;
 
   .current-focal-point-indicator {
-    @include transition(opacity 0.2s ease);
+    @include mixin.transition(opacity 0.2s ease);
     box-shadow: 1px 1px 10px 0 theme('colors.black-50');
     position: absolute;
     border: 3px solid theme('colors.border-button-outline-default');

--- a/client/scss/layouts/_login.scss
+++ b/client/scss/layouts/_login.scss
@@ -1,3 +1,5 @@
+@use '../tools' as mixin;
+
 @mixin login-fullscreen-background() {
   @at-root {
     :root {
@@ -41,7 +43,7 @@
     margin-bottom: theme('spacing.8');
 
     ul {
-      @include unlist();
+      @include mixin.unlist();
 
       li {
         border-radius: theme('borderRadius.sm');
@@ -62,7 +64,7 @@
     margin-bottom: 15vh; // should appear slightly above centre
     max-width: calc(theme('spacing.32') * 3.15);
 
-    @include media-breakpoint-up(sm) {
+    @include mixin.media-breakpoint-up(sm) {
       max-width: calc(theme('spacing.32') * 3.5);
       padding: theme('spacing.12') theme('spacing.14');
     }

--- a/client/scss/layouts/_report.scss
+++ b/client/scss/layouts/_report.scss
@@ -1,5 +1,7 @@
+@use '../tools' as mixin;
+
 .report {
-  @include nice-margin();
+  @include mixin.nice-margin();
   display: grid;
   grid-column-gap: theme('spacing.12');
 
@@ -22,7 +24,7 @@
     margin-inline-end: theme('spacing.3');
   }
 
-  @include media-breakpoint-down(md) {
+  @include mixin.media-breakpoint-down(md) {
     form {
       margin-bottom: theme('spacing.3');
     }

--- a/client/scss/overrides/_utilities.focus.scss
+++ b/client/scss/overrides/_utilities.focus.scss
@@ -1,10 +1,12 @@
+@use '../settings' as variable;
+
 // stylelint-disable declaration-no-important
 // Set global focus outline styles so they are consistent across the UI,
 // without individual components having to explicitly define focus styles.
 // Using !important because we want to enforce only one style is used across the UI.
 // Remove :focus selectors once we stop supporting Safari 15.4.
 *:focus {
-  outline: $focus-outline-width solid theme('colors.focus') !important;
+  outline: variable.$focus-outline-width solid theme('colors.focus') !important;
 }
 
 *:focus:not(:focus-visible) {
@@ -12,5 +14,5 @@
 }
 
 *:focus-visible {
-  outline: $focus-outline-width solid theme('colors.focus') !important;
+  outline: variable.$focus-outline-width solid theme('colors.focus') !important;
 }

--- a/client/scss/overrides/_utilities.legacy.scss
+++ b/client/scss/overrides/_utilities.legacy.scss
@@ -1,14 +1,17 @@
-.nice-padding {
-  padding-inline-start: $mobile-nice-padding;
-  padding-inline-end: $mobile-nice-padding;
+@use '../tools' as mixin;
+@use '../settings' as variable;
 
-  @include media-breakpoint-up(sm) {
-    padding-inline-start: $desktop-nice-padding;
-    padding-inline-end: $desktop-nice-padding;
+.nice-padding {
+  padding-inline-start: variable.$mobile-nice-padding;
+  padding-inline-end: variable.$mobile-nice-padding;
+
+  @include mixin.media-breakpoint-up(sm) {
+    padding-inline-start: variable.$desktop-nice-padding;
+    padding-inline-end: variable.$desktop-nice-padding;
   }
 }
 
 // Show a transparency grid in background
 .show-transparency {
-  background: url('#{$images-root}transparency.svg');
+  background: url('#{variable.$images-root}transparency.svg');
 }

--- a/client/scss/overrides/_vendor.datetimepicker.scss
+++ b/client/scss/overrides/_vendor.datetimepicker.scss
@@ -1,5 +1,6 @@
 // stylelint-disable selector-max-combinators, max-nesting-depth
 @use 'sass:map';
+@use '../settings' as variable;
 
 .xdsoft_datetimepicker {
   box-shadow: 0 5px 10px -5px theme('colors.black-35');
@@ -93,7 +94,7 @@
     float: inline-start;
 
     &:before {
-      mask-image: url('#{$images-root}icons/arrow-left.svg');
+      mask-image: url('#{variable.$images-root}icons/arrow-left.svg');
     }
   }
 
@@ -102,7 +103,7 @@
     margin-inline-start: 5px;
 
     &:before {
-      mask-image: url('#{$images-root}icons/home.svg');
+      mask-image: url('#{variable.$images-root}icons/home.svg');
     }
   }
 
@@ -110,7 +111,7 @@
     float: inline-end;
 
     &:before {
-      mask-image: url('#{$images-root}icons/arrow-right.svg');
+      mask-image: url('#{variable.$images-root}icons/arrow-right.svg');
     }
   }
 
@@ -132,11 +133,11 @@
     }
 
     .xdsoft_prev:before {
-      mask-image: url('#{$images-root}icons/arrow-up.svg');
+      mask-image: url('#{variable.$images-root}icons/arrow-up.svg');
     }
 
     .xdsoft_next:before {
-      mask-image: url('#{$images-root}icons/arrow-down.svg');
+      mask-image: url('#{variable.$images-root}icons/arrow-down.svg');
     }
 
     .xdsoft_time_box {

--- a/client/scss/overrides/_vendor.tagit.scss
+++ b/client/scss/overrides/_vendor.tagit.scss
@@ -1,4 +1,5 @@
 @use 'sass:map';
+@use '../settings' as variable;
 
 // taggit tagging
 .tagit {
@@ -79,7 +80,7 @@
     width: 16px;
     height: 16px;
     background: theme('colors.icon-secondary');
-    mask-image: url('#{$images-root}icons/cross.svg');
+    mask-image: url('#{variable.$images-root}icons/cross.svg');
     mask-repeat: no-repeat;
   }
 }

--- a/client/scss/overrides/_vendor.tippy.scss
+++ b/client/scss/overrides/_vendor.tippy.scss
@@ -1,5 +1,5 @@
 // stylelint-disable selector-attribute-name-disallowed-list
-@import '../../../node_modules/tippy.js/dist/tippy';
+@use '../../../node_modules/tippy.js/dist/tippy';
 
 .tippy-box {
   // Special font size 12px for tooltips

--- a/client/scss/tools/_functions.breakpoints.scss
+++ b/client/scss/tools/_functions.breakpoints.scss
@@ -1,5 +1,6 @@
 @use 'sass:list';
 @use 'sass:map';
+@use '../settings' as variable;
 // Based upon the fine work and thoughts from Bootstrap v4.
 // Copyright 2011-2018 The Bootstrap Authors
 // Copyright 2011-2018 Twitter, Inc.
@@ -9,7 +10,7 @@
 //    >> breakpoint-next(sm)
 //    md
 @function breakpoint-next($name) {
-  $breakpoint-names: map.keys($breakpoints);
+  $breakpoint-names: map.keys(variable.$breakpoints);
   $n: list.index($breakpoint-names, $name);
   @return if(
     $n < list.length($breakpoint-names),
@@ -22,7 +23,7 @@
 //    >> breakpoint-min(sm)
 //    50em
 @function breakpoint-min($name) {
-  $min: map.get($breakpoints, $name);
+  $min: map.get(variable.$breakpoints, $name);
   @return if($min != 0, $min, null);
 }
 

--- a/client/scss/tools/_mixins.general.scss
+++ b/client/scss/tools/_mixins.general.scss
@@ -4,6 +4,8 @@
 // Please note that the mixins partial shouldn't include any classes. This is so
 // it can be included in any file without accidentally producing output
 
+@use '../settings' as variable;
+
 // Turns on font-smoothing when used. Use sparingly.
 @mixin font-smoothing {
   -webkit-font-smoothing: antialiased;
@@ -75,7 +77,7 @@
 // Where included, show the focus outline within focusable items instead of around them.
 // This is useful when focusable items are tightly packed and there is no space in-between.
 @mixin show-focus-outline-inside {
-  outline-offset: -1 * $focus-outline-width;
+  outline-offset: -1 * variable.$focus-outline-width;
 }
 
 /**

--- a/client/scss/tools/_mixins.grid.scss
+++ b/client/scss/tools/_mixins.grid.scss
@@ -1,4 +1,7 @@
 @use 'sass:math';
+@use '../settings' as variable;
+@use '../tools/mixins.breakpoints' as mixin-breakpoints;
+@use '../tools/mixins.general' as mixin-general;
 
 // grid settings
 $grid-columns: 12;
@@ -9,7 +12,7 @@ $padding: math.div($grid-gutter-width, 2);
 
 // Our row container
 @mixin row($padding: 0) {
-  @include clearfix();
+  @include mixin-general.clearfix();
   display: block;
   margin-inline-end: auto;
   margin-inline-start: auto;
@@ -34,25 +37,25 @@ $padding: math.div($grid-gutter-width, 2);
 // only used in places where padding not applied to same elements as row or row-flush
 // most of the time this class should be applied directly to the html elements
 @mixin nice-padding {
-  padding-inline-start: $mobile-nice-padding;
-  padding-inline-end: $mobile-nice-padding;
+  padding-inline-start: variable.$mobile-nice-padding;
+  padding-inline-end: variable.$mobile-nice-padding;
 
-  @include media-breakpoint-up(sm) {
-    padding-inline-start: $desktop-nice-padding;
-    padding-inline-end: $desktop-nice-padding;
+  @include mixin-breakpoints.media-breakpoint-up(sm) {
+    padding-inline-start: variable.$desktop-nice-padding;
+    padding-inline-end: variable.$desktop-nice-padding;
   }
 }
 
 @mixin nice-margin {
-  margin-inline-start: $mobile-nice-padding;
-  margin-inline-end: $mobile-nice-padding;
+  margin-inline-start: variable.$mobile-nice-padding;
+  margin-inline-end: variable.$mobile-nice-padding;
 
-  @include media-breakpoint-up(sm) {
-    margin-inline-start: $desktop-nice-padding;
-    margin-inline-end: $desktop-nice-padding;
+  @include mixin-breakpoints.media-breakpoint-up(sm) {
+    margin-inline-start: variable.$desktop-nice-padding;
+    margin-inline-end: variable.$desktop-nice-padding;
   }
 }
 
 @mixin max-form-width {
-  max-width: $max-form-width;
+  max-width: variable.$max-form-width;
 }

--- a/client/src/components/ComboBox/ComboBox.scss
+++ b/client/src/components/ComboBox/ComboBox.scss
@@ -3,9 +3,11 @@
 $spacing: theme('spacing.[2.5]');
 $spacing-sm: theme('spacing.5');
 
+@use '../../../scss/tools' as mixin;
+
 .w-combobox {
   width: min(400px, 80vw);
-  @include dark-theme() {
+  @include mixin.dark-theme() {
     background-color: theme('colors.surface-tooltip');
   }
   background: theme('colors.surface-page');
@@ -20,7 +22,7 @@ $spacing-sm: theme('spacing.5');
   padding: $spacing;
   padding-bottom: 0;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     padding: $spacing-sm;
     padding-bottom: 0;
   }
@@ -47,7 +49,7 @@ $spacing-sm: theme('spacing.5');
   padding: $spacing;
   padding-top: 0;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     width: 400px;
     padding: $spacing-sm;
     padding-top: 0;
@@ -61,7 +63,7 @@ $spacing-sm: theme('spacing.5');
   font-size: 1rem;
   font-weight: 700;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     margin-bottom: $spacing-sm;
   }
 

--- a/client/src/components/CommentApp/components/Comment/style.scss
+++ b/client/src/components/CommentApp/components/Comment/style.scss
@@ -1,6 +1,8 @@
+@use '../../../../../scss/tools' as mixin;
+
 .comment {
   @include box;
-  @include more-contrast-interactive();
+  @include mixin.more-contrast-interactive();
 
   width: 300px;
   display: block;

--- a/client/src/components/CommentApp/components/CommentHeader/style.scss
+++ b/client/src/components/CommentApp/components/CommentHeader/style.scss
@@ -1,3 +1,5 @@
+@use '../../../../../scss/tools' as mixin;
+
 .comment-header {
   position: relative;
 
@@ -40,7 +42,7 @@
 
     > button,
     > details > summary {
-      @include more-contrast-interactive();
+      @include mixin.more-contrast-interactive();
       border-radius: theme('borderRadius.sm');
       list-style-type: none; // Hides triangle on Firefox
       width: 30px;

--- a/client/src/components/CommentApp/main.scss
+++ b/client/src/components/CommentApp/main.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/settings/variables';
+@use '../../../scss/settings/variables' as variable;
 
 $color-comment-separator: theme('colors.border-furniture');
 

--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -25,6 +25,10 @@ $draftail-block-hoverable-area-offset: 40px;
 
 $draftail-editor-font-family: theme('fontFamily.sans');
 
+@use '../../../scss/tools' as mixin;
+@use '../../../scss/settings' as variable;
+@use '../../../scss/components/forms/input-base' as input-mixin;
+
 @import '../../../../node_modules/draft-js/dist/Draft';
 @import '../../../../node_modules/draftail/src/index';
 
@@ -80,10 +84,10 @@ $draftail-editor-font-family: theme('fontFamily.sans');
   // Number used inside a `calc` function, which doesn’t support unitless zero.
   // stylelint-disable-next-line length-zero-no-unit
   --draftail-offset-inline-start: 0px;
-  @include input-base();
+  @include input-mixin.input-base();
 
   &--focus {
-    outline: $focus-outline-width solid theme('colors.focus');
+    outline: variable.$focus-outline-width solid theme('colors.focus');
   }
 }
 
@@ -110,13 +114,13 @@ $draftail-editor-font-family: theme('fontFamily.sans');
     color: $draftail-editor-text;
     top: calc(theme('spacing.slim-header') * 2);
 
-    @include media-breakpoint-up(sm) {
+    @include mixin.media-breakpoint-up(sm) {
       top: theme('spacing.slim-header');
     }
   }
 
   .Draftail-ToolbarButton--active {
-    @include light-theme() {
+    @include mixin.light-theme() {
       background-color: theme('colors.surface-header');
       border-color: theme('colors.border-furniture');
 
@@ -165,10 +169,10 @@ $draftail-editor-font-family: theme('fontFamily.sans');
   color: theme('colors.text-button-outline-default');
   width: $icon-size;
   height: $icon-size;
-  margin-inline-end: calc($nested-field-indent-sm - $icon-size / 2 - 2px);
+  margin-inline-end: calc(variable.$nested-field-indent-sm - $icon-size / 2 - 2px);
 
-  @include media-breakpoint-up(sm) {
-    margin-inline-end: calc($nested-field-indent - $icon-size / 2 - 2px);
+  @include mixin.media-breakpoint-up(sm) {
+    margin-inline-end: calc(variable.$nested-field-indent - $icon-size / 2 - 2px);
   }
 
   // Increase the hoverable area of the trigger button
@@ -220,7 +224,7 @@ $draftail-editor-font-family: theme('fontFamily.sans');
 }
 
 .Draftail-ToolbarButton {
-  @include more-contrast-interactive();
+  @include mixin.more-contrast-interactive();
   display: flex;
   align-items: center;
   justify-content: center;

--- a/client/src/components/Draftail/blocks/MediaBlock.scss
+++ b/client/src/components/Draftail/blocks/MediaBlock.scss
@@ -1,3 +1,5 @@
+@use '../../../../scss/tools' as mixin;
+
 .MediaBlock {
   display: inline-block;
   position: relative;
@@ -16,7 +18,7 @@
     pointer-events: none;
 
     .icon {
-      @include svg-icon();
+      @include mixin.svg-icon();
     }
   }
 

--- a/client/src/components/Minimap/CollapseAll.scss
+++ b/client/src/components/Minimap/CollapseAll.scss
@@ -1,5 +1,7 @@
+@use '../../../scss/tools' as mixin;
+
 .w-minimap__collapse-all {
-  @include more-contrast-interactive();
+  @include mixin.more-contrast-interactive();
   display: none;
   // Keep the icon at a stable position and reduce the amount of shifting of the button.
   min-width: 110px;
@@ -14,7 +16,7 @@
     background-color: theme('colors.surface-page');
   }
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     display: inline-flex;
   }
 

--- a/client/src/components/Minimap/Minimap.scss
+++ b/client/src/components/Minimap/Minimap.scss
@@ -6,6 +6,8 @@ $minimap-collapsed-width: 30px;
 $minimap-overflow: theme('spacing.2');
 $minimap-z-index: calc(theme('zIndex.header') - 20);
 
+@use '../../../scss/tools' as mixin;
+
 @import './CollapseAll';
 @import './MinimapItem';
 
@@ -22,7 +24,7 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
     calc(var(--w-direction-factor) * (100% - $minimap-collapsed-width-mobile))
   );
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     transform: translateX(
       calc(var(--w-direction-factor) * (100% - $minimap-collapsed-width))
     );
@@ -54,7 +56,7 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   color: theme('colors.icon-primary');
   transform: rotate(180deg);
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     margin-top: 18px;
     padding: theme('spacing.[1.5]');
   }

--- a/client/src/components/Minimap/MinimapItem.scss
+++ b/client/src/components/Minimap/MinimapItem.scss
@@ -1,3 +1,5 @@
+@use '../../../scss/tools' as mixin;
+
 .w-minimap-item {
   @apply w-label-3 w-outline-offset-inside;
   display: inline-flex;
@@ -8,7 +10,7 @@
   font-weight: theme('fontWeight.normal');
   border-inline-start: 1px solid transparent;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     padding-inline-start: theme('spacing.2');
     padding-inline-end: theme('spacing.2');
   }
@@ -36,7 +38,7 @@
       border-inline-start-width: 3px;
     }
 
-    @include more-contrast() {
+    @include mixin.more-contrast() {
       border-inline-start-width: 3px;
     }
   }

--- a/client/src/components/PageExplorer/PageExplorer.scss
+++ b/client/src/components/PageExplorer/PageExplorer.scss
@@ -3,8 +3,9 @@ $menu-footer-height: 50px;
 
 @use 'sass:map';
 @use '../../../scss/settings' as variable;
+@use '../../../scss/tools' as mixin;
 
-@import 'PageExplorerItem';
+@use 'PageExplorerItem';
 
 .c-page-explorer {
   @apply w-bg-surface-menu-item-active;
@@ -15,10 +16,10 @@ $menu-footer-height: 50px;
   flex: 1;
 
   *:focus {
-    @include show-focus-outline-inside;
+    @include mixin.show-focus-outline-inside;
   }
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     width: 485px;
     box-shadow: 2px 2px 5px $c-page-explorer-bg-active;
   }
@@ -47,7 +48,7 @@ $explorer-header-horizontal-padding: 10px;
   margin-inline-start: variable.$mobile-nav-indent;
   height: variable.$mobile-nav-indent;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     margin-inline-start: initial;
     height: initial;
   }
@@ -79,7 +80,7 @@ $explorer-header-horizontal-padding: 10px;
     vertical-align: text-top;
   }
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     padding: 1em 1.5em;
   }
 }
@@ -128,7 +129,7 @@ $explorer-header-horizontal-padding: 10px;
   padding: 1em;
   color: theme('colors.text-label-menus-default');
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     padding: 1em 1.75em;
   }
 }
@@ -149,11 +150,11 @@ $explorer-header-horizontal-padding: 10px;
     color: theme('colors.text-label-menus-active');
   }
 
-  @include hover {
+  @include mixin.hover {
     background: $c-page-explorer-bg-active;
   }
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     padding: 1em 1.75em;
     height: $menu-footer-height;
   }

--- a/client/src/components/PageExplorer/PageExplorer.scss
+++ b/client/src/components/PageExplorer/PageExplorer.scss
@@ -2,6 +2,7 @@ $c-page-explorer-bg-active: theme('colors.black-50');
 $menu-footer-height: 50px;
 
 @use 'sass:map';
+@use '../../../scss/settings' as variable;
 
 @import 'PageExplorerItem';
 
@@ -43,8 +44,8 @@ $explorer-header-horizontal-padding: 10px;
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;
-  margin-inline-start: $mobile-nav-indent;
-  height: $mobile-nav-indent;
+  margin-inline-start: variable.$mobile-nav-indent;
+  height: variable.$mobile-nav-indent;
 
   @include media-breakpoint-up(sm) {
     margin-inline-start: initial;

--- a/client/src/components/PageExplorer/PageExplorerItem.scss
+++ b/client/src/components/PageExplorer/PageExplorerItem.scss
@@ -1,3 +1,5 @@
+@use '../../../scss/tools' as mixin;
+
 .c-page-explorer__item {
   @apply w-flex w-flex-row w-flex-nowrap w-border-0 w-border-b w-border-solid w-border-surface-menus w-divide-x w-divide-solid w-divide-surface-menus w-divide-y-0;
 }
@@ -6,7 +8,7 @@
   @apply w-inline-flex w-items-start sm:w-items-center w-flex-wrap w-grow w-cursor-pointer w-gap-1 w-transition hover:w-bg-surface-menus focus:w-bg-surface-menus focus:w-text-text-label-menus-active hover:w-text-text-label-menus-active;
   padding: 1.45em 1em;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     padding: 1.45em 1.75em;
   }
 }

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -1,8 +1,17 @@
 $sidebar-toggle-spacing: 12px;
 $sidebar-toggle-size: 35px;
 
+@use '../../../scss/tools' as mixin;
+@use '../../../scss/settings' as variable;
+
+@use 'SidebarPanel';
+@use 'menu/MenuItem';
+@use 'menu/SubMenuItem';
+@use 'modules/MainMenu';
+@use 'modules/WagtailBranding';
+
 @mixin sidebar-toggle() {
-  @include transition(background-color $menu-transition-duration ease);
+  @include mixin.transition(background-color variable.$menu-transition-duration ease);
 
   position: absolute;
   top: $sidebar-toggle-spacing;
@@ -21,7 +30,7 @@ $sidebar-toggle-size: 35px;
     height: 16px;
   }
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     position: static;
     inset-inline-end: $sidebar-toggle-spacing;
     inset-inline-start: initial;
@@ -30,7 +39,7 @@ $sidebar-toggle-size: 35px;
   .has-messages & {
     top: $sidebar-toggle-spacing + 70px;
 
-    @include media-breakpoint-up(sm) {
+    @include mixin.media-breakpoint-up(sm) {
       top: $sidebar-toggle-spacing;
     }
   }
@@ -39,13 +48,13 @@ $sidebar-toggle-size: 35px;
 .sidebar,
 .sidebar-loading {
   @apply w-fixed w-flex w-flex-col w-h-full w-bg-surface-menus w-z-sidebar w-transition-sidebar;
-  width: $menu-width;
+  width: variable.$menu-width;
   inset-inline-start: 0;
 
   @media (forced-colors: active) {
     border-inline-end: 1px solid transparent;
   }
-  @include dark-theme-more-contrast() {
+  @include mixin.dark-theme-more-contrast() {
     border-inline-end: 1px solid theme('colors.border-furniture-more-contrast');
   }
 
@@ -58,12 +67,13 @@ $sidebar-toggle-size: 35px;
   }
 
   &--slim {
-    width: $menu-width-slim;
+    width: variable.$menu-width-slim;
   }
 
   // The sidebar can move completely off-screen in mobile mode for extra room
   &--hidden {
-    inset-inline-start: -$menu-width;
+    $neg-menu-width: -(variable.$menu-width);
+    inset-inline-start: $neg-menu-width;
   }
 
   // When sidebar is completely closed and animations have finished
@@ -88,7 +98,7 @@ $sidebar-toggle-size: 35px;
 }
 
 .sidebar-collapsed .sidebar-loading {
-  width: $menu-width-slim;
+  width: variable.$menu-width-slim;
 }
 
 // This is a separate component as it needs to display in the header
@@ -107,9 +117,4 @@ $sidebar-toggle-size: 35px;
   }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
-@import 'SidebarPanel';
-@import 'menu/MenuItem';
-@import 'menu/SubMenuItem';
-@import 'modules/MainMenu';
-@import 'modules/WagtailBranding';
+

--- a/client/src/components/Sidebar/SidebarPanel.scss
+++ b/client/src/components/Sidebar/SidebarPanel.scss
@@ -1,6 +1,9 @@
+@use '../../../scss/tools' as mixin;
+@use '../../../scss/settings' as variable;
+
 .sidebar-panel {
   // With CSS variable allows panels with different widths to animate properly
-  --width: #{$menu-width};
+  --width: #{variable.$menu-width};
   @apply w-transition-sidebar;
 
   visibility: hidden;
@@ -15,7 +18,7 @@
   flex-direction: column;
   overflow: hidden;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     z-index: var(--z-index);
     width: var(--width);
   }
@@ -36,9 +39,9 @@
     transform: translateX(0);
   }
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     @at-root .sidebar--slim #{&} {
-      inset-inline-start: $menu-width-slim;
+      inset-inline-start: variable.$menu-width-slim;
     }
     // Don't apply this to nested submenus though
     @at-root .sidebar--slim .sidebar-panel #{&} {
@@ -46,12 +49,12 @@
     }
 
     &--open {
-      inset-inline-start: $menu-width;
+      inset-inline-start: variable.$menu-width;
       transform: translateX(0);
 
       // Don't apply this to nested submenus though
       @at-root .sidebar--slim .sidebar-panel #{&} {
-        inset-inline-start: $menu-width-slim;
+        inset-inline-start: variable.$menu-width-slim;
         transform: translateX(0);
       }
     }

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -1,13 +1,16 @@
+@use '../../../../scss/tools' as mixin;
+@use '../../../../scss/settings' as variable;
+
 .sidebar-menu-item {
   $root: &;
-  @include transition(border-color $menu-transition-duration ease);
+  @include mixin.transition(border-color variable.$menu-transition-duration ease);
   position: relative;
 
   &__link {
     @apply w-text-14 w-leading-none w-transition;
-    @include transition(
-      border-color $menu-transition-duration ease,
-      background-color $menu-transition-duration ease
+    @include mixin.transition(
+      border-color variable.$menu-transition-duration ease,
+      background-color variable.$menu-transition-duration ease
     );
     position: relative;
     display: flex;
@@ -69,7 +72,7 @@
 }
 
 .menuitem-label {
-  @include transition(opacity $menu-transition-duration ease);
+  @include mixin.transition(opacity variable.$menu-transition-duration ease);
   margin-inline-start: 0.875rem;
   line-height: 1.25;
   text-overflow: ellipsis;

--- a/client/src/components/Sidebar/menu/SubMenuItem.scss
+++ b/client/src/components/Sidebar/menu/SubMenuItem.scss
@@ -1,10 +1,13 @@
+@use '../../../../scss/tools' as mixin;
+@use '../../../../scss/settings' as variable;
+
 .sidebar-sub-menu-trigger-icon {
   $root: &;
 
-  @include transition(
-    transform $menu-transition-duration ease,
-    width $menu-transition-duration ease,
-    height $menu-transition-duration ease
+  @include mixin.transition(
+    transform variable.$menu-transition-duration ease,
+    width variable.$menu-transition-duration ease,
+    height variable.$menu-transition-duration ease
   );
   display: block;
   width: 1rem;
@@ -27,11 +30,11 @@
 
 .sidebar-sub-menu-panel {
   @apply w-flex w-flex-col w-bg-surface-menu-item-active w-h-screen w-transition-sidebar;
-  width: $menu-width;
+  width: variable.$menu-width;
 
   > h2,
   &__list {
-    width: $menu-width;
+    width: variable.$menu-width;
   }
 
   > h2 {
@@ -40,7 +43,7 @@
   }
 
   ul > li {
-    @include transition(border-color $menu-transition-duration ease);
+    @include mixin.transition(border-color variable.$menu-transition-duration ease);
     position: relative;
   }
 
@@ -74,17 +77,17 @@
   }
 
   &--open {
-    transform: translate3d($menu-width, 0, 0);
+    transform: translate3d(variable.$menu-width, 0, 0);
 
     // If another submenu is opening, display this menu behind it
     z-index: -1;
 
     @at-root .sidebar--slim #{&} {
-      transform: translate3d($menu-width-slim, 0, 0);
+      transform: translate3d(variable.$menu-width-slim, 0, 0);
     }
     // Don't apply this to nested submenus though
     @at-root .sidebar--slim .sidebar-sub-menu-panel #{&} {
-      transform: translate3d($menu-width, 0, 0);
+      transform: translate3d(variable.$menu-width, 0, 0);
     }
   }
 }

--- a/client/src/components/Sidebar/modules/MainMenu.scss
+++ b/client/src/components/Sidebar/modules/MainMenu.scss
@@ -1,3 +1,6 @@
+@use '../../../../scss/tools' as mixin;
+@use '../../../../scss/settings' as variable;
+
 .sidebar-main-menu {
   overflow: auto;
   overflow-x: hidden;
@@ -9,7 +12,7 @@
   }
 
   *:focus {
-    @include show-focus-outline-inside;
+    @include mixin.show-focus-outline-inside;
   }
 
   .icon--submenu-header {
@@ -23,18 +26,18 @@
   > ul > li > a {
     // Need !important to override body.ready class
     // stylelint-disable-next-line declaration-no-important
-    transition: padding $menu-transition-duration ease !important;
+    transition: padding variable.$menu-transition-duration ease !important;
   }
 
   .menuitem-label {
-    transition: opacity $menu-transition-duration ease;
+    transition: opacity variable.$menu-transition-duration ease;
   }
 }
 
 .sidebar-footer {
   @apply w-bg-surface-menus w-mt-auto;
   // stylelint-disable-next-line declaration-no-important
-  transition: width $menu-transition-duration ease !important; // Override body.ready
+  transition: width variable.$menu-transition-duration ease !important; // Override body.ready
 
   > ul,
   ul > li {
@@ -48,7 +51,7 @@
   }
 
   > ul {
-    @include transition(max-height $menu-transition-duration ease);
+    @include mixin.transition(max-height variable.$menu-transition-duration ease);
     visibility: hidden;
 
     max-height: 0;
@@ -62,7 +65,7 @@
   }
 
   &__account {
-    @include show-focus-outline-inside();
+    @include mixin.show-focus-outline-inside();
 
     &-toggle {
       @apply w-pl-2 w-inline-flex w-justify-between w-w-full w-translate-x-0 w-transition w-duration-150;

--- a/client/src/components/Sidebar/modules/WagtailBranding.scss
+++ b/client/src/components/Sidebar/modules/WagtailBranding.scss
@@ -2,6 +2,9 @@
 
 $logo-size: 110px;
 
+@use '../../../../scss/tools' as mixin;
+@use '../../../../scss/settings' as variable;
+
 // Wagging animation
 @keyframes tail-wag {
   from {
@@ -25,18 +28,18 @@ $logo-size: 110px;
   height: $logo-size;
   transition:
     transform 150ms cubic-bezier(0.28, 0.15, 0, 2.1),
-    width $menu-transition-duration ease,
-    height $menu-transition-duration ease,
-    padding-top $menu-transition-duration ease;
+    width variable.$menu-transition-duration ease,
+    height variable.$menu-transition-duration ease,
+    padding-top variable.$menu-transition-duration ease;
   border-radius: 100%;
 
-  @include media-breakpoint-up(sm) {
+  @include mixin.media-breakpoint-up(sm) {
     margin-top: 0.5rem;
   }
 
   // Reduce overall size when in slim mode
   .sidebar--slim & {
-    @include show-focus-outline-inside();
+    @include mixin.show-focus-outline-inside();
     width: 40px;
     height: 110px;
   }
@@ -95,7 +98,7 @@ $logo-size: 110px;
   margin: 2em auto;
   text-align: center;
   padding: 10px 0;
-  transition: padding $menu-transition-duration ease;
+  transition: padding variable.$menu-transition-duration ease;
 
   &:hover {
     color: theme('colors.text-label-menus-active');

--- a/client/src/components/StreamField/StreamField.scss
+++ b/client/src/components/StreamField/StreamField.scss
@@ -1,4 +1,4 @@
-@import 'scss/components/c-sf-add-button';
+@use 'scss/components/c-sf-add-button';
 
 [aria-expanded='true'] + .w-panel__heading .c-sf-block__title {
   @apply w-sr-only;

--- a/client/storybook/preview.scss
+++ b/client/storybook/preview.scss
@@ -1,5 +1,5 @@
-@import '../scss/settings';
-@import '../scss/tools';
+@use '../scss/settings' as variable;
+@use '../scss/tools' as mixin;
 
 body {
   font-size: 1rem;
@@ -17,5 +17,5 @@ textarea {
 }
 
 .icon {
-  @include svg-icon();
+  @include mixin.svg-icon();
 }

--- a/wagtail/admin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/core.scss
@@ -1,1 +1,1 @@
-@import '../../../../../client/scss/core';
+@use '../../../../../client/scss/core';

--- a/wagtail/admin/static_src/wagtailadmin/scss/panels/draftail.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/panels/draftail.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../client/scss/settings';
-@import '../../../../../../client/scss/tools';
-@import '../../../../../../client/scss/components/forms/input-base';
+@use '../../../../../../client/scss/settings';
+@use '../../../../../../client/scss/tools';
+@use '../../../../../../client/scss/components/forms/input-base';
 @import '../../../../../../client/src/components/Draftail/Draftail';

--- a/wagtail/admin/static_src/wagtailadmin/scss/panels/streamfield.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/panels/streamfield.scss
@@ -1,3 +1,3 @@
-@import '../../../../../../client/scss/settings';
-@import '../../../../../../client/scss/tools';
-@import '../../../../../../client/src/components/StreamField/StreamField';
+@use '../../../../../../client/scss/settings';
+@use '../../../../../../client/scss/tools';
+@use '../../../../../../client/src/components/StreamField/StreamField';

--- a/wagtail/contrib/typed_table_block/static_src/typed_table_block/scss/typed_table_block.scss
+++ b/wagtail/contrib/typed_table_block/static_src/typed_table_block/scss/typed_table_block.scss
@@ -1,5 +1,5 @@
-@import '../../../../../../client/scss/settings';
-@import '../../../../../../client/scss/tools';
+@use '../../../../../../client/scss/settings';
+@use '../../../../../../client/scss/tools';
 
 .typed-table-block {
   // Layout is handled by the table markup.


### PR DESCRIPTION
Fixes #12729 

Migrated  Sass code to the @use module system, as @import is deprecated. 

Intially were are 44 warnings and now there are 36.

<details>
<summary>Click to see the screenshot</summary>

![image](https://github.com/user-attachments/assets/e0e0b48b-19ed-479e-8076-1aa827eb6e37)

</details>
