### PR TITLE
Fix font size of footer action buttons when there is only one item

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -57,6 +57,7 @@ Changelog
  * Fix: Ensure there is consistent padding in homepage panels table headers (Aditya (megatrron))
  * Fix: Prevent redundant calls to context processors when rendering userbar (Ihor Marhitych)
  * Fix: Fix validation of duplicate field names in form builder when fields have been deleted (Ian Meigh)
+ * Fix: Fix font size of footer action buttons when there is only one item (Sage Abdullah)
  * Docs: Add missing `django.contrib.admin` to list of apps in "add to Django project" guide (Mohamed Rabiaa)
  * Docs: Add tutorial on deploying on Ubuntu to third-party tutorials (Mohammad Fathi Rahman)
  * Docs: Document that request_or_site is optional on BaseGenericSetting.load (Matt Westcott)

--- a/client/scss/components/_footer.scss
+++ b/client/scss/components/_footer.scss
@@ -102,6 +102,7 @@
       // Unset these styles in favor of a fixed height and the grid gap
       height: $text-input-height;
       margin-inline-start: initial;
+      font-size: theme('fontSize.16');
     }
 
     @include media-breakpoint-up(sm) {
@@ -139,7 +140,6 @@
   }
 
   > .button {
-    font-size: theme('fontSize.16');
     flex-grow: 1;
   }
 }

--- a/docs/releases/7.0.md
+++ b/docs/releases/7.0.md
@@ -69,6 +69,7 @@ We have a new pagination interface for all listing views and most choosers, incl
  * Ensure there is consistent padding in homepage panels table headers (Aditya (megatrron))
  * Prevent redundant calls to context processors when rendering userbar (Ihor Marhitych)
  * Fix validation of duplicate field names in form builder when fields have been deleted (Ian Meigh)
+ * Fix font size of footer action buttons when there is only one item (Sage Abdullah)
 
 ### Documentation
 


### PR DESCRIPTION
This was a regression #12456 that I kept forgetting to fix...

The primary footer action button is supposed to have a `font-size` of `1rem`. There was a bug in the initial implementation that caused custom listing buttons to also have a `font-size` of `1rem`, and #12456 was an attempt to fix it. Unfortunately that fix caused the `font-size: 1rem` to not be applied to footer actions that only have one action (e.g. in image and documents edit views), which led to them having a `font-size: 0.875rem` (14px) instead.

## Reviewing

To review, check the following places:

### Footer actions with only one action

<details><summary>Details</summary>


Example: image/document edit views. The footer action button should have a `font-size: 1rem`

<img width="646" alt="image" src="https://github.com/user-attachments/assets/2a63c315-701c-4784-9eb1-114d83665341" />

This is also the case when you try to edit a locked page/snippet as a user who does not own the lock

<img width="646" alt="image" src="https://github.com/user-attachments/assets/00232cf4-516f-44d7-b5a0-a1c5ce25ec24" />

</details> 


### Footer actions with multiple actions

<details><summary>Details</summary>


Example: page editor, snippets with `DraftStateMixin`

<img width="646" alt="image" src="https://github.com/user-attachments/assets/ad435412-9b26-4491-93c4-b04f21a9e3f4" />

The main action should have `font-size: 1rem` (16px), while the ones inside the dropdown should have `font-size: 0.875rem` (14px)
</details> 


### Bulk actions


<details><summary>Details</summary>

Example: bulk actions in pages, images, etc.

<img width="706" alt="image" src="https://github.com/user-attachments/assets/e5dbeaf0-adc0-4a83-9b48-efbfb406ef04" />

The footer buttons should all have a smaller `font-size` of around 12px, so the `font-size: 1rem` and the `font-size: 0.875rem` should not be applied.

</details> 

### Custom page listing buttons

<details><summary>Details</summary>

Following the example in #12456, add the following to `bakerydemo/base/wagtail_hooks.py`:

```py
from wagtail.admin import widgets as wagtailadmin_widgets


@hooks.register("register_page_listing_buttons")
def page_listing_buttons_new_signature(page, user, next_url=None):
    yield wagtailadmin_widgets.PageListingButton(
        "Custom button", "/custom-url", priority=10
    )

```

and open the page explorer.

<img width="685" alt="image" src="https://github.com/user-attachments/assets/76ceb077-d276-4220-8b5e-6142d697a436" />

The custom button should have the same size as the bulk actions one (i.e. small, ~12px).

</details> 