### PR TITLE
Add serializers and tests for Site, Page, and Collection models

### DIFF
--- a/wagtail/docs/reference/collections/index.rst
+++ b/wagtail/docs/reference/collections/index.rst
@@ -1,0 +1,7 @@
+Collections
+===========
+
+.. toctree::
+   :maxdepth: 1
+
+   serialization

--- a/wagtail/docs/reference/collections/serialization.rst
+++ b/wagtail/docs/reference/collections/serialization.rst
@@ -1,0 +1,6 @@
+Collection serialization
+========================
+
+Collections can be serialized using their natural key, which is a list of collection names from the root to the target.
+
+This allows accurate reconstruction of the collection hierarchy during deserialization.

--- a/wagtail/docs/reference/images/index.rst
+++ b/wagtail/docs/reference/images/index.rst
@@ -1,0 +1,7 @@
+Image Reference
+===============
+
+.. toctree::
+   :maxdepth: 1
+
+   serialization

--- a/wagtail/docs/reference/images/serialization.rst
+++ b/wagtail/docs/reference/images/serialization.rst
@@ -1,0 +1,33 @@
+Image serialization
+===================
+
+Wagtail now provides a `ModelSerializer` for the `Image` model using Django REST Framework.
+
+Serializer
+----------
+
+The `ImageSerializer` enables serialization of `Image` model instances including all fields:
+
+.. code-block:: python
+
+    from wagtail.images.serializers import ImageSerializer
+
+    serializer = ImageSerializer(instance=image)
+    print(serializer.data)
+
+Natural key
+-----------
+
+The `ImageSerializer` also provides a `natural_key` static method:
+
+.. code-block:: python
+
+    ImageSerializer.natural_key(image)
+
+This returns the file name (path) of the image:
+
+.. code-block:: text
+
+    "images/example.jpg"
+
+This can be used for more deterministic fixture generation or serialization where object identity needs to be preserved across environments.

--- a/wagtail/docs/reference/index.rst
+++ b/wagtail/docs/reference/index.rst
@@ -1,0 +1,31 @@
+Collections
+===========
+
+.. toctree::
+   :maxdepth: 1
+
+   collections/index
+
+Pages
+=====
+
+.. toctree::
+   :maxdepth: 1
+
+   pages/index
+
+Sites
+=====
+
+.. toctree::
+   :maxdepth: 1
+
+   sites/index
+
+Images
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   images/index

--- a/wagtail/docs/reference/pages/index.rst
+++ b/wagtail/docs/reference/pages/index.rst
@@ -1,0 +1,7 @@
+Pages
+=====
+
+.. toctree::
+   :maxdepth: 1
+
+   serialization

--- a/wagtail/docs/reference/pages/serialization.rst
+++ b/wagtail/docs/reference/pages/serialization.rst
@@ -1,0 +1,6 @@
+Page serialization
+==================
+
+Pages can be serialized using their ``url_path`` as a natural key.
+
+This ensures that the full hierarchy and location of the page is preserved when transferring data between environments.

--- a/wagtail/docs/reference/sites/index.rst
+++ b/wagtail/docs/reference/sites/index.rst
@@ -1,0 +1,7 @@
+Sites
+=====
+
+.. toctree::
+   :maxdepth: 1
+
+   serialization

--- a/wagtail/docs/reference/sites/serializations.rst
+++ b/wagtail/docs/reference/sites/serializations.rst
@@ -1,0 +1,6 @@
+Site serialization
+==================
+
+Sites use a natural key based on ``hostname`` and ``port``.
+
+This makes it possible to accurately map a Site object during import/export or data migrations.

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -894,6 +894,10 @@ class Image(AbstractImage):
         "focal_point_height",
     )
 
+    def natural_key(self):
+        """Returns the image file name as a natural key."""
+        return self.file.name
+
     class Meta(AbstractImage.Meta):
         verbose_name = _("image")
         verbose_name_plural = _("images")

--- a/wagtail/models/media.py
+++ b/wagtail/models/media.py
@@ -118,6 +118,15 @@ class Collection(MP_Node):
         # Output unicode plain-text version
         return "{}↳ {}".format(" " * 4 * display_depth, self.name)
 
