### PR TITLE
Improve locale filter in all choosers

### DIFF
--- a/client/src/components/ChooserWidget/SnippetChooserWidget.js
+++ b/client/src/components/ChooserWidget/SnippetChooserWidget.js
@@ -1,19 +1,8 @@
 import { ChooserModal } from '../../includes/chooserModal';
 import { Chooser, ChooserFactory } from '.';
-import { WAGTAIL_CONFIG } from '../../config/wagtailConfig';
 
 class SnippetChooserModal extends ChooserModal {
-  getURLParams(opts) {
-    const params = super.getURLParams(opts);
-    if (WAGTAIL_CONFIG.ACTIVE_CONTENT_LOCALE) {
-      // The user is editing a piece of translated content.
-      // Pass the locale along as a request parameter. If this
-      // snippet is also translatable, the results will be
-      // pre-filtered by this locale.
-      params.locale = WAGTAIL_CONFIG.ACTIVE_CONTENT_LOCALE;
-    }
-    return params;
-  }
+  // left as is for backwards compatibility.
 }
 
 export class SnippetChooser extends Chooser {

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -3,6 +3,7 @@
 import $ from 'jquery';
 import { initTabs } from './tabs';
 import { gettext } from '../utils/gettext';
+import { WAGTAIL_CONFIG } from '../config/wagtailConfig';
 
 const validateCreationForm = (form) => {
   let hasErrors = false;
@@ -353,6 +354,13 @@ class ChooserModal {
     }
     if (opts.linkedFieldFilters) {
       Object.assign(urlParams, opts.linkedFieldFilters);
+    }
+    if (WAGTAIL_CONFIG.ACTIVE_CONTENT_LOCALE) {
+      // The user is editing a piece of translated content.
+      // Pass the locale along as a request parameter. If this
+      // model is also translatable, the results will be
+      // pre-filtered by this locale.
+      urlParams.locale = WAGTAIL_CONFIG.ACTIVE_CONTENT_LOCALE;
     }
     return urlParams;
   }

--- a/wagtail/admin/forms/choosers.py
+++ b/wagtail/admin/forms/choosers.py
@@ -133,13 +133,13 @@ class LocaleFilterMixin(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        locales = Locale.objects.all()
-        if locales:
+        choices = [
+            (locale.language_code, locale.get_display_name())
+            for locale in Locale.objects.all()
+        ]
+        if choices:
             self.fields["locale"] = forms.ChoiceField(
-                choices=[
-                    (locale.language_code, locale.get_display_name())
-                    for locale in locales
-                ],
+                choices=[("", _("All")), *choices],
                 required=False,
                 widget=forms.Select(attrs={"data-chooser-modal-search-filter": True}),
             )

--- a/wagtail/admin/tests/viewsets/test_chooser_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_chooser_viewset.py
@@ -1,23 +1,28 @@
 import json
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
+from django.urls import reverse
 
 from wagtail.admin import widgets
+from wagtail.models import Locale
+from wagtail.test.snippets.models import TranslatableSnippet
 from wagtail.test.testapp.models import Advert
 from wagtail.test.testapp.views import AdvertChooserWidget
 from wagtail.test.utils.wagtail_tests import WagtailTestUtils
 
 
 class TestChooserViewSetWithFilteredObjects(WagtailTestUtils, TestCase):
-    def setUp(self):
-        self.user = self.login()
-
+    @classmethod
+    def setUpTestData(cls):
         Advert.objects.create(text="Head On, apply directly to the forehead")
 
         advert2 = Advert.objects.create(
             url="https://quiznos.com", text="We like the subs"
         )
         advert2.tags.add("animated")
+
+    def setUp(self):
+        self.user = self.login()
 
     def test_get(self):
         response = self.client.get("/admin/animated_advert_chooser/")
@@ -54,3 +59,32 @@ class TestChooserViewSetWithFilteredObjects(WagtailTestUtils, TestCase):
                 "linkedFields": {"url": "#id_cool_url"},
             },
         )
+
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_filter_by_locale(self):
+        fr_locale = Locale.objects.create(language_code="fr")
+
+        TranslatableSnippet.objects.create(text="English snippet")
+        TranslatableSnippet.objects.create(text="French snippet", locale=fr_locale)
+
+        chooser_url = reverse(
+            "wagtailsnippetchoosers_snippetstests_translatablesnippet:choose"
+        )
+        response = self.client.get(chooser_url)
+        self.assertEqual(response.status_code, 200)
+        soup = self.get_soup(json.loads(response.content)["html"])
+
+        options = soup.select("select[name=locale] option")
+        self.assertEqual(len(options), 3)
+        self.assertListEqual(
+            [(option["value"], option.text) for option in options],
+            [("", "All"), ("en", "English"), ("fr", "French")],
+        )
+
+        self.assertEqual(len(response.context["results"]), 2)
+        self.assertEqual(response.context["results"][0].text, "English snippet")
+        self.assertEqual(response.context["results"][1].text, "French snippet")
+
+        response = self.client.get(f"{chooser_url}?locale=en")
+        self.assertEqual(len(response.context["results"]), 1)
+        self.assertEqual(response.context["results"][0].text, "English snippet")

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 
 from django.conf import settings
 from django.contrib.admin.utils import quote
@@ -107,8 +108,10 @@ class BeforeAfterHookMixin(HookResponseMixin):
 class LocaleMixin:
     @cached_property
     def i18n_enabled(self) -> bool:
-        return getattr(settings, "WAGTAIL_I18N_ENABLED", False) and issubclass(
-            self.model, TranslatableMixin
+        return (
+            getattr(settings, "WAGTAIL_I18N_ENABLED", False)
+            and (model := getattr(self, "model", None)) is not None
+            and issubclass(model, TranslatableMixin)
         )
 
     @cached_property
@@ -119,7 +122,7 @@ class LocaleMixin:
     def translations(self):
         return self.get_translations() if self.locale else []
 
-    def get_locale(self):
+    def get_locale(self) -> Optional[Locale]:
         if not getattr(self, "model", None):
             return None
 

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -129,8 +129,7 @@ class LocaleMixin:
         if hasattr(self, "object") and self.object:
             return self.object.locale
 
-        selected_locale = self.request.GET.get("locale")
-        if selected_locale:
+        if selected_locale := self.request.GET.get("locale"):
             return get_object_or_404(Locale, language_code=selected_locale)
         return Locale.get_default()
 


### PR DESCRIPTION
This PR fixes #13041:

- adds an empty options for all locales in the chooser locale filter
- moves the logic to append the locale url param to the base chooser out of snippets. This has the benefit of prefiltering all choosers
- adds the locale column to the base chooser columns if i18n is enabled and the chooser mode is translatable. The locale column is taken from #12917


<details>
<summary>Screenshots 📸</summary>

| Before | After |
|--------|--------|
| <img width="973" alt="page chooser with locales. before" src="https://github.com/user-attachments/assets/8c0dc0b8-7efc-49e0-b43d-ae5abc929814" /> | <img width="1035" alt="page chooser with locales, prefiltered. after" src="https://github.com/user-attachments/assets/cd0826cb-907e-4cf8-b0fb-333968a23a41" />  |
| <img width="1237" alt="snippet chooser locale filter before" src="https://github.com/user-attachments/assets/6a671848-aa9f-47f8-b764-f4fc0cceef1d" /> | <img width="1035" alt="snippet chooser locale filter after" src="https://github.com/user-attachments/assets/1bb83c11-9fc7-4fd3-9e6f-487a83909063" /> | 





