### PR TITLE
Count streamfield errors correctly in panel titles and minimap

### DIFF
--- a/client/src/components/Minimap/index.tsx
+++ b/client/src/components/Minimap/index.tsx
@@ -37,7 +37,7 @@ const createMinimapLink = (
   const ariaLevel = heading.getAttribute('aria-level');
   const headingLevel = `h${ariaLevel || heading.tagName[1] || 2}`;
   const errorCount = [].slice
-    .call(panel.querySelectorAll('.error-message'))
+    .call(panel.querySelectorAll('.error-message,.help-critical'))
     .filter((err) => err.closest('[data-panel]') === panel).length;
 
   return {

--- a/client/src/controllers/CountController.ts
+++ b/client/src/controllers/CountController.ts
@@ -44,7 +44,8 @@ export class CountController extends Controller<HTMLFormElement> {
   declare readonly totalTarget: HTMLElement;
 
   connect() {
-    this.count();
+    /** Delay setup to give a chance for client-side validation to inject elements */
+    setTimeout(() => this.count(), 200);
   }
 
   count() {


### PR DESCRIPTION
Refs #12823

This issue was actually two smaller issues in a trench coat:

1) 🕵️🏻 The first one where panel titles report an incorrect error count stems from the fact that streamfield errors (as well as some other block types) are rendered in javascript. This is a problem because the panel titles decorations that count errors are initialized before those errors are injected in the page and thus are not counted.

2) 🕵🏻 The second one where the minimap doesn't show streamfield errors (again, some other block types are affected here too). The problem here was a CSS selector that failed to account for js-generated errors (unlike the error counting logic which used a more thorough selector).

I couldn't figure out how or where to write tests for this, some guidance would be appreciated.

<details>
<summary>Screenshots</summary>
<strong>Before</strong>

![Screenshot 2025-02-18 at 09-28-28 New Standard page - Wagtail](https://github.com/user-attachments/assets/5b10514e-a55e-40d9-89b2-80cb21a91249)

<strong>After</strong>

![Screenshot 2025-02-18 at 09-29-32 New Standard page - Wagtail](https://github.com/user-attachments/assets/4863e9a6-3a6b-4c3a-9e8d-69fb0651a8f1)

</details>
