### PR TITLE
Improve translatability of strings in rich text editor

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,8 @@ Changelog
  * Fix: Do not show the content type column as sortable when searching pages (Srishti Jaiswal, Sage Abdullah)
  * Fix: Support simple subqueries for `in` and `exact` lookup on Elasticsearch (Sage Abdullah)
  * Fix: Force preview panel scroll behavior to instant to avoid flickering (Sage Abdullah)
+ * Fix: Support translating with the preferred language for rich text formatting labels (Bernhard Bliem, Sage Abdullah)
+ * Fix: Make "Actions" label translatable within the rich text toolbar (Bernhard Bliem, Sage Abdullah)
  * Docs: Add missing `django.contrib.admin` to list of apps in "add to Django project" guide (Mohamed Rabiaa)
  * Maintenance: Migrate away from deprecated Sass import rules to module system (Srishti Jaiswal)
  * Maintenance: Apply Sass mixed declarations migration in preparation for CSS nesting (Prabhpreet Kaur)

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -419,7 +419,7 @@ class BoundDraftailWidget {
 
       if (split.enabled) {
         blockCommands.push({
-          label: 'Actions',
+          label: gettext('Actions'),
           type: 'custom-actions',
           items: [new DraftailSplitCommand(this, split)],
         });

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -22,6 +22,8 @@ depth: 1
 ### Bug fixes
 
  * Take preferred language into account for translatable strings in client-side code (Bernhard Bliem, Sage Abdullah)
+ * Support translating with the preferred language for rich text formatting labels (Bernhard Bliem, Sage Abdullah)
+ * Make "Actions" label translatable within the rich text toolbar (Bernhard Bliem, Sage Abdullah)
  * Do not show the content type column as sortable when searching pages (Srishti Jaiswal, Sage Abdullah)
  * Support simple subqueries for `in` and `exact` lookup on Elasticsearch (Sage Abdullah)
  * Force preview panel scroll behavior to instant to avoid flickering (Sage Abdullah)

--- a/wagtail/admin/locale/ar/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/ar/LC_MESSAGES/django.po
@@ -1110,9 +1110,29 @@ msgstr "حذف الصفحة '%(title)s'"
 msgid "Unpublish page '%(title)s'"
 msgstr "إلغاء نشر الصفحة '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "ترويسة %(level)d"
+msgid "Heading 1"
+msgstr "ترويسة 1"
+
+
+msgid "Heading 2"
+msgstr "ترويسة 2"
+
+
+msgid "Heading 3"
+msgstr "ترويسة 3"
+
+
+msgid "Heading 4"
+msgstr "ترويسة 4"
+
+
+msgid "Heading 5"
+msgstr "ترويسة 5"
+
+
+msgid "Heading 6"
+msgstr "ترويسة 6"
+
 
 msgid "Bulleted list"
 msgstr "قائمة ذات تعداد نقطي"

--- a/wagtail/admin/locale/be/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/be/LC_MESSAGES/django.po
@@ -1083,9 +1083,29 @@ msgstr "Выдаліць старонку '%(title)s'"
 msgid "Unpublish page '%(title)s'"
 msgstr "Выдаліць з публікацыі '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Заголовак %(level)d"
+msgid "Heading 1"
+msgstr "Заголовак 1"
+
+
+msgid "Heading 2"
+msgstr "Заголовак 2"
+
+
+msgid "Heading 3"
+msgstr "Заголовак 3"
+
+
+msgid "Heading 4"
+msgstr "Заголовак 4"
+
+
+msgid "Heading 5"
+msgstr "Заголовак 5"
+
+
+msgid "Heading 6"
+msgstr "Заголовак 6"
+
 
 msgid "Bulleted list"
 msgstr "Маркіраваны спіс"

--- a/wagtail/admin/locale/ca/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/ca/LC_MESSAGES/django.po
@@ -3413,9 +3413,29 @@ msgstr "Ordenar el menú"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Canviar l'ordre de les pàgines filles de '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Capçalera %(level)d"
+msgid "Heading 1"
+msgstr "Capçalera 1"
+
+
+msgid "Heading 2"
+msgstr "Capçalera 2"
+
+
+msgid "Heading 3"
+msgstr "Capçalera 3"
+
+
+msgid "Heading 4"
+msgstr "Capçalera 4"
+
+
+msgid "Heading 5"
+msgstr "Capçalera 5"
+
+
+msgid "Heading 6"
+msgstr "Capçalera 6"
+
 
 msgid "Bulleted list"
 msgstr "Llista de pics"

--- a/wagtail/admin/locale/cs/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/cs/LC_MESSAGES/django.po
@@ -1758,9 +1758,29 @@ msgstr "Zrušit publikaci stránky %(title)s"
 msgid "View page history for '%(title)s'"
 msgstr "Zobrazit historii stránky '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Hlavička %(level)d"
+msgid "Heading 1"
+msgstr "Hlavička 1"
+
+
+msgid "Heading 2"
+msgstr "Hlavička 2"
+
+
+msgid "Heading 3"
+msgstr "Hlavička 3"
+
+
+msgid "Heading 4"
+msgstr "Hlavička 4"
+
+
+msgid "Heading 5"
+msgstr "Hlavička 5"
+
+
+msgid "Heading 6"
+msgstr "Hlavička 6"
+
 
 msgid "Bulleted list"
 msgstr "Nečíslovaný seznam"

--- a/wagtail/admin/locale/de/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/de/LC_MESSAGES/django.po
@@ -3534,9 +3534,29 @@ msgstr "Menüreihenfolge sortieren"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Reihenfolge der Unterseiten von %(title)s ändern"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Überschrift %(level)d"
+msgid "Heading 1"
+msgstr "Überschrift 1"
+
+
+msgid "Heading 2"
+msgstr "Überschrift 2"
+
+
+msgid "Heading 3"
+msgstr "Überschrift 3"
+
+
+msgid "Heading 4"
+msgstr "Überschrift 4"
+
+
+msgid "Heading 5"
+msgstr "Überschrift 5"
+
+
+msgid "Heading 6"
+msgstr "Überschrift 6"
+
 
 msgid "Bulleted list"
 msgstr "Aufzählung"

--- a/wagtail/admin/locale/es/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/es/LC_MESSAGES/django.po
@@ -2736,9 +2736,29 @@ msgstr "Ordenar menú"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Cambiar el orden de las páginas hijas de '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Encabezado %(level)d"
+msgid "Heading 1"
+msgstr "Encabezado 1"
+
+
+msgid "Heading 2"
+msgstr "Encabezado 2"
+
+
+msgid "Heading 3"
+msgstr "Encabezado 3"
+
+
+msgid "Heading 4"
+msgstr "Encabezado 4"
+
+
+msgid "Heading 5"
+msgstr "Encabezado 5"
+
+
+msgid "Heading 6"
+msgstr "Encabezado 6"
+
 
 msgid "Bulleted list"
 msgstr "Lista con viñetas"

--- a/wagtail/admin/locale/et/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/et/LC_MESSAGES/django.po
@@ -1494,9 +1494,29 @@ msgstr "Lehe ' %(title)s' avaldamise tühistamine"
 msgid "View page history for '%(title)s'"
 msgstr "Kuva lehe ajalugu: %(title)s"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Pealkiri %(level)d"
+msgid "Heading 1"
+msgstr "Pealkiri 1"
+
+
+msgid "Heading 2"
+msgstr "Pealkiri 2"
+
+
+msgid "Heading 3"
+msgstr "Pealkiri 3"
+
+
+msgid "Heading 4"
+msgstr "Pealkiri 4"
+
+
+msgid "Heading 5"
+msgstr "Pealkiri 5"
+
+
+msgid "Heading 6"
+msgstr "Pealkiri 6"
+
 
 msgid "Bulleted list"
 msgstr "Täppidega loend"

--- a/wagtail/admin/locale/fi/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/fi/LC_MESSAGES/django.po
@@ -2310,9 +2310,29 @@ msgstr "Peruuta sivun '%(title)s' julkaisu"
 msgid "View page history for '%(title)s'"
 msgstr "Näytä sivun '%(title)s' historia"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Otsikko %(level)d"
+msgid "Heading 1"
+msgstr "Otsikko 1"
+
+
+msgid "Heading 2"
+msgstr "Otsikko 2"
+
+
+msgid "Heading 3"
+msgstr "Otsikko 3"
+
+
+msgid "Heading 4"
+msgstr "Otsikko 4"
+
+
+msgid "Heading 5"
+msgstr "Otsikko 5"
+
+
+msgid "Heading 6"
+msgstr "Otsikko 6"
+
 
 msgid "Bulleted list"
 msgstr "Numeroimaton luettelo"

--- a/wagtail/admin/locale/fr/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/fr/LC_MESSAGES/django.po
@@ -3529,9 +3529,29 @@ msgstr "Ordre de tri des sous-pages"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Modifier l'ordre des sous-pages de « %(title)s »"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "En-tête %(level)d "
+msgid "Heading 1"
+msgstr "En-tête 1 "
+
+
+msgid "Heading 2"
+msgstr "En-tête 2 "
+
+
+msgid "Heading 3"
+msgstr "En-tête 3 "
+
+
+msgid "Heading 4"
+msgstr "En-tête 4 "
+
+
+msgid "Heading 5"
+msgstr "En-tête 5 "
+
+
+msgid "Heading 6"
+msgstr "En-tête 6 "
+
 
 msgid "Bulleted list"
 msgstr "Liste à puce"

--- a/wagtail/admin/locale/gl/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/gl/LC_MESSAGES/django.po
@@ -3396,9 +3396,29 @@ msgstr "Axustar orde do menú"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Cambiar orde das páxinas fillas de '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Cabeceira %(level)d"
+msgid "Heading 1"
+msgstr "Cabeceira 1"
+
+
+msgid "Heading 2"
+msgstr "Cabeceira 2"
+
+
+msgid "Heading 3"
+msgstr "Cabeceira 3"
+
+
+msgid "Heading 4"
+msgstr "Cabeceira 4"
+
+
+msgid "Heading 5"
+msgstr "Cabeceira 5"
+
+
+msgid "Heading 6"
+msgstr "Cabeceira 6"
+
 
 msgid "Bulleted list"
 msgstr "Lista de viñetas"

--- a/wagtail/admin/locale/hr_HR/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/hr_HR/LC_MESSAGES/django.po
@@ -1574,9 +1574,29 @@ msgstr "Pogledaj povijest stranice '%(title)s'"
 msgid "Sort menu order"
 msgstr "Sortiraj poredak izbornika"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Naslov %(level)d"
+msgid "Heading 1"
+msgstr "Naslov 1"
+
+
+msgid "Heading 2"
+msgstr "Naslov 2"
+
+
+msgid "Heading 3"
+msgstr "Naslov 3"
+
+
+msgid "Heading 4"
+msgstr "Naslov 4"
+
+
+msgid "Heading 5"
+msgstr "Naslov 5"
+
+
+msgid "Heading 6"
+msgstr "Naslov 6"
+
 
 msgid "Bulleted list"
 msgstr "Popis s predznacima"

--- a/wagtail/admin/locale/hu/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/hu/LC_MESSAGES/django.po
@@ -3106,9 +3106,29 @@ msgstr "Menü sorrend rendezése"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "'%(title)s' aloldalak sorrendjének megváltoztatása"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Fejléc %(level)d"
+msgid "Heading 1"
+msgstr "Fejléc 1"
+
+
+msgid "Heading 2"
+msgstr "Fejléc 2"
+
+
+msgid "Heading 3"
+msgstr "Fejléc 3"
+
+
+msgid "Heading 4"
+msgstr "Fejléc 4"
+
+
+msgid "Heading 5"
+msgstr "Fejléc 5"
+
+
+msgid "Heading 6"
+msgstr "Fejléc 6"
+
 
 msgid "Bulleted list"
 msgstr "Lista"

--- a/wagtail/admin/locale/is_IS/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/is_IS/LC_MESSAGES/django.po
@@ -3338,9 +3338,29 @@ msgstr "Röðun undirsíðna"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Breyta röðun undirsíðna '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Fyrirsögn %(level)d"
+msgid "Heading 1"
+msgstr "Fyrirsögn 1"
+
+
+msgid "Heading 2"
+msgstr "Fyrirsögn 2"
+
+
+msgid "Heading 3"
+msgstr "Fyrirsögn 3"
+
+
+msgid "Heading 4"
+msgstr "Fyrirsögn 4"
+
+
+msgid "Heading 5"
+msgstr "Fyrirsögn 5"
+
+
+msgid "Heading 6"
+msgstr "Fyrirsögn 6"
+
 
 msgid "Bulleted list"
 msgstr "Ónúmeraður listi"

--- a/wagtail/admin/locale/it/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/it/LC_MESSAGES/django.po
@@ -3087,9 +3087,29 @@ msgstr "Gestisci l'ordine del menu"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Cambia l'ordinamento delle pagine figlio di '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Titolo %(level)d"
+msgid "Heading 1"
+msgstr "Titolo 1"
+
+
+msgid "Heading 2"
+msgstr "Titolo 2"
+
+
+msgid "Heading 3"
+msgstr "Titolo 3"
+
+
+msgid "Heading 4"
+msgstr "Titolo 4"
+
+
+msgid "Heading 5"
+msgstr "Titolo 5"
+
+
+msgid "Heading 6"
+msgstr "Titolo 6"
+
 
 msgid "Bulleted list"
 msgstr "Elenco puntato"

--- a/wagtail/admin/locale/ko/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/ko/LC_MESSAGES/django.po
@@ -2129,9 +2129,29 @@ msgstr "메뉴 순서 분류"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "파생 페이지의 '%(title)s' 순서를 바꿈"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "머리말 %(level)d"
+msgid "Heading 1"
+msgstr "머리말 1"
+
+
+msgid "Heading 2"
+msgstr "머리말 2"
+
+
+msgid "Heading 3"
+msgstr "머리말 3"
+
+
+msgid "Heading 4"
+msgstr "머리말 4"
+
+
+msgid "Heading 5"
+msgstr "머리말 5"
+
+
+msgid "Heading 6"
+msgstr "머리말 6"
+
 
 msgid "Bulleted list"
 msgstr "머릿기호 목록"

--- a/wagtail/admin/locale/lt/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/lt/LC_MESSAGES/django.po
@@ -1185,9 +1185,29 @@ msgstr "Nebepublikuoti '%(title)s' puslapio"
 msgid "Sort menu order"
 msgstr "Meniu rikiavimo tvarka"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Antraštė %(level)d"
+msgid "Heading 1"
+msgstr "Antraštė 1"
+
+
+msgid "Heading 2"
+msgstr "Antraštė 2"
+
+
+msgid "Heading 3"
+msgstr "Antraštė 3"
+
+
+msgid "Heading 4"
+msgstr "Antraštė 4"
+
+
+msgid "Heading 5"
+msgstr "Antraštė 5"
+
+
+msgid "Heading 6"
+msgstr "Antraštė 6"
+
 
 msgid "Bulleted list"
 msgstr "Pažymėtas sąrašas"

--- a/wagtail/admin/locale/nb/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/nb/LC_MESSAGES/django.po
@@ -1406,9 +1406,29 @@ msgstr "Slett siden «%(title)s»"
 msgid "Unpublish page '%(title)s'"
 msgstr "Avpublisér siden «%(title)s»"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Overskrift %(level)d"
+msgid "Heading 1"
+msgstr "Overskrift 1"
+
+
+msgid "Heading 2"
+msgstr "Overskrift 2"
+
+
+msgid "Heading 3"
+msgstr "Overskrift 3"
+
+
+msgid "Heading 4"
+msgstr "Overskrift 4"
+
+
+msgid "Heading 5"
+msgstr "Overskrift 5"
+
+
+msgid "Heading 6"
+msgstr "Overskrift 6"
+
 
 msgid "Bulleted list"
 msgstr "Punktliste"

--- a/wagtail/admin/locale/nl/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/nl/LC_MESSAGES/django.po
@@ -3444,9 +3444,29 @@ msgstr "Sorteer menu volgorde"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Verander volgorde van onderliggende pagina's van '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Kop %(level)d"
+msgid "Heading 1"
+msgstr "Kop 1"
+
+
+msgid "Heading 2"
+msgstr "Kop 2"
+
+
+msgid "Heading 3"
+msgstr "Kop 3"
+
+
+msgid "Heading 4"
+msgstr "Kop 4"
+
+
+msgid "Heading 5"
+msgstr "Kop 5"
+
+
+msgid "Heading 6"
+msgstr "Kop 6"
+
 
 msgid "Bulleted list"
 msgstr "Lijst met opsommingstekens"

--- a/wagtail/admin/locale/pl/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/pl/LC_MESSAGES/django.po
@@ -3156,9 +3156,29 @@ msgstr "Sortuj menu"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Zmień kolejność stron podrzędnych od '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Nagłówek %(level)d"
+msgid "Heading 1"
+msgstr "Nagłówek 1"
+
+
+msgid "Heading 2"
+msgstr "Nagłówek 2"
+
+
+msgid "Heading 3"
+msgstr "Nagłówek 3"
+
+
+msgid "Heading 4"
+msgstr "Nagłówek 4"
+
+
+msgid "Heading 5"
+msgstr "Nagłówek 5"
+
+
+msgid "Heading 6"
+msgstr "Nagłówek 6"
+
 
 msgid "Bulleted list"
 msgstr "Lista wypunktowana"

--- a/wagtail/admin/locale/pt_BR/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/pt_BR/LC_MESSAGES/django.po
@@ -2956,9 +2956,29 @@ msgstr "Ordem do menu de classificação "
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Alterar a ordem das páginas filhas de '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Cabeçalho %(level)d"
+msgid "Heading 1"
+msgstr "Cabeçalho 1"
+
+
+msgid "Heading 2"
+msgstr "Cabeçalho 2"
+
+
+msgid "Heading 3"
+msgstr "Cabeçalho 3"
+
+
+msgid "Heading 4"
+msgstr "Cabeçalho 4"
+
+
+msgid "Heading 5"
+msgstr "Cabeçalho 5"
+
+
+msgid "Heading 6"
+msgstr "Cabeçalho 6"
+
 
 msgid "Bulleted list"
 msgstr "Lista com marcadores"

--- a/wagtail/admin/locale/pt_PT/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/pt_PT/LC_MESSAGES/django.po
@@ -2075,9 +2075,29 @@ msgstr "Ordenar ordem de menu"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Alterar a ordem das páginas-filha de '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Cabeçalho %(level)d"
+msgid "Heading 1"
+msgstr "Cabeçalho 1"
+
+
+msgid "Heading 2"
+msgstr "Cabeçalho 2"
+
+
+msgid "Heading 3"
+msgstr "Cabeçalho 3"
+
+
+msgid "Heading 4"
+msgstr "Cabeçalho 4"
+
+
+msgid "Heading 5"
+msgstr "Cabeçalho 5"
+
+
+msgid "Heading 6"
+msgstr "Cabeçalho 6"
+
 
 msgid "Bulleted list"
 msgstr "Lista de pontos"

--- a/wagtail/admin/locale/ro/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/ro/LC_MESSAGES/django.po
@@ -3158,9 +3158,29 @@ msgstr "Sortează ordinea de meniu"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Schimbă ordinea paginilor descendente la '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Antet %(level)d"
+msgid "Heading 1"
+msgstr "Antet 1"
+
+
+msgid "Heading 2"
+msgstr "Antet 2"
+
+
+msgid "Heading 3"
+msgstr "Antet 3"
+
+
+msgid "Heading 4"
+msgstr "Antet 4"
+
+
+msgid "Heading 5"
+msgstr "Antet 5"
+
+
+msgid "Heading 6"
+msgstr "Antet 6"
+
 
 msgid "Bulleted list"
 msgstr "Listă cu puncte"

--- a/wagtail/admin/locale/ru/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/ru/LC_MESSAGES/django.po
@@ -3607,9 +3607,29 @@ msgstr "Задать порядок сортировки"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Изменить порядок дочерних страниц '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Заголовок %(level)d"
+msgid "Heading 1"
+msgstr "Заголовок 1"
+
+
+msgid "Heading 2"
+msgstr "Заголовок 2"
+
+
+msgid "Heading 3"
+msgstr "Заголовок 3"
+
+
+msgid "Heading 4"
+msgstr "Заголовок 4"
+
+
+msgid "Heading 5"
+msgstr "Заголовок 5"
+
+
+msgid "Heading 6"
+msgstr "Заголовок 6"
+
 
 msgid "Bulleted list"
 msgstr "Маркированный список"

--- a/wagtail/admin/locale/sl/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/sl/LC_MESSAGES/django.po
@@ -2917,9 +2917,29 @@ msgstr "Vrstni red menija"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Spremenite vrstni red podrejenih strani '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Naslovnica%(level)d"
+msgid "Heading 1"
+msgstr "Naslovnica1"
+
+
+msgid "Heading 2"
+msgstr "Naslovnica2"
+
+
+msgid "Heading 3"
+msgstr "Naslovnica3"
+
+
+msgid "Heading 4"
+msgstr "Naslovnica4"
+
+
+msgid "Heading 5"
+msgstr "Naslovnica5"
+
+
+msgid "Heading 6"
+msgstr "Naslovnica6"
+
 
 msgid "Bulleted list"
 msgstr "Označen seznam"

--- a/wagtail/admin/locale/sv/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/sv/LC_MESSAGES/django.po
@@ -2623,9 +2623,29 @@ msgstr "Sortera menyordning"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Ändra sortering på undersidor till '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Rubrik %(level)d"
+msgid "Heading 1"
+msgstr "Rubrik 1"
+
+
+msgid "Heading 2"
+msgstr "Rubrik 2"
+
+
+msgid "Heading 3"
+msgstr "Rubrik 3"
+
+
+msgid "Heading 4"
+msgstr "Rubrik 4"
+
+
+msgid "Heading 5"
+msgstr "Rubrik 5"
+
+
+msgid "Heading 6"
+msgstr "Rubrik 6"
+
 
 msgid "Bulleted list"
 msgstr "Punktlista"

--- a/wagtail/admin/locale/tr/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/tr/LC_MESSAGES/django.po
@@ -1023,9 +1023,29 @@ msgstr "'%(title)s' sayfasını sil"
 msgid "Unpublish page '%(title)s'"
 msgstr "'%(title)s' sayfasını yayından kaldır"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Başlık %(level)d"
+msgid "Heading 1"
+msgstr "Başlık 1"
+
+
+msgid "Heading 2"
+msgstr "Başlık 2"
+
+
+msgid "Heading 3"
+msgstr "Başlık 3"
+
+
+msgid "Heading 4"
+msgstr "Başlık 4"
+
+
+msgid "Heading 5"
+msgstr "Başlık 5"
+
+
+msgid "Heading 6"
+msgstr "Başlık 6"
+
 
 msgid "Bulleted list"
 msgstr "Numarasız liste"

--- a/wagtail/admin/locale/tr_TR/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/tr_TR/LC_MESSAGES/django.po
@@ -974,9 +974,29 @@ msgstr "'%(title)s' sayfasını sil"
 msgid "Unpublish page '%(title)s'"
 msgstr "'%(title)s' sayfasını yayından kaldır"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Başlık %(level)d"
+msgid "Heading 1"
+msgstr "Başlık 1"
+
+
+msgid "Heading 2"
+msgstr "Başlık 2"
+
+
+msgid "Heading 3"
+msgstr "Başlık 3"
+
+
+msgid "Heading 4"
+msgstr "Başlık 4"
+
+
+msgid "Heading 5"
+msgstr "Başlık 5"
+
+
+msgid "Heading 6"
+msgstr "Başlık 6"
+
 
 msgid "Bulleted list"
 msgstr "Numarasız liste"

--- a/wagtail/admin/locale/uk/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/uk/LC_MESSAGES/django.po
@@ -2188,9 +2188,29 @@ msgstr "Сортувати порядок меню"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "Змінити порядок дочірніх сторінок у '%(title)s'"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "Заголовок %(level)d"
+msgid "Heading 1"
+msgstr "Заголовок 1"
+
+
+msgid "Heading 2"
+msgstr "Заголовок 2"
+
+
+msgid "Heading 3"
+msgstr "Заголовок 3"
+
+
+msgid "Heading 4"
+msgstr "Заголовок 4"
+
+
+msgid "Heading 5"
+msgstr "Заголовок 5"
+
+
+msgid "Heading 6"
+msgstr "Заголовок 6"
+
 
 msgid "Bulleted list"
 msgstr "Маркований список"

--- a/wagtail/admin/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/wagtail/admin/locale/zh_Hans/LC_MESSAGES/django.po
@@ -2205,9 +2205,29 @@ msgstr "排序菜单顺序"
 msgid "Change ordering of child pages of '%(title)s'"
 msgstr "更改“%(title)s”的子页面顺序"
 
-#, python-format
-msgid "Heading %(level)d"
-msgstr "标题%(level)d"
+msgid "Heading 1"
+msgstr "标题1"
+
+
+msgid "Heading 2"
+msgstr "标题2"
+
+
+msgid "Heading 3"
+msgstr "标题3"
+
+
+msgid "Heading 4"
+msgstr "标题4"
+
+
+msgid "Heading 5"
+msgstr "标题5"
+
+
+msgid "Heading 6"
+msgstr "标题6"
+
 
 msgid "Bulleted list"
 msgstr "项目列表"

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import override_settings
 from django.urls import reverse, reverse_lazy
+from django.utils import translation
 
 from wagtail.admin.rich_text import DraftailRichTextArea, get_rich_text_editor_widget
 from wagtail.admin.rich_text.converters.editor_html import (
@@ -636,3 +637,16 @@ class TestRichTextChooserUrls(WagtailTestUtils, BaseRichTextEditHandlerTestCase)
         self.assertIn("/admin/images/chooser/", html)
         self.assertIn("/admin/embeds/chooser/", html)
         self.assertIn("/admin/documents/chooser/", html)
+
+
+class TestDraftailLazyTranslations(SimpleTestCase):
+    def test_context_i18n(self):
+        widget = DraftailRichTextArea(features=["h2"])
+        context_default_language = widget.get_context(None, None, {})
+        with translation.override("de"):
+            context_de = widget.get_context(None, None, {})
+        # At least the description of the h2 feature should be different
+        self.assertNotEqual(
+            context_default_language["widget"]["attrs"]["data-w-init-detail-value"],
+            context_de["widget"]["attrs"]["data-w-init-detail-value"],
+        )

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -3,7 +3,6 @@ from django.contrib.auth.models import Permission
 from django.urls import reverse, reverse_lazy
 from django.utils.functional import cached_property
 from django.utils.http import urlencode
-from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 from draftjs_exporter.dom import DOM
 
@@ -495,7 +494,7 @@ def register_core_features(features):
             {
                 "icon": "h1",
                 "type": "header-one",
-                "description": gettext("Heading %(level)d") % {"level": 1},
+                "description": _("Heading 1"),
             }
         ),
     )
@@ -516,7 +515,7 @@ def register_core_features(features):
             {
                 "icon": "h2",
                 "type": "header-two",
-                "description": gettext("Heading %(level)d") % {"level": 2},
+                "description": _("Heading 2"),
             }
         ),
     )
