### PR TITLE
Ensure `insert_editor_js` hook documentation reflects current usage

### DIFF
--- a/docs/contributing/styleguide.md
+++ b/docs/contributing/styleguide.md
@@ -16,6 +16,8 @@ INSTALLED_APPS = (
 
 This will add a 'Styleguide' item to the Settings menu in the admin.
 
-At present the styleguide is static: new UI components must be added to it manually, and there are no hooks into it for other modules to use. We hope to support hooks in the future.
+At present the styleguide is static: new UI components must be added to it manually, and there are no specific hooks into it for other modules to use. It will include the output of the [](insert_editor_js) hook for any custom edit forms JavaScript that may be used.
+
+We hope to support specific styleguide hooks in the future.
 
 The styleguide doesn't currently provide examples of all the core interface components; notably the Page, Document, Image and Snippet chooser interfaces are not currently represented.

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -514,7 +514,9 @@ def global_admin_css():
 
 ### `insert_editor_js`
 
-Add additional JavaScript files or code snippets to the page editor.
+Add additional JavaScript files or code snippets to page, snippets and ModelViewSet editing and creation views. This hook's output is also included in the [](styleguide) view to better test editing customizations.
+
+See [](extending_client_side) for more details about how to integrate these kinds of customizations.
 
 ```python
 # wagtail_hooks.py
@@ -562,6 +564,8 @@ window.addEventListener('DOMContentLoaded', (event) => {
 ### `insert_global_admin_js`
 
 Add additional JavaScript files or code snippets to all admin pages.
+
+See [](extending_client_side) for more details about how to integrate these kinds of customizations.
 
 ```python
 from django.utils.html import format_html

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
@@ -2,7 +2,7 @@
 
 {% comment %}
     DEPRECATED: Remove this template in a future release and replace with the direct hook_output template tag, customizations should use the hook only.
-    Do not add any further standalone script imports here, this template will be deprecated in a future release.
+    Do not add any further standalone script imports here, this template will be deprecated in a future release - RemovedInWagtail80
 {% endcomment %}
 
 {% hook_output 'insert_editor_js' %}


### PR DESCRIPTION
The `insert_editor_js` has been used across multiple editing/creation views for some time. Instead of starting a deprecation path for these, we should just document where they are used instead.

This PR also updates the comments in `wagtail/admin/templates/wagtailadmin/pages/_editor_js.html` so that we remember to remove this template in a future major version bump. We will instead use the hook's output directly in the 3 current files where it's used rather then indirectly via the template partial.

* Fixes #13021
* Relates to #2936
