### PR TITLE
#12953 Added Default Tests for Root and Homepage Pages in Wagtail Starter Projects

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@
  * Add toggle from grid to list layout for image listings (Joel William)
  * Add support for opt-in collapsible `StructBlock`s (Sage Abdullah)
  * Add `form_attrs` support to all StreamField blocks (Sage Abdullah)
+ * Update project template documentation to include testing instructions and include starting test file in template (Aditya (megatrron))
  * Fix: Handle lazy translation strings as `preview_value` for `RichTextBlock` (Seb Corbin)
  * Fix: Fix handling of newline-separated choices in form builder when using non-windows newline characters (Baptiste Mispelon)
  * Fix: Ensure `WAGTAILADMIN_LOGIN_URL` is respected when logging out of the admin (Antoine Rodriguez, Ramon de Jezus)

--- a/docs/reference/project_template.md
+++ b/docs/reference/project_template.md
@@ -16,6 +16,7 @@ mysite/
                 home_page.html
         __init__.py
         models.py
+        tests.py
     search/
         templates/
             search/
@@ -96,6 +97,26 @@ The Django settings files are split up into `base.py`, `dev.py`, `production.py`
 ```{note}
 On production servers, we recommend that you only store secrets in ``local.py`` (such as API keys and passwords). This can save you headaches in the future if you are ever trying to debug why a server is behaving badly. If you are using multiple servers which need different settings then we recommend that you create a different ``production.py`` file for each one.
 ```
+
+### Writing and running tests
+
+When you create a new project using `wagtail start`, there will be a set of basic tests included in the `home/tests.py` file.
+
+These tests check:
+
+-   If the _root `Page`_ (ID=1) is automatically created.
+-   That the _home `Page`_ can be created as a child of the root page.
+-   A placeholder test for other sub-pages, such as the `BlogIndexPage`, ready for implementation.
+
+#### Running the tests
+
+To run the tests, navigate to your project folder and run:
+
+```sh
+python manage.py test
+```
+
+For more about testing within Django see [Writing tests with Django](inv:django#topics/testing/overview), or Wagtail specific unit testing utils, see [Testing your Wagtail site](/advanced_topics/testing).
 
 ### Dockerfile
 

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -77,6 +77,7 @@ For more details, see the documentation on [enabling the user bar](headless_user
  * Add a keyboard shortcut to easily toggle the visibility of the minimap side panel (Dhruvi Patel)
  * Add API for extracting preview page content (Sage Abdullah)
  * Add `form_attrs` support to all StreamField blocks (Sage Abdullah)
+ * Update project template documentation to include testing instructions and include starting test file in template (Aditya (megatrron))
 
 ### Bug fixes
 

--- a/wagtail/project_template/home/tests.py
+++ b/wagtail/project_template/home/tests.py
@@ -1,0 +1,43 @@
+from django.urls import reverse
+from home.models import HomePage
+
+from wagtail.models import Page
+from wagtail.test.utils import WagtailPageTestCase
+
+
+class HomeSetUpTests(WagtailPageTestCase):
+    """
+    Tests for basic page structure setup and HomePage creation.
+    """
+
+    def test_root_create(self):
+        root_page = Page.objects.get(pk=1)
+        self.assertIsNotNone(root_page)
+
+    def test_homepage_create(self):
+        root_page = Page.objects.get(pk=1)
+        homepage = HomePage(title="Home")
+        root_page.add_child(instance=homepage)
+        self.assertTrue(HomePage.objects.filter(title="Home").exists())
+
+
+class HomeTests(WagtailPageTestCase):
+    """
+    Tests for homepage functionality and rendering.
+    """
+
+    def setUp(self):
+        """
+        Create a homepage instance for testing.
+        """
+        root_page = Page.objects.get(pk=1)
+        self.homepage = HomePage(title="Home")
+        root_page.add_child(instance=self.homepage)
+
+    def test_homepage_status_code(self):
+        response = self.client.get(reverse("home"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_homepage_template_used(self):
+        response = self.client.get(reverse("home"))
+        self.assertTemplateUsed(response, "home/home_page.html")


### PR DESCRIPTION
**#12953 Add Default Tests for Root and Homepage Pages in Wagtail Starter Projects** 
Added tests.py file in wagtail/wagtail/project_template/home/ with given code
Reinstalled wagtail locally through "pip install -e ."
Ran given tests "python manage.py test home" in created project directory.
Updated wagtail/docs/getting_started/tutorial.md