### PR TITLE
Add `normalize()` implementation to TypedTableBlock

### DIFF
--- a/wagtail/contrib/typed_table_block/blocks.py
+++ b/wagtail/contrib/typed_table_block/blocks.py
@@ -188,6 +188,11 @@ class BaseTypedTableBlock(Block):
                 "caption": "",
             }
 
+    def normalize(self, value):
+        if value is None or isinstance(value, TypedTable):
+            return value
+        return self.to_python(value)
+
     def to_python(self, value):
         if value:
             columns = [

--- a/wagtail/contrib/typed_table_block/tests.py
+++ b/wagtail/contrib/typed_table_block/tests.py
@@ -162,6 +162,33 @@ class TestTableBlock(TestCase):
             ["fr", "68000000", "A large country with baguettes"],
         )
 
+    def test_normalize(self):
+        # Should be able to handle JSONish data from the database, which can be
+        # useful when defining a default value for a TypedTableBlock
+        table = self.block.normalize(self.db_data)
+        self.assertEqual(table.caption, "Countries and their food")
+        self.assertIsInstance(table, TypedTable)
+        self.assertEqual(len(table.columns), 2)
+        self.assertEqual(table.columns[0]["heading"], "Country")
+        self.assertEqual(table.columns[1]["heading"], "Description")
+        rows = list(table.rows)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(
+            [block.value for block in rows[0]],
+            ["nl", "A small country with stroopwafels"],
+        )
+        self.assertEqual(
+            [block.value for block in rows[1]], ["fr", "A large country with baguettes"]
+        )
+
+        # For a TypedTable instance, normalize should return the instance as-is
+        normalized_table = self.block.normalize(table)
+        self.assertIs(normalized_table, table)
+
+        # Should normalize None as-is
+        none_value = self.block.normalize(None)
+        self.assertIs(none_value, None)
+
     def test_to_python(self):
         """
         Test that we can turn JSONish data from the database into a TypedTable instance


### PR DESCRIPTION
I wanted to add `preview_value` to a `TypedTableBlock` in bakerydemo, but I found that I had to use a `TypedTable` instance, which isn't documented. I don't think the dict representation is documented either, but given that it's already used in `get_prep_value` and `get_api_representation`, I thought it would make sense to also accept it for `default`/`preview_value`.

Both `default` and `preview_value` are processed through `normalize()`, so I think there needs to be a `TypedTableBlock.normalize()` method.

However, the `to_python()` implementation already has the logic to convert the dict representation to a `TypedTable`, so I opted to reuse it instead – with the addition of returning the value as-is if it's `None` or a `TypedTable` instance.

I'm not sure if this is the right approach. I don't think I quite understand what the relationship between `normalize()` and `to_python()` should be like. I found that `StreamBlock.normalize()` calls `to_python()` on itself, but in return `StreamBlock.to_python()` calls `normalize()` on its child blocks. In other blocks, they seem mostly independent, sometimes using a shared private method or have the same code entirely.

Maybe there should be a separate method for `TypedTableBlock` that both `to_python()` and `normalize()` use?

I do agree that we do need a method that gracefully converts close-enough representation of the block's value to its native type as per #9738, but I thought [that's what `to_python()` was meant for](https://docs.djangoproject.com/en/stable/howto/custom-model-fields/#converting-values-to-python-objects), at least for model fields. Perhaps there's a case where `normalize()` and `to_python()` must return different things? (For `None`, maybe 🤔)