### PR TITLE
CSP style-src HTML-CSS refactorings 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ Changelog
  * Fix: Allow upload of AVIF images through image chooser on Firefox (Matt Westcott)
  * Fix: Accept any string beginning with 'y' as confirmation for `import_redirects` command (Matt Westcott)
  * Fix: Fix error when accessing the submissions listing view with a non-form page (Sage Abdullah)
+ * Fix: Replace inline styles with CSS classes in HTML files (Srishti Jaiswal)
  * Docs: Add missing tag library imports to footer template code in tutorial (Dimaco)
  * Maintenance: Refactor `get_embed` to remove `finder` argument which was only used for mocking in unit tests (Jigyasu Rajput)
  * Maintenance: Simplify handling of `None` values in `TypedTableBlock` (Jigyasu Rajput)

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -39,6 +39,7 @@ depth: 1
  * Allow upload of AVIF images through image chooser on Firefox (Matt Westcott)
  * Accept any string beginning with 'y' as confirmation for `import_redirects` command (Matt Westcott)
  * Fix error when accessing the submissions listing view with a non-form page (Sage Abdullah)
+ * Replace inline styles with CSS classes in HTML files (Srishti Jaiswal)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
@@ -29,7 +29,7 @@
                                 </a>
                             </div>
 
-                            <small class="col4" style="text-align:end">
+                            <small class="col4 w-text-end">
                                 <a href="{% url 'wagtailadmin_pages:type_use' app_label model_name %}" class="nolink">{% blocktrans trimmed with page_type=verbose_name %}Pages using {{ page_type }}{% endblocktrans %}</a>
                             </small>
 

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
@@ -92,7 +92,7 @@
         {% page_permissions page as page_perms %}
         {% if page_perms.can_unpublish %}
             {% url 'wagtailadmin_pages:unpublish' page.id as unpublish_url %}
-            <p style="margin-top: 1em">{% blocktrans trimmed %}Alternatively you can <a href="{{ unpublish_url }}">unpublish the page</a>. This removes the page from public view and you can edit or publish it again later.{% endblocktrans %}</p>
+            <p class="w-mt-4">{% blocktrans trimmed %}Alternatively you can <a href="{{ unpublish_url }}">unpublish the page</a>. This removes the page from public view and you can edit or publish it again later.{% endblocktrans %}</p>
         {% endif %}
     </div>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/edit_alias.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit_alias.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block form %}
-    <div class="nice-padding" style="padding-top: 20px;">
+    <div class="nice-padding w-pt-5">
         <p>{% trans "This page is an alias of another page." %}</p>
 
         <p>

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -112,7 +112,7 @@
                         <h2><a href="">Something here</a></h2>
                     </div>
 
-                    <small class="col6" style="text-align:end">Something else</small>
+                    <small class="col6 w-text-end">Something else</small>
                 </div>
             </li>
             <li>
@@ -121,7 +121,7 @@
                         <a href="">Something here</a>
                     </div>
 
-                    <small class="col6" style="text-align:end">Something else</small>
+                    <small class="col6 w-text-end">Something else</small>
                 </div>
             </li>
             <li>
@@ -130,7 +130,7 @@
                         <a href="">Something here</a>
                     </div>
 
-                    <small class="col6" style="text-align:end">Something else</small>
+                    <small class="col6 w-text-end">Something else</small>
                 </div>
             </li>
         </ul>
@@ -420,7 +420,7 @@
 
         {% url "wagtailstyleguide" as add_link %}
         {% include "wagtailadmin/shared/header.html" with title=page_title action_url=add_link icon="image" action_text="button" search_url="wagtailimages:index" %}
-        <div id="listing-results" style="display: none;">{% comment %} Not implemented, hide content to avoid confusion {% endcomment %}</div>
+        <div id="listing-results" hidden>{% comment %} Not implemented, hide content to avoid confusion {% endcomment %}</div>
     {% endpanel %}
 
     {% panel id="forms" heading="Forms" %}
@@ -467,7 +467,7 @@
         <p>&nbsp;</p>
 
         <div id="progress-example2" class="progress active">
-            <div class="bar" style="width: 50%;">50%</div>
+            <div class="bar w-w-1/2">50%</div>
         </div>
     {% endpanel %}
 
@@ -487,13 +487,13 @@
         <h3>Loading mask</h3>
         <p>Add the following <code>div</code> around any items you wish to display with a spinner overlay and fading out</p>
         <p>Remove the "loading" class to disable the effect</p>
-        <div class="loading-mask loading" style="width:200px">
+        <div class="loading-mask loading w-w-52">
             {% include "wagtailadmin/logo.html"%}
         </div>
 
         <h3>Image transparency</h3>
         <p>It can be useful to show users the transparent areas of images. Add a transparency checkerboard with the <code>.show-transparency</code> on the <code>img</code> or <code>svg</code> tag thus:</p>
-        <div style="width:200px">
+        <div class="w-w-52">
             {% include "wagtailadmin/logo.html" with classname="show-transparency" %}
         </div>
     {% endpanel %}

--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -49,7 +49,7 @@
     </div>
 
     <div id="overall-progress" class="progress progress-secondary">
-        <div class="bar" style="width: 0%;">0%</div>
+        <div class="bar w-w-0">0%</div>
     </div>
 
     <ul id="upload-list" class="upload-list multiple"></ul>
@@ -59,7 +59,7 @@
             <div class="left col3">
                 <div class="preview">
                     <div class="progress">
-                        <div class="bar" style="width: 0%;"></div>
+                        <div class="bar w-w-0"></div>
                     </div>
                 </div>
             </div>

--- a/wagtail/images/templates/wagtailimages/images/url_generator.html
+++ b/wagtail/images/templates/wagtailimages/images/url_generator.html
@@ -1,13 +1,6 @@
 {% extends "wagtailadmin/generic/base.html" %}
 {% load wagtailimages_tags wagtailadmin_tags i18n %}
 
-{% block extra_css %}
-    <style>
-        .loading-mask {
-            max-height: clamp(25rem, 50vh, 50rem);
-        }
-    </style>
-{% endblock %}
 
 {% block main_content %}
     <div class="w-image-url-generator w-mt-8" data-generator-url="{% url 'wagtailimages:generate_url' object.id '__filterspec__' %}">
@@ -23,7 +16,7 @@
         {% trans "Preview" as heading %}
         {% panel id="preview" icon="view" heading=heading %}
             <div class="w-image-url-generator__preview">
-                <div class="loading-mask w-block w-border-2 w-border-border-furniture w-overflow-scroll w-p-4 w-rounded-sm">
+                <div class="loading-mask w-block w-border-2 w-border-border-furniture w-overflow-scroll w-p-4 w-rounded-sm w-max-h-[clamp(25rem,50vh,50rem)]">
                     <img class="preview w-max-w-none" src="" alt="{% trans 'Preview' %}" />
                 </div>
             </div>

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -52,7 +52,7 @@
     </div>
 
     <div id="overall-progress" class="progress progress-secondary">
-        <div class="bar" style="width: 0%;">0%</div>
+        <div class="bar w-w-0">0%</div>
     </div>
 
     <ul id="upload-list" class="upload-list multiple"></ul>
@@ -65,7 +65,7 @@
                         {% icon name="image" %}
                     </div>
                     <div class="progress">
-                        <div class="bar" style="width: 0%;"></div>
+                        <div class="bar w-w-0"></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #12937 (Half Part)

Replaced inline styles with appropriate Tailwind CSS classes to improve maintainability and CSP compatibility.