### PR TITLE
Use locale-appropriate formatting on Hits column in promo search report

### DIFF
--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -60,10 +60,10 @@ class BaseReportViewTestCase(AdminTemplateTestUtils, WagtailTestUtils, TestCase)
     def setUp(self):
         self.user = self.login()
 
-    def get(self, params={}):
+    def get(self, params={}, **kwargs):
         if self.results_only:
             params["_w_filter_fragment"] = "true"
-        return self.client.get(self.url, params)
+        return self.client.get(self.url, params, **kwargs)
 
     def assertActiveFilter(self, soup, name, value):
         # Should render the export buttons inside the header "more" dropdown

--- a/wagtail/admin/ui/tables/__init__.py
+++ b/wagtail/admin/ui/tables/__init__.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from collections.abc import Mapping
 
 from django.contrib.admin.utils import quote
+from django.contrib.humanize.templatetags.humanize import intcomma
 from django.forms import MediaDefiningClass
 from django.template.loader import get_template
 from django.templatetags.l10n import unlocalize
@@ -170,6 +171,15 @@ class Column(BaseColumn):
             context["value"] = self.empty_value_display
         else:
             context["value"] = value
+        return context
+
+
+class NumberColumn(Column):
+    """A specialised column that displays numbers with locale-aware formatting"""
+
+    def get_cell_context_data(self, instance, parent_context):
+        context = super().get_cell_context_data(instance, parent_context)
+        context["value"] = intcomma(context["value"])
         return context
 
 

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -1728,6 +1728,22 @@ class TestQueryHitsReportView(BaseReportViewTestCase):
                     results,
                 )
 
+    def test_hits_column_localized(self):
+        _add_N_hits(self.query, 10_000)
+
+        def _get_hits(lang):
+            response = self.get(headers={"accept-language": lang})
+            soup = self.get_soup(response.content)
+            trs = soup.select("main tr")
+            self.assertEqual(len(trs), 4)  # 1 header + 3 body rows
+            _, hits = trs[1].select("td")
+            return hits.text.strip()
+
+        for lang, expected in [("en", "10,003"), ("fr", "10\N{NO-BREAK SPACE}003")]:
+            with self.subTest(lang=lang):
+                hits = _get_hits(lang=lang)
+                self.assertEqual(hits, expected)
+
 
 class TestFilteredQueryHitsView(BaseReportViewTestCase):
     url_name = "wagtailsearchpromotions:search_terms"

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -4,6 +4,7 @@ from io import BytesIO, StringIO
 
 from django.contrib.auth.models import Permission
 from django.core import management
+from django.db.models import F
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -22,6 +23,18 @@ from wagtail.contrib.search_promotions.templatetags.wagtailsearchpromotions_tags
 from wagtail.log_actions import registry as log_registry
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
+
+
+def _add_N_hits(query, n, date=None):
+    """
+    Add multiple daily hits to the given query
+    """
+    if n < 2:
+        raise ValueError("You must add at least 2 hits")
+    if date is None:
+        date = timezone.now().date()
+    query.add_hit(date=date)  # Make sure the associated QueryDailyHits is created
+    QueryDailyHits.objects.filter(query=query, date=date).update(hits=F("hits") + n - 1)
 
 
 class TestSearchPromotions(TestCase):
@@ -87,8 +100,7 @@ class TestSearchPromotions(TestCase):
 
     def test_get_most_popular(self):
         popularQuery = Query.get("popular")
-        for i in range(5):
-            popularQuery.add_hit()
+        _add_N_hits(popularQuery, 5)
         SearchPromotion.objects.create(
             query=Query.get("popular"),
             page_id=2,
@@ -117,8 +129,7 @@ class TestSearchPromotions(TestCase):
         FIVE_DAYS_AGO = TODAY - timedelta(days=5)
 
         popularQuery = Query.get("popular")
-        for i in range(5):
-            popularQuery.add_hit(date=FIVE_DAYS_AGO)
+        _add_N_hits(popularQuery, 5, date=FIVE_DAYS_AGO)
 
         surpriseQuery = Query.get("surprise")
         surpriseQuery.add_hit(date=TODAY)
@@ -382,8 +393,7 @@ class TestSearchPromotionsIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
         )
 
         popularQuery = Query.get("optimal")
-        for i in range(50):
-            popularQuery.add_hit()
+        _add_N_hits(popularQuery, 50)
         SearchPromotion.objects.create(
             query=popularQuery,
             page_id=1,
@@ -392,8 +402,7 @@ class TestSearchPromotionsIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
         )
 
         popularQuery = Query.get("suboptimal")
