### PR TITLE
Hide add locale button when no more languages are available

### DIFF
--- a/wagtail/locales/views.py
+++ b/wagtail/locales/views.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import gettext_lazy
+from django.utils.translation import gettext_lazy, ngettext_lazy
 
 from wagtail.admin import messages
 from wagtail.admin.ui.tables import Column, TitleColumn
@@ -31,14 +31,18 @@ def _can_add_locale() -> bool:
     return created_locales.count() < len(content_languages)
 
 
-class UsageColumn(Column):
+class LocaleUsageColumn(Column):
     def get_value(self, locale):
         num_pages, num_others = get_locale_usage(locale)
-        # TODO: make this translatable
-        val = "%d pages" % num_pages
         if num_others:
-            val += " + %d others" % num_others
-        return val
+            return gettext_lazy("%(num_pages)d pages and %(num_others)d others") % {
+                "num_pages": num_pages,
+                "num_others": num_others,
+            }
+
+        return ngettext_lazy("%(num_pages)d page", "%(num_pages)d pages", num_pages) % {
+            "num_pages": num_pages
+        }
 
 
 class IndexView(generic.IndexView):
@@ -55,7 +59,7 @@ class IndexView(generic.IndexView):
             sort_key="language_code",
             url_name="wagtaillocales:edit",
         ),
-        UsageColumn("usage", label=gettext_lazy("Usage")),
+        LocaleUsageColumn("usage", label=gettext_lazy("Usage")),
     ]
 
     def get_add_url(self) -> Optional[str]:


### PR DESCRIPTION
This PR
- Hides the "Add locale" button on the Locales index view  when all defined locales are added, and denies access to the Locale create view too
- Makes the Locale UsageColumn value translatable

Fixes #13029