+    def natural_key(self):
+        """Returns the path of collection names from root to self as a natural key."""
+        names = []
+        current = self
+        while current:
+            names.insert(0, current.name)
+            current = current.get_parent() if hasattr(current, "get_parent") else None
+        return tuple(names)
+
     class Meta:
         verbose_name = _("collection")
         verbose_name_plural = _("collections")

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -11,10 +11,7 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core import checks
-from django.core.exceptions import (
-    FieldDoesNotExist,
-    ValidationError,
-)
+from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.db import models, transaction
 from django.db.models import Q, Value
 from django.db.models.expressions import Subquery
@@ -29,9 +26,7 @@ from django.utils.functional import Promise, cached_property
 from django.utils.text import capfirst, slugify
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
-from modelcluster.models import (
-    ClusterableModel,
-)
+from modelcluster.models import ClusterableModel
 from treebeard.mp_tree import MP_Node
 
 from wagtail.actions.copy_for_translation import CopyPageForTranslationAction
@@ -53,11 +48,7 @@ from wagtail.fields import StreamField
 from wagtail.log_actions import log
 from wagtail.query import PageQuerySet
 from wagtail.search import index
-from wagtail.signals import (
-    page_published,
-    page_slug_changed,
-    pre_validate_delete,
-)
+from wagtail.signals import page_published, page_slug_changed, pre_validate_delete
 from wagtail.url_routing import RouteResult
 from wagtail.utils.deprecation import RemovedInWagtail70Warning
 from wagtail.utils.timestamps import ensure_utc
@@ -2044,6 +2035,10 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             for codename, _, name in PAGE_PERMISSION_TYPES
             if codename not in {"add_page", "change_page", "delete_page", "view_page"}
         ]
+
+    def natural_key(self):
+        """Returns the page's url_path as a natural key."""
+        return (self.url_path,)
 
 
 # set module path of Page so that when Sphinx autodoc sees Page in type annotations

--- a/wagtail/serializers/collection_serializer.py
+++ b/wagtail/serializers/collection_serializer.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+from wagtail.models.media import Collection
+
+class CollectionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Collection
+        fields = '__all__'
+    
+    @staticmethod
+    def natural_key(collection:Collection):
+        return (collection.name)

--- a/wagtail/serializers/collection_serializer.py
+++ b/wagtail/serializers/collection_serializer.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
+
 from wagtail.models.media import Collection
+
 
 class CollectionSerializer(serializers.ModelSerializer):
     class Meta:

--- a/wagtail/serializers/collection_serializer.py
+++ b/wagtail/serializers/collection_serializer.py
@@ -6,8 +6,8 @@ from wagtail.models.media import Collection
 class CollectionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Collection
-        fields = '__all__'
-    
+        fields = "__all__"
+
     @staticmethod
-    def natural_key(collection:Collection):
-        return (collection.name)
+    def natural_key(collection: Collection):
+        return collection.name

--- a/wagtail/serializers/image_serializer.py
+++ b/wagtail/serializers/image_serializer.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+
+from wagtail.images import get_image_model
+Image = get_image_model()
+
+class ImageSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Image
+        fields = '__all__'
+    
+    @staticmethod
+    def natural_key(image):
+        return (image.file.name)

--- a/wagtail/serializers/image_serializer.py
+++ b/wagtail/serializers/image_serializer.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from wagtail.images import get_image_model
+
 Image = get_image_model()
 
 class ImageSerializer(serializers.ModelSerializer):

--- a/wagtail/serializers/image_serializer.py
+++ b/wagtail/serializers/image_serializer.py
@@ -4,11 +4,12 @@ from wagtail.images import get_image_model
 
 Image = get_image_model()
 
+
 class ImageSerializer(serializers.ModelSerializer):
     class Meta:
         model = Image
-        fields = '__all__'
-    
+        fields = "__all__"
+
     @staticmethod
     def natural_key(image):
-        return (image.file.name)
+        return image.file.name

--- a/wagtail/serializers/page_serializer.py
+++ b/wagtail/serializers/page_serializer.py
@@ -6,9 +6,8 @@ from wagtail.models.pages import Page
 class PageSerializer(serializers.ModelSerializer):
     class Meta:
         model = Page
-        fields = ('__all__')
-    
-    @staticmethod
-    def natural_key(page:Page):
-        return (page.url_path)
+        fields = "__all__"
 
+    @staticmethod
+    def natural_key(page: Page):
+        return page.url_path

--- a/wagtail/serializers/page_serializer.py
+++ b/wagtail/serializers/page_serializer.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+from wagtail.models.pages import Page
+
+class PageSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Page
+        fields = ('__all__')
+    
+    @staticmethod
+    def natural_key(page:Page):
+        return (page.url_path)
+

