### PR TITLE
[formbuilder] Fix handling of newline-separated choices when using non-windows newline characters

### DIFF
--- a/wagtail/contrib/forms/forms.py
+++ b/wagtail/contrib/forms/forms.py
@@ -8,6 +8,17 @@ from django.utils.translation import gettext_lazy as _
 from wagtail.admin.forms import WagtailAdminPageForm
 
 
+def _split_by_newline_or_comma(value):
+    """
+    Split the given string either by new lines, or if no new line is present then
+    by comma.
+    """
+    if len(lines := value.strip().splitlines()) > 1:
+        return [line.strip().rstrip(",").strip() for line in lines]
+    else:
+        return list(map(str.strip, value.split(",")))
+
+
 class BaseForm(django.forms.Form):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("label_suffix", "")
@@ -100,19 +111,7 @@ class FormBuilder:
         Split the provided choices into a list, separated by new lines.
         If no new lines in the provided choices, split by commas.
         """
-
-        if "\n" in field.choices:
-            choices = (
-                (
-                    x.strip().rstrip(",").strip(),
-                    x.strip().rstrip(",").strip(),
-                )
-                for x in field.choices.split("\r\n")
-            )
-        else:
-            choices = ((x.strip(), x.strip()) for x in field.choices.split(","))
-
-        return choices
+        return [(x, x) for x in _split_by_newline_or_comma(field.choices)]
 
     def get_formatted_field_initial(self, field):
         """
@@ -120,15 +119,7 @@ class FormBuilder:
         Split the supplied default values into a list, separated by new lines.
         If no new lines in the provided default values, split by commas.
         """
-
-        if "\n" in field.default_value:
-            values = [
-                x.strip().rstrip(",").strip() for x in field.default_value.split("\r\n")
-            ]
-        else:
-            values = [x.strip() for x in field.default_value.split(",")]
-
-        return values
+        return _split_by_newline_or_comma(field.default_value)
 
     @property
     def formfields(self):

--- a/wagtail/contrib/forms/tests/test_forms.py
+++ b/wagtail/contrib/forms/tests/test_forms.py
@@ -1,3 +1,5 @@
+import itertools
+
 from django import forms
 from django.test import TestCase
 
@@ -221,88 +223,41 @@ class TestFormBuilder(TestCase):
         self.assertIn(get_field_clean_name(unsaved_field_1.label), fb.formfields)
         self.assertIn(get_field_clean_name(unsaved_field_2.label), fb.formfields)
 
-    def test_newline_value_separation_in_choices_and_default_value_fields(self):
-        """Ensure that the new line present between input choices or values gets formatted into choices or value list
-        respectively as an alternative to commas.
+    def test_newline_value_separation_in_choices(self):
         """
-        multiselect_field = FormField.objects.create(
-            page=self.form_page,
-            sort_order=2,
-            label="Your favorite colours",
-            field_type="multiselect",
-            required=True,
-            choices="red\r\nblue\r\ngreen",
-        )
-        self.form_page.form_fields.add(multiselect_field)
+        Ensure that choices can be separated either by newlines or by commas.
+        """
+        field_types = ["multiselect", "dropdown", "checkboxes", "radio"]
+        testdata = [
+            ("red\r\ngreen\r\nblue", ["red", "green", "blue"]),
+        ]
+        for field_type, (choices, expected) in itertools.product(field_types, testdata):
+            field = FormField(field_type=field_type, choices=choices, label="test")
+            builder = FormBuilder([field])
+            form_field = builder.formfields["test"]
+            with self.subTest(field_type=field_type, choices=choices):
+                self.assertEqual(
+                    [choice for choice, _ in form_field.choices],
+                    expected,
+                )
 
