### PR TITLE
Fix custom rendition docs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,10 @@ Changelog
  * Maintenance: Refactor `get_embed` to remove `finder` argument which was only used for mocking in unit tests (Jigyasu Rajput)
  * Maintenance: Simplify handling of `None` values in `TypedTableBlock` (Jigyasu Rajput)
 
+7.0.1 (xx.xx.xxxx) - IN DEVELOPMENT
+~~~~~~~~~~~~~~~~~~
+
+ * Docs: Use tuple instead of set in `UniqueConstraint` examples for a custom rendition model to avoid spurious migrations (Alec Baron)
 
 7.0 LTS (06.05.2025)
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/advanced_topics/images/custom_image_model.md
+++ b/docs/advanced_topics/images/custom_image_model.md
@@ -42,7 +42,7 @@ class CustomRendition(AbstractRendition):
     class Meta:
        constraints = [
             models.UniqueConstraint(
-                fields={"image", "filter_spec", "focal_point_key"},
+                fields=("image", "filter_spec", "focal_point_key"),
                 name="unique_rendition",
             )
         ]

--- a/docs/releases/7.0.1.md
+++ b/docs/releases/7.0.1.md
@@ -1,0 +1,24 @@
+# Wagtail 7.0.1 release notes - IN DEVELOPMENT
+
+_Unreleased_
+
+```{contents}
+---
+local:
+depth: 1
+---
+```
+
+## What's new
+
+### Bug fixes
+
+ * ...
+
+### Documentation
+
+ * Use tuple instead of set in `UniqueConstraint` examples for a custom rendition model to avoid spurious migrations (Alec Baron)
+
+### Maintenance
+
+ * ...

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -7,6 +7,7 @@ Release notes
    upgrading
    release_process
    7.1
+   7.0.1
    7.0
    6.4.2
    6.4.1

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1405,8 +1405,8 @@ class AbstractRendition(ImageFileMixin, models.Model):
                         "on the 'image', 'filter_spec', and 'focal_point_key' fields."
                         % cls._meta.label,
                         hint=(
-                            "Add models.UniqueConstraint(fields={"
-                            '"image", "filter_spec", "focal_point_key"}, '
+                            "Add models.UniqueConstraint(fields=("
+                            '"image", "filter_spec", "focal_point_key"), '
                             'name="unique_rendition") to %s.Meta.constraints.'
                             % (cls.__name__,)
                         ),

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -551,8 +551,8 @@ class TestRenditions(TestCase):
         )
         self.assertEqual(
             errors[0].hint,
-            "Add models.UniqueConstraint(fields={"
-            '"image", "filter_spec", "focal_point_key"}, '
+            "Add models.UniqueConstraint(fields=("
+            '"image", "filter_spec", "focal_point_key"), '
             'name="unique_rendition") to CustomRendition.Meta.constraints.',
         )
 


### PR DESCRIPTION
Fixes a minor documentation issue introduced in release 7.0, related to defining a custom rendition model's unique constraint with `models.UniqueConstraint` instead of `unique_together`.

The current documentation for a custom rendition model now suggests defining the unique constraint as such:
```
constraints = [
    models.UniqueConstraint(
        fields={"image", "filter_spec", "focal_point_key"},
        name="unique_rendition",
    )
]
```

which causes repeated migration operations to be generated every time `manage.py makemigrations` is called, since `UniqueConstraint.fields` is not always evaluated in the same order. Changing the `UniqueConstraint.fields` definition to a tuple solves the issue.

This problem was already addressed in another part of the codebase with commit [32f4a78c96a1513ddf0613554a39f0284c78a758](https://github.com/wagtail/wagtail/commit/32f4a78c96a1513ddf0613554a39f0284c78a758), but the documentation has not yet been updated accordingly.

It is probably appropriate to also push these changes to the 7.0.x branch in addition to main.