### PR TITLE
Expand docs for StreamField block previews

### DIFF
--- a/docs/reference/streamfield/blocks.md
+++ b/docs/reference/streamfield/blocks.md
@@ -2,7 +2,7 @@
 
 # StreamField block reference
 
-This document details the block types provided by Wagtail for use in [StreamField](streamfield), and how they can be combined into new block types.
+This document details the block types provided by Wagtail for use in [StreamField](streamfield_topic), and how they can be combined into new block types.
 
 ```{note}
    While block definitions look similar to model fields, they are not the same thing. Blocks are only valid within a StreamField - using them in place of a model field will not work.
@@ -32,16 +32,16 @@ body = StreamField([
 })
 ```
 
-## Block options
+## Block options and methods
 
-All block definitions accept the following optional keyword arguments:
+All block definitions accept the following optional keyword arguments or `Meta` class attributes:
 
 -   `default`
     -   The default value that a new 'empty' block should receive.
 -   `label`
     -   The label to display in the editor interface when referring to this block - defaults to a prettified version of the block name (or, in a context where no name is assigned - such as within a `ListBlock` - the empty string).
 -   `icon`
-    -   The name of the icon to display for this block type in the menu of available block types. For a list of icon names, see the Wagtail style guide, which can be enabled by adding `wagtail.contrib.styleguide` to your project’s `INSTALLED_APPS`.
+    -   The name of the icon to display for this block type in the editor. For more details, see our [icons overview](icons).
 -   `template`
     -   The path to a Django template that will be used to render this block on the front end. See [Template rendering](streamfield_template_rendering)
 -   `group`
@@ -49,7 +49,7 @@ All block definitions accept the following optional keyword arguments:
 
 (block_preview_arguments)=
 
-[StreamField blocks can have previews](configuring_block_previews) that will be shown inside the block picker. To accommodate the feature, all block definitions also accept the following optional keyword arguments:
+[StreamField blocks can have previews](configuring_block_previews) that will be shown inside the block picker. To accommodate the feature, all block definitions also accept the following options:
 
 -   `description`
     -   The description of the block. For [](field_block_types), it will fall back to `help_text` if not provided.
@@ -60,6 +60,15 @@ All block definitions accept the following optional keyword arguments:
 
 ```{versionadded} 6.4
 The `description`, `preview_value`, and `preview_template` keyword arguments were added.
+```
+
+All block definitions have the following methods that can be overridden:
+
+```{eval-rst}
+.. autoclass:: wagtail.blocks.Block
+
+    .. automethod:: wagtail.blocks.Block.get_context
+    .. automethod:: wagtail.blocks.Block.get_template
 ```
 
 (field_block_types)=

--- a/docs/reference/streamfield/blocks.md
+++ b/docs/reference/streamfield/blocks.md
@@ -51,15 +51,15 @@ All block definitions accept the following optional keyword arguments or `Meta` 
 
 [StreamField blocks can have previews](configuring_block_previews) that will be shown inside the block picker. To accommodate the feature, all block definitions also accept the following options:
 
--   `description`
-    -   The description of the block. For [](field_block_types), it will fall back to `help_text` if not provided.
 -   `preview_value`
-    -   The placeholder value that will be used for rendering the preview. If not provided, it will fall back to the `default` value.
+    -   The placeholder value that will be used for rendering the preview. See {meth}`~wagtail.blocks.Block.get_preview_value` for more details.
 -   `preview_template`
-    -   The template that is used to render the preview. If not provided, it will use the `wagtailcore/shared/block_preview.html` base template that reuses the block's real `template`.
+    -   The template that is used to render the preview. See {meth}`~wagtail.blocks.Block.get_preview_template` for more details.
+-   `description`
+    -   The description of the block to be shown to editors. See {meth}`~wagtail.blocks.Block.get_description` for more details.
 
 ```{versionadded} 6.4
-The `description`, `preview_value`, and `preview_template` keyword arguments were added.
+The `preview_value`, `preview_template`, and `description` keyword arguments were added.
 ```
 
 All block definitions have the following methods that can be overridden:
@@ -69,6 +69,10 @@ All block definitions have the following methods that can be overridden:
 
     .. automethod:: wagtail.blocks.Block.get_context
     .. automethod:: wagtail.blocks.Block.get_template
