### PR TITLE
Ensure ImproperlyConfigured is thrown from db_field on unbound FieldPanels as intended

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Fix: Ensure `InlinePanel` will be correctly ordered after the first save when `min_num` is used (Elhussein Almasri, Joel William)
  * Fix: Avoid deprecation warnings about URLField `assume_scheme` on Django 5.x (Sage Abdullah)
  * Fix: Fix setup.cfg syntax for setuptools v78 (Sage Abdullah)
+ * Fix: Ensure `ImproperlyConfigured` is thrown from `db_field` on unbound `FieldPanel`s as intended (Matt Westcott)
  * Docs: Add missing `django.contrib.admin` to list of apps in "add to Django project" guide (Mohamed Rabiaa)
  * Docs: Add tutorial on deploying on Ubuntu to third-party tutorials (Mohammad Fathi Rahman)
  * Docs: Document that request_or_site is optional on BaseGenericSetting.load (Matt Westcott)

--- a/docs/releases/6.5.md
+++ b/docs/releases/6.5.md
@@ -34,6 +34,7 @@ depth: 1
  * Ensure `InlinePanel` will be correctly ordered after the first save when `min_num` is used (Elhussein Almasri, Joel William)
  * Avoid deprecation warnings about URLField `assume_scheme` on Django 5.x (Sage Abdullah)
  * Fix setup.cfg syntax for setuptools v78 (Sage Abdullah)
+ * Ensure `ImproperlyConfigured` is thrown from `db_field` on unbound `FieldPanel`s as intended (Matt Westcott)
 
 ### Documentation
 

--- a/wagtail/admin/panels/field_panel.py
+++ b/wagtail/admin/panels/field_panel.py
@@ -108,14 +108,12 @@ class FieldPanel(Panel):
 
     @cached_property
     def db_field(self):
-        try:
-            model = self.model
-        except AttributeError:
+        if self.model is None:
             raise ImproperlyConfigured(
                 "%r must be bound to a model before calling db_field" % self
             )
 
-        return model._meta.get_field(self.field_name)
+        return self.model._meta.get_field(self.field_name)
 
     @property
     def clean_name(self):

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -886,6 +886,12 @@ class TestFieldPanel(TestCase):
             instance=self.event,
         )
 
+    def test_accessing_db_field_before_bind(self):
+        field_panel = FieldPanel("barbecue")
+
+        with self.assertRaises(ImproperlyConfigured):
+            field_panel.db_field
+
     def test_non_model_field(self):
         # defining a FieldPanel for a field which isn't part of a model is OK,
         # because it might be defined on the form instead


### PR DESCRIPTION
Encountered while investigating [regression in wagtail-localize tests](https://github.com/wagtail/wagtail-localize/actions/runs/14027070555/job/39267538142) following 96f9ebe3f6846099641e4b2d49e3e8f9f34aea59.

Since the refactor of the base panel class in b599fce714913e80a9e0dccb9eda402af8438c63, self.model is always defined (initially as None) so the ImproperlyConfigured exception would never be thrown.