### PR TITLE
Fix simple subqueries for `in` and `exact` lookup on Elasticsearch

### DIFF
--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -5,7 +5,7 @@ from django.db.models.functions.datetime import Extract as ExtractDate
 from django.db.models.functions.datetime import ExtractYear
 from django.db.models.lookups import Lookup
 from django.db.models.query import QuerySet
-from django.db.models.sql.where import NothingNode, SubqueryConstraint, WhereNode
+from django.db.models.sql.where import NothingNode, WhereNode
 
 from wagtail.search.index import class_is_indexed, get_indexed_models
 from wagtail.search.query import MATCH_ALL, PlainText
@@ -184,11 +184,6 @@ class BaseSearchQueryCompiler:
 
         elif isinstance(where_node, NothingNode):
             return self._process_match_none()
-
-        elif isinstance(where_node, SubqueryConstraint):
-            raise FilterError(
-                "Could not apply filter on search results: Subqueries are not allowed."
-            )
 
         elif isinstance(where_node, WhereNode):
             # Get child filters

--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -561,9 +561,10 @@ class Elasticsearch7SearchQueryCompiler(BaseSearchQueryCompiler):
             }
 
         if lookup == "in":
-            if isinstance(value, Query):
+            if isinstance(value, (Query, Subquery)):
                 db_alias = self.queryset._db or DEFAULT_DB_ALIAS
-                resultset = value.get_compiler(db_alias).execute_sql(result_type=MULTI)
+                query = value.query if isinstance(value, Subquery) else value
+                resultset = query.get_compiler(db_alias).execute_sql(result_type=MULTI)
                 value = [row[0] for chunk in resultset for row in chunk]
 
             elif not isinstance(value, list):

--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from urllib.parse import urlparse
 
 from django.db import DEFAULT_DB_ALIAS, models
+from django.db.models import Subquery
 from django.db.models.sql import Query
 from django.db.models.sql.constants import MULTI, SINGLE
 from django.utils.crypto import get_random_string
@@ -505,9 +506,10 @@ class Elasticsearch7SearchQueryCompiler(BaseSearchQueryCompiler):
                     }
                 }
             else:
-                if isinstance(value, Query):
+                if isinstance(value, (Query, Subquery)):
                     db_alias = self.queryset._db or DEFAULT_DB_ALIAS
-                    value = value.get_compiler(db_alias).execute_sql(result_type=SINGLE)
+                    query = value.query if isinstance(value, Subquery) else value
+                    value = query.get_compiler(db_alias).execute_sql(result_type=SINGLE)
                     # The result is either a tuple with one element or None
                     if value:
                         value = value[0]

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -429,20 +429,26 @@ class BackendTests(WagtailTestUtils):
         values = models.Book.objects.filter(number_of_pages__lt=440).values_list(
             "number_of_pages", flat=True
         )
-        results = self.backend.search(
-            MATCH_ALL, models.Book.objects.filter(number_of_pages__in=values)
-        )
+        cases = {
+            "implicit": values,
+            "explicit": Subquery(values),
+        }
+        for case, subquery in cases.items():
+            with self.subTest(case=case):
+                results = self.backend.search(
+                    MATCH_ALL, models.Book.objects.filter(number_of_pages__in=subquery)
+                )
 
-        self.assertUnsortedListEqual(
-            [r.title for r in results],
-            [
-                "The Hobbit",
-                "JavaScript: The good parts",
-                "The Fellowship of the Ring",
-                "Foundation",
-                "The Two Towers",
-            ],
-        )
+                self.assertUnsortedListEqual(
+                    [r.title for r in results],
+                    [
+                        "The Hobbit",
+                        "JavaScript: The good parts",
+                        "The Fellowship of the Ring",
+                        "Foundation",
+                        "The Two Towers",
+                    ],
+                )
 
     def test_filter_isnull_true(self):
         # Note: We don't know the birth dates of any of the programming guide authors

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -301,6 +301,23 @@ class BackendTests(WagtailTestUtils):
             [r.title for r in results], ["The Return of the King"]
         )
 
+    def test_filter_exact_values_list_subquery(self):
+        protagonist = (
+            models.Character.objects.filter(name="Frodo Baggins")
+            .order_by("novel_id")
+            .values_list("pk", flat=True)[:1]
+        )
+
+        results = self.backend.search(
+            MATCH_ALL,
+            models.Novel.objects.filter(protagonist_id=protagonist),
+        )
+
+        self.assertUnsortedListEqual(
+            [r.title for r in results],
+            ["The Fellowship of the Ring"],
+        )
+
     def test_filter_lt(self):
         results = self.backend.search(
             MATCH_ALL, models.Book.objects.filter(number_of_pages__lt=440)


### PR DESCRIPTION
The first commit fixes tests against Django's `main` after https://github.com/django/django/pull/19160, which removed the `SubqueryConstraint` class because it was deemed obsolete.

I'd never heard of `SubqueryConstraint` until now. It's not `Subquery` and is unrelated to database "constraints". I got curious why we use such an obscure Django class in our code. 

The blame points to 4f5b9ffaf10282d9b37812a4ea7e01e2baac2ca3, but apparently it came from when we only had the Elasticsearch backend (no SQL database backends). The real commit that introduced it was b78b6486829f748daf42d6240426abb44d8329a5, which dates all the way back to 2014. Looking at a related commit 0e2b621d39b3b54725d92ae20ad755f486a3a2a3, it got me thinking: when was the now-famous `Subquery` class introduced in Django?

Django 1.11, apparently: https://docs.djangoproject.com/en/1.11/ref/models/expressions/#subquery-expressions

With further digging, I found the following commits in Wagtail:
- 39c9372e525a270c7e572d4ad2f9cec0e7e45b60
- a3f682ca85896f39f7e77cb80733aff4276fe7ec
- eef46dde92f97768e647d386af45c0855685298e

The last one in particular was the first time subquery handling was introduced, I believe. PR: https://github.com/wagtail/wagtail/pull/3499

However, since subquery was (somewhat) handled, I wonder whether the code that checks for `SubqueryConstraint` has ever run? Well, apparently [not according to Codecov](https://app.codecov.io/gh/wagtail/wagtail/blob/main/wagtail%2Fsearch%2Fbackends%2Fbase.py#L189) (at least not recently). I suspect this might be because we kept the check when we supported both Django 1.11 and older, but forgot to remove it when we dropped support for Django < 1.11. So, I opted to remove the check entirely.

The handling for subqueries in `in` got me thinking, why is it supported for `in` but not `exact`? So, I added a similar logic in the second commit for the `exact` lookup which I think would've also fixed #12862.

The last two commits are a workaround when the subquery is declared explicitly with `Subquery()`, which currently would fail. I call it a workaround because I'm pretty sure it wouldn't work if the `Subquery` is more complex e.g. uses `OuterRef`, in which case it can't be executed independently.

I'm not so confident with the changes here because the tests use `MATCH_ALL`, but at least the results are as expected...