### PR TITLE
Use the correct event listener to adjust minimap positioning

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Default to the `standard` tokenizer on Elasticsearch, to correctly handle numbers as tokens (Matt Westcott)
  * Fix: Take preferred language into account for translatable strings in client-side code (Bernhard Bliem, Sage Abdullah)
  * Fix: Do not show the content type column as sortable when searching pages (Srishti Jaiswal, Sage Abdullah)
+ * Fix: Ensure the top of the minimap correctly adjusts when resizing the browser viewport (Thibaud Colas)
  * Docs: Add missing `django.contrib.admin` to list of apps in "add to Django project" guide (Mohamed Rabiaa)
  * Docs: Fix typo in the headless documentation page (Mahmoud Nasser)
  * Maintenance: Migrate away from deprecated Sass import rules to module system (Srishti Jaiswal)

--- a/client/src/components/Minimap/index.tsx
+++ b/client/src/components/Minimap/index.tsx
@@ -127,7 +127,7 @@ export const initMinimap = (
     container.style.setProperty('--offset-top', `${container.offsetTop}px`);
   const updateOffsetTop = debounce(setOffsetTop, 100);
 
-  document.addEventListener('resize', updateOffsetTop);
+  window.addEventListener('resize', updateOffsetTop);
 
   setOffsetTop();
   updateMinimap(container);

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -23,6 +23,7 @@ depth: 1
 
  * Take preferred language into account for translatable strings in client-side code (Bernhard Bliem, Sage Abdullah)
  * Do not show the content type column as sortable when searching pages (Srishti Jaiswal, Sage Abdullah)
+ * Ensure the top of the minimap correctly adjusts when resizing the browser viewport (Thibaud Colas)
 
 ### Documentation
 


### PR DESCRIPTION
Spotted by @benenright. The minimap’s top offset doesn’t adjust between desktop and mobile based on the slim header’s height. And that’s because "someone" used the wrong event listener when implementing that behavior 💀

Correct behavior:

![offset-top](https://github.com/user-attachments/assets/0668fb60-69b3-42f3-ad46-a73d3d8f6130)
