### PR TITLE
Raise clear error when non-StreamBlock is passed as top-level block in StreamField

### DIFF
--- a/wagtail/fields.py
+++ b/wagtail/fields.py
@@ -146,6 +146,13 @@ class StreamField(models.Field):
 
             block = StreamBlock(child_blocks)
 
+        if not isinstance(block, StreamBlock):
+            raise TypeError(
+                f"The top-level block must be a StreamBlock (got {type(block).__name__}). "
+                "Either pass a StreamBlock instance/class, or a list of block definitions "
+                "as (name, block) tuples."
+            )
+
         block.set_meta_options(self.block_opts)
         return block
 

--- a/wagtail/tests/test_streamfield.py
+++ b/wagtail/tests/test_streamfield.py
@@ -1152,3 +1152,17 @@ class TestDeconstructStreamFieldWithLookup(TestCase):
                 },
             },
         )
+
+
+class TestBlockTypeValidation(TestCase):
+    def test_non_streamblock_raises_correct_error(self):
+        """stream_block raises useful error message when non-StreamBlock is provided."""
+        msg = (
+            "The top-level block must be a StreamBlock (got StructBlock). "
+            "Either pass a StreamBlock instance/class, or a list of block definitions "
+            "as (name, block) tuples."
+        )
+
+        with self.assertRaisesMessage(TypeError, msg):
+            field = StreamField(blocks.StructBlock([("name", blocks.CharBlock())]))
+            field.stream_block


### PR DESCRIPTION
Fixes #13067