--- a/wagtail/serializers/page_serializer.py
+++ b/wagtail/serializers/page_serializer.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
+
 from wagtail.models.pages import Page
+
 
 class PageSerializer(serializers.ModelSerializer):
     class Meta:

--- a/wagtail/serializers/site_serializer.py
+++ b/wagtail/serializers/site_serializer.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+from wagtail.models.sites import Site
+
+class SiteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Site
+        fields = '__all__'
+    
+    @staticmethod
+    def natural_key(site:Site):
+        return (site.hostname,site.port)
+    

--- a/wagtail/serializers/site_serializer.py
+++ b/wagtail/serializers/site_serializer.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
+
 from wagtail.models.sites import Site
+
 
 class SiteSerializer(serializers.ModelSerializer):
     class Meta:

--- a/wagtail/serializers/site_serializer.py
+++ b/wagtail/serializers/site_serializer.py
@@ -6,9 +6,8 @@ from wagtail.models.sites import Site
 class SiteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Site
-        fields = '__all__'
-    
+        fields = "__all__"
+
     @staticmethod
-    def natural_key(site:Site):
-        return (site.hostname,site.port)
-    
+    def natural_key(site: Site):
+        return (site.hostname, site.port)

--- a/wagtail/tests/serializers/test_collection_serializer.py
+++ b/wagtail/tests/serializers/test_collection_serializer.py
@@ -1,0 +1,10 @@
+import pytest
+from wagtail.models import Collection
+from wagtail.serializers.collection_serializer import CollectionSerializer
+
+@pytest.mark.django_db
+def test_collection():
+    root = Collection.get_first_root_node()
+    collection = root.add_child(name = 'test')
+    serializer = CollectionSerializer(collection)
+    assert serializer.data['name'] == "test"

--- a/wagtail/tests/serializers/test_collection_serializer.py
+++ b/wagtail/tests/serializers/test_collection_serializer.py
@@ -1,6 +1,8 @@
 import pytest
+
 from wagtail.models import Collection
 from wagtail.serializers.collection_serializer import CollectionSerializer
+
 
 @pytest.mark.django_db
 def test_collection():

--- a/wagtail/tests/serializers/test_collection_serializer.py
+++ b/wagtail/tests/serializers/test_collection_serializer.py
@@ -7,6 +7,6 @@ from wagtail.serializers.collection_serializer import CollectionSerializer
 @pytest.mark.django_db
 def test_collection():
     root = Collection.get_first_root_node()
-    collection = root.add_child(name = 'test')
+    collection = root.add_child(name="test")
     serializer = CollectionSerializer(collection)
-    assert serializer.data['name'] == "test"
+    assert serializer.data["name"] == "test"

--- a/wagtail/tests/serializers/test_image_serializer.py
+++ b/wagtail/tests/serializers/test_image_serializer.py
@@ -1,10 +1,12 @@
+import tempfile
+
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image as PilImage
+
 from wagtail.images import get_image_model
 from wagtail.serializers.image_serializer import ImageSerializer
 
-from PIL import Image as PilImage
-import tempfile
 
 def generate_test_image():
     with tempfile.NamedTemporaryFile(suffix=".jpg") as f:

--- a/wagtail/tests/serializers/test_image_serializer.py
+++ b/wagtail/tests/serializers/test_image_serializer.py
@@ -1,0 +1,27 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from wagtail.images import get_image_model
+from wagtail.serializers.image_serializer import ImageSerializer
+
+from PIL import Image as PilImage
+import tempfile
+
+def generate_test_image():
+    with tempfile.NamedTemporaryFile(suffix=".jpg") as f:
+        image = PilImage.new('RGB', (100, 100), color='red')
+        image.save(f, format='JPEG')
+        f.seek(0)
+        return SimpleUploadedFile(name='test.jpg', content=f.read(), content_type='image/jpeg')
+
+Image = get_image_model()
+
+@pytest.mark.django_db
+def test_image_serializer():
+    image_file = generate_test_image()
+    image = Image.objects.create(
+        title = "test image",
+        file = image_file,
+    )
+    serializer = ImageSerializer(instance = image)
+    assert serializer.data['title'] == "test image"
+    assert "file" in serializer.data

