### PR TITLE
Fix LocaleController tests

### DIFF
--- a/client/src/controllers/LocaleController.test.js
+++ b/client/src/controllers/LocaleController.test.js
@@ -2,6 +2,10 @@ import { Application } from '@hotwired/stimulus';
 import { LocaleController } from './LocaleController';
 import { InitController } from './InitController';
 
+// Ensure the labels are consistent with the snapshot regardless of DST.
+jest.useFakeTimers();
+jest.setSystemTime(new Date('2025-01-11'));
+
 describe('LocaleController', () => {
   let app;
   let select;


### PR DESCRIPTION
Fixes #12955.

I think we should keep the snapshots. It makes it clear what the expected behaviour is, and ensures the localization works. Without using snapshots, I imagine we'd have to mock a bunch of stuff. With how simple the implementation is, we'd be pretty much testing the mocks themselves.