### PR TITLE
Fix no results with autocomplete search on MySQL

### DIFF
--- a/wagtail/search/migrations/0009_remove_ngram_autocomplete.py
+++ b/wagtail/search/migrations/0009_remove_ngram_autocomplete.py
@@ -1,0 +1,45 @@
+from django.db import connection, migrations
+
+# This migration takes on the base model defined in 0005_create_indexentry and adds certain fields that are specific to each database system
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtailsearch", "0008_remove_query_and_querydailyhits_models"),
+    ]
+
+    # Reverse the usage of ngram parser with MySQL introduced in
+    # ``0006_customise_indexentry.py``.
+    #
+    # Ngram parser is designed primarily for languages which to not use spaces to
+    # delimit words (most commonly CJK languages). When using ngram with English or
+    # other non-CJK languages, it has the adverse affect of parsing words into
+    # non-sensical queries that return no results. MySQL default ngram token size is 2
+    # characters, so for example the word "wagtail" would be parsed into 6 separate
+    # words as follows":
+    #
+    #    "wa" "ag" "gt" "ta" "ai" "il"
+    #
+    # In English, these tokens would provide useless search results, and in most cases,
+    # no results are returned at all when using autocomplete from the Wagtail admin.
+    #
+    # See: https://dev.mysql.com/doc/refman/8.0/en/fulltext-search-ngram.html
+    if connection.vendor == "mysql" and not connection.mysql_is_mariadb:
+        operations = [
+            migrations.RunSQL(
+                sql="""
+                ALTER TABLE wagtailsearch_indexentry
+                    DROP INDEX `fulltext_autocomplete`;
+
+                ALTER TABLE wagtailsearch_indexentry
+                    ADD FULLTEXT INDEX `fulltext_autocomplete` (`autocomplete`);
+                """,
+                reverse_sql="""
+                ALTER TABLE wagtailsearch_indexentry
+                    DROP INDEX `fulltext_autocomplete`;
+
+                ALTER TABLE wagtailsearch_indexentry
+                    ADD FULLTEXT INDEX `fulltext_autocomplete` (`autocomplete`);
+                    WITH PARSER ngram;
+                """,
+            )
+        ]

--- a/wagtail/search/migrations/0009_remove_ngram_autocomplete.py
+++ b/wagtail/search/migrations/0009_remove_ngram_autocomplete.py
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
                     DROP INDEX `fulltext_autocomplete`;
 
                 ALTER TABLE wagtailsearch_indexentry
-                    ADD FULLTEXT INDEX `fulltext_autocomplete` (`autocomplete`);
+                    ADD FULLTEXT INDEX `fulltext_autocomplete` (`autocomplete`)
                     WITH PARSER ngram;
                 """,
             )


### PR DESCRIPTION
Removes the ngram parser from autocomplete index on MySQL. This behavior was only originally applied to MySQL, not MariaDB or other database engines.

Ngram parser is designed primarily for languages which to not use spaces to delimit words (most commonly CJK languages). When using ngram with English or other non-CJK languages, it has the adverse affect of parsing words into non-sensical queries that return no results. MySQL default ngram token size is 2 characters, so for example the word "wagtail" would be parsed into 6 separate words as follows:
```
"wa" "ag" "gt" "ta" "ai" "il"
```

In English, these tokens would provide useless search results, and in most cases, no results are returned at all when using autocomplete from the Wagtail admin.

See: https://dev.mysql.com/doc/refman/8.0/en/fulltext-search-ngram.html

Testing:
* This problem has been plaguing our MySQL sites for some time now, but has been elusive to figure out.
* Tested this migration on a MySQL 8.0 database with 13,000 index entries, and it completed in about 1 second.
* I'd appreciate if other site owners could test this on their databases, to confirm if it is a useful fix, and if the time to run the migration is reasonable.
* You DO NOT need to run `update_index` afterwards.