-        for i in range(25):
-            popularQuery.add_hit()
+        _add_N_hits(popularQuery, 25)
         SearchPromotion.objects.create(
             query=popularQuery,
             page_id=1,
@@ -1569,13 +1578,8 @@ class TestQueryStringNormalisation(TestCase):
 
 class TestQueryPopularity(TestCase):
     def test_query_popularity(self):
-        # Add 3 hits to unpopular query
-        for i in range(3):
-            Query.get("unpopular query").add_hit()
-
-        # Add 10 hits to popular query
-        for i in range(10):
-            Query.get("popular query").add_hit()
+        _add_N_hits(Query.get("unpopular query"), 3)
+        _add_N_hits(Query.get("popular query"), 10)
 
         # Get most popular queries
         popular_queries = Query.get_most_popular()
@@ -1585,9 +1589,7 @@ class TestQueryPopularity(TestCase):
         self.assertEqual(popular_queries[0], Query.get("popular query"))
         self.assertEqual(popular_queries[1], Query.get("unpopular query"))
 
-        # Add 5 hits to little popular query
-        for i in range(5):
-            Query.get("little popular query").add_hit()
+        _add_N_hits(Query.get("little popular query"), 5)
 
         # Check list again, little popular query should be in the middle
         self.assertEqual(popular_queries.count(), 3)
@@ -1596,8 +1598,7 @@ class TestQueryPopularity(TestCase):
         self.assertEqual(popular_queries[2], Query.get("unpopular query"))
 
         # Unpopular query goes viral!
-        for i in range(20):
-            Query.get("unpopular query").add_hit()
+        _add_N_hits(Query.get("unpopular query"), 20)
 
         # Unpopular query should be most popular now
         self.assertEqual(popular_queries.count(), 3)
@@ -1612,14 +1613,11 @@ class TestQueryHitsReportView(BaseReportViewTestCase):
     @classmethod
     def setUpTestData(self):
         self.query = Query.get("A query with three hits")
-        self.query.add_hit()
-        self.query.add_hit()
-        self.query.add_hit()
+        _add_N_hits(self.query, 3)
         Query.get("a query with no hits")
         Query.get("A query with one hit").add_hit()
         query = Query.get("A query with two hits")
-        query.add_hit()
-        query.add_hit()
+        _add_N_hits(query, 2)
 
     def test_simple(self):
         response = self.get()

--- a/wagtail/contrib/search_promotions/views/reports.py
+++ b/wagtail/contrib/search_promotions/views/reports.py
@@ -3,7 +3,7 @@ from django_filters import DateFromToRangeFilter
 
 from wagtail.admin.auth import permission_denied
 from wagtail.admin.filters import DateRangePickerWidget, WagtailFilterSet
-from wagtail.admin.ui.tables import Column
+from wagtail.admin.ui.tables import Column, NumberColumn
 from wagtail.admin.views.reports import ReportView
 from wagtail.contrib.search_promotions.models import Query
 
@@ -31,7 +31,7 @@ class SearchTermsReportView(ReportView):
     index_results_url_name = "wagtailsearchpromotions:search_terms_results"
     columns = [
         Column("query_string", label=_("Search term(s)"), sort_key="query_string"),
-        Column("_hits", label=_("Views"), sort_key="_hits"),
+        NumberColumn("_hits", label=_("Views"), sort_key="_hits"),
     ]
     export_headings = {
         "query_string": _("Search term(s)"),

--- a/wagtail/contrib/search_promotions/views/settings.py
+++ b/wagtail/contrib/search_promotions/views/settings.py
@@ -10,7 +10,11 @@ from django.utils.translation import gettext_lazy
 from wagtail.admin import messages
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
-from wagtail.admin.ui.tables import Column, RelatedObjectsColumn, TitleColumn
+from wagtail.admin.ui.tables import (
+    NumberColumn,
+    RelatedObjectsColumn,
+    TitleColumn,
+)
 from wagtail.admin.views import generic
 from wagtail.contrib.search_promotions import forms, models
 from wagtail.contrib.search_promotions.models import Query, SearchPromotion
@@ -51,7 +55,7 @@ class IndexView(generic.IndexView):
             label=gettext_lazy("Promoted results"),
             width="40%",
         ),
-        Column(
+        NumberColumn(
             "views",
             label=gettext_lazy("Views"),
             width="20%",

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -17,7 +17,7 @@ from wagtail.admin.ui.components import MediaContainer
 from wagtail.admin.ui.side_panels import ChecksSidePanel, PreviewSidePanel
 from wagtail.admin.ui.tables import (
     BulkActionsCheckboxColumn,
-    Column,
+    NumberColumn,
     TitleColumn,
 )
 from wagtail.admin.views import generic
@@ -127,7 +127,7 @@ class ModelIndexView(generic.BaseListingView):
                 get_url=lambda type: type["url"],
                 sort_key="name",
             ),
-            Column(
+            NumberColumn(
                 "count",
                 label=_("Instances"),
                 sort_key="count",


### PR DESCRIPTION
I noticed that the "Hits" column in the promoted search report was a bit hard to read when the numbers were big.

Adding an `intcomma` filter on the output made it a bit easier to read, and because it's locale-aware it should then match the user's locale (see tests) which is a bonus.


I also added a small refactor commit to the start of the branch to make it simpler to add multiple hits to a search without having to use a loop. I wonder if that'd be useful enough to properly add that method to the model instead 🤔 