### PR TITLE
Relocate the init_new_page signal and update docs

### DIFF
--- a/docs/reference/signals.md
+++ b/docs/reference/signals.md
@@ -215,8 +215,6 @@ This signal is emitted from a `CreateView` when a new page is initialized in the
 
 It's useful for pre-populating the page form programmatically when default values are not sufficient.
 
-Please note that this signal is imported from `wagtail.admin.signals` and not `wagtail.signals`.
-
 -   `sender` - `CreateView`
 -   `page` - The new page instance
 -   `parent_page` - The parent page of the new page
@@ -224,7 +222,7 @@ Please note that this signal is imported from `wagtail.admin.signals` and not `w
 Here's an example of how to use this signal to pre-populate a new page's title using the page's parent's title as a prefix:
 
 ```python
-from wagtail.admin.signals import init_new_page
+from wagtail.signals import init_new_page
 
 def prepopulate_page(sender, page, parent, **kwargs):
     if parent:

--- a/docs/reference/signals.md
+++ b/docs/reference/signals.md
@@ -230,3 +230,5 @@ def prepopulate_page(sender, page, parent, **kwargs):
 
 init_new_page.connect(prepopulate_page)
 ```
+
+For more complex customizations of the page creation and editing forms, see [](custom_edit_handler_forms).

--- a/docs/reference/signals.md
+++ b/docs/reference/signals.md
@@ -125,7 +125,7 @@ The following arguments are emitted by this signal:
 -   `instance` - The updated (and saved), specific `Page` instance.
 -   `instance_before` - A copy of the specific `Page` instance from **before** the changes were saved.
 
-## workflow_submitted
+## `workflow_submitted`
 
 This signal is emitted from a `WorkflowState` when a page is submitted to a workflow.
 
@@ -134,7 +134,7 @@ This signal is emitted from a `WorkflowState` when a page is submitted to a work
 -   `user` - The user who submitted the workflow
 -   `kwargs` - Any other arguments passed to `workflow_submitted.send()`
 
-## workflow_rejected
+## `workflow_rejected`
 
 This signal is emitted from a `WorkflowState` when a page is rejected from a workflow.
 
@@ -143,7 +143,7 @@ This signal is emitted from a `WorkflowState` when a page is rejected from a wor
 -   `user` - The user who rejected the workflow
 -   `kwargs` - Any other arguments passed to `workflow_rejected.send()`
 
-## workflow_approved
+## `workflow_approved`
 
 This signal is emitted from a `WorkflowState` when a page's workflow completes successfully
 
@@ -152,7 +152,7 @@ This signal is emitted from a `WorkflowState` when a page's workflow completes s
 -   `user` - The user who last approved the workflow
 -   `kwargs` - Any other arguments passed to `workflow_approved.send()`
 
-## workflow_cancelled
+## `workflow_cancelled`
 
 This signal is emitted from a `WorkflowState` when a page's workflow is canceled
 
@@ -161,7 +161,7 @@ This signal is emitted from a `WorkflowState` when a page's workflow is canceled
 -   `user` - The user who canceled the workflow
 -   `kwargs` - Any other arguments passed to `workflow_cancelled.send()`
 
-## task_submitted
+## `task_submitted`
 
 This signal is emitted from a `TaskState` when a page is submitted to a task.
 
@@ -170,7 +170,7 @@ This signal is emitted from a `TaskState` when a page is submitted to a task.
 -   `user` - The user who submitted the page to the task
 -   `kwargs` - Any other arguments passed to `task_submitted.send()`
 
-## task_rejected
+## `task_rejected`
 
 This signal is emitted from a `TaskState` when a page is rejected from a task.
 
@@ -179,7 +179,7 @@ This signal is emitted from a `TaskState` when a page is rejected from a task.
 -   `user` - The user who rejected the task
 -   `kwargs` - Any other arguments passed to `task_rejected.send()`
 
-## task_approved
+## `task_approved`
 
 This signal is emitted from a `TaskState` when a page's task is approved
 
@@ -188,7 +188,7 @@ This signal is emitted from a `TaskState` when a page's task is approved
 -   `user` - The user who approved the task
 -   `kwargs` - Any other arguments passed to `task_approved.send()`
 
-## task_cancelled
+## `task_cancelled`
 
 This signal is emitted from a `TaskState` when a page's task is canceled.
 
@@ -197,7 +197,7 @@ This signal is emitted from a `TaskState` when a page's task is canceled.
 -   `user` - The user who canceled the task
 -   `kwargs` - Any other arguments passed to `task_cancelled.send()`
 
-## copy_for_translation_done
+## `copy_for_translation_done`
 
 This signal is emitted from `CopyForTranslationAction` or `CopyPageForTranslationAction` when a translatable model or page is copied to a new locale (translated).
 
@@ -206,3 +206,27 @@ A translatable model is a model that implements the [TranslatableMixin](wagtail.
 -   `sender` - `CopyForTranslationAction` or `CopyPageForTranslationAction`
 -   `source_obj` - The source object
 -   `target_obj` - The copy of the source object in the new locale
+
+## `init_new_page`
+
+This signal is emitted from a `CreateView` when a new page is initialized in the admin interface. In other words, it's emitted when a user navigates to a form to create a new page.
+
+It's useful for pre-populating the page form programmatically when default values are not sufficient.
+
+Please note that this signal is imported from `wagtail.admin.signals` and not `wagtail.signals`.
+
+-   `sender` - `CreateView`
+-   `page` - The new page instance
+-   `parent_page` - The parent page of the new page
+
+Here's an example of how to use this signal to pre-populate a new page's title using the page's parent's title as a prefix:
+
+```python
+from wagtail.admin.signals import init_new_page
+
+def prepopulate_page(sender, page, parent, **kwargs):
+    if parent:
+        page.title = f"{parent.title}: New Page Title"
+
+init_new_page.connect(prepopulate_page)
+```

--- a/docs/reference/signals.md
+++ b/docs/reference/signals.md
@@ -207,6 +207,8 @@ A translatable model is a model that implements the [TranslatableMixin](wagtail.
 -   `source_obj` - The source object
 -   `target_obj` - The copy of the source object in the new locale
 
+(init_new_page_signal)=
+
 ## `init_new_page`
 
 This signal is emitted from a `CreateView` when a new page is initialized in the admin interface. In other words, it's emitted when a user navigates to a form to create a new page.

--- a/wagtail/admin/signals.py
+++ b/wagtail/admin/signals.py
@@ -1,4 +1,0 @@
-from django.dispatch import Signal
-
-# provides args: page, parent
-init_new_page = Signal()

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -13,7 +13,7 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 from django.views.generic.base import View
 
-from wagtail.admin import messages, signals
+from wagtail.admin import messages
 from wagtail.admin.action_menu import PageActionMenu
 from wagtail.admin.ui.components import MediaContainer
 from wagtail.admin.ui.side_panels import (
@@ -32,6 +32,7 @@ from wagtail.models import (
     PageSubscription,
     PageViewRestriction,
 )
+from wagtail.signals import init_new_page
 
 
 def add_subpage(request, parent_page_id):
@@ -389,9 +390,7 @@ class CreateView(WagtailAdminTemplateMixin, HookResponseMixin, View):
         return self.render_to_response(self.get_context_data())
 
     def get(self, request):
-        signals.init_new_page.send(
-            sender=CreateView, page=self.page, parent=self.parent_page
-        )
+        init_new_page.send(sender=CreateView, page=self.page, parent=self.parent_page)
         self.form = self.form_class(
             instance=self.page,
             subscription=self.subscription,

--- a/wagtail/signals.py
+++ b/wagtail/signals.py
@@ -68,3 +68,7 @@ pre_validate_delete = Signal()
 # Translation signals
 # provides args: sender, source_obj, target_obj
 copy_for_translation_done = Signal()
+
+# Admin signals
+# provides args: page, parent
+init_new_page = Signal()


### PR DESCRIPTION
The `init_new_page` signal is quite useful for things like pre-populating a new page form programatically.

This PR moves it to the main signals file and adds relevant documentation describing the signal, so that more people are aware of it.

It also adds ticks <code>`</code> to signal headlines to keep things consistent.