### PR TITLE
Avoid loading icons sprite and JS files in 404 page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Set content security policy (CSP) headers to block embedded content when serving images and documents (Jake Howard, with thanks to Ali İltizar for the initial report)
  * Add `page` as a third parameter to the `construct_wagtail_userbar` hook (claudobahn)
  * Enable breadcrumbs in revisions compare view (Sage Abdullah)
+ * Skip loading of unused JavaScript to speed up 404 page rendering (Sage Abdullah)
  * Fix: Improve handling of translations for bulk page action confirmation messages (Matt Westcott)
  * Fix: Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
  * Fix: Ensure manual edits to `StreamField` values do not throw an error (Stefan Hammer)

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -28,6 +28,7 @@ depth: 1
  * Set content security policy (CSP) headers to block embedded content when serving images and documents (Jake Howard, with thanks to Ali İltizar for the initial report)
  * Add `page` as a third parameter to the [`construct_wagtail_userbar`](construct_wagtail_userbar) hook (claudobahn)
  * Enable breadcrumbs in revisions compare view (Sage Abdullah)
+ * Skip loading of unused JavaScript to speed up 404 page rendering (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/404.html
+++ b/wagtail/admin/templates/wagtailadmin/404.html
@@ -2,6 +2,10 @@
 {% load wagtailadmin_tags wagtailcore_tags i18n %}
 {% block titletag %}{% trans "Error 404: Page not found" %}{% endblock %}
 
+{# Avoid loading all of Wagtail’s icons sprite and JavaScript as they're unused here. #}
+{% block icons_sprite %}{% endblock %}
+{% block js %}{% endblock %}
+
 {% block furniture %}
     <main class="page404__bg">
         <div class="w-w-full w-h-full w-max-w-6xl w-mx-auto w-flex w-items-center w-justify-center">

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -508,6 +508,9 @@ class Test404(WagtailTestUtils, TestCase):
             # Check 404 error after CommonMiddleware redirect
             self.assertEqual(response.status_code, 404)
             self.assertTemplateUsed(response, "wagtailadmin/404.html")
+            soup = self.get_soup(response.content)
+            self.assertFalse(soup.select("script"))
+            self.assertFalse(soup.select("[data-sprite]"))
 
     def test_not_logged_in_redirect(self):
         response = self.client.get("/admin/sdfgdsfgdsfgsdf/")


### PR DESCRIPTION
Part of #12578.