### PR TITLE
Fix error when restoring scroll position for cross-domain preview iframe

### DIFF
--- a/client/src/controllers/PreviewController.ts
+++ b/client/src/controllers/PreviewController.ts
@@ -716,11 +716,17 @@ export class PreviewController extends Controller<HTMLElement> {
 
     // Restore scroll position with instant scroll to avoid flickering if the
     // previewed page has scroll-behavior: smooth.
-    newIframe.contentWindow?.scroll({
-      top: this.iframeTarget.contentWindow?.scrollY as number,
-      left: this.iframeTarget.contentWindow?.scrollX as number,
-      behavior: 'instant',
-    });
+    try {
+      newIframe.contentWindow?.scroll({
+        top: this.iframeTarget.contentWindow?.scrollY as number,
+        left: this.iframeTarget.contentWindow?.scrollX as number,
+        behavior: 'instant',
+      });
+    } catch {
+      // The iframe is likely cross-domain, e.g. in a headless setup, in which
+      // case we cannot call `scroll()` directly. Continue without restoring the
+      // scroll position.
+    }
 
     // Remove any other existing iframes. Normally there are two iframes at this
     // point, the old one and the new one. However, the `load` event may be fired


### PR DESCRIPTION
Currently, using a cross-domain iframe in the preview panel will fail during the scroll restoration. This is because you are not allowed to access the properties of a cross-domain iframe, so it will fail with `SecurityError: Failed to read a named property 'scroll' from 'Window': Blocked a frame with origin "http://127.0.0.1:8000" from accessing a cross-origin frame.`.

This can be replicated using wagtail-headless-preview's `REDIRECT_ON_PREVIEW = True` so that the preview is served through a redirect instead of a nested iframe. Try it out using https://github.com/wagtail/bakerydemo-nextjs/ and setting `REDIRECT_ON_PREVIEW = True`.

This PR fixes the issue by ignoring the exception. Scroll restoration still doesn't work, but at least the preview can still be reloaded instead of failing half-way through.

In order to have scroll restoration, we'll need to implement cross-frame communication (e.g. using `postMessage`) that tells the iframe window to scroll itself to the desired position. It's quite complicated, so I think this is a logical first step.