### PR TITLE
Prevent main menu from re-rendering when clicking outside while the menu is closed

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changelog
  * Add support for specifying an operator on `Fuzzy` queries (Tom Usher)
  * Remove support for Safari 15 (Thibaud Colas)
  * Populate the ImageBlock alt text from the image’s default alt text when selecting a new image (Matt Westcott)
+ * Prevent main menu from re-rendering when clicking outside while the menu is closed (Sage Abdullah)
  * Fix: Improve handling of translations for bulk page action confirmation messages (Matt Westcott)
  * Fix: Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
  * Fix: Ensure manual edits to `StreamField` values do not throw an error (Stefan Hammer)

--- a/client/src/components/Sidebar/modules/MainMenu.tsx
+++ b/client/src/components/Sidebar/modules/MainMenu.tsx
@@ -239,7 +239,7 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
       const sidebar = document.querySelector('[data-wagtail-sidebar]');
 
       const isInside = sidebar && sidebar.contains(e.target as Node);
-      if (!isInside) {
+      if (!isInside && state.navigationPath !== '') {
         dispatch({
           type: 'set-navigation-path',
           path: '',
@@ -256,7 +256,7 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
       document.removeEventListener('mousedown', onClickOutside);
       document.removeEventListener('touchend', onClickOutside);
     };
-  }, []);
+  }, [state.navigationPath]);
 
   const onClickAccountSettings = () => {
     // Pass account expand information to Sidebar component

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -48,6 +48,7 @@ This feature was developed by Jake Howard.
  * Add support for specifying an operator on `Fuzzy` queries (Tom Usher)
  * Remove support for Safari 15 (Thibaud Colas)
  * Populate the ImageBlock alt text from the image’s default alt text when selecting a new image (Matt Westcott)
+ * Prevent main menu from re-rendering when clicking outside while the menu is closed (Sage Abdullah)
 
 ### Bug fixes
 


### PR DESCRIPTION
Fixes #12703.



## With menu interaction

### Before

https://github.com/user-attachments/assets/889835ad-b872-4d0c-8921-3b14e1990e0d

### After

https://github.com/user-attachments/assets/22504c93-9379-4891-b81a-f5c6ef7d9974

## Without menu interaction

### Before

https://github.com/user-attachments/assets/ca8cf9cd-dac4-451c-8e70-12bd024d1e39

### After

https://github.com/user-attachments/assets/71d14857-5eea-45e6-ba88-89434350b371

