### PR TITLE
Add upgrade note about fixing tests for background tasks

### DIFF
--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -205,7 +205,7 @@ TASKS = {
 }
 ```
 
-Django's test framework also typically runs tests inside transactions, and so this situation is also likely to arise in tests that perform database updates and then - within the same test - expect these changes to be immediately reflected in search queries, object usage counts, and other processes that are now handled with background tasks. This can be addressed by setting `ENQUEUE_ON_COMMIT` to `False` as above in the test settings, or by wrapping the database updates in `with self.captureOnCommitCallbacks(execute=True)` to ensure that these tasks are completed before the test continues:
+Django's test framework typically runs tests inside transactions, and so this situation is also likely to arise in tests that perform database updates and then - within the same test - expect these changes to be immediately reflected in search queries, object usage counts, and other processes that are now handled with background tasks. This can be addressed by setting `ENQUEUE_ON_COMMIT` to `False` as above in the test settings, or by wrapping the database updates in `with self.captureOnCommitCallbacks(execute=True)` to ensure that these tasks are completed before the test continues:
 
 ```python
 def test_search(self):

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -205,6 +205,19 @@ TASKS = {
 }
 ```
 
+Django's test framework also typically runs tests inside transactions, and so this situation is also likely to arise in tests that perform database updates and then - within the same test - expect these changes to be immediately reflected in search queries, object usage counts, and other processes that are now handled with background tasks. This can be addressed by setting `ENQUEUE_ON_COMMIT` to `False` as above in the test settings, or by wrapping the database updates in `with self.captureOnCommitCallbacks(execute=True)` to ensure that these tasks are completed before the test continues:
+
+```python
+def test_search(self):
+    home_page = Page.objects.get(slug="home")
+
+    with self.captureOnCommitCallbacks(execute=True):  # Added
+        home_page.add_child(instance=EventPage(title="Christmas party"))
+
+    response = self.client.get("/search/?q=Christmas")
+    self.assertContains(response, "Christmas party")
+```
+
 ## Upgrade considerations - deprecation of old functionality
 
 ## Upgrade considerations - changes affecting Wagtail customizations


### PR DESCRIPTION
Addition to the upgrade note added in https://github.com/wagtail/wagtail/pull/12787 to cover how to update tests that make database changes and expect to see the results reflected immediately in search queries and other processes that now only happen at the end of a transaction.
