### PR TITLE
fix: Custom Image Model Defaults Not Respected in Admin

### DIFF
--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -51,7 +51,9 @@ class BaseImageForm(BaseCollectionMemberForm):
                 if isinstance(field, forms.BooleanField):
                     try:
                         model_field = self.instance._meta.get_field(field_name)
-                        if model_field.default is not models.NOT_PROVIDED:  # Check if this field has a default value in the model
+                        if (
+                            model_field.default is not models.NOT_PROVIDED
+                        ):  # Check if this field has a default value in the model
                             default_value = model_field.default
                             if callable(default_value):
                                 default_value = default_value()

--- a/wagtail/images/tests/test_form_default_image_boolean_default.py
+++ b/wagtail/images/tests/test_form_default_image_boolean_default.py
@@ -7,21 +7,20 @@ from wagtail.images.models import AbstractImage, Image
 
 class CustomImageWithBooleanField(AbstractImage):
     watermark = models.BooleanField(default=True)
-    
-    admin_form_fields = Image.admin_form_fields + (
-        "watermark",
-    )
+
+    admin_form_fields = Image.admin_form_fields + ("watermark",)
+
 
 class TestImageFormBooleanDefaults(TestCase):
     def test_boolean_field_default_respected(self):
         # Get the form class for our custom model
         ImageForm = get_image_form(CustomImageWithBooleanField)
-        
+
         # Create a new form instance (no instance passed, so it's for a new image)
         form = ImageForm()
-        self.assertTrue(form.initial.get('watermark'))
-        
+        self.assertTrue(form.initial.get("watermark"))
+
         # Check with an explicit instance too
         instance = CustomImageWithBooleanField()
         form_with_instance = ImageForm(instance=instance)
-        self.assertTrue(form_with_instance.initial.get('watermark'))
+        self.assertTrue(form_with_instance.initial.get("watermark"))

--- a/wagtail/images/tests/test_form_default_image_boolean_default.py
+++ b/wagtail/images/tests/test_form_default_image_boolean_default.py
@@ -1,0 +1,27 @@
+from django.db import models
+from django.test import TestCase
+
+from wagtail.images.forms import get_image_form
+from wagtail.images.models import AbstractImage, Image
+
+
+class CustomImageWithBooleanField(AbstractImage):
+    watermark = models.BooleanField(default=True)
+    
+    admin_form_fields = Image.admin_form_fields + (
+        "watermark",
+    )
+
+class TestImageFormBooleanDefaults(TestCase):
+    def test_boolean_field_default_respected(self):
+        # Get the form class for our custom model
+        ImageForm = get_image_form(CustomImageWithBooleanField)
+        
+        # Create a new form instance (no instance passed, so it's for a new image)
+        form = ImageForm()
+        self.assertTrue(form.initial.get('watermark'))
+        
+        # Check with an explicit instance too
+        instance = CustomImageWithBooleanField()
+        form_with_instance = ImageForm(instance=instance)
+        self.assertTrue(form_with_instance.initial.get('watermark'))


### PR DESCRIPTION
## Description

Fixes #12948

This PR addresses an issue where BooleanFields with `default=True` in custom image models were not having their default values respected in the admin interface when uploading new images. When users define custom image models that extend AbstractImage with BooleanFields that have default values set to True, the checkboxes in the admin form appear unchecked instead of checked when uploading new images.

## Technical Explanation

The issue occurs because:

1. When a new image upload form is initialized, Django's ModelForm creates a new instance of the model
2. Form fields don't automatically initialize with model defaults for BooleanFields
3. The absence of a checkbox in form data is interpreted as False by Django

The fix enhances the `BaseImageForm.__init__` method to check for BooleanFields when creating a new image instance and explicitly sets their initial values to match the model field defaults, ensuring the form reflects the correct default state.

## Changes

- Modified `BaseImageForm.__init__` to properly set initial values for BooleanFields based on their model defaults
- Added test cases to verify the fix works correctly
- Updated documentation to note this behavior change

## How to test

1. Create a custom image model with a BooleanField that has `default=True`:
```python
class CustomImage(AbstractImage):
    watermark = models.BooleanField(default=True)
    
    admin_form_fields = Image.admin_form_fields + (
        "watermark",
    )