### PR TITLE
Do not hardcode hash in TestImage.test_file_hash

### DIFF
--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -1,3 +1,4 @@
+import hashlib
 import unittest
 
 from django.conf import settings
@@ -131,9 +132,11 @@ class TestImage(TestCase):
             self.image.get_file_size()
 
     def test_file_hash(self):
-        self.assertEqual(
-            self.image.get_file_hash(), "4dd0211870e130b7e1690d2ec53c499a54a48fef"
-        )
+        with self.image.file.open() as f:
+            loaded_hash = hashlib.sha1(f.read()).hexdigest()
+        # Ensure get_file_hash() (which does the hash by chunks) returns the
+        # same hash as the one calculated by loading the file into memory.
+        self.assertEqual(self.image.get_file_hash(), loaded_hash)
 
     def test_get_suggested_focal_point_svg(self):
         """


### PR DESCRIPTION
Extracted from #13045, as this is still relevant for running the tests on macOS.

Pillow changed its behaviour in how it handles PNGs (https://github.com/python-pillow/Pillow/issues/8796), resulting in `test_file_hash` added in 3c0c64642b9e5b8d28b111263c7f4bddad6c3880 failing. I opted to fix this by comparing that the hash returned by `get_file_hash()` (computed by our `hash_filelike` util) is equal to the hash calculated by loading the whole file in memory and doing a hexdigest, which I believe was the only thing we care about in regards to the hash value.