### PR TITLE
Fix method override issue in ViewSet.inject_view_methods due to late binding

### DIFF
--- a/wagtail/admin/viewsets/base.py
+++ b/wagtail/admin/viewsets/base.py
@@ -67,6 +67,7 @@ class ViewSet(WagtailMenuRegisterable):
         def make_view_method(viewset_method):
             def _view_method(self, *args, **kwargs):
                 return viewset_method(*args, **kwargs)
+
             return _view_method
 
         for method_name in method_names:

--- a/wagtail/admin/viewsets/base.py
+++ b/wagtail/admin/viewsets/base.py
@@ -63,13 +63,16 @@ class ViewSet(WagtailMenuRegisterable):
         """
         viewset = self
         overrides = {}
+
+        def make_view_method(viewset_method):
+            def _view_method(self, *args, **kwargs):
+                return viewset_method(*args, **kwargs)
+            return _view_method
+
         for method_name in method_names:
             viewset_method = getattr(viewset, method_name, None)
             if viewset_method:
-
-                def view_method(self, *args, **kwargs):
-                    return viewset_method(*args, **kwargs)
-
+                view_method = make_view_method(viewset_method)
                 view_method.__name__ = method_name
                 overrides[method_name] = view_method
 


### PR DESCRIPTION
Resolved a bug where dynamically created view methods all referenced the last method in the loop, caused by Python's late binding in closures. Replaced inline function with a factory function to correctly capture each method reference during iteration.

# Story

Im working on my custom `ChooserViewSet`. I wanted to overwrite `get_filter_form_class`. To do this normaly I need to overwrite `ChooserViewSet.choose_view_class` and in that class I can put my custom `get_filter_form_class`. 
There is easier way to do it.
I found there is `inject_view_methods` function who looks like this:
```
view_class = self.inject_view_methods(
            self.choose_view_class, ["get_object_list"]
        )
```
Eazy, just add another method to the list right? No. When I made something like this:
```
view_class = self.inject_view_methods(
            self.choose_view_class, ["get_object_list", "get_filter_form_class"]
        )
```
both methods started returning the same thing.

# Solution

I asked ChatGPT because that looked super weird and this is his explanation:
> The issue with your inject_view_methods function lies in the closure over the method_name and viewset_method variables inside the loop. Specifically, Python's late binding behavior in closures means that the created view_method function will capture the last value of viewset_method from the loop, rather than the one corresponding to each iteration.
>
> As a result, all dynamically created methods will call the same viewset_method (the one from the last iteration of the loop), instead of the correct one for each method_name.

I updated the code, created `make_view_method` and now everything works as expected.
