### PR TITLE
Stop rendering to content type in search result

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Allow a custom image rendition model to define its unique constraint with `models.UniqueConstraint` instead of `unique_together` (Oliver Parker, Cynthia Kiser, Sage Abdullah)
  * Default to the `standard` tokenizer on Elasticsearch, to correctly handle numbers as tokens (Matt Westcott)
  * Fix: Take preferred language into account for translatable strings in client-side code (Bernhard Bliem, Sage Abdullah)
+ * Fix: Do not show the content type column as sortable when searching pages (Srishti Jaiswal, Sage Abdullah)
  * Docs: Add missing `django.contrib.admin` to list of apps in "add to Django project" guide (Mohamed Rabiaa)
 
 

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -22,6 +22,7 @@ depth: 1
 ### Bug fixes
 
  * Take preferred language into account for translatable strings in client-side code (Bernhard Bliem, Sage Abdullah)
+ * Do not show the content type column as sortable when searching pages (Srishti Jaiswal, Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -166,6 +166,37 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
             page_ids, [self.child_page.id, self.new_page.id, self.old_page.id]
         )
 
+    def test_ordering_by_content_type(self):
+        orderings = {
+            "content_type": (
+                [self.child_page.id, self.new_page.id, self.old_page.id],
+                "-content_type",
+            ),
+            "-content_type": (
+                [self.old_page.id, self.child_page.id, self.new_page.id],
+                "content_type",
+            ),
+        }
+        url = reverse("wagtailadmin_explore", args=(self.root_page.id,))
+        for ordering, (pages, reverse_param) in orderings.items():
+            with self.subTest(ordering=ordering):
+                response = self.client.get(url, {"ordering": ordering})
+                self.assertEqual(response.status_code, 200)
+                self.assertTemplateUsed(
+                    response, "wagtailadmin/pages/explorable_index.html"
+                )
+                self.assertEqual(response.context["ordering"], ordering)
+
+                # Child pages should be ordered by content type
+                page_ids = [page.id for page in response.context["pages"]]
+                self.assertEqual(page_ids, pages)
+
+                # The type column should contain a link to order by content type
+                soup = self.get_soup(response.content)
+                thead = soup.select_one("main table thead")
+                link = thead.select_one(f"a[href='{url}?ordering={reverse_param}']")
+                self.assertIsNotNone(link)
+
     def test_ordering_search_results_by_created_at(self):
         response = self.client.get(
             reverse("wagtailadmin_explore", args=(self.root_page.id,)),
@@ -187,6 +218,16 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
+
+        # The type column should not contain a link to order by content type
+        soup = self.get_soup(response.content)
+        headings = soup.select("main table thead th")
+        type_th = None
+        for heading in headings:
+            if heading.text.strip() == "Type":
+                type_th = heading
+        self.assertIsNotNone(type_th)
+        self.assertIsNone(type_th.select_one("a"))
 
     def test_change_default_child_page_ordering_attribute(self):
         # save old get_default_order to reset at end of test

--- a/wagtail/admin/tests/pages/test_page_search.py
+++ b/wagtail/admin/tests/pages/test_page_search.py
@@ -284,6 +284,16 @@ class TestPageSearch(WagtailTestUtils, TransactionTestCase):
                     f"{url}?q=&amp;content_type=tests.eventindex",
                 )
 
+                # The type column should not contain a link to order by content type
+                soup = self.get_soup(response.content)
+                headings = soup.select("main table thead th")
+                type_th = None
+                for heading in headings:
+                    if heading.text.strip() == "Type":
+                        type_th = heading
+                self.assertIsNotNone(type_th)
+                self.assertIsNone(type_th.select_one("a"))
+
     def test_empty_search_with_content_type_filter(self):
         root_page = Page.objects.get(id=2)
         event_index = EventIndex(

--- a/wagtail/admin/ui/tables/pages.py
+++ b/wagtail/admin/ui/tables/pages.py
@@ -82,6 +82,15 @@ class OrderingColumn(BaseColumn):
     cell_template_name = "wagtailadmin/pages/listing/_ordering_cell.html"
 
 
+class PageTypeColumn(Column):
+    def get_header_context_data(self, parent_context):
+        context = super().get_header_context_data(parent_context)
+        # Cannot order by page type while searching, due to
+        # https://github.com/wagtail/wagtail/issues/6616
+        context["is_orderable"] = not parent_context.get("is_searching")
+        return context
+
+
 class NavigateToChildrenColumn(BaseColumn):
     cell_template_name = "wagtailadmin/pages/listing/_navigation_explore.html"
 

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -23,7 +23,7 @@ from wagtail.admin.ui.components import MediaContainer
 from wagtail.admin.ui.side_panels import (
     PageStatusSidePanel,
 )
-from wagtail.admin.ui.tables import Column, DateColumn
+from wagtail.admin.ui.tables import DateColumn
 from wagtail.admin.ui.tables.pages import (
     BulkActionsColumn,
     NavigateToChildrenColumn,
@@ -31,6 +31,7 @@ from wagtail.admin.ui.tables.pages import (
     PageStatusColumn,
     PageTable,
     PageTitleColumn,
+    PageTypeColumn,
     ParentPageColumn,
 )
 from wagtail.admin.views import generic
@@ -147,7 +148,7 @@ class PageListingMixin:
             sort_key="latest_revision_created_at",
             width="12%",
         ),
-        Column(
+        PageTypeColumn(
             "type",
             label=_("Type"),
             accessor="page_type_display_name",

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -60,6 +60,9 @@ class SearchView(PageListingMixin, PermissionCheckedMixin, BaseListingView):
     index_results_url_name = "wagtailadmin_pages:search_results"
     # We override get_queryset here that has a custom search implementation
     is_searchable = True
+    # The queryset always gets passed to the search backend even if
+    # the search query is empty, so we are always "searching"
+    is_searching = True
     # This view has its own filtering mechanism that doesn't use django-filter
     filterset_class = None
     template_name = "wagtailadmin/pages/search.html"


### PR DESCRIPTION
Fixes wagtail/wagtail#12769 

Until the Wagtail issue [#6616](https://github.com/wagtail/wagtailsearch/issues/9) is resolved, the sort arrow link should not be rendered for the content type in search results.
This issue is resolved acc to-- [this comment](https://github.com/wagtail/wagtail/issues/12769#issuecomment-2589573494)
cc: @laymonage 

Before :
search in the main menu-
![image](https://github.com/user-attachments/assets/576d7454-ce99-40c3-9caa-dcf09ae7bee2)

search in the page listing-
![image](https://github.com/user-attachments/assets/acd08b0b-f6d0-48a0-b1e7-ab7120044d2f)

After:

https://github.com/user-attachments/assets/e47c4679-dcb4-4517-87ff-ce28596cd2af