@@ -537,7 +536,7 @@ def register_core_features(features):
             {
                 "icon": "h3",
                 "type": "header-three",
-                "description": gettext("Heading %(level)d") % {"level": 3},
+                "description": _("Heading 3"),
             }
         ),
     )
@@ -558,7 +557,7 @@ def register_core_features(features):
             {
                 "icon": "h4",
                 "type": "header-four",
-                "description": gettext("Heading %(level)d") % {"level": 4},
+                "description": _("Heading 4"),
             }
         ),
     )
@@ -579,7 +578,7 @@ def register_core_features(features):
             {
                 "icon": "h5",
                 "type": "header-five",
-                "description": gettext("Heading %(level)d") % {"level": 5},
+                "description": _("Heading 5"),
             }
         ),
     )
@@ -600,7 +599,7 @@ def register_core_features(features):
             {
                 "icon": "h6",
                 "type": "header-six",
-                "description": gettext("Heading %(level)d") % {"level": 6},
+                "description": _("Heading 6"),
             }
         ),
     )
@@ -621,7 +620,7 @@ def register_core_features(features):
             {
                 "type": "unordered-list-item",
                 "icon": "list-ul",
-                "description": gettext("Bulleted list"),
+                "description": _("Bulleted list"),
             }
         ),
     )
