### PR TITLE
Fix/missing django.contrib.admin in Wagtail documentation

### DIFF
--- a/docs/advanced_topics/add_to_django_project.md
+++ b/docs/advanced_topics/add_to_django_project.md
@@ -64,7 +64,8 @@ INSTALLED_APPS = [
 
   'taggit',
   'modelcluster',
-
+  
+  'django.contrib.admin',
   'django.contrib.auth',
   'django.contrib.contenttypes',
   'django.contrib.sessions',
@@ -187,6 +188,7 @@ INSTALLED_APPS = [
     'taggit',
     'modelcluster',
 
+    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',


### PR DESCRIPTION
The Wagtail documentation includes `admin.site.urls` in `urls.py` but does not mention adding `django.contrib.admin` to `INSTALLED_APPS` in the `settings.py`. This causes an error when running the project. This PR updates the add_to_django_project guide to include django.contrib.admin in `INSTALLED_APPS`.