### PR TITLE
Allow SnippetChooserBlock icon to take precedence over snippet viewset icon

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Ensure that bulk deletion views respect protected foreign keys (Sage Abdullah)
  * Add minimum length validation for `RichTextBlock` and `RichTextField` (Alec Baron)
  * Support `preserve-svg` in Jinja2 image tags (Vishesh Garg)
+ * Allow `SnippetChooserBlock`'s `icon` to take precedence over `SnippetViewSet.icon` (Matt Westcott)
  * Fix: Handle lazy translation strings as `preview_value` for `RichTextBlock` (Seb Corbin)
  * Fix: Fix handling of newline-separated choices in form builder when using non-windows newline characters (Baptiste Mispelon)
  * Fix: Ensure `WAGTAILADMIN_LOGIN_URL` is respected when logging out of the admin (Antoine Rodriguez, Ramon de Jezus)

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -24,6 +24,7 @@ depth: 1
  * Ensure that bulk deletion views respect protected foreign keys (Sage Abdullah)
  * Add minimum length validation for `RichTextBlock` and `RichTextField` (Alec Baron)
  * Support `preserve-svg` in Jinja2 image tags (Vishesh Garg)
+ * Allow `SnippetChooserBlock`'s `icon` to take precedence over `SnippetViewSet.icon` (Matt Westcott)
 
 ### Bug fixes
 

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -156,6 +156,30 @@ class TestSnippetChooserBlockWithIcon(TestCase):
         # It should use the icon defined in the FullFeaturedSnippetViewSet
         self.assertEqual(js_args[2]["icon"], "cog")
 
+    def test_adapt_with_explicit_icon(self):
+        block = SnippetChooserBlock(FullFeaturedSnippet, icon="thumbtack")
+
+        block.set_name("test_snippetchooserblock")
+        js_args = FieldBlockAdapter().js_args(block)
+
+        self.assertEqual(js_args[2]["icon"], "thumbtack")
+
+    def test_adapt_with_explicit_default_icon(self):
+        block = SnippetChooserBlock(FullFeaturedSnippet, icon="snippet")
+
+        block.set_name("test_snippetchooserblock")
+        js_args = FieldBlockAdapter().js_args(block)
+
+        self.assertEqual(js_args[2]["icon"], "snippet")
+
+    def test_adapt_with_no_icon_specified_on_block_or_viewset(self):
+        block = SnippetChooserBlock(Advert)
+
+        block.set_name("test_snippetchooserblock")
+        js_args = FieldBlockAdapter().js_args(block)
+
+        self.assertEqual(js_args[2]["icon"], "snippet")
+
     def test_deconstruct(self):
         block = SnippetChooserBlock(FullFeaturedSnippet, required=False)
         path, args, kwargs = block.deconstruct()


### PR DESCRIPTION
Supersedes #12127 and #12883

Without this, a definition such as `SnippetChooserBlock("base.Person", icon="cog")` will pick up the icon defined on the Person snippet viewset rather than the one explicitly set on the block.