### PR TITLE
Fix TestFormPageWithCustomFormBuilder assertion against Django 5.1.5 and other security releases

### DIFF
--- a/wagtail/contrib/forms/tests/test_models.py
+++ b/wagtail/contrib/forms/tests/test_models.py
@@ -603,11 +603,13 @@ class TestFormPageWithCustomFormBuilder(WagtailTestUtils, TestCase):
             html=True,
         )
         # check ip address field has rendered
-        self.assertContains(
-            response,
-            '<input type="text" name="device_ip_address" required id="id_device_ip_address" />',
-            html=True,
-        )
+        # (not comparing HTML directly because https://docs.djangoproject.com/en/5.1/releases/5.1.5/
+        # added a maxlength attribute)
+        soup = self.get_soup(response.content)
+        input = soup.find("input", {"name": "device_ip_address"})
+        self.assertEqual(input["type"], "text")
+        self.assertEqual(input["required"], "")
+        self.assertEqual(input["id"], "id_device_ip_address")
 
     def test_post_invalid_form(self):
         response = self.client.post(


### PR DESCRIPTION
Django 5.1.5 (and other security releases released today) has added a `max_length` attribute to GenericIPAddressField, which breaks an assertion in the form builder tests that compares HTML directly. Change this to a BeautifulSoup-based test so that it works on older and newer releases.