@@ -645,7 +644,7 @@ def register_core_features(features):
             {
                 "type": "ordered-list-item",
                 "icon": "list-ol",
-                "description": gettext("Numbered list"),
+                "description": _("Numbered list"),
             }
         ),
     )
@@ -669,7 +668,7 @@ def register_core_features(features):
             {
                 "type": "blockquote",
                 "icon": "openquote",
-                "description": gettext("Blockquote"),
+                "description": _("Blockquote"),
             }
         ),
     )
@@ -691,7 +690,7 @@ def register_core_features(features):
             {
                 "type": "BOLD",
                 "icon": "bold",
-                "description": gettext("Bold"),
+                "description": _("Bold"),
             }
         ),
     )
@@ -713,7 +712,7 @@ def register_core_features(features):
             {
                 "type": "ITALIC",
                 "icon": "italic",
-                "description": gettext("Italic"),
+                "description": _("Italic"),
             }
         ),
     )
@@ -736,7 +735,7 @@ def register_core_features(features):
             {
                 "type": "LINK",
                 "icon": "link",
-                "description": gettext("Link"),
+                "description": _("Link"),
                 # We want to enforce constraints on which links can be pasted into rich text.
                 # Keep only the attributes Wagtail needs.
                 "attributes": ["url", "id", "parentId"],
@@ -783,7 +782,7 @@ def register_core_features(features):
             {
                 "type": "SUPERSCRIPT",
                 "icon": "superscript",
-                "description": gettext("Superscript"),
+                "description": _("Superscript"),
             }
         ),
     )
