### PR TITLE
 Replace Hardcoded String Concatenation with gettext for Localization…

### DIFF
--- a/client/src/controllers/LocaleController.ts
+++ b/client/src/controllers/LocaleController.ts
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus';
+import { gettext, interpolate } from '../utils/gettext';
 
 /**
  * Localizes elements in the current locale.
@@ -58,7 +59,10 @@ export class LocaleController extends Controller<HTMLSelectElement> {
       if (!timeZone) return;
       const localized = LocaleController.getTZLabel(timeZone);
       const option = opt;
-      option.textContent = `${option.textContent}: ${localized}`;
+      option.textContent = interpolate(gettext('%s: %s'), [
+        option.textContent,
+        localized,
+      ]);
     });
   }
 }


### PR DESCRIPTION
PR Description:
This PR updates the logic used to generate the option.textContent in the Page Locale select dropdown, replacing the hardcoded colon (:) with a translatable string using gettext.

What’s Changed:
Replaced:
option.textContent = \`${option.textContent}: ${localized}\`;
with:
option.textContent = interpolate(gettext('%s: %s'), [option.textContent, localized]);

Why This Matters:
Removed Hardcoding: The colon separator is no longer hardcoded, allowing better flexibility.
Enabled Translation: The string '%s: %s' is now marked for translation via gettext, enabling extraction using tools like makemessages.
Improved Localization Support: Translators can now adapt the format to their language needs (e.g., adding spaces before colons in French).

🎯 Result:

This change ensures the dropdown is fully localizable and provides a more consistent and flexible experience for users in different languages.

Fixes #13044 .

