### PR TITLE
Make all formbuilder field types accept a custom widget

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Improve performance of batch purging page urls in the frontend cache, avoiding n+1 query issues (Andy Babic)
  * Add better support and documentation for overriding or extending icons used in the in the userbar (Sébastien Corbin)
  * List the comments action, if comments are enabled, within the admin keyboard shortcuts dialog (Dhruvi Patel)
+ * Add better support and documentation for overriding the default field widgets used within form pages (Baptiste Mispelon)
  * Fix: Take preferred language into account for translatable strings in client-side code (Bernhard Bliem, Sage Abdullah)
  * Fix: Do not show the content type column as sortable when searching pages (Srishti Jaiswal, Sage Abdullah)
  * Fix: Support simple subqueries for `in` and `exact` lookup on Elasticsearch (Sage Abdullah)

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -27,6 +27,7 @@ This version adds formal support for Django 5.2.
  * Improve performance of batch purging page urls in the frontend cache, avoiding n+1 query issues (Andy Babic)
  * Add better support and documentation for overriding or extending [icons used in the in the userbar](custom_icons_userbar) (Sébastien Corbin)
  * List the comments action, if comments are enabled, within the admin keyboard shortcuts dialog (Dhruvi Patel)
+ * Add better support and documentation for [overriding the default field widgets](custom_form_field_type_widgets) used within form pages (Baptiste Mispelon)
 
 ### Bug fixes
 

--- a/wagtail/contrib/forms/forms.py
+++ b/wagtail/contrib/forms/forms.py
@@ -29,7 +29,8 @@ class FormBuilder:
         return django.forms.CharField(**options)
 
     def create_multiline_field(self, field, options):
-        return django.forms.CharField(widget=django.forms.Textarea, **options)
+        options.setdefault("widget", django.forms.Textarea)
+        return django.forms.CharField(**options)
 
     def create_date_field(self, field, options):
         return django.forms.DateField(**options)
@@ -56,20 +57,21 @@ class FormBuilder:
 
     def create_radio_field(self, field, options):
         options["choices"] = self.get_formatted_field_choices(field)
-        return django.forms.ChoiceField(widget=django.forms.RadioSelect, **options)
+        options.setdefault("widget", django.forms.RadioSelect)
+        return django.forms.ChoiceField(**options)
 
     def create_checkboxes_field(self, field, options):
         options["choices"] = self.get_formatted_field_choices(field)
         options["initial"] = self.get_formatted_field_initial(field)
-        return django.forms.MultipleChoiceField(
-            widget=django.forms.CheckboxSelectMultiple, **options
-        )
+        options.setdefault("widget", django.forms.CheckboxSelectMultiple)
+        return django.forms.MultipleChoiceField(**options)
 
     def create_checkbox_field(self, field, options):
         return django.forms.BooleanField(**options)
 
     def create_hidden_field(self, field, options):
