### PR TITLE
Allow upload of AVIF images through image chooser on Firefox

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Changelog
  * Fix: Fix behaviour of `ViewSet.inject_view_methods` with multiple methods (Gorlik)
  * Fix: Preserve query strings in URLs submitted to CloudFront for invalidation (Jigyasu Rajput)
  * Fix: Handle non-JSON-safe fields in `exclude_fields_in_copy` (Matt Westcott)
+ * Fix: Allow upload of AVIF images through image chooser on Firefox (Matt Westcott)
  * Maintenance: Refactor `get_embed` to remove `finder` argument which was only used for mocking in unit tests (Jigyasu Rajput)
  * Maintenance: Simplify handling of `None` values in `TypedTableBlock` (Jigyasu Rajput)
  * Maintenance: Remove squash.io configuration (Sage Abdullah)

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -33,6 +33,7 @@ depth: 1
  * Fix behaviour of `ViewSet.inject_view_methods` with multiple methods (Gorlik)
  * Preserve query strings in URLs submitted to CloudFront for invalidation (Jigyasu Rajput)
  * Handle non-JSON-safe fields in `exclude_fields_in_copy` (Matt Westcott)
+ * Allow upload of AVIF images through image chooser on Firefox (Matt Westcott)
 
 ### Documentation
 

--- a/wagtail/images/fields.py
+++ b/wagtail/images/fields.py
@@ -190,10 +190,15 @@ class WagtailImageField(ImageField):
             isinstance(widget, FileInput)
             and "accept" not in widget.attrs
             and attrs.get("accept") == "image/*"
-            and "heic" in self.allowed_image_extensions
         ):
-            # File upload dialogs (at least on Chrome / Mac) don't count heic as part of image/*, as it's not a
-            # web-safe format, so add it explicitly
-            attrs["accept"] = "image/*, image/heic"
+            # File upload dialogs will often not allow selecting heic or avif if the accept attribute is
+            # given as "image/*" - we need to add explicit mimetypes for these
+            extra_mime_types = []
+            if "heic" in self.allowed_image_extensions:
+                extra_mime_types.append("image/heic")
+            if "avif" in self.allowed_image_extensions:
+                extra_mime_types.append("image/avif")
+            if extra_mime_types:
+                attrs["accept"] = ", ".join(["image/*"] + extra_mime_types)
 
         return attrs


### PR DESCRIPTION
Fixes #12979. Add an explicit `image/avif` to the accepts attribute of the filename to signal to Firefox that selecting .avif files should be allowed, as we previously did for heic in d02e09e00e63f1ab03d74b1ae2f0336507c3585e.
