### PR TITLE
match X links for embedded content

### DIFF
--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -504,6 +504,7 @@ twitter = {
     "endpoint": "https://api.twitter.com/1/statuses/oembed.{format}",
     "urls": [
         r"^https?://twitter\.com/(?:#!)?[^#?/]+/status/.+$",
+        r"^https?://x\.com/(?:#!)?[^#?/]+/status/.+$",
     ],
 }
 


### PR DESCRIPTION
Is there a reason `x.com` links aren't matched for embeds? I just wanted to embed a tweet and noticed it. If it is a political decision (no offense), do all the other providers also align with wagtail's values?