### PR TITLE
Fix nondeterministic page order in test_ordering_by_content_type

### DIFF
--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -167,13 +167,26 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         )
 
     def test_ordering_by_content_type(self):
+        # Delete the child_page to avoid nondeterministic ordering with the
+        # new_page when ordering by content type, as they are the same type
+        self.child_page.delete()
+
+        event_page = SingleEventPage(
+            title="Wagtail Space 2025",
+            location="virtual",
+            audience="public",
+            cost="free",
+            date_from="2025-06-16",
+        )
+        self.root_page.add_child(instance=event_page)
+
         orderings = {
             "content_type": (
-                [self.child_page.id, self.new_page.id, self.old_page.id],
+                [self.new_page.id, self.old_page.id, event_page.id],
                 "-content_type",
             ),
             "-content_type": (
-                [self.old_page.id, self.child_page.id, self.new_page.id],
+                [event_page.id, self.old_page.id, self.new_page.id],
                 "content_type",
             ),
         }


### PR DESCRIPTION
The tests I added in #12784 were flaky because there are two pages using the `SimplePage` type, and the order of the two pages aren't always consistent after ordering by `content_type`.

This PR fixes it by deleting one of the `SimplePage`s. I added another page with a completely different page type for good measure.