### PR TITLE
Initial change: Allow prefetch and selection of related data on Page object, for EditView

### DIFF
--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -333,6 +333,15 @@ class EditView(WagtailAdminTemplateMixin, HookResponseMixin, View):
         self.scheduled_revision = self.real_page_record.scheduled_revision
         self.page_content_type = self.real_page_record.cached_content_type
         self.page_class = self.real_page_record.specific_class
+        self.prefetch_related = self.page_class.prefetch_related
+        self.select_related = self.page_class.select_related
+        self.real_page_record = get_object_or_404(
+            self.page_class.objects.select_related(
+                *self.select_related,
+            ).prefetch_related(
+                *self.prefetch_related,
+            ),
+        )
 
         if self.page_class is None:
             raise PageClassNotFoundError(

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -479,6 +479,10 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         HTTPMethod.PUT,
     ]
 
+    # Allows prefetching of related objects for admin views
+    prefetch_related_objects = []
+    select_related_objects = []
+
     @staticmethod
     def route_for_request(request: HttpRequest, path: str) -> RouteResult | None:
         """


### PR DESCRIPTION
**Issue:**
Suppose I have a custom listing page that has clusterable objects which I intend to be inline. The performance slows down if there are hundreds of them and I view the edit page.

```
class CustomListingPage(Page):
    ...
    content_panels = Page.content_panels + [
        ...
        InlinePanel("clusterables")
    ]

class ClusterableObject(index.Indexed, ClusterableModel):
    page = ParentalKey(CustomListingPage, on_delete=models.CASCADE, related_name="clusterables")
    ...

    panels = [
        ...
        MultiFieldPanel(
            children=[
                InlinePanel("reports", min_num=1),
            ],
            heading="Reports",
        )


class Report(index.Indexed, Orderable):
    clusterable = ParentalKey(ClusterableObject, on_delete=models.CASCADE, related_name="reports")
    report_type = models.ForeignKey(
        ...
    )
    document = models.ForeignKey(
        settings.WAGTAILDOCS_DOCUMENT_MODEL,
        null=True,
        verbose_name=_("document"),
        on_delete=models.SET_NULL,
        related_name="+",
    )

    panels = [
        FieldPanel("report_type"),
        FieldPanel("document"),
    ]
```

Suppose my CustomListingPage has ~200+ clusterables. Viewing the edit page, it's a bit slow, especially if my Clusterable object has its own foreign keys that I want to be included in the inline panel.

**Solution:**
Allow developers to specify which fields should be prefetched and/or selected when viewing the edit page.