### PR TITLE
Add created_at as a FilterField to enable sorting in Document search 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -46,6 +46,7 @@ Changelog
  * Fix: Fix crash when loading the dashboard with only the "unlock" or "bulk delete" page permissions (Unyime Emmanuel Udoh, Sage Abdullah)
  * Fix: Improve deprecation warning for `WidgetWithScript` by raising it with `stacklevel=3` (Joren Hammudoglu)
  * Fix: Correctly place comment buttons next to date / datetime / time fields. (Srishti Jaiswal)
+ * Fix: Add missing `FilterField("created_at")` to `AbstractDocument` to fix ordering by `created_at` after searching in the documents index view (Srishti Jaiswal)
  * Docs: Move the model reference page from reference/pages to the references section as it covers all Wagtail core models (Srishti Jaiswal)
  * Docs: Move the panels reference page from references/pages to the references section as panels are available for any model editing, merge panels API into this page (Srishti Jaiswal)
  * Docs: Move the tags documentation to standalone advanced topic, instead of being inside the reference/pages section (Srishti Jaiswal)

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -58,6 +58,7 @@ depth: 1
  * Fix crash when loading the dashboard with only the "unlock" or "bulk delete" page permissions (Unyime Emmanuel Udoh, Sage Abdullah)
  * Improve deprecation warning for `WidgetWithScript` by raising it with `stacklevel=3` (Joren Hammudoglu)
  * Correctly place comment buttons next to date / datetime / time fields. (Srishti Jaiswal)
+ * Add missing `FilterField("created_at")` to `AbstractDocument` to fix ordering by `created_at` after searching in the documents index view (Srishti Jaiswal)
 
 ### Documentation
 

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -57,6 +57,7 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
             ],
         ),
         index.FilterField("uploaded_by_user"),
+        index.FilterField("created_at"),
     ]
 
     def clean(self):


### PR DESCRIPTION
Fixes #12627 

There was a bug when sorting the documents by their creation date in the search results.

Before:

https://github.com/user-attachments/assets/30c9fe7d-f207-4226-8582-2bb1b9996d94

After:


https://github.com/user-attachments/assets/55b16bac-1832-4d9f-b882-705759a079c3

