### PR TITLE
Document that request_or_site is optional on BaseGenericSetting.load

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Fix: Ensure `InlinePanel` will be correctly ordered after the first save when `min_num` is used (Elhussein Almasri, Joel William)
  * Docs: Add missing `django.contrib.admin` to list of apps in "add to Django project" guide (Mohamed Rabiaa)
  * Docs: Add tutorial on deploying on Ubuntu to third-party tutorials (Mohammad Fathi Rahman)
+ * Docs: Document that request_or_site is optional on BaseGenericSetting.load (Matt Westcott)
  * Maintenance: Migrate away from deprecated Sass import rules to module system (Srishti Jaiswal)
  * Maintenance: Apply Sass mixed declarations migration in preparation for CSS nesting (Prabhpreet Kaur)
  * Maintenance: Refactor styles for Draftail, minimap, and comments to fix remaining Sass migration warnings (Thibaud Colas)

--- a/docs/reference/contrib/settings.md
+++ b/docs/reference/contrib/settings.md
@@ -147,6 +147,8 @@ def view(request):
     ...
 ```
 
+The `request_or_site` argument is optional - if this is passed, and is a request object, the result will be cached on the request to avoid repeated database lookups within the same request.
+
 (site_settings)=
 
 #### Site-specific settings

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -37,6 +37,7 @@ depth: 1
 
  * Add missing `django.contrib.admin` to list of apps in "add to Django project" guide (Mohamed Rabiaa)
  * Add tutorial on deploying on Ubuntu to third-party tutorials (Mohammad Fathi Rahman)
+ * Document that request_or_site is optional on BaseGenericSetting.load (Matt Westcott)
 
 ### Maintenance
 


### PR DESCRIPTION
While responding to #12944, I noticed that the documentation for [retrieving a `BaseGenericSetting` in python code](https://docs.wagtail.org/en/stable/reference/contrib/settings.html#generic-settings) shows a request object being passed to `GenericSocialMediaSettings.load`, and does not mention that this argument is optional. Since the whole point of `BaseGenericSetting` is that it isn't tied to a site, this seems like a fairly fundamental detail to include.