### PR TITLE
Run CI on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ concurrency:
 # - django 4.2, python 3.11, mariadb:10.5
 # - django 5.1, python 3.12, mysql:8.4, parallel, USE_EMAIL_USER_MODEL=yes
 # - django 5.1, python 3.12, mariadb:11.4, USE_EMAIL_USER_MODEL=yes
-# - django 5.1, python 3.13, sqlite, parallel, WAGTAIL_CHECK_TEMPLATE_NUMBER_FORMAT=1
+# - django 5.1, python 3.13, sqlite, parallel, WAGTAIL_CHECK_TEMPLATE_NUMBER_FORMAT=1 (Windows and Linux)
 # - django 5.1, python 3.13, postgres:15, psycopg 3, parallel, DISABLE_TIMEZONE=yes
 # - django stable/5.2.x, python 3.12, postgres:15, psycopg 3 (allow failures)
 # - django main, python 3.13, postgres:latest, psycopg 3, parallel (allow failures)
@@ -44,7 +44,7 @@ permissions:
 
 jobs:
   test-sqlite:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
@@ -52,6 +52,12 @@ jobs:
             django: 'Django>=5.1,<5.2'
             check_template_number_format: '1'
             parallel: '--parallel'
+            os: ubuntu-latest
+          - python: '3.13'
+            django: 'Django>=5.1,<5.2'
+            check_template_number_format: '1'
+            parallel: '--parallel'
+            os: windows-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Whilst Linux has a monopoly on deployment environments, many people still develop on Windows. This adds Windows to a small part of the CI matrix, to ensure Wagtail runs sensibly on Windows.
