### PR TITLE
fix(FormBuilder): handle Arabic label length in AbstractFormField to prevent DB DataError

### DIFF
--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -78,7 +78,6 @@ class AbstractFormField(Orderable):
 
     clean_name = models.CharField(
         verbose_name=_("name"),
-        max_length=255,
         blank=True,
         default="",
         help_text=_(


### PR DESCRIPTION
When creating a form in Wagtail using AbstractFormField, entering an Arabic label
(e.g., "أقر بأن الإبلاغ...") triggered a DataError because the clean_name field had
max_length=255. Although the visible label contained fewer than 255 characters,
its Unicode-escaped version exceeded the limit, causing PostgreSQL to reject the save.

This fix removes the max_length=255 constraint from the clean_name field to ensure
compatibility with longer Unicode representations, particularly beneficial for Arabic content.

This change improves support for Arabic and other non-Latin languages in form field labels.

If there is a better solution or workaround for this issue, kindly let me know.
<img width="724" alt="Screenshot 1446-11-03 at 12 33 10 AM" src="https://github.com/user-attachments/assets/da2cb3a8-4f2d-449d-af7e-3410aed08df3" />

