### PR TITLE
Make GitHub highlight html files as Django templates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Make GitHub highlight html files as Django templates
+*.html linguist-language=django

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ Changelog
  * Maintenance: Cleanup Stimulus controller imports, JSDoc & linting (LB (Ben) Johnston)
  * Maintenance: Rename `SkipLinkController` to `FocusController` with improved reusability, updated unit tests, and added story (LB (Ben) Johnston)
  * Maintenance: Fix CI testing issues with the Stimulus `LocaleController` time zones & non-deterministic page ordering tests (Sage Abdullah)
+ * Maintenance: Make GitHub highlight `.html` files as Django templates (Jake Howard)
 
 
 6.4.1 (21.02.2025)

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -52,6 +52,7 @@ depth: 1
  * Cleanup Stimulus controller imports, JSDoc & linting (LB (Ben) Johnston)
  * Rename `SkipLinkController` to `FocusController` with improved reusability, updated unit tests, and added story (LB (Ben) Johnston)
  * Fix CI testing issues with the Stimulus `LocaleController` time zones & non-deterministic page ordering tests (Sage Abdullah)
+ * Make GitHub highlight `.html` files as Django templates (Jake Howard)
 
 ## Upgrade considerations - changes affecting all projects
 


### PR DESCRIPTION
Shamelessly stolen from https://github.com/django/django/pull/19279
