### PR TITLE
fix: add missing space between two words

### DIFF
--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -152,7 +152,7 @@ There are no tabs on non-Page model editing within InlinePanels.""".format(
                 class_name, panel_name
             )
         else:
-            error_hint = """Ensure that {} uses `panels` instead of `{}`\
+            error_hint = """Ensure that {} uses `panels` instead of `{}` \
 or set up an `edit_handler` if you want a tabbed editing interface.
 There are no default tabs on non-Page models so there will be no \
 {} tab for the {} to render in.""".format(

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -6041,7 +6041,7 @@ class TestPanelConfigurationChecks(WagtailTestUtils, TestCase):
 
         warning = checks.Warning(
             "StandardSnippet.content_panels will have no effect on snippets editing",
-            hint="""Ensure that StandardSnippet uses `panels` instead of `content_panels`\
+            hint="""Ensure that StandardSnippet uses `panels` instead of `content_panels` \
 or set up an `edit_handler` if you want a tabbed editing interface.
 There are no default tabs on non-Page models so there will be no\
  Content tab for the content_panels to render in.""",


### PR DESCRIPTION
Otherwise, logs show such lines:

```
HINT: Ensure that MainMenu uses `panels` instead of `content_panels`or set up an `edit_handler` ...
```