### PR TITLE
Fix TypedTableBlock.normalize to return empty TypedTable for None

### DIFF
--- a/wagtail/contrib/typed_table_block/blocks.py
+++ b/wagtail/contrib/typed_table_block/blocks.py
@@ -139,57 +139,49 @@ class BaseTypedTableBlock(Block):
         )
 
     def get_prep_value(self, table):
-        if table:
-            return {
-                "columns": [
-                    {"type": col["block"].name, "heading": col["heading"]}
-                    for col in table.columns
-                ],
-                "rows": [
-                    {
-                        "values": [
-                            column["block"].get_prep_value(val)
-                            for column, val in zip(table.columns, row["values"])
-                        ]
-                    }
-                    for row in table.row_data
-                ],
-                "caption": table.caption,
-            }
-        else:
-            return {
-                "columns": [],
-                "rows": [],
-                "caption": "",
-            }
+        return {
+            "columns": [
+                {"type": col["block"].name, "heading": col["heading"]}
+                for col in table.columns
+            ],
+            "rows": [
+                {
+                    "values": [
+                        column["block"].get_prep_value(val)
+                        for column, val in zip(table.columns, row["values"])
+                    ]
+                }
+                for row in table.row_data
+            ],
+            "caption": table.caption,
+        }
 
     def get_api_representation(self, table, context=None):
-        if table:
-            return {
-                "columns": [
-                    {"type": col["block"].name, "heading": col["heading"]}
-                    for col in table.columns
-                ],
-                "rows": [
-                    {
-                        "values": [
-                            column["block"].get_api_representation(val, context=context)
-                            for column, val in zip(table.columns, row["values"])
-                        ]
-                    }
-                    for row in table.row_data
-                ],
-                "caption": table.caption,
-            }
-        else:
-            return {
-                "columns": [],
-                "rows": [],
-                "caption": "",
-            }
+        return {
+            "columns": [
+                {"type": col["block"].name, "heading": col["heading"]}
+                for col in table.columns
+            ],
+            "rows": [
+                {
+                    "values": [
+                        column["block"].get_api_representation(val, context=context)
+                        for column, val in zip(table.columns, row["values"])
+                    ]
+                }
+                for row in table.row_data
+            ],
+            "caption": table.caption,
+        }
 
     def normalize(self, value):
-        if value is None or isinstance(value, TypedTable):
+        if value is None:
+            return TypedTable(
+                columns=[],
+                row_data=[],
+                caption="",
+            )
+        elif isinstance(value, TypedTable):
             return value
         return self.to_python(value)
 
@@ -225,62 +217,46 @@ class BaseTypedTableBlock(Block):
             )
 
     def get_form_state(self, table):
-        if table:
-            return {
-                "columns": [
-                    {"type": col["block"].name, "heading": col["heading"]}
-                    for col in table.columns
-                ],
-                "rows": [
-                    {
-                        "values": [
-                            column["block"].get_form_state(val)
-                            for column, val in zip(table.columns, row["values"])
-                        ]
-                    }
-                    for row in table.row_data
-                ],
-                "caption": table.caption,
-            }
-        else:
-            return {
-                "columns": [],
-                "rows": [],
-                "caption": "",
-            }
+        return {
+            "columns": [
+                {"type": col["block"].name, "heading": col["heading"]}
+                for col in table.columns
+            ],
+            "rows": [
+                {
+                    "values": [
+                        column["block"].get_form_state(val)
+                        for column, val in zip(table.columns, row["values"])
+                    ]
+                }
+                for row in table.row_data
+            ],
+            "caption": table.caption,
+        }
 
     def clean(self, table):
-        if table:
-            # a dict where each key is a row index, and the value is a dict of errors on that row keyed by column index
-            cell_errors = {}
-            cleaned_rows = []
-            for row_index, row in enumerate(table.row_data):
-                row_errors = {}
-                row_data = []
-                for col_index, column in enumerate(table.columns):
-                    val = row["values"][col_index]
-                    try:
-                        row_data.append(column["block"].clean(val))
-                    except ValidationError as e:
-                        row_errors[col_index] = e
+        cell_errors = {}
+        cleaned_rows = []
+        for row_index, row in enumerate(table.row_data):
+            row_errors = {}
+            row_data = []
+            for col_index, column in enumerate(table.columns):
+                val = row["values"][col_index]
+                try:
+                    row_data.append(column["block"].clean(val))
+                except ValidationError as e:
+                    row_errors[col_index] = e
 
-                if row_errors:
-                    cell_errors[row_index] = row_errors
-                else:
-                    cleaned_rows.append({"values": row_data})
-
-            if cell_errors:
-                raise TypedTableBlockValidationError(cell_errors=cell_errors)
+            if row_errors:
+                cell_errors[row_index] = row_errors
             else:
-                return TypedTable(
-                    columns=table.columns, row_data=cleaned_rows, caption=table.caption
-                )
+                cleaned_rows.append({"values": row_data})
 
+        if cell_errors:
+            raise TypedTableBlockValidationError(cell_errors=cell_errors)
         else:
             return TypedTable(
-                columns=[],
-                row_data=[],
-                caption="",
+                columns=table.columns, row_data=cleaned_rows, caption=table.caption
             )
 
     def deconstruct(self):

--- a/wagtail/contrib/typed_table_block/tests.py
+++ b/wagtail/contrib/typed_table_block/tests.py
@@ -185,9 +185,12 @@ class TestTableBlock(TestCase):
         normalized_table = self.block.normalize(table)
         self.assertIs(normalized_table, table)
 
-        # Should normalize None as-is
+        # Should normalize None to an empty TypedTable
         none_value = self.block.normalize(None)
-        self.assertIs(none_value, None)
+        self.assertIsInstance(none_value, TypedTable)
+        self.assertEqual(none_value.columns, [])
+        self.assertEqual(none_value.row_data, [])
+        self.assertEqual(none_value.caption, "")
 
     def test_to_python(self):
         """


### PR DESCRIPTION
### **Description**  
Fixes #12848 
This PR updates `TypedTableBlock.normalize` to return an empty `TypedTable` when `None` is passed as input. This removes `None` as a possible block-native value, simplifying the logic in methods such as:  
- `get_prep_value`  
- `get_api_representation`  
- `get_form_state`  
- `clean`  

These methods previously had to check if `value` was `None` and handle it separately. With this change, we eliminate redundant `if table` conditions, making the code more consistent and readable.  

### **Changes Made**  
- Updated `TypedTableBlock.normalize` to return an empty `TypedTable` when `None` is provided.  
- Removed unnecessary `if table` checks in methods handling `TypedTable`.  
- Simplified data processing by assuming `table` is always a valid `TypedTable`.  

### **Why this change?**  
- Follows up on #12808 and aligns with the discussion in #12808 (comment).  
- Helps streamline logic by ensuring `TypedTableBlock` methods always receive a `TypedTable` instance, avoiding edge cases.  
- Improves maintainability by reducing redundant checks.  

### **References**  
- Closes #12848  
- Follow-up to #12808  
- Isuue #12827 has been resolved first 