### PR TITLE
Updated keyboard shortcut for comments

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Changelog
  * Add the ability to set the default privacy restriction for new pages using `get_default_privacy_setting` (Shlomo Markowitz)
  * Improve performance of batch purging page urls in the frontend cache, avoiding n+1 query issues (Andy Babic)
  * Add better support and documentation for overriding or extending icons used in the in the userbar (Sébastien Corbin)
+ * List the comments action, if comments are enabled, within the admin keyboard shortcuts dialog (Dhruvi Patel)
  * Fix: Take preferred language into account for translatable strings in client-side code (Bernhard Bliem, Sage Abdullah)
  * Fix: Do not show the content type column as sortable when searching pages (Srishti Jaiswal, Sage Abdullah)
  * Fix: Support simple subqueries for `in` and `exact` lookup on Elasticsearch (Sage Abdullah)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -876,6 +876,7 @@
 * Baptiste Mispelon
 * Mohammad Fathi Rahman
 * Ashish Nagmoti
+* Dhruvi Patel
 
 ## Translators
 

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -26,6 +26,7 @@ This version adds formal support for Django 5.2.
  * Add the ability to set the [default privacy restriction for new pages](set_default_page_privacy) using `get_default_privacy_setting` (Shlomo Markowitz)
  * Improve performance of batch purging page urls in the frontend cache, avoiding n+1 query issues (Andy Babic)
  * Add better support and documentation for overriding or extending [icons used in the in the userbar](custom_icons_userbar) (Sébastien Corbin)
