### PR TITLE
solved issue #12804 & #12810

### DIFF
--- a/wagtail/contrib/redirects/tmp_storages.py
+++ b/wagtail/contrib/redirects/tmp_storages.py
@@ -89,7 +89,8 @@ class CacheStorage(BaseStorage):
         return cache.get(self.CACHE_PREFIX + self.name)
 
     def remove(self):
-        cache.delete(self.name)
+        cache.delete(self.CACHE_PREFIX + self.name)
+
 
 
 class MediaStorage(BaseStorage):


### PR DESCRIPTION
The key being deleted does not include the CACHE_PREFIX, which means the cached entry with the prefixed key remains in the cache.


