### PR TITLE
6.4 release notes & docs - typos, links & formatting cleanup

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,7 +41,7 @@ Changelog
  * Fix: Normalize `StreamField.get_default()` to prevent creation forms from breaking (Matt Westcott)
  * Fix: Prevent out-of-order migrations from skipping creation of image/document choose permissions (Matt Westcott)
  * Fix: Use correct connections on multi-database setups in database search backends (Jake Howard)
- * Fix: Ensure Cloudfront cache invalidation is called with a list, for compatibility with current botocore versions (Jake Howard)
+ * Fix: Ensure CloudFront cache invalidation is called with a list, for compatibility with current botocore versions (Jake Howard)
  * Fix: Show the correct privacy status in the sidebar when creating a new page (Joel William)
  * Fix: Prevent generic model edit view from unquoting non-integer primary keys multiple times (Matt Westcott)
  * Fix: Ensure comments are functional when editing Page models with `read_only` `Fieldpanel`s in use (Strapchay)
@@ -149,7 +149,7 @@ Changelog
 6.3.2 (02.01.2025)
 ~~~~~~~~~~~~~~~~~~
 
- * Fix: Ensure Cloudfront cache invalidation is called with a list, for compatibility with current botocore versions (Jake Howard)
+ * Fix: Ensure CloudFront cache invalidation is called with a list, for compatibility with current botocore versions (Jake Howard)
  * Fix: Ensure Draftail features wrap when a large amount of features are added (Bart Cieliński)
  * Fix: Implement `get_block_by_content_path` on `ImageBlock` to prevent errors on commenting (Matt Westcott)
  * Docs: Update tutorial to reflect the move of the "Add child page" action to a top-level button in the header as a '+' icon (Clifford Gama)

--- a/docs/advanced_topics/accessibility_considerations.md
+++ b/docs/advanced_topics/accessibility_considerations.md
@@ -20,7 +20,7 @@ As part of defining your site’s models, here are areas to pay special attentio
 
 ### Alt text for images
 
-Wherever an image is used, the content editor should be able to mark the image as decorative or provide a context-specific text alternative. The image embed in our rich text editor supports this behavior.  Wagtail 6.3 added [`ImageBlock`](streamfield_imageblock) to provide this behavior for images within StreamFields.
+Wherever an image is used, the content editor should be able to mark the image as decorative or provide a context-specific text alternative. The image embed in our rich text editor supports this behavior. Wagtail 6.3 added [`ImageBlock`](streamfield_imageblock) to provide this behavior for images within StreamFields.
 
 Wagtail 6.3 also added an optional `description` field to the Wagtail image model and to custom image models inheriting from `wagtail.images.models.AbstractImage`. Text in that field will be offered as the default alt text when inserting images in rich text or using ImageBlock. If the description field is empty, the title field will be used instead. If you would like to customize this behavior, [override the `default_alt_text` property](custom_image_model) in your image model.
 

