### PR TITLE
Fix up `stubs` & `adapter` contents to better support Jest testing

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changelog
  * Maintenance: Validate against invalid characters in Lexeme values (Matt Westcott)
  * Maintenance: Split up `wagtail.models` module into submodules (Matt Westcott)
  * Maintenance: Update `ruff` to 0.9.6 (Sage Abdullah)
+ * Maintenance: Fix up `stubs` & `adapter` contents to better support Jest testing (LB (Ben) Johnston)
 
 
 6.4.1 (21.02.2025)

--- a/client/tests/adapter.js
+++ b/client/tests/adapter.js
@@ -1,6 +1,46 @@
+/**
+ * Jest adapter and overrides to support Jest testing with Enzyme
+ * and JSDom.
+ * This will only be loaded in Jest tests, not in Storybook.
+ */
+
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({
   adapter: new Adapter(),
 });
+
+/** Mock window.scrollTo as not provided via JSDom */
+window.scrollTo = jest.fn();
+
+/** Mock scrollIntoView on elements, this is not provided by JSDom */
+Element.prototype.scrollIntoView = jest.fn();
+
+/** Mock console.warn to filter out warnings from React due to Draftail legacy Component API usage.
+ * Draftail/Draft-js is unlikely to support these and the warnings are not useful for unit test output.
+ */
+/* eslint-disable no-console */
+const consoleWarnOriginal = console.warn;
+console.warn = function filterWarnings(...args) {
+  /* eslint-enable no-console */
+
+  const [warning, component] = args;
+
+  const legacyReactWarnings = [
+    'Warning: componentWillMount has been renamed, and is not recommended for use.',
+    'Warning: componentWillReceiveProps has been renamed, and is not recommended for use.',
+    'Warning: componentWillUpdate has been renamed, and is not recommended for use.',
+  ];
+
+  const ignoredComponents = ['DraftEditor', 'PluginEditor'];
+
+  if (
+    legacyReactWarnings.some((_) => warning.includes(_)) &&
+    ignoredComponents.includes(component)
+  ) {
+    return;
+  }
+
+  consoleWarnOriginal.apply(console, args);
+};

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -56,34 +56,3 @@ global.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = { type: 'document' };
 
 class PageChooserModal {}
 global.PageChooserModal = PageChooserModal;
-
-/** Mock window.scrollTo as not provided via JSDom */
-window.scrollTo = () => {};
-
-/** Mock console.warn to filter out warnings from React due to Draftail legacy Component API usage.
- * Draftail/Draft-js is unlikely to support these and the warnings are not useful for unit test output.
- */
-/* eslint-disable no-console */
-const consoleWarnOriginal = console.warn;
-console.warn = function filterWarnings(...args) {
-  /* eslint-enable no-console */
-
-  const [warning, component] = args;
-
-  const legacyReactWarnings = [
-    'Warning: componentWillMount has been renamed, and is not recommended for use.',
-    'Warning: componentWillReceiveProps has been renamed, and is not recommended for use.',
-    'Warning: componentWillUpdate has been renamed, and is not recommended for use.',
-  ];
-
-  const ignoredComponents = ['DraftEditor', 'PluginEditor'];
-
-  if (
-    legacyReactWarnings.some((_) => warning.includes(_)) &&
-    ignoredComponents.includes(component)
-  ) {
-    return;
-  }
-
-  consoleWarnOriginal.apply(console, args);
-};

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -44,6 +44,7 @@ depth: 1
  * Validate against invalid characters in Lexeme values (Matt Westcott)
  * Split up `wagtail.models` module into submodules (Matt Westcott)
  * Update `ruff` to 0.9.6 (Sage Abdullah)
+ * Fix up `stubs` & `adapter` contents to better support Jest testing (LB (Ben) Johnston)
 
 ## Upgrade considerations - changes affecting all projects
 


### PR DESCRIPTION
We have some further confusion around `stubs` and `adapter`, with a mix of Jest only items added to the 'shared' `stubs` file. We probably could do a better job of naming these but I did not want to change things too much, instead I have also added a file level JSDoc to `adapter`.

## Detailed changes
- Ensure Jest only adapter items are in adapter.js
- Ensure Jest AND Storybook items are in stubs.js
- Allow warnings about React deprecations to show in Storybook
- Add mock for someElement.scrollIntoView in the adapter & other scroll mocks for better testing capabilities
- Commit also added to support PR https://github.com/wagtail/wagtail/pull/12555

## Additional links

See previous related PRs https://github.com/wagtail/wagtail/pull/10886 & https://github.com/wagtail/wagtail/pull/12902
