### PR TITLE
added scroll offset in bottom to give better typing experience wheb t…

### DIFF
--- a/client/scss/components/_grid.legacy.scss
+++ b/client/scss/components/_grid.legacy.scss
@@ -24,6 +24,8 @@
 
   @include media-breakpoint-up(sm) {
     scroll-padding-top: calc(theme('spacing.slim-header') + $gap);
+    // Increase the scroll offset to account for pages with sticky bottom button
+    scroll-padding-bottom: 100px;
   }
 }
 


### PR DESCRIPTION
### RichText Editor Scroll Improvement

Fixes #7777

This update improves the RichText editor by adding a `bottom scroll offset`.
The offset ensures that the typing area remains visible and avoids being obstructed by the sticky “Publish” button on `Desktop` devices.
