### PR TITLE
Validate against invalid characters in Lexeme values

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Maintenance: Migrate away from deprecated Sass import rules to module system (Srishti Jaiswal)
  * Maintenance: Apply Sass mixed declarations migration in preparation for CSS nesting (Prabhpreet Kaur)
  * Maintenance: npm package updates; `downshift`, `focus-trap-react`, `immer`, `redux`, `uuid` (LB (Ben) Johnston)
+ * Maintenance: Validate against invalid characters in Lexeme values (Matt Westcott)
 
 
 6.4.1 (21.02.2025)

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -37,6 +37,7 @@ depth: 1
  * Migrate away from deprecated Sass import rules to module system (Srishti Jaiswal)
  * Apply Sass mixed declarations migration in preparation for CSS nesting (Prabhpreet Kaur)
  * npm package updates; `downshift`, `focus-trap-react`, `immer`, `redux`, `uuid` (LB (Ben) Johnston)
+ * Validate against invalid characters in Lexeme values (Matt Westcott)
 
 ## Upgrade considerations - changes affecting all projects
 

--- a/wagtail/search/backends/database/mysql/query.py
+++ b/wagtail/search/backends/database/mysql/query.py
@@ -51,13 +51,17 @@ class Lexeme(LexemeCombinable, Value):
         self.prefix = prefix
         self.invert = invert
         self.weight = weight
+
+        if not value:
+            raise ValueError("Lexeme value cannot be empty.")
+        if re.search(r"\W+", value):
+            raise ValueError(
+                f"Lexeme value '{value}' must consist of alphanumeric characters and '_' only."
+            )
         super().__init__(value, output_field=output_field)
 
     def as_sql(self, compiler, connection):
-        param = re.sub(
-            r"\W+", " ", self.value
-        )  # Remove non-word characters. This is done to disallow the usage of full text search operators in the MATCH clause, because MySQL doesn't include these kinds of characters in FULLTEXT indexes.
-
+        param = self.value
         template = "%s"
 
         if self.prefix:

--- a/wagtail/search/tests/test_mysql_backend.py
+++ b/wagtail/search/tests/test_mysql_backend.py
@@ -143,6 +143,28 @@ class TestMySQLSearchBackend(BackendTests, TransactionTestCase):
             {"JavaScript: The good parts"},
         )
 
+    def test_lexeme_validation(self):
+        from wagtail.search.backends.database.mysql.query import Lexeme
+
+        with self.assertRaisesMessage(ValueError, "Lexeme value cannot be empty."):
+            Lexeme("")
+
+        Lexeme("hello")  # no error
+
+        with self.assertRaises(
+            ValueError,
+            "Lexeme value 'hello world' must consist of alphanumeric characters "
+            "and '_' only.",
+        ):
+            Lexeme("hello world")
+
+        with self.assertRaises(
+            ValueError,
+            "Lexeme value 'hello world' must consist of alphanumeric characters "
+            "and '_' only.",
+        ):
+            Lexeme("rimsky@korsakov")
+
     @skip(
         "The MySQL backend doesn't support choosing individual fields for the search, only (body, title) or (autocomplete) fields may be searched."
     )


### PR DESCRIPTION
Follow-up to (and incorporates) #12829 - not for backporting.