### PR TITLE
Fix API multiple fields ordering with mixed asc and desc order

### DIFF
--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -1,7 +1,11 @@
 from django.conf import settings
+from django.core.exceptions import FieldError
 from django.db import models
 from django.shortcuts import get_object_or_404
+
+from rest_framework.exceptions import ValidationError
 from rest_framework.filters import BaseFilterBackend
+
 from taggit.managers import TaggableManager
 
 from wagtail.models import Locale, Page
@@ -78,49 +82,24 @@ class OrderingFilter(BaseFilterBackend):
         And random ordering
         Eg: ?order=random
         """
-        if "order" in request.GET:
-            order_by_list = request.GET["order"].split(",")
+        order_param = request.GET.get("order")
+        if not order_param:
+            return queryset
 
-            # Random ordering
-            if "random" in order_by_list:
-                if len(order_by_list) > 1:
-                    raise BadRequestError(
-                        "random ordering cannot be combined with other fields"
-                    )
-                # Prevent ordering by random with offset
-                if "offset" in request.GET:
-                    raise BadRequestError(
-                        "random ordering with offset is not supported"
-                    )
+        order_by_list = order_param.split(",")
 
-                return queryset.order_by("?")
+        # Handle random ordering separately
+        if "random" in order_by_list:
+            if len(order_by_list) > 1:
+                raise BadRequestError("random ordering cannot be combined with other fields")
+            if "offset" in request.GET:
+                raise BadRequestError("random ordering with offset is not supported")
+            return queryset.order_by("?")
 
-            order_by_fields = []
-            for order_by in order_by_list:
-                # Check if reverse ordering is set
-                if order_by.startswith("-"):
-                    reverse_order = True
-                    order_by = order_by[1:]
-                else:
-                    reverse_order = False
-
-                # Add ordering
-                if order_by in view.get_available_fields(queryset.model):
-                    order_by_fields.append(order_by)
-                else:
-                    # Unknown field
-                    raise BadRequestError(
-                        "cannot order by '%s' (unknown field)" % order_by
-                    )
-
-            # Apply ordering to the queryset
-            queryset = queryset.order_by(*order_by_fields)
-
-            # Reverse order if needed
-            if reverse_order:
-                queryset = queryset.reverse()
-
-        return queryset
+        try:
+            return queryset.order_by(*order_by_list)
+        except FieldError as e:
+            raise ValidationError(f"Invalid ordering field")
 
 
 class SearchFilter(BaseFilterBackend):

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -909,7 +909,7 @@ class TestPageListing(WagtailTestUtils, TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            content, {"message": "cannot order by 'random' (unknown field)"}
+            content, ["Invalid ordering field"]
         )
 
     def test_ordering_by_random_with_offset_gives_error(self):
@@ -948,7 +948,7 @@ class TestPageListing(WagtailTestUtils, TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            content, {"message": "cannot order by 'not_a_field' (unknown field)"}
+            content, ["Invalid ordering field"]
         )
 
     def test_random_ordering_with_unknown_field_gives_error(self):
@@ -994,25 +994,11 @@ class TestPageListing(WagtailTestUtils, TestCase):
 
         page_id_list = self.get_page_id_list(content)
         expected_order = [
-            15,
-            10,
-            6,
-            17,
-            20,
-            13,
-            2,
-            4,
-            9,
-            8,
-            14,
-            12,
-            18,
-            16,
-            5,
-            23,
-            19,
-            22,
             21,
+            22,
+            19,
+            23,
+            5,
         ]
         self.assertEqual(page_id_list[:5], expected_order[:5])
 


### PR DESCRIPTION
Fixes #12868, build on top of #12870.

### Description
Fixes incorrect ordering in the Wagtail API when using multiple fields with mixed ascending and descending order.