### PR TITLE
Configure block previews and descriptions in block chooser within rich text

### DIFF
--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -243,8 +243,11 @@ class DraftailInsertBlockCommand {
 
     this.blockMax = addSibling.getBlockMax(blockDef.name);
     this.icon = blockDef.meta.icon;
-    this.description = blockDef.meta.label;
+    this.label = blockDef.meta.label;
     this.type = blockDef.name;
+    this.blockDefId = blockDef.meta.blockDefId;
+    this.isPreviewable = blockDef.meta.isPreviewable;
+    this.description = blockDef.meta.description;
   }
 
   render({ option }) {
@@ -255,7 +258,7 @@ class DraftailInsertBlockCommand {
             this.blockMax
           })`
         : '';
-    return `${option.description}${limitText}`;
+    return `${option.label}${limitText}`;
   }
 
   onSelect({ editorState }) {

--- a/client/src/entrypoints/admin/telepath/widgets.test.js
+++ b/client/src/entrypoints/admin/telepath/widgets.test.js
@@ -526,6 +526,28 @@ describe('telepath: wagtail.widgets.DraftailRichTextArea', () => {
     });
     parentCapabilities = new Map();
     parentCapabilities.set('split', { enabled: true, fn: jest.fn() });
+    parentCapabilities.set('addSibling', {
+      enabled: true,
+      getBlockMax: () => 5,
+      blockGroups: [
+        [
+          'Media',
+          [
+            {
+              name: 'image_block',
+              meta: {
+                icon: 'image',
+                label: 'Image',
+                blockDefId: 'blockdef-1234',
+                isPreviewable: true,
+                description: 'Full-width image',
+              },
+            },
+          ],
+        ],
+      ],
+      fn: jest.fn(),
+    });
     const inputId = 'the-id';
     boundWidget = widgetDef.render(
       document.getElementById('placeholder'),
@@ -616,9 +638,21 @@ describe('telepath: wagtail.widgets.DraftailRichTextArea', () => {
     ReactTestUtils.act(() =>
       boundWidget.setCapabilityOptions('split', { enabled: true }),
     );
-    expect(inputElement.draftailEditor.props.commands).toHaveLength(3);
-    expect(inputElement.draftailEditor.props.commands[2].items[0].type).toBe(
+    expect(inputElement.draftailEditor.props.commands).toHaveLength(4);
+    expect(inputElement.draftailEditor.props.commands[3].items[0].type).toBe(
       'split',
+    );
+  });
+
+  test('configures the block chooser based on siblings capability', () => {
+    expect(inputElement.draftailEditor.props.commands[2].items[0]).toEqual(
+      expect.objectContaining({
+        icon: 'image',
+        label: 'Image',
+        blockDefId: 'blockdef-1234',
+        isPreviewable: true,
+        description: 'Full-width image',
+      }),
     );
   });
 });


### PR DESCRIPTION
Follow-up to #12700, adding missing block preview configuration when displaying the block chooser within rich text fields. Aside from the extra configuration needed, the block preview works the exact same as outside of those fields.

Tested in Chrome 130 and Firefox 134 on macOS 14.4.

![12813](https://github.com/user-attachments/assets/b3401fea-f924-4402-89d8-a37771cb785b)
