### PR TITLE
Update example for customizing "p-as-heading" check

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changelog
 
 * Fix: Correctly place comment buttons next to date / datetime / time fields. (Srishti Jaiswal)
 * Fix: Reduce confusing spacing below StreamField blocks help text (Rishabh Sharma)
+* Docs: Update example for customizing "p-as-heading" accessibility check without overriding built-in checks (Cynthia Kiser)
 
 6.4 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~
@@ -86,6 +87,7 @@ Changelog
  * Docs: Fix Django HTML syntax formatting issue on the documents overview page (LB (Ben) Johnston)
  * Docs: Separate virtual environment creation and activation steps in tutorial (Ankit Kumar)
  * Docs: Update tutorial to use plain strings in place of `FieldPanel` / `InlinePanel` where appropriate (Unyime Emmanuel Udoh)
+ * Docs: Update example for customizing "p-as-heading" accessibility check without overriding built-in checks (Cynthia Kiser)
  * Maintenance: Close open files when reading within utils/setup.py (Ataf Fazledin Ahamed)
  * Maintenance: Avoid redundant `ALLOWED_HOSTS` check in `Site.find_for_request` (Jake Howard)
  * Maintenance: Update `CloneController` to ensure that `added`/`cleared` events are not dispatched as cancelable (LB (Ben) Johnston)

--- a/docs/advanced_topics/accessibility_considerations.md
+++ b/docs/advanced_topics/accessibility_considerations.md
@@ -153,19 +153,22 @@ from wagtail.admin.userbar import AccessibilityItem
 
 
 class CustomAccessibilityItem(AccessibilityItem):
-    axe_custom_checks = [
-        {
-	    # Flag heading-like paragraphs based only on font weight compared to surroundings.
-            "id": "p-as-heading",
-            "options": {
-                "margins": [
-                    { "weight": 150 },
-                ],
-                "passLength": 1,
-                "failLength": 0.5
+    def get_axe_custom_checks(self, request):
+        checks = super().get_axe_custom_checks(request)
+        # Flag heading-like paragraphs based only on font weight compared to surroundings.
+        checks.append(
+            {
+                "id": "p-as-heading",
+                "options": {
+                    "margins": [
+                        { "weight": 150 },
+                    ],
+                    "passLength": 1,
+                    "failLength": 0.5
+                },
             },
-        },
-    ]
+        )
+        return checks
 
 
 @hooks.register('construct_wagtail_userbar')

--- a/docs/releases/6.3.3.md
+++ b/docs/releases/6.3.3.md
@@ -19,4 +19,4 @@ depth: 1
 
 ### Documentation
 
- * ...
+ * Update example for customizing "p-as-heading" accessibility check without overriding built-in checks (Cynthia Kiser)

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -96,6 +96,7 @@ depth: 1
  * Fix Django HTML syntax formatting issue on the [documents overview](documents_overview) page (LB (Ben) Johnston)
  * Separate virtual environment creation and activation steps in tutorial (Ankit Kumar)
  * Update tutorial to use plain strings in place of `FieldPanel` / `InlinePanel` where appropriate (Unyime Emmanuel Udoh)
+ * Update example for customizing "p-as-heading" accessibility check without overriding built-in checks (Cynthia Kiser)
 
 ### Maintenance
 


### PR DESCRIPTION
Now that Wagtail itself has an `axe_custom_check` for `check-image-alt-text`, we need to update our example so it appends a custom check to the existing checks rather than overwriting the entire list.
