### PR TITLE
Universal listings: Add registry for active django-filter adapters

### DIFF
--- a/wagtail/admin/active_filters.py
+++ b/wagtail/admin/active_filters.py
@@ -1,0 +1,6 @@
+from collections import namedtuple
+
+# Represents a django-filter filter that is currently in force on a listing queryset
+ActiveFilter = namedtuple(
+    "ActiveFilter", ["auto_id", "field_label", "value", "removed_filter_url"]
+)

--- a/wagtail/admin/active_filters.py
+++ b/wagtail/admin/active_filters.py
@@ -5,6 +5,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.forms import BoundField, ModelChoiceField
 from django.http import QueryDict
 from django.utils.formats import date_format
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 from wagtail.utils.registry import ObjectTypeRegistry
 from wagtail.utils.utils import flatten_choices
@@ -124,8 +126,12 @@ class ModelMultipleChoiceFilterAdapter(BaseFilterAdapter):
 
 
 class RangeFilterAdapter(BaseFilterAdapter):
+    # Translators: A placeholder for a range filter value that has not been set,
+    # e.g. Some number: any - 1000
+    empty_value_label = gettext_lazy("any")
+
     def format_value(self, value):
-        return str(value) if value is not None else ""
+        return str(value) if value is not None else self.empty_value_label
 
     def get_active_filters(self):
         start_value_display = self.format_value(self.value.start)