-        dropdown_field = FormField.objects.create(
-            page=self.form_page,
-            sort_order=2,
-            label="Pick your next destination",
-            field_type="dropdown",
-            required=True,
-            choices="hawaii\r\nparis\r\nabuja",
-        )
-        self.form_page.form_fields.add(dropdown_field)
-
-        checkboxes_field = FormField.objects.create(
-            page=self.form_page,
-            sort_order=3,
-            label="Do you possess these attributes",
-            field_type="checkboxes",
-            required=False,
-            choices="good, kind and gentle.\r\nstrong, bold and brave.",
-        )
-        self.form_page.form_fields.add(checkboxes_field)
-
-        radio_field = FormField.objects.create(
-            page=self.form_page,
-            sort_order=2,
-            label="Your favorite animal",
-            help_text="Choose one",
-            field_type="radio",
-            required=True,
-            choices="cat\r\ndog\r\nbird",
-        )
-        self.form_page.form_fields.add(radio_field)
-
-        checkboxes_field_with_default_value = FormField.objects.create(
-            page=self.form_page,
-            sort_order=3,
-            label="Choose the correct answer",
-            field_type="checkboxes",
-            required=False,
-            choices="a\r\nb\r\nc",
-            default_value="a\r\nc",
-        )
-        self.form_page.form_fields.add(checkboxes_field_with_default_value)
-
-        fb = FormBuilder(self.form_page.get_form_fields())
-        form_class = fb.get_form_class()
-
-        self.assertEqual(
-            [("red", "red"), ("blue", "blue"), ("green", "green")],
-            form_class.base_fields["your_favorite_colours"].choices,
-        )
-        self.assertEqual(
-            [("cat", "cat"), ("dog", "dog"), ("bird", "bird")],
-            form_class.base_fields["your_favorite_animal"].choices,
-        )
-        self.assertEqual(
-            [
-                ("good, kind and gentle.", "good, kind and gentle."),
-                ("strong, bold and brave.", "strong, bold and brave."),
-            ],
-            form_class.base_fields["do_you_possess_these_attributes"].choices,
-        )
-        self.assertEqual(
-            [("hawaii", "hawaii"), ("paris", "paris"), ("abuja", "abuja")],
-            form_class.base_fields["pick_your_next_destination"].choices,
-        )
-        self.assertEqual(
-            ["a", "c"],
-            form_class.base_fields["choose_the_correct_answer"].initial,
-        )
+    def test_newline_value_separation_in_default_value(self):
+        """
+        Ensure that default values can be separated by newlines.
+        """
+        for choices, default_value, expected in [
+            ("a\r\nb\r\nc", "a\r\nc", ["a", "c"]),
+        ]:
+            field = FormField(
+                label="test",
+                field_type="checkboxes",
+                choices=choices,
+                default_value=default_value,
+            )
+            builder = FormBuilder([field])
+            form_field = builder.formfields["test"]
+            with self.subTest(choices=choices, default_value=default_value):
+                self.assertEqual(form_field.initial, expected)
 
 
 class TestCustomFormBuilder(TestCase):

--- a/wagtail/contrib/forms/tests/test_forms.py
+++ b/wagtail/contrib/forms/tests/test_forms.py
@@ -229,7 +229,17 @@ class TestFormBuilder(TestCase):
         """
         field_types = ["multiselect", "dropdown", "checkboxes", "radio"]
         testdata = [
+            ("red\ngreen\nblue", ["red", "green", "blue"]),
+            ("red\rgreen\rblue", ["red", "green", "blue"]),
             ("red\r\ngreen\r\nblue", ["red", "green", "blue"]),
+            ("red\r\ngreen\nblue", ["red", "green", "blue"]),
+            ("red\ngreen\nblue\n", ["red", "green", "blue"]),
+            ("\nred\ngreen\nblue", ["red", "green", "blue"]),
+            ("red,\ngreen \n blue", ["red", "green", "blue"]),
+            ("red  ,\ngreen \n blue", ["red", "green", "blue"]),
+            ("  red  \ngreen\nblue", ["red", "green", "blue"]),
+            ("red\n,green\nblue", ["red", ",green", "blue"]),
+            ("red\ngreen, blue\nyellow", ["red", "green, blue", "yellow"]),
         ]
         for field_type, (choices, expected) in itertools.product(field_types, testdata):
             field = FormField(field_type=field_type, choices=choices, label="test")
@@ -246,7 +256,13 @@ class TestFormBuilder(TestCase):
         Ensure that default values can be separated by newlines.
         """
         for choices, default_value, expected in [
+            ("a\nb\nc", "a", ["a"]),
+            ("a\nb\nc", "a\nc", ["a", "c"]),
+            ("a\rb\rc", "a\rc", ["a", "c"]),
             ("a\r\nb\r\nc", "a\r\nc", ["a", "c"]),
+            ("a\nb\nc", "a\r\nc", ["a", "c"]),
+            ("a\nb\rc", "a\r\nc", ["a", "c"]),
+            ("a\nb\nc", "a\nd", ["a", "d"]),
         ]:
             field = FormField(
                 label="test",


### PR DESCRIPTION
In the unlikely scenario where you'd manage to store your `FormField`'s `choices` in the database with `\n` line endings instead of `\r\n`, then the choices will not be correctly split.

Unlikely because HTTP normalizes all line endings to `\r\n`, this would require creating the `FormField` a different way than via the admin (a migration file, a script, ...)

I've split this PR over two commits:

1) The first one only touches the tests and "parameterises" them to make it easier to add more tests later on
2) The second actually changes the behavior of the `choices` generation code. It also adds tests that I think were missing for the logic of stripping whitespace and commas.