### PR TITLE
fixes 11021 - added prop to FocusTrap to ensure proper comment focus

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -52,6 +52,7 @@
  * Fix: Update `BooleanColumn` icons so they can be distinguished without relying on color (Sage Abdullah)
  * Fix: Do not delete default homepage by ID in home app migration (Matt Westcott)
  * Fix: Update the start project template to align with Django's recommendation to have the `django.middleware.security.SecurityMiddleware` first (Brylie Christopher Oxley)
+ * Fix: Ensure keyboard usage will correctly focus on new comments, including replies, when the side panel is open or closed (Dhruvi Patel)
  * Docs: Add missing tag library imports to footer template code in tutorial (Dimaco)
  * Docs: Improve documentation around securing user-uploaded files (Jake Howard)
  * Docs: Introduce search_fields in a dedicated tutorial section instead of the introduction (Matt Westcott)

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -617,22 +617,35 @@ export default class CommentComponent extends React.Component<CommentProps> {
 
     return (
       <FocusTrap
-        focusTrapOptions={
-          {
-            preventScroll: true,
-            clickOutsideDeactivates: true,
-            onDeactivate: () => {
-              this.props.store.dispatch(
-                setFocusedComment(null, {
-                  updatePinnedComment: true,
-                  forceFocus: false,
-                }),
-              );
-            },
-            initialFocus: '[data-focus-target="true"]',
-            delayFocus: false,
-          } as any
-        } // For some reason, the types for FocusTrap props don't yet include preventScroll.
+        focusTrapOptions={{
+          preventScroll: true,
+          clickOutsideDeactivates: true,
+          onDeactivate: () => {
+            this.props.store.dispatch(
+              setFocusedComment(null, {
+                updatePinnedComment: true,
+                forceFocus: false,
+              }),
+            );
+          },
+          /** Allow delay for side panel to open and comment card to fade in with animations. */
+          checkCanFocusTrap: (containers: (HTMLElement | SVGElement)[]) => {
+            const hasFocusTargetWithSidePanelOpen = containers.some(
+              (container) =>
+                container.matches(
+                  '[data-form-side="comments"].form-side--comments [data-focus-target="true"]',
+                ),
+            );
+
+            if (hasFocusTargetWithSidePanelOpen) return Promise.resolve();
+
+            return new Promise((resolve) => {
+              setTimeout(resolve, 250);
+            });
+          },
+          initialFocus: '[data-focus-target="true"]',
+          delayInitialFocus: true,
+        }}
         active={this.props.isFocused && this.props.forceFocus}
       >
         <li

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -67,6 +67,7 @@ The [](../reference/contrib/settings) app now allows permission over site settin
  * Update `BooleanColumn` icons so they can be distinguished without relying on color (Sage Abdullah)
  * Do not delete default homepage by ID in home app migration (Matt Westcott)
  * Update the start project template to align with Django's recommendation to have the `django.middleware.security.SecurityMiddleware` first (Brylie Christopher Oxley)
+ * Ensure keyboard usage will correctly focus on new comments, including replies, when the side panel is open or closed (Dhruvi Patel)
 
 ### Documentation
 


### PR DESCRIPTION
Fixes: https://github.com/wagtail/wagtail/issues/11021 
Rework of closed PR: https://github.com/wagtail/wagtail/pull/11022

I have gone through the latest FocusTrap docs, but there isn't anything related to the delay option. 

As per the note of @lb-  in PR https://github.com/wagtail/wagtail/pull/11022 and the mention in the comment on this issue (https://github.com/focus-trap/focus-trap-react/issues/785#issuecomment-1239500349), this issue seems to be resolved by introducing a delay

I've retained the changes from the original PR, and the fix works on both newly created and existing pages.

![Screenshot from 2025-05-12 10-47-46](https://github.com/user-attachments/assets/8a3abbfd-de20-46b9-810c-4b871160b380)

Unit test case status for JavaScript:

![Screenshot from 2025-05-12 11-14-48](https://github.com/user-attachments/assets/1b3eb054-1bc5-446c-8e4f-c92eed5b6ba7)


Let me know if I need to add unit tests for these changes. 
