### PR TITLE
Integrate django-tasks (rebase of #12040)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ install_requires = [
     "anyascii>=0.1.5",
     "telepath>=0.3.1,<1",
     "laces>=0.1,<0.2",
+    "django-tasks>=0.6.1,<0.7",
 ]
 
 # Testing dependencies

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -289,7 +289,8 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         self.assertEqual(len(actions), 0)
 
     def test_usage_count_information_shown(self):
-        PageChooserModel.objects.create(page=self.event_page)
+        with self.captureOnCommitCallbacks(execute=True):
+            PageChooserModel.objects.create(page=self.event_page)
 
         # Tests that the edit page loads
         response = self.client.get(

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -910,10 +910,11 @@ class TestBreadcrumbs(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertBreadcrumbsItemsRendered(items, response.content)
 
     def test_usage_view_pagination(self):
-        for i in range(25):
-            VariousOnDeleteModel.objects.create(
-                text=f"Toybox {i}", cascading_toy=self.object
-            )
+        with self.captureOnCommitCallbacks(execute=True):
+            for i in range(25):
+                VariousOnDeleteModel.objects.create(
+                    text=f"Toybox {i}", cascading_toy=self.object
+                )
 
         usage_url = reverse(
             "feature_complete_toy:usage",
@@ -1208,15 +1209,16 @@ class TestHistoryView(WagtailTestUtils, TestCase):
 class TestUsageView(WagtailTestUtils, TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.user = cls.create_test_user()
-        cls.object = FeatureCompleteToy.objects.create(name="Buzz")
-        cls.url = reverse(
-            "feature_complete_toy:usage",
-            args=(quote(cls.object.pk),),
-        )
-        cls.tbx = VariousOnDeleteModel.objects.create(
-            text="Toybox", cascading_toy=cls.object
-        )
+        with cls.captureOnCommitCallbacks(execute=True):
+            cls.user = cls.create_test_user()
+            cls.object = FeatureCompleteToy.objects.create(name="Buzz")
+            cls.url = reverse(
+                "feature_complete_toy:usage",
+                args=(quote(cls.object.pk),),
+            )
+            cls.tbx = VariousOnDeleteModel.objects.create(
+                text="Toybox", cascading_toy=cls.object
+            )
 
     def setUp(self):
         self.user = self.login(self.user)

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -605,11 +605,13 @@ class TestDocumentCacheInvalidation(TestCase):
         signal_handlers.unregister_signal_handlers()
 
     def test_resave_document_purges(self, purge):
-        get_document_model().objects.get(id=5).save()
+        with self.captureOnCommitCallbacks(execute=True):
+            get_document_model().objects.get(id=5).save()
 
         purge.assert_any_call("http://api.example.com/api/main/documents/5/")
 
     def test_delete_document_purges(self, purge):
-        get_document_model().objects.get(id=5).delete()
+        with self.captureOnCommitCallbacks(execute=True):
+            get_document_model().objects.get(id=5).delete()
 
         purge.assert_any_call("http://api.example.com/api/main/documents/5/")

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -597,11 +597,13 @@ class TestImageCacheInvalidation(TestCase):
         signal_handlers.unregister_signal_handlers()
 
     def test_resave_image_purges(self, purge):
-        get_image_model().objects.get(id=5).save()
+        with self.captureOnCommitCallbacks(execute=True):
+            get_image_model().objects.get(id=5).save()
 
         purge.assert_any_call("http://api.example.com/api/main/images/5/")
 
     def test_delete_image_purges(self, purge):
-        get_image_model().objects.get(id=5).delete()
+        with self.captureOnCommitCallbacks(execute=True):
+            get_image_model().objects.get(id=5).delete()
 
         purge.assert_any_call("http://api.example.com/api/main/images/5/")

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1886,22 +1886,26 @@ class TestPageCacheInvalidation(TestCase):
         signal_handlers.unregister_signal_handlers()
 
     def test_republish_page_purges(self, purge):
-        Page.objects.get(id=2).specific.save_revision().publish()
+        with self.captureOnCommitCallbacks(execute=True):
+            Page.objects.get(id=2).specific.save_revision().publish()
 
         purge.assert_any_call("http://api.example.com/api/main/pages/2/")
 
     def test_unpublish_page_purges(self, purge):
-        Page.objects.get(id=2).unpublish()
+        with self.captureOnCommitCallbacks(execute=True):
+            Page.objects.get(id=2).unpublish()
 
         purge.assert_any_call("http://api.example.com/api/main/pages/2/")
 
     def test_delete_page_purges(self, purge):
-        Page.objects.get(id=16).delete()
+        with self.captureOnCommitCallbacks(execute=True):
+            Page.objects.get(id=16).delete()
 
         purge.assert_any_call("http://api.example.com/api/main/pages/16/")
 
     def test_save_draft_doesnt_purge(self, purge):
-        Page.objects.get(id=2).specific.save_revision()
+        with self.captureOnCommitCallbacks(execute=True):
+            Page.objects.get(id=2).specific.save_revision()
 
         purge.assert_not_called()
 

--- a/wagtail/contrib/frontend_cache/tasks.py
+++ b/wagtail/contrib/frontend_cache/tasks.py
@@ -1,0 +1,83 @@
+import logging
+import re
+from collections import defaultdict
+from urllib.parse import urlsplit, urlunsplit
+
+from django.conf import settings
+from django_tasks import task
+
+from wagtail.coreutils import get_content_languages
+
+from .utils import get_backends
+
+logger = logging.getLogger("wagtail.frontendcache")
+
+
+@task()
+def purge_urls_from_cache_task(urls, backend_settings=None, backends=None):
+    if not urls:
+        return
+
+    backends = get_backends(backend_settings, backends)
+
+    # If no backends are configured, there's nothing to do
+    if not backends:
+        return
+
+    # Convert each url to urls one for each managed language (WAGTAILFRONTENDCACHE_LANGUAGES setting).
+    # The managed languages are common to all the defined backends.
+    # This depends on settings.USE_I18N
+    # If WAGTAIL_I18N_ENABLED is True, this defaults to WAGTAIL_CONTENT_LANGUAGES
+    wagtail_i18n_enabled = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
+    content_languages = get_content_languages() if wagtail_i18n_enabled else {}
+    languages = getattr(
+        settings, "WAGTAILFRONTENDCACHE_LANGUAGES", list(content_languages.keys())
+    )
+    if settings.USE_I18N and languages:
+        langs_regex = "^/(%s)/" % "|".join(languages)
+        new_urls = []
+
+        # Purge the given url for each managed language
+        for isocode in languages:
+            for url in urls:
+                up = urlsplit(url)
+                new_url = urlunsplit(
+                    (
+                        up.scheme,
+                        up.netloc,
+                        re.sub(langs_regex, "/%s/" % isocode, up.path),
+                        up.query,
+                        up.fragment,
+                    )
+                )
+
+                # Check for best performance. True if re.sub found no match
+                # It happens when i18n_patterns was not used in urls.py to serve content for different languages from different URLs
+                if new_url in new_urls:
+                    continue
+
+                new_urls.append(new_url)
+
+        urls = new_urls
+
+    urls_by_hostname = defaultdict(list)
+
+    for url in urls:
+        urls_by_hostname[urlsplit(url).netloc].append(url)
+
+    for hostname, urls in urls_by_hostname.items():
+        backends_for_hostname = {
+            backend_name: backend
+            for backend_name, backend in backends.items()
+            if backend.invalidates_hostname(hostname)
+        }
+
+        if not backends_for_hostname:
+            logger.info("Unable to find purge backend for %s", hostname)
+            continue
+
+        for backend_name, backend in backends_for_hostname.items():
+            for url in urls:
+                logger.info("[%s] Purging URL: %s", backend_name, url)
+
+            backend.purge_batch(urls)

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -447,32 +447,37 @@ class TestCachePurgingFunctions(TestCase):
         PURGED_URLS.clear()
 
     def test_purge_url_from_cache(self):
-        purge_url_from_cache("http://localhost/foo")
+        with self.captureOnCommitCallbacks(execute=True):
+            purge_url_from_cache("http://localhost/foo")
         self.assertEqual(PURGED_URLS, {"http://localhost/foo"})
 
     def test_purge_urls_from_cache(self):
-        purge_urls_from_cache(["http://localhost/foo", "http://localhost/bar"])
+        with self.captureOnCommitCallbacks(execute=True):
+            purge_urls_from_cache(["http://localhost/foo", "http://localhost/bar"])
         self.assertEqual(PURGED_URLS, {"http://localhost/foo", "http://localhost/bar"})
 
     def test_purge_page_from_cache(self):
-        page = EventIndex.objects.get(url_path="/home/events/")
-        purge_page_from_cache(page)
+        with self.captureOnCommitCallbacks(execute=True):
+            page = EventIndex.objects.get(url_path="/home/events/")
+            purge_page_from_cache(page)
         self.assertEqual(
             PURGED_URLS, {"http://localhost/events/", "http://localhost/events/past/"}
         )
 
     def test_purge_pages_from_cache(self):
-        purge_pages_from_cache(EventIndex.objects.all())
+        with self.captureOnCommitCallbacks(execute=True):
+            purge_pages_from_cache(EventIndex.objects.all())
         self.assertEqual(
             PURGED_URLS, {"http://localhost/events/", "http://localhost/events/past/"}
         )
 
     def test_purge_batch(self):
-        batch = PurgeBatch()
-        page = EventIndex.objects.get(url_path="/home/events/")
-        batch.add_page(page)
-        batch.add_url("http://localhost/foo")
-        batch.purge()
+        with self.captureOnCommitCallbacks(execute=True):
+            batch = PurgeBatch()
+            page = EventIndex.objects.get(url_path="/home/events/")
+            batch.add_page(page)
+            batch.add_url("http://localhost/foo")
+            batch.purge()
 
         self.assertEqual(
             PURGED_URLS,
@@ -493,7 +498,8 @@ class TestCachePurgingFunctions(TestCase):
     )
     def test_invalidate_specific_location(self):
         with self.assertLogs(level="INFO") as log_output:
-            purge_url_from_cache("http://localhost/foo")
+            with self.captureOnCommitCallbacks(execute=True):
+                purge_url_from_cache("http://localhost/foo")
 
         self.assertEqual(PURGED_URLS, set())
         self.assertIn(
@@ -501,7 +507,8 @@ class TestCachePurgingFunctions(TestCase):
             log_output.output[0],
         )
 
-        purge_url_from_cache("http://example.com/foo")
+        with self.captureOnCommitCallbacks(execute=True):
+            purge_url_from_cache("http://example.com/foo")
         self.assertEqual(PURGED_URLS, {"http://example.com/foo"})
 
 
@@ -520,10 +527,11 @@ class TestCloudflareCachePurgingFunctions(TestCase):
         PURGED_URLS.clear()
 
     def test_cloudflare_purge_batch_chunked(self):
-        batch = PurgeBatch()
-        urls = [f"https://localhost/foo{i}" for i in range(1, 65)]
-        batch.add_urls(urls)
-        batch.purge()
+        with self.captureOnCommitCallbacks(execute=True):
+            batch = PurgeBatch()
+            urls = [f"https://localhost/foo{i}" for i in range(1, 65)]
+            batch.add_urls(urls)
+            batch.purge()
 
         self.assertCountEqual(PURGED_URLS, set(urls))
 
@@ -543,24 +551,27 @@ class TestCachePurgingSignals(TestCase):
         PURGED_URLS.clear()
 
     def test_purge_on_publish(self):
-        page = EventIndex.objects.get(url_path="/home/events/")
-        page.save_revision().publish()
+        with self.captureOnCommitCallbacks(execute=True):
+            page = EventIndex.objects.get(url_path="/home/events/")
+            page.save_revision().publish()
         self.assertEqual(
             PURGED_URLS, {"http://localhost/events/", "http://localhost/events/past/"}
         )
 
     def test_purge_on_unpublish(self):
-        page = EventIndex.objects.get(url_path="/home/events/")
-        page.unpublish()
+        with self.captureOnCommitCallbacks(execute=True):
+            page = EventIndex.objects.get(url_path="/home/events/")
+            page.unpublish()
         self.assertEqual(
             PURGED_URLS, {"http://localhost/events/", "http://localhost/events/past/"}
         )
 
     def test_purge_with_unroutable_page(self):
-        root = Page.objects.get(url_path="/")
-        page = EventIndex(title="new top-level page")
-        root.add_child(instance=page)
-        page.save_revision().publish()
+        with self.captureOnCommitCallbacks(execute=True):
+            root = Page.objects.get(url_path="/")
+            page = EventIndex(title="new top-level page")
+            root.add_child(instance=page)
+            page.save_revision().publish()
         self.assertEqual(PURGED_URLS, set())
 
     @override_settings(
@@ -569,8 +580,9 @@ class TestCachePurgingSignals(TestCase):
         WAGTAILFRONTENDCACHE_LANGUAGES=["en", "fr", "pt-br"],
     )
     def test_purge_on_publish_in_multilang_env(self):
-        page = EventIndex.objects.get(url_path="/home/events/")
-        page.save_revision().publish()
+        with self.captureOnCommitCallbacks(execute=True):
+            page = EventIndex.objects.get(url_path="/home/events/")
+            page.save_revision().publish()
 
         self.assertEqual(
             PURGED_URLS,
@@ -591,8 +603,9 @@ class TestCachePurgingSignals(TestCase):
         WAGTAIL_CONTENT_LANGUAGES=[("en", "English"), ("fr", "French")],
     )
     def test_purge_on_publish_with_i18n_enabled(self):
-        page = EventIndex.objects.get(url_path="/home/events/")
-        page.save_revision().publish()
+        with self.captureOnCommitCallbacks(execute=True):
+            page = EventIndex.objects.get(url_path="/home/events/")
+            page.save_revision().publish()
 
         self.assertEqual(
             PURGED_URLS,
@@ -610,9 +623,10 @@ class TestCachePurgingSignals(TestCase):
         WAGTAIL_CONTENT_LANGUAGES=[("en", "English"), ("fr", "French")],
     )
     def test_purge_on_publish_without_i18n_enabled(self):
-        # It should ignore WAGTAIL_CONTENT_LANGUAGES as WAGTAIL_I18N_ENABLED isn't set
-        page = EventIndex.objects.get(url_path="/home/events/")
-        page.save_revision().publish()
+        with self.captureOnCommitCallbacks(execute=True):
+            # It should ignore WAGTAIL_CONTENT_LANGUAGES as WAGTAIL_I18N_ENABLED isn't set
+            page = EventIndex.objects.get(url_path="/home/events/")
+            page.save_revision().publish()
         self.assertEqual(
             PURGED_URLS,
             {"http://localhost/en/events/", "http://localhost/en/events/past/"},
@@ -696,7 +710,8 @@ class TestPurgeBatchClass(TestCase):
         batch.add_url("http://localhost/events/")
 
         with self.assertLogs(level="ERROR") as log_output:
-            batch.purge(backend_settings=backend_settings)
+            with self.captureOnCommitCallbacks(execute=True):
+                batch.purge(backend_settings=backend_settings)
 
         self.assertIn(
             "Couldn't purge 'http://localhost/events/' from Cloudflare. HTTPError: 500",

--- a/wagtail/contrib/frontend_cache/utils.py
+++ b/wagtail/contrib/frontend_cache/utils.py
@@ -1,13 +1,8 @@
 import logging
-import re
-from collections import defaultdict
-from urllib.parse import urlsplit, urlunsplit
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
-
-from wagtail.coreutils import get_content_languages
 
 logger = logging.getLogger("wagtail.frontendcache")
 
@@ -64,72 +59,9 @@ def purge_url_from_cache(url, backend_settings=None, backends=None):
 
 
 def purge_urls_from_cache(urls, backend_settings=None, backends=None):
-    if not urls:
-        return
+    from .tasks import purge_urls_from_cache_task
 
-    backends = get_backends(backend_settings, backends)
-
-    # If no backends are configured, there's nothing to do
-    if not backends:
-        return
-
-    # Convert each url to urls one for each managed language (WAGTAILFRONTENDCACHE_LANGUAGES setting).
-    # The managed languages are common to all the defined backends.
-    # This depends on settings.USE_I18N
-    # If WAGTAIL_I18N_ENABLED is True, this defaults to WAGTAIL_CONTENT_LANGUAGES
-    wagtail_i18n_enabled = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
-    content_languages = get_content_languages() if wagtail_i18n_enabled else {}
-    languages = getattr(
-        settings, "WAGTAILFRONTENDCACHE_LANGUAGES", list(content_languages.keys())
-    )
-    if settings.USE_I18N and languages:
-        langs_regex = "^/(%s)/" % "|".join(languages)
-        new_urls = []
-
-        # Purge the given url for each managed language
-        for isocode in languages:
-            for url in urls:
-                up = urlsplit(url)
-                new_url = urlunsplit(
-                    (
-                        up.scheme,
-                        up.netloc,
-                        re.sub(langs_regex, "/%s/" % isocode, up.path),
-                        up.query,
-                        up.fragment,
-                    )
-                )
-
-                # Check for best performance. True if re.sub found no match
-                # It happens when i18n_patterns was not used in urls.py to serve content for different languages from different URLs
-                if new_url in new_urls:
-                    continue
-
-                new_urls.append(new_url)
-
-        urls = new_urls
-
-    urls_by_hostname = defaultdict(list)
-
-    for url in urls:
-        urls_by_hostname[urlsplit(url).netloc].append(url)
-
-    for hostname, urls in urls_by_hostname.items():
-        backends_for_hostname = {
-            backend_name: backend
-            for backend_name, backend in backends.items()
-            if backend.invalidates_hostname(hostname)
-        }
-
-        if not backends_for_hostname:
-            logger.info("Unable to find purge backend for %s", hostname)
-            continue
-
-        for backend_name, backend in backends_for_hostname.items():
-            for url in urls:
-                logger.info("[%s] Purging URL: %s", backend_name, url)
-
-            backend.purge_batch(urls)
+    purge_urls_from_cache_task.enqueue(list(urls), backend_settings, backends)
 
 
 def _get_page_cached_urls(page):

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -801,14 +801,15 @@ class TestRedirectsAddView(WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailredirects/add.html")
 
     def test_add(self):
-        response = self.post(
-            {
-                "old_path": "/test",
-                "site": "",
-                "is_permanent": "on",
-                "redirect_link": "http://www.test.com/",
-            }
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(
+                {
+                    "old_path": "/test",
+                    "site": "",
+                    "is_permanent": "on",
+                    "redirect_link": "http://www.test.com/",
+                }
+            )
 
         # Should redirect back to index
         self.assertRedirects(response, reverse("wagtailredirects:index"))
@@ -827,15 +828,16 @@ class TestRedirectsAddView(WagtailTestUtils, TestCase):
         self.assertEqual(PURGED_URLS, {"http://localhost/test"})
 
     def test_add_with_site(self):
-        localhost = Site.objects.get(hostname="localhost")
-        response = self.post(
-            {
-                "old_path": "/test",
-                "site": localhost.id,
-                "is_permanent": "on",
-                "redirect_link": "http://www.test.com/",
-            }
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            localhost = Site.objects.get(hostname="localhost")
+            response = self.post(
+                {
+                    "old_path": "/test",
+                    "site": localhost.id,
+                    "is_permanent": "on",
+                    "redirect_link": "http://www.test.com/",
+                }
+            )
 
         # Should redirect back to index
         self.assertRedirects(response, reverse("wagtailredirects:index"))
@@ -849,72 +851,76 @@ class TestRedirectsAddView(WagtailTestUtils, TestCase):
         self.assertEqual(PURGED_URLS, {"http://localhost/test"})
 
     def test_add_validation_error(self):
-        response = self.post(
-            {
-                "old_path": "",
-                "site": "",
-                "is_permanent": "on",
-                "redirect_link": "http://www.test.com/",
-            }
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(
+                {
+                    "old_path": "",
+                    "site": "",
+                    "is_permanent": "on",
+                    "redirect_link": "http://www.test.com/",
+                }
+            )
 
         # Should not redirect to index
         self.assertEqual(response.status_code, 200)
         self.assertEqual(PURGED_URLS, set())
 
     def test_cannot_add_duplicate_with_no_site(self):
-        models.Redirect.objects.create(
-            old_path="/test", site=None, redirect_link="http://elsewhere.com/"
-        )
-        response = self.post(
-            {
-                "old_path": "/test",
-                "site": "",
-                "is_permanent": "on",
-                "redirect_link": "http://www.test.com/",
-            }
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            models.Redirect.objects.create(
+                old_path="/test", site=None, redirect_link="http://elsewhere.com/"
+            )
+            response = self.post(
+                {
+                    "old_path": "/test",
+                    "site": "",
+                    "is_permanent": "on",
+                    "redirect_link": "http://www.test.com/",
+                }
+            )
 
         # Should not redirect to index
         self.assertEqual(response.status_code, 200)
         self.assertEqual(PURGED_URLS, set())
 
     def test_cannot_add_duplicate_on_same_site(self):
-        localhost = Site.objects.get(hostname="localhost")
-        models.Redirect.objects.create(
-            old_path="/test", site=localhost, redirect_link="http://elsewhere.com/"
-        )
-        response = self.post(
-            {
-                "old_path": "/test",
-                "site": localhost.pk,
-                "is_permanent": "on",
-                "redirect_link": "http://www.test.com/",
-            }
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            localhost = Site.objects.get(hostname="localhost")
+            models.Redirect.objects.create(
+                old_path="/test", site=localhost, redirect_link="http://elsewhere.com/"
+            )
+            response = self.post(
+                {
+                    "old_path": "/test",
+                    "site": localhost.pk,
+                    "is_permanent": "on",
+                    "redirect_link": "http://www.test.com/",
+                }
+            )
 
         # Should not redirect to index
         self.assertEqual(response.status_code, 200)
         self.assertEqual(PURGED_URLS, set())
 
     def test_can_reuse_path_on_other_site(self):
-        localhost = Site.objects.get(hostname="localhost")
-        contact_page = Page.objects.get(url_path="/home/contact-us/")
-        other_site = Site.objects.create(
-            hostname="other.example.com", port=80, root_page=contact_page
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            localhost = Site.objects.get(hostname="localhost")
+            contact_page = Page.objects.get(url_path="/home/contact-us/")
+            other_site = Site.objects.create(
+                hostname="other.example.com", port=80, root_page=contact_page
+            )
 
-        models.Redirect.objects.create(
-            old_path="/test", site=localhost, redirect_link="http://elsewhere.com/"
-        )
-        response = self.post(
-            {
-                "old_path": "/test",
-                "site": other_site.pk,
-                "is_permanent": "on",
-                "redirect_link": "http://www.test.com/",
-            }
-        )
+            models.Redirect.objects.create(
+                old_path="/test", site=localhost, redirect_link="http://elsewhere.com/"
+            )
+            response = self.post(
+                {
+                    "old_path": "/test",
+                    "site": other_site.pk,
+                    "is_permanent": "on",
+                    "redirect_link": "http://www.test.com/",
+                }
+            )
 
         # Should redirect back to index
         self.assertRedirects(response, reverse("wagtailredirects:index"))
@@ -926,14 +932,15 @@ class TestRedirectsAddView(WagtailTestUtils, TestCase):
         self.assertEqual(PURGED_URLS, redirects.get().old_links())
 
     def test_add_long_redirect(self):
-        response = self.post(
-            {
-                "old_path": "/test",
-                "site": "",
-                "is_permanent": "on",
-                "redirect_link": "https://www.google.com/search?q=this+is+a+very+long+url+because+it+has+a+huge+search+term+appended+to+the+end+of+it+even+though+someone+should+really+not+be+doing+something+so+crazy+without+first+seeing+a+psychiatrist",
-            }
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(
+                {
+                    "old_path": "/test",
+                    "site": "",
+                    "is_permanent": "on",
+                    "redirect_link": "https://www.google.com/search?q=this+is+a+very+long+url+because+it+has+a+huge+search+term+appended+to+the+end+of+it+even+though+someone+should+really+not+be+doing+something+so+crazy+without+first+seeing+a+psychiatrist",
+                }
+            )
 
         # Should redirect back to index
         self.assertRedirects(response, reverse("wagtailredirects:index"))
@@ -1002,14 +1009,15 @@ class TestRedirectsEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertEqual(self.get(redirect_id=100000).status_code, 404)
 
     def test_edit(self):
-        response = self.post(
-            {
-                "old_path": "/test",
-                "is_permanent": "on",
-                "site": "",
-                "redirect_link": "http://www.test.com/ive-been-edited",
-            }
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(
+                {
+                    "old_path": "/test",
+                    "is_permanent": "on",
+                    "site": "",
+                    "redirect_link": "http://www.test.com/ive-been-edited",
+                }
+            )
 
         # Should redirect back to index
         self.assertRedirects(response, reverse("wagtailredirects:index"))
@@ -1025,16 +1033,17 @@ class TestRedirectsEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertEqual(PURGED_URLS, {"http://localhost/test"})
 
     def test_edit_with_site(self):
-        localhost = Site.objects.get(hostname="localhost")
+        with self.captureOnCommitCallbacks(execute=True):
+            localhost = Site.objects.get(hostname="localhost")
 
-        response = self.post(
-            {
-                "old_path": "/test",
-                "is_permanent": "on",
-                "site": localhost.id,
-                "redirect_link": "http://www.test.com/ive-been-edited",
-            }
-        )
+            response = self.post(
+                {
+                    "old_path": "/test",
+                    "is_permanent": "on",
+                    "site": localhost.id,
+                    "redirect_link": "http://www.test.com/ive-been-edited",
+                }
+            )
 
         # Should redirect back to index
         self.assertRedirects(response, reverse("wagtailredirects:index"))
@@ -1049,31 +1058,33 @@ class TestRedirectsEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertEqual(PURGED_URLS, {"http://localhost/test"})
 
     def test_edit_validation_error(self):
-        response = self.post(
-            {
-                "old_path": "",
-                "is_permanent": "on",
-                "site": "",
-                "redirect_link": "http://www.test.com/ive-been-edited",
-            }
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(
+                {
+                    "old_path": "",
+                    "is_permanent": "on",
+                    "site": "",
+                    "redirect_link": "http://www.test.com/ive-been-edited",
+                }
+            )
 
         # Should not redirect to index
         self.assertEqual(response.status_code, 200)
         self.assertEqual(PURGED_URLS, set())
 
     def test_edit_duplicate(self):
-        models.Redirect.objects.create(
-            old_path="/othertest", site=None, redirect_link="http://elsewhere.com/"
-        )
-        response = self.post(
-            {
-                "old_path": "/othertest",
-                "is_permanent": "on",
-                "site": "",
-                "redirect_link": "http://www.test.com/ive-been-edited",
-            }
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            models.Redirect.objects.create(
+                old_path="/othertest", site=None, redirect_link="http://elsewhere.com/"
+            )
+            response = self.post(
+                {
+                    "old_path": "/othertest",
+                    "is_permanent": "on",
+                    "site": "",
+                    "redirect_link": "http://www.test.com/ive-been-edited",
+                }
+            )
 
         # Should not redirect to index
         self.assertEqual(response.status_code, 200)
@@ -1153,7 +1164,8 @@ class TestRedirectsDeleteView(WagtailTestUtils, TestCase):
         self.assertEqual(self.get(redirect_id=100000).status_code, 404)
 
     def test_delete(self):
-        response = self.post()
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post()
 
         # Should redirect back to index
         self.assertRedirects(response, reverse("wagtailredirects:index"))

--- a/wagtail/documents/signal_handlers.py
+++ b/wagtail/documents/signal_handlers.py
@@ -2,11 +2,15 @@ from django.db import transaction
 from django.db.models.signals import post_delete
 
 from wagtail.documents import get_document_model
+from wagtail.tasks import delete_file_from_storage_task
 
 
 def post_delete_file_cleanup(instance, **kwargs):
-    # Pass false so FileField doesn't save the model.
-    transaction.on_commit(lambda: instance.file.delete(False))
+    transaction.on_commit(
+        lambda: delete_file_from_storage_task.enqueue(
+            instance.file.storage.deconstruct(), instance.file.name
+        )
+    )
 
 
 def register_signal_handlers():

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -1003,7 +1003,8 @@ class TestDocumentDeleteView(WagtailTestUtils, TestCase):
         )
 
     def test_delete_get_with_protected_reference(self):
-        VariousOnDeleteModel.objects.create(protected_document=self.document)
+        with self.captureOnCommitCallbacks(execute=True):
+            VariousOnDeleteModel.objects.create(protected_document=self.document)
         response = self.client.get(self.delete_url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/generic/confirm_delete.html")
@@ -1025,7 +1026,8 @@ class TestDocumentDeleteView(WagtailTestUtils, TestCase):
         )
 
     def test_delete_post_with_protected_reference(self):
-        VariousOnDeleteModel.objects.create(protected_document=self.document)
+        with self.captureOnCommitCallbacks(execute=True):
+            VariousOnDeleteModel.objects.create(protected_document=self.document)
         response = self.client.post(self.delete_url)
         self.assertRedirects(response, reverse("wagtailadmin_home"))
         self.assertTrue(
@@ -2092,21 +2094,23 @@ class TestUsageCount(WagtailTestUtils, TestCase):
         self.assertEqual(doc.get_usage().count(), 0)
 
     def test_used_document_usage_count(self):
-        doc = models.Document.objects.get(id=1)
-        page = EventPage.objects.get(id=4)
-        event_page_related_link = EventPageRelatedLink()
-        event_page_related_link.page = page
-        event_page_related_link.link_document = doc
-        event_page_related_link.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            doc = models.Document.objects.get(id=1)
+            page = EventPage.objects.get(id=4)
+            event_page_related_link = EventPageRelatedLink()
+            event_page_related_link.page = page
+            event_page_related_link.link_document = doc
+            event_page_related_link.save()
         self.assertEqual(doc.get_usage().count(), 1)
 
     def test_usage_count_appears(self):
-        doc = models.Document.objects.get(id=1)
-        page = EventPage.objects.get(id=4)
-        event_page_related_link = EventPageRelatedLink()
-        event_page_related_link.page = page
-        event_page_related_link.link_document = doc
-        event_page_related_link.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            doc = models.Document.objects.get(id=1)
+            page = EventPage.objects.get(id=4)
+            event_page_related_link = EventPageRelatedLink()
+            event_page_related_link.page = page
+            event_page_related_link.link_document = doc
+            event_page_related_link.save()
         response = self.client.get(reverse("wagtaildocs:edit", args=(1,)))
         self.assertContains(response, "Used 1 time")
 
@@ -2126,12 +2130,13 @@ class TestGetUsage(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertEqual(list(doc.get_usage()), [])
 
     def test_used_document_get_usage(self):
-        doc = models.Document.objects.get(id=1)
-        page = EventPage.objects.get(id=4)
-        event_page_related_link = EventPageRelatedLink()
-        event_page_related_link.page = page
-        event_page_related_link.link_document = doc
-        event_page_related_link.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            doc = models.Document.objects.get(id=1)
+            page = EventPage.objects.get(id=4)
+            event_page_related_link = EventPageRelatedLink()
+            event_page_related_link.page = page
+            event_page_related_link.link_document = doc
+            event_page_related_link.save()
 
         self.assertIsInstance(doc.get_usage()[0], tuple)
         self.assertIsInstance(doc.get_usage()[0][0], Page)
@@ -2139,12 +2144,13 @@ class TestGetUsage(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertIsInstance(doc.get_usage()[0][1][0], ReferenceIndex)
 
     def test_usage_page(self):
-        doc = models.Document.objects.get(id=1)
-        page = EventPage.objects.get(id=4)
-        event_page_related_link = EventPageRelatedLink()
-        event_page_related_link.page = page
-        event_page_related_link.link_document = doc
-        event_page_related_link.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            doc = models.Document.objects.get(id=1)
+            page = EventPage.objects.get(id=4)
+            event_page_related_link = EventPageRelatedLink()
+            event_page_related_link.page = page
+            event_page_related_link.link_document = doc
+            event_page_related_link.save()
         response = self.client.get(reverse("wagtaildocs:document_usage", args=(1,)))
         self.assertContains(response, "Christmas")
         self.assertContains(response, '<table class="listing">')
@@ -2174,12 +2180,13 @@ class TestGetUsage(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertNotContains(response, '<table class="listing">')
 
     def test_usage_page_with_only_change_permission(self):
-        doc = models.Document.objects.get(id=1)
-        page = EventPage.objects.get(id=4)
-        event_page_related_link = EventPageRelatedLink()
-        event_page_related_link.page = page
-        event_page_related_link.link_document = doc
-        event_page_related_link.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            doc = models.Document.objects.get(id=1)
+            page = EventPage.objects.get(id=4)
+            event_page_related_link = EventPageRelatedLink()
+            event_page_related_link.page = page
+            event_page_related_link.link_document = doc
+            event_page_related_link.save()
 
         # Create a user with change_document permission but not add_document
         user = self.create_user(

--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -3,7 +3,6 @@ from django.db.models import ForeignKey
 from django.utils.translation import gettext_lazy as _
 
 from . import checks, get_image_model  # NOQA: F401
-from .signal_handlers import register_signal_handlers
 
 
 class WagtailImagesAppConfig(AppConfig):
@@ -14,6 +13,8 @@ class WagtailImagesAppConfig(AppConfig):
     default_attrs = {}
 
     def ready(self):
+        from .signal_handlers import register_signal_handlers
+
         register_signal_handlers()
 
         # Set up model forms to use AdminImageChooser for any ForeignKey to the image model

--- a/wagtail/images/signal_handlers.py
+++ b/wagtail/images/signal_handlers.py
@@ -1,8 +1,10 @@
 from django.conf import settings
 from django.db import transaction
-from django.db.models.signals import post_delete, pre_save
+from django.db.models.signals import post_delete, post_save
 
 from wagtail.images import get_image_model
+
+from .tasks import set_image_focal_point_task
 
 
 def post_delete_file_cleanup(instance, **kwargs):
@@ -14,21 +16,22 @@ def post_delete_purge_rendition_cache(instance, **kwargs):
     instance.purge_from_cache()
 
 
-def pre_save_image_feature_detection(instance, **kwargs):
+def post_save_image_feature_detection(instance, **kwargs):
     if getattr(settings, "WAGTAILIMAGES_FEATURE_DETECTION_ENABLED", False):
         # Make sure the image is not from a fixture
-        if kwargs["raw"] is False:
-            # Make sure the image doesn't already have a focal point
-            if not instance.has_focal_point():
-                # Set the focal point
-                instance.set_focal_point(instance.get_suggested_focal_point())
+        # and the image doesn't already have a focal point
+        if kwargs["raw"] is False and not instance.has_focal_point():
+            # Set the focal point
+            set_image_focal_point_task.enqueue(
+                instance._meta.app_label, instance._meta.model_name, instance.pk
+            )
 
 
 def register_signal_handlers():
     Image = get_image_model()
     Rendition = Image.get_rendition_model()
 
-    pre_save.connect(pre_save_image_feature_detection, sender=Image)
+    post_save.connect(post_save_image_feature_detection, sender=Image)
     post_delete.connect(post_delete_file_cleanup, sender=Image)
     post_delete.connect(post_delete_file_cleanup, sender=Rendition)
     post_delete.connect(post_delete_purge_rendition_cache, sender=Rendition)

--- a/wagtail/images/tasks.py
+++ b/wagtail/images/tasks.py
@@ -1,0 +1,18 @@
+from django.apps import apps
+from django_tasks import task
+
+
+@task()
+def set_image_focal_point_task(app_label, model_name, pk):
+    model = apps.get_model(app_label, model_name)
+    instance = model.objects.get(pk=pk)
+    instance.set_focal_point(instance.get_suggested_focal_point())
+
+    instance.save(
+        update_fields=[
+            "focal_point_x",
+            "focal_point_y",
+            "focal_point_width",
+            "focal_point_height",
+        ]
+    )

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1453,7 +1453,8 @@ class TestImageDeleteView(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 302)
 
     def test_delete_get_with_protected_reference(self):
-        VariousOnDeleteModel.objects.create(protected_image=self.image)
+        with self.captureOnCommitCallbacks(execute=True):
+            VariousOnDeleteModel.objects.create(protected_image=self.image)
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailimages/images/confirm_delete.html")
@@ -1476,7 +1477,8 @@ class TestImageDeleteView(WagtailTestUtils, TestCase):
         )
 
     def test_delete_post_with_protected_reference(self):
-        VariousOnDeleteModel.objects.create(protected_image=self.image)
+        with self.captureOnCommitCallbacks(execute=True):
+            VariousOnDeleteModel.objects.create(protected_image=self.image)
         response = self.post()
         self.assertRedirects(response, reverse("wagtailadmin_home"))
         self.assertTrue(Image.objects.filter(id=self.image.id).exists())
@@ -1493,18 +1495,19 @@ class TestUsage(WagtailTestUtils, TestCase):
         )
 
     def test_usage_page(self):
-        home_page = Page.objects.get(id=2)
-        home_page.add_child(
-            instance=EventPage(
-                title="Christmas",
-                slug="christmas",
-                feed_image=self.image,
-                date_from=datetime.date.today(),
-                audience="private",
-                location="Test",
-                cost="Test",
-            )
-        ).save_revision().publish()
+        with self.captureOnCommitCallbacks(execute=True):
+            home_page = Page.objects.get(id=2)
+            home_page.add_child(
+                instance=EventPage(
+                    title="Christmas",
+                    slug="christmas",
+                    feed_image=self.image,
+                    date_from=datetime.date.today(),
+                    audience="private",
+                    location="Test",
+                    cost="Test",
+                )
+            ).save_revision().publish()
 
         response = self.client.get(
             reverse("wagtailimages:image_usage", args=[self.image.id])
@@ -1521,9 +1524,10 @@ class TestUsage(WagtailTestUtils, TestCase):
         self.assertNotContains(response, '<table class="listing">')
 
     def test_usage_no_tags(self):
-        # tags should not count towards an image's references
-        self.image.tags.add("illustration")
-        self.image.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            # tags should not count towards an image's references
+            self.image.tags.add("illustration")
+            self.image.save()
         response = self.client.get(
             reverse("wagtailimages:image_usage", args=[self.image.id])
         )
@@ -1531,18 +1535,19 @@ class TestUsage(WagtailTestUtils, TestCase):
         self.assertNotContains(response, '<table class="listing">')
 
     def test_usage_page_with_only_change_permission(self):
-        home_page = Page.objects.get(id=2)
-        home_page.add_child(
-            instance=EventPage(
-                title="Christmas",
-                slug="christmas",
-                feed_image=self.image,
-                date_from=datetime.date.today(),
-                audience="private",
-                location="Test",
-                cost="Test",
-            )
-        ).save_revision().publish()
+        with self.captureOnCommitCallbacks(execute=True):
+            home_page = Page.objects.get(id=2)
+            home_page.add_child(
+                instance=EventPage(
+                    title="Christmas",
+                    slug="christmas",
+                    feed_image=self.image,
+                    date_from=datetime.date.today(),
+                    audience="private",
+                    location="Test",
+                    cost="Test",
+                )
+            ).save_revision().publish()
 
         # Create a user with change_image permission but not add_image
         user = self.create_user(

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -984,11 +984,12 @@ class TestUsageCount(TestCase):
         self.assertEqual(self.image.get_usage().count(), 0)
 
     def test_used_image_document_usage_count(self):
-        page = EventPage.objects.get(id=4)
-        event_page_carousel_item = EventPageCarouselItem()
-        event_page_carousel_item.page = page
-        event_page_carousel_item.image = self.image
-        event_page_carousel_item.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            page = EventPage.objects.get(id=4)
+            event_page_carousel_item = EventPageCarouselItem()
+            event_page_carousel_item.page = page
+            event_page_carousel_item.image = self.image
+            event_page_carousel_item.save()
         self.assertEqual(self.image.get_usage().count(), 1)
 
 
@@ -1005,11 +1006,12 @@ class TestGetUsage(TestCase):
         self.assertEqual(list(self.image.get_usage()), [])
 
     def test_used_image_document_get_usage(self):
-        page = EventPage.objects.get(id=4)
-        event_page_carousel_item = EventPageCarouselItem()
-        event_page_carousel_item.page = page
-        event_page_carousel_item.image = self.image
-        event_page_carousel_item.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            page = EventPage.objects.get(id=4)
+            event_page_carousel_item = EventPageCarouselItem()
+            event_page_carousel_item.page = page
+            event_page_carousel_item.image = self.image
+            event_page_carousel_item.save()
 
         self.assertIsInstance(self.image.get_usage()[0], tuple)
         self.assertIsInstance(self.image.get_usage()[0][0], Page)

--- a/wagtail/search/signal_handlers.py
+++ b/wagtail/search/signal_handlers.py
@@ -1,16 +1,13 @@
 from django.db.models.signals import post_delete, post_save
 
-from wagtail.search import index
+from . import index
+from .tasks import insert_or_update_object_task
 
 
-def post_save_signal_handler(instance, update_fields=None, **kwargs):
-    if update_fields is not None:
-        # fetch a fresh copy of instance from the database to ensure
-        # that we're not indexing any of the unsaved data contained in
-        # the fields that were not passed in update_fields
-        instance = type(instance).objects.get(pk=instance.pk)
-
-    index.insert_or_update_object(instance)
+def post_save_signal_handler(instance, **kwargs):
+    insert_or_update_object_task.enqueue(
+        instance._meta.app_label, instance._meta.model_name, instance.pk
+    )
 
 
 def post_delete_signal_handler(instance, **kwargs):

--- a/wagtail/search/tasks.py
+++ b/wagtail/search/tasks.py
@@ -1,0 +1,10 @@
+from django.apps import apps
+from django_tasks import task
+
+from wagtail.search import index
+
+
+@task()
+def insert_or_update_object_task(app_label, model_name, pk):
+    model = apps.get_model(app_label, model_name)
+    index.insert_or_update_object(model.objects.get(pk=pk))

--- a/wagtail/search/tests/test_index_functions.py
+++ b/wagtail/search/tests/test_index_functions.py
@@ -160,9 +160,10 @@ class TestRemoveObject(WagtailTestUtils, TestCase):
 class TestSignalHandlers(WagtailTestUtils, TestCase):
     def test_index_on_create(self, backend):
         backend().reset_mock()
-        obj = models.Book.objects.create(
-            title="Test", publication_date=date(2017, 10, 18), number_of_pages=100
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            obj = models.Book.objects.create(
+                title="Test", publication_date=date(2017, 10, 18), number_of_pages=100
+            )
         backend().add.assert_called_with(obj)
 
     def test_index_on_update(self, backend):
@@ -172,7 +173,8 @@ class TestSignalHandlers(WagtailTestUtils, TestCase):
 
         backend().reset_mock()
         obj.title = "Updated test"
-        obj.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            obj.save()
 
         self.assertEqual(backend().add.call_count, 1)
         indexed_object = backend().add.call_args[0][0]
@@ -184,7 +186,8 @@ class TestSignalHandlers(WagtailTestUtils, TestCase):
         )
 
         backend().reset_mock()
-        obj.delete()
+        with self.captureOnCommitCallbacks(execute=True):
+            obj.delete()
         backend().delete.assert_called_with(obj)
 
     def test_do_not_index_fields_omitted_from_update_fields(self, backend):
@@ -195,7 +198,8 @@ class TestSignalHandlers(WagtailTestUtils, TestCase):
         backend().reset_mock()
         obj.title = "Updated test"
         obj.publication_date = date(2001, 10, 19)
-        obj.save(update_fields=["title"])
+        with self.captureOnCommitCallbacks(execute=True):
+            obj.save(update_fields=["title"])
 
         self.assertEqual(backend().add.call_count, 1)
         indexed_object = backend().add.call_args[0][0]

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -4129,9 +4129,10 @@ class TestSnippetDelete(WagtailTestUtils, TestCase):
         self.assertContains(response, delete_url)
 
     def test_delete_get_with_protected_reference(self):
-        VariousOnDeleteModel.objects.create(
-            text="Undeletable", on_delete_protect=self.test_snippet
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            VariousOnDeleteModel.objects.create(
+                text="Undeletable", on_delete_protect=self.test_snippet
+            )
         delete_url = reverse(
             "wagtailsnippets_tests_advert:delete",
             args=[quote(self.test_snippet.pk)],
@@ -4186,9 +4187,10 @@ class TestSnippetDelete(WagtailTestUtils, TestCase):
         self.assertEqual(Advert.objects.filter(text="test_advert").count(), 0)
 
     def test_delete_post_with_protected_reference(self):
-        VariousOnDeleteModel.objects.create(
-            text="Undeletable", on_delete_protect=self.test_snippet
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            VariousOnDeleteModel.objects.create(
+                text="Undeletable", on_delete_protect=self.test_snippet
+            )
         delete_url = reverse(
             "wagtailsnippets_tests_advert:delete",
             args=[quote(self.test_snippet.pk)],

--- a/wagtail/snippets/tests/test_usage.py
+++ b/wagtail/snippets/tests/test_usage.py
@@ -74,15 +74,16 @@ class TestSnippetUsageView(WagtailTestUtils, TestCase):
         self.assertEqual(sublabel.get_text(strip=True), "Draft-enabled Bar, In Draft")
 
     def test_usage(self):
-        # resave so that usage count gets updated
-        page = Page.objects.get(pk=2)
-        page.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            # resave so that usage count gets updated
+            page = Page.objects.get(pk=2)
+            page.save()
 
-        gfk_page = GenericSnippetPage(
-            title="Foobar Title",
-            snippet_content_object=Advert.objects.get(pk=1),
-        )
-        page.add_child(instance=gfk_page)
+            gfk_page = GenericSnippetPage(
+                title="Foobar Title",
+                snippet_content_object=Advert.objects.get(pk=1),
+            )
+            page.add_child(instance=gfk_page)
 
         response = self.client.get(
             reverse(
@@ -124,9 +125,10 @@ class TestSnippetUsageView(WagtailTestUtils, TestCase):
         self.assertRedirects(response, reverse("wagtailadmin_home"))
 
     def test_usage_without_edit_permission_on_page(self):
-        # resave so that usage count gets updated
-        page = Page.objects.get(pk=2)
-        page.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            # resave so that usage count gets updated
+            page = Page.objects.get(pk=2)
+            page.save()
 
         # Create a user with edit access to snippets but not pages
         user = self.create_user(
@@ -157,9 +159,10 @@ class TestSnippetUsageView(WagtailTestUtils, TestCase):
         self.assertContains(response, "<li>Advert</li>", html=True)
 
     def test_usage_with_describe_on_delete_cascade(self):
-        # resave so that usage count gets updated
-        page = Page.objects.get(pk=2)
-        page.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            # resave so that usage count gets updated
+            page = Page.objects.get(pk=2)
+            page.save()
 
         response = self.client.get(
             reverse("wagtailsnippets_tests_advert:usage", args=["1"])
@@ -173,9 +176,10 @@ class TestSnippetUsageView(WagtailTestUtils, TestCase):
         self.assertContains(response, ": the advert placement will also be deleted")
 
     def test_usage_with_describe_on_delete_set_null(self):
-        # resave so that usage count gets updated
-        page = EventPage.objects.first()
-        page.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            # resave so that usage count gets updated
+            page = EventPage.objects.first()
+            page.save()
 
         self.assertEqual(page.feed_image.get_usage().count(), 1)
 
@@ -191,13 +195,14 @@ class TestSnippetUsageView(WagtailTestUtils, TestCase):
         self.assertContains(response, ": will unset the reference")
 
     def test_usage_with_describe_on_delete_gfk(self):
-        advert = Advert.objects.get(pk=1)
+        with self.captureOnCommitCallbacks(execute=True):
+            advert = Advert.objects.get(pk=1)
 
-        gfk_page = GenericSnippetPage(
-            title="Foobar Title",
-            snippet_content_object=advert,
-        )
-        Page.objects.get(pk=1).add_child(instance=gfk_page)
+            gfk_page = GenericSnippetPage(
+                title="Foobar Title",
+                snippet_content_object=advert,
+            )
+            Page.objects.get(pk=1).add_child(instance=gfk_page)
 
         self.assertEqual(ReferenceIndex.get_grouped_references_to(advert).count(), 1)
 

--- a/wagtail/tasks.py
+++ b/wagtail/tasks.py
@@ -1,5 +1,6 @@
 from django.apps import apps
 from django.db import transaction
+from django.utils.module_loading import import_string
 from django_tasks import task
 from modelcluster.fields import ParentalKey
 
@@ -30,3 +31,11 @@ def update_reference_index_task(app_label, model_name, pk):
     if ReferenceIndex.is_indexed(instance._meta.model):
         with transaction.atomic():
             ReferenceIndex.create_or_update_for_object(instance)
+
+
+@task()
+def delete_file_from_storage_task(deconstructed_storage, path):
+    storage_module, storage_args, storage_kwargs = deconstructed_storage
+    storage = import_string(storage_module)(*storage_args, **storage_kwargs)
+
+    storage.delete(path)

--- a/wagtail/tasks.py
+++ b/wagtail/tasks.py
@@ -1,0 +1,32 @@
+from django.apps import apps
+from django.db import transaction
+from django_tasks import task
+from modelcluster.fields import ParentalKey
+
+from wagtail.models import ReferenceIndex
+
+
+@task()
+def update_reference_index_task(app_label, model_name, pk):
+    model = apps.get_model(app_label, model_name)
+    instance = model.objects.get(pk=pk)
+
+    # If the model is a child model, find the parent instance and index that instead
+    while True:
+        parental_keys = list(
+            filter(
+                lambda field: isinstance(field, ParentalKey),
+                instance._meta.get_fields(),
+            )
+        )
+        if not parental_keys:
+            break
+
+        instance = getattr(instance, parental_keys[0].name)
+        if instance is None:
+            # parent is null, so there is no valid object to record references against
+            return
+
+    if ReferenceIndex.is_indexed(instance._meta.model):
+        with transaction.atomic():
+            ReferenceIndex.create_or_update_for_object(instance)

--- a/wagtail/tests/test_management_commands.py
+++ b/wagtail/tests/test_management_commands.py
@@ -225,7 +225,7 @@ class TestPublishScheduledPagesCommand(WagtailTestUtils, TestCase):
                 .exclude(approved_go_live_at__isnull=True)
                 .exists()
             )
-            with self.assertNumQueries(48):
+            with self.assertNumQueries(49):
                 with self.captureOnCommitCallbacks(execute=True):
                     management.call_command("publish_scheduled_pages")
 
@@ -283,7 +283,7 @@ class TestPublishScheduledPagesCommand(WagtailTestUtils, TestCase):
                 .exists()
             )
 
-            with self.assertNumQueries(48):
+            with self.assertNumQueries(49):
                 with self.captureOnCommitCallbacks(execute=True):
                     management.call_command("publish_scheduled_pages")
 
@@ -320,7 +320,7 @@ class TestPublishScheduledPagesCommand(WagtailTestUtils, TestCase):
         page.title = "Goodbye world!"
         page.save_revision()
 
-        with self.assertNumQueries(48):
+        with self.assertNumQueries(49):
             with self.captureOnCommitCallbacks(execute=True):
                 management.call_command("publish_scheduled_pages")
 
@@ -349,7 +349,7 @@ class TestPublishScheduledPagesCommand(WagtailTestUtils, TestCase):
             .exists()
         )
 
-        with self.assertNumQueries(46):
+        with self.assertNumQueries(47):
             with self.captureOnCommitCallbacks(execute=True):
                 management.call_command("publish_scheduled_pages")
 
@@ -386,7 +386,7 @@ class TestPublishScheduledPagesCommand(WagtailTestUtils, TestCase):
             p = Page.objects.get(slug="hello-world")
             self.assertTrue(p.live)
 
-            with self.assertNumQueries(27):
+            with self.assertNumQueries(29):
                 with self.captureOnCommitCallbacks(execute=True):
                     management.call_command("publish_scheduled_pages")
 

--- a/wagtail/tests/test_management_commands.py
+++ b/wagtail/tests/test_management_commands.py
@@ -225,8 +225,9 @@ class TestPublishScheduledPagesCommand(WagtailTestUtils, TestCase):
                 .exclude(approved_go_live_at__isnull=True)
                 .exists()
             )
-            with self.assertNumQueries(44):
-                management.call_command("publish_scheduled_pages")
+            with self.assertNumQueries(48):
+                with self.captureOnCommitCallbacks(execute=True):
+                    management.call_command("publish_scheduled_pages")
 
             p = Page.objects.get(slug="hello-world")
             self.assertTrue(p.live)
@@ -282,8 +283,9 @@ class TestPublishScheduledPagesCommand(WagtailTestUtils, TestCase):
                 .exists()
             )
 
-            with self.assertNumQueries(44):
-                management.call_command("publish_scheduled_pages")
+            with self.assertNumQueries(48):
+                with self.captureOnCommitCallbacks(execute=True):
+                    management.call_command("publish_scheduled_pages")
 
             p = Page.objects.get(slug="hello-world")
             self.assertTrue(p.live)
@@ -318,8 +320,9 @@ class TestPublishScheduledPagesCommand(WagtailTestUtils, TestCase):
         page.title = "Goodbye world!"
         page.save_revision()
 
-        with self.assertNumQueries(44):
-            management.call_command("publish_scheduled_pages")
+        with self.assertNumQueries(48):
+            with self.captureOnCommitCallbacks(execute=True):
+                management.call_command("publish_scheduled_pages")
 
         p = Page.objects.get(slug="hello-world")
         self.assertTrue(p.live)
@@ -346,8 +349,9 @@ class TestPublishScheduledPagesCommand(WagtailTestUtils, TestCase):
             .exists()
         )
 
-        with self.assertNumQueries(42):
-            management.call_command("publish_scheduled_pages")
+        with self.assertNumQueries(46):
+            with self.captureOnCommitCallbacks(execute=True):
+                management.call_command("publish_scheduled_pages")
 
         p = Page.objects.get(slug="hello-world")
         self.assertFalse(p.live)
@@ -382,8 +386,9 @@ class TestPublishScheduledPagesCommand(WagtailTestUtils, TestCase):
             p = Page.objects.get(slug="hello-world")
             self.assertTrue(p.live)
 
-            with self.assertNumQueries(26):
-                management.call_command("publish_scheduled_pages")
+            with self.assertNumQueries(27):
+                with self.captureOnCommitCallbacks(execute=True):
+                    management.call_command("publish_scheduled_pages")
 
             p = Page.objects.get(slug="hello-world")
             self.assertFalse(p.live)
@@ -411,7 +416,8 @@ class TestPublishScheduledPagesCommand(WagtailTestUtils, TestCase):
         self.assertTrue(p.live)
 
         with self.assertNumQueries(6):
-            management.call_command("publish_scheduled_pages")
+            with self.captureOnCommitCallbacks(execute=True):
+                management.call_command("publish_scheduled_pages")
 
         p = Page.objects.get(slug="hello-world")
         self.assertTrue(p.live)
@@ -459,7 +465,8 @@ class TestPublishScheduledCommand(WagtailTestUtils, TestCase):
             )
 
             with self.assertNumQueries(15):
-                management.call_command("publish_scheduled")
+                with self.captureOnCommitCallbacks(execute=True):
+                    management.call_command("publish_scheduled")
 
             self.snippet.refresh_from_db()
             self.assertTrue(self.snippet.live)
@@ -507,7 +514,8 @@ class TestPublishScheduledCommand(WagtailTestUtils, TestCase):
             )
 
             with self.assertNumQueries(15):
-                management.call_command("publish_scheduled")
+                with self.captureOnCommitCallbacks(execute=True):
+                    management.call_command("publish_scheduled")
 
             self.snippet.refresh_from_db()
             self.assertTrue(self.snippet.live)
@@ -536,7 +544,8 @@ class TestPublishScheduledCommand(WagtailTestUtils, TestCase):
         self.snippet.save_revision()
 
         with self.assertNumQueries(15):
-            management.call_command("publish_scheduled")
+            with self.captureOnCommitCallbacks(execute=True):
+                management.call_command("publish_scheduled")
 
         self.snippet.refresh_from_db()
         self.assertTrue(self.snippet.live)
@@ -560,7 +569,8 @@ class TestPublishScheduledCommand(WagtailTestUtils, TestCase):
         )
 
         with self.assertNumQueries(14):
-            management.call_command("publish_scheduled")
+            with self.captureOnCommitCallbacks(execute=True):
+                management.call_command("publish_scheduled")
 
         self.assertFalse(self.snippet.live)
         self.assertTrue(
@@ -588,7 +598,8 @@ class TestPublishScheduledCommand(WagtailTestUtils, TestCase):
             self.assertTrue(self.snippet.live)
 
             with self.assertNumQueries(10):
-                management.call_command("publish_scheduled")
+                with self.captureOnCommitCallbacks(execute=True):
+                    management.call_command("publish_scheduled")
 
             self.snippet.refresh_from_db()
             self.assertFalse(self.snippet.live)
@@ -609,7 +620,8 @@ class TestPublishScheduledCommand(WagtailTestUtils, TestCase):
         self.assertTrue(self.snippet.live)
 
         with self.assertNumQueries(6):
-            management.call_command("publish_scheduled")
+            with self.captureOnCommitCallbacks(execute=True):
+                management.call_command("publish_scheduled")
 
         self.snippet.refresh_from_db()
         self.assertTrue(self.snippet.live)


### PR DESCRIPTION
Rebase of #12040 on current main, now running against django-tasks 0.6.1. I encountered a number of issues along the way:

* Numerous tests failed as a result of the `enqueue_on_commit` setting introduced in https://github.com/RealOrangeOne/django-tasks/pull/57 (django-tasks 0.4). To get past this initial hurdle I added a `TASKS` setting with `"ENQUEUE_ON_COMMIT": False` to the test settings, although clearly that's not appropriate for real-world use since we don't want to require end users to add `TASKS` settings to their projects. I now see that we can add this to the `@task` decorators instead, although before doing that it would be good to establish _why_ the new transaction management breaks things. (Maybe it's specific to the test runner, which generally wraps whole tests in a transaction, meaning that we're asserting the result before the task has run? Although, is it expected for that behaviour to come into play even when using the immediate backend? @RealOrangeOne, can you advise?)
* The change from lists to sets in 22fe143d36cc050ea1e1b7c0500379077430b278 broke `purge_urls_from_cache_task`, because sets aren't JSON-serializable - easily fixed by casting `urls` back to a list when calling `purge_urls_from_cache_task.enqueue`.
* The query count assertions in `wagtail.tests.test_management_commands.TestPublishScheduledPagesCommand` (added in #12488) have crept up a bit as a result of the reference index and search index commits. I guess that's expected because we have to do a round trip from instances to IDs to make a valid call to `enqueue`, and back again within the task itself?