+    .. automethod:: wagtail.blocks.Block.get_preview_value
+    .. automethod:: wagtail.blocks.Block.get_preview_context
+    .. automethod:: wagtail.blocks.Block.get_preview_template
+    .. automethod:: wagtail.blocks.Block.get_description
 ```
 
 (field_block_types)=

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -27,7 +27,7 @@ This feature was developed by Jake Howard.
 
 ### Previews for StreamField blocks
 
-You can now set up previews for StreamField blocks. The preview will be shown in the block chooser, along with a description for the block. This feature can help users choose the right block when writing content inside a StreamField. To enable this feature, see [](configuring_block_previews).
+You can now set up previews for StreamField blocks. The preview will be shown in the block picker, along with a description for the block. This feature can help users choose the right block when writing content inside a StreamField. To enable this feature, see [](configuring_block_previews).
 
 This feature was developed by Sage Abdullah and Thibaud Colas.
 

--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -555,11 +555,31 @@ class QuoteBlock(blocks.StructBlock):
         description = "A quote with attribution to the source, rendered as a blockquote."
 ```
 
-Alternatively, you can also override the `get_preview_value`, `get_preview_context`, and `get_preview_template` methods to achieve the desired results.
+For more details on the preview options, see the corresponding {meth}`~wagtail.blocks.Block.get_preview_value`, {meth}`~wagtail.blocks.Block.get_preview_template`, and  {meth}`~wagtail.blocks.Block.get_description` methods, as well as the {meth}`~wagtail.blocks.Block.get_preview_context` method.
 
-In many cases, you likely want to use the block's real template that you already configure via `template` or `get_template` as described in [](streamfield_per_block_templates). Wagtail provides a default preview template for all blocks that makes use of the `{% include_block %}` tag (as described in [](streamfield_template_rendering)), which will reuse your block's specific template.
+In particular, the `get_preview_value()` method can be overridden to provide a dynamic preview value, such as from the database:
 
-However, the default preview template does not include any static assets that may be necessary to render your blocks properly. If you only need to add static assets to the preview page, you can skip specifying `preview_template` and instead override the default template globally. You can do so by creating a `wagtailcore/shared/block_preview.html` template inside one of your `templates` directories (with a higher precedence than the `wagtail` app) with the following content:
+```python
+from myapp.models import Quote
+
+
+class QuoteBlock(blocks.StructBlock):
+    ...
+
+    def get_preview_value(self, value):
+        quote = Quote.objects.first()
+        return {"text": quote.text, "source": quote.source}
+```
+
+(streamfield_global_preview_template)=
+
+### Overriding the global preview template
+
+In many cases, you likely want to use the block's real template that you already configure via `template` or `get_template` as described in [](streamfield_per_block_templates). However, such templates are only an HTML fragment for the block, whereas the preview requires a complete HTML document as the template.
+
+To avoid having to specify `preview_template` for each block, Wagtail provides a default preview template for all blocks. This template makes use of the `{% include_block %}` tag (as described in [](streamfield_template_rendering)), which will reuse your block's specific template.
+
+Note that the default preview template does not include any static assets that may be necessary to render your blocks properly. If you only need to add static assets to the default preview template, you can skip specifying `preview_template` for each block and instead override the default template globally. You can do so by creating a `wagtailcore/shared/block_preview.html` template inside one of your `templates` directories (with a higher precedence than the `wagtail` app) with the following content:
 
 ```html+django
 {% extends "wagtailcore/shared/block_preview.html" %}

--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -518,11 +518,17 @@ All block types, not just `StructBlock`, support the `template` property. Howeve
 
 ## Configuring block previews
 
+```{versionadded} 6.4
+The ability to have previews for StreamField blocks was added.
+```
+
 StreamField blocks can have previews that will be shown inside the block picker when you add a block in the editor. To enable this feature, you must configure the preview value and template. You can also add a description to help users pick the right block for their content.
 
 You can do so by [passing the keyword arguments](block_preview_arguments) `preview_value`, `preview_template`, and `description` when instantiating a block:
 
-```py
+```{code-block} python
+:emphasize-lines: 6-8
+
 ("quote", blocks.StructBlock(
     [
         ("text", blocks.TextBlock()),
@@ -536,7 +542,9 @@ You can do so by [passing the keyword arguments](block_preview_arguments) `previ
 
 You can also set `preview_value`, `preview_template`, and `description` as attributes in the `Meta` class of the block. For example:
 
-```py
+```{code-block} python
+:emphasize-lines: 6-8
+
 class QuoteBlock(blocks.StructBlock):
     text = blocks.TextBlock()
     source = blocks.CharBlock()
