### PR TITLE
Enable alt text quality check by default. Fix #12636

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -59,6 +59,7 @@ Changelog
  * Fix: Prevent redundant calls to `Site.find_for_request()` from `Page.get_url_parts()` (Andy Babic)
  * Fix: Prevent error on listings when searching and filtering by locale (Matt Westcott, Sage Abdullah)
  * Fix: Add missing space in panels check warning message (Stéphane Blondon)
+ * Fix: Make sure alt text quality check is on by default as documented (Thibaud Colas)
  * Docs: Move the model reference page from reference/pages to the references section as it covers all Wagtail core models (Srishti Jaiswal)
  * Docs: Move the panels reference page from references/pages to the references section as panels are available for any model editing, merge panels API into this page (Srishti Jaiswal)
  * Docs: Move the tags documentation to standalone advanced topic, instead of being inside the reference/pages section (Srishti Jaiswal)
@@ -134,6 +135,7 @@ Changelog
 
 * Fix: Correctly place comment buttons next to date / datetime / time fields. (Srishti Jaiswal)
 * Fix: Reduce confusing spacing below StreamField blocks help text (Rishabh Sharma)
+* Fix: Make sure alt text quality check is on by default as documented (Thibaud Colas)
 * Docs: Update example for customizing "p-as-heading" accessibility check without overriding built-in checks (Cynthia Kiser)
 
 

--- a/docs/releases/6.3.3.md
+++ b/docs/releases/6.3.3.md
@@ -16,6 +16,7 @@ depth: 1
 
  * Correctly place comment buttons next to date / datetime / time fields. (Srishti Jaiswal)
  * Reduce confusing spacing below StreamField blocks help text (Rishabh Sharma)
+ * Make sure alt text quality check is on by default as documented (Thibaud Colas)
 
 ### Documentation
 

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -85,6 +85,7 @@ This feature was developed by Jake Howard.
  * Prevent redundant calls to `Site.find_for_request()` from `Page.get_url_parts()` (Andy Babic)
  * Prevent error on listings when searching and filtering by locale (Matt Westcott, Sage Abdullah)
  * Add missing space in panels check warning message (Stéphane Blondon)
+ * Make sure alt text quality check is on by default as documented (Thibaud Colas)
 
 ### Documentation
 

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -61,6 +61,7 @@ class AccessibilityItem(BaseItem):
         "input-button-name",
         "link-name",
         "p-as-heading",
+        "alt-text-quality",
     ]
 
     #: A dictionary that maps axe-core rule IDs to a dictionary of rule options,


### PR DESCRIPTION
Turns on our `alt-text-quality` custom accessibility check by default, per #12636. The check was introduced in v6.2. I believe our intention was to turn it on by default but we didn’t, and I don’t recall the details of our rationale either way.

In any case with the Wagtail 6.3 and soon 6.4 alt text improvements, we’re in a good place to have this on by default.

## Testing this

On the bakerydemo,

1. Create new content with problematic alt text (for example "test.png")
2. Note the alt text is flagged as problematic
3. Remove the bakerydemo’s `replace_userbar_accessibility_item` in wagtail_hooks. 
4. Note the alt text is still flagged as problematic