### PR TITLE
Cleanup Stimulus controller imports, JSDoc & linting

### DIFF
--- a/client/src/controllers/ActionController.ts
+++ b/client/src/controllers/ActionController.ts
@@ -7,50 +7,61 @@ import { WAGTAIL_CONFIG } from '../config/wagtailConfig';
  * triggering a form submission where the form is created dynamically
  * in the DOM and then submitted.
  *
- * @example - triggering a click
+ * @example - Triggering a click
+ * ```html
  * <button
- *  type="button"
- *  data-controller="w-action"
- *  data-action="some-event#click"
+ *   type="button"
+ *   data-controller="w-action"
+ *   data-action="some-event#click"
  * >
- *  Go
+ *   Go
  * </button>
+ * ```
  *
- * @example - triggering a dynamic POST submission
+ * @example - Triggering a dynamic POST submission
+ * ```html
  * <button
- *  type="submit"
- *  data-controller="w-action"
- *  data-action="w-action#post"
- *  data-w-action-url-value='url/to/post/to'
+ *   type="submit"
+ *   data-controller="w-action"
+ *   data-action="w-action#post"
+ *   data-w-action-url-value='url/to/post/to'
  * >
  *  Enable
  * </button>
+ * ```
  *
- * @example - triggering a POST request via sendBeacon
+ * @example - Triggering a POST request via sendBeacon
+ * ```html
  * <button data-controller="w-action" data-action="blur->w-action#sendBeacon">
- *  If you move focus away from this button, a POST request will be sent.
+ *   If you move focus away from this button, a POST request will be sent.
  * </button>
+ * ```
  *
- * @example - triggering a dynamic redirect
- * // note: a link is preferred normally
+ * @example - Triggering a dynamic redirect (a link is normally preferred)
+ * ```html
  * <form>
  *   <select name="url" data-controller="w-action" data-action="change->w-action#redirect">
  *     <option value="/path/to/1">1</option>
  *     <option value="/path/to/2">2</option>
  *   </select>
  * </form>
+ * ```
  *
- * @example - triggering selection of the text in a field
+ * @example - Triggering selection of the text in a field
+ * ```html
  * <form>
  *   <textarea name="url" data-controller="w-action" data-action="click->w-action#select">
  *     This text will all be selected on focus.
  *   </textarea>
  * </form>
+ * ```
  *
- * @example - ensuring a button's click does not propagate
+ * @example - Ensuring a button's click does not propagate
+ * ```html
  * <div>
  *   <button type="button" data-controller="w-action" data-action="w-action#noop:stop">Go</button>
  * </div>
+ * ```
  */
 export class ActionController extends Controller<
   HTMLButtonElement | HTMLInputElement | HTMLTextAreaElement

--- a/client/src/controllers/AutosizeController.ts
+++ b/client/src/controllers/AutosizeController.ts
@@ -7,7 +7,9 @@ import { debounce } from '../utils/debounce';
  * types in the field so that it expands to show all content.
  *
  * @example
