### PR TITLE
Fix console errors in Draftail tests

### DIFF
--- a/client/src/entrypoints/admin/draftail.test.js
+++ b/client/src/entrypoints/admin/draftail.test.js
@@ -116,6 +116,8 @@ describe('importing the module multiple times', () => {
 
     // Subsequent imports (e.g. in AJAX responses)
     jest.isolateModules(() => {
+      // Ensure stubs are loaded in the new isolated context
+      require('../../../tests/stubs');
       require('./draftail');
     });
 


### PR DESCRIPTION
Despite the passing tests, there are actually console errors logged to the output when running `draftail.test.js` after #12716. This is because the `WAGTAIL_CONFIG` object is imported by `ComboBoxPreview`, which is imported by `ComboBox`, which in turn is imported by the `Draftail` component.

The test that raises the error in `draftail.test.js` is the test added in a5bb99bf67a5534082a9f7f4f44a33f5086b67f0, which uses `jest.isolateModules` and thus doesn't have the `stubs.js` file (where we put the stubs for the `wagtail-`config element) loaded.

The tests do not fail because the `getWagtailConfig()` only logs the error with `console.error` without actually re-throwing the error.

## Before

<img width="653" alt="image" src="https://github.com/user-attachments/assets/8173ed4f-40b4-4d24-a4a9-e5c6c89a9dd0" />


## After

<img width="598" alt="image" src="https://github.com/user-attachments/assets/b24bae6e-afa9-4426-afe4-afa23c9f2fdf" />
