### PR TITLE
fix `stacklevel`  in the `warn` call in  `WidgetWithScript`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ Changelog
  * Fix: Add `aria-expanded` attribute to new column button on `TypedTableBlock` to reflect menu state (Ayaan Qadri, Scott Cranfill)
  * Fix: Allow page models to extend base `Page` panel definitions without importing `wagtail.admin` (Matt Westcott)
  * Fix: Fix crash when loading the dashboard with only the "unlock" or "bulk delete" page permissions (Unyime Emmanuel Udoh, Sage Abdullah)
+ * Fix: Improve deprecation warning for `WidgetWithScript` by raising it with `stacklevel=3` (Joren Hammudoglu)
  * Docs: Move the model reference page from reference/pages to the references section as it covers all Wagtail core models (Srishti Jaiswal)
  * Docs: Move the panels reference page from references/pages to the references section as panels are available for any model editing, merge panels API into this page (Srishti Jaiswal)
  * Docs: Move the tags documentation to standalone advanced topic, instead of being inside the reference/pages section (Srishti Jaiswal)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -864,6 +864,7 @@
 * Guilhem Saurel
 * James Harrington
 * Unyime Emmanuel Udoh
+* Joren Hammudoglu
 
 ## Translators
 

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -55,6 +55,7 @@ depth: 1
  * Add `aria-expanded` attribute to new column button on `TypedTableBlock` to reflect menu state (Ayaan Qadri, Scott Cranfill)
  * Allow page models to extend base `Page` panel definitions without importing `wagtail.admin` (Matt Westcott)
  * Fix crash when loading the dashboard with only the "unlock" or "bulk delete" page permissions (Unyime Emmanuel Udoh, Sage Abdullah)
+ * Improve deprecation warning for `WidgetWithScript` by raising it with `stacklevel=3` (Joren Hammudoglu)
 
 ### Documentation
 

--- a/wagtail/tests/test_utils.py
+++ b/wagtail/tests/test_utils.py
@@ -1,6 +1,7 @@
 import hashlib
 import pickle
 import unittest
+import warnings
 from io import BytesIO
 from pathlib import Path
 
@@ -27,6 +28,7 @@ from wagtail.coreutils import (
     string_to_ascii,
 )
 from wagtail.models import Page, Site
+from wagtail.utils.deprecation import RemovedInWagtail70Warning
 from wagtail.utils.file import hash_filelike
 from wagtail.utils.utils import deep_update, flatten_choices
 from wagtail.utils.version import get_main_version
@@ -615,4 +617,24 @@ class TestFlattenChoices(SimpleTestCase):
                 "tennis": "Tennis",
                 "unknown": "Unknown",
             },
+        )
+
+
+class TestWidgetWithScript(TestCase):
+    def test_deprecation(self):
+        message = "The usage of `WidgetWithScript` hook is deprecated. Use external scripts instead."
+
+        with unittest.mock.patch("warnings.warn", wraps=warnings.warn) as warn_mock:
+            with self.assertWarnsMessage(RemovedInWagtail70Warning, message):
+                from wagtail.utils.widgets import WidgetWithScript
+
+                class MyWidget(WidgetWithScript):
+                    pass
+
+        # Make sure warn was called with stacklevel=3, so the actual caller
+        # that imports WidgetWithScript is shown in the warning message
+        warn_mock.assert_called_with(
+            message,
+            category=RemovedInWagtail70Warning,
+            stacklevel=3,
         )

--- a/wagtail/utils/widgets.py
+++ b/wagtail/utils/widgets.py
@@ -10,6 +10,7 @@ class WidgetWithScript(Widget):
     warn(
         "The usage of `WidgetWithScript` hook is deprecated. Use external scripts instead.",
         category=RemovedInWagtail70Warning,
+        stacklevel=3,
     )
 
     def render_html(self, name, value, attrs):


### PR DESCRIPTION
I currently see the following warning

```
[...]/wagtail/utils/widgets.py:10: RemovedInWagtail70Warning: The usage of `WidgetWithScript` hook is deprecated. Use external scripts instead.
  warn(
```

The warning is triggered by one of the many 3rd party libraries that are installed; but this doesn't tell me which one. 

By setting the `stacklevel` kwarg to `2` (it's `1` by default), the location of the actual caller will be displayed, instead of the location of where the warning itself is issued (the current situation).