### PR TITLE
Fall back to AVIF plugin from pillow-heif if pillow was not built with AVIF support

### DIFF
--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -46,3 +46,18 @@ class WagtailImagesAppConfig(AppConfig):
         from wagtail.models.reference_index import ReferenceIndex
 
         ReferenceIndex.register_model(Image)
+
+        try:
+            from PIL import _plugins
+            from PIL.AvifImagePlugin import SUPPORTED
+            from pillow_heif.AvifImagePlugin import register_avif_opener
+
+            if not SUPPORTED:
+                # Pillow was built without AVIF support, so remove the plugin
+                # and register the plugin from pillow-heif instead.
+                _plugins[:] = [
+                    plugin for plugin in _plugins if plugin != "AvifImagePlugin"
+                ]
+                register_avif_opener()
+        except ImportError:
+            pass

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -1,3 +1,4 @@
+import hashlib
 import unittest
 
 from django.conf import settings
@@ -131,9 +132,11 @@ class TestImage(TestCase):
             self.image.get_file_size()
 
     def test_file_hash(self):
-        self.assertEqual(
-            self.image.get_file_hash(), "4dd0211870e130b7e1690d2ec53c499a54a48fef"
-        )
+        with self.image.file.open() as f:
+            loaded_hash = hashlib.sha1(f.read()).hexdigest()
+        # Ensure get_file_hash() (which does the hash by chunks) returns the
+        # same hash as the one calculated by loading the file into memory.
+        self.assertEqual(self.image.get_file_hash(), loaded_hash)
 
     def test_get_suggested_focal_point_svg(self):
         """


### PR DESCRIPTION
Consider this a hack...

Pillow 11.2.x was released with half-baked built-in support for AVIF: there's no wheels with AVIF support (11.2.0 was meant to have them, but they had to reissue the release as 11.2.0 due to massive increase in size). You need to build it from source (with libavif installed) in order to use AVIF. However, the image opener is [registered regardless whether AVIF support is available or not](https://github.com/python-pillow/Pillow/blob/3d4119521c853e1014012f73fdf9b2a8dc137722/src/PIL/AvifImagePlugin.py#L287-L292). This results in libraries like [pillow-heif](https://github.com/bigcat88/pillow_heif) and [pillow-avif-plugin](https://github.com/fdintino/pillow-avif-plugin) becoming broken, as the image is always opened with Pillow's built-in AVIF opener (and failing immediately).

A potential workaround is to disable the built-in AVIF plugin and re-register the opener from one of the external plugins, which this PR does. This is probably too much of a hack to be in a final release, so we might have to put an upper bound on Pillow for now, and revisit when they release 11.3.0 in July.

Also, Pillow changed its behaviour in how it handles PNGs (https://github.com/python-pillow/Pillow/issues/8796), resulting in `test_file_hash` added in 3c0c64642b9e5b8d28b111263c7f4bddad6c3880 failing. I opted to fix this by comparing that the hash returned by `get_file_hash()` (computed by our `hash_filelike` util) is equal to the hash calculated by loading the whole file in memory and doing a hexdigest, which I believe was the only thing we care about in regards to the hash value.