### PR TITLE
Add Locale column to generic listings

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/tables/locale_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/locale_cell.html
@@ -1,0 +1,4 @@
+{% load wagtailadmin_tags %}
+<td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
+    {% status value classname="w-status--label" %}
+</td>

--- a/wagtail/admin/ui/tables/__init__.py
+++ b/wagtail/admin/ui/tables/__init__.py
@@ -13,7 +13,8 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext, gettext_lazy
 
 from wagtail.admin.ui.components import Component
-from wagtail.coreutils import multigetattr
+from wagtail.coreutils import get_locales_display_names, multigetattr
+from wagtail.models import Locale
 
 
 class BaseColumn(metaclass=MediaDefiningClass):
@@ -303,6 +304,29 @@ class LiveStatusTagColumn(StatusTagColumn):
             primary=lambda instance: instance.live,
             **kwargs,
         )
+
+
+class LocaleColumn(StatusTagColumn):
+    """Represents a Locale tag."""
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            "locale_id",
+            label=kwargs.pop("label", gettext("Locale")),
+            sort_key=kwargs.pop("sort_key", "locale"),
+            primary=False,
+            **kwargs,
+        )
+
+    def get_cell_context_data(self, instance, parent_context):
+        context = super().get_cell_context_data(instance, parent_context)
+        value = self.get_value(instance)
+        if isinstance(value, int):
+            value = get_locales_display_names().get(value)
+        elif isinstance(value, Locale):
+            value = value.get_display_name()
+        context["value"] = value
+        return context
 
 
 class DateColumn(Column):

--- a/wagtail/admin/ui/tables/__init__.py
+++ b/wagtail/admin/ui/tables/__init__.py
@@ -306,15 +306,16 @@ class LiveStatusTagColumn(StatusTagColumn):
         )
 
 
-class LocaleColumn(StatusTagColumn):
-    """Represents a Locale tag."""
+class LocaleColumn(Column):
+    """Represents a Locale label."""
+
+    cell_template_name = "wagtailadmin/tables/locale_cell.html"
 
     def __init__(self, **kwargs):
         super().__init__(
             "locale_id",
             label=kwargs.pop("label", gettext("Locale")),
             sort_key=kwargs.pop("sort_key", "locale"),
-            primary=False,
             **kwargs,
         )
 

--- a/wagtail/admin/ui/tables/__init__.py
+++ b/wagtail/admin/ui/tables/__init__.py
@@ -316,6 +316,7 @@ class LocaleColumn(Column):
             "locale_id",
             label=kwargs.pop("label", gettext("Locale")),
             sort_key=kwargs.pop("sort_key", "locale"),
+            classname=kwargs.pop("classname", "w-text-16"),
             **kwargs,
         )
 

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -21,7 +21,7 @@ from wagtail.admin.forms.models import WagtailAdminModelForm
 from wagtail.admin.models import EditingSession
 from wagtail.admin.templatetags.wagtailadmin_tags import user_display_name
 from wagtail.admin.ui.editing_sessions import EditingSessionsModule
-from wagtail.admin.ui.tables import TitleColumn
+from wagtail.admin.ui.tables import LiveStatusTagColumn, TitleColumn
 from wagtail.admin.utils import get_latest_str, set_query_params
 from wagtail.locks import BasicLock, ScheduledForPublishLock, WorkflowLock
 from wagtail.log_actions import log
@@ -223,6 +223,13 @@ class IndexViewOptionalFeaturesMixin:
             )
             return queryset
         return super()._annotate_queryset_updated_at(queryset)
+
+    @cached_property
+    def list_display(self):
+        list_display = super().list_display.copy()
+        if issubclass(self.model, DraftStateMixin):
+            list_display.append(LiveStatusTagColumn())
+        return list_display
 
 
 class CreateEditViewOptionalFeaturesMixin:

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -106,6 +106,12 @@ class BeforeAfterHookMixin(HookResponseMixin):
 
 class LocaleMixin:
     @cached_property
+    def i18n_enabled(self) -> bool:
+        return getattr(settings, "WAGTAIL_I18N_ENABLED", False) and issubclass(
+            self.model, TranslatableMixin
+        )
+
+    @cached_property
     def locale(self):
         return self.get_locale()
 
@@ -117,8 +123,7 @@ class LocaleMixin:
         if not getattr(self, "model", None):
             return None
 
-        i18n_enabled = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
-        if not i18n_enabled or not issubclass(self.model, TranslatableMixin):
+        if not self.i18n_enabled:
             return None
 
         if hasattr(self, "object") and self.object:

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -129,13 +129,6 @@ class IndexView(
         )
         return queryset.annotate(_updated_at=models.Subquery(latest_log))
 
