### PR TITLE
Remove Safari 15 support

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -1,16 +1,7 @@
 {
   "sourceType": "unambiguous",
   "presets": [
-    [
-      "@babel/preset-env",
-      {
-        "targets": {
-          "chrome": 100,
-          "safari": 15,
-          "firefox": 91
-        }
-      }
-    ],
+    "@babel/preset-env",
     "@babel/preset-typescript",
     "@babel/preset-react"
   ],

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
  * Replace l18n library with JavaScript Intl API for time zone options in Account view (Sage Abdullah)
  * Use explicit label for defaulting to server language in account settings (Sage Abdullah)
  * Add support for specifying an operator on `Fuzzy` queries (Tom Usher)
+ * Remove support for Safari 15 (Thibaud Colas)
  * Fix: Improve handling of translations for bulk page action confirmation messages (Matt Westcott)
  * Fix: Ensure custom rich text feature icons are correctly handled when provided as a list of SVG paths (Temidayo Azeez, Joel William, LB (Ben) Johnston)
  * Fix: Ensure manual edits to `StreamField` values do not throw an error (Stefan Hammer)

--- a/client/scss/components/_dropdown-button.scss
+++ b/client/scss/components/_dropdown-button.scss
@@ -26,16 +26,6 @@ $radius: theme('borderRadius.sm');
     width: 100%;
   }
 
-  @supports not selector(:has(*)) {
-    // Use no corner radius and always-on borders if `:has` is not supported.
-    --primary-button-radius-top: 0;
-    --primary-button-radius-bottom: 0;
-    --toggle-button-radius-top: 0;
-    --toggle-button-radius-bottom: 0;
-    --first-item-border-top: #{$separator};
-    --last-item-border-top: #{$separator};
-  }
-
   &:has(:not([hidden]) > [data-placement^='bottom']) {
     --primary-button-radius-top: #{$radius};
     --primary-button-radius-bottom: 0;

--- a/client/scss/components/_form-side.scss
+++ b/client/scss/components/_form-side.scss
@@ -85,13 +85,6 @@
     &:focus-within:has(:focus-visible) {
       @include focus-outline;
     }
-
-    @supports not selector(:focus-visible) {
-      &:focus-within {
-        /* Fallback for browsers without :focus-visible support */
-        @include focus-outline;
-      }
-    }
   }
 
   &__resize-grip-icon {

--- a/client/scss/components/forms/_switch.scss
+++ b/client/scss/components/forms/_switch.scss
@@ -93,12 +93,6 @@ $switch-border-radius: math.div(($switch-height + $switch-border * 2), 2);
     outline: theme('colors.focus') solid $switch-outline;
   }
 
-  @supports not selector(:focus-visible) {
-    [type='checkbox']:focus + &__toggle {
-      outline: theme('colors.focus') solid $switch-outline;
-    }
-  }
-
   [type='checkbox'] {
     position: absolute;
     opacity: 0;

--- a/client/scss/overrides/_utilities.focus.scss
+++ b/client/scss/overrides/_utilities.focus.scss
@@ -2,15 +2,6 @@
 // Set global focus outline styles so they are consistent across the UI,
 // without individual components having to explicitly define focus styles.
 // Using !important because we want to enforce only one style is used across the UI.
-// Remove :focus selectors once we stop supporting Safari 15.4.
-*:focus {
-  outline: $focus-outline-width solid theme('colors.focus') !important;
-}
-
-*:focus:not(:focus-visible) {
-  outline: none !important;
-}
-
 *:focus-visible {
   outline: $focus-outline-width solid theme('colors.focus') !important;
 }

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -206,14 +206,14 @@ Wagtail is meant to be used on a wide variety of devices and browsers. Supported
 
 | Browser       | Device/OS  | Version(s)         |
 | ------------- | ---------- | ------------------ |
-| Mobile Safari | iOS Phone  | Last 2: 16, 17     |
-| Mobile Safari | iOS Tablet | Last 2: 16, 17     |
+| Mobile Safari | iOS Phone  | Last 2: 17, 18     |
+| Mobile Safari | iOS Tablet | Last 2: 17, 18     |
 | Chrome        | Android    | Last 2             |
 | Chrome        | Desktop    | Last 2             |
 | MS Edge       | Windows    | Last 2             |
 | Firefox       | Desktop    | Latest             |
-| Firefox ESR   | Desktop    | Latest             |
-| Safari        | macOS      | Last 3: 15, 16, 17 |
+| Firefox ESR   | Desktop    | Latest: 128        |
+| Safari        | macOS      | Last 3: 16, 17, 18 |
 
 We aim for Wagtail to work in those environments. Our development standards ensure that the site is usable on other browsers **and will work on future browsers**.
 

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -32,6 +32,7 @@ depth: 1
  * Replace l18n library with JavaScript Intl API for time zone options in Account view (Sage Abdullah)
  * Use explicit label for defaulting to server language in account settings (Sage Abdullah)
  * Add support for specifying an operator on `Fuzzy` queries (Tom Usher)
+ * Remove support for Safari 15 (Thibaud Colas)
 
 ### Bug fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9581,9 +9581,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001677",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
-      "integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
+      "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
       "dev": true,
       "funding": [
         {
@@ -29599,9 +29599,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001677",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
-      "integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
+      "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "last 2 ChromeAndroid versions",
     "last 2 Edge versions",
     "last 1 Firefox version",
-    "iOS >= 16",
-    "Safari >= 15",
+    "iOS >= 17",
+    "Safari >= 16",
     "not ie 11"
   ],
   "jest": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "last 2 Edge versions",
     "last 1 Firefox version",
     "iOS >= 17",
-    "Safari >= 16",
-    "not ie 11"
+    "Safari >= 16"
   ],
   "jest": {
     "moduleFileExtensions": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
-    "lib": ["ES2022", "ES2022.Intl", "DOM", "DOM.iterable"],
+    "lib": ["ES2023", "ES2023.Intl", "DOM", "DOM.iterable"],
     "moduleResolution": "node",
     "noImplicitAny": false, // TODO: Enable once all existing code is typed
     "noUnusedLocals": true,
@@ -14,7 +14,7 @@
     "skipLibCheck": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "target": "ES2022"
+    "target": "ES2023"
   },
   "files": [
     "client/src/index.ts",


### PR DESCRIPTION
See #11257. This does the baseline removal and documentation updates, to match our current support targets: Safari 18, Safari 17, Safari 16. I chose to keep the code changes minimal. Here are additional improvements we could choose to take on, with this change in support targets:

- Iframe lazy-loading now supported in Safari 16.6 – needs research
- Lookbehind in JS regular expressions – optimization/cleanup
- (offline support?) – discussion?
- Passkeys – discussion?
- AVIF – good feature request
- Declarative shadow DOM - optimization/cleanup

---

As part of this work, I also opened #12725 to keep tabs on browser improvements we could consider leveraging when dropping support for Safari 16.

