### PR TITLE
Allow customising InspectView field display value via methods on the view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
  * Introduce new designs for listings and chooser pagination (except page chooser) (Jordan Teichmann, Sage Abdullah)
  * Add default "Locale" column to listings of translatable models (Dan Braghis, Sage Abdullah)
  * Hide add locale button when no more languages are available (Dan Braghis)
+ * Allow customizing `InspectView` field display value via methods on the view (Dan Braghis)
  * Fix: Take preferred language into account for translatable strings in client-side code (Bernhard Bliem, Sage Abdullah)
  * Fix: Do not show the content type column as sortable when searching pages (Srishti Jaiswal, Sage Abdullah)
  * Fix: Support simple subqueries for `in` and `exact` lookup on Elasticsearch (Sage Abdullah)

--- a/docs/releases/7.0.md
+++ b/docs/releases/7.0.md
@@ -44,6 +44,7 @@ We have a new pagination interface for all listing views and most choosers, incl
  * Change 'Publish' button label to 'Schedule to publish' if go-live schedule is set (Sage Abdullah)
  * Add default "Locale" column to listings of translatable models (Dan Braghis, Sage Abdullah)
  * Hide add locale button when no more languages are available (Dan Braghis)
+ * Allow customizing `InspectView` field display value via methods on the view (Dan Braghis)
 
 ### Bug fixes
 

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -1364,7 +1364,7 @@ class TestInspectView(WagtailTestUtils, TestCase):
             reverse("fctoy_alt1:inspect", args=(quote(self.object.pk),))
         )
         expected_fields = ["Name"]
-        expected_values = ["Test Toy"]
+        expected_values = [f"Test Toy ({self.object.pk})"]
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/generic/inspect.html")
         soup = self.get_soup(response.content)

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -1105,8 +1105,13 @@ class InspectView(PermissionCheckedMixin, WagtailAdminTemplateMixin, TemplateVie
         return capfirst(label_for_field(field_name, model=self.model))
 
     def get_field_display_value(self, field_name, field):
-        # First we check for a 'get_fieldname_display' property/method on
+        # First we check for a `get_fieldname_display_value` method on the InspectView
+        # then for a 'get_fieldname_display' property/method on
         # the model, and return the value of that, if present.
+        value_func = getattr(self, f"get_{field_name}_display_value", None)
+        if value_func is not None and callable(value_func):
+            return value_func()
+
         value_func = getattr(self.object, "get_%s_display" % field_name, None)
         if value_func is not None:
             if callable(value_func):

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -13,7 +13,7 @@ from wagtail.admin.auth import user_passes_test
 from wagtail.admin.filters import WagtailFilterSet
 from wagtail.admin.panels import FieldPanel
 from wagtail.admin.ui.tables import BooleanColumn, Column, UpdatedAtColumn
-from wagtail.admin.views.generic import DeleteView, EditView, IndexView
+from wagtail.admin.views.generic import DeleteView, EditView, IndexView, InspectView
 from wagtail.admin.viewsets.base import ViewSet, ViewSetGroup
 from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.admin.viewsets.model import ModelViewSet, ModelViewSetGroup
@@ -238,12 +238,18 @@ class FeatureCompleteToyViewSet(ModelViewSet):
     ]
 
 
+class FCToyAlt1InspectView(InspectView):
+    def get_name_display_value(self):
+        return f"{self.object.name} ({self.object.strid})"
+
+
 class FCToyAlt1ViewSet(ModelViewSet):
     model = FeatureCompleteToy
     icon = "media"
     list_filter = {"name": ["icontains"]}
     form_fields = ["name"]
     menu_label = "FC Toys Alt 1"
+    inspect_view_class = FCToyAlt1InspectView
     inspect_view_enabled = True
     inspect_view_fields_exclude = ["strid", "release_date"]
     copy_view_enabled = False


### PR DESCRIPTION
This is useful when you may have different inspect views or you don't want to pollute the model's `get_fieldname_display` attributes/methods