### PR TITLE
Adjust block chooser styles to match latest designs for block previews

### DIFF
--- a/client/src/components/ComboBox/ComboBox.scss
+++ b/client/src/components/ComboBox/ComboBox.scss
@@ -1,8 +1,8 @@
 // Ensure consistent spacing across the whole component.
 // With the scrolling and show/hide of the field, correct spacing is critical.
 $spacing: theme('spacing.[2.5]');
-$spacing-sm: theme('spacing.5');
-$width: min(1000px, 75vw);
+$spacing-sm: theme('spacing.4');
+$width: clamp(300px, 75vw, 1000px);
 
 .w-combobox-container {
   @include dark-theme() {
@@ -28,9 +28,9 @@ $width: min(1000px, 75vw);
 
   // Case 1: base case
   // Use max-content width to minimize shifting due to content wrapping,
-  // while also ensuring it's not wider than 75% of the viewport.
+  // constraining width to 75% of viewport for devices above 400px width.
   width: max-content;
-  max-width: 75vw;
+  max-width: max(300px, 75vw);
 
   // Case 2: there's a previewable block, but the preview may or may not be active
   // On smaller screens, the preview will be shown below. We don't want the
@@ -87,12 +87,13 @@ $width: min(1000px, 75vw);
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-auto-flow: column;
-  gap: theme('spacing.[0.5]');
+  gap: theme('spacing.1');
   padding: $spacing;
   padding-top: 0;
 
   @include media-breakpoint-up(sm) {
     width: 100%;
+    column-gap: theme('spacing.5');
     padding: $spacing-sm;
     padding-top: 0;
   }
@@ -120,14 +121,21 @@ $width: min(1000px, 75vw);
 }
 
 .w-combobox__option-preview {
+  @include more-contrast-interactive();
+  @include show-focus-outline-inside();
+  color: theme('colors.icon-secondary');
   background: none;
+  border: 1px solid transparent;
   padding: 0;
   width: 100%;
 
   .icon {
-    color: theme('colors.icon-secondary');
     width: theme('spacing.3');
     height: theme('spacing.3');
+  }
+
+  &:hover {
+    color: theme('colors.icon-secondary-hover');
   }
 }
 
@@ -143,17 +151,17 @@ $width: min(1000px, 75vw);
   display: grid;
   grid-template-columns: theme('spacing.8') 1fr;
   align-items: center;
-  padding: theme('spacing.2');
-  border: 1px solid transparent;
+  padding: theme('spacing.[2.5]');
+  border: 1px dotted theme('colors.border-button-small-outline-default');
   font-size: 0.875rem;
   line-height: theme('lineHeight.tight');
   border-radius: theme('borderRadius.sm');
+  cursor: pointer;
 
   &[aria-selected='true'] {
     border-color: theme('colors.border-button-outline-default');
     color: theme('colors.text-link-default');
     background: transparent;
-    cursor: pointer;
 
     @media (forced-colors: active) {
       background: Highlight;

--- a/client/src/components/ComboBox/ComboBox.scss
+++ b/client/src/components/ComboBox/ComboBox.scss
@@ -137,6 +137,15 @@ $width: clamp(300px, 75vw, 1000px);
   &:hover {
     color: theme('colors.icon-secondary-hover');
   }
+
+  &[aria-expanded='true'] {
+    color: theme('colors.text-link-default');
+
+    @media (forced-colors: active) {
+      background: Highlight;
+      color: HighlightText;
+    }
+  }
 }
 
 .w-combobox__option-row--col1 {

--- a/client/src/components/ComboBox/ComboBox.tsx
+++ b/client/src/components/ComboBox/ComboBox.tsx
@@ -68,6 +68,7 @@ export default function ComboBox<ComboBoxOption extends ComboBoxItem>({
     (category) => category.items || [],
   );
   const [inputItems, setInputItems] = useState<ComboBoxOption[]>(flatItems);
+  const [previewedIndex, setPreviewedIndex] = useState<number>(-1);
   // Re-create the categories so the two-column layout flows as expected.
   const categories = items.reduce<ComboBoxCategory<ComboBoxOption>[]>(
     (cats, cat, index) => {
@@ -88,7 +89,6 @@ export default function ComboBox<ComboBoxOption extends ComboBoxItem>({
     getMenuProps,
     getInputProps,
     getItemProps,
-    highlightedIndex,
     setHighlightedIndex,
     setInputValue,
     openMenu,
@@ -153,11 +153,10 @@ export default function ComboBox<ComboBoxOption extends ComboBoxItem>({
       setInputItems(filtered);
       // Always reset the first item to highlighted on filtering, to speed up selection.
       setHighlightedIndex(0);
+      // Hide any preview when the user starts typing.
+      setPreviewedIndex(-1);
     },
   });
-
-  const [lastHighlightedIndex, setLastHighlightedIndex] =
-    useState(highlightedIndex);
 
   useEffect(() => {
     if (inputValue) {
@@ -178,15 +177,8 @@ export default function ComboBox<ComboBoxOption extends ComboBoxItem>({
     }
   }, [inputValue]);
 
-  if (
-    inputItems[highlightedIndex] &&
-    highlightedIndex !== lastHighlightedIndex
-  ) {
-    setLastHighlightedIndex(highlightedIndex);
-  }
-
   const previewedBlock =
-    inputItems[highlightedIndex] || inputItems[lastHighlightedIndex];
+    previewedIndex >= 0 ? inputItems[previewedIndex] : null;
 
   return (
     <div className="w-combobox-container">
@@ -283,8 +275,13 @@ export default function ComboBox<ComboBoxOption extends ComboBoxItem>({
                         <button
                           className="w-combobox__option-preview"
                           aria-label={comboBoxPreviewLabel}
+                          aria-expanded={previewedIndex === itemIndex}
                           type="button"
-                          onClick={() => setHighlightedIndex(itemIndex)}
+                          onClick={() =>
+                            setPreviewedIndex(
+                              previewedIndex === itemIndex ? -1 : itemIndex,
+                            )
+                          }
                         >
                           <Icon name="view" />
                         </button>


### PR DESCRIPTION
Follow-up to #12798, in particular:

- Switches the block preview activation to be on button toggle only – no hover anymore. This makes it more predictable and less intrusive.
- Refines the layout of block options to be closer to the intended design
- Fixes a minor issue with layout on smaller screen widths (320-375px in particular)
- Adds more styles for forced colors and "more contrast" mode

## Testing

Tested in Chrome 132, Firefox 134, Safari 17.4 on macOS 14.4. And forced colors mode, and "prefers contrast: more". Recording across different renderings:

https://github.com/user-attachments/assets/aacaba3a-fad5-4ced-aba2-120cfea3c25b


