### PR TITLE
Fix TimeField serialization in Elasticsearch backend

### DIFF
--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -11,6 +11,7 @@ from django.utils.crypto import get_random_string
 from elasticsearch import VERSION as ELASTICSEARCH_VERSION
 from elasticsearch import Elasticsearch, NotFoundError
 from elasticsearch.helpers import bulk
+from datetime import time
 
 from wagtail.search.backends.base import (
     BaseSearchBackend,

--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -76,7 +76,7 @@ class Elasticsearch7Mapping:
         "SlugField": "string",
         "SmallIntegerField": "integer",
         "TextField": "string",
-        "TimeField": "date",
+        "TimeField": "keyword",
         "URLField": "string",
     }
 
@@ -270,6 +270,14 @@ class Elasticsearch7Mapping:
         edgengrams = []
         for field in self.model.get_search_fields():
             value = field.get_value(obj)
+
+            if isinstance(value, time):
+                value = value.strftime("%H:%M:%S") if value else None
+            elif isinstance(value, (list, tuple)):
+                value = [
+                    item.strftime("%H:%M:%S") if isinstance(item, time) else item
+                    for item in value
+                ]
 
             if isinstance(field, RelatedFields):
                 if isinstance(value, (models.Manager, models.QuerySet)):


### PR DESCRIPTION
This PR fixes the serialization of `TimeField` in the Elasticsearch backend, addressing the `TypeError: Unable to serialize datetime.time` error when indexing pages with `TimeField`.

**Changes:**
- Updated `type_map` in `Elasticsearch7Mapping` to map `TimeField` to `"keyword"` instead of `"date"`.
- Modified `get_document` to convert `datetime.time` objects to strings in `HH:MM:SS` format (e.g., `"12:00:00"`).

**Testing:**
- Tested with Elasticsearch 7 using an `EventPage` model with a `TimeField`.
- Confirmed `update_index` runs without errors and search queries return expected results.

Fixes #13032

Please let me know if further changes or tests are needed!