@@ -135,7 +141,13 @@ class RangeFilterAdapter(BaseFilterAdapter):
             ActiveFilter(
                 self.bound_field.auto_id,
                 self.filter.label,
-                f"{start_value_display} - {end_value_display}",
+                # Translators: A label for a range filter value,
+                # e.g. Some number: 0 - 1000
+                _("%(range_start)s - %(range_end)s")
+                % {
+                    "range_start": start_value_display,
+                    "range_end": end_value_display,
+                },
                 self.get_url_without_filter_param(
                     [widget.suffixed(self.name, suffix) for suffix in widget.suffixes]
                 ),
@@ -145,7 +157,7 @@ class RangeFilterAdapter(BaseFilterAdapter):
 
 class DateFromToRangeFilterAdapter(RangeFilterAdapter):
     def format_value(self, value):
-        return date_format(value) if value is not None else ""
+        return date_format(value) if value is not None else self.empty_value_label
 
 
 filter_adapter_class_registry = ObjectTypeRegistry()

--- a/wagtail/admin/active_filters.py
+++ b/wagtail/admin/active_filters.py
@@ -1,6 +1,196 @@
 from collections import namedtuple
 
+import django_filters
+from django.core.exceptions import ImproperlyConfigured
+from django.forms import BoundField, ModelChoiceField
+from django.http import QueryDict
+from django.utils.formats import date_format
+
+from wagtail.utils.registry import ObjectTypeRegistry
+from wagtail.utils.utils import flatten_choices
+
 # Represents a django-filter filter that is currently in force on a listing queryset
 ActiveFilter = namedtuple(
     "ActiveFilter", ["auto_id", "field_label", "value", "removed_filter_url"]
+)
+
+
+class BaseFilterAdapter:
+    def __init__(
+        self,
+        filter: django_filters.Filter,
+        bound_field: BoundField,
+        value,
+        base_url: str,
+        query_dict: QueryDict,
+    ):
+        self.filter = filter
+        self.bound_field = bound_field
+        self.value = value
+        self.base_url = base_url
+        self.query_dict = query_dict
+
+    def get_url_without_filter_param(self, param):
+        """
+        Return the base URL with the given filter parameter removed from the
+        query string.
+        """
+        query_dict = self.query_dict.copy()
+        if isinstance(param, (list, tuple)):
+            for p in param:
+                query_dict.pop(p, None)
+        else:
+            query_dict.pop(param, None)
+        return self.base_url + "?" + query_dict.urlencode()
+
+    def get_url_without_filter_param_value(self, param, value):
+        """
+        Return the index URL where the filter parameter with the given value has
+        been removed from the query string, preserving all other values for that
+        parameter.
+        """
+        query_dict = self.query_dict.copy()
+        query_dict.setlist(
+            param, [v for v in query_dict.getlist(param) if v != str(value)]
+        )
+        return self.base_url + "?" + query_dict.urlencode()
+
+    def get_active_filters(self):
+        """
+        Return a list of `ActiveFilter` objects representing the filter values
+        that are currently in force on the listing queryset.
+        """
+        yield ActiveFilter(
+            self.bound_field.auto_id,
+            self.filter.label,
+            str(self.value),
+            self.get_url_without_filter_param(self.bound_field.name),
+        )
+
+
+class ChoiceFilterAdapter(BaseFilterAdapter):
+    def get_active_filters(self):
+        choices = flatten_choices(self.filter.field.choices)
+        yield (
+            ActiveFilter(
+                self.bound_field.auto_id,
+                self.filter.label,
+                choices.get(str(self.value), str(self.value)),
+                self.get_url_without_filter_param(self.bound_field.name),
+            )
+        )
+
+
+class MultipleChoiceFilterAdapter(BaseFilterAdapter):
+    def get_active_filters(self):
+        choices = flatten_choices(self.filter.field.choices)
+        yield from (
+            ActiveFilter(
+                self.bound_field.auto_id,
+                self.filter.label,
+                choices.get(str(item), str(item)),
+                self.get_url_without_filter_param_value(self.bound_field.name, item),
+            )
+            for item in self.value
+        )
+
+
+class ModelChoiceFilterAdapter(BaseFilterAdapter):
+    def get_active_filters(self):
+        field: ModelChoiceField = self.filter.field
+        yield (
+            ActiveFilter(
+                self.bound_field.auto_id,
+                self.filter.label,
+                field.label_from_instance(self.value),
+                self.get_url_without_filter_param(self.bound_field.name),
+            )
+        )
+
+
+class ModelMultipleChoiceFilterAdapter(BaseFilterAdapter):
+    def get_active_filters(self):
+        field: ModelChoiceField = self.filter.field
+        yield from (
+            ActiveFilter(
+                self.bound_field.auto_id,
+                self.filter.label,
+                field.label_from_instance(item),
+                self.get_url_without_filter_param_value(self.bound_field.name, item.pk),
+            )
+            for item in self.value
+        )
+
+
+class DateFromToRangeFilterAdapter(BaseFilterAdapter):
+    def get_active_filters(self):
+        start_date_display = date_format(self.value.start) if self.value.start else ""
+        end_date_display = date_format(self.value.stop) if self.value.stop else ""
+        widget = self.filter.field.widget
+        yield (
+            ActiveFilter(
+                self.bound_field.auto_id,
+                self.filter.label,
+                f"{start_date_display} - {end_date_display}",
+                self.get_url_without_filter_param(
+                    [
+                        widget.suffixed(self.bound_field.name, suffix)
+                        for suffix in widget.suffixes
+                    ]
+                ),
+            )
+        )
+
+
+filter_adapter_class_registry = ObjectTypeRegistry()
+
+
+def register_filter_adapter_class(
+    filter_class: django_filters.Filter,
+    adapter_class: BaseFilterAdapter = None,
+    exact_class: BaseFilterAdapter = False,
+):
+    """
+    Define how a django-filter Filter should be displayed when it's active.
+    The ``adapter_class`` should be a subclass of
+    ``wagtail.admin.active_filters.BaseFilterAdapter``.
+
+    This is mainly useful for defining how active filters are rendered in
+    listing views.
+    """
+    if adapter_class is None:
+        raise ImproperlyConfigured(
+            "register_filter_adapter_class must be passed a 'adapter_class' keyword argument"
+        )
+
+    filter_adapter_class_registry.register(
+        filter_class,
+        value=adapter_class,
+        exact_class=exact_class,
+    )
+
+
+register_filter_adapter_class(
+    django_filters.Filter,
+    BaseFilterAdapter,
+)
+register_filter_adapter_class(
+    django_filters.ChoiceFilter,
+    ChoiceFilterAdapter,
+)
+register_filter_adapter_class(
+    django_filters.MultipleChoiceFilter,
+    MultipleChoiceFilterAdapter,
+)
+register_filter_adapter_class(
+    django_filters.ModelChoiceFilter,
+    ModelChoiceFilterAdapter,
+)
+register_filter_adapter_class(
+    django_filters.ModelMultipleChoiceFilter,
+    ModelMultipleChoiceFilterAdapter,
+)
+register_filter_adapter_class(
+    django_filters.DateFromToRangeFilter,
+    DateFromToRangeFilterAdapter,
 )

--- a/wagtail/admin/active_filters.py
+++ b/wagtail/admin/active_filters.py
@@ -26,6 +26,7 @@ class BaseFilterAdapter:
     ):
         self.filter = filter
         self.bound_field = bound_field
+        self.name = bound_field.name
         self.value = value
         self.base_url = base_url
         self.query_dict = query_dict
@@ -64,7 +65,7 @@ class BaseFilterAdapter:
             self.bound_field.auto_id,
             self.filter.label,
             str(self.value),
