### PR TITLE
Filter "all images in listing" by current user permissions

### DIFF
--- a/wagtail/documents/tests/test_bulk_actions/test_bulk_add_to_collection.py
+++ b/wagtail/documents/tests/test_bulk_actions/test_bulk_add_to_collection.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import Group, Permission
 from django.test import TestCase
 from django.urls import reverse
 
@@ -70,6 +70,90 @@ class TestBulkAddDocumentsToCollection(WagtailTestUtils, TestCase):
         )
 
     def test_add_to_collection(self):
+        # Make post request
+        response = self.client.post(self.url, self.post_data)
+
+        # User should be redirected back to the index
+        self.assertEqual(response.status_code, 302)
+
+        # Documents should be moved to new collection
+        for document in self.documents:
+            self.assertEqual(
+                Document.objects.get(id=document.id).collection_id,
+                self.dest_collection.id,
+            )
+
+
+class TestBulkAddAllDocumentsToCollection(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.user = self.login()
+        self.root_collection = Collection.get_first_root_node()
+        self.dest_collection = self.root_collection.add_child(name="Destination")
+        self.documents = [
+            Document.objects.create(title=f"Test document - {i}") for i in range(1, 6)
+        ]
+        self.url = (
+            reverse(
+                "wagtail_bulk_action",
+                args=(
+                    "wagtaildocs",
+                    "document",
+                    "add_to_collection",
+                ),
+            )
+            + "?id=all"
+        )
+        self.post_data = {"collection": str(self.dest_collection.id)}
+
+    def test_add_all_to_collection_with_limited_permissions(self):
+        # Create a group with document permissions on the source collection only
+        self.other_collection = self.root_collection.add_child(name="Other")
+
+        group = Group.objects.create(name="Other Collection Editors")
+        self.other_collection.group_permissions.create(
+            group=group, permission=Permission.objects.get(codename="change_document")
+        )
+
+        self.user.is_superuser = False
+        self.user.groups.add(group)
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            )
+        )
+        self.user.save()
+
+        # The user needs to have access to at least one document in order to access the bulk action page
+        other_document = Document.objects.create(
+            title="Test document - other", collection=self.other_collection
+        )
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+        html = response.content.decode()
+
+        self.assertInHTML(other_document.title, html)
+        for document in self.documents:
+            self.assertNotInHTML(f"<li>{document.title}</li>", html)
+
+        self.client.post(self.url, self.post_data)
+
+        # Documents should not be moved to new collection
+        for document in self.documents:
+            self.assertEqual(
+                Document.objects.get(id=document.id).collection_id,
+                self.root_collection.id,
+            )
+
+    def test_simple(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(
+            response, "wagtaildocs/bulk_actions/confirm_bulk_add_to_collection.html"
+        )
+
+    def test_add_all_to_collection(self):
         # Make post request
         response = self.client.post(self.url, self.post_data)
 

--- a/wagtail/documents/views/bulk_actions/document_bulk_action.py
+++ b/wagtail/documents/views/bulk_actions/document_bulk_action.py
@@ -10,7 +10,9 @@ class DocumentBulkAction(BulkAction):
     models = [get_document_model()]
 
     def get_all_objects_in_listing_query(self, parent_id):
-        listing_objects = self.model.objects.all()
+        listing_objects = self.permission_policy.instances_user_has_permission_for(
+            self.request.user, "change"
+        )
         if parent_id is not None:
             listing_objects = listing_objects.filter(collection_id=parent_id)
 

--- a/wagtail/images/tests/test_bulk_actions/test_bulk_add_to_collection.py
+++ b/wagtail/images/tests/test_bulk_actions/test_bulk_add_to_collection.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import Group, Permission
 from django.test import TestCase
 from django.urls import reverse
 
@@ -71,6 +71,89 @@ class TestBulkAddImagesToCollection(WagtailTestUtils, TestCase):
         )
 
     def test_add_to_collection(self):
+        # Make post request
+        response = self.client.post(self.url, self.post_data)
+
+        # User should be redirected back to the index
+        self.assertEqual(response.status_code, 302)
+
+        # Images should be moved to new collection
+        for image in self.images:
+            self.assertEqual(
+                Image.objects.get(id=image.id).collection_id, self.dest_collection.id
+            )
+
+
+class TestBulkAddAllImagesToCollection(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.user = self.login()
+        self.root_collection = Collection.get_first_root_node()
+        self.dest_collection = self.root_collection.add_child(name="Destination")
+        self.images = [
+            Image.objects.create(title=f"Test image - {i}", file=test_file)
+            for i in range(1, 6)
+        ]
+        self.url = (
+            reverse(
+                "wagtail_bulk_action",
+                args=(
+                    "wagtailimages",
+                    "image",
+                    "add_to_collection",
+                ),
+            )
+            + "?id=all"
+        )
+        self.post_data = {"collection": str(self.dest_collection.id)}
+
+    def test_add_all_to_collection_with_limited_permissions(self):
+        # Create a group with image permissions on the source collection only
+        self.other_collection = self.root_collection.add_child(name="Other")
+
+        group = Group.objects.create(name="Other Collection Editors")
+        self.other_collection.group_permissions.create(
+            group=group, permission=Permission.objects.get(codename="change_image")
+        )
+
+        self.user.is_superuser = False
+        self.user.groups.add(group)
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            )
+        )
+        self.user.save()
+
+        # The user needs to have access to at least one image in order to access the bulk action page
+        other_image = Image.objects.create(
+            title="Test image - other", file=test_file, collection=self.other_collection
+        )
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+        html = response.content.decode()
+
+        self.assertInHTML(other_image.title, html)
+        for image in self.images:
+            self.assertNotInHTML(f"<li>{image.title}</li>", html)
+
+        self.client.post(self.url, self.post_data)
+
+        # Images should not be moved to new collection
+        for image in self.images:
+            self.assertEqual(
+                Image.objects.get(id=image.id).collection_id, self.root_collection.id
+            )
+
+    def test_simple(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(
+            response, "wagtailimages/bulk_actions/confirm_bulk_add_to_collection.html"
+        )
+
+    def test_add_all_to_collection(self):
         # Make post request
         response = self.client.post(self.url, self.post_data)
 

--- a/wagtail/images/views/bulk_actions/image_bulk_action.py
+++ b/wagtail/images/views/bulk_actions/image_bulk_action.py
@@ -8,7 +8,7 @@ class ImageBulkAction(BulkAction):
     models = [get_image_model()]
 
     def get_all_objects_in_listing_query(self, parent_id):
-        listing_objects = images_permission_policy.instances_user_has_permission_for(
+        listing_objects = self.permission_policy.instances_user_has_permission_for(
             self.request.user, "change"
         )
         if parent_id is not None:

--- a/wagtail/images/views/bulk_actions/image_bulk_action.py
+++ b/wagtail/images/views/bulk_actions/image_bulk_action.py
@@ -8,7 +8,9 @@ class ImageBulkAction(BulkAction):
     models = [get_image_model()]
 
     def get_all_objects_in_listing_query(self, parent_id):
-        listing_objects = self.model.objects.all()
+        listing_objects = images_permission_policy.instances_user_has_permission_for(
+            self.request.user, "change"
+        )
         if parent_id is not None:
             listing_objects = listing_objects.filter(collection_id=parent_id)
 


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/12969

- [x] Filter images by current user's permission.
- [x] Add tests.
- [x] Check if documents have the same issue. ~(they don't)~ They do; same fix applied.