### PR TITLE
Backport SubqueryConstraint fix to 6.3.x for Django 5.2 compatibility

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ Changelog
 6.3.4 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~~~
 
+ * Added support for Django 5.2
  * Fix: Add missing “Close” label to the upgrade notification dismiss button (Sage Abdullah)
  * Fix: Fix white text on white background in previews for sites that use color-scheme without a background-color (Sage Abdullah)
  * Maintenance: Remove upper version boundary for django-filter (Dan Braghis)

--- a/docs/releases/6.3.4.md
+++ b/docs/releases/6.3.4.md
@@ -11,9 +11,15 @@ depth: 1
 
 ## What's new
 
+### Django 5.2 support
+
+This release adds support for Django 5.2.
+
+### Bug fixes
+
+ * Add missing “Close” label to the upgrade notification dismiss button (Sage Abdullah)
+ * Fix white text on white background in previews for sites that use color-scheme without a background-color (Sage Abdullah)
 
 ### Maintenance
 
  * Remove upper version boundary for django-filter (Dan Braghis)
- * Add missing “Close” label to the upgrade notification dismiss button (Sage Abdullah)
- * Fix white text on white background in previews for sites that use color-scheme without a background-color (Sage Abdullah)

--- a/docs/releases/upgrading.md
+++ b/docs/releases/upgrading.md
@@ -59,7 +59,7 @@ The compatible versions of Django and Python for each Wagtail release are:
 
 | Wagtail release | Compatible Django versions | Compatible Python versions  |
 | --------------- | -------------------------- | --------------------------- |
-| 6.3 LTS         | 4.2, 5.0, 5.1              | 3.9, 3.10, 3.11, 3.12, 3.13 |
+| 6.3 LTS         | 4.2, 5.0, 5.1, 5.2[^*]     | 3.9, 3.10, 3.11, 3.12, 3.13 |
 | 6.2             | 4.2, 5.0                   | 3.8, 3.9, 3.10, 3.11, 3.12  |
 | 6.1             | 4.2, 5.0                   | 3.8, 3.9, 3.10, 3.11, 3.12  |
 | 6.0             | 4.2, 5.0                   | 3.8, 3.9, 3.10, 3.11, 3.12  |

--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -5,7 +5,7 @@ from django.db.models.functions.datetime import Extract as ExtractDate
 from django.db.models.functions.datetime import ExtractYear
 from django.db.models.lookups import Lookup
 from django.db.models.query import QuerySet
-from django.db.models.sql.where import SubqueryConstraint, WhereNode
+from django.db.models.sql.where import WhereNode
 
 from wagtail.search.index import class_is_indexed, get_indexed_models
 from wagtail.search.query import MATCH_ALL, PlainText
@@ -177,11 +177,6 @@ class BaseSearchQueryCompiler:
             # Process the filter
             return self._process_filter(
                 field_attname, lookup, value, check_only=check_only
-            )
-
-        elif isinstance(where_node, SubqueryConstraint):
-            raise FilterError(
-                "Could not apply filter on search results: Subqueries are not allowed."
             )
 
         elif isinstance(where_node, WhereNode):


### PR DESCRIPTION
_Please describe the problem you're fixing here. Include the issue number, if applicable._
