### PR TITLE
Insert missing space into 6.3 release notes header

### DIFF
--- a/docs/releases/6.3.md
+++ b/docs/releases/6.3.md
@@ -216,7 +216,7 @@ If access to JSON translation strings within JavaScript is needed, use `window.w
 
 The upgrade notification panel can still be removed with the [`WAGTAIL_ENABLE_UPDATE_CHECK = False`](update_notifications) setting.
 
-### `SiteSummaryPanel` is no longer removable with `construct_homepage_panels`hook
+### `SiteSummaryPanel` is no longer removable with `construct_homepage_panels` hook
 
 The summary items can still be removed with the [`construct_homepage_summary_items`](construct_homepage_summary_items) hook.
 


### PR DESCRIPTION
No issue raised for this fix, which simply adds a missing space in a 6.3 Release notes header.