-            self.get_url_without_filter_param(self.bound_field.name),
+            self.get_url_without_filter_param(self.name),
         )
 
 
@@ -76,7 +77,7 @@ class ChoiceFilterAdapter(BaseFilterAdapter):
                 self.bound_field.auto_id,
                 self.filter.label,
                 choices.get(str(self.value), str(self.value)),
-                self.get_url_without_filter_param(self.bound_field.name),
+                self.get_url_without_filter_param(self.name),
             )
         )
 
@@ -89,7 +90,7 @@ class MultipleChoiceFilterAdapter(BaseFilterAdapter):
                 self.bound_field.auto_id,
                 self.filter.label,
                 choices.get(str(item), str(item)),
-                self.get_url_without_filter_param_value(self.bound_field.name, item),
+                self.get_url_without_filter_param_value(self.name, item),
             )
             for item in self.value
         )
@@ -103,7 +104,7 @@ class ModelChoiceFilterAdapter(BaseFilterAdapter):
                 self.bound_field.auto_id,
                 self.filter.label,
                 field.label_from_instance(self.value),
-                self.get_url_without_filter_param(self.bound_field.name),
+                self.get_url_without_filter_param(self.name),
             )
         )
 
@@ -116,7 +117,7 @@ class ModelMultipleChoiceFilterAdapter(BaseFilterAdapter):
                 self.bound_field.auto_id,
                 self.filter.label,
                 field.label_from_instance(item),
-                self.get_url_without_filter_param_value(self.bound_field.name, item.pk),
+                self.get_url_without_filter_param_value(self.name, item.pk),
             )
             for item in self.value
         )
@@ -136,10 +137,7 @@ class RangeFilterAdapter(BaseFilterAdapter):
                 self.filter.label,
                 f"{start_value_display} - {end_value_display}",
                 self.get_url_without_filter_param(
-                    [
-                        widget.suffixed(self.bound_field.name, suffix)
-                        for suffix in widget.suffixes
-                    ]
+                    [widget.suffixed(self.name, suffix) for suffix in widget.suffixes]
                 ),
             )
         )

--- a/wagtail/admin/active_filters.py
+++ b/wagtail/admin/active_filters.py
@@ -122,16 +122,19 @@ class ModelMultipleChoiceFilterAdapter(BaseFilterAdapter):
         )
 
 
-class DateFromToRangeFilterAdapter(BaseFilterAdapter):
+class RangeFilterAdapter(BaseFilterAdapter):
+    def format_value(self, value):
+        return str(value) if value is not None else ""
+
     def get_active_filters(self):