-    def get_base_queryset(self):
-        base_queryset = super().get_base_queryset()
-        if self.i18n_enabled:
-            base_queryset = base_queryset.prefetch_related("locale")
-
-        return base_queryset
-
     def order_queryset(self, queryset):
         has_updated_at_column = any(
             getattr(column, "accessor", None) == "_updated_at"

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -71,9 +71,6 @@ class IndexView(
     inspect_url_name = None
     delete_url_name = None
     any_permission_required = ["add", "change", "delete", "view"]
-    # note: the LocaleColumn is included by default but excluded from the columns
-    # property if i18n is disabled or the model is not translatable.
-    list_display = ["__str__", LocaleColumn(), UpdatedAtColumn()]
     list_filter = None
     show_other_searches = False
 
@@ -246,7 +243,14 @@ class IndexView(
         )
 
     @cached_property
-    def columns(self) -> list[Column]:
+    def list_display(self):
+        list_display = ["__str__", UpdatedAtColumn()]
+        if self.i18n_enabled:
+            list_display.insert(1, LocaleColumn())
+        return list_display
+
+    @cached_property
+    def columns(self):
         # If not explicitly overridden, derive from list_display
         columns = []
         for i, field in enumerate(self.list_display):
@@ -256,10 +260,6 @@ class IndexView(
                 column = self._get_title_column(field)
             else:
                 column = self._get_custom_column(field)
-
-            if isinstance(column, LocaleColumn) and not self.i18n_enabled:
-                continue
-
             columns.append(column)
 
         return columns

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -393,7 +393,7 @@ class ModelViewSet(ViewSet):
         - An instance of the ``wagtail.admin.ui.tables.Column`` class.
 
         If the name refers to a database field, the ability to sort the listing
-        by the database column will be offerred and the field's verbose name
+        by the database column will be offered and the field's verbose name
         will be used as the column header.
 
         If the name refers to a callable or property, an ``admin_order_field``
@@ -404,7 +404,11 @@ class ModelViewSet(ViewSet):
         This list will be passed to the ``list_display`` attribute of the index
         view. If left unset, the ``list_display`` attribute of the index view
         will be used instead, which by default is defined as
-        ``["__str__", wagtail.admin.ui.tables.UpdatedAtColumn()]``.
+        ``["__str__", wagtail.admin.ui.tables.LocaleColumn(), wagtail.admin.ui.tables.UpdatedAtColumn()]``.
+
+        Note that if WAGTAIL_I18N_ENABLED = False, or the model is not translatable
+        (i.e. does not inherit from TranslatableMixin), then the LocaleColumn is
+        excluded by the default IndexView.columns property.
         """
         return self.index_view_class.list_display
 

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -410,7 +410,7 @@ class ModelViewSet(ViewSet):
         (i.e. does not inherit from TranslatableMixin), then the LocaleColumn is
         excluded by the default IndexView.columns property.
         """
-        return self.index_view_class.list_display
+        return self.UNDEFINED
 
     @cached_property
     def list_filter(self):

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -406,9 +406,7 @@ class ModelViewSet(ViewSet):
         will be used instead, which by default is defined as
         ``["__str__", wagtail.admin.ui.tables.LocaleColumn(), wagtail.admin.ui.tables.UpdatedAtColumn()]``.
 
-        Note that if WAGTAIL_I18N_ENABLED = False, or the model is not translatable
-        (i.e. does not inherit from TranslatableMixin), then the LocaleColumn is
-        excluded by the default IndexView.columns property.
+        Note that the ``LocaleColumn`` is only included if the model is translatable.
         """
         return self.UNDEFINED
 

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -18,7 +18,6 @@ from wagtail.admin.ui.side_panels import ChecksSidePanel, PreviewSidePanel
 from wagtail.admin.ui.tables import (
     BulkActionsCheckboxColumn,
     Column,
-    LiveStatusTagColumn,
     TitleColumn,
 )
 from wagtail.admin.views import generic
@@ -776,13 +775,6 @@ class SnippetViewSet(ModelViewSet):
             icon=self.icon,
             per_page=self.chooser_per_page,
         )
-
-    @cached_property
-    def list_display(self):
-        list_display = super().list_display.copy()
-        if self.draftstate_enabled:
-            list_display.append(LiveStatusTagColumn())
-        return list_display
 
     @cached_property
     def icon(self):


### PR DESCRIPTION
This PR adds a Locale column to generic `IndexView` listings when the model inherits from `TranslatableMixin` and `WAGTAIL_I18N_ENABLED = True`.

To reproduce (with Bakerydemo):

1. go to Snippets > Footer text
2. add a footer text snippet
3. translate to one of the configured languages
4. back to Snippets > Footer text
   before: shows all versions (original, translated). no locale indicator
   after: shows all versions, but has a locale column

Related: https://github.com/wagtail/wagtail-localize/issues/826


<details><summary>Before</summary>

![before-unfiltered](https://github.com/user-attachments/assets/220260c6-093b-44ef-9d87-401bc6b43c53)
![before-filtered](https://github.com/user-attachments/assets/265fcc0c-75b6-4008-bb7b-70359306769b)

</details> 

<details><summary>After</summary>

![after-unfiltered](https://github.com/user-attachments/assets/30693bc7-fa43-476a-ae5f-29dbf2ba607f)
![after-filtered](https://github.com/user-attachments/assets/1c55e01c-5a1d-44c2-95bc-e6cc96f93592)

</details> 
