### PR TITLE
Ensure block preview is hidden when the user clears out the search input

### DIFF
--- a/client/src/components/ComboBox/ComboBox.tsx
+++ b/client/src/components/ComboBox/ComboBox.tsx
@@ -139,6 +139,9 @@ export default function ComboBox<ComboBoxOption extends ComboBoxItem>({
     },
 
     onInputValueChange: (changes) => {
+      // Hide any preview when the user types or clears the search input.
+      setPreviewedIndex(-1);
+
       const { inputValue: val } = changes;
       if (!val) {
         setInputItems(flatItems);
@@ -153,8 +156,6 @@ export default function ComboBox<ComboBoxOption extends ComboBoxItem>({
       setInputItems(filtered);
       // Always reset the first item to highlighted on filtering, to speed up selection.
       setHighlightedIndex(0);
-      // Hide any preview when the user starts typing.
-      setPreviewedIndex(-1);
     },
   });
 


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/pull/12835#discussion_r1937506372

## Before

https://github.com/user-attachments/assets/c19e16af-3e08-4779-924b-42182526073e

## After

https://github.com/user-attachments/assets/0c2b5eb9-4da7-40d9-bfb6-e149f8fb89ad

