### PR TITLE
Update oembed finder to use requests instead of urllib.request

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ testing = [
   "azure-mgmt-cdn>=12.0,<13.0",
   "azure-mgmt-frontdoor>=1.0,<1.1",
   "django-pattern-library>=0.7",
+  "responses>=0.25,<1",
   # For coverage and PEP8 linting
   "coverage>=3.7.0",
   "doc8==1.1.2",

--- a/wagtail/embeds/finders/oembed.py
+++ b/wagtail/embeds/finders/oembed.py
@@ -1,11 +1,7 @@
-import json
 import re
 from datetime import timedelta
-from urllib import request as urllib_request
-from urllib.error import URLError
-from urllib.parse import urlencode
-from urllib.request import Request
 
+import requests
 from django.utils import timezone
 
 from wagtail.embeds.exceptions import EmbedNotFoundException
@@ -60,12 +56,12 @@ class OEmbedFinder(EmbedFinder):
             params["maxheight"] = max_height
 
         # Perform request
-        request = Request(endpoint + "?" + urlencode(params))
-        request.add_header("User-agent", "Mozilla/5.0")
         try:
-            r = urllib_request.urlopen(request)
-            oembed = json.loads(r.read().decode("utf-8"))
-        except (URLError, json.decoder.JSONDecodeError):
+            r = requests.get(
+                endpoint, params=params, headers={"User-agent": "Mozilla/5.0"}
+            )
+            oembed = r.json()
+        except requests.RequestException:
             raise EmbedNotFoundException
 
         # Convert photos into HTML


### PR DESCRIPTION
As per https://github.com/wagtail/wagtail/pull/13057#issuecomment-2866126178 - `urllib.request` is liable to fail with SSL errors that `requests` can handle gracefully (along with having a much nicer API).

Use [responses](https://pypi.org/project/responses/) to mock the requests library within tests.

I haven't updated the Facebook / Instagram finders because I have no desire to jump through their app approval hoops, but while they inherit from `OEmbedFinder` they entirely override the `find_embed` method (which is the only thing we changed in `OEmbedFinder`) so there should be no change of behaviour there.