### PR TITLE
Elastic search boosting for Fuzzy and Phrase queries

### DIFF
--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -603,7 +603,7 @@ class Elasticsearch7SearchQueryCompiler(BaseSearchQueryCompiler):
 
             return {"multi_match": match_query}
 
-    def _compile_fuzzy_query(self, query, fields):
+    def _compile_fuzzy_query(self, query, fields, boost=1.0):
         match_query = {
             "query": query.query_string,
             "fuzziness": "AUTO",
@@ -614,33 +614,36 @@ class Elasticsearch7SearchQueryCompiler(BaseSearchQueryCompiler):
 
         if len(fields) == 1:
             if fields[0].boost != 1.0:
-                match_query["boost"] = fields[0].boost
+                match_query["boost"] = boost * fields[0].boost
             return {"match": {fields[0].field_name: match_query}}
         else:
+            if fields[0].boost != 1.0:
+                match_query["boost"] = boost
             match_query["fields"] = [field.field_name_with_boost for field in fields]
             return {"multi_match": match_query}
 
-    def _compile_phrase_query(self, query, fields):
+    def _compile_phrase_query(self, query, fields, boost=1.0):
         if len(fields) == 1:
             if fields[0].boost != 1.0:
                 return {
                     "match_phrase": {
                         fields[0].field_name: {
                             "query": query.query_string,
-                            "boost": fields[0].boost,
+                            "boost": boost * fields[0].boost,
                         }
                     }
                 }
             else:
                 return {"match_phrase": {fields[0].field_name: query.query_string}}
         else:
-            return {
-                "multi_match": {
-                    "query": query.query_string,
-                    "fields": [field.field_name_with_boost for field in fields],
-                    "type": "phrase",
-                }
+            multi_match_query = {
+                "query": query.query_string,
+                "fields": [field.field_name_with_boost for field in fields],
+                "type": "phrase",
             }
+            if boost != 1.0:
+                multi_match_query["boost"] = boost
+            return {"multi_match": multi_match_query}
 
     def _compile_query(self, query, field, boost=1.0):
         if isinstance(query, MatchAll):
@@ -680,10 +683,10 @@ class Elasticsearch7SearchQueryCompiler(BaseSearchQueryCompiler):
             return self._compile_plaintext_query(query, [field], boost)
 
         elif isinstance(query, Fuzzy):
-            return self._compile_fuzzy_query(query, [field])
+            return self._compile_fuzzy_query(query, [field], boost)
 
         elif isinstance(query, Phrase):
-            return self._compile_phrase_query(query, [field])
+            return self._compile_phrase_query(query, [field], boost)
 
         elif isinstance(query, Boost):
             return self._compile_query(query.subquery, field, boost * query.boost)


### PR DESCRIPTION
My understanding of the search backends, we have 2 types of boosing:
- Field level boosting, applied using the the `boost` attribute on the `Field` class
- Query level boosting, applied by building a custom query using the `Boost` class from `wagtail.search.query`

This PR aims to implement query and field level boosting for the Fuzzy and Phrase queries in the Elasticsearch backend.

## Reasoning behind the changes:

### The `_compile_fuzzy_query` method
There are 2 types of query that are generated in the `_compile_fuzzy_query` method, `match` and `multi_match`.

#### `match`

The [Elasticsearch7 `match` documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-match-query.html) doesn't really mention much about boosting. However the [OpenSearch `match` documentation](https://opensearch.org/docs/latest/query-dsl/full-text/match/#parameters) does!
Since neither documentation state support for field level boosting, and the match query is only used to match a single field, we opted to multiply the query level boost and the field level boost and add this to the `boost` key in the `match` query.

#### `multi_match`

Wagtail already implements field level queries as per the [Elasticsearch7 `multi_match` documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-multi-match-query.html)
> Individual fields can be boosted with the caret (^) notation
> ```
> GET /_search
> {
>   "query": {
>     "multi_match" : {
>       "query" : "this is a test",
>       "fields" : [ "subject^3", "message" ] 
>     }
>   }
> }
> ```

This PR adds the query level boosting based on the Elasticsearch7 documentation above, and the [OpenSearch documentation](https://opensearch.org/docs/latest/query-dsl/full-text/multi-match/#parameters).
> Boosts the clause by the given multiplier
The above is why we add the `boost` key to the `multi_match` query.

### The `_compile_phrase_query ` method
There are 2 types of query that are generated in the `_compile_phrase_query ` method, `match_phrase` and `multi_match`

#### `multi_match`
Since we already did the research for this above, we know that we can use the `^` approach for field level boosting and the `boost` key for query level boosting. Wagtail already handles the field level boosting, so we just added the boost to the `boost` key.

#### `match_phrase`
Neither the [Elasticsearch 7 `match_phrase` documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-match-query-phrase.html) or the [OpenSearch `match_phrase` documentation](https://opensearch.org/docs/latest/query-dsl/full-text/match-phrase/#parameters) mention boosting. However since Wagtail already applies boosting using the `boost` key and this is only for a single field, we applied the same logic as before and multiplied the field and query boost together.

Note for Cam: It might be worth doing some verification to see if boosting `match_phrase` actually works