### PR TITLE
Clean up spelling & docs cross-links for R7.0 release notes

### DIFF
--- a/docs/releases/7.0.md
+++ b/docs/releases/7.0.md
@@ -19,7 +19,7 @@ This version adds formal support for Django 5.2.
 
 ### Deferring validation on saving drafts
 
-This release introduces a change to the validation behaviour when saving pages (or snippets using [`DraftStateMixin`](wagtailsnippets_saving_draft_changes_of_snippets)) as drafts. In most cases, required fields will not be enforced when saving as draft, allowing users to save work-in-progress versions without filling in all fields. Validation is applied as normal when the page or snippet is published, scheduled, or submitted to a workflow. The new behaviour is enabled by default, but see the notes below on [](configuring_deferred_validation).
+This release introduces a change to the validation behavior when saving pages (or snippets using [`DraftStateMixin`](wagtailsnippets_saving_draft_changes_of_snippets)) as drafts. In most cases, required fields will not be enforced when saving as draft, allowing users to save work-in-progress versions without filling in all fields. Validation is applied as normal when the page or snippet is published, scheduled, or submitted to a workflow. The new behavior is enabled by default, but see the notes below on [](configuring_deferred_validation).
 
 This feature was developed by Matt Westcott and Sage Abdullah.
 
@@ -71,11 +71,11 @@ We have a new pagination interface for all listing views and most choosers, incl
 
 ### Documentation
 
- * Add missing `django.contrib.admin` to list of apps in "add to Django project" guide (Mohamed Rabiaa)
- * Add tutorial on deploying on Ubuntu to third-party tutorials (Mohammad Fathi Rahman)
- * Document that request_or_site is optional on BaseGenericSetting.load (Matt Westcott)
- * Mention third-party StreamField based form builder packages in the [form builder](form_builder) documentation (Matt Westcott)
- * Clarify that `insert_editor_js` hook applies to all core editing/creation views (LB (Ben) Johnston)
+ * Add missing `django.contrib.admin` to list of apps in ["add to Django project" guide](../advanced_topics/add_to_django_project) (Mohamed Rabiaa)
+ * Add tutorial on deploying on Ubuntu to [third-party tutorials](../advanced_topics/third_party_tutorials) (Mohammad Fathi Rahman)
+ * Document that `request_or_site` is optional on `BaseGenericSetting.load` (Matt Westcott)
+ * Mention third-party `StreamField` based form builder packages in the [form builder](form_builder) documentation (Matt Westcott)
+ * Clarify that [`insert_editor_js` hook](insert_editor_js) applies to all core editing/creation views (LB (Ben) Johnston)
  * Clarify requirement for non-page models using model mixins to be registered as snippets (Sage Abdullah)
  * Document the `page.move` method from django-treebeard (Shlomo Markowitz)
 
@@ -126,8 +126,8 @@ The `classnames` keyword argument on the following classes is no longer supporte
 ### Renamed settings
 
  * The `WAGTAIL_AUTO_UPDATE_PREVIEW` setting is removed and should be replaced with [`WAGTAIL_AUTO_UPDATE_PREVIEW_INTERVAL = 0`](wagtail_auto_update_preview_interval) to disable auto-update.
- * The `PASSWORD_REQUIRED_TEMPLATE` setting is no longer recognised and should be replaced with [`WAGTAIL_PASSWORD_REQUIRED_TEMPLATE`](frontend_authentication).
- * The `DOCUMENT_PASSWORD_REQUIRED_TEMPLATE` setting is no longer recognised and should be replaced with [`WAGTAILDOCS_PASSWORD_REQUIRED_TEMPLATE`](frontend_authentication).
+ * The `PASSWORD_REQUIRED_TEMPLATE` setting is no longer recognized and should be replaced with [`WAGTAIL_PASSWORD_REQUIRED_TEMPLATE`](frontend_authentication).
+ * The `DOCUMENT_PASSWORD_REQUIRED_TEMPLATE` setting is no longer recognized and should be replaced with [`WAGTAILDOCS_PASSWORD_REQUIRED_TEMPLATE`](frontend_authentication).
 
 ### Replaced mechanism for customizing user form classes
 
@@ -156,6 +156,7 @@ The settings `WAGTAIL_USER_EDIT_FORM`, `WAGTAIL_USER_CREATION_FORM` and `WAGTAIL
 ## Upgrade considerations - changes affecting all projects
 
 (configuring_deferred_validation)=
+
 ### Configuring deferred validation of required fields
 
 For text-based fields (such as `CharField`, `TextField`, `RichTextField` and `StreamField`), the new behaviour of skipping required field validation on saving drafts is in place automatically, with no code changes required. For non-text-based fields (such as `IntegerField` and `DateField`) that are not defined with `null=True`, the database will not allow saving of blank values, and so the form will continue to enforce these as required fields even when saving as draft.
@@ -167,7 +168,6 @@ To allow a non-text-based field to be left blank on saving drafts, add `null=Tru
 ```
 
 can be changed as follows to allow it to be left blank when saving as draft:
-
 
 ```python
     date_published = models.DateField("Date article published", null=True)


### PR DESCRIPTION
* Add extra docs links in the documentation updates
* Update some spelling to be US spelling
* Fix up whitespace items