### PR TITLE
Purge frontend cache when a page is moved or its slug is changed

### DIFF
--- a/docs/reference/signals.md
+++ b/docs/reference/signals.md
@@ -88,6 +88,8 @@ The following arguments are emitted for both signals:
 -   `url_path_after` - The value of `instance.url_path` **after** moving.
 -   `kwargs` - Any other arguments passed to `pre_page_move.send()` or `post_page_move.send()`.
 
+Additionally, `post_page_move` receives `instance_before`, which is the specific `Page` instance from before the move (as passed as `instance` to `pre_page_move`).
+
 ### Distinguishing between a 'move' and a 'reorder'
 
 The signal can be emitted as a result of a page being moved to a different section (a 'move'), or as a result of a page being moved to a different position within the same section (a 'reorder'). Knowing the difference between the two can be particularly useful, because only a 'move' affects a page's URL (and that of its descendants), whereas a 'reorder' only affects the natural page order; which is probably less impactful.

--- a/wagtail/actions/move_page.py
+++ b/wagtail/actions/move_page.py
@@ -76,6 +76,7 @@ class MovePageAction:
             parent_page_after=parent_after,
             url_path_before=old_url_path,
             url_path_after=new_url_path,
+            instance_before=page,
         )
 
         # Log

--- a/wagtail/admin/tests/pages/test_move_page.py
+++ b/wagtail/admin/tests/pages/test_move_page.py
@@ -173,6 +173,7 @@ class TestPageMove(WagtailTestUtils, TestCase):
             parent_page_after=self.section_b,
             url_path_before="/home/section-a/hello-world/",
             url_path_after="/home/section-b/hello-world/",
+            instance_before=Page.objects.get(pk=self.test_page_a.pk).specific,
         )
 
     def test_before_move_page_hook(self):

--- a/wagtail/contrib/frontend_cache/signal_handlers.py
+++ b/wagtail/contrib/frontend_cache/signal_handlers.py
@@ -1,15 +1,29 @@
 from django.apps import apps
 
-from wagtail.contrib.frontend_cache.utils import purge_page_from_cache
-from wagtail.signals import page_published, page_unpublished
+from wagtail.contrib.frontend_cache.utils import purge_pages_from_cache
+from wagtail.signals import (
+    page_published,
+    page_slug_changed,
+    page_unpublished,
+    post_page_move,
+)
 
 
 def page_published_signal_handler(instance, **kwargs):
-    purge_page_from_cache(instance)
+    purge_pages_from_cache([instance])
 
 
 def page_unpublished_signal_handler(instance, **kwargs):
-    purge_page_from_cache(instance)
+    purge_pages_from_cache([instance])
+
+
+def page_slug_changed_signal_handler(instance, instance_before, **kwargs):
+    purge_pages_from_cache([instance, instance_before])
+
+
+def post_page_move_signal_handler(instance, instance_before, **kwargs):
+    # Purge the page's new and old URLs
+    purge_pages_from_cache([instance, instance_before])
 
 
 def register_signal_handlers():
@@ -21,3 +35,5 @@ def register_signal_handlers():
     for model in indexed_models:
         page_published.connect(page_published_signal_handler, sender=model)
         page_unpublished.connect(page_unpublished_signal_handler, sender=model)
+        page_slug_changed.connect(page_slug_changed_signal_handler, sender=model)
+        post_page_move.connect(post_page_move_signal_handler, sender=model)

--- a/wagtail/contrib/redirects/tests/test_signal_handlers.py
+++ b/wagtail/contrib/redirects/tests/test_signal_handlers.py
@@ -93,13 +93,16 @@ class TestAutocreateRedirects(WagtailTestUtils, TestCase):
                 "http://localhost/events/final-event",
                 "http://localhost/events/christmas",
                 "http://localhost/events",
+                "http://localhost/events/",
+                "http://localhost/events-extra/",
+                "http://localhost/events-extra/past/",
+                "http://localhost/events/past/",
             },
         )
 
     def test_no_redirects_created_when_page_is_root_for_all_sites_it_belongs_to(self):
         self.trigger_page_slug_changed_signal(self.home_page)
         self.assertFalse(Redirect.objects.exists())
-        self.assertEqual(len(PURGED_URLS), 0)
 
     def test_handling_of_existing_redirects(self):
         # the page we'll be triggering the change for here is...
@@ -159,6 +162,10 @@ class TestAutocreateRedirects(WagtailTestUtils, TestCase):
                 "http://localhost/events/final-event",
                 "http://localhost/events/christmas",
                 "http://localhost/events",
+                "http://localhost/events/",
+                "http://localhost/events-extra/",
+                "http://localhost/events/past/",
+                "http://localhost/events-extra/past/",
             },
         )
 
@@ -200,6 +207,8 @@ class TestAutocreateRedirects(WagtailTestUtils, TestCase):
             PURGED_URLS,
             {
                 "http://localhost/routable-page",
+                "http://localhost/routable-page/",
+                "http://localhost/events/routable-page/",
                 "http://localhost/routable-page/not-a-valid-route",
                 "http://localhost/routable-page/render-method-test",
             },
@@ -226,10 +235,8 @@ class TestAutocreateRedirects(WagtailTestUtils, TestCase):
 
         # No redirects should have been created
         self.assertFalse(Redirect.objects.exists())
-        self.assertEqual(len(PURGED_URLS), 0)
 
     @override_settings(WAGTAILREDIRECTS_AUTO_CREATE=False)
     def test_no_redirects_created_if_disabled(self):
         self.trigger_page_slug_changed_signal(self.event_index)
         self.assertFalse(Redirect.objects.exists())
-        self.assertEqual(len(PURGED_URLS), 0)

--- a/wagtail/signals.py
+++ b/wagtail/signals.py
@@ -23,7 +23,7 @@ page_slug_changed = Signal()
 # provides args: instance, parent_page_before, parent_page_after, url_path_before, url_path_after
 pre_page_move = Signal()
 
-# provides args: instance, parent_page_before, parent_page_after, url_path_before, url_path_after
+# provides args: instance, parent_page_before, parent_page_after, url_path_before, url_path_after, instance_before
 post_page_move = Signal()
 
 


### PR DESCRIPTION
Currently, if a page is moved, or the slug is changed, the cache isn't necessarily cleared. This PR purges both the new location and the previous to avoid stale caches.
