### PR TITLE
Prevent error when searching and filtering by locale

### DIFF
--- a/wagtail/admin/filters.py
+++ b/wagtail/admin/filters.py
@@ -10,6 +10,7 @@ from wagtail.admin.models import popular_tags_for_model
 from wagtail.admin.utils import get_user_display_name
 from wagtail.admin.widgets import AdminDateInput, BooleanRadioSelect, FilteredSelect
 from wagtail.coreutils import get_content_languages, get_content_type_label
+from wagtail.models import Locale
 
 
 class DateRangePickerWidget(SuffixedMultiWidget):
@@ -93,7 +94,8 @@ class FilteredModelChoiceFilter(django_filters.ModelChoiceFilter):
 class LocaleFilter(django_filters.ChoiceFilter):
     def filter(self, qs, language_code):
         if language_code:
-            return qs.filter(locale__language_code=language_code)
+            locale = Locale.objects.filter(language_code=language_code)
+            return qs.filter(locale_id=locale.values_list("pk", flat=True)[:1])
         return qs
 
 

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -653,6 +653,24 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertIn("Simple page", page_type_labels)
         self.assertNotIn("Page", page_type_labels)
 
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_filter_by_locale_and_search(self):
+        fr_locale = Locale.objects.create(language_code="fr")
+        self.root_page.copy_for_translation(fr_locale, copy_parents=True)
+
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=(self.root_page.id,)),
+            {"locale": "en", "q": "hello"},
+        )
+        self.assertEqual(response.status_code, 200)
+        page_ids = {page.id for page in response.context["pages"]}
+        self.assertIn(self.child_page.id, page_ids)
+        self.assertContainsActiveFilter(
+            response,
+            "Locale: English",
+            "locale=en",
+        )
+
     def test_filter_by_date_updated(self):
         new_page_child = SimplePage(
             title="New page child",


### PR DESCRIPTION
Ref: https://github.com/wagtail/wagtail/issues/6616#issuecomment-2590737050

The current locale filter logic performs a related field filter on `locale__language_code` which isn't supported when searching, as per #6616. Change this to look up the locale object in a separate query.