@@ -804,7 +803,7 @@ def register_core_features(features):
             {
                 "type": "SUBSCRIPT",
                 "icon": "subscript",
-                "description": gettext("Subscript"),
+                "description": _("Subscript"),
             }
         ),
     )
@@ -825,7 +824,7 @@ def register_core_features(features):
             {
                 "type": "STRIKETHROUGH",
                 "icon": "strikethrough",
-                "description": gettext("Strikethrough"),
+                "description": _("Strikethrough"),
             }
         ),
     )
@@ -846,7 +845,7 @@ def register_core_features(features):
             {
                 "type": "CODE",
                 "icon": "code",
-                "description": gettext("Code"),
+                "description": _("Code"),
             }
         ),
     )

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -4,8 +4,8 @@ from django.conf import settings
 from django.template.response import TemplateResponse
 from django.urls import include, path, reverse, reverse_lazy
 from django.utils.cache import add_never_cache_headers
-from django.utils.translation import gettext, ngettext
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail import hooks
@@ -78,7 +78,7 @@ def register_document_feature(features):
             {
                 "type": "DOCUMENT",
                 "icon": "doc-full-inverse",
-                "description": gettext("Document"),
+                "description": _("Document"),
                 "chooserUrls": {
                     "documentChooser": reverse_lazy("wagtaildocs_chooser:choose")
                 },

--- a/wagtail/embeds/wagtail_hooks.py
+++ b/wagtail/embeds/wagtail_hooks.py
@@ -1,5 +1,5 @@
 from django.urls import include, path, reverse_lazy
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail import hooks

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -1,6 +1,6 @@
 from django.urls import include, path, reverse, reverse_lazy
-from django.utils.translation import gettext, ngettext
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail import hooks
@@ -76,7 +76,7 @@ def register_image_feature(features):
             {
                 "type": "IMAGE",
                 "icon": "image",
-                "description": gettext("Image"),
+                "description": _("Image"),
                 # We do not want users to be able to copy-paste hotlinked images into rich text.
                 # Keep only the attributes Wagtail needs.
                 "attributes": ["id", "src", "alt", "format"],


### PR DESCRIPTION
Split from #11075.

How I generated the translations:
- Instead of running the whole `rebuild-translation-sources` script, I only ran the `django-admin makemessages --locale=en --ignore=test/* --ignore=tests/* --ignore=tests.py` command inside the `wagtail/admin` directory. See second-to-last commit for the results.
- Cherry-picked the translations for the heading strings from the original version of #11075. See last commit for the results.
  - I assume it was done by replacing the original `"Heading %(level)d"` translations with the manually interpolated versions, as described in the PR.
  - Re-ran `compilemessages` afterwards.
  - Not sure how this plays with Transifex, though. I think it makes sense – when we rebuild the English translation sources before the next release and do a `tx push`, the manually crafted heading translations will be pushed as well.