### PR TITLE
added char counter for the meta title and description

### DIFF
--- a/client/src/entrypoints/admin/seo_char_count.js
+++ b/client/src/entrypoints/admin/seo_char_count.js
@@ -1,27 +1,33 @@
-(function() {
+(function () {
     function updateCharCount(inputId) {
         const input = document.getElementById(inputId);
-        if (!input) return;
-
-        const label = document.querySelector('label[for="' + inputId + '"]');
-        if (!label) return;
-
-        function refreshLabel() {
-            const length = input.value.length;
-            const originalText = label.dataset.originalText || label.textContent;
-            if (!label.dataset.originalText) {
-                label.dataset.originalText = originalText;
-            }
-            label.textContent = `${label.dataset.originalText} (${length})`;
+        if (!input) {
+            return;
         }
 
-        // Update on load
+        const label = document.querySelector('label[for="' + inputId + '"]');
+        if (!label) {
+            return;
+        }
+
+        const originalText = label.textContent.trim();
+        if (!originalText) {
+            return;
+        }
+
+        const span = document.createElement('span');
+        span.setAttribute('aria-live', 'polite');
+        label.appendChild(span);
+
+        function refreshLabel() {
+            span.textContent = ` (${input.value.length})`;
+        }
+
         refreshLabel();
-        // Update as the user types
         input.addEventListener('input', refreshLabel);
     }
 
-    // Call for both fields
     updateCharCount('id_seo_title');
     updateCharCount('id_search_description');
 })();
+

--- a/client/src/entrypoints/admin/seo_char_count.js
+++ b/client/src/entrypoints/admin/seo_char_count.js
@@ -1,0 +1,27 @@
+(function() {
+    function updateCharCount(inputId) {
+        const input = document.getElementById(inputId);
+        if (!input) return;
+
+        const label = document.querySelector('label[for="' + inputId + '"]');
+        if (!label) return;
+
+        function refreshLabel() {
+            const length = input.value.length;
+            const originalText = label.dataset.originalText || label.textContent;
+            if (!label.dataset.originalText) {
+                label.dataset.originalText = originalText;
+            }
+            label.textContent = `${label.dataset.originalText} (${length})`;
+        }
+
+        // Update on load
+        refreshLabel();
+        // Update as the user types
+        input.addEventListener('input', refreshLabel);
+    }
+
+    // Call for both fields
+    updateCharCount('id_seo_title');
+    updateCharCount('id_search_description');
+})();

--- a/client/src/entrypoints/admin/seo_char_count.js
+++ b/client/src/entrypoints/admin/seo_char_count.js
@@ -1,33 +1,32 @@
 (function () {
-    function updateCharCount(inputId) {
-        const input = document.getElementById(inputId);
-        if (!input) {
-            return;
-        }
-
-        const label = document.querySelector('label[for="' + inputId + '"]');
-        if (!label) {
-            return;
-        }
-
-        const originalText = label.textContent.trim();
-        if (!originalText) {
-            return;
-        }
-
-        const span = document.createElement('span');
-        span.setAttribute('aria-live', 'polite');
-        label.appendChild(span);
-
-        function refreshLabel() {
-            span.textContent = ` (${input.value.length})`;
-        }
-
-        refreshLabel();
-        input.addEventListener('input', refreshLabel);
+  function updateCharCount(inputId) {
+    const input = document.getElementById(inputId);
+    if (!input) {
+      return;
     }
 
-    updateCharCount('id_seo_title');
-    updateCharCount('id_search_description');
-})();
+    const label = document.querySelector('label[for="' + inputId + '"]');
+    if (!label) {
+      return;
+    }
 
+    const originalText = label.textContent.trim();
+    if (!originalText) {
+      return;
+    }
+
+    const span = document.createElement('span');
+    span.setAttribute('aria-live', 'polite');
+    label.appendChild(span);
+
+    function refreshLabel() {
+      span.textContent = ` (${input.value.length})`;
+    }
+
+    refreshLabel();
+    input.addEventListener('input', refreshLabel);
+  }
+
+  updateCharCount('id_seo_title');
+  updateCharCount('id_search_description');
+})();

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -54,6 +54,7 @@ module.exports = function exports(env, argv) {
       'wagtailadmin',
       'workflow-action',
       'bulk-actions',
+      'seo_char_count',
     ],
     'images': [
       'image-chooser',

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -1207,3 +1207,11 @@ for action_class in [
     UnpublishBulkAction,
 ]:
     hooks.register("register_bulk_action", action_class)
+
+
+@hooks.register("insert_global_admin_js")
+def global_admin_js():
+    """
+    Adds the SEO character count JavaScript globally in the admin interface.
+    """
+    return '<script defer src="/static/wagtailadmin/js/seo_char_count.js"></script>'


### PR DESCRIPTION
This PR addresses an SEO pain point (#12446) that I’ve noticed frequently in my circles where Wagtail is used. When filling in the meta description or search description, users often want real-time feedback on the character count, as the recommended length is typically 60–70 characters.

What this PR does:

Adds a character counter to meta and search description fields in the Wagtail admin interface.
Future Considerations:

It could be beneficial to implement a similar counter for H1 titles or the main title field. However, since the main title doesn’t have a label in Wagtail CMS, this needs further discussion and consideration.
Feedback Needed:

I’m not 100% sure if the way I added the script to the admin interface is the best approach. If this implementation is not correct, feel free to reject the PR or suggest improvements.