### PR TITLE
Implement new and improved pagination controls

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changelog
  * Allow workflow tasks to specify a template for the action modal via `get_template_for_action` (Sage Abdullah)
  * Change 'Publish' button label to 'Schedule to publish' if go-live schedule is set (Sage Abdullah)
  * Exclude snippets that have their own menu items from the "Snippets" menu (Andy Chosak, Matt Westcott)
+ * Introduce new designs for listings and chooser pagination (except page chooser) (Jordan Teichmann, Sage Abdullah)
  * Fix: Take preferred language into account for translatable strings in client-side code (Bernhard Bliem, Sage Abdullah)
  * Fix: Do not show the content type column as sortable when searching pages (Srishti Jaiswal, Sage Abdullah)
  * Fix: Support simple subqueries for `in` and `exact` lookup on Elasticsearch (Sage Abdullah)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -878,6 +878,7 @@
 * Ashish Nagmoti
 * Dhruvi Patel
 * Sylvain Boissel
+* Jordan Teichmann
 
 ## Translators
 

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -542,10 +542,12 @@ table.listing {
         border-radius: 3px;
         color: var(--w-color-text-label);
         margin: 0.1875rem;
+      }
 
-        &.current,
-        &:hover,
-        &:focus {
+      &.pagination__page-number--current,
+      &:hover,
+      &:focus-within {
+        a {
           background-color: var(--w-color-primary);
           border: 0;
           color: var(--w-color-text-button);
@@ -565,15 +567,13 @@ table.listing {
   }
 
   @include dark-theme() {
-    li {
-      &.pagination__page-number {
-        a {
-          &.current,
-          &:hover,
-          &:focus {
-            background-color: var(--w-color-secondary);
-          }
-        }
+    li.pagination__page-number:where(
+        .pagination__page-number--current,
+        :hover,
+        :focus-within
+      ) {
+      a {
+        background-color: var(--w-color-secondary);
       }
     }
   }

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -508,6 +508,7 @@ table.listing {
   ul {
     @include unlist();
     display: flex;
+    flex-wrap: wrap;
     flex-grow: 1;
     justify-content: center;
   }
@@ -532,48 +533,44 @@ table.listing {
       a,
       span {
         font-weight: theme('fontWeight.medium');
-        height: 2rem;
-        min-width: 2.125rem;
-        margin: 0.1875rem;
+        height: theme('spacing.8');
+        min-width: theme('spacing.8');
+        margin: theme('spacing.1');
       }
 
       a {
-        border: 1px solid var(--w-color-border-furniture);
-        border-radius: 3px;
-        color: var(--w-color-text-label);
-        margin: 0.1875rem;
+        border: 1px solid theme('colors.border-furniture');
+        border-radius: theme('borderRadius.sm');
+        color: theme('colors.text-label');
       }
 
-      &.pagination__page-number--current,
-      &:hover,
-      &:focus-within {
-        a {
-          background-color: var(--w-color-primary);
-          border: 0;
-          color: var(--w-color-text-button);
-        }
+      &.pagination__page-number--current a {
+        background-color: theme('colors.primary.DEFAULT');
+        border-color: transparent;
+        color: theme('colors.text-button');
+      }
+
+      &:hover a {
+        background-color: theme('colors.surface-button-outline-hover');
+        border-color: theme('colors.border-button-outline-hover');
+        color: theme('colors.text-button-outline-hover');
       }
     }
   }
 
   .prev,
   .next {
-    a {
-      border: 0;
-      text-decoration: underline;
-      color: var(--w-color-text-link-default);
-    }
     margin: 0 0.5rem;
   }
 
   @include dark-theme() {
     li.pagination__page-number:where(
         .pagination__page-number--current,
-        :hover,
-        :focus-within
+        :hover
       ) {
       a {
-        background-color: var(--w-color-secondary);
+        background-color: theme('colors.secondary.DEFAULT');
+        color: theme('colors.text-button');
       }
     }
   }

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -545,7 +545,7 @@ table.listing {
       }
 
       &.pagination__page-number--current a {
-        background-color: theme('colors.primary.DEFAULT');
+        background-color: theme('colors.surface-button-default');
         border-color: transparent;
         color: theme('colors.text-button');
       }
@@ -561,18 +561,6 @@ table.listing {
   .prev,
   .next {
     margin: 0 0.5rem;
-  }
-
-  @include dark-theme() {
-    li.pagination__page-number:where(
-        .pagination__page-number--current,
-        :hover
-      ) {
-      a {
-        background-color: theme('colors.secondary.DEFAULT');
-        color: theme('colors.text-button');
-      }
-    }
   }
 }
 

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -479,6 +479,20 @@ table.listing {
 
 .pagination {
   text-align: center;
+  align-items: center;
+
+  &__start,
+  &__end {
+    display: flex;
+    flex: 1;
+    @include media-breakpoint-down(md) {
+      flex-basis: auto;
+    }
+  }
+
+  &__end {
+    justify-content: end;
+  }
 
   p {
     margin: 0;
@@ -486,19 +500,75 @@ table.listing {
 
   ul {
     @include unlist();
-    margin-top: -1.7em;
+    display: flex;
+    flex-grow: 1;
+    justify-content: center;
   }
 
   li {
     line-height: 1em;
+    display: flex;
+    align-items: center;
+
+    a:not([href]) {
+      visibility: hidden;
+    }
+
+    a,
+    span {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
+    &.pagination__page-number {
+      a,
+      span {
+        font-weight: theme('fontWeight.medium');
+        height: 2rem;
+        min-width: 2.125rem;
+        margin: 0.1875rem;
+      }
+
+      a {
+        border: 1px solid var(--w-color-border-furniture);
+        border-radius: 3px;
+        color: var(--w-color-text-label);
+        margin: 0.1875rem;
+
+        &.current,
+        &:hover,
+        &:focus {
+          background-color: var(--w-color-primary);
+          border: 0;
+          color: var(--w-color-text-button);
+        }
+      }
+    }
   }
 
-  .prev {
-    float: inline-start;
-  }
-
+  .prev,
   .next {
-    float: inline-end;
+    a {
+      border: 0;
+      text-decoration: underline;
+      color: var(--w-color-text-link-default);
+    }
+    margin: 0 0.5rem;
+  }
+
+  @include dark-theme() {
+    li {
+      &.pagination__page-number {
+        a {
+          &.current,
+          &:hover,
+          &:focus {
+            background-color: var(--w-color-secondary);
+          }
+        }
+      }
+    }
   }
 }
 

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -479,7 +479,14 @@ table.listing {
 
 .pagination {
   text-align: center;
+  display: flex;
   align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+
+  @include media-breakpoint-up(sm) {
+    flex-wrap: nowrap;
+  }
 
   &__start,
   &__end {

--- a/docs/releases/7.0.md
+++ b/docs/releases/7.0.md
@@ -23,6 +23,10 @@ This release introduces a change to the validation behaviour when saving pages (
 
 This feature was developed by Matt Westcott and Sage Abdullah.
 
+### New and improved pagination
+
+We have a new pagination interface for all listing views and most choosers, including page numbers. This simplifies navigation for listings with tens or hundreds of pages, so users can jump directly to the last pages. Thank you to Jordan Teichmann for implementing the new designs, with guidance from Sage Abdullah.
+
 ### Other features
 
  * Add `WAGTAIL_` prefix to Wagtail-specific tag settings (Aayushman Singh)

--- a/wagtail/admin/paginator.py
+++ b/wagtail/admin/paginator.py
@@ -1,0 +1,88 @@
+from django.conf import settings
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.utils.module_loading import import_string
+
+
+class WagtailPaginator(Paginator):
+    num_page_buttons = 6
+
+    def get_elided_page_range(self, page_number):
+        """
+        Provides a range of page numbers where the number of positions
+        occupied by page numbers and ellipses is fixed to num_page_buttons.
+
+        For example, if there are 10 pages where num_page_buttons is 6, the output will be:
+        At page 1:  1 2 3 4 … 10
+        At page 6:  1 … 6 7 … 10
+        At page 10: 1 … 7 8 9 10
+
+        The paginator will show the current page in the middle (odd number of buttons)
+        or to the left side of the middle (even number of buttons).
+        """
+
+        try:
+            number = self.validate_number(page_number)
+        except PageNotAnInteger:
+            number = 1
+        except EmptyPage:
+            number = self.num_pages
+
+        if self.num_page_buttons < 5:
+            # We provide no page range if fewer than 5 num_page_buttons.
+            # This displays only "Previous" and "Next" buttons.
+            return []
+
+        # Provide all page numbers if fewer than num_page_buttons.
+        if self.num_pages <= self.num_page_buttons:
+            yield from self.page_range
+            return
+
+        # These thresholds are the maximum number of buttons
+        # that can be shown on the start or end of the page range
+        # before the middle part of the range expands.
+        # For even num_page_buttons values both thresholds are the same.
+        # For odd num_page_buttons values the start threshold is one more than the end threshold.
+        end_threshold = self.num_page_buttons // 2
+        start_threshold = end_threshold + (self.num_page_buttons % 2)
+
+        # Show the first page.
+        yield 1
+
+        # Show middle pages.
+        if number <= start_threshold:
+            # Result: 1 [ 2 3 4 … ] 10
+            yield from range(2, self.num_page_buttons - 1)
+            yield self.ELLIPSIS
+        elif number < self.num_pages - end_threshold:
+            # Result: 1 [ … 5 6* 7 … ] 10
+            middle_size = (
+                self.num_page_buttons - 4
+            )  # 4 spaces are occupied by first/last page numbers and ellipses
+            offset = (middle_size - 1) // 2
+            yield self.ELLIPSIS
+            yield from range(number - offset, number + middle_size - offset)
+            yield self.ELLIPSIS
+        else:
+            # Result: 1 [ … 7 8 9 ] 10
+            yield self.ELLIPSIS
+            yield from range(
+                self.num_pages - (self.num_page_buttons - 3), self.num_pages
+            )
+
+        # Show the last page.
+        yield self.num_pages
+
+
+def get_wagtail_paginator_class():
+    """
+    Get the paginator class from the ``WAGTAILADMIN_PAGINATOR_CLASS`` setting,
+    which allows developers to provide a custom paginator class.
+    Defaults to the ``WagtailPaginator`` class if not defined.
+    """
+    paginator_class_override = getattr(settings, "WAGTAILADMIN_PAGINATOR_CLASS", "")
+    if paginator_class_override:
+        paginator_class = import_string(paginator_class_override)
+    else:
+        paginator_class = WagtailPaginator
+
+    return paginator_class

--- a/wagtail/admin/paginator.py
+++ b/wagtail/admin/paginator.py
@@ -1,8 +1,42 @@
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.utils.functional import cached_property
+from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 
 
 class WagtailPaginator(Paginator):
     num_page_buttons = 6
+
+    @cached_property
+    def model(self):
+        return getattr(self.object_list, "model", None)
+
+    @cached_property
+    def verbose_name(self):
+        if self.model:
+            return self.model._meta.verbose_name
+        return _("item")
+
+    @cached_property
+    def verbose_name_plural(self):
+        if self.model:
+            return self.model._meta.verbose_name_plural
+        return _("items")
+
+    @cached_property
+    def items_count_label(self):
+        label = ngettext(
+            # Translators: The label to use when displaying the number of items
+            # in a list, e.g. "1 image" or "2 images".
+            "%(count)d %(item_name)s",
+            "%(count)d %(item_name_plural)s",
+            self.count,
+        )
+        return label % {
+            "count": self.count,
+            "item_name": self.verbose_name,
+            "item_name_plural": self.verbose_name_plural,
+        }
 
     def get_elided_page_range(self, page_number):
         """

--- a/wagtail/admin/paginator.py
+++ b/wagtail/admin/paginator.py
@@ -1,6 +1,4 @@
-from django.conf import settings
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.utils.module_loading import import_string
 
 
 class WagtailPaginator(Paginator):
@@ -55,9 +53,8 @@ class WagtailPaginator(Paginator):
             yield self.ELLIPSIS
         elif number < self.num_pages - end_threshold:
             # Result: 1 [ … 5 6* 7 … ] 10
-            middle_size = (
-                self.num_page_buttons - 4
-            )  # 4 spaces are occupied by first/last page numbers and ellipses
+            # 4 spaces are occupied by first/last page numbers and ellipses
+            middle_size = self.num_page_buttons - 4
             offset = (middle_size - 1) // 2
             yield self.ELLIPSIS
             yield from range(number - offset, number + middle_size - offset)
@@ -71,18 +68,3 @@ class WagtailPaginator(Paginator):
 
         # Show the last page.
         yield self.num_pages
-
-
-def get_wagtail_paginator_class():
-    """
-    Get the paginator class from the ``WAGTAILADMIN_PAGINATOR_CLASS`` setting,
-    which allows developers to provide a custom paginator class.
-    Defaults to the ``WagtailPaginator`` class if not defined.
-    """
-    paginator_class_override = getattr(settings, "WAGTAILADMIN_PAGINATOR_CLASS", "")
-    if paginator_class_override:
-        paginator_class = import_string(paginator_class_override)
-    else:
-        paginator_class = WagtailPaginator
-
-    return paginator_class

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -20,7 +20,7 @@
             </a>
         </li>
         {% for page_number in elided_page_range %}
-            <li class="pagination__page-number{% if page_number == items.number %} pagination__page-number--current{% endif %}">
+            <li class="pagination__page-number{% if page_number == items.number %} pagination__page-number--current{% endif %}"{% if page_number == items.number %} aria-current="page"{% endif %}>
                 {% if page_number == items.paginator.ELLIPSIS %}
                     <span>{{ page_number }}</span>
                 {% else %}

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -8,13 +8,13 @@
 {% endcomment %}
 {% resolve_url linkurl as url_path %}
 
-<nav class="pagination w-flex w-justify-between w-flex-wrap sm:w-flex-nowrap" aria-label="{% trans 'Pagination' %}">
+<nav class="pagination" aria-label="{% trans 'Pagination' %}">
     <div class="pagination__start">
         <p>{% blocktrans trimmed with page_num=items.number|intcomma total_pages=items.paginator.num_pages|intcomma %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}</p>
     </div>
     <ul>
         <li class="prev">
-            <a{% if items.has_previous %} href="{{ url_path }}{% querystring p=items.previous_page_number %}"{% endif%}>
+            <a{% if items.has_previous %} href="{{ url_path }}{% querystring p=items.previous_page_number %}"{% endif %}>
                 {% icon name="arrow-left" classname="default" %}
                 {% trans 'Previous' %}
             </a>

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -8,24 +8,42 @@
 {% endcomment %}
 {% resolve_url linkurl as url_path %}
 
-<nav class="pagination" aria-label="{% trans 'Pagination' %}">
-    <p>{% blocktrans trimmed with page_num=items.number|intcomma total_pages=items.paginator.num_pages|intcomma %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}</p>
-    <ul>
-        <li class="prev">
-            {% if items.has_previous %}
-                <a href="{{ url_path }}{% querystring p=items.previous_page_number %}">
+{% with items.paginator.num_pages|intcomma as total_pages %}
+    <nav class="pagination w-flex w-justify-between w-flex-wrap sm:w-flex-nowrap" aria-label="{% trans 'Pagination' %}">
+        <div class="pagination__start">
+            <p>{% blocktrans trimmed with page_num=items.number|intcomma total_pages=total_pages %}Page {{ page_num }} of {{ total_pages }}{% endblocktrans %}</p>
+        </div>
+        <ul>
+            <li class="prev">
+                <a{% if items.has_previous %} href="{{ url_path }}{% querystring p=items.previous_page_number %}"{% endif%}>
                     {% icon name="arrow-left" classname="default" %}
                     {% trans 'Previous' %}
                 </a>
-            {% endif %}
-        </li>
-        <li class="next">
-            {% if items.has_next %}
-                <a href="{{ url_path }}{% querystring p=items.next_page_number %}">
+            </li>
+            {% for page_number in elided_page_range %}
+                <li class="pagination__page-number">
+                    {% if page_number == items.paginator.ELLIPSIS %}
+                        <span>{{ page_number }}</span>
+                    {% else %}
+                        <a href="{{ url_path }}{% querystring p=page_number %}" class="{% if page_number == items.number %}current{% endif %}" aria-label="{% blocktrans trimmed with page_num=page_number|intcomma %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}">
+                            {{ page_number|intcomma }}
+                        </a>
+                    {% endif %}
+                </li>
+            {% endfor %}
+            <li class="next">
+                <a{% if items.has_next %} href="{{ url_path }}{% querystring p=items.next_page_number %}"{% endif %}>
                     {% trans 'Next' %}
                     {% icon name="arrow-right" classname="default" %}
                 </a>
+            </li>
+        </ul>
+        <div class="pagination__end">
+            {% if verbose_name_plural and items.paginator.count > 1 %}
+                {% blocktrans trimmed with count=items.paginator.count|intcomma verbose_name_plural=verbose_name_plural|capfirst %}
+                    {{ count }} {{ verbose_name_plural }}
+                {% endblocktrans %}
             {% endif %}
-        </li>
-    </ul>
-</nav>
+        </div>
+    </nav>
+{% endwith %}

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -20,11 +20,11 @@
             </a>
         </li>
         {% for page_number in elided_page_range %}
-            <li class="pagination__page-number">
+            <li class="pagination__page-number{% if page_number == items.number %} pagination__page-number--current{% endif %}">
                 {% if page_number == items.paginator.ELLIPSIS %}
                     <span>{{ page_number }}</span>
                 {% else %}
-                    <a href="{{ url_path }}{% querystring p=page_number %}" class="{% if page_number == items.number %}current{% endif %}">
+                    <a href="{{ url_path }}{% querystring p=page_number %}">
                         {{ page_number|intcomma }}
                     </a>
                 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -20,11 +20,11 @@
             </a>
         </li>
         {% for page_number in elided_page_range %}
-            <li class="pagination__page-number{% if page_number == items.number %} pagination__page-number--current{% endif %}"{% if page_number == items.number %} aria-current="page"{% endif %}>
+            <li class="pagination__page-number{% if page_number == items.number %} pagination__page-number--current{% endif %}">
                 {% if page_number == items.paginator.ELLIPSIS %}
                     <span>{{ page_number }}</span>
                 {% else %}
-                    <a href="{{ url_path }}{% querystring p=page_number %}">
+                    <a href="{{ url_path }}{% querystring p=page_number %}" {% if page_number == items.number %} aria-current="page"{% endif %}>
                         {{ page_number|intcomma }}
                     </a>
                 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -8,42 +8,40 @@
 {% endcomment %}
 {% resolve_url linkurl as url_path %}
 
-{% with items.paginator.num_pages|intcomma as total_pages %}
-    <nav class="pagination w-flex w-justify-between w-flex-wrap sm:w-flex-nowrap" aria-label="{% trans 'Pagination' %}">
-        <div class="pagination__start">
-            <p>{% blocktrans trimmed with page_num=items.number|intcomma total_pages=total_pages %}Page {{ page_num }} of {{ total_pages }}{% endblocktrans %}</p>
-        </div>
-        <ul>
-            <li class="prev">
-                <a{% if items.has_previous %} href="{{ url_path }}{% querystring p=items.previous_page_number %}"{% endif%}>
-                    {% icon name="arrow-left" classname="default" %}
-                    {% trans 'Previous' %}
-                </a>
+<nav class="pagination w-flex w-justify-between w-flex-wrap sm:w-flex-nowrap" aria-label="{% trans 'Pagination' %}">
+    <div class="pagination__start">
+        <p>{% blocktrans trimmed with page_num=items.number|intcomma total_pages=items.paginator.num_pages|intcomma %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}</p>
+    </div>
+    <ul>
+        <li class="prev">
+            <a{% if items.has_previous %} href="{{ url_path }}{% querystring p=items.previous_page_number %}"{% endif%}>
+                {% icon name="arrow-left" classname="default" %}
+                {% trans 'Previous' %}
+            </a>
+        </li>
+        {% for page_number in elided_page_range %}
+            <li class="pagination__page-number">
+                {% if page_number == items.paginator.ELLIPSIS %}
+                    <span>{{ page_number }}</span>
+                {% else %}
+                    <a href="{{ url_path }}{% querystring p=page_number %}" class="{% if page_number == items.number %}current{% endif %}">
+                        {{ page_number|intcomma }}
+                    </a>
+                {% endif %}
             </li>
-            {% for page_number in elided_page_range %}
-                <li class="pagination__page-number">
-                    {% if page_number == items.paginator.ELLIPSIS %}
-                        <span>{{ page_number }}</span>
-                    {% else %}
-                        <a href="{{ url_path }}{% querystring p=page_number %}" class="{% if page_number == items.number %}current{% endif %}" aria-label="{% blocktrans trimmed with page_num=page_number|intcomma %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}">
-                            {{ page_number|intcomma }}
-                        </a>
-                    {% endif %}
-                </li>
-            {% endfor %}
-            <li class="next">
-                <a{% if items.has_next %} href="{{ url_path }}{% querystring p=items.next_page_number %}"{% endif %}>
-                    {% trans 'Next' %}
-                    {% icon name="arrow-right" classname="default" %}
-                </a>
-            </li>
-        </ul>
-        <div class="pagination__end">
-            {% if verbose_name_plural and items.paginator.count > 1 %}
-                {% blocktrans trimmed with count=items.paginator.count|intcomma verbose_name_plural=verbose_name_plural|capfirst %}
-                    {{ count }} {{ verbose_name_plural }}
-                {% endblocktrans %}
-            {% endif %}
-        </div>
-    </nav>
-{% endwith %}
+        {% endfor %}
+        <li class="next">
+            <a{% if items.has_next %} href="{{ url_path }}{% querystring p=items.next_page_number %}"{% endif %}>
+                {% trans 'Next' %}
+                {% icon name="arrow-right" classname="default" %}
+            </a>
+        </li>
+    </ul>
+    <div class="pagination__end">
+        {% if verbose_name_plural and items.paginator.count > 1 %}
+            {% blocktrans trimmed with count=items.paginator.count|intcomma verbose_name_plural=verbose_name_plural|capfirst %}
+                {{ count }} {{ verbose_name_plural }}
+            {% endblocktrans %}
+        {% endif %}
+    </div>
+</nav>

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -38,10 +38,6 @@
         </li>
     </ul>
     <div class="pagination__end">
-        {% if verbose_name_plural and items.paginator.count > 1 %}
-            {% blocktrans trimmed with count=items.paginator.count|intcomma verbose_name_plural=verbose_name_plural|capfirst %}
-                {{ count }} {{ verbose_name_plural }}
-            {% endblocktrans %}
-        {% endif %}
+        {{ items.paginator.items_count_label|capfirst }}
     </div>
 </nav>

--- a/wagtail/admin/tests/pages/test_page_usage.py
+++ b/wagtail/admin/tests/pages/test_page_usage.py
@@ -125,4 +125,5 @@ class TestPageUsage(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailadmin/generic/listing.html")
         self.assertContains(response, "Page 2 of 3.")
         self.assertContains(response, f"{usage_url}?p=1")
+        self.assertContains(response, f"{usage_url}?p=2")
         self.assertContains(response, f"{usage_url}?p=3")

--- a/wagtail/admin/tests/test_paginator.py
+++ b/wagtail/admin/tests/test_paginator.py
@@ -1,0 +1,104 @@
+from django.core.paginator import Paginator
+from django.test import TestCase, override_settings
+
+from wagtail.admin.paginator import WagtailPaginator, get_wagtail_paginator_class
+
+
+class TestWagtailPaginator(TestCase):
+    def test_elided_page_range(self):
+        """
+        Test the get_elided_page_range method of WagtailPaginator.
+
+        For example, if there are 10 pages, the output should be:
+        At page 1:  1 2 3 4 … 10
+        At page 6:  1 … 6 7 … 10
+        At page 10: 1 … 7 8 9 10
+        """
+
+        ellipsis = WagtailPaginator.ELLIPSIS
+
+        test_cases = [
+            # Format: (total pages, current page, num_page_buttons, [expected elided page range])
+            # Exmaples of test cases that should fail:
+            # (3, 1, 6, [1, 2]), # Too few pages
+            # (10, 1, 6, [1, 2, 3, 4, ellipsis, 9, 10]), # Too many pages
+            # (10, 6, 6, [1, ellipsis, 5, 6, ellipsis, 10]), # Wrong middle position
+            # (10, 10, 6, [1, ellipsis, 7, 8, 9]), # Too few pages
+            # num_page_buttons=4
+            # If the number of page buttons is less than 5, the elided range should be empty.
+            (10, 3, 4, []),
+            # num_page_buttons=5
+            (1, 1, 5, [1]),
+            (3, 1, 5, [1, 2, 3]),
+            (3, 3, 5, [1, 2, 3]),
+            (5, 2, 5, [1, 2, 3, 4, 5]),
+            (10, 1, 5, [1, 2, 3, ellipsis, 10]),
+            (10, 6, 5, [1, ellipsis, 6, ellipsis, 10]),
+            (10, 10, 5, [1, ellipsis, 8, 9, 10]),
+            # Our default number of page buttons.
+            # num_page_buttons=6
+            (1, 1, 6, [1]),
+            (3, 1, 6, [1, 2, 3]),
+            (3, 3, 6, [1, 2, 3]),
+            (6, 2, 6, [1, 2, 3, 4, 5, 6]),
+            (6, 6, 6, [1, 2, 3, 4, 5, 6]),
+            (10, 1, 6, [1, 2, 3, 4, ellipsis, 10]),
+            (10, 6, 6, [1, ellipsis, 6, 7, ellipsis, 10]),
+            (10, 10, 6, [1, ellipsis, 7, 8, 9, 10]),
+            # num_page_buttons=7
+            (7, 2, 7, [1, 2, 3, 4, 5, 6, 7]),
+            (10, 1, 7, [1, 2, 3, 4, 5, ellipsis, 10]),
+            (10, 6, 7, [1, ellipsis, 5, 6, 7, ellipsis, 10]),
+            (10, 10, 7, [1, ellipsis, 6, 7, 8, 9, 10]),
+            # num_page_buttons=8
+            (8, 3, 8, [1, 2, 3, 4, 5, 6, 7, 8]),
+            (10, 1, 8, [1, 2, 3, 4, 5, 6, ellipsis, 10]),
+            (20, 6, 8, [1, ellipsis, 5, 6, 7, 8, ellipsis, 20]),
+            (10, 10, 8, [1, ellipsis, 5, 6, 7, 8, 9, 10]),
+            # num_page_buttons=9
+            (9, 3, 9, [1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            (10, 1, 9, [1, 2, 3, 4, 5, 6, 7, ellipsis, 10]),
+            (10, 6, 9, [1, ellipsis, 4, 5, 6, 7, 8, 9, 10]),
+            (20, 6, 9, [1, ellipsis, 4, 5, 6, 7, 8, ellipsis, 20]),
+            (10, 10, 9, [1, ellipsis, 4, 5, 6, 7, 8, 9, 10]),
+            # num_page_buttons=10
+            (10, 3, 10, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+            (10, 1, 10, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+            (10, 6, 10, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+            (20, 6, 10, [1, ellipsis, 4, 5, 6, 7, 8, 9, ellipsis, 20]),
+            (10, 10, 10, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        ]
+
+        for (
+            total_pages,
+            current_page,
+            num_page_buttons,
+            expected_elided_page_range,
+        ) in test_cases:
+            paginator = WagtailPaginator(
+                list(range(total_pages)), 1
+            )  # 1 object per page
+            paginator.num_page_buttons = num_page_buttons
+            elided_page_range = paginator.get_elided_page_range(current_page)
+            self.assertSequenceEqual(
+                list(elided_page_range),
+                expected_elided_page_range,
+                f"Elided page range failed for total_pages={total_pages}, current_page={current_page}, num_page_buttons={num_page_buttons}",
+            )
+
+
+class TestGetWagtailPaginatorClass(TestCase):
+    def test_default_paginator_class(self):
+        # Test that the default paginator is WagtailPaginator when no setting is provided
+        self.assertIs(get_wagtail_paginator_class(), WagtailPaginator)
+
+    @override_settings(WAGTAILADMIN_PAGINATOR_CLASS="django.core.paginator.Paginator")
+    def test_get_paginator_class(self):
+        # Test that the provided setting is a subclass of Paginator
+        self.assertIs(get_wagtail_paginator_class(), Paginator)
+
+    @override_settings(WAGTAILADMIN_PAGINATOR_CLASS="myapp.is.not.real.Paginator")
+    def test_invalid_paginator_class(self):
+        # Test handling of invalid class path
+        with self.assertRaises(ImportError):
+            get_wagtail_paginator_class()

--- a/wagtail/admin/tests/test_paginator.py
+++ b/wagtail/admin/tests/test_paginator.py
@@ -1,7 +1,6 @@
-from django.core.paginator import Paginator
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
-from wagtail.admin.paginator import WagtailPaginator, get_wagtail_paginator_class
+from wagtail.admin.paginator import WagtailPaginator
 
 
 class TestWagtailPaginator(TestCase):
@@ -85,20 +84,3 @@ class TestWagtailPaginator(TestCase):
                 expected_elided_page_range,
                 f"Elided page range failed for total_pages={total_pages}, current_page={current_page}, num_page_buttons={num_page_buttons}",
             )
-
-
-class TestGetWagtailPaginatorClass(TestCase):
-    def test_default_paginator_class(self):
-        # Test that the default paginator is WagtailPaginator when no setting is provided
-        self.assertIs(get_wagtail_paginator_class(), WagtailPaginator)
-
-    @override_settings(WAGTAILADMIN_PAGINATOR_CLASS="django.core.paginator.Paginator")
-    def test_get_paginator_class(self):
-        # Test that the provided setting is a subclass of Paginator
-        self.assertIs(get_wagtail_paginator_class(), Paginator)
-
-    @override_settings(WAGTAILADMIN_PAGINATOR_CLASS="myapp.is.not.real.Paginator")
-    def test_invalid_paginator_class(self):
-        # Test handling of invalid class path
-        with self.assertRaises(ImportError):
-            get_wagtail_paginator_class()

--- a/wagtail/admin/tests/test_paginator.py
+++ b/wagtail/admin/tests/test_paginator.py
@@ -18,7 +18,7 @@ class TestWagtailPaginator(TestCase):
 
         test_cases = [
             # Format: (total pages, current page, num_page_buttons, [expected elided page range])
-            # Exmaples of test cases that should fail:
+            # Examples of test cases that should fail:
             # (3, 1, 6, [1, 2]), # Too few pages
             # (10, 1, 6, [1, 2, 3, 4, ellipsis, 9, 10]), # Too many pages
             # (10, 6, 6, [1, ellipsis, 5, 6, ellipsis, 10]), # Wrong middle position

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -315,7 +315,7 @@ class TestWorkflowsIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["object_list"]), 20)
         self.assertContains(response, url + "?p=1")
-        self.assertNotContains(response, url + "?p=2")
+        self.assertContains(response, url + "?p=2")
         self.assertContains(response, url + "?p=3")
 
         response = self.get({"p": 4})
@@ -1301,7 +1301,7 @@ class TestTaskIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["object_list"]), 50)
         self.assertContains(response, url + "?p=1")
-        self.assertNotContains(response, url + "?p=2")
+        self.assertContains(response, url + "?p=2")
         self.assertContains(response, url + "?p=3")
 
         response = self.get({"p": 4})

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -23,7 +23,7 @@ from django_filters.filters import (
 
 from wagtail.admin import messages
 from wagtail.admin.forms.search import SearchForm
-from wagtail.admin.paginator import get_wagtail_paginator_class
+from wagtail.admin.paginator import WagtailPaginator
 from wagtail.admin.ui.tables import Column, Table
 from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.admin.widgets.button import ButtonWithDropdown
@@ -215,7 +215,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
     default_ordering = None
     filterset_class = None
     verbose_name_plural = None
-    paginator_class = get_wagtail_paginator_class()
+    paginator_class = WagtailPaginator
 
     def get_template_names(self):
         if self.results_only:

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -23,6 +23,7 @@ from django_filters.filters import (
 
 from wagtail.admin import messages
 from wagtail.admin.forms.search import SearchForm
+from wagtail.admin.paginator import get_wagtail_paginator_class
 from wagtail.admin.ui.tables import Column, Table
 from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.admin.widgets.button import ButtonWithDropdown
@@ -214,6 +215,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
     default_ordering = None
     filterset_class = None
     verbose_name_plural = None
+    paginator_class = get_wagtail_paginator_class()
 
     def get_template_names(self):
         if self.results_only:
@@ -573,6 +575,13 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
 
         if context["is_paginated"]:
             context["items_count"] = context["paginator"].count
+            try:
+                page_number = int(self.request.GET.get(self.page_kwarg, 1))
+            except (ValueError, TypeError):
+                page_number = 1
+            context["elided_page_range"] = context["paginator"].get_elided_page_range(
+                page_number
+            )
         else:
             context["items_count"] = len(context["object_list"])
 

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -575,12 +575,8 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
 
         if context["is_paginated"]:
             context["items_count"] = context["paginator"].count
-            try:
-                page_number = int(self.request.GET.get(self.page_kwarg, 1))
-            except (ValueError, TypeError):
-                page_number = 1
             context["elided_page_range"] = context["paginator"].get_elided_page_range(
-                page_number
+                self.request.GET.get(self.page_kwarg, 1)
             )
         else:
             context["items_count"] = len(context["object_list"])

--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -239,12 +239,6 @@ class BaseChooseView(
             "select", label=_("Select"), width="1%", accessor="pk"
         )
 
-    @cached_property
-    def verbose_name_plural(self):
-        if self.model_class:
-            return self.model_class._meta.verbose_name_plural
-        return None
-
     def get_results_page(self, request):
         objects = self.get_object_list()
         objects = self.apply_object_list_ordering(objects)

--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -28,7 +28,7 @@ from wagtail.admin.forms.choosers import (
     SearchFilterMixin,
 )
 from wagtail.admin.modal_workflow import render_modal_workflow
-from wagtail.admin.paginator import get_wagtail_paginator_class
+from wagtail.admin.paginator import WagtailPaginator
 from wagtail.admin.ui.tables import Column, Table, TitleColumn
 from wagtail.coreutils import resolve_model_string
 from wagtail.models import CollectionMember, TranslatableMixin
@@ -132,7 +132,7 @@ class BaseChooseView(
     results_template_name = "wagtailadmin/generic/chooser/results.html"
     construct_queryset_hook_name = None
     url_filter_parameters = []
-    paginator_class = get_wagtail_paginator_class()
+    paginator_class = WagtailPaginator
 
     def get_object_list(self):
         return self.model_class.objects.all()

--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -279,6 +279,10 @@ class BaseSearchResults:
         self._results_cache = None
         self._count_cache = None
         self._score_field = None
+        # Attach the model to mimic a QuerySet so that we can inspect it after
+        # doing a search, e.g. to get the model's name in a paginator.
+        # The query_compiler may be None, e.g. when using EmptySearchResults.
+        self.model = query_compiler.queryset.model if query_compiler else None
 
     def _set_limits(self, start=None, stop=None):
         if stop is not None:


### PR DESCRIPTION
Rebase of #12607, fixes #12004 except for page choosers.

Implementing this for page choosers require some refactoring around how the links are ajax-ified. This is currently done using the separate `_pagination.html` and `{% paginate %}` template tag, instead of the generic and more widely-used `pagination_nav.html`. I think we can leave this for 7.1 instead.