### PR TITLE
Fix typo in docstring

### DIFF
--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2700,7 +2700,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         .. note::
 
             If using ``RoutablePageMixin``, you may want to override this method
-            to include the paths of popualar routes.
+            to include the paths of popular routes.
 
         .. note::
 


### PR DESCRIPTION
This typo ends up visible in the docs as well: https://docs.wagtail.org/en/stable/reference/models.html#wagtail.models.Page.get_route_paths