### PR TITLE
Avoid deprecation warnings about URLField assume_scheme on Django 5.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,11 +166,6 @@ jobs:
           tee -a testproject/settings/local.py << EOF
           from warnings import filterwarnings
           SILENCED_SYSTEM_CHECKS = ["wagtailadmin.W001"]
-          # Remove when all experimental jobs use Django >= 6.0
-          filterwarnings(
-              "ignore", "The FORMS_URLFIELD_ASSUME_HTTPS transitional setting is deprecated."
-          )
-          FORMS_URLFIELD_ASSUME_HTTPS = True
           # Remove when https://github.com/wagtail/Willow/issues/166 is resolved
           filterwarnings(
               "ignore", "The AVIF support in this library is marked as deprecated"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [bdist_wheel]
-python-tag = py3
+python_tag = py3
 
 [doc8]
 ignore = D001
-ignore-path = _build,docs/_build
+ignore_path = _build,docs/_build
 
 [tool:pytest]
 django_find_project = false

--- a/wagtail/admin/forms/choosers.py
+++ b/wagtail/admin/forms/choosers.py
@@ -5,6 +5,7 @@ from django.core import validators
 from django.forms.widgets import TextInput
 from django.utils.translation import gettext_lazy as _
 
+from wagtail.compat import URLField
 from wagtail.models import Locale
 from wagtail.search.backends import get_search_backend
 
@@ -21,7 +22,7 @@ class URLOrAbsolutePathValidator(validators.URLValidator):
             return super().__call__(value)
 
 
-class URLOrAbsolutePathField(forms.URLField):
+class URLOrAbsolutePathField(URLField):
     widget = TextInput
     default_validators = [URLOrAbsolutePathValidator()]
 

--- a/wagtail/admin/forms/models.py
+++ b/wagtail/admin/forms/models.py
@@ -1,5 +1,6 @@
 import copy
 
+from django import VERSION as DJANGO_VERSION
 from django import forms
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
@@ -89,6 +90,13 @@ register_form_field_override(
     models.SlugField,
     override={"widget": widgets.SlugInput},
 )
+
+# Remove the following block when the minimum Django version is >= 5.0.
+if (5, 0) <= DJANGO_VERSION < (6, 0):
+    register_form_field_override(
+        models.URLField,
+        override={"assume_scheme": "https"},
+    )
 
 
 # Callback to allow us to override the default form fields provided for each model field.

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -4,6 +4,7 @@ from functools import wraps
 from typing import Any, Optional
 from unittest import mock
 
+from django import VERSION as DJANGO_VERSION
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -215,6 +216,22 @@ class TestGetFormForModel(TestCase):
 
         self.assertEqual(type(form.fields["date_from"]), forms.DateField)
         self.assertEqual(type(form.fields["date_from"].widget), forms.PasswordInput)
+
+    def test_urlfield_assume_scheme_override(self):
+        EventPageForm = get_form_for_model(
+            EventPage,
+            form_class=WagtailAdminPageForm,
+            fields=["signup_link"],
+        )
+        form = EventPageForm()
+
+        field = form.fields["signup_link"]
+        self.assertEqual(type(field), forms.URLField)
+
+        # Remove the condition and keep the assertion when the minimum Django
+        # version is >= 5.0.
+        if DJANGO_VERSION >= (5, 0):
+            self.assertEqual(field.assume_scheme, "https")
 
     def test_tag_widget_is_passed_tag_model(self):
         RestaurantPageForm = get_form_for_model(

--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -13,6 +13,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
 from wagtail.admin.staticfiles import versioned_static
+from wagtail.compat import URLField
 from wagtail.coreutils import camelcase_to_underscore, resolve_model_string
 from wagtail.rich_text import (
     RichText,
@@ -318,7 +319,7 @@ class URLBlock(FieldBlock):
         validators=(),
         **kwargs,
     ):
-        self.field = forms.URLField(
+        self.field = URLField(
             required=required,
             help_text=help_text,
             max_length=max_length,

--- a/wagtail/compat.py
+++ b/wagtail/compat.py
@@ -1,3 +1,5 @@
+from django import VERSION as DJANGO_VERSION
+from django import forms
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -27,3 +29,17 @@ except ImportError:
         PUT = "PUT"
         DELETE = "DELETE"
         PATCH = "PATCH"
+
+
+URLField = forms.URLField
+
+# Prevent deprecation warning about the default scheme changing from "http" to
+# "https" in Django 5.0, while also avoiding the need to set the
+# FORMS_URLFIELD_ASSUME_HTTPS that would raise a different deprecation warning.
+# Remove the following block when the minimum Django version is >= 5.0.
+if (5, 0) <= DJANGO_VERSION < (6, 0):
+
+    class URLField(forms.URLField):
+        def __init__(self, *args, **kwargs):
+            kwargs.setdefault("assume_scheme", "https")
+            super().__init__(*args, **kwargs)

--- a/wagtail/contrib/forms/forms.py
+++ b/wagtail/contrib/forms/forms.py
@@ -6,6 +6,7 @@ from django.utils.html import conditional_escape
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.forms import WagtailAdminPageForm
+from wagtail.compat import URLField
 
 
 class BaseForm(django.forms.Form):
@@ -40,7 +41,7 @@ class FormBuilder:
         return django.forms.EmailField(**options)
 
     def create_url_field(self, field, options):
-        return django.forms.URLField(**options)
+        return URLField(**options)
 
     def create_number_field(self, field, options):
         return django.forms.DecimalField(**options)

--- a/wagtail/contrib/redirects/forms.py
+++ b/wagtail/contrib/redirects/forms.py
@@ -2,12 +2,13 @@ from django import forms
 from django.core.signing import BadSignature, Signer
 from django.utils.translation import gettext_lazy as _
 
+from wagtail.admin.forms.models import WagtailAdminModelForm
 from wagtail.admin.widgets import AdminPageChooser
 from wagtail.contrib.redirects.models import Redirect
 from wagtail.models import Site
 
 
-class RedirectForm(forms.ModelForm):
+class RedirectForm(WagtailAdminModelForm):
     site = forms.ModelChoiceField(
         label=_("From site"),
         queryset=Site.objects.all(),
@@ -45,7 +46,7 @@ class RedirectForm(forms.ModelForm):
                     _("A redirect with this path already exists.")
                 )
 
-    class Meta:
+    class Meta(WagtailAdminModelForm.Meta):
         model = Redirect
         fields = ("old_path", "site", "is_permanent", "redirect_page", "redirect_link")
 

--- a/wagtail/contrib/search_promotions/forms.py
+++ b/wagtail/contrib/search_promotions/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.forms.models import inlineformset_factory
 from django.utils.translation import gettext_lazy as _
 
+from wagtail.admin.forms.models import WagtailAdminModelForm
 from wagtail.admin.widgets import AdminPageChooser
 from wagtail.contrib.search_promotions.models import Query, SearchPromotion
 
@@ -29,7 +30,7 @@ class QueryForm(forms.ModelForm):
         fields = ["query_string"]
 
 
-class SearchPromotionForm(forms.ModelForm):
+class SearchPromotionForm(WagtailAdminModelForm):
     sort_order = forms.IntegerField(required=False)
 
     def __init__(self, *args, **kwargs):
@@ -79,7 +80,7 @@ class SearchPromotionForm(forms.ModelForm):
 
         return cleaned_data
 
-    class Meta:
+    class Meta(WagtailAdminModelForm.Meta):
         model = SearchPromotion
         fields = (
             "query",

--- a/wagtail/contrib/styleguide/views.py
+++ b/wagtail/contrib/styleguide/views.py
@@ -23,6 +23,7 @@ from wagtail.admin.widgets import (
     AdminTimeInput,
     SwitchInput,
 )
+from wagtail.compat import URLField
 from wagtail.documents.widgets import AdminDocumentChooser
 from wagtail.images.widgets import AdminImageChooser
 from wagtail.models import Page
@@ -72,7 +73,7 @@ class ExampleForm(forms.Form):
     text = forms.CharField(required=True, help_text="help text")
     auto_height_text = forms.CharField(required=True)
     default_rich_text = forms.CharField(required=True)
-    url = forms.URLField(required=True)
+    url = URLField(required=True)
     email = forms.EmailField(max_length=254)
     date = forms.DateField()
     time = forms.TimeField()


### PR DESCRIPTION
Fixes #12701, built on top of #12978.

I haven't verified if this completely removes the warnings – there might be some left if there are auto-generated form fields from `models.URLField`. I'll double check after this. 

Not sure if we can write tests for _not_ raising a warning 🤔 