### PR TITLE
Add deprecation notice for listings without breadcrumbs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -59,6 +59,7 @@ Changelog
  * Maintenance: Migrate setuptools configuration from `setup.py` and `setup.cfg` to `pyproject.toml` (Sage Abdullah)
  * Maintenance: Refactor `move_choose_destination` to a class-based view (Chiemezuo Akujobi)
  * Maintenance: Remove deprecated `wagtailadmin/shared/ajax_pagination_nav.html` template (Sage Abdullah)
+ * Maintenance: Formally deprecate support for listing views with no breadcrumbs (Sage Abdullah)
 
 
 6.4.1 (21.02.2025)

--- a/docs/releases/7.0.md
+++ b/docs/releases/7.0.md
@@ -187,6 +187,16 @@ In previous releases, the `save()` method on page models called the `full_clean`
 
 The `TAG_LIMIT` and `TAG_SPACES_ALLOWED` settings have been renamed to `WAGTAIL_TAG_LIMIT` and `WAGTAIL_TAG_SPACES_ALLOWED` respectively. The old settings will continue to work for now, but will be removed in a future release.
 
+### Custom listing views must now have breadcrumbs
+
+If your project has custom listing views in the admin that make use of the `wagtailadmin/generic/index.html` template but do not provide a `breadcrumbs_items` context variable, you will need to add this context variable to your view.
+
+The `breadcrumbs_items` context variable is used to display the breadcrumbs in the admin interface as part of the Universal Listings project. This should be done automatically by the `get_breadcrumbs_items` method in the `wagtail.admin.views.generic.base.BaseListingView` class (or its subclasses, e.g. `wagtail.admin.views.generic.IndexView`).
+
+If you have a custom listing view that does not inherit from the `BaseListingView` class, you will need to add the `breadcrumbs_items` context variable manually. Once added, the title header will be replaced by the breadcrumbs and the filters on the right sidebar will be replaced by the new AJAX-based filters pop-up in the header.
+
+For now, listing views with no breadcrumbs will continue to have the title header and the legacy filters on the right sidebar, but the support will be removed in a future release.
+
 ## Upgrade considerations - changes to undocumented internals
 
 ### Removal of `insert_editor_js` hook output in some non-editor views

--- a/wagtail/admin/templates/wagtailadmin/generic/index.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index.html
@@ -2,6 +2,11 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block main_header %}
+    {% comment %}
+        RemovedInWagtail80Warning: This block override is for supporting listing
+        views that do not use breadcrumbs. There is no longer such a view in
+        Wagtail core, but we keep this block until the deprecation ends.
+    {% endcomment %}
     {% fragment as extra_actions %}
         {% block extra_actions %}
             {% if view.list_export %}
@@ -16,10 +21,10 @@
 
 {% block listing %}
     {% comment %}
-        DEPRECATED: This block override is for supporting views that have filters
+        RemovedInWagtail80Warning: This block override is for supporting views that have filters
         but not using breadcrumbs (thus have no slim_header to put the filters in).
         There is no longer such a view in Wagtail core, but we keep this block
-        until we can enforce the use of breadcrumbs in all listing views.
+        until the deprecation ends.
     {% endcomment %}
     {% if filters and not breadcrumbs_items %}
         <div class="filterable">

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -1164,7 +1164,6 @@ class RevisionsCompareView(WagtailAdminTemplateMixin, TemplateView):
     history_label = gettext_lazy("History")
     page_title = gettext_lazy("Compare")
     template_name = "wagtailadmin/generic/revisions/compare.html"
-    _show_breadcrumbs = True
     model = None
 
     def get_breadcrumbs_items(self):

--- a/wagtail/contrib/search_promotions/views/settings.py
+++ b/wagtail/contrib/search_promotions/views/settings.py
@@ -87,7 +87,6 @@ class SearchPromotionCreateEditMixin:
     edit_url_name = "wagtailsearchpromotions:edit"
     form_class = forms.QueryForm
     header_icon = "pick"
-    _show_breadcrumbs = True
     page_subtitle = gettext_lazy("Promoted search result")
 
     def get_success_message(self, instance=None):


### PR DESCRIPTION
- The `_show_breadcrumbs` flag was supposed to be removed in #12676. However, two occurrences were missed during the rebase of #12675 and #12614 after the removal was merged.
- Add deprecation notice for listings without breadcrumbs per https://github.com/wagtail/wagtail/pull/13011#discussion_r2044394884. We can probably remove the support right away, but we've never mentioned the deprecation explicitly in the release notes, so I opted to leave it for now. Not raising a proper `RemovedInWagtail80Warning` as it's in a template so it's not as straightforward without creating a template tag.