### PR TITLE
Document snippets requirement for features provided by model mixins

### DIFF
--- a/docs/advanced_topics/i18n.md
+++ b/docs/advanced_topics/i18n.md
@@ -513,6 +513,8 @@ For headless sites, the Wagtail API supports two extra filters for international
 
 For more information, see [](apiv2_i18n_filters).
 
+(translatable_snippets)=
+
 #### Translatable snippets
 
 You can make a snippet translatable by making it inherit from `wagtail.models.TranslatableMixin`.

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -575,6 +575,8 @@ database queries making them unable to be edited or viewed.
 `TranslatableMixin` is an abstract model that can be added to any non-page Django model to make it translatable.
 Pages already include this mixin, so there is no need to add it.
 
+For a non-page model to be translatable in the admin, it must also be [registered as a snippet](wagtailsnippets_registering). See also [](translatable_snippets).
+
 ### Database fields
 
 ```{eval-rst}
@@ -628,6 +630,8 @@ If your model defines a [`Meta` class](inv:django#ref/models/options) (either wi
 `PreviewableMixin` is a mixin class that can be added to any non-page Django model to allow previewing its instances.
 Pages already include this mixin, so there is no need to add it.
 
+For a non-page model to be previewable in the admin, it must also be [registered as a snippet](wagtailsnippets_registering). See also [](wagtailsnippets_making_snippets_previewable).
+
 ### Methods and properties
 
 ```{eval-rst}
@@ -654,6 +658,8 @@ Pages already include this mixin, so there is no need to add it.
 
 `RevisionMixin` is an abstract model that can be added to any non-page Django model to allow saving revisions of its instances.
 Pages already include this mixin, so there is no need to add it.
+
+For a non-page model to be revisionable in the admin, it must also be [registered as a snippet](wagtailsnippets_registering). See also [](wagtailsnippets_saving_revisions_of_snippets).
 
 ### Database fields
 
@@ -686,6 +692,8 @@ Pages already include this mixin, so there is no need to add it.
 
 `DraftStateMixin` is an abstract model that can be added to any non-page Django model to allow its instances to have unpublished changes.
 This mixin requires {class}`~wagtail.models.RevisionMixin` to be applied. Pages already include this mixin, so there is no need to add it.
+
+For a non-page model to have publishing features in the admin, it must also be [registered as a snippet](wagtailsnippets_registering). See also [](wagtailsnippets_saving_draft_changes_of_snippets).
 
 ### Database fields
 
@@ -743,6 +751,8 @@ This mixin requires {class}`~wagtail.models.RevisionMixin` to be applied. Pages 
 `LockableMixin` is an abstract model that can be added to any non-page Django model to allow its instances to be locked.
 Pages already include this mixin, so there is no need to add it. See [](wagtailsnippets_locking_snippets) for more details.
 
+For a non-page model to be lockable in the admin, it must also be [registered as a snippet](wagtailsnippets_registering). See also [](wagtailsnippets_locking_snippets).
+
 ### Database fields
 
 ```{eval-rst}
@@ -782,6 +792,8 @@ Pages already include this mixin, so there is no need to add it. See [](wagtails
 
 `WorkflowMixin` is a mixin class that can be added to any non-page Django model to allow its instances to be submitted to workflows.
 This mixin requires {class}`~wagtail.models.RevisionMixin` and {class}`~wagtail.models.DraftStateMixin` to be applied. Pages already include this mixin, so there is no need to add it. See [](wagtailsnippets_enabling_workflows) for more details.
+
+For a non-page model to have workflow features in the admin, it must also be [registered as a snippet](wagtailsnippets_registering). See also [](wagtailsnippets_enabling_workflows).
 
 ### Methods and properties
 


### PR DESCRIPTION
Prompted by #12989.

With fewer gaps between `ModelViewSet` and `SnippetViewSet`, we're inevitably going to get more questions about "why can't these features work with `ModelViewSet`"?

Given how the code is structured, especially with how the generic model views are also used for Wagtail internals that don't need those features, it makes sense that we don't incorporate the corresponding view code for `ModelViewSet` by default.

However, there are legit use cases for models "that don't fit the definition of snippets" to have some of the features, e.g. previews (#11347 and #12989) and bulk actions (#11371) In the case of `PreviewableMixin` we might be able to make it an exception as it doesn't have any model fields. But we might also want to meet halfway by documenting how these features can be enabled (e.g. documenting `CreateEditViewOptionalFeaturesMixin`) and making sure they work, but leave it opt-in for `ModelViewSet`.