--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -38,7 +38,9 @@ This tutorial uses [`venv`](inv:python#tutorial/venv), which is packaged with Py
 ```doscon
 py -m venv mysite\env
 ```
+
 Activate this virtual environment using:
+
 ```doscon
 mysite\env\Scripts\activate.bat
 
@@ -49,14 +51,18 @@ mysite\env\Scripts\activate
 
 **On GNU/Linux or MacOS** (bash):
 
-Create the virtual environment using:  
+Create the virtual environment using:
+
 ```sh
 python -m venv mysite/env
 ```
+
 Activate the virtual environment using:
+
 ```sh
 source mysite/env/bin/activate
 ```
+
 Upon activation, your command line will show `(env)` to indicate that you're now working within this virtual environment.
 
 **For other shells** see the [`venv` documentation](inv:python#tutorial/venv).
@@ -566,7 +572,7 @@ class BlogPage(Page):
 
         # Add this
          "gallery_images",
-        ] 
+        ]
 
 
 class BlogPageGalleryImage(Orderable):
@@ -737,7 +743,7 @@ class BlogPage(Page):
     ]
 ```
 
-Here you have used the  `MultiFieldPanel` in `content_panels` to group  the `date` and `authors` fields together for readability. By doing this, you are creating a single panel object that encapsulates multiple fields within a list or tuple into a single `heading` string. This feature is particularly useful for organizing related fields in the admin interface, making the UI more intuitive for content editors.
+Here you have used the  `MultiFieldPanel` in `content_panels` to group the `date` and `authors` fields together for readability. By doing this, you are creating a single panel object that encapsulates multiple fields within a list or tuple into a single `heading` string. This feature is particularly useful for organizing related fields in the admin interface, making the UI more intuitive for content editors.
 
 Migrate your database by running `python manage.py makemigrations` and `python manage.py migrate`, and then go to your [admin interface](https://guide.wagtail.org/en-latest/concepts/wagtail-interfaces/#admin-interface) . Notice that the list of authors is presented as a multiple select box. This is the default representation for a multiple choice field - however, users often find a set of checkboxes to be more familiar and easier to work with.
 

--- a/docs/reference/contrib/index.md
+++ b/docs/reference/contrib/index.md
@@ -34,7 +34,7 @@ Provides a view that generates a Google XML sitemap of your public Wagtail conte
 
 ## [](frontendcache)
 
-A module for automatically purging pages from a cache (Varnish, Squid, Cloudflare or Cloudfront) when their content is changed.
+A module for automatically purging pages from a cache (Varnish, Squid, Cloudflare or CloudFront) when their content is changed.
 
 ## [](routablepage)
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -1178,16 +1178,18 @@ def add_custom_headers(next_serve_page):
 ```
 
 Parameters passed to the function:
-- `page` - the Page object being served
-- `request` - the request object
-- `args` - positional arguments that will be passed to the page's serve method
-- `kwargs` - keyword arguments that will be passed to the page's serve method
+
+-   `page` - the Page object being served
+-   `request` - the request object
+-   `args` - positional arguments that will be passed to the page's serve method
+-   `kwargs` - keyword arguments that will be passed to the page's serve method
 
 This hook is particularly useful for:
-- Adding/modifying response headers
-- Implementing access restrictions
-- Modifying the response content
-- Adding logging or monitoring
+
+-   Adding/modifying response headers
+-   Implementing access restrictions
+-   Modifying the response content
+-   Adding logging or monitoring
 
 ## Document serving
 

--- a/docs/reference/panels.md
+++ b/docs/reference/panels.md
@@ -71,7 +71,6 @@ Instead of
 ```
 ````
 
-
 (multiFieldPanel)=
 
 ### MultiFieldPanel

--- a/docs/releases/6.3.2.md
+++ b/docs/releases/6.3.2.md
@@ -13,7 +13,7 @@ depth: 1
 
 ### Bug fixes
 
- * Ensure Cloudfront cache invalidation is called with a list, for compatibility with current botocore versions (Jake Howard)
+ * Ensure CloudFront cache invalidation is called with a list, for compatibility with current botocore versions (Jake Howard)
  * Ensure Draftail features wrap when a large amount of features are added (Bart Cieliński)
  * Implement `get_block_by_content_path` on `ImageBlock` to prevent errors on commenting (Matt Westcott)
 

--- a/docs/releases/6.3.3.md
+++ b/docs/releases/6.3.3.md
@@ -11,7 +11,6 @@ depth: 1
 
 ## What's new
 
-
 ### Bug fixes
 
  * Correctly place comment buttons next to date / datetime / time fields. (Srishti Jaiswal)

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -104,7 +104,7 @@ This feature was developed by Thibaud Colas and Sage Abdullah, thanks to a spons
  * Normalize `StreamField.get_default()` to prevent creation forms from breaking (Matt Westcott)
  * Prevent out-of-order migrations from skipping creation of image/document choose permissions (Matt Westcott)
  * Use correct connections on multi-database setups in database search backends (Jake Howard)
- * Ensure Cloudfront cache invalidation is called with a list, for compatibility with current botocore versions (Jake Howard)
+ * Ensure CloudFront cache invalidation is called with a list, for compatibility with current botocore versions (Jake Howard)
  * Show the correct privacy status in the sidebar when creating a new page (Joel William)
  * Prevent generic model edit view from unquoting non-integer primary keys multiple times (Matt Westcott)
  * Ensure comments are functional when editing Page models with `read_only` `FieldPanel`s in use (Strapchay)

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -39,12 +39,12 @@ Thank you to Sævar Öfjörð Magnússon and Alex Fulcher for creating this new 
 
 ### Alt text improvements
 
-Building upon improvements in past versions, this releases comes with further enhancements to alt text management:
+Building upon improvements in past versions, this release comes with further enhancements to alt text management:
 
  * The [content modeling accessibility considerations](content_modeling) now reflect the latest capabilities for alt text.
- * The new ImageBlock alt text is now populated from the image’s default alt text when selecting a new image.
- * The ImageBlock alt text field is also populated from the image’s default alt text when converting from an ImageChooserBlock.
- * Alt text quality is now checked by default as was intended with the `alt-text-quality` content check.
+ * The new `ImageBlock` alt text is now populated from the image’s default alt text when selecting a new image.
+ * The `ImageBlock` alt text field is also populated from the image’s default alt text when converting from an ImageChooserBlock.
+ * Alt text quality is now checked by default, as was intended with the `alt-text-quality` content check.
 
 Thank you to Matt Westcott, Thibaud Colas, and Cynthia Kiser for their work on these improvements.
 
@@ -153,12 +153,12 @@ This feature was developed by Thibaud Colas and Sage Abdullah, thanks to a spons
  * Fix link to `HTTPMethod` in `Page.handle_options_request()` docs (Sage Abdullah)
  * Improve [](pages_theory) with added & more consistent section headings and admonitions to aid in readability (Clifford Gama)
  * Fix non-functional link to the community guidelines in the [Your first contribution](../contributing/first_contribution_guide.md) page (Ankit Kumar)
- * Introduce tags and filters by name in "Writing templates" docs (Clifford Gama)
+ * Introduce tags and filters by name in the [](writing_templates) docs (Clifford Gama)
  * Fix Django HTML syntax formatting issue on the [documents overview](documents_overview) page (LB (Ben) Johnston)
  * Separate virtual environment creation and activation steps in tutorial (Ankit Kumar)
  * Update tutorial to use plain strings in place of `FieldPanel` / `InlinePanel` where appropriate (Unyime Emmanuel Udoh)
- * Update example for customizing "p-as-heading" accessibility check without overriding built-in checks (Cynthia Kiser)
- * Document `get_template` method on StreamField blocks (Matt Westcott)
+ * Update example for customizing ["p-as-heading" accessibility check](built_in_accessibility_checker) without overriding built-in checks (Cynthia Kiser)
+ * Document [`get_template` method on StreamField blocks](streamfield_get_template) (Matt Westcott)
 
 ### Maintenance
 
@@ -177,7 +177,7 @@ This feature was developed by Thibaud Colas and Sage Abdullah, thanks to a spons
  * Remove unnecessary DOM canvas.toBlob polyfill (LB (Ben) Johnston)
  * Ensure Storybook core files are correctly running through Eslint (LB (Ben) Johnston)
  * Add a new Stimulus `ZoneController` (`w-zone`) to support dynamic class name changes & event handling on container elements (Ayaan Qadri)
- * Migrate jQuery class toggling & drag/drop event handling within the multiple upload views to the Stimulus ZoneController usage (Ayaan Qadri)
+ * Migrate jQuery class toggling & drag/drop event handling within the multiple upload views to the Stimulus `ZoneController` usage (Ayaan Qadri)
  * Test project template for warnings when run against Django pre-release versions (Sage Abdullah)
  * Refactor redirects create/delete views to use generic views (Sage Abdullah)
  * Add JSDoc description, adopt linting recommendations, and add more unit tests for `ModalWorkflow` (LB (Ben) Johnston)
@@ -216,7 +216,9 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = 10_000
 
 ### Form builder - validation of fields with custom `related_name`
 
-On previous releases, form page models (defined through `AbstractEmailForm`, `AbstractForm`, `FormMixin` or `EmailFormMixin`) did not validate form fields where the `related_name` was different to the default value of `form_fields`. As a result, it was possible to create forms with duplicate field names - in this case, only a single field is displayed and captured in the resulting form. As of Wagtail 6.4, validation is now applied on these fields. Existing forms will continue to behave as before and no data will be lost, but editing them will now raise a validation error.
+On previous releases, form page models (defined through `AbstractEmailForm`, `AbstractForm`, `FormMixin` or `EmailFormMixin`) did not validate form fields where the `related_name` was different to the default value of `form_fields`. As a result, it was possible to create forms with duplicate field names - in this case, only a single field is displayed and captured in the resulting form.
+
+In this new release, validation is now applied on these fields, existing forms will continue to behave as before and no data will be lost. However, editing them will now raise a validation error and users may need to delete any duplicated fields that they had previously missed.
 
 ### Background tasks run at end of current transaction
 
@@ -274,7 +276,6 @@ The old style will now produce a deprecation warning.
 ### Changes to `content_panels`, `promote_panels` and `settings_panels` values on base `Page` model
 
 Previously, the `content_panels`, `promote_panels` and `settings_panels` attributes on the base `Page` model were defined as lists of `Panel` instances. These lists now contain instances of `wagtail.models.PanelPlaceholder` instead, which are resolved to `Panel` instances at runtime. Panel definitions that simply extend these lists (such as `content_panels = Page.content_panels + [...]`) are unaffected; however, any logic that inspects these lists (for example, finding a panel in the list to insert a new one immediately after it) will need to be updated to handle the new object types.
-
 
 ### Removal of unused Rangy JS library
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -9,7 +9,7 @@ callables
 camelCase
 CDN
 Cloudflare
-Cloudfront
+CloudFront
 contrib
 CSP
 Ctrl

--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -494,6 +494,8 @@ class EventBlock(blocks.StructBlock):
 
 In this example, the variable `is_happening_today` will be made available within the block template. The `parent_context` keyword argument is available when the block is rendered through an `{% include_block %}` tag, and is a dict of variables passed from the calling template.
 
+(streamfield_get_template)=
+
 Similarly, a `get_template` method can be defined to dynamically select a template based on the block value:
 
 ```python


### PR DESCRIPTION
## Overview
- Fix a few small typos & formatting issues in the 6.4 release notes
- Ensure the form builder changes are better documented in the upgrade considerations
- Add links to other docs pages where possible release notes
- Improve consistency with usage of `code` backticks on modules
- Add docs reference for StreamField `get_template` docs
- Fix up spelling of `CloudFront` across release notes & docs
- Fix a few minor whitespace formatting items throughout docs