### PR TITLE
Fix cache key deletion in CacheStorage.remove()

### DIFF
--- a/wagtail/contrib/redirects/tmp_storages.py
+++ b/wagtail/contrib/redirects/tmp_storages.py
@@ -88,7 +88,8 @@ class CacheStorage(BaseStorage):
         return cache.get(self.CACHE_PREFIX + self.name)
 
     def remove(self):
-        cache.delete(self.name)
+        cache.delete(self.CACHE_PREFIX + self.name)  # ✅ Now correctly deletes the cached entry
+
 
 
 class MediaStorage(BaseStorage):


### PR DESCRIPTION
Previously, the `remove()` method in `CacheStorage` did not include the `CACHE_PREFIX` when deleting cached entries, causing them to persist until expiration.

This commit fixes the issue by ensuring the correct cache key is used when calling `cache.delete()`.

Related: #12797

_Please describe the problem you're fixing here. Include the issue number, if applicable._


check it any changes needed
