### PR TITLE
Fix white text on white background in previews for sites that use color-scheme without a background-color

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ Changelog
  * Fix: Ensure the top of the minimap correctly adjusts when resizing the browser viewport (Thibaud Colas)
  * Fix: Remove obsolete SubqueryConstraint check in search backends, for provisional Django 5.2 compatibility (Sage Abdullah)
  * Fix: Add missing “Close” label to the upgrade notification dismiss button (Sage Abdullah)
+ * Fix: Fix white text on white background in previews for sites that use color-scheme without a background-color (Sage Abdullah)
  * Docs: Fix typo in the headless documentation page (Mahmoud Nasser)
  * Docs: Fix typo in `Page.get_route_paths` docstring (Baptiste Mispelon)
  * Docs: Upgrade sphinx-wagtail-theme to v6.5.0 (Sage Abdullah)
@@ -177,6 +178,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~~
 
  * Fix: Add missing “Close” label to the upgrade notification dismiss button (Sage Abdullah)
+ * Fix: Fix white text on white background in previews for sites that use color-scheme without a background-color (Sage Abdullah)
  * Maintenance: Remove upper version boundary for django-filter (Dan Braghis)
 
 

--- a/client/scss/components/_preview-panel.scss
+++ b/client/scss/components/_preview-panel.scss
@@ -3,6 +3,7 @@
 
 .w-preview {
   --w-preview-background-color: var(--w-color-white);
+  --w-preview-color-scheme: normal;
   --preview-width-ratio: min(
     1,
     var(--preview-panel-width, 450) / var(--preview-device-width, 375)
@@ -40,6 +41,16 @@
     &:empty {
       // Ensure that sites without a background show with a fallback, only when iframe has loaded
       background-color: var(--w-preview-background-color);
+      // Sites that do not have a background but have color-scheme will have the
+      // colors (background, text, etc.) automatically styled by the browser.
+      // If the color-scheme matches Wagtail's current color-scheme, the browser
+      // will give the iframe a transparent background. If we only set the
+      // white background-color above, the white background will be used
+      // while the rest of the content follows the color-scheme of the site,
+      // which might result in white text on a white background.
+      // Since we cannot know the actual value of the content's color-scheme,
+      // we set the color-scheme to normal to ensure the iframe stays opaque.
+      color-scheme: var(--w-preview-color-scheme);
     }
 
     [dir='rtl'] & {

--- a/docs/releases/6.3.4.md
+++ b/docs/releases/6.3.4.md
@@ -16,3 +16,4 @@ depth: 1
 
  * Remove upper version boundary for django-filter (Dan Braghis)
  * Add missing “Close” label to the upgrade notification dismiss button (Sage Abdullah)
+ * Fix white text on white background in previews for sites that use color-scheme without a background-color (Sage Abdullah)

--- a/docs/releases/6.4.1.md
+++ b/docs/releases/6.4.1.md
@@ -20,6 +20,7 @@ depth: 1
  * Ensure the top of the minimap correctly adjusts when resizing the browser viewport (Thibaud Colas)
  * Remove obsolete SubqueryConstraint check in search backends, for provisional Django 5.2 compatibility (Sage Abdullah)
  * Add missing “Close” label to the upgrade notification dismiss button (Sage Abdullah)
+ * Fix white text on white background in previews for sites that use color-scheme without a background-color (Sage Abdullah)
 
 ### Documentation
 


### PR DESCRIPTION
Fixes #12764.

See https://fvsch.com/transparent-iframes for a good breakdown of the problem, as well as the solution. The solution follows the one described under the ["Better fix: white background, local color-scheme!"](https://fvsch.com/transparent-iframes#toc-5) heading, but I opted to use `color-scheme: normal` instead of `color-scheme: light`, which seems to work just as well.