-        start_date_display = date_format(self.value.start) if self.value.start else ""
-        end_date_display = date_format(self.value.stop) if self.value.stop else ""
+        start_value_display = self.format_value(self.value.start)
+        end_value_display = self.format_value(self.value.stop)
         widget = self.filter.field.widget
         yield (
             ActiveFilter(
                 self.bound_field.auto_id,
                 self.filter.label,
-                f"{start_date_display} - {end_date_display}",
+                f"{start_value_display} - {end_value_display}",
                 self.get_url_without_filter_param(
                     [
                         widget.suffixed(self.bound_field.name, suffix)
@@ -140,6 +143,11 @@ class DateFromToRangeFilterAdapter(BaseFilterAdapter):
                 ),
             )
         )
+
+
+class DateFromToRangeFilterAdapter(RangeFilterAdapter):
+    def format_value(self, value):
+        return date_format(value) if value is not None else ""
 
 
 filter_adapter_class_registry = ObjectTypeRegistry()
@@ -189,6 +197,10 @@ register_filter_adapter_class(
 register_filter_adapter_class(
     django_filters.ModelMultipleChoiceFilter,
     ModelMultipleChoiceFilterAdapter,
+)
+register_filter_adapter_class(
+    django_filters.RangeFilter,
+    RangeFilterAdapter,
 )
 register_filter_adapter_class(
     django_filters.DateFromToRangeFilter,

--- a/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/active_filters.html
@@ -3,7 +3,14 @@
     {% for filter in active_filters %}
         <li class="w-pill">
             <button class="w-pill__content" data-controller="w-action" data-w-active-filter-id="{{ filter.auto_id }}" aria-controls="drilldown-{{ filter.auto_id }}">
-                <span class="w-text-14">{{ filter.field_label }}:</span>
+                <span class="w-text-14">
+                    {% comment %}
+                    Translators: A label for an active filtering field in listing views, e.g. "Date updated:". Some languages may require a space before the colon.
+                    {% endcomment %}
+                    {% blocktranslate trimmed with field_label=filter.field_label %}
+                        {{ field_label }}:
+                    {% endblocktranslate %}
+                </span>
                 <b class="w-ml-1">{{ filter.value }}</b>
             </button>
             <button

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -718,7 +718,7 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertEqual(page_ids, {self.new_page.id, new_page_child.id})
         self.assertContainsActiveFilter(
             response,
-            "Date updated: Jan. 1, 2015 -",
+            "Date updated: Jan. 1, 2015 - any",
             "latest_revision_created_at_from=2015-01-01",
         )
 

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -6,22 +6,14 @@ from django.db import models
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
-from django.utils.formats import date_format
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic.base import ContextMixin, TemplateResponseMixin
 from django.views.generic.list import BaseListView
-from django_filters.filters import (
-    ChoiceFilter,
-    DateFromToRangeFilter,
-    ModelChoiceFilter,
-    ModelMultipleChoiceFilter,
-    MultipleChoiceFilter,
-)
 
 from wagtail.admin import messages
-from wagtail.admin.filters import ActiveFilter
+from wagtail.admin.active_filters import filter_adapter_class_registry
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.paginator import WagtailPaginator
 from wagtail.admin.ui.tables import Column, Table
@@ -29,7 +21,6 @@ from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.admin.widgets.button import ButtonWithDropdown
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
-from wagtail.utils.utils import flatten_choices
 
 
 class WagtailAdminTemplateMixin(TemplateResponseMixin, ContextMixin):
@@ -313,41 +304,17 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
             queryset = self.filters.filter_queryset(queryset)
         return queryset
 
-    def get_url_without_filter_param(self, param):
-        """
-        Return the index URL with the given filter parameter removed from the query string
-        """
-        base_url = self.index_results_url.split("?")[0]
-        query_dict = self.request.GET.copy()
-        query_dict.pop(self.page_kwarg, None)  # reset pagination to first page
-        if isinstance(param, (list, tuple)):
-            for p in param:
-                query_dict.pop(p, None)
-        else:
-            query_dict.pop(param, None)
-        query_dict["_w_filter_fragment"] = 1
-        return base_url + "?" + query_dict.urlencode()
-
-    def get_url_without_filter_param_value(self, param, value):
-        """
-        Return the index URL where the filter parameter with the given value has been removed
-        from the query string, preserving all other values for that parameter
-        """
-        base_url = self.index_results_url.split("?")[0]
-        query_dict = self.request.GET.copy()
-        query_dict.pop(self.page_kwarg, None)  # reset pagination to first page
-        query_dict.setlist(
-            param, [v for v in query_dict.getlist(param) if v != str(value)]
-        )
-        query_dict["_w_filter_fragment"] = 1
-        return base_url + "?" + query_dict.urlencode()
-
     @cached_property
     def active_filters(self):
         filters = []
 
         if not self.filters:
             return filters
+
+        base_url = self.index_results_url.split("?")[0]
+        query_dict = self.request.GET.copy()
+        query_dict.pop(self.page_kwarg, None)  # reset pagination to first page
+        query_dict["_w_filter_fragment"] = 1
 
         for field_name in self.filters.form.changed_data:
             filter_def = self.filters.filters[field_name]
@@ -360,76 +327,11 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
             if value == bound_field.initial:
                 continue  # filter value is the same as the default
 
-            if isinstance(filter_def, ModelMultipleChoiceFilter):
-                field = filter_def.field
-                for item in value:
-                    filters.append(
-                        ActiveFilter(
-                            bound_field.auto_id,
-                            filter_def.label,
-                            field.label_from_instance(item),
-                            self.get_url_without_filter_param_value(
-                                field_name, item.pk
-                            ),
-                        )
-                    )
-            elif isinstance(filter_def, MultipleChoiceFilter):
-                choices = flatten_choices(filter_def.field.choices)
-                for item in value:
-                    filters.append(
-                        ActiveFilter(
-                            bound_field.auto_id,
-                            filter_def.label,
-                            choices.get(str(item), str(item)),
-                            self.get_url_without_filter_param_value(field_name, item),
-                        )
-                    )
-            elif isinstance(filter_def, ModelChoiceFilter):
-                field = filter_def.field
-                filters.append(
-                    ActiveFilter(
-                        bound_field.auto_id,
-                        filter_def.label,
-                        field.label_from_instance(value),
-                        self.get_url_without_filter_param(field_name),
-                    )
-                )
-            elif isinstance(filter_def, DateFromToRangeFilter):
-                start_date_display = date_format(value.start) if value.start else ""
-                end_date_display = date_format(value.stop) if value.stop else ""
-                widget = filter_def.field.widget
-                filters.append(
-                    ActiveFilter(
-                        bound_field.auto_id,
-                        filter_def.label,
-                        f"{start_date_display} - {end_date_display}",
-                        self.get_url_without_filter_param(
-                            [
-                                widget.suffixed(field_name, suffix)
-                                for suffix in widget.suffixes
-                            ]
-                        ),
-                    )
-                )
-            elif isinstance(filter_def, ChoiceFilter):
-                choices = flatten_choices(filter_def.field.choices)
-                filters.append(
-                    ActiveFilter(
-                        bound_field.auto_id,
-                        filter_def.label,
-                        choices.get(str(value), str(value)),
-                        self.get_url_without_filter_param(field_name),
-                    )
-                )
-            else:
-                filters.append(
-                    ActiveFilter(
-                        bound_field.auto_id,
-                        filter_def.label,
-                        str(value),
-                        self.get_url_without_filter_param(field_name),
-                    )
-                )
+            filter_adapter_class = filter_adapter_class_registry.get(filter_def)
+            filter_adapter = filter_adapter_class(
+                filter_def, bound_field, value, base_url, query_dict
+            )
+            filters.extend(filter_adapter.get_active_filters())
 
         return filters
 

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -1,5 +1,4 @@
 import warnings
-from collections import namedtuple
 
 from django.contrib.admin.utils import quote, unquote
 from django.core.exceptions import ImproperlyConfigured
@@ -22,6 +21,7 @@ from django_filters.filters import (
 )
 
 from wagtail.admin import messages
+from wagtail.admin.filters import ActiveFilter
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.paginator import WagtailPaginator
 from wagtail.admin.ui.tables import Column, Table
@@ -190,12 +190,6 @@ class BaseOperationView(BaseObjectMixin, View):
         self.perform_operation()
         self.add_success_message()
         return redirect(self.get_success_url())
-
-
-# Represents a django-filters filter that is currently in force on a listing queryset
-ActiveFilter = namedtuple(
-    "ActiveFilter", ["auto_id", "field_label", "value", "removed_filter_url"]
-)
 
 
 class BaseListingView(WagtailAdminTemplateMixin, BaseListView):

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "wagtail",
     "modelcluster",
     "taggit",
+    "django_filters",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -170,6 +170,7 @@ INSTALLED_APPS = [
     "wagtail",
     "taggit",
     "rest_framework",
+    "django_filters",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -1,5 +1,6 @@
 import os
 
+import django_filters
 from django import forms
 from django.http import HttpResponse
 from django.utils.safestring import mark_safe
@@ -262,6 +263,11 @@ def register_toy_viewset():
 
 
 class FullFeaturedSnippetFilterSet(WagtailFilterSet):
+    some_number = django_filters.RangeFilter(
+        field_name="some_number",
+        label="Number range",
+    )
+
     class Meta:
         model = FullFeaturedSnippet
         fields = ["country_code", "some_date"]


### PR DESCRIPTION
Fixes #11686 and fixes #12800.

To test, use the following diff on bakerydemo:

```diff
diff --git a/bakerydemo/base/wagtail_hooks.py b/bakerydemo/base/wagtail_hooks.py
index b33ee8a..8d9dae7 100644
--- a/bakerydemo/base/wagtail_hooks.py
+++ b/bakerydemo/base/wagtail_hooks.py
@@ -1,3 +1,4 @@
+import django_filters
 from wagtail import hooks
 from wagtail.admin.filters import WagtailFilterSet
 from wagtail.admin.userbar import AccessibilityItem
@@ -45,6 +46,8 @@ def replace_userbar_accessibility_item(request, items):


 class PersonFilterSet(RevisionFilterSetMixin, WagtailFilterSet):
+    id = django_filters.RangeFilter(field_name="pk", label="ID range")
+
     class Meta:
         model = Person
         fields = {
diff --git a/bakerydemo/settings/base.py b/bakerydemo/settings/base.py
index 38d0803..00f21c8 100644
--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -67,6 +67,7 @@ INSTALLED_APPS = [
     "modelcluster",
     "taggit",
     "wagtailfontawesomesvg",
+    "django_filters",
     # Uncomment to enable django-debug-toolbar
     # "debug_toolbar",
     "django_extensions",
```

and use the newly added filter on the People listing

### Before

<img width="464" alt="image" src="https://github.com/user-attachments/assets/0cf72b88-8982-4b97-8437-38b28d870d6d" />

### After

<img width="461" alt="image" src="https://github.com/user-attachments/assets/bebbe42a-563f-4e2b-a85d-6025706f2018" />


