### PR TITLE
Revert "Simplify example of appending a rich text block to a streamfield"

### DIFF
--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -588,7 +588,8 @@ my_page.body[0] = ('heading', "My story")
 del my_page.body[-1]
 
 # Append a rich text block to the stream
-my_page.body.append(('paragraph', "<p>And they all lived happily ever after.</p>"))
+from wagtail.rich_text import RichText
+my_page.body.append(('paragraph', RichText("<p>And they all lived happily ever after.</p>")))
 
 # Save the updated data back to the database
 my_page.save()


### PR DESCRIPTION
See #12827 - `normalize` is not applied on append, so the value type must match.

This reverts commit b0cda80626e3a1af7f24b37be76eda1de24250ca.