--- a/wagtail/tests/serializers/test_image_serializer.py
+++ b/wagtail/tests/serializers/test_image_serializer.py
@@ -10,20 +10,24 @@ from wagtail.serializers.image_serializer import ImageSerializer
 
 def generate_test_image():
     with tempfile.NamedTemporaryFile(suffix=".jpg") as f:
-        image = PilImage.new('RGB', (100, 100), color='red')
-        image.save(f, format='JPEG')
+        image = PilImage.new("RGB", (100, 100), color="red")
+        image.save(f, format="JPEG")
         f.seek(0)
-        return SimpleUploadedFile(name='test.jpg', content=f.read(), content_type='image/jpeg')
+        return SimpleUploadedFile(
+            name="test.jpg", content=f.read(), content_type="image/jpeg"
+        )
+
 
 Image = get_image_model()
+
 
 @pytest.mark.django_db
 def test_image_serializer():
     image_file = generate_test_image()
     image = Image.objects.create(
-        title = "test image",
-        file = image_file,
+        title="test image",
+        file=image_file,
     )
-    serializer = ImageSerializer(instance = image)
-    assert serializer.data['title'] == "test image"
+    serializer = ImageSerializer(instance=image)
+    assert serializer.data["title"] == "test image"
     assert "file" in serializer.data

--- a/wagtail/tests/serializers/test_page_serializer.py
+++ b/wagtail/tests/serializers/test_page_serializer.py
@@ -1,0 +1,23 @@
+import pytest
+from wagtail.serializers.page_serializer import PageSerializer
+from wagtail.test.testapp.models import SimplePage
+from wagtail.models import Page,ContentType
+
+@pytest.mark.django_db
+def test_page_serializer():
+    content_type = ContentType.objects.create(
+        app_label = "test",
+        model = "test model",
+    )
+    root = Page.get_first_root_node()
+    page = root.add_child(instance = SimplePage(
+        title = "test",
+        draft_title = "test",
+        slug = "test",
+        content = "this is a test page",
+        content_type = content_type
+    ))
+
+    serializer = PageSerializer(page)
+    assert serializer.data['title'] == "test"
+    assert serializer.data['draft_title'] == "test"

--- a/wagtail/tests/serializers/test_page_serializer.py
+++ b/wagtail/tests/serializers/test_page_serializer.py
@@ -1,7 +1,9 @@
 import pytest
+
+from wagtail.models import ContentType, Page
 from wagtail.serializers.page_serializer import PageSerializer
 from wagtail.test.testapp.models import SimplePage
-from wagtail.models import Page,ContentType
+
 
 @pytest.mark.django_db
 def test_page_serializer():

--- a/wagtail/tests/serializers/test_page_serializer.py
+++ b/wagtail/tests/serializers/test_page_serializer.py
@@ -8,18 +8,20 @@ from wagtail.test.testapp.models import SimplePage
 @pytest.mark.django_db
 def test_page_serializer():
     content_type = ContentType.objects.create(
-        app_label = "test",
-        model = "test model",
+        app_label="test",
+        model="test model",
     )
     root = Page.get_first_root_node()
-    page = root.add_child(instance = SimplePage(
-        title = "test",
-        draft_title = "test",
-        slug = "test",
-        content = "this is a test page",
-        content_type = content_type
-    ))
+    page = root.add_child(
+        instance=SimplePage(
+            title="test",
+            draft_title="test",
+            slug="test",
+            content="this is a test page",
+            content_type=content_type,
+        )
+    )
 
     serializer = PageSerializer(page)
-    assert serializer.data['title'] == "test"
-    assert serializer.data['draft_title'] == "test"
+    assert serializer.data["title"] == "test"
+    assert serializer.data["draft_title"] == "test"

--- a/wagtail/tests/serializers/test_site_serializer.py
+++ b/wagtail/tests/serializers/test_site_serializer.py
@@ -1,9 +1,11 @@
 import pytest
+
 from wagtail.models import ContentType
-from wagtail.models.sites import Site
 from wagtail.models.pages import Page
-from wagtail.test.testapp.models import SimplePage
+from wagtail.models.sites import Site
 from wagtail.serializers.site_serializer import SiteSerializer
+from wagtail.test.testapp.models import SimplePage
+
 
 @pytest.mark.django_db
 def test_site_serializer():

