### PR TITLE
Fix `Block.is_previewable` detection on blocks with non-`None` unset default values

### DIFF
--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -299,6 +299,10 @@ class Block(metaclass=BaseBlock):
         return self.get_default()
 
     @cached_property
+    def _has_default(self):
+        return getattr(self.meta, "default", None) is not None
+
+    @cached_property
     def is_previewable(self):
         # To prevent showing a broken preview if the block preview has not been
         # configured, consider the block to be previewable if either:
@@ -314,7 +318,7 @@ class Block(metaclass=BaseBlock):
         )
         has_preview_value = (
             hasattr(self.meta, "preview_value")
-            or getattr(self.meta, "default", None) is not None
+            or self._has_default
             or self.__class__.get_preview_context is not Block.get_preview_context
             or self.__class__.get_preview_value is not Block.get_preview_value
         )

--- a/wagtail/blocks/list_block.py
+++ b/wagtail/blocks/list_block.py
@@ -147,7 +147,8 @@ class ListBlock(Block):
         else:
             self.child_block = child_block
 
-        if not hasattr(self.meta, "default"):
+        self._has_default = hasattr(self.meta, "default")
+        if not self._has_default:
             # Default to a list consisting of one empty (i.e. default-valued) child item
             self.meta.default = [self.child_block.get_default()]
 

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -460,6 +460,10 @@ class BaseStreamBlock(Block):
 
         return errors
 
+    @cached_property
+    def _has_default(self):
+        return self.meta.default is not BaseStreamBlock._meta_class.default
+
     class Meta:
         # No icon specified here, because that depends on the purpose that the
         # block is being used for. Feel encouraged to specify an icon in your

--- a/wagtail/blocks/struct_block.py
+++ b/wagtail/blocks/struct_block.py
@@ -382,6 +382,10 @@ class BaseStructBlock(Block):
             "prefix": prefix,
         }
 
+    @cached_property
+    def _has_default(self):
+        return self.meta.default is not BaseStructBlock._meta_class.default
+
     class Meta:
         default = {}
         form_classname = "struct-block"

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -93,6 +93,11 @@ class TestBlock(SimpleTestCase):
             "specific_template_and_custom_value": [
                 blocks.Block(preview_template="foo.html", preview_value="bar"),
             ],
+            "unset_default_not_none": [
+                blocks.ListBlock(blocks.Block()),
+                blocks.StreamBlock(),
+                blocks.StructBlock(),
+            ],
         }
 
         # Test without a global template override
@@ -109,6 +114,9 @@ class TestBlock(SimpleTestCase):
             # Providing both a preview template and value also makes the block
             # previewable, this is the same as providing a custom template only
             ("specific_template_and_custom_value", True),
+            # These blocks define their own unset default value that is not
+            # `None`, and that value should not make it previewable
+            ("unset_default_not_none", False),
         ]
         for variant, is_previewable in cases:
             with self.subTest(variant=variant, custom_global_template=False):
@@ -134,6 +142,9 @@ class TestBlock(SimpleTestCase):
                 ("custom_value", True),
                 # Unchanged – providing both also makes the block previewable
                 ("specific_template_and_custom_value", True),
+                # Unchanged – even after providing a global template override,
+                # these blocks should not be previewable
+                ("unset_default_not_none", False),
             ]
             for variant, is_previewable in cases:
                 with self.subTest(variant=variant, custom_global_template=True):


### PR DESCRIPTION
Some built-in blocks, in particular `StreamBlock`, `StructBlock`, and `ListBlock`, have their own unset default values (a _default_ `default`, if you will) that are not `None`.

The `Block.is_previewable` property naively checks whether `self.meta.default` is not `None` when checking for whether the block has a default value. If a global template override is provided, these blocks will be considered "previewable", despite not necessarily having default values for their child blocks. As a result, the block picker would show a preview, but the iframe may end up rendering a bunch of `None` values.

To replicate this issue, check out the branch from https://github.com/wagtail/bakerydemo/pull/521 and apply the following patch:

```diff
diff --git a/bakerydemo/base/blocks.py b/bakerydemo/base/blocks.py
index 4bf75a0..e55e9a8 100644
--- a/bakerydemo/base/blocks.py
+++ b/bakerydemo/base/blocks.py
@@ -27,17 +27,9 @@ class ImageBlock(StructBlock):
         # Cache the image object for previews to avoid repeated queries
         return get_image_model().objects.last()

-    def get_preview_value(self):
-        return {
-            **self.meta.preview_value,
-            "image": self.preview_image,
-            "caption": self.preview_image.description,
-        }
-
     class Meta:
         icon = "image"
         template = "blocks/image_block.html"
-        preview_value = {"attribution": "The Wagtail Bakery"}
         description = "An image with optional caption and attribution"


```

Before this PR, the image block will have a preview that shows as "None – None". After this PR, it shouldn't be previewable in the first place (no eye icon and the preview iframe won't be displayed at all).

### Before

<img width="1021" alt="image" src="https://github.com/user-attachments/assets/e1e9e766-e35b-4a2e-a28e-8b479cccce8e" />

### After

<img width="530" alt="image" src="https://github.com/user-attachments/assets/6489ffd9-106f-4678-a8d4-36c0d456749c" />
