### PR TITLE
Fix Garbled word order in GraphQL downsides section

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Fix: Take preferred language into account for translatable strings in client-side code (Bernhard Bliem, Sage Abdullah)
  * Fix: Do not show the content type column as sortable when searching pages (Srishti Jaiswal, Sage Abdullah)
  * Docs: Add missing `django.contrib.admin` to list of apps in "add to Django project" guide (Mohamed Rabiaa)
+ * Docs: Fix typo in the headless documentation page (Mahmoud Nasser)
 
 
 6.4 (03.02.2025)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -871,6 +871,7 @@
 * Jatin Bhardwaj
 * Mohamed Rabiaa
 * Bernhard Bliem
+* Mahmoud Nasser
 
 ## Translators
 

--- a/docs/advanced_topics/headless.md
+++ b/docs/advanced_topics/headless.md
@@ -57,7 +57,7 @@ GraphQL is a newer API technology than REST. Unlike REST, GraphQL isn't an archi
 -   You will need to install a library package to use GraphQL.
 -   There are currently fewer tools and resources available for supporting GraphQL.
 -   Fewer developers are familiar with GraphQL.
--   GraphQL can introduce performance additional security and considerations due to their flexibility.
+-   GraphQL can introduce additional performance and security considerations due to its flexibility.
 
 #### GraphQL libraries compatible with Wagtail
 

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -27,6 +27,7 @@ depth: 1
 ### Documentation
 
  * Add missing `django.contrib.admin` to list of apps in "add to Django project" guide (Mohamed Rabiaa)
+ * Fix typo in the headless documentation page (Mahmoud Nasser)
 
 ### Maintenance
 


### PR DESCRIPTION
### Description
This PR fixes a minor wording issue in the Wagtail documentation related to GraphQL downsides.

### Issue Reference
Fixes #12852

### Problem
The sentence in the documentation was unclear:
> "GraphQL can introduce performance additional security and considerations due to their flexibility."

### Fix
- Reworded the sentence for clarity.
- Updated the **Downsides of GraphQL** section in the Wagtail documentation.

### Before:
> "GraphQL can introduce performance additional security and considerations due to their flexibility."

### After:
> "GraphQL introduces additional performance and security considerations due to its flexibility."

### Additional Notes
- This is a small documentation fix with no code changes.
- Let me know if any further improvements are needed!