--- a/wagtail/tests/serializers/test_site_serializer.py
+++ b/wagtail/tests/serializers/test_site_serializer.py
@@ -1,0 +1,32 @@
+import pytest
+from wagtail.models import ContentType
+from wagtail.models.sites import Site
+from wagtail.models.pages import Page
+from wagtail.test.testapp.models import SimplePage
+from wagtail.serializers.site_serializer import SiteSerializer
+
+@pytest.mark.django_db
+def test_site_serializer():
+    content_type = ContentType.objects.create(
+        app_label = "test",
+        model = "test"
+    )
+    root = Page.get_first_root_node()
+    page = root.add_child(instance = SimplePage(
+        title = "test",
+        draft_title = "test",
+        slug = "test",
+        content = "this is a test page",
+        content_type = content_type,
+
+    ))
+    site = Site.objects.create(
+        hostname = "test",
+        site_name = "test",
+        root_page = page,
+        is_default_site = True,
+    )
+
+    serializer = SiteSerializer(site)
+    assert serializer.data['hostname'] == "test"
+    assert serializer.data['site_name'] == "test"

--- a/wagtail/tests/serializers/test_site_serializer.py
+++ b/wagtail/tests/serializers/test_site_serializer.py
@@ -9,26 +9,24 @@ from wagtail.test.testapp.models import SimplePage
 
 @pytest.mark.django_db
 def test_site_serializer():
-    content_type = ContentType.objects.create(
-        app_label = "test",
-        model = "test"
-    )
+    content_type = ContentType.objects.create(app_label="test", model="test")
     root = Page.get_first_root_node()
-    page = root.add_child(instance = SimplePage(
-        title = "test",
-        draft_title = "test",
-        slug = "test",
-        content = "this is a test page",
-        content_type = content_type,
-
-    ))
+    page = root.add_child(
+        instance=SimplePage(
+            title="test",
+            draft_title="test",
+            slug="test",
+            content="this is a test page",
+            content_type=content_type,
+        )
+    )
     site = Site.objects.create(
-        hostname = "test",
-        site_name = "test",
-        root_page = page,
-        is_default_site = True,
+        hostname="test",
+        site_name="test",
+        root_page=page,
+        is_default_site=True,
     )
 
     serializer = SiteSerializer(site)
-    assert serializer.data['hostname'] == "test"
-    assert serializer.data['site_name'] == "test"
+    assert serializer.data["hostname"] == "test"
+    assert serializer.data["site_name"] == "test"

--- a/wagtail/tests/test_natural_keys.py
+++ b/wagtail/tests/test_natural_keys.py
@@ -1,0 +1,47 @@
+import io
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image as PILImage
+
+from wagtail.images.models import Image
+from wagtail.models import Collection, Page, Site
+
+
+@pytest.mark.django_db
+def test_image_natural_key():
+    # creating a small picture
+    img_io = io.BytesIO()
+    image = PILImage.new("RGB", (100, 100), color="red")
+    image.save(img_io, format="JPEG")
+    img_io.seek(0)
+
+    # change to upload file for use in imageField
+    uploaded_file = SimpleUploadedFile(
+        "test.jpeg", img_io.read(), content_type="image/jpeg"
+    )
+
+    # create image part
+    wagtail_image = Image.objects.create(title="Test Image", file=uploaded_file)
+
+    assert wagtail_image.natural_key() == (wagtail_image.file.name)
+
+
+@pytest.mark.django_db
+def test_page_natural_key():
+    root_page = Page.objects.get(depth=1)
+    new_page = root_page.add_child(instance=Page(title="Child Page"))
+    assert new_page.natural_key() == (new_page.url_path,)
+
+
+@pytest.mark.django_db
+def test_site_natural_key():
+    site = Site.objects.create(hostname="localhost", port=8000, root_page_id=1)
+    assert site.natural_key() == ("localhost", 8000)
+
+
+@pytest.mark.django_db
+def test_collection_natural_key():
+    root = Collection.get_first_root_node()
+    child = root.add_child(name="Sub Collection")
+    assert child.natural_key() == ("Root", "Sub Collection")


### PR DESCRIPTION
This PR introduces model serializers and unit tests for Wagtail's Site, Page, and Collection models. These serializers enable support for Django's native serialization framework, allowing export and transfer of Wagtail objects between environments. This also simplifies the generation of test fixtures.

Each serializer includes a get_natural_key method where applicable, allowing for uniquely identifiable and human-readable references. Associated test cases are included to validate the serialization behavior.

This feature aims to improve interoperability and testability, and may also serve as a base for broader data portability support in Wagtail.