### PR TITLE
Add the return format when get_url_parts() raises NoReverseMatch

### DIFF
--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -1254,7 +1254,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         """
         Determine the URL for this page and return it as a tuple of
         ``(site_id, site_root_url, page_url_relative_to_site_root)``.
-        Return ``None`` if the page is not routable.
+        Return ``None`` if the page is not routable, or return
+        ``(site_id, None, None)`` if NoReverseMatch exception is raised.
 
         This is used internally by the ``full_url``, ``url``, ``relative_url``
         and ``get_site`` properties and methods; pages with custom URL routing


### PR DESCRIPTION
Issue #12908 notes an unexpected return value from Pages.get_url_parts().

This PR adds a clarifying note to the docstring, mentioning that there is a third return format (side_id, None, None) when a NoReverseMatch exception is raised.