-        return django.forms.CharField(widget=django.forms.HiddenInput, **options)
+        options.setdefault("widget", django.forms.HiddenInput)
+        return django.forms.CharField(**options)
 
     def get_create_field_function(self, type):
         """

--- a/wagtail/contrib/forms/tests/test_forms.py
+++ b/wagtail/contrib/forms/tests/test_forms.py
@@ -6,6 +6,7 @@ from wagtail.contrib.forms.utils import get_field_clean_name
 from wagtail.models import Page
 from wagtail.test.testapp.models import (
     ExtendedFormField,
+    FormBuilderWithCustomWidget,
     FormField,
     FormPage,
     FormPageWithCustomFormBuilder,
@@ -303,6 +304,67 @@ class TestFormBuilder(TestCase):
             ["a", "c"],
             form_class.base_fields["choose_the_correct_answer"].initial,
         )
+
+    def test_custom_widget(self):
+        """
+        All builtin field types should be able to receive a custom widget
+        """
+        self.form_page.form_builder = FormBuilderWithCustomWidget
+        form = self.form_page.get_form(auto_id=None)
+        for fieldname, expected_render in [
+            (
+                "your_name",
+                '<input type="text" name="your_name" maxlength="255" class="custom">',
+            ),
+            ("your_message", '<input type="text" name="your_message" class="custom">'),
+            (
+                "your_birthday",
+                '<input type="text" name="your_birthday" class="custom">',
+            ),
+            (
+                "your_birthtime",
+                '<input type="text" name="your_birthtime" class="custom">',
+            ),
+            (
+                "your_email",
+                '<input type="text" name="your_email" maxlength="320" class="custom">',
+            ),
+            (
+                "your_homepage",
+                '<input type="text" name="your_homepage" class="custom">',
+            ),
+            (
+                "your_favourite_number",
+                '<input type="text" name="your_favourite_number" class="custom">',
+            ),
+            (
+                "your_favourite_text_editors",
+                '<input type="text" name="your_favourite_text_editors" class="custom">',
+            ),
+            (
+                "your_favourite_python_ides",
+                '<input type="text" name="your_favourite_python_ides" class="custom">',
+            ),
+            (
+                "u03a5our_favourite_u03a1ython_ixd0e",
+                '<input type="text" name="u03a5our_favourite_u03a1ython_ixd0e" class="custom">',
+            ),
+            (
+                "your_choices",
+                '<input type="text" name="your_choices" value="[\'\']" class="custom">',
+            ),
+            (
+                "i_agree_to_the_terms_of_use",
+                '<input type="text" name="i_agree_to_the_terms_of_use" class="custom">',
+            ),
+            (
+                "a_hidden_field",
+                '<input type="text" name="a_hidden_field" class="custom">',
+            ),
+        ]:
+            with self.subTest(field=fieldname):
+                form.fields[fieldname].required = False  # makes testing easier
+                self.assertHTMLEqual(form[fieldname].as_widget(), expected_render)
 
 
 class TestCustomFormBuilder(TestCase):

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -932,6 +932,65 @@ class CustomFormBuilder(FormBuilder):
         return forms.GenericIPAddressField(**options)
 
 
+class FormBuilderWithCustomWidget(FormBuilder):
+    """
+    A form builder that customizes all default field type and
+    passes a `widget` parameter in the options to the parent class.
+    """
+
+    def create_singleline_field(self, field, options):
+        options["widget"] = forms.TextInput(attrs={"class": "custom"})
+        return super().create_singleline_field(field, options)
+
+    def create_multiline_field(self, field, options):
+        options["widget"] = forms.TextInput(attrs={"class": "custom"})
+        return super().create_multiline_field(field, options)
+
+    def create_email_field(self, field, options):
+        options["widget"] = forms.TextInput(attrs={"class": "custom"})
+        return super().create_email_field(field, options)
+
+    def create_number_field(self, field, options):
+        options["widget"] = forms.TextInput(attrs={"class": "custom"})
+        return super().create_number_field(field, options)
+
+    def create_url_field(self, field, options):
+        options["widget"] = forms.TextInput(attrs={"class": "custom"})
+        return super().create_url_field(field, options)
+
+    def create_checkbox_field(self, field, options):
+        options["widget"] = forms.TextInput(attrs={"class": "custom"})
+        return super().create_checkbox_field(field, options)
+
+    def create_checkboxes_field(self, field, options):
+        options["widget"] = forms.TextInput(attrs={"class": "custom"})
+        return super().create_checkboxes_field(field, options)
+
+    def create_dropdown_field(self, field, options):
+        options["widget"] = forms.TextInput(attrs={"class": "custom"})
+        return super().create_dropdown_field(field, options)
+
+    def create_multiselect_field(self, field, options):
+        options["widget"] = forms.TextInput(attrs={"class": "custom"})
+        return super().create_multiselect_field(field, options)
+
+    def create_radio_field(self, field, options):
+        options["widget"] = forms.TextInput(attrs={"class": "custom"})
+        return super().create_radio_field(field, options)
+
+    def create_date_field(self, field, options):
+        options["widget"] = forms.TextInput(attrs={"class": "custom"})
+        return super().create_date_field(field, options)
+
+    def create_datetime_field(self, field, options):
+        options["widget"] = forms.TextInput(attrs={"class": "custom"})
+        return super().create_datetime_field(field, options)
+
+    def create_hidden_field(self, field, options):
+        options["widget"] = forms.TextInput(attrs={"class": "custom"})
+        return super().create_hidden_field(field, options)
+
+
 class FormPageWithCustomFormBuilder(AbstractEmailForm):
     """
     A Form page that has a custom form builder and uses a custom


### PR DESCRIPTION
Prior to this change, it was inconsistent whether passing a `widget` argument as an option to a `create_<field>_field()` method would work or not (it might work, or might result in a `TypeError` caused by the duplicate argument).

Because of this inconsistency, this change should be fully backwards-compatible.
