### PR TITLE
Define default `GenericRelation`s for `RevisionMixin` and `WorkflowMixin`

### DIFF
--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -796,6 +796,8 @@ This mixin requires {class}`~wagtail.models.RevisionMixin` and {class}`~wagtail.
 
     .. automethod:: get_workflow
 
+    .. autoattribute:: _workflow_states
+
     .. autoattribute:: workflow_states
 
     .. autoattribute:: workflow_in_progress

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -673,6 +673,8 @@ Pages already include this mixin, so there is no need to add it.
 .. class:: RevisionMixin
     :no-index:
 
+    .. autoattribute:: _revisions
+
     .. autoattribute:: revisions
 
     .. automethod:: save_revision

--- a/docs/topics/snippets/features.md
+++ b/docs/topics/snippets/features.md
@@ -295,7 +295,15 @@ If a snippet model inherits from {class}`~wagtail.models.WorkflowMixin`, Wagtail
 
 Since the `WorkflowMixin` utilizes revisions and publishing mechanisms in Wagtail, inheriting from this mixin also requires inheriting from `RevisionMixin` and `DraftStateMixin`. It is also recommended to enable locking by inheriting from `LockableMixin`, so that the snippet instance can be locked and only editable by reviewers when it is in a workflow. See the above sections for more details.
 
-In addition to inheriting the mixins, it is highly recommended to define a {class}`~django.contrib.contenttypes.fields.GenericRelation` to the {class}`~wagtail.models.WorkflowState` model so that you can do related queries and that the workflow-related data is properly cleaned up when the snippet instance is deleted.
+The mixin defines a `workflow_states` property that gives you a queryset of all workflow states for the snippet instance. It also comes with a default {class}`~django.contrib.contenttypes.fields.GenericRelation` to the {class}`~wagtail.models.WorkflowState` model so that the workflow states are properly cleaned up when the snippet instance is deleted.
+
+The default `GenericRelation` does not have a {attr}`~django.contrib.contenttypes.fields.GenericRelation.related_query_name`, so it does not give you the ability to query and filter from the `WorkflowState` model back to the snippet model. If you would like this feature, you can define your own `GenericRelation` with a custom `related_query_name`.
+
+For more details, see the default `GenericRelation` {attr}`~wagtail.models.WorkflowMixin._workflow_states` and the property {attr}`~wagtail.models.WorkflowMixin.workflow_states`.
+
+```{versionadded} 6.5
+The default `GenericRelation` {attr}`~wagtail.models.WorkflowMixin._workflow_states` was added.
+```
 
 For example, workflows (with locking) can be enabled for the `Advert` snippet by defining it as follows:
 

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -342,7 +342,13 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         verbose_name=_("latest revision created at"), null=True, editable=False
     )
 
-    _revisions = GenericRelation("wagtailcore.Revision", related_query_name="page")
+    _revisions = GenericRelation(
+        "wagtailcore.Revision",
+        content_type_field="content_type",
+        object_id_field="object_id",
+        related_query_name="page",
+        for_concrete_model=False,
+    )
 
     # Add GenericRelation to allow WorkflowState.objects.filter(page=...) queries.
     # There is no need to override the workflow_states property, as the default

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -350,7 +350,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         for_concrete_model=False,
     )
 
-    # Add GenericRelation to allow WorkflowState.objects.filter(page=...) queries.
+    # Override WorkflowMixin's GenericRelation to specify related_query_name
+    # so we can do WorkflowState.objects.filter(page=...) queries.
     # There is no need to override the workflow_states property, as the default
     # implementation in WorkflowMixin already ensures that the queryset uses the
     # base Page content type.

--- a/wagtail/models/revisions.py
+++ b/wagtail/models/revisions.py
@@ -293,10 +293,7 @@ class RevisionMixin(models.Model):
         ``related_query_name`` of the ``GenericRelation`` and add custom logic
         (e.g. to always use the specific instance in ``Page``).
         """
-        return Revision.objects.filter(
-            content_type=self.get_content_type(),
-            object_id=self.pk,
-        )
+        return Revision.objects.for_instance(self)
 
     def get_base_content_type(self):
         parents = self._meta.get_parent_list()

--- a/wagtail/models/workflows.py
+++ b/wagtail/models/workflows.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import Group
-from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core import checks
 from django.core.exceptions import PermissionDenied, ValidationError
@@ -1155,8 +1155,18 @@ class TaskState(SpecificMixin, models.Model):
         verbose_name_plural = _("Task states")
 
 
-class WorkflowMixin:
+class WorkflowMixin(models.Model):
     """A mixin that allows a model to have workflows."""
+
+    _workflow_states = GenericRelation(
+        "wagtailcore.WorkflowState",
+        content_type_field="base_content_type",
+        object_id_field="object_id",
+        for_concrete_model=False,
+    )
+
+    class Meta:
+        abstract = True
 
     @classmethod
     def check(cls, **kwargs):

--- a/wagtail/models/workflows.py
+++ b/wagtail/models/workflows.py
@@ -1164,6 +1164,22 @@ class WorkflowMixin(models.Model):
         object_id_field="object_id",
         for_concrete_model=False,
     )
+    """
+    A default ``GenericRelation`` for the purpose of automatically deleting
+    workflow states when the object is deleted. This is not used to query the
+    object's workflow states. Instead, the :meth:`workflow_states` property is
+    used for that purpose. As such, this default relation is considered private.
+
+    This ``GenericRelation`` does not have a
+    :attr:`~django.contrib.contenttypes.fields.GenericRelation.related_query_name`,
+    so it cannot be used for reverse-related queries from ``WorkflowState`` back
+    to this model. If the feature is desired, subclasses can define their own
+    ``GenericRelation`` to ``WorkflowState`` with a custom
+    ``related_query_name``.
+
+    .. versionadded:: 6.5
+        The default ``GenericRelation`` :attr:`~wagtail.models.WorkflowMixin._workflow_states` was added.
+    """
 
     class Meta:
         abstract = True
@@ -1246,15 +1262,13 @@ class WorkflowMixin(models.Model):
     @property
     def workflow_states(self):
         """
-        Returns workflow states that belong to the object.
-
-        To allow filtering ``WorkflowState`` queries by the object,
-        subclasses should define a
-        :class:`~django.contrib.contenttypes.fields.GenericRelation` to
-        :class:`~wagtail.models.WorkflowState` with the desired
-        ``related_query_name``. This property can be replaced with the
-        ``GenericRelation`` or overridden to allow custom logic, which can be
-        useful if the model has inheritance.
+        Returns workflow states that belong to the object. For non-page models,
+        this is done by querying the :class:`~wagtail.models.WorkflowState`
+        model directly rather than using a
+        :class:`~django.contrib.contenttypes.fields.GenericRelation`, to avoid
+        `a known limitation <https://code.djangoproject.com/ticket/31269>`_ in
+        Django for models with multi-table inheritance where the relation's
+        content type may not match the instance's type.
         """
         return WorkflowState.objects.for_instance(self)
 

--- a/wagtail/tests/test_revision_model.py
+++ b/wagtail/tests/test_revision_model.py
@@ -7,6 +7,7 @@ from freezegun import freeze_time
 from wagtail.models import Page, Revision, get_default_page_content_type
 from wagtail.test.testapp.models import (
     FullFeaturedSnippet,
+    RevisableChildModel,
     RevisableGrandChildModel,
     RevisableModel,
     SimplePage,
@@ -90,17 +91,32 @@ class TestRevisableModel(TestCase):
         self.assertEqual(instance.get_base_content_type(), base_content_type)
         self.assertEqual(instance.get_content_type(), content_type)
 
-        # The for_instance() method should return the revision,
-        # whether we're using the specific instance
+        # The `for_instance()` method of `Revision.objects` and the model's
+        # `revisions` property should return the revision,
+        # whether we're using the most specific instance
         self.assertIsInstance(instance, RevisableModel)
+        self.assertIsInstance(instance, RevisableChildModel)
         self.assertIsInstance(instance, RevisableGrandChildModel)
         self.assertEqual(Revision.objects.for_instance(instance).first(), revision)
+        self.assertEqual(instance.revisions.first(), revision)
+
+        # the intermediary instance
+        intermediary_instance = RevisableChildModel.objects.get(pk=instance.pk)
+        self.assertIsInstance(intermediary_instance, RevisableModel)
+        self.assertIsInstance(intermediary_instance, RevisableChildModel)
+        self.assertNotIsInstance(intermediary_instance, RevisableGrandChildModel)
+        self.assertEqual(
+            Revision.objects.for_instance(intermediary_instance).first(),
+            revision,
+        )
+        self.assertEqual(intermediary_instance.revisions.first(), revision)
 
         # or the base instance
         base_instance = RevisableModel.objects.get(pk=instance.pk)
         self.assertIsInstance(base_instance, RevisableModel)
         self.assertNotIsInstance(base_instance, RevisableGrandChildModel)
         self.assertEqual(Revision.objects.for_instance(base_instance).first(), revision)
+        self.assertEqual(base_instance.revisions.first(), revision)
 
     def test_content_type_for_page_model(self):
         hello_page = self.create_page()
@@ -119,17 +135,20 @@ class TestRevisableModel(TestCase):
         self.assertEqual(hello_page.get_base_content_type(), base_content_type)
         self.assertEqual(hello_page.get_content_type(), content_type)
 
-        # The for_instance() method should return the revision,
+        # The `for_instance()` method of `Revision.objects` and the model's
+        # `revisions` property should return the revision,
         # whether we're using the specific instance
         self.assertIsInstance(hello_page, SimplePage)
         self.assertIsInstance(hello_page, Page)
         self.assertEqual(Revision.objects.for_instance(hello_page).first(), revision)
+        self.assertEqual(hello_page.revisions.first(), revision)
 
         # or the base instance
         base_instance = Page.objects.get(pk=hello_page.pk)
         self.assertIsInstance(base_instance, Page)
         self.assertNotIsInstance(base_instance, SimplePage)
         self.assertEqual(Revision.objects.for_instance(base_instance).first(), revision)
+        self.assertEqual(base_instance.revisions.first(), revision)
 
     def test_as_object(self):
         self.instance.text = "updated"

--- a/wagtail/tests/test_workflow.py
+++ b/wagtail/tests/test_workflow.py
@@ -449,7 +449,7 @@ class TestPageWorkflows(WagtailTestUtils, TestCase):
         self.assertIsNone(self.object.locked_at)
         self.assertIsNone(self.object.locked_by)
 
-    def test_workflow_state_cascade_on_object_delete(self, cascades=True):
+    def test_workflow_state_cascade_on_object_delete(self):
         data = self.start_workflow()
         query = {
             "base_content_type": self.object.get_base_content_type(),
@@ -460,7 +460,7 @@ class TestPageWorkflows(WagtailTestUtils, TestCase):
             data["workflow_state"],
         )
         self.object.delete()
-        self.assertIs(WorkflowState.objects.filter(**query).exists(), not cascades)
+        self.assertIs(WorkflowState.objects.filter(**query).exists(), False)
 
 
 class TestSnippetWorkflows(TestPageWorkflows):
@@ -493,9 +493,6 @@ class TestSnippetWorkflowsNotLockable(TestSnippetWorkflows):
         self.assertEqual(workflow_state.content_object, self.object)
         self.assertEqual(workflow_state.status, "in_progress")
 
-    def test_workflow_state_cascade_on_object_delete(self):
-        # We expect the cascade to not happen as the model does not define
-        # a GenericRelation to WorkflowState. However, workflows should still
-        # work as expected.
-        # See https://github.com/wagtail/wagtail/issues/11300 for more details.
-        return super().test_workflow_state_cascade_on_object_delete(cascades=False)
+    # The ModeratedModel does not explicitly define a `GenericRelation` to
+    # `WorkflowState`, but the `WorkflowState` should still be deleted when the
+    # object is deleted (test_workflow_state_cascade_on_object_delete passes).


### PR DESCRIPTION
Fixes #12776, supersedes #11750.

I'm not sure how much we want to document the difference between the `GenericRelation` vs the `@property` that we have to work around https://code.djangoproject.com/ticket/31269. 

Also, the `GenericRelation`s could also have a default `related_query_name` of `%(app_label)s_%(class)s` so that Django interpolates them for the non-abstract models. However, I don't know how well that plays with multiple inheritance and proxy models, so I'm leaning towards not defining `related_query_name` and advising developers to define it themselves if they need it.