### PR TITLE
Defer validation of StreamField min block counts when saving drafts

### DIFF
--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -172,15 +172,16 @@ class BaseStreamBlock(Block):
             except ValidationError as e:
                 errors[i] = e
 
-        if self.meta.min_num is not None and self.meta.min_num > len(value):
-            non_block_errors.append(
-                ValidationError(
-                    _("The minimum number of items is %(min_num)d")
-                    % {"min_num": self.meta.min_num}
+        if self.required and not ignore_required_constraints:
+            if self.meta.min_num is not None and self.meta.min_num > len(value):
+                non_block_errors.append(
+                    ValidationError(
+                        _("The minimum number of items is %(min_num)d")
+                        % {"min_num": self.meta.min_num}
+                    )
                 )
-            )
-        elif self.required and not ignore_required_constraints and len(value) == 0:
-            non_block_errors.append(ValidationError(_("This field is required.")))
+            elif len(value) == 0:
+                non_block_errors.append(ValidationError(_("This field is required.")))
 
         if self.meta.max_num is not None and self.meta.max_num < len(value):
             non_block_errors.append(

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -161,6 +161,7 @@ class BaseStreamBlock(Block):
         return self.meta.required
 
     def clean(self, value, ignore_required_constraints=False):
+        required = self.required and not ignore_required_constraints
         cleaned_data = []
         errors = {}
         non_block_errors = ErrorList()
@@ -172,7 +173,7 @@ class BaseStreamBlock(Block):
             except ValidationError as e:
                 errors[i] = e
 
-        if self.required and not ignore_required_constraints:
+        if required:
             if self.meta.min_num is not None and self.meta.min_num > len(value):
                 non_block_errors.append(
                     ValidationError(
@@ -201,7 +202,7 @@ class BaseStreamBlock(Block):
                 max_num = min_max.get("max_num", None)
                 min_num = min_max.get("min_num", None)
                 block_count = block_counts[block_name]
-                if min_num is not None and min_num > block_count:
+                if required and min_num is not None and min_num > block_count:
                     non_block_errors.append(
                         ValidationError(
                             "{}: {}".format(

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -160,7 +160,7 @@ class BaseStreamBlock(Block):
     def required(self):
         return self.meta.required
 
-    def clean(self, value):
+    def clean(self, value, ignore_required_constraints=False):
         cleaned_data = []
         errors = {}
         non_block_errors = ErrorList()
@@ -179,7 +179,7 @@ class BaseStreamBlock(Block):
                     % {"min_num": self.meta.min_num}
                 )
             )
-        elif self.required and len(value) == 0:
+        elif self.required and not ignore_required_constraints and len(value) == 0:
             non_block_errors.append(ValidationError(_("This field is required.")))
 
         if self.meta.max_num is not None and self.meta.max_num < len(value):

--- a/wagtail/tests/test_streamfield.py
+++ b/wagtail/tests/test_streamfield.py
@@ -8,6 +8,7 @@ from django.test import TestCase, skipUnlessDBFeature
 from django.utils.safestring import SafeString
 
 from wagtail import blocks
+from wagtail.admin.forms import WagtailAdminModelForm
 from wagtail.blocks import StreamBlockValidationError, StreamValue
 from wagtail.fields import StreamField
 from wagtail.images.models import Image
@@ -22,6 +23,7 @@ from wagtail.test.testapp.models import (
     JSONStreamModel,
     StreamPage,
 )
+from wagtail.test.utils.form_data import nested_form_data, streamfield
 
 
 class TestLazyStreamField(TestCase):
@@ -546,6 +548,57 @@ class TestStreamFieldCountValidation(TestCase):
         body = [self.rich_text_body, self.text_body]
         instance = JSONMinMaxCountStreamModel.objects.create(body=json.dumps(body))
         self.assertTrue(instance.body.stream_block.clean(instance.body))
+
+    def test_minimum_count_disregarded_when_deferring_validation(self):
+        class StreamForm(WagtailAdminModelForm):
+            class Meta:
+                model = JSONMinMaxCountStreamModel
+                fields = ["body"]
+                defer_required_on_fields = ["body"]
+
+        form_data = nested_form_data(
+            {
+                "body": streamfield(
+                    [
+                        ("text", "Some text"),
+                    ]
+                )
+            }
+        )
+        form = StreamForm(form_data)
+        self.assertFalse(form.is_valid())
+
+        form = StreamForm(form_data)
+        # form.defer_required_fields()
+        # self.assertTrue(form.is_valid())
+
+    def test_maximum_count_respected_when_deferring_validation(self):
+        class StreamForm(WagtailAdminModelForm):
+            class Meta:
+                model = JSONMinMaxCountStreamModel
+                fields = ["body"]
+                defer_required_on_fields = ["body"]
+
+        form_data = nested_form_data(
+            {
+                "body": streamfield(
+                    [
+                        ("text", "Some text"),
+                        ("text", "Some text"),
+                        ("text", "Some text"),
+                        ("text", "Some text"),
+                        ("text", "Some text"),
+                        ("text", "Some text"),
+                    ]
+                )
+            }
+        )
+        form = StreamForm(form_data)
+        self.assertFalse(form.is_valid())
+
+        form = StreamForm(form_data)
+        # form.defer_required_fields()
+        self.assertFalse(form.is_valid())
 
     def test_maximum_count(self):
         # 5 blocks okay


### PR DESCRIPTION
Follow-up to (and incorporates) #12923, implementing [RFC 104](https://github.com/wagtail/rfcs/pull/104).

When saving pages/snippets as a draft, minimum block counts on the top-level StreamBlock are now disregarded, whether they are set as `blank=False` on the StreamField, `required=True` on the block, or through a `min_num` or `block_counts` option.