### PR TITLE
Add missing `aria-label` to upgrade banner dismiss button

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ Changelog
  * Fix: Fix regression where nested sub-menu items would not be visible (Sage Abdullah)
  * Fix: Ensure the top of the minimap correctly adjusts when resizing the browser viewport (Thibaud Colas)
  * Fix: Remove obsolete SubqueryConstraint check in search backends, for provisional Django 5.2 compatibility (Sage Abdullah)
+ * Fix: Add missing “Close” label to the upgrade notification dismiss button (Sage Abdullah)
  * Docs: Fix typo in the headless documentation page (Mahmoud Nasser)
  * Docs: Fix typo in `Page.get_route_paths` docstring (Baptiste Mispelon)
  * Docs: Upgrade sphinx-wagtail-theme to v6.5.0 (Sage Abdullah)
@@ -175,6 +176,7 @@ Changelog
 6.3.4 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~~~
 
+ * Fix: Add missing “Close” label to the upgrade notification dismiss button (Sage Abdullah)
  * Maintenance: Remove upper version boundary for django-filter (Dan Braghis)
 
 

--- a/docs/releases/6.3.4.md
+++ b/docs/releases/6.3.4.md
@@ -15,3 +15,4 @@ depth: 1
 ### Maintenance
 
  * Remove upper version boundary for django-filter (Dan Braghis)
+ * Add missing “Close” label to the upgrade notification dismiss button (Sage Abdullah)

--- a/docs/releases/6.4.1.md
+++ b/docs/releases/6.4.1.md
@@ -19,6 +19,7 @@ depth: 1
  * Fix regression where nested sub-menu items would not be visible (Sage Abdullah)
  * Ensure the top of the minimap correctly adjusts when resizing the browser viewport (Thibaud Colas)
  * Remove obsolete SubqueryConstraint check in search backends, for provisional Django 5.2 compatibility (Sage Abdullah)
+ * Add missing “Close” label to the upgrade notification dismiss button (Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html
+++ b/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html
@@ -25,6 +25,7 @@
         data-action="w-dismissible#toggle"
         {% if dismissible_value %}data-w-dismissible-value-param="{{ dismissible_value }}"{% endif %}
         data-w-upgrade-target="dismiss"
+        aria-label="{% trans 'Close' %}"
         class="w-ml-auto w-flex w-items-center w-justify-center w-bg-transparent w-rounded-full w-p-0 w-w-8 w-h-8
                w-text-current
                w-border

--- a/wagtail/admin/tests/test_upgrade_notification.py
+++ b/wagtail/admin/tests/test_upgrade_notification.py
@@ -78,6 +78,7 @@ class TestUpgradeNotificationPanel(WagtailTestUtils, TestCase):
         )
         toggle = soup.select_one("[data-action='w-dismissible#toggle']")
         self.assertIsNotNone(toggle)
+        self.assertEqual(toggle.get("aria-label"), "Close")
         self.assertIsNone(toggle.get(self.ATTR_LAST_DISMISSED_VALUE))
 
     @override_settings(WAGTAIL_ENABLE_UPDATE_CHECK=False)
@@ -115,6 +116,7 @@ class TestUpgradeNotificationPanel(WagtailTestUtils, TestCase):
                 )
                 toggle = soup.select_one("[data-action='w-dismissible#toggle']")
                 self.assertIsNotNone(toggle)
+                self.assertEqual(toggle.get("aria-label"), "Close")
                 self.assertIsNone(toggle.get(self.ATTR_LAST_DISMISSED_VALUE))
 
     def test_render_html_dismissed_version(self):
@@ -140,6 +142,7 @@ class TestUpgradeNotificationPanel(WagtailTestUtils, TestCase):
         )
         toggle = soup.select_one("[data-action='w-dismissible#toggle']")
         self.assertIsNotNone(toggle)
+        self.assertEqual(toggle.get("aria-label"), "Close")
         self.assertEqual(
             toggle.get(self.ATTR_LAST_DISMISSED_VALUE),
             "6.2.2",


### PR DESCRIPTION
Spotted in [`0bca21f` (#12846)](https://github.com/wagtail/wagtail/pull/12846/commits/0bca21fb04252c61ec9663e6f4616ad5f1893d97) and the ui-tests failures in the `stable/6.3.x` branch.

This is a bug in a feature introduced in 6.3, so this should be backported there as well (or not...). Although I suppose the translatable string won't make it into the release anymore.