### PR TITLE
Unit test + Fix for order of InlinePanel with min_num argument

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Changelog
  * Fix: Support translating with the preferred language for rich text formatting labels (Bernhard Bliem, Sage Abdullah)
  * Fix: Make "Actions" label translatable within the rich text toolbar (Bernhard Bliem, Sage Abdullah)
  * Fix: Fix incorrect "Views (past week)" heading on promoted search results listing (Baptiste Mispelon)
+ * Fix: Ensure `InlinePanel` will be correctly ordered after the first save when `min_num` is used (Elhussein Almasri, Joel William)
  * Docs: Add missing `django.contrib.admin` to list of apps in "add to Django project" guide (Mohamed Rabiaa)
  * Docs: Add tutorial on deploying on Ubuntu to third-party tutorials (Mohammad Fathi Rahman)
  * Maintenance: Migrate away from deprecated Sass import rules to module system (Srishti Jaiswal)

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -28,6 +28,7 @@ depth: 1
  * Support simple subqueries for `in` and `exact` lookup on Elasticsearch (Sage Abdullah)
  * Force preview panel scroll behavior to instant to avoid flickering (Sage Abdullah)
  * Fix incorrect "Views (past week)" heading on promoted search results listing (Baptiste Mispelon)
+ * Ensure `InlinePanel` will be correctly ordered after the first save when `min_num` is used (Elhussein Almasri, Joel William)
 
 ### Documentation
 

--- a/wagtail/admin/panels/inline_panel.py
+++ b/wagtail/admin/panels/inline_panel.py
@@ -105,7 +105,9 @@ class InlinePanel(Panel):
 
                 # ditto for the ORDER field, if present
                 if self.formset.can_order:
-                    subform.fields[ORDERING_FIELD_NAME].widget = forms.HiddenInput()
+                    subform.fields[ORDERING_FIELD_NAME].widget = forms.HiddenInput(
+                        attrs={"value": index + 1}
+                    )
 
                 self.children.append(
                     self.child_edit_handler.get_bound_panel(

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -1531,6 +1531,29 @@ class TestInlinePanel(WagtailTestUtils, TestCase):
         # Label is the singular term, derived from the related model's verbose_name
         self.assertEqual(panel.label, "Social link")
 
+    def test_inline_panel_order_with_min_num(self):
+        event_page = EventPage.objects.get(slug="christmas")
+
+        speaker_object_list = ObjectList(
+            [InlinePanel("speakers", label="Speakers", min_num=2)]
+        ).bind_to_model(EventPage)
+
+        EventPageForm = speaker_object_list.get_form_class()
+        form = EventPageForm(instance=event_page)
+
+        bound_panel = speaker_object_list.get_bound_panel(
+            instance=event_page, form=form, request=self.request
+        )
+
+        formset = bound_panel.children[0].formset
+
+        for index, form in enumerate(formset.forms):
+            self.assertEqual(
+                str(form.fields["ORDER"].widget.attrs.get("value")),
+                str(index + 1),
+                f"Initial form at index {index} should have ORDER value {index + 1}",
+            )
+
 
 class TestNonOrderableInlinePanel(WagtailTestUtils, TestCase):
     fixtures = ["test.json"]


### PR DESCRIPTION
This PR fixes issue #9391 
It extends the PR #11889 by adding unit tests
