### PR TITLE
Add missing apps.py file

### DIFF
--- a/wagtail/project_template/home/app.py
+++ b/wagtail/project_template/home/app.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class HomeConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "home"

--- a/wagtail/project_template/home/apps.py
+++ b/wagtail/project_template/home/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class HomeConfig(AppConfig):
-    default_auto_field = "django.db.models.BigAutoField"
+    default_auto_field = "django.db.models.AutoField"
     name = "home"


### PR DESCRIPTION
The Home app was missing an `apps.py` file, which causes a warning when creating a model.

```
WARNINGS:
home.[Model] (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```

(It could also be solved by adding the `DEFAULT_AUTO_FIELD` setting to `wagtail/wagtail/project_template/settings/base.py`)