### PR TITLE
Fix error when filtering by locale and searching with Elasticsearch

### DIFF
--- a/wagtail/admin/filters.py
+++ b/wagtail/admin/filters.py
@@ -94,8 +94,15 @@ class FilteredModelChoiceFilter(django_filters.ModelChoiceFilter):
 class LocaleFilter(django_filters.ChoiceFilter):
     def filter(self, qs, language_code):
         if language_code:
-            locale = Locale.objects.filter(language_code=language_code)
-            return qs.filter(locale_id=locale.values_list("pk", flat=True)[:1])
+            try:
+                locale_id = (
+                    Locale.objects.filter(language_code=language_code)
+                    .values_list("pk", flat=True)
+                    .get()
+                )
+            except Locale.DoesNotExist:
+                return qs.none()
+            return qs.filter(locale_id=locale_id)
         return qs
 
 


### PR DESCRIPTION
My suggestion in https://github.com/wagtail/wagtail/pull/12772#discussion_r1918208857 fails with the Elasticsearch backend, as the compiled `locale_id_filter` results in a Django `Query` object that cannot be serialized by the backend.

Use the original approach in that PR instead, i.e. by evaluating a separate query to get the ID, but with the initial suggestion of only fetching the pk with `values_list`.

This was a bit tricky to test. I had to put this hack together:

```diff
diff --git a/wagtail/admin/tests/pages/test_explorer_view.py b/wagtail/admin/tests/pages/test_explorer_view.py
index c9d20e940a..f94b55dc40 100644
--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -1,6 +1,8 @@
+from io import StringIO
+
 from django.contrib.auth.models import AbstractBaseUser, Group, Permission
 from django.contrib.contenttypes.models import ContentType
-from django.core import paginator
+from django.core import management, paginator
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.http import urlencode
@@ -655,6 +657,12 @@ class TestPageExplorer(WagtailTestUtils, TestCase):

     @override_settings(WAGTAIL_I18N_ENABLED=True)
     def test_filter_by_locale_and_search(self):
+        management.call_command(
+            "update_index",
+            backend_name="default",
+            stdout=StringIO(),
+            chunk_size=50,
+        )
         fr_locale = Locale.objects.create(language_code="fr")
         self.root_page.copy_for_translation(fr_locale, copy_parents=True)

diff --git a/wagtail/test/settings.py b/wagtail/test/settings.py
index 840f6f318b..670a1ffa7f 100644
--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -245,7 +245,7 @@ if "ELASTICSEARCH_URL" in os.environ:
         "AUTO_UPDATE": False,
         "INDEX_SETTINGS": {"settings": {"index": {"number_of_shards": 1}}},
     }
-
+    WAGTAILSEARCH_BACKENDS["default"] = WAGTAILSEARCH_BACKENDS["elasticsearch"]

 WAGTAIL_SITE_NAME = "Test Site"
```

Running Elasticsearch 8 in Docker with the following:

```shell
docker network create elasticsearch
docker run -d --name elasticsearch --net elasticsearch -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -e 'xpack.security.enabled=false' elasticsearch:8.17.1
```

and running the test with the following:

```shell
python runtests.py --elasticsearch8 wagtail.admin.tests.pages.test_explorer_view.TestPageExplorer.test_filter_by_locale_and_search
```

I didn't update the CI or add an equivalent test to be run in the CI as it's quite tricky to write one that I'd be happy with.