### PR TITLE
Revert use of ngettext in items_count_label

### DIFF
--- a/wagtail/admin/paginator.py
+++ b/wagtail/admin/paginator.py
@@ -1,7 +1,6 @@
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
-from django.utils.translation import ngettext
 
 
 class WagtailPaginator(Paginator):
@@ -25,18 +24,10 @@ class WagtailPaginator(Paginator):
 
     @cached_property
     def items_count_label(self):
-        label = ngettext(
-            # Translators: The label to use when displaying the number of items
-            # in a list, e.g. "1 image" or "2 images".
-            "%(count)d %(item_name)s",
-            "%(count)d %(item_name_plural)s",
-            self.count,
-        )
-        return label % {
-            "count": self.count,
-            "item_name": self.verbose_name,
-            "item_name_plural": self.verbose_name_plural,
-        }
+        if self.count == 1:
+            return f"1 {self.verbose_name}"
+        else:
+            return f"{self.count} {self.verbose_name_plural}"
 
     def get_elided_page_range(self, page_number):
         """


### PR DESCRIPTION
The use of ngettext here (from #13042) breaks `django-admin compilemessages`. The singular and plural forms do not contain the same placeholder variables, so when a translation is added using the expected one of `item_name` or `item_name_plural`, compilation fails with:

```
Execution of msgfmt failed: /Users/matthew/Development/tbx/wagtail/devscript/wagtail/wagtail/admin/locale/fr/LC_MESSAGES/django.po:465: a format specification for argument 'item_name', as in 'msgstr[0]', doesn't exist in 'msgid_plural'
msgfmt: found 1 fatal error
```

Languages with more complex pluralisation rules than "one or many" will not be able to use these correctly in this case anyway, as Django's use of `verbose_name` versus `verbose_name_plural` does not capture this complexity - so there is no loss of fidelity from switching this to a naive `if count == 1` check.