### PR TITLE
Fix overzealous text wrapping in listing tables

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -52,7 +52,10 @@ ul.listing {
 
   td {
     vertical-align: middle;
-    overflow-wrap: anywhere;
+    
+    a.nolink[download] {
+      overflow-wrap: anywhere;
+    }
   }
 
   td.title {


### PR DESCRIPTION

This PR addresses [#12985](https://github.com/wagtail/wagtail/issues/12985), which reports unintended word-breaking behavior in `.listing` table cells, particularly visible when using `wagtail-localize`.

### Problem
As @alxbridge mentioned in [#12985](https://github.com/wagtail/wagtail/issues/12985), a global `overflow-wrap: anywhere;` rule on all `.listing td` elements (introduced in [#12357](https://github.com/wagtail/wagtail/pull/12357)) was intended to improve wrapping for long document names. 

However, it caused **overzealous word-breaking**, affecting longer content elsewhere in the table — for example, locale names like `"Simplified Chinese (简体中文)"`, where we would prefer to keep the English words intact:
![image](https://github.com/user-attachments/assets/11b6b6c0-27f8-47b0-80a3-32e5c069ab57)

### Solution
This PR narrows the scope of `overflow-wrap: anywhere;` from:
```scss
  td {
    vertical-align: middle;
    overflow-wrap: anywhere;
  }
```
 to only target:

```
  td {
    vertical-align: middle;
    
    a.nolink[download] {
      overflow-wrap: anywhere;
    }
  }
```

This restricts the word-breaking behavior to document download links (used in the document chooser), while preserving natural wrapping for all other table content.
### Result
✅ Download filenames still break anywhere if needed:
![image](https://github.com/user-attachments/assets/3c3426c9-a1b1-4e36-bde7-804e88bf85e0)
✅ Other table content now uses regular word wrapping:
![image](https://github.com/user-attachments/assets/0af1c004-afc2-44ae-9e17-6d51e9c0a80f)


