### PR TITLE
Fix incorrect column label in promoted search tables

### DIFF
--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/queries/chooser/results.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/queries/chooser/results.html
@@ -7,7 +7,7 @@
     <thead>
         <tr>
             <th class="title">{% trans "Terms" %}</th>
-            <th>{% trans "Views (past week)" %}</th>
+            <th>{% trans "Views" %}</th>
         </tr>
     </thead>
     <tbody>

--- a/wagtail/contrib/search_promotions/views/settings.py
+++ b/wagtail/contrib/search_promotions/views/settings.py
@@ -53,7 +53,7 @@ class IndexView(generic.IndexView):
         ),
         Column(
             "views",
-            label=gettext_lazy("Views (past week)"),
+            label=gettext_lazy("Views"),
             width="20%",
             sort_key="views",
         ),


### PR DESCRIPTION
The promoted search tables are not actually filtered by date.
