### PR TITLE
Stop non-alphanumeric characters in search terms breaking MySQL search backend

### DIFF
--- a/wagtail/search/backends/database/mysql/mysql.py
+++ b/wagtail/search/backends/database/mysql/mysql.py
@@ -346,7 +346,7 @@ class MySQLSearchQueryCompiler(BaseSearchQueryCompiler):
         if isinstance(query, PlainText):
             terms = query.query_string.split()
             if not terms:
-                return None
+                return SearchQuery("")
 
             last_term = terms.pop()
 

--- a/wagtail/search/backends/database/mysql/mysql.py
+++ b/wagtail/search/backends/database/mysql/mysql.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 from collections import OrderedDict
 
@@ -344,7 +345,10 @@ class MySQLSearchQueryCompiler(BaseSearchQueryCompiler):
 
     def build_search_query_content(self, query, invert=False):
         if isinstance(query, PlainText):
-            terms = query.query_string.split()
+            # For Boolean full text search queries in MySQL,
+            # non-alphanumeric characters act as separators
+            terms = [term for term in re.split("\W+", query.query_string) if term]
+
             if not terms:
                 return SearchQuery("")
 

--- a/wagtail/search/tests/test_mysql_backend.py
+++ b/wagtail/search/tests/test_mysql_backend.py
@@ -68,6 +68,25 @@ class TestMySQLSearchBackend(BackendTests, TransactionTestCase):
             all_other_titles | {"JavaScript: The Definitive Guide"},
         )
 
+    def test_empty_search(self):
+        results = self.backend.search("", models.Book.objects.all())
+        self.assertSetEqual(
+            {r.title for r in results},
+            set(),
+        )
+
+        results = self.backend.search(" ", models.Book.objects.all())
+        self.assertSetEqual(
+            {r.title for r in results},
+            set(),
+        )
+
+        results = self.backend.search("*", models.Book.objects.all())
+        self.assertSetEqual(
+            {r.title for r in results},
+            set(),
+        )
+
     @skip(
         "The MySQL backend doesn't support choosing individual fields for the search, only (body, title) or (autocomplete) fields may be searched."
     )

--- a/wagtail/search/tests/test_mysql_backend.py
+++ b/wagtail/search/tests/test_mysql_backend.py
@@ -87,6 +87,62 @@ class TestMySQLSearchBackend(BackendTests, TransactionTestCase):
             set(),
         )
 
+    def test_empty_autocomplete(self):
+        results = self.backend.autocomplete("", models.Book.objects.all())
+        self.assertSetEqual(
+            {r.title for r in results},
+            set(),
+        )
+
+        results = self.backend.autocomplete(" ", models.Book.objects.all())
+        self.assertSetEqual(
+            {r.title for r in results},
+            set(),
+        )
+
+        results = self.backend.autocomplete("*", models.Book.objects.all())
+        self.assertSetEqual(
+            {r.title for r in results},
+            set(),
+        )
+
+    def test_symbols_in_search_term(self):
+        # symbols as their own tokens should be ignored
+        results = self.backend.search("javascript @ parts", models.Book.objects.all())
+        self.assertSetEqual(
+            {r.title for r in results},
+            {"JavaScript: The good parts"},
+        )
+
+        results = self.backend.search("javascript parts @", models.Book.objects.all())
+        self.assertSetEqual(
+            {r.title for r in results},
+            {"JavaScript: The good parts"},
+        )
+
+        results = self.backend.search("@ javascript parts", models.Book.objects.all())
+        self.assertSetEqual(
+            {r.title for r in results},
+            {"JavaScript: The good parts"},
+        )
+
+        # tokens containing both symbols and alphanumerics should not be discarded
+        # or treated as equivalent to the same token without symbols
+        results = self.backend.search("java@script parts", models.Book.objects.all())
+        self.assertSetEqual(
+            {r.title for r in results},
+            set(),
+        )
+
+    def test_autocomplete_with_symbols(self):
+        # the * is not part of the autocomplete mechanism, but if someone includes it
+        # we want it to be gracefully ignored
+        results = self.backend.autocomplete("parts javasc*", models.Book.objects.all())
+        self.assertSetEqual(
+            {r.title for r in results},
+            {"JavaScript: The good parts"},
+        )
+
     @skip(
         "The MySQL backend doesn't support choosing individual fields for the search, only (body, title) or (autocomplete) fields may be searched."
     )


### PR DESCRIPTION
Fixes #8614 and #12811, supersedes #12600

As per https://github.com/wagtail/wagtail/pull/12600#issuecomment-2620089822, we change the logic for splitting search queries so that all symbols (not just spaces) are treated as token separators. This ensures that the resulting Lexeme objects are purely alphanumeric, avoiding syntax errors that arise from insufficient escaping.

This PR does not add any extra validation to the `Lexeme` class to reject non-alphanumerics, to minimise changes and keep it suitable for backporting (in case people are relying on the undefined behaviour, knowingly or not). I'll make a follow-up PR for 6.5 to add that.