@@ -551,7 +559,7 @@ Alternatively, you can also override the `get_preview_value`, `get_preview_conte
 
 In many cases, you likely want to use the block's real template that you already configure via `template` or `get_template` as described in [](streamfield_per_block_templates). Wagtail provides a default preview template for all blocks that makes use of the `{% include_block %}` tag (as described in [](streamfield_template_rendering)), which will reuse your block's specific template.
 
-However, the default template does not include any static assets that may be necessary to render your blocks properly. If you only need to add static assets to the preview page, you can skip specifying `preview_template` and instead override the default template globally. You can do so by creating a `wagtailcore/shared/block_preview.html` template inside one of your `templates` directories (with a higher precedence than the `wagtail` app) with the following content:
+However, the default preview template does not include any static assets that may be necessary to render your blocks properly. If you only need to add static assets to the preview page, you can skip specifying `preview_template` and instead override the default template globally. You can do so by creating a `wagtailcore/shared/block_preview.html` template inside one of your `templates` directories (with a higher precedence than the `wagtail` app) with the following content:
 
 ```html+django
 {% extends "wagtailcore/shared/block_preview.html" %}
@@ -568,7 +576,9 @@ However, the default template does not include any static assets that may be nec
 {% endblock %}
 ```
 
-For more details on overriding templates, see also Django's guide on [](inv:django#howto/overriding-templates).
+For more details on overriding templates, see Django's guide on [](inv:django#howto/overriding-templates).
+
+The global `wagtailcore/shared/block_preview.html` override will be used for all blocks by default. If you want to use a different template for a particular block, you can still specify `preview_template`, which will take precedence.
 
 ## Customizations
 

--- a/wagtail/admin/views/generic/preview.py
+++ b/wagtail/admin/views/generic/preview.py
@@ -197,6 +197,8 @@ class StreamFieldBlockPreview(TemplateView):
     def base_context(self):
         # Do NOT use the name `block` in the context, as it will conflict with
         # the current block inside a template {% block %} tag.
+        # If any changes are made here that needs to be publicly documented,
+        # make sure to update the docs for `Block.get_preview_context`.
         return {
             "request": self.request,
             "block_def": self.block_def,

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -224,8 +224,9 @@ class Block(metaclass=BaseBlock):
 
     def get_context(self, value, parent_context=None):
         """
-        Return a dict of context variables (derived from the block value and combined with the parent_context)
-        to be used as the template context when rendering this value through a template.
+        Return a dict of context variables (derived from the block ``value`` and combined with the
+        ``parent_context``) to be used as the template context when rendering this value through a
+        template. See :ref:`the usage example <streamfield_get_context>` for more details.
         """
 
         context = parent_context or {}
@@ -239,11 +240,9 @@ class Block(metaclass=BaseBlock):
 
     def get_template(self, value=None, context=None):
         """
-        Return the template to use for rendering the block if specified on meta class.
-        This extraction was added to make dynamic templates possible if you override this method
-
-        value contains the current value of the block, allowing overridden methods to
-        select the proper template based on the actual block value.
+        Return the template to use for rendering the block if specified.
+        This method allows for dynamic templates based on the block instance and a given ``value``.
+        See :ref:`the usage example <streamfield_get_template>` for more details.
         """
         return getattr(self.meta, "template", None)
 


### PR DESCRIPTION
Notable changes:

- Use the term "block picker" instead of "block chooser" to avoid confusion with choosers. This is also the more common term in the existing docs.
- [Configuring block previews](https://wagtail--12840.org.readthedocs.build/en/12840/topics/streamfield.html#configuring-block-previews)
  - Add example for overriding `get_preview_value()`.
  - Add a dedicated subsection for overriding the global preview template, with some minor tweaks to clarify the reasoning of why it's necessary as opposed to just reusing `get_template()` as-is.
- [Reference docs for the `Block` class](https://wagtail--12840.org.readthedocs.build/en/12840/reference/streamfield/blocks.html#wagtail.blocks.Block)
  - The `get_preview_value()`, `get_preview_template()`, `get_description()`, and `get_preview_context()` methods are now documented. There are links from the "configuring block previews" to these methods to improve discoverability.
  - This is not related to the block previews, but the `get_context` and `get_template` methods are now publicly documented. We already have examples of them in the topic guide, and I feel it'd look weird if the reference docs only show the preview-related methods. I tweaked the docstrings a bit to be more concise.
- Reordered the preview-related options to be more consistent.