### PR TITLE
Test against Django stable/5.2.x branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ concurrency:
 # - django 5.1, python 3.13, sqlite, parallel, USE_EMAIL_USER_MODEL=yes
 # - django 5.1, python 3.13, postgres:15, psycopg 3, parallel, DISABLE_TIMEZONE=yes
 # - django stable/5.1.x, python 3.11, postgres:15, psycopg 3 (allow failures)
+# - django stable/5.2.x, python 3.12, postgres:15, psycopg 3 (allow failures)
 # - django main, python 3.13, postgres:latest, psycopg 3, parallel (allow failures)
 # - elasticsearch 7, django 4.2, python 3.9, postgres:latest, psycopg 2
 # - opensearch 2, django 5.0, python 3.10, sqlite
@@ -106,6 +107,11 @@ jobs:
             parallel: '--parallel'
           - python: '3.11'
             django: 'git+https://github.com/django/django.git@stable/5.1.x#egg=Django'
+            psycopg: 'psycopg>=3.1.8'
+            postgres: 'postgres:15'
+            experimental: true
+          - python: '3.12'
+            django: 'git+https://github.com/django/django.git@stable/5.2.x#egg=Django'
             psycopg: 'psycopg>=3.1.8'
             postgres: 'postgres:15'
             experimental: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,9 @@ jobs:
             experimental: true
             postgres: 'postgres:latest'
             parallel: '--parallel'
+            install_extras: |
+              pip uninstall -y django-modelcluster
+              pip install "git+https://github.com/wagtail/django-modelcluster.git@main#egg=django-modelcluster"
     services:
       postgres:
         image: ${{ matrix.postgres || 'postgres:12' }}


### PR DESCRIPTION
Not sure if we want this before 6.4 feature freeze, so I'm marking as draft for now.

Also if https://github.com/wagtail/django-modelcluster/pull/198 is merged, we might want to use the `main` branch instead.