### PR TITLE
Fix CloudFront invalidation to include query strings in URLs

### DIFF
--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -370,6 +370,75 @@ class TestBackendConfiguration(SimpleTestCase):
             backends.get("cloudfront").invalidates_hostname("torchbox.com")
         )
 
+    @mock.patch(
+        "wagtail.contrib.frontend_cache.backends.cloudfront.CloudfrontBackend._create_invalidation"
+    )
+    def test_cloudfront_purge_with_query_string(self, mock_create_invalidation):
+        """Test that CloudFront invalidation includes query strings when purging URLs."""
+        backends = get_backends(
+            backend_settings={
+                "cloudfront": {
+                    "BACKEND": "wagtail.contrib.frontend_cache.backends.CloudfrontBackend",
+                    "DISTRIBUTION_ID": "frontend",
+                    "AWS_ACCESS_KEY_ID": "test-access-key",
+                    "AWS_SECRET_ACCESS_KEY": "test-secret-key",
+                },
+            }
+        )
+
+        backends["cloudfront"].purge(
+            "http://www.example.com/path/to/page?query=value&another=param"
+        )
+        mock_create_invalidation.assert_called_once_with(
+            "frontend", ["/path/to/page?query=value&another=param"]
+        )
+
+    @mock.patch(
+        "wagtail.contrib.frontend_cache.backends.cloudfront.CloudfrontBackend._create_invalidation"
+    )
+    def test_cloudfront_purge_root_with_query_string(self, mock_create_invalidation):
+        """Test that CloudFront invalidation handles root URLs with query strings."""
+        backends = get_backends(
+            backend_settings={
+                "cloudfront": {
+                    "BACKEND": "wagtail.contrib.frontend_cache.backends.CloudfrontBackend",
+                    "DISTRIBUTION_ID": "frontend",
+                    "AWS_ACCESS_KEY_ID": "test-access-key",
+                    "AWS_SECRET_ACCESS_KEY": "test-secret-key",
+                },
+            }
+        )
+
+        backends["cloudfront"].purge("http://www.example.com?query=value")
+        mock_create_invalidation.assert_called_once_with("frontend", ["/?query=value"])
+
+    @mock.patch(
+        "wagtail.contrib.frontend_cache.backends.cloudfront.CloudfrontBackend._create_invalidation"
+    )
+    def test_cloudfront_purge_batch_with_query_strings(self, mock_create_invalidation):
+        """Test that CloudFront invalidation batch includes query strings."""
+        backends = get_backends(
+            backend_settings={
+                "cloudfront": {
+                    "BACKEND": "wagtail.contrib.frontend_cache.backends.CloudfrontBackend",
+                    "DISTRIBUTION_ID": "frontend",
+                    "AWS_ACCESS_KEY_ID": "test-access-key",
+                    "AWS_SECRET_ACCESS_KEY": "test-secret-key",
+                },
+            }
+        )
+
+        backends["cloudfront"].purge_batch(
+            [
+                "http://www.example.com/path/to/page?query=value",
+                "http://www.example.com/another/path",
+                "http://www.example.com?root=query",
+            ]
+        )
+        mock_create_invalidation.assert_called_once_with(
+            "frontend", ["/path/to/page?query=value", "/another/path", "/?root=query"]
+        )
+
     def test_multiple(self):
         backends = get_backends(
             backend_settings={


### PR DESCRIPTION
### Summary 
Fixes issue #12822 
This PR ensures that CloudFront invalidation requests include query strings. Previously, only the path was invalidated, which led to incorrect behavior.

### Changes:
- Changed `set` → `list` in `paths_by_distribution_id` to preserve order.
- Updated invalidation logic to include query strings.
- Modified `_create_invalidation` call to remove unnecessary conversion.
- Added tests to verify:
  - Query strings are included in invalidation requests.
  - Root URLs with query strings are handled correctly.
  - Batch purging supports query strings properly.

### Testing:
- passes `python runtests.py wagtail.contrib.frontend_cache.tests` 
