### PR TITLE
Fix add URL logic when locales are full

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/generic/index.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index.html
@@ -5,12 +5,20 @@
     {% fragment as extra_actions %}
         {% block extra_actions %}
             {% if view.list_export %}
-                {% include view.export_buttons_template_name %}
+                {% if view.get_add_url %}
+                    {% with view.get_add_url as add_url %}
+                        {% if add_url %}
+                            {% include view.export_buttons_template_name %}
+                        {% endif %}
+                    {% endwith %}
+                {% endif %}
             {% endif %}
         {% endblock %}
     {% endfragment %}
     {% if not breadcrumbs_items %}
-        {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=header_action_url action_text=header_action_label action_icon=header_action_icon extra_actions=extra_actions icon=header_icon search_url=search_url search_form=search_form search_results_url=index_results_url only %}
+        {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=header_action_url
+        action_text=header_action_label action_icon=header_action_icon extra_actions=extra_actions icon=header_icon
+        search_url=search_url search_form=search_form search_results_url=index_results_url only %}
     {% endif %}
 {% endblock %}
 

--- a/wagtail/locales/views.py
+++ b/wagtail/locales/views.py
@@ -1,5 +1,5 @@
 from django.utils.translation import gettext_lazy
-
+from django.conf import settings
 from wagtail.admin import messages
 from wagtail.admin.ui.tables import Column, TitleColumn
 from wagtail.admin.views import generic
@@ -44,7 +44,21 @@ class IndexView(generic.IndexView):
         ),
         UsageColumn("usage", label=gettext_lazy("Usage")),
     ]
-
+    
+    def get_add_url(self):
+        languages = getattr(settings,'WAGTAIL_CONTENT_LANGUAGES',None)
+        if languages is not None:
+            if Locale.objects.all().count() >= len(languages):
+                return None
+        return super().get_add_url()
+    
+    def get_header_action_url(self):
+        return self.get_add_url()
+    
+    def get_context_data(self, **kwargs):
+        context =  super().get_context_data(**kwargs)
+        context["header_action_url"] = self.get_header_action_url()
+        return context
 
 class CreateView(generic.CreateView):
     page_title = gettext_lazy("Add locale")

--- a/wagtail/locales/views.py
+++ b/wagtail/locales/views.py
@@ -1,5 +1,6 @@
-from django.utils.translation import gettext_lazy
 from django.conf import settings
+from django.utils.translation import gettext_lazy
+
 from wagtail.admin import messages
 from wagtail.admin.ui.tables import Column, TitleColumn
 from wagtail.admin.views import generic

--- a/wagtail/tests/test_views.py
+++ b/wagtail/tests/test_views.py
@@ -1,15 +1,15 @@
 from unittest import mock
 
-from django.test import TestCase,override_settings
+from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 
 from wagtail.coreutils import get_dummy_request
-from wagtail.models import Page, Site,Locale
+from wagtail.locales.views import IndexView
+from wagtail.models import Locale, Page, Site
 from wagtail.test.testapp.models import SimplePage
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.views import serve
-from wagtail.locales.views import IndexView
 
 
 class TestLoginView(WagtailTestUtils, TestCase):

--- a/wagtail/tests/test_views.py
+++ b/wagtail/tests/test_views.py
@@ -1,13 +1,15 @@
 from unittest import mock
 
-from django.test import TestCase
+from django.test import TestCase,override_settings
+from django.test.client import RequestFactory
 from django.urls import reverse
 
 from wagtail.coreutils import get_dummy_request
-from wagtail.models import Page, Site
+from wagtail.models import Page, Site,Locale
 from wagtail.test.testapp.models import SimplePage
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.views import serve
+from wagtail.locales.views import IndexView
 
 
 class TestLoginView(WagtailTestUtils, TestCase):
@@ -98,3 +100,18 @@ class TestServeView(TestCase):
                     response_b = self.client.get("/simple/")
                 self.assertEqual(response_b.content, b"Intercepted")
                 self.assertEqual(m.call_count, 1)
+
+class TestIndexView(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+    
+    @override_settings(WAGTAIL_CONTENT_LANGUAGES=[{'code': 'fa'}])
+    def test_get_add_url_none_when_locales_full(self):
+        Locale.objects.create(language_code='fa')
+
+        request = self.factory.get('/admin/locales/')
+        view = IndexView()
+        view.setup(request)
+        view.request = request
+
+        self.assertIsNone(view.get_add_url())


### PR DESCRIPTION
## Summary
This pull request fixes the logic for the "Add" button in the index view when all locales are already created.
Previously, it could incorrectly display the add button even when no locales were available.

## Changes
- Updated the view logic to correctly handle full locales.
- Updated the corresponding template to match the new behavior.
- Added a unit test (`test_get_add_url_none_when_locales_full`) to ensure correct behavior when locales are full.

## Testing
- Added tests to cover the scenario where no additional locales can be created.
- Ran tests locally with `pytest` to confirm that all tests pass.

## Notes
- This addresses potential UX issues by ensuring that the "Add" action only appears when appropriate.

