### PR TITLE
fix: prepend UTF-8 BOM to exported CSV files for proper Unicode support in Excel

### DIFF
--- a/wagtail/admin/views/mixins.py
+++ b/wagtail/admin/views/mixins.py
@@ -280,8 +280,13 @@ class SpreadsheetExportMixin:
 
     def write_csv_response(self, queryset):
         stream = self.stream_csv(queryset)
+        # Add UTF-8 BOM to fix Excel showing '?????' for Arabic text
 
-        response = StreamingHttpResponse(stream, content_type="text/csv")
+        def bom_and_stream():
+          yield "\ufeff"  # UTF-8 BOM
+          yield from stream
+
+        response = StreamingHttpResponse(bom_and_stream(), content_type="text/csv")
         response["Content-Disposition"] = 'attachment; filename="{}.csv"'.format(
             self.get_filename()
         )

--- a/wagtail/admin/views/mixins.py
+++ b/wagtail/admin/views/mixins.py
@@ -280,11 +280,11 @@ class SpreadsheetExportMixin:
 
     def write_csv_response(self, queryset):
         stream = self.stream_csv(queryset)
-        # Add UTF-8 BOM to fix Excel showing '?????' for Arabic text
 
+        # Add UTF-8 BOM to fix Excel showing '?????' for Arabic text
         def bom_and_stream():
-          yield "\ufeff"  # UTF-8 BOM
-          yield from stream
+            yield "\ufeff"  # UTF-8 BOM
+            yield from stream
 
         response = StreamingHttpResponse(bom_and_stream(), content_type="text/csv")
         response["Content-Disposition"] = 'attachment; filename="{}.csv"'.format(


### PR DESCRIPTION
fix: prepend UTF-8 BOM to exported CSV files for proper Unicode support in Excel

Background:
When exporting data containing Arabic (or other non-Latin) characters from Wagtail, the resulting CSV files appeared corrupted in Microsoft Excel, showing '??????' instead of the actual characters.

Solution:
This commit updates the `write_csv_response` method to prepend a UTF-8 BOM to the CSV output stream. This ensures that Excel correctly recognizes the file as UTF-8 encoded and displays all characters properly.

Tested with Arabic records and confirmed correct display in Excel.