+ * List the comments action, if comments are enabled, within the admin keyboard shortcuts dialog (Dhruvi Patel)
 
 ### Bug fixes
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1381,6 +1381,7 @@ def keyboard_shortcuts_dialog(context):
     Note: Shortcut keys are intentionally not translated.
     """
 
+    comments_enabled = get_comments_enabled()
     user_agent = context["request"].headers.get("User-Agent", "")
     is_mac = re.search(r"Mac|iPod|iPhone|iPad", user_agent)
     KEYS = get_keyboard_key_labels_from_request(context["request"])
@@ -1404,8 +1405,17 @@ def keyboard_shortcuts_dialog(context):
                 ),
             ],
             ("actions-model", _("Actions")): [
-                (_("Save changes"), f"{modifier} + s"),
-                (_("Preview"), f"{modifier} + p"),
+                (_("Save changes"), f"{KEYS.MOD} + s"),
+                (_("Preview"), f"{KEYS.MOD} + p"),
+                (
+                    _("Add or show comments"),
+                    f"{KEYS.CTRL} + {KEYS.ALT} + m",
+                ),
+            ]
+            if comments_enabled
+            else [
+                (_("Save changes"), f"{KEYS.MOD} + s"),
+                (_("Preview"), f"{KEYS.MOD} + p"),
             ],
             ("rich-text-content", _("Text content")): [
                 (_("Insert or edit a link"), f"{KEYS.MOD} + k")

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -37,6 +37,7 @@ from wagtail.admin.staticfiles import versioned_static as versioned_static_func
 from wagtail.admin.ui import sidebar
 from wagtail.admin.utils import (
     get_admin_base_url,
+    get_keyboard_key_labels_from_request,
     get_latest_str,
     get_user_display_name,
     get_valid_next_url_from_request,
@@ -1382,24 +1383,24 @@ def keyboard_shortcuts_dialog(context):
 
     user_agent = context["request"].headers.get("User-Agent", "")
     is_mac = re.search(r"Mac|iPod|iPhone|iPad", user_agent)
-    modifier = "⌘" if is_mac else "Ctrl"
+    KEYS = get_keyboard_key_labels_from_request(context["request"])
 
     return {
         "shortcuts": {
             ("actions-common", _("Common actions")): [
-                (_("Copy"), f"{modifier} + c"),
-                (_("Cut"), f"{modifier} + x"),
-                (_("Paste"), f"{modifier} + v"),
+                (_("Copy"), f"{KEYS.MOD} + c"),
+                (_("Cut"), f"{KEYS.MOD} + x"),
+                (_("Paste"), f"{KEYS.MOD} + v"),
                 (
                     _("Paste and match style")
                     if is_mac
                     else _("Paste without formatting"),
-                    f"{modifier} + Shift + v",
+                    f"{KEYS.MOD} + {KEYS.SHIFT} + v",
                 ),
-                (_("Undo"), f"{modifier} + z"),
+                (_("Undo"), f"{KEYS.MOD} + z"),
                 (
                     _("Redo"),
-                    f"{modifier} + Shift + z" if is_mac else f"{modifier} + y",
+                    f"{KEYS.MOD} + {KEYS.SHIFT} + z" if is_mac else f"{KEYS.MOD} + y",
                 ),
             ],
             ("actions-model", _("Actions")): [
@@ -1407,16 +1408,15 @@ def keyboard_shortcuts_dialog(context):
                 (_("Preview"), f"{modifier} + p"),
             ],
             ("rich-text-content", _("Text content")): [
-                (_("Insert or edit a link"), f"{modifier} + k")
+                (_("Insert or edit a link"), f"{KEYS.MOD} + k")
             ],
             ("rich-text-formatting", _("Text formatting")): [
-                (_("Bold"), f"{modifier} + b"),
-                (_("Italic"), f"{modifier} + i"),
-                (_("Underline"), f"{modifier} + u"),
-                (_("Monospace (code)"), f"{modifier} + j"),
-                (_("Strike-through"), f"{modifier} + x"),
-                (_("Superscript"), f"{modifier} + ."),
-                (_("Subscript"), f"{modifier} + ,"),
+                (_("Italic"), f"{KEYS.MOD} + i"),
+                (_("Underline"), f"{KEYS.MOD} + u"),
+                (_("Monospace (code)"), f"{KEYS.MOD} + j"),
+                (_("Strike-through"), f"{KEYS.MOD} + x"),
+                (_("Superscript"), f"{KEYS.MOD} + ."),
+                (_("Subscript"), f"{KEYS.MOD} + ,"),
             ],
         }
     }

--- a/wagtail/admin/tests/test_keyboard_shortcuts.py
+++ b/wagtail/admin/tests/test_keyboard_shortcuts.py
@@ -109,6 +109,48 @@ class TestKeyboardShortcutsDialog(WagtailTestUtils, TestCase):
         )
         self.assertIn("Keyboard shortcut", shortcuts_dialog.find("thead").prettify())
 
+    @override_settings(WAGTAILADMIN_COMMENTS_ENABLED=True)
+    def test_keyboard_shortcuts_with_comments_enabled(self):
+        """
+        Test the presence of a comments shortcut if Comments enabled
+        """
+        response = self.client.get(reverse("wagtailadmin_home"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(
+            response, "wagtailadmin/shared/keyboard_shortcuts_dialog.html"
+        )
+
+        soup = self.get_soup(response.content)
+
+        shortcuts_dialog = soup.select_one("#keyboard-shortcuts-dialog")
+        all_shortcuts_text = [
+            kbd.string.strip() for kbd in shortcuts_dialog.select("kbd")
+        ]
+
+        self.assertIn("Add or show comments", shortcuts_dialog.prettify())
+        self.assertIn("Ctrl + Alt + m", all_shortcuts_text)
+
+    @override_settings(WAGTAILADMIN_COMMENTS_ENABLED=False)
+    def test_keyboard_shortcuts_with_comments_disabled(self):
+        """
+        Test the absence of a comments shortcut if Comments disabled
+        """
+        response = self.client.get(reverse("wagtailadmin_home"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(
+            response, "wagtailadmin/shared/keyboard_shortcuts_dialog.html"
+        )
+
+        soup = self.get_soup(response.content)
+
+        shortcuts_dialog = soup.select_one("#keyboard-shortcuts-dialog")
+        all_shortcuts_text = [
+            kbd.string.strip() for kbd in shortcuts_dialog.select("kbd")
+        ]
+
+        self.assertNotIn("comments", shortcuts_dialog.prettify())
+        self.assertNotIn("Ctrl + Alt + m", all_shortcuts_text)
+
 
 class TestMacKeyboardShortcutsDialog(WagtailTestUtils, TestCase):
     def setUp(self):
@@ -133,7 +175,46 @@ class TestMacKeyboardShortcutsDialog(WagtailTestUtils, TestCase):
         # Check that the keyboard shortcuts dialog has Mac-specific content
         soup = self.get_soup(response.content)
         shortcuts_dialog = soup.select_one("#keyboard-shortcuts-dialog")
-        all_shortcuts = shortcuts_dialog.select("kbd")
-        for shortcut in all_shortcuts:
-            # All shortcuts should have the ⌘ symbol
-            self.assertIn("⌘", shortcut.prettify())
+        self.assertIn("⌘", shortcuts_dialog.prettify())
+
+    @override_settings(WAGTAILADMIN_COMMENTS_ENABLED=True)
+    def test_keyboard_shortcuts_with_comments_enabled(self):
+        """
+        Test the presence comments shortcut if Comments enabled
+        """
+        response = self.client.get(reverse("wagtailadmin_home"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(
+            response, "wagtailadmin/shared/keyboard_shortcuts_dialog.html"
+        )
+
+        soup = self.get_soup(response.content)
+
+        shortcuts_dialog = soup.select_one("#keyboard-shortcuts-dialog")
+        all_shortcuts_text = [
+            kbd.string.strip() for kbd in shortcuts_dialog.select("kbd")
+        ]
+
+        self.assertIn("Add or show comments", shortcuts_dialog.prettify())
+        self.assertIn("^ + ⌥ + m", all_shortcuts_text)
+
+    @override_settings(WAGTAILADMIN_COMMENTS_ENABLED=False)
+    def test_keyboard_shortcuts_with_comments_disabled(self):
+        """
+        Test the absence comments shortcut if Comments disabled
+        """
+        response = self.client.get(reverse("wagtailadmin_home"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(
+            response, "wagtailadmin/shared/keyboard_shortcuts_dialog.html"
+        )
+
+        soup = self.get_soup(response.content)
+
+        shortcuts_dialog = soup.select_one("#keyboard-shortcuts-dialog")
+        all_shortcuts_text = [
+            kbd.string.strip() for kbd in shortcuts_dialog.select("kbd")
+        ]
+
+        self.assertNotIn("comments", shortcuts_dialog.prettify())
+        self.assertNotIn("^ + ⌥ + m", all_shortcuts_text)

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -1,3 +1,5 @@
+import re
+from types import SimpleNamespace
 from urllib.parse import parse_qs, urlsplit, urlunsplit
 
 from django.conf import settings
@@ -80,3 +82,30 @@ def set_query_params(url: str, params: dict):
     querydict = {key: value for key, value in querydict.items() if value is not None}
     query = urlencode(querydict, doseq=True)
     return urlunsplit((scheme, netloc, path, query, fragment))
+
+
+def get_keyboard_key_labels_from_request(request):
+    """
+    Returns an instance of SimpleNamespace based on the user's keyboard layout
+    based on the User-Agent header in the request.
+
+    These are intentionally not translated, as they are key labels that are assumed
+    to be consistent across all languages.
+    """
+
+    user_agent = request.headers.get("User-Agent", "")
+    is_mac_os = re.search(r"Mac|iPod|iPhone|iPad", user_agent)
+
+    labels = {
+        "ALT": "⌥" if is_mac_os else "Alt",
+        "CMD": "⌘" if is_mac_os else "Ctrl",
+        "CTRL": "^" if is_mac_os else "Ctrl",
+        "DEL": "Delete",
+        "ENTER": "Return" if is_mac_os else "Enter",
+        "ESC": "Esc",
+        "MOD": "⌘" if is_mac_os else "Ctrl",
+        "SHIFT": "Shift",
+        "TAB": "Tab",
+    }
+
+    return SimpleNamespace(**labels)


### PR DESCRIPTION
Updated wagtail keyboard shortcuts for comments with reference to this discussion: https://github.com/wagtail/wagtail/discussions/12050/#discussioncomment-11489664

Here I have resolved the comments for the **Old PR** : [#12679](https://github.com/wagtail/wagtail/pull/12679)

**Shortcuts before changes** 

This is also applicable if comments are not enabled

![comment_not_enabled](https://github.com/user-attachments/assets/5e642876-10cd-4dd1-8b60-199af9351760)

**Shortcuts after changes**

If comments are enabled then actions will be updated.

![comments_enabled](https://github.com/user-attachments/assets/d96128b8-c455-448c-a6e1-f5ceed673b9b)
