### PR TITLE
fix: fix bug, wrong logout redirect after WAGTAILADMIN_LOGIN_URL setting

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
  * Add iHeart oembed provider (Storm Heg)
  * Fix: Handle lazy translation strings as `preview_value` for `RichTextBlock` (Seb Corbin)
  * Fix: Fix handling of newline-separated choices in form builder when using non-windows newline characters (Baptiste Mispelon)
+ * Fix: Ensure `WAGTAILADMIN_LOGIN_URL` is respected when logging out of the admin (Antoine Rodriguez, Ramon de Jezus)
  * Maintenance: Refactor `get_embed` to remove `finder` argument which was only used for mocking in unit tests (Jigyasu Rajput)
 
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -883,6 +883,7 @@
 * Arthur Tripp
 * Ian Meigh
 * Jigyasu Rajput
+* Antoine Rodriguez
 
 ## Translators
 

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -19,6 +19,7 @@ depth: 1
 
  * Handle lazy translation strings as `preview_value` for `RichTextBlock` (Seb Corbin)
  * Fix handling of newline-separated choices in form builder when using non-windows newline characters (Baptiste Mispelon)
+ * Ensure `WAGTAILADMIN_LOGIN_URL` is respected when logging out of the admin (Antoine Rodriguez, Ramon de Jezus)
 
 ### Documentation
 

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -121,6 +121,25 @@ class TestAuthentication(WagtailTestUtils, TestCase):
         # Check that the user was logged out
         self.assertNotIn("_auth_user_id", self.client.session)
 
+    @override_settings(WAGTAILADMIN_LOGIN_URL="fallback")
+    def test_logout_redirect_with_custom_login_url(self):
+        """
+        This tests that if the WAGTAILADMIN_LOGIN_URL setting is customized,
+        the user will be redirected to that URL when logging out of the admin.
+        """
+        # Login
+        self.login()
+
+        # Get logout page
+        response = self.client.post(reverse("wagtailadmin_logout"))
+
+        # Check that the user was redirected to the URL set for the
+        # WAGTAILADMIN_LOGIN_URL setting
+        self.assertRedirects(response, reverse("fallback"))
+
+        # Check that the user was logged out
+        self.assertNotIn("_auth_user_id", self.client.session)
+
     def test_not_logged_in_redirect(self):
         """
         This tests that a not logged in user is redirected to the

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -419,7 +419,9 @@ class LoginView(auth_views.LoginView):
 
 
 class LogoutView(auth_views.LogoutView):
-    next_page = "wagtailadmin_login"
+    @property
+    def next_page(self):
+        return getattr(settings, "WAGTAILADMIN_LOGIN_URL", "wagtailadmin_login")
 
     def dispatch(self, request, *args, **kwargs):
         response = super().dispatch(request, *args, **kwargs)

--- a/wagtail/test/urls.py
+++ b/wagtail/test/urls.py
@@ -45,7 +45,7 @@ urlpatterns = [
     ),
     path("sitemap-<str:section>.xml", sitemaps_views.sitemap, name="sitemap"),
     path("testapp/", include(testapp_urls)),
-    path("fallback/", lambda: HttpResponse("ok"), name="fallback"),
+    path("fallback/", lambda request: HttpResponse("ok"), name="fallback"),
 ]
 
 if apps.is_installed("pattern_library"):


### PR DESCRIPTION
- Admin Logout wouldn't redirect user to the path specified in the WAGTAILADMIN_LOGIN_URL setting, this fixes it as a WAGTAILADMIN_LOGOUT_URL setting doesn't currently exist. Fix #13056
- Fixes "fallback/" path in urls of wagtail test project, necessary for current main fix.

_Please describe the problem you're fixing here. Include the issue number, if applicable._

@laymonage 