### PR TITLE
Do not show upgrade notification if the installed version is the latest

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -63,6 +63,12 @@ Changelog
  * Maintenance: Formally deprecate support for listing views with no breadcrumbs (Sage Abdullah)
 
 
+6.4.2 (xx.xx.xxxx) - IN DEVELOPMENT
+~~~~~~~~~~~~~~~~~~
+
+ * Fix: Do not show upgrade notification if the installed version is the latest (Sage Abdullah)
+
+
 6.4.1 (21.02.2025)
 ~~~~~~~~~~~~~~~~~~
 

--- a/client/src/controllers/UpgradeController.ts
+++ b/client/src/controllers/UpgradeController.ts
@@ -102,9 +102,9 @@ export class UpgradeController extends Controller<HTMLElement> {
         const latestVersion = new VersionNumber(data.version);
         const versionDelta = currentVersion.howMuchBehind(latestVersion);
 
-        // Check with the last dismissed version if it exists, so we don't
-        // show the notification again if the user has already dismissed it.
-        if (!this.knownVersion.howMuchBehind(latestVersion)) {
+        // Do not show the notification if the current version is the latest
+        // or the last dismissed (known) version is the latest.
+        if (!versionDelta || !this.knownVersion.howMuchBehind(latestVersion)) {
           return;
         }
 

--- a/docs/releases/6.4.2.md
+++ b/docs/releases/6.4.2.md
@@ -1,0 +1,24 @@
+# Wagtail 6.4.2 release notes - IN DEVELOPMENT
+
+_Unreleased_
+
+```{contents}
+---
+local:
+depth: 1
+---
+```
+
+## What's new
+
+### Bug fixes
+
+ * Do not show upgrade notification if the installed version is the latest (Sage Abdullah)
+
+### Documentation
+
+ * ...
+
+### Maintenance
+
+ * ...

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -7,6 +7,7 @@ Release notes
    upgrading
    release_process
    7.0
+   6.4.2
    6.4.1
    6.4
    6.3.4


### PR DESCRIPTION
I have a deja vu feeling that I initially already implemented this check, then it got lost when I extracted the `knownVersion` property...

The current implementation has a bug:

![image](https://github.com/user-attachments/assets/ae763dd7-e788-4d78-81d4-b3a5feb513a6)

## Testing

Create the following `latest.txt` somewhere in your system:

```json
{
    "version": "7.2.3",
    "url":     "https://docs.wagtail.org/en/stable/releases/7.2.3.html",
    "minorUrl": "https://docs.wagtail.org/en/stable/releases/7.2.html",
    "lts": {
        "version": "7.1.1",
        "url": "https://docs.wagtail.org/en/stable/releases/7.1.1.html",
        "minorUrl": "https://docs.wagtail.org/en/stable/releases/7.1.html"
    }
}
```

and serve the directory where it is placed, e.g. with `npx serve --cors -p 9000`.

Apply the following patch:

```diff
diff --git a/wagtail/__init__.py b/wagtail/__init__.py
index d7258b5392..b30658f079 100644
--- a/wagtail/__init__.py
+++ b/wagtail/__init__.py
@@ -6,7 +6,7 @@ from wagtail.utils.version import get_semver_version, get_version

 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (6, 5, 0, "alpha", 0)
+VERSION = (7, 2, 3, "final", 0)

 __version__ = get_version(VERSION)

diff --git a/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html b/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html
index 7630985e1e..3d910991b7 100644
--- a/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html
+++ b/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html
@@ -2,6 +2,7 @@
 {% wagtail_version as current_version %}
 <div class="w-panel-upgrade w-flex w-mb-[-2rem] sm:w-mb-0 w-gap-5 w-items-center w-pl-slim-header w-pr-5 sm:w-px-[3.5rem] w-py-5 w-text-text-context w-bg-surface-info-panel w-border-b w-border-transparent"
      data-controller="w-upgrade w-dismissible"
+     data-w-upgrade-url-value="http://localhost:9000/latest.txt"
      data-w-upgrade-current-version-value="{{ current_version }}"
      {% if lts_only %}data-w-upgrade-lts-only-value="true"{% endif %}
      data-w-dismissible-id-value="{{ dismissible_id }}"
```

Open the dashboard. With this PR, it should not show a notification.

If you switch to the main branch, it would show an incorrect notification, i.e.

> Your version: 7.2.3. New version: 7.2.3.

Dismiss the upgrade banner. Reload, it should not show you the upgrade notification again.

Now, update the mock `latest.txt` to be on 7.2.4.

Reload, it should now show you a correct upgrade notification, i.e.

> Your version: 7.2.3. New version: 7.2.4. 

Now, update `wagtail/__init__.py` to be on 7.2.4.

```py
VERSION = (7, 2, 4, "final", 0)
```

If you're still on the main branch, an incorrect notification will be shown once you reload:

> Your version: 7.2.4. New version: 7.2.4.

Switch to this PR branch and rebuild the assets. If you reload, the incorrect notification will not be shown.

If you update `latest.txt` to be on 7.2.5 and reload, a correct notification will be shown, i.e.

> Your version: 7.2.4. New version: 7.2.5.