### PR TITLE
Ensure comment button as close as possible to radio select and select field

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
  * Fix: Avoid deprecation warnings about URLField `assume_scheme` on Django 5.x (Sage Abdullah)
  * Fix: Fix setup.cfg syntax for setuptools v78 (Sage Abdullah)
  * Fix: Ensure `ImproperlyConfigured` is thrown from `db_field` on unbound `FieldPanel`s as intended (Matt Westcott)
+ * Fix: Refine the positioning of the add comment button next to select, radio, checkbox fields (Srishti Jaiswal)
  * Docs: Add missing `django.contrib.admin` to list of apps in "add to Django project" guide (Mohamed Rabiaa)
  * Docs: Add tutorial on deploying on Ubuntu to third-party tutorials (Mohammad Fathi Rahman)
  * Docs: Document that request_or_site is optional on BaseGenericSetting.load (Matt Westcott)

--- a/client/scss/components/forms/_radio-checkbox-multiple.scss
+++ b/client/scss/components/forms/_radio-checkbox-multiple.scss
@@ -7,6 +7,9 @@
 .w-field--checkbox_select_multiple_with_disabled_options,
 .w-field--boolean_radio_select,
 .w-field--radio_select {
+  // Make sure comment buttons are as close as possible.
+  display: inline-block;
+
   ul {
     list-style: none;
     padding: 0;

--- a/client/scss/components/forms/_select.scss
+++ b/client/scss/components/forms/_select.scss
@@ -64,3 +64,8 @@ select[multiple] {
     padding: 0 theme('spacing.5');
   }
 }
+
+.w-field--select {
+  // Make sure comment buttons are as close as possible.
+  display: inline-block;
+}

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -35,6 +35,7 @@ depth: 1
  * Avoid deprecation warnings about URLField `assume_scheme` on Django 5.x (Sage Abdullah)
  * Fix setup.cfg syntax for setuptools v78 (Sage Abdullah)
  * Ensure `ImproperlyConfigured` is thrown from `db_field` on unbound `FieldPanel`s as intended (Matt Westcott)
+ * Refine the positioning of the add comment button next to select, radio, checkbox fields (Srishti Jaiswal)
 
 ### Documentation
 


### PR DESCRIPTION
Fixes #12687 

As suggested in https://github.com/wagtail/wagtail/pull/12685, this PR fixes the issue for the radio select ,select fields and  checkbox_select_multiple field etc.

e.g for select_field:

![image](https://github.com/user-attachments/assets/330fab06-e724-418a-ba7c-ee947ecba73a)

e.g for radio_select_field:

![image](https://github.com/user-attachments/assets/db1a5dcd-f275-4b48-9906-600f000346b6)

e.g checkbox_select_multiple field:

![image](https://github.com/user-attachments/assets/30066ffd-fa6b-4077-b048-8470f0f53667)
