### PR TITLE
Add a button to jump to the first navigation error

### DIFF
--- a/client/src/controllers/CloneController.ts
+++ b/client/src/controllers/CloneController.ts
@@ -159,4 +159,25 @@ export class CloneController extends Controller<HTMLElement> {
     const content = template.content.firstElementChild?.cloneNode(true);
     return content instanceof HTMLElement ? content : null;
   }
+
+  /**
+   * If called with an event, finds the first error item in the minimap,
+   * scrolls to it, and focuses on it and announces the action for screen readers.
+   */
+
+  jumpToError(event?: Event) {
+    event?.preventDefault();
+    const firstErrorItem = document.querySelector(
+      '.w-minimap-item--error',
+    ) as HTMLElement;
+
+    const anchor = firstErrorItem.getAttribute('href')!;
+    const targetElement = document.querySelector(anchor) as HTMLElement;
+
+    targetElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    if (!targetElement.hasAttribute('tabindex')) {
+      targetElement.setAttribute('tabindex', '-1');
+    }
+    targetElement.focus();
+  }
 }

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -835,9 +835,14 @@ class EditView(WagtailAdminTemplateMixin, HookResponseMixin, View):
                 self.request, _("The page could not be saved as it is locked")
             )
         else:
+            error_message = format_html(
+                '{} <span class="buttons"><button type="button" class="button button-small button-secondary" data-action="click->w-messages#jumpToError">{}</button></span>',
+                _("The page could not be saved due to validation errors."),
+                _("Jump to the Error"),
+            )
             messages.validation_error(
                 self.request,
-                _("The page could not be saved due to validation errors"),
+                error_message,
                 self.form,
             )
         self.errors_debug = repr(self.form.errors) + repr(


### PR DESCRIPTION
Fixes #12128 

This PR adds a "Jump to the Error" button in the error notification area, allowing users to quickly navigate to the first error.

Before:

![image](https://github.com/user-attachments/assets/a99a8606-517c-4153-8e2a-3a139eb2c8d2)



After:

https://github.com/user-attachments/assets/cd63d5fe-20ce-48f9-a882-2e3a8b21fdec

