### PR TITLE
Fix CacheStorage remove method to use CACHE_PREFIX

### DIFF
--- a/wagtail/contrib/redirects/tmp_storages.py
+++ b/wagtail/contrib/redirects/tmp_storages.py
@@ -88,7 +88,7 @@ class CacheStorage(BaseStorage):
         return cache.get(self.CACHE_PREFIX + self.name)
 
     def remove(self):
-        cache.delete(self.name)
+        cache.delete(self.CACHE_PREFIX + self.name)
 
 
 class MediaStorage(BaseStorage):


### PR DESCRIPTION
This pull request addresses an issue with the `CacheStorage` class in the Wagtail redirects module. Previously, the `remove()` method did not utilize the `CACHE_PREFIX` when deleting cache entries, which could lead to incomplete cleanup of temporary data.

#### Changes Made:

- Updated the `remove()` method in the `CacheStorage` class to include the `CACHE_PREFIX` when deleting entries from the cache.
- Added a new test case, `test_cache_storage_remove_uses_prefix`, to verify that the cache key includes the prefix during removal.
- Ensured that this change did not affect existing tests related to file storage and cache functionality.
- Related Issue:

This PR addresses issue #12804