+ * ```html
  * <textarea data-controller="w-autosize"></textarea>
+ * ```
  */
 export class AutosizeController extends Controller<HTMLTextAreaElement> {
   resizeObserver?: ResizeObserver;

--- a/client/src/controllers/BlockController.ts
+++ b/client/src/controllers/BlockController.ts
@@ -12,21 +12,25 @@ declare global {
  * Used to initialize the top-level element of a BlockWidget (the form widget for a StreamField).
  *
  * @example
+ * ```html
  * <div
- *  id="some-id"
- *  data-controller="w-block"
- *  data-w-block-data-value='{"_args":["..."], "_type": "wagtail.blocks.StreamBlock"}'
+ *   id="some-id"
+ *   data-controller="w-block"
+ *   data-w-block-data-value='{"_args":["..."], "_type": "wagtail.blocks.StreamBlock"}'
  * >
  * </div>
+ * ```
  *
- * @example - with initial arguments
+ * @example - With initial arguments
+ * ```html
  * <div
- *  id="some-id"
- *  data-controller="w-block"
- *  data-w-block-data-value='{"_args":["..."], "_type": "wagtail.blocks.StreamBlock"}'
- *  data-w-block-arguments-value='[[{ type: "paragraph_block", value: "..."}], {messages:["An error..."]}]'
+ *   id="some-id"
+ *   data-controller="w-block"
+ *   data-w-block-data-value='{"_args":["..."], "_type": "wagtail.blocks.StreamBlock"}'
+ *   data-w-block-arguments-value='[[{ type: "paragraph_block", value: "..."}], {messages:["An error..."]}]'
  * >
  * </div>
+ * ```
  */
 export class BlockController extends Controller<HTMLElement> {
   static values = {

--- a/client/src/controllers/BulkController.ts
+++ b/client/src/controllers/BulkController.ts
@@ -14,6 +14,7 @@ type ToggleAllOptions = ToggleOptions & {
  * Adds the ability to collectively toggle a set of (non-disabled) checkboxes.
  *
  * @example - Basic usage
+ * ```html
  * <div data-controller="w-bulk">
  *   <input type="checkbox" data-action="w-bulk#toggleAll" data-w-bulk-target="all">
  *   <div>
@@ -26,6 +27,7 @@ type ToggleAllOptions = ToggleOptions & {
  * </div>
  *
  * @example - Showing and hiding an actions container
+ * ```html
  * <div data-controller="w-bulk" data-w-bulk-action-inactive-class="w-invisible">
  *   <div class="w-invisible" data-w-bulk-target="action" id="inner-actions">
  *     <button type="button">Some action</button>
@@ -37,8 +39,10 @@ type ToggleAllOptions = ToggleOptions & {
  *     <input data-action="w-bulk#toggle" data-w-bulk-target="item" type="checkbox" />
  *   </div>
  * </div>
+ * ```
  *
  * @example - Using groups to allow toggles to be controlled separately or together
+ * ```html
  * <table data-controller="w-bulk">
  *   <thead>
  *     <tr>
@@ -74,7 +78,7 @@ type ToggleAllOptions = ToggleOptions & {
  *     </td>
  *    </tfoot>
  * </table>
- *
+ * ```
  */
 export class BulkController extends Controller<HTMLElement> {
   static classes = ['actionInactive'];

--- a/client/src/controllers/BulkController.ts
+++ b/client/src/controllers/BulkController.ts
@@ -1,3 +1,5 @@
+/* eslint no-param-reassign: ["error", { "ignorePropertyModificationsFor": ["checked"] }] */
+
 import { Controller } from '@hotwired/stimulus';
 
 type ToggleOptions = {
@@ -183,7 +185,6 @@ export class BulkController extends Controller<HTMLElement> {
 
       activeItems.forEach((target, index) => {
         if (index >= start && index <= end) {
-          // eslint-disable-next-line no-param-reassign
           target.checked = !!activeItems[lastClickedIndex].checked;
           this.dispatch('change', { target, bubbles: true });
         }
@@ -198,7 +199,6 @@ export class BulkController extends Controller<HTMLElement> {
     const isAllChecked = totalCheckedItems === activeItems.length;
 
     this.getValidTargets(group, this.allTargets).forEach((target) => {
-      // eslint-disable-next-line no-param-reassign
       target.checked = isAllChecked;
     });
 
@@ -242,7 +242,6 @@ export class BulkController extends Controller<HTMLElement> {
 
     this.getValidTargets(group).forEach((target) => {
       if (target.checked !== isChecked) {
-        // eslint-disable-next-line no-param-reassign
         target.checked = isChecked;
         target.dispatchEvent(new Event('change', { bubbles: true }));
       }

--- a/client/src/controllers/ClipboardController.ts
+++ b/client/src/controllers/ClipboardController.ts
@@ -11,8 +11,8 @@ type CopyOptions = {
  * @example
  * ```html
  * <div data-controller="w-clipboard">
- *  <input type="text" value="Hello World" data-w-clipboard-target="value" />
- *  <button type="button" data-action="w-clipboard#copy">Copy</button>
+ *   <input type="text" value="Hello World" data-w-clipboard-target="value" />
+ *   <button type="button" data-action="w-clipboard#copy">Copy</button>
  * </div>
  * ```
  */

--- a/client/src/controllers/CloneController.ts
+++ b/client/src/controllers/CloneController.ts
@@ -19,6 +19,7 @@ type AddOptions = {
  * Additionally, it will allow for clearing all previously added elements.
  *
  * @example - Using with the w-messages identifier
+ * ```html
  * <div
  *   data-controller="w-messages"
  *   data-action="w-messages:add@document->w-messages#add"
@@ -28,8 +29,9 @@ type AddOptions = {
  *   <ul data-w-messages-target="container"></ul>
  *   <template data-w-messages-target="template">
  *     <li data-message-status="error-or-success"><span></span></li>
- *  </template>
+ *   </template>
  * </div>
+ * ```
  *
  * @example - Using to show a temporary element with auto-clearing
  * ```html
@@ -39,12 +41,12 @@ type AddOptions = {
  *  data-w-clone-auto-clear-value="5_000"
  * >
  *   <div data-w-clone-target="container"></div>
- *   <template data-w-clone-target="template">
- *     <p>Page has loaded, this will be removed in 5 seconds.</p>
- *   </template>
+ *     <template data-w-clone-target="template">
+ *       <p>Page has loaded, this will be removed in 5 seconds.</p>
+ *     </template>
  *   </div>
  * </div>
- *
+ * ```
  */
 export class CloneController extends Controller<HTMLElement> {
   static classes = ['added', 'hide', 'show'];

--- a/client/src/controllers/CountController.ts
+++ b/client/src/controllers/CountController.ts
@@ -9,10 +9,12 @@ const DEFAULT_ERROR_SELECTOR = '.error-message,.help-critical';
  * to `body.`
  *
  * @example
+ * ```html
  * <div data-controller="w-count">
- *  <span data-w-count-target="label"></span>
- *  <span class="error-message">An error</span>
+ *   <span data-w-count-target="label"></span>
+ *   <span class="error-message">An error</span>
  * </div>
+ * ```
  */
 export class CountController extends Controller<HTMLFormElement> {
   static classes = ['active'];

--- a/client/src/controllers/CountController.ts
+++ b/client/src/controllers/CountController.ts
@@ -29,7 +29,7 @@ export class CountController extends Controller<HTMLFormElement> {
   declare containerValue: string;
   /** selector string, used to find the elements to count within the container */
   declare findValue: string;
-  /** override pluralisation strings, e.g. `data-w-count-labels-value='["One item","Many items"]'` */
+  /** override pluralization strings, e.g. `data-w-count-labels-value='["One item","Many items"]'` */
   declare labelsValue: string[];
   /** minimum value, anything equal or below will trigger blank labels in the UI */
   declare minValue: number;

--- a/client/src/controllers/DialogController.ts
+++ b/client/src/controllers/DialogController.ts
@@ -9,12 +9,14 @@ const FLOATING = 'floating';
  * scroll when the dialog is open.
  *
  * @example
+ * ```html
  * <div
- *    data-controller="w-dialog"
- *    data-w-dialog-theme-value="floating"
+ *   data-controller="w-dialog"
+ *   data-w-dialog-theme-value="floating"
  *   >
  *    <div data-w-dialog-target="body"></div>
- *  </div>
+ * </div>
+ * ```
  */
 export class DialogController extends Controller<HTMLElement> {
   static values = {

--- a/client/src/controllers/DismissibleController.ts
+++ b/client/src/controllers/DismissibleController.ts
@@ -3,7 +3,7 @@ import { WAGTAIL_CONFIG } from '../config/wagtailConfig';
 
 /**
  * Updates the server, using a PATCH request when the toggle is clicked on a dismissible
- * element initialised by DismissibleController
+ * element initialized by DismissibleController
  *
  * @param data - The dismissible represented as an object with keys as
  * the id and its new state: whether it is dismissed (boolean)
@@ -29,8 +29,8 @@ export const updateDismissibles = (
 
 /**
  * Adds the ability to make an element dismissible so that it updates it's class and makes an async request.
- * Initialise such elements with a default handler that performs the dismissal.
- * This only initialises elements that are rendered by the server (if they have the data attr), so elements
+ * Initialize such elements with a default handler that performs the dismissal.
+ * This only initializes elements that are rendered by the server (if they have the data attr), so elements
  * that are rendered by the client (e.g. React) needs to be handled separately.
  *
  * @example

--- a/client/src/controllers/DismissibleController.ts
+++ b/client/src/controllers/DismissibleController.ts
@@ -34,13 +34,15 @@ export const updateDismissibles = (
  * that are rendered by the client (e.g. React) needs to be handled separately.
  *
  * @example
+ * ```html
  * <section
  *  data-controller="w-dismissible"
  *  data-w-dismissible-dismissed-class="w-dismissible--dismissed"
  *  data-w-dismissible-id-value="Whats new in Wagtail"
  * >
- *  <button type="button" data-action="w-dismiss#dismissible">Close</button>
+ *   <button type="button" data-action="w-dismiss#dismissible">Close</button>
  * </section>
+ * ```
  */
 export class DismissibleController extends Controller<HTMLElement> {
   static classes = ['dismissed'];

--- a/client/src/controllers/DrilldownController.ts
+++ b/client/src/controllers/DrilldownController.ts
@@ -1,3 +1,5 @@
+/* eslint no-param-reassign: ["error", { "ignorePropertyModificationsFor": ["hidden","textContent"] }] */
+
 import { Controller } from '@hotwired/stimulus';
 
 import type { ActionController } from './ActionController';
@@ -99,9 +101,7 @@ export class DrilldownController extends Controller<HTMLElement> {
       const count = name
         ? document.querySelectorAll(`[${this.countAttrValue}=${name}]`).length
         : total;
-      // eslint-disable-next-line no-param-reassign
       countTarget.hidden = count === 0;
-      // eslint-disable-next-line no-param-reassign
       countTarget.textContent = count.toString();
     });
   }

--- a/client/src/controllers/DropdownController.ts
+++ b/client/src/controllers/DropdownController.ts
@@ -86,10 +86,12 @@ type TippyTheme = 'dropdown' | 'drilldown' | 'dropdown-button';
  * A Tippy.js tooltip with interactive "dropdown" options.
  *
  * @example
+ * ```html
  * <div data-controller="w-dropdown" data-w-dropdown-hide-on-click-value-"true">
- *  <button type="button" data-w-dropdown-target="toggle" aria-label="Actions"></button>
- *  <div data-w-dropdown-target="content">[…]</div>
+ *   <button type="button" data-w-dropdown-target="toggle" aria-label="Actions"></button>
+ *   <div data-w-dropdown-target="content">[…]</div>
  * </div>
+ * ```
  */
 export class DropdownController extends Controller<HTMLElement> {
   static targets = ['toggle', 'content'];

--- a/client/src/controllers/FormsetController.ts
+++ b/client/src/controllers/FormsetController.ts
@@ -10,30 +10,30 @@ import { runInlineScripts } from '../utils/runInlineScripts';
  * @example
  * ```html
  * <form data-controller="w-formset">
- *  <input type="hidden" name="form-TOTAL_FORMS" value="2" data-w-formset-target="totalFormsInput">
- *  <input type="hidden" name="form-MIN_NUM_FORMS" value="0" data-w-formset-target="minFormsInput">
- *  <input type="hidden" name="form-MAX_NUM_FORMS" value="50" data-w-formset-target="maxFormsInput">
- *  <input type="hidden" name="form-INITIAL_FORMS" value="2">
- *  <ul data-w-formset-target="forms">
- *    <li data-w-formset-target="child">
- *      <input type="text" name="form-0-name">
- *      <input type="hidden" name="form-0-DELETE" data-w-formset-target="deleteInput">
- *      <button type="button" data-action="w-formset#delete">Delete</button>
- *    </li>
- *    <li data-w-formset-target="child">
- *      <input type="text" name="form-1-name">
- *      <input type="hidden" name="form-1-DELETE" data-w-formset-target="deleteInput">
- *      <button type="button" data-action="w-formset#delete">Delete</button>
- *    </li>
- *  </ul>
- *  <button type="button" data-action="w-formset#add">Add</button>
- *  <template data-w-formset-target="template">
- *    <li data-w-formset-target="child">
- *      <input type="text" name="form-__prefix__-name">
- *      <input type="hidden" name="form-__prefix__-DELETE" data-w-formset-target="deleteInput">
- *      <button type="button" data-action="w-formset#delete">Delete</button>
- *    </li>
- *  </template>
+ *   <input type="hidden" name="form-TOTAL_FORMS" value="2" data-w-formset-target="totalFormsInput">
+ *   <input type="hidden" name="form-MIN_NUM_FORMS" value="0" data-w-formset-target="minFormsInput">
+ *   <input type="hidden" name="form-MAX_NUM_FORMS" value="50" data-w-formset-target="maxFormsInput">
+ *   <input type="hidden" name="form-INITIAL_FORMS" value="2">
+ *   <ul data-w-formset-target="forms">
+ *     <li data-w-formset-target="child">
+ *       <input type="text" name="form-0-name">
+ *       <input type="hidden" name="form-0-DELETE" data-w-formset-target="deleteInput">
+ *       <button type="button" data-action="w-formset#delete">Delete</button>
+ *     </li>
+ *     <li data-w-formset-target="child">
+ *       <input type="text" name="form-1-name">
+ *       <input type="hidden" name="form-1-DELETE" data-w-formset-target="deleteInput">
+ *       <button type="button" data-action="w-formset#delete">Delete</button>
+ *     </li>
+ *   </ul>
+ *   <button type="button" data-action="w-formset#add">Add</button>
+ *   <template data-w-formset-target="template">
+ *     <li data-w-formset-target="child">
+ *       <input type="text" name="form-__prefix__-name">
+ *       <input type="hidden" name="form-__prefix__-DELETE" data-w-formset-target="deleteInput">
+ *       <button type="button" data-action="w-formset#delete">Delete</button>
+ *     </li>
+ *   </template>
  * </form>
  * ```
  */

--- a/client/src/controllers/InitController.ts
+++ b/client/src/controllers/InitController.ts
@@ -6,19 +6,25 @@ import { debounce } from '../utils/debounce';
  * add or remove classes when ready to be interacted with.
  *
  * @example - Dynamic classes when ready
+ * ```html
  * <div class="keep-me hide-me" data-controller="w-init" data-w-init-remove-class="hide-me" data-w-init-ready-class="loaded">
  *   When the DOM is ready, this div will have the class 'loaded' added and 'hide-me' removed.
  * </div>
+ * ```
  *
  * @example - Custom event dispatching
+ * ```html
  * <div class="keep-me hide-me" data-controller="w-init" data-w-init-event-value="custom:event other-custom:event">
  *   When the DOM is ready, two additional custom events will be dispatched; `custom:event` and `other-custom:event`.
  * </div>
+ * ```
  *
  * @example - Detail dispatching
+ * ```html
  * <article data-controller="w-init" data-w-init-detail-value='{"status": "success", "message": "Article has entered the room"}'>
  *  When the DOM is ready, the detail with value of a JSON object above will be dispatched.
  * </article>
+ * ```
  */
 export class InitController extends Controller<HTMLElement> {
   static classes = ['ready', 'remove'];

--- a/client/src/controllers/LocaleController.ts
+++ b/client/src/controllers/LocaleController.ts
@@ -2,6 +2,15 @@ import { Controller } from '@hotwired/stimulus';
 
 /**
  * Localizes elements in the current locale.
+ *
+ * @example
+ * ```html
+ * <select data-controller="w-locale" data-action="w-locale#localizeTimeZoneOptions">
+ *   <option value="" selected>Use server time zone</option>
+ *   <option value="Asia/Jakarta">Asia/Jakarta</option>
+ *   <option value="Asia/Tokyo">Asia/Tokyo</option>
+ * </select>
+ * ```
  */
 export class LocaleController extends Controller<HTMLSelectElement> {
   /**

--- a/client/src/controllers/OrderableController.ts
+++ b/client/src/controllers/OrderableController.ts
@@ -12,6 +12,15 @@ enum Direction {
  *
  * Once re-ordering is completed an async request will be made to the
  * provided URL to submit the update per item.
+ *
+ * @example
+ * ```html
+ * <fieldset data-controller="w-orderable" data-w-orderable-url-value="/path/to/orderable/">
+ *   <input type="button" data-w-orderable-target="item" data-w-orderable-item-id="1" value="Item 1"/>
+ *   <input type="button" data-w-orderable-target="item" data-w-orderable-item-id="2" value="Item 2"/>
+ *   <input type="button" data-w-orderable-target="item" data-w-orderable-item-id="3" value="Item 3"/>
+ * </fieldset>
+ * ```
  */
 export class OrderableController extends Controller<HTMLElement> {
   static classes = ['active', 'chosen', 'drag', 'ghost'];

--- a/client/src/controllers/PreviewController.ts
+++ b/client/src/controllers/PreviewController.ts
@@ -557,7 +557,7 @@ export class PreviewController extends Controller<HTMLElement> {
    * @returns whether the data is valid
    */
   async checkAndUpdatePreview() {
-    // Small performance optimisation: the hasChanges() method will not be called
+    // Small performance optimization: the hasChanges() method will not be called
     // if there is a pending update due to the || operator short-circuiting
     if (this.updatePromise || !this.hasChanges()) return undefined;
     return this.setPreviewData();

--- a/client/src/controllers/ProgressController.ts
+++ b/client/src/controllers/ProgressController.ts
@@ -7,6 +7,7 @@ const DEFAULT_CLASS = 'button-longrunning';
  * until the duration has elapsed. Will also update the button's label while in progress.
  *
  * @example
+ * ```html
  * <button
  *   type="submit"
  *   class="button button-longrunning"
@@ -16,9 +17,10 @@ const DEFAULT_CLASS = 'button-longrunning';
  *   data-w-progress-duration-seconds-value="40"
  *   data-action="w-progress#activate"
  * >
- *  {% icon name="spinner" %}
- *  <em data-w-progress-target="label">{% trans 'Sign in' %}</em>
+ *   {% icon name="spinner" %}
+ *   <em data-w-progress-target="label">{% trans 'Sign in' %}</em>
  * </button>
+ * ```
  */
 export class ProgressController extends Controller<HTMLButtonElement> {
   static classes = ['active'];

--- a/client/src/controllers/RevealController.ts
+++ b/client/src/controllers/RevealController.ts
@@ -1,3 +1,5 @@
+/* eslint no-param-reassign: ["error", { "ignorePropertyModificationsFor": ["hidden"] }] */
+
 import { Controller } from '@hotwired/stimulus';
 
 /**
@@ -108,7 +110,6 @@ export class RevealController extends Controller<HTMLElement> {
       });
       contentTargets.forEach((content) => {
         content.classList.remove(...openedContentClasses);
-        // eslint-disable-next-line no-param-reassign
         content.hidden = true;
       });
       this.element.classList.add(...closedClasses);
@@ -122,7 +123,7 @@ export class RevealController extends Controller<HTMLElement> {
       });
       contentTargets.forEach((content) => {
         content.classList.add(...openedContentClasses);
-        content.hidden = false; // eslint-disable-line no-param-reassign
+        content.hidden = false;
       });
       this.element.classList.remove(...closedClasses);
       this.element.classList.add(...openedClasses);

--- a/client/src/controllers/RevealController.ts
+++ b/client/src/controllers/RevealController.ts
@@ -8,10 +8,12 @@ import { Controller } from '@hotwired/stimulus';
  * @see https://w3c.github.io/aria/#aria-expanded
  *
  * @example
+ * ```html
  * <section data-controller="w-reveal">
- *  <button type="button" data-action="w-reveal#toggle" data-w-reveal-target="toggle" aria-controls="my-content" type="button">Toggle</button>
- *  <div id="my-content">CONTENT</div>
+ *   <button type="button" data-action="w-reveal#toggle" data-w-reveal-target="toggle" aria-controls="my-content" type="button">Toggle</button>
+ *   <div id="my-content">CONTENT</div>
  * </section>
+ * ```
  */
 export class RevealController extends Controller<HTMLElement> {
   static classes = [

--- a/client/src/controllers/SlugController.ts
+++ b/client/src/controllers/SlugController.ts
@@ -79,7 +79,7 @@ export class SlugController extends Controller<HTMLInputElement> {
    * or can be used to simply return the transformed value.
    *
    * The urlify (Django port) function performs extra processing on the string &
-   * is more suitable for creating a slug from the title, rather than sanitising manually.
+   * is more suitable for creating a slug from the title, rather than sanitizing manually.
    * If the urlify util returns an empty string it will fall back to the slugify method.
    *
    * If a custom event with detail.value is provided, that value will be used

--- a/client/src/controllers/SlugController.ts
+++ b/client/src/controllers/SlugController.ts
@@ -8,7 +8,9 @@ type SlugMethods = 'slugify' | 'urlify';
  * Adds ability to slugify the value of an input element.
  *
  * @example
+ * ```html
  * <input type="text" name="slug" data-controller="w-slug" data-action="blur->w-slug#slugify" />
+ * ```
  */
 export class SlugController extends Controller<HTMLInputElement> {
   static values = {

--- a/client/src/controllers/SubmitController.ts
+++ b/client/src/controllers/SubmitController.ts
@@ -3,14 +3,15 @@ import { Controller } from '@hotwired/stimulus';
 /**
  * Adds the ability for a field to trigger an automatic submission of its attached form.
  *
- * @example
- * // once any change is made to the below select field, the form will be auto submitted
+ * @example - Once any change is made to the below select field, the form will be auto submitted
+ * ```html
  * <form>
  *   <select name="order" data-controller="w-submit" data-action="change->w-submit#submit">
  *     <option value="A-Z">A to Z</option>
  *     <option value="Z-A">Z to A</option>
  *   </select>
  * </form>
+ * ```
  */
 export class SubmitController extends Controller<
   HTMLInputElement | HTMLSelectElement

--- a/client/src/controllers/SwapController.ts
+++ b/client/src/controllers/SwapController.ts
@@ -12,41 +12,46 @@ import { WAGTAIL_CONFIG } from '../config/wagtailConfig';
  * values.
  *
  * @example - A form that will update the results based on the form's input
- *  <div id="results"></div>
- *  <form
- *    data-controller="w-swap"
- *    data-action="input->w-swap#submitLazy"
- *    data-w-swap-src-value="path/to/search"
- *    data-w-swap-target-value="#results"
- *  >
- *  <input id="search" type="text" name="query" />
- *  <input id="filter" type="text" name="filter" />
+ * ```html
+ * <div id="results"></div>
+ * <form
+ *   data-controller="w-swap"
+ *   data-action="input->w-swap#submitLazy"
+ *   data-w-swap-src-value="path/to/search"
+ *   data-w-swap-target-value="#results"
+ * >
+ *   <input id="search" type="text" name="query" />
+ *   <input id="filter" type="text" name="filter" />
  * </form>
+ * ```
  *
  * @example - A single input that will update the results & the URL
- *  <div id="results"></div>
- *  <input
- *    id="search"
- *    type="text"
- *    name="q"
- *    data-controller="w-swap"
- *    data-action="input->w-swap#searchLazy"
- *    data-w-swap-src-value="path/to/search"
- *    data-w-swap-target-value="#listing-results"
- *  />
+ * ```html
+ * <div id="results"></div>
+ * <input
+ *   id="search"
+ *   type="text"
+ *   name="q"
+ *   data-controller="w-swap"
+ *   data-action="input->w-swap#searchLazy"
+ *   data-w-swap-src-value="path/to/search"
+ *   data-w-swap-target-value="#listing-results"
+ * />
+ * ```
  *
  * @example - A single button that will update the results
- *  <div id="results"></div>
- *  <button
- *    id="clear"
- *    data-controller="w-swap"
- *    data-action="input->w-swap#replaceLazy"
- *    data-w-swap-src-value="path/to/results/?type=bar"
- *    data-w-swap-target-value="#results"
- *  >
- *    Clear owner filter
- *  </button>
- *
+ * ```html
+ * <div id="results"></div>
+ * <button
+ *   id="clear"
+ *   data-controller="w-swap"
+ *   data-action="input->w-swap#replaceLazy"
+ *   data-w-swap-src-value="path/to/results/?type=bar"
+ *   data-w-swap-target-value="#results"
+ * >
+ *   Clear owner filter
+ * </button>
+ * ```
  */
 export class SwapController extends Controller<
   HTMLFormElement | HTMLInputElement | HTMLButtonElement

--- a/client/src/controllers/SwapController.ts
+++ b/client/src/controllers/SwapController.ts
@@ -91,7 +91,7 @@ export class SwapController extends Controller<
   replaceLazy?: { (...args: any[]): void; cancel(): void };
   /** Debounced function to search results and then replace the DOM */
   searchLazy?: { (...args: any[]): void; cancel(): void };
-  /** Debounced function to submit the serialised form and then replace the DOM */
+  /** Debounced function to submit the serialized form and then replace the DOM */
   submitLazy?: { (...args: any[]): void; cancel(): void };
   /** A function that writes the HTML to the target */
   writeDeferred?: () => Promise<string>;
@@ -227,7 +227,7 @@ export class SwapController extends Controller<
 
   /**
    * Update the target element's content with the response from a request based on the input's form
-   * values serialised. Do not account for anything in the main location/URL, simply replace the content within
+   * values serialized. Do not account for anything in the main location/URL, simply replace the content within
    * the target element.
    */
   submit() {
@@ -235,7 +235,7 @@ export class SwapController extends Controller<
     let data: FormData | undefined = new FormData(form);
 
     let url = this.srcValue;
-    // serialise the form to a query string if it's a GET request
+    // serialize the form to a query string if it's a GET request
     if (form.getAttribute('method')?.toUpperCase() === 'GET') {
       // cast as any to avoid https://github.com/microsoft/TypeScript/issues/43797
       url += '?' + new URLSearchParams(data as any).toString();

--- a/client/src/controllers/SyncController.ts
+++ b/client/src/controllers/SyncController.ts
@@ -7,6 +7,7 @@ import { debounce } from '../utils/debounce';
  * or more targeted other inputs.
  *
  * @example
+ * ```html
  * <section>
  *   <input type="text" name="title" id="title" />
  *   <input
@@ -19,6 +20,7 @@ import { debounce } from '../utils/debounce';
  *     data-w-sync-target-value="#title"
  *   />
  * </section>
+ * ```
  */
 export class SyncController extends Controller<HTMLInputElement> {
   static values = {

--- a/client/src/controllers/TagController.ts
+++ b/client/src/controllers/TagController.ts
@@ -15,10 +15,14 @@ declare global {
  * See https://github.com/aehlke/tag-it
  *
  * @example
+ * ```html
  * <input id="id_tags" type="text" name="tags" data-controller="w-tag" data-w-tag-url-value="/admin/tag-autocomplete/" />
+ * ```
  *
- * @example - with delay
+ * @example - With delay
+ * ```html
  * <input id="id_tags" type="text" name="tags" data-controller="w-tag" data-w-tag-delay-value="300" data-w-tag-url-value="/admin/tag-autocomplete/" />
+ * ```
  */
 export class TagController extends Controller {
   static values = {

--- a/client/src/controllers/TeleportController.ts
+++ b/client/src/controllers/TeleportController.ts
@@ -12,15 +12,17 @@ import { runInlineScripts } from '../utils/runInlineScripts';
  * Depending on location of the controlled element.
  *
  * @example
+ * ```html
  * <aside>
  *   <template
- *    data-controller="w-teleport"
- *    data-w-teleport-target-value="#other-location"
+ *     data-controller="w-teleport"
+ *     data-w-teleport-target-value="#other-location"
  *   >
- *    <div class="content-to-clone">Some content</div>
+ *     <div class="content-to-clone">Some content</div>
  *   </template>
  *   <div id="other-location"></div>
  * </aside>
+ * ```
  */
 export class TeleportController extends Controller<HTMLTemplateElement> {
   static values = {

--- a/client/src/controllers/TooltipController.ts
+++ b/client/src/controllers/TooltipController.ts
@@ -30,9 +30,11 @@ export const hideTooltipOnEsc = {
  * A Tippy.js tooltip with simple popover content.
  *
  * @example
+ * ```html
  * <button type="button" data-controller="w-tooltip" data-w-tooltip-content-value="More detail here">
- *  A button with a tooltip
+ *   A button with a tooltip
  * </button>
+ * ```
  */
 export class TooltipController extends Controller<HTMLElement> {
   static values = {

--- a/client/src/controllers/UnsavedController.ts
+++ b/client/src/controllers/UnsavedController.ts
@@ -21,6 +21,7 @@ const DEFAULT_DURATIONS = {
  * are about to move away from the page with potentially unsaved changes.
  *
  * @example - Warn the user when there are unsaved edits
+ * ```html
  * <form
  *   data-controller="w-unsaved"
  *   data-action="w-unsaved#submit beforeunload@window->w-unsaved#confirm change->w-unsaved#check"
@@ -29,8 +30,10 @@ const DEFAULT_DURATIONS = {
  *   <input type="text" value="something" />
  *   <button>Submit</submit>
  * </form>
+ * ```
  *
  * @example - Watch comments for changes in addition to edits (default is edits only)
+ * ```html
  * <form
  *   data-controller="w-unsaved"
  *   data-action="w-unsaved#submit beforeunload@window->w-unsaved#confirm change->w-unsaved#check"
@@ -40,8 +43,10 @@ const DEFAULT_DURATIONS = {
  *   <input type="text" value="something" />
  *   <button>Submit</submit>
  * </form>
+ * ```
  *
  * @example - Force the confirmation dialog
+ * ```html
  * <form
  *   data-controller="w-unsaved"
  *   data-action="w-unsaved#submit beforeunload@window->w-unsaved#confirm change->w-unsaved#check"
@@ -51,8 +56,10 @@ const DEFAULT_DURATIONS = {
  *   <input type="text" value="something" />
  *   <button>Submit</submit>
  * </form>
+ * ```
  *
  * @example - Force the confirmation dialog without watching for edits/comments
+ * ```html
  * <form
  *   data-controller="w-unsaved"
  *   data-action="w-unsaved#submit beforeunload@window->w-unsaved#confirm"
@@ -63,6 +70,7 @@ const DEFAULT_DURATIONS = {
  *   <input type="text" value="something" />
  *   <button>Submit</submit>
  * </form>
+ * ```
  */
 export class UnsavedController extends Controller<HTMLFormElement> {
   static values = {

--- a/client/src/controllers/UpgradeController.ts
+++ b/client/src/controllers/UpgradeController.ts
@@ -17,7 +17,7 @@ interface LatestVersionData extends VersionData {
  * is out of date.
  *
  * Expected JSON payload:
- *
+ * ```json
  * {
  *     "version": "2.15.2",
  *     "url":     "https://docs.wagtail.io/en/stable/releases/2.15.2.html",
@@ -28,6 +28,18 @@ interface LatestVersionData extends VersionData {
  *         "minorUrl": "https://docs.wagtail.io/en/stable/releases/2.12.html"
  *     }
  * }
+ * ```
+ *
+ * @example
+ * ```html
+ * <div
+ *   data-controller="w-upgrade"
+ *   data-w-upgrade-current-version-value="6.3.1"
+ *   data-w-upgrade-url-value="https://path.to/latest.txt"
+ * >
+ *   <p>A new version of Wagtail is available!</p>
+ * </div>
+ * ```
  */
 export class UpgradeController extends Controller<HTMLElement> {
   static targets = ['latestVersion', 'link', 'dismiss'];

--- a/client/src/controllers/ZoneController.ts
+++ b/client/src/controllers/ZoneController.ts
@@ -30,7 +30,7 @@ enum ZoneMode {
  *   data-w-zone-active-class="public"
  *   data-w-zone-inactive-class="private"
  *   data-w-zone-switch-key-value="isPublic"
- *>
+ * >
  *  Content
  * </div>
  * ```

--- a/client/src/controllers/index.ts
+++ b/client/src/controllers/index.ts
@@ -15,6 +15,7 @@ import { DropdownController } from './DropdownController';
 import { FormsetController } from './FormsetController';
 import { InitController } from './InitController';
 import { KeyboardController } from './KeyboardController';
+import { LocaleController } from './LocaleController';
 import { OrderableController } from './OrderableController';
 import { PreviewController } from './PreviewController';
 import { ProgressController } from './ProgressController';
@@ -32,7 +33,6 @@ import { TooltipController } from './TooltipController';
 import { UnsavedController } from './UnsavedController';
 import { UpgradeController } from './UpgradeController';
 import { ZoneController } from './ZoneController';
-import { LocaleController } from './LocaleController';
 
 /**
  * Important: Only add default core controllers that should load with the base admin JS bundle.


### PR DESCRIPTION
* Fix ordering of imports for Stimulus controller index
* Update JSDoc spelling to be aligned with US English
* Fix JSDoc `@example` usage to have the description within the same line, use the `html` markdown blocks & have consistent indentation
* Add some JSDoc `@example` entries to controllers that did not have them, the only one without an example now is the PreviewController
* Avoid repeated declarations of ignoring ESLint `no-param-reassign`, instead bring to the top of file if it's suitable as a global ignore, only for specific properties though. We do this in a few other controllers and it helps make the code cleaner while also ensuring our linting alignment.