### PR TITLE
Support searching `none()` querysets

### DIFF
--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -5,7 +5,7 @@ from django.db.models.functions.datetime import Extract as ExtractDate
 from django.db.models.functions.datetime import ExtractYear
 from django.db.models.lookups import Lookup
 from django.db.models.query import QuerySet
-from django.db.models.sql.where import SubqueryConstraint, WhereNode
+from django.db.models.sql.where import NothingNode, SubqueryConstraint, WhereNode
 
 from wagtail.search.index import class_is_indexed, get_indexed_models
 from wagtail.search.query import MATCH_ALL, PlainText
@@ -67,6 +67,9 @@ class BaseSearchQueryCompiler:
         return field
 
     def _process_lookup(self, field, lookup, value):
+        raise NotImplementedError
+
+    def _process_match_none(self):
         raise NotImplementedError
 
     def _connect_filters(self, filters, connector, negated):
@@ -178,6 +181,9 @@ class BaseSearchQueryCompiler:
             return self._process_filter(
                 field_attname, lookup, value, check_only=check_only
             )
+
+        elif isinstance(where_node, NothingNode):
+            return self._process_match_none()
 
         elif isinstance(where_node, SubqueryConstraint):
             raise FilterError(

--- a/wagtail/search/backends/database/fallback.py
+++ b/wagtail/search/backends/database/fallback.py
@@ -56,6 +56,9 @@ class DatabaseSearchQueryCompiler(BaseSearchQueryCompiler):
             **{field.get_attname(self.queryset.model) + "__" + lookup: value}
         )
 
+    def _process_match_none(self):
+        return models.Q(pk__in=[])
+
     def _connect_filters(self, filters, connector, negated):
         if connector == "AND":
             q = models.Q(*filters)

--- a/wagtail/search/backends/database/mysql/mysql.py
+++ b/wagtail/search/backends/database/mysql/mysql.py
@@ -522,6 +522,9 @@ class MySQLSearchQueryCompiler(BaseSearchQueryCompiler):
         lhs = field.get_attname(self.queryset.model) + "__" + lookup
         return Q(**{lhs: value})
 
+    def _process_match_none(self):
+        return Q(pk__in=[])
+
     def _connect_filters(self, filters, connector, negated):
         if connector == "AND":
             q = Q(*filters)

--- a/wagtail/search/backends/database/postgres/postgres.py
+++ b/wagtail/search/backends/database/postgres/postgres.py
@@ -561,6 +561,9 @@ class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
         lhs = field.get_attname(self.queryset.model) + "__" + lookup
         return Q(**{lhs: value})
 
+    def _process_match_none(self):
+        return Q(pk__in=[])
+
     def _connect_filters(self, filters, connector, negated):
         if connector == "AND":
             q = Q(*filters)

--- a/wagtail/search/backends/database/sqlite/sqlite.py
+++ b/wagtail/search/backends/database/sqlite/sqlite.py
@@ -580,6 +580,9 @@ class SQLiteSearchQueryCompiler(BaseSearchQueryCompiler):
         lhs = field.get_attname(self.queryset.model) + "__" + lookup
         return Q(**{lhs: value})
 
+    def _process_match_none(self):
+        return Q(pk__in=[])
+
     def _connect_filters(self, filters, connector, negated):
         if connector == "AND":
             q = Q(*filters)

--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -565,6 +565,9 @@ class Elasticsearch7SearchQueryCompiler(BaseSearchQueryCompiler):
                 }
             }
 
+    def _process_match_none(self):
+        return {"bool": {"mustNot": {"match_all": {}}}}
+
     def _connect_filters(self, filters, connector, negated):
         if filters:
             if len(filters) == 1:

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -638,6 +638,13 @@ class BackendTests(WagtailTestUtils):
             ],
         )
 
+    def test_filter_none(self):
+        results = self.backend.search(MATCH_ALL, models.Book.objects.none())
+        self.assertListEqual(list(results), [])
+
+        results = self.backend.search("JavaScript", models.Book.objects.none())
+        self.assertListEqual(list(results), [])
+
     # FACET TESTS
 
     def test_facet(self):


### PR DESCRIPTION
Add support across all search backends for queries such as `Page.objects.none().search("bread")`, which return no results. Prompted by https://github.com/wagtail/wagtail/pull/12862#discussion_r1949017190 - this edge case should now be handled if it ever does arise.