### PR TITLE
Defer database lookups in permission_order.register(), to avoid Django runtime warning

### DIFF
--- a/wagtail/users/permission_order.py
+++ b/wagtail/users/permission_order.py
@@ -2,16 +2,37 @@ from django.contrib.contenttypes.models import ContentType
 
 from wagtail.coreutils import resolve_model_string
 
-CONTENT_TYPE_ORDER = {}
+
+class ContentTypeOrder:
+    def __init__(self):
+        self.model_order = {}
+        self.content_type_order = {}
+        self.valid = False
+
+    def register(self, model, **kwargs):
+        """
+        Registers order against the model content_type, used to
+        control the order the models and its permissions appear
+        in the groups object permission editor
+        """
+        order = kwargs.pop("order", None)
+        if order is not None:
+            self.model_order[resolve_model_string(model)] = order
+            self.valid = False
+
+    def get(self, content_type, default=None):
+        if not self.valid:
+            self.content_type_order = {
+                ContentType.objects.get_for_model(model).id: order
+                for model, order in self.model_order.items()
+            }
+            self.valid = True
+
+        return self.content_type_order.get(content_type, default)
+
+
+content_type_order = ContentTypeOrder()
 
 
 def register(model, **kwargs):
-    """
-    Registers order against the model content_type, used to
-    control the order the models and its permissions appear
-    in the groups object permission editor
-    """
-    order = kwargs.pop("order", None)
-    if order is not None:
-        content_type = ContentType.objects.get_for_model(resolve_model_string(model))
-        CONTENT_TYPE_ORDER[content_type.id] = order
+    content_type_order.register(model, **kwargs)

--- a/wagtail/users/templatetags/wagtailusers_tags.py
+++ b/wagtail/users/templatetags/wagtailusers_tags.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext_noop
 from wagtail import hooks
 from wagtail.admin.models import Admin
 from wagtail.coreutils import accepts_kwarg
-from wagtail.users.permission_order import CONTENT_TYPE_ORDER
+from wagtail.users.permission_order import content_type_order
 from wagtail.utils.deprecation import RemovedInWagtail70Warning
 
 register = template.Library()
@@ -98,7 +98,7 @@ def format_permissions(permission_bound_field):
     # from the queryset, and the stability of sorted().
     content_type_ids = sorted(
         dict.fromkeys(permissions.values_list("content_type_id", flat=True)),
-        key=lambda ct: CONTENT_TYPE_ORDER.get(ct, float("inf")),
+        key=lambda ct: content_type_order.get(ct, float("inf")),
     )
 
     # iterate over permission_bound_field to build a lookup of individual renderable


### PR DESCRIPTION
Fixes #12742.

This PR retains the ability to register the permissions order from within an `AppConfig.ready()` method, but defers the content type lookup until the group view is requested. This avoids the Django >=5.0 runtime warning.

My initial implementation was simpler than this, using module-level functions and the `functools.cache` decorator for efficiency. However, this did not play nicely with the corresponding tests which change the permissions order without a module reload. I therefore implemented a simple cache mechanism within a new `ContentTypeOrder` class.

Once accepted, it would be good to backport this to 6.3 LTS.
