### PR TITLE
Adjust accessibility dialog position based on userbar's position

### DIFF
--- a/client/scss/components/_userbar.scss
+++ b/client/scss/components/_userbar.scss
@@ -21,19 +21,23 @@ $userbar-z-index: 9999;
 $positions: (
   'top-left': (
     'vertical': 'top',
-    'horizontal': 'left',
+    'horizontal': 'inline-start',
+    'horizontal-inv': 'inline-end',
   ),
   'top-right': (
     'vertical': 'top',
-    'horizontal': 'right',
+    'horizontal': 'inline-end',
+    'horizontal-inv': 'inline-start',
   ),
   'bottom-left': (
     'vertical': 'bottom',
-    'horizontal': 'left',
+    'horizontal': 'inline-start',
+    'horizontal-inv': 'inline-end',
   ),
   'bottom-right': (
     'vertical': 'bottom',
-    'horizontal': 'right',
+    'horizontal': 'inline-end',
+    'horizontal-inv': 'inline-start',
   ),
 );
 
@@ -216,20 +220,14 @@ $positions: (
 
 .w-dialog--userbar {
   // Display off to the side of the page rather than in the middle.
-  inset-inline-start: auto;
   font-family: theme('fontFamily.sans');
-  padding-inline-end: 2rem;
   z-index: $userbar-z-index;
 
   .w-dialog__close-button {
-    $size: theme('spacing.6');
-    width: $size;
-    height: $size;
-    top: calc(-1 * $size / 2);
-    inset-inline-end: calc(-1 * $size / 2);
     border-radius: theme('borderRadius.full');
     border: 2px solid theme('colors.icon-primary');
     background: theme('colors.surface-page');
+    z-index: calc($userbar-z-index + 1);
   }
 
   .w-dialog__close-icon {
@@ -292,14 +290,15 @@ $positions: (
 @each $pos, $attrs in $positions {
   $vertical: map.get($attrs, vertical);
   $horizontal: map.get($attrs, horizontal);
+  $horizontal-inv: map.get($attrs, horizontal-inv);
 
   .w-userbar--#{$pos} {
     #{$vertical}: $position;
-    #{$horizontal}: $position;
+    inset-#{$horizontal}: $position;
 
     .w-userbar-items {
       #{$vertical}: 100%;
-      #{$horizontal}: 0;
+      inset-#{$horizontal}: 0;
       padding-#{$vertical}: theme('spacing.2');
     }
 
@@ -324,6 +323,19 @@ $positions: (
             transition-delay: 0.05s * $i;
           }
         }
+      }
+    }
+
+    .w-dialog--userbar {
+      inset-#{$horizontal-inv}: auto;
+      padding-#{$horizontal}: theme('spacing.8');
+
+      .w-dialog__close-button {
+        $size: theme('spacing.6');
+        width: $size;
+        height: $size;
+        inset-#{$horizontal}: calc(-1 * $size / 2);
+        top: calc(-1 * $size / 2);
       }
     }
   }

--- a/client/src/controllers/TeleportController.test.js
+++ b/client/src/controllers/TeleportController.test.js
@@ -134,6 +134,47 @@ describe('TeleportController', () => {
       expect(shadowRoot.querySelector('template')).toBeNull();
     });
 
+    it('should allow for a custom target container within the shadow root', async () => {
+      const shadowHost = document.createElement('div');
+      const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+      document.body.append(shadowHost);
+
+      // Create a custom target container within the shadow DOM
+      shadowRoot.innerHTML = /* html */ `
+        <div>
+          <aside data-my-element="foo"></aside>
+          <!--
+           The template will be moved here, and then the content will be
+           teleported to the <aside> when the app starts
+          -->
+        </div>
+      `;
+
+      // Move the template to the shadow DOM
+      const template = document.getElementById('template');
+      shadowRoot.firstElementChild.append(template);
+      template.setAttribute(
+        'data-w-teleport-target-value',
+        '[data-my-element]',
+      );
+
+      // Create a new application with the shadow DOM as the root element
+      application = new Application(shadowRoot.firstElementChild);
+      application.register('w-teleport', TeleportController);
+      application.start();
+
+      await Promise.resolve();
+
+      application.stop();
+
+      // The content should be teleported to the <aside> element
+      expect(shadowRoot.querySelector('[data-my-element]').innerHTML).toContain(
+        '<div id="content">Some content</div>',
+      );
+      // The template should be removed from the DOM
+      expect(shadowRoot.querySelector('template')).toBeNull();
+    });
+
     it('should clear the target container if the reset value is set to true', async () => {
       document.body.innerHTML += `
         <div id="target-container"><p>I should not be here</p></div>

--- a/client/src/controllers/TeleportController.ts
+++ b/client/src/controllers/TeleportController.ts
@@ -74,9 +74,10 @@ export class TeleportController extends Controller<HTMLTemplateElement> {
     if (this.targetValue) {
       target = document.querySelector(this.targetValue);
     } else {
-      const rootNode = this.element.getRootNode();
-      target =
-        rootNode instanceof Document ? rootNode.body : rootNode.firstChild;
+      const root = this.element.getRootNode() as Document | ShadowRoot;
+      // If no target selector is provided, default to the body if the root node
+      // is a document, otherwise use the first element in the shadow root.
+      target = root instanceof Document ? root.body : root.firstElementChild;
     }
 
     if (!(target instanceof Element)) {

--- a/client/src/controllers/TeleportController.ts
+++ b/client/src/controllers/TeleportController.ts
@@ -70,11 +70,15 @@ export class TeleportController extends Controller<HTMLTemplateElement> {
    */
   get target() {
     let target: any;
+    const root = this.element.getRootNode() as Document | ShadowRoot;
 
     if (this.targetValue) {
-      target = document.querySelector(this.targetValue);
+      // Look for the target in the shadow root first, then the document, as
+      // using document.querySelector won't match elements in the shadow root.
+      target =
+        root.querySelector(this.targetValue) ||
+        document.querySelector(this.targetValue);
     } else {
-      const root = this.element.getRootNode() as Document | ShadowRoot;
       // If no target selector is provided, default to the body if the root node
       // is a document, otherwise use the first element in the shadow root.
       target = root instanceof Document ? root.body : root.firstElementChild;

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_accessibility.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_accessibility.html
@@ -13,7 +13,7 @@
         <span class="w-a11y-result__count" data-a11y-result-count></span>
     {% endfragment %}
     {% fragment as dialog_classname %}w-dialog--userbar {% admin_theme_classname %}{% endfragment %}
-    {% dialog id="accessibility-results" theme="floating" classname=dialog_classname title=dialog_title subtitle=issues_found a11y_count="a11y_count" %}
+    {% dialog id="accessibility-results" theme="floating" classname=dialog_classname title=dialog_title subtitle=issues_found a11y_count="a11y_count" dialog_root_selector="[data-wagtail-userbar]" %}
         {# Contents of the dialog created in JS based on these templates. #}
         <template id="w-a11y-result-row-template">
             <div class="w-a11y-result__row" data-a11y-result-row>


### PR DESCRIPTION
Fixes #11540, closes #11819 with a different approach.

- The first commit fixes an issue in `TeleportController` when it's used in a shadow DOM and if the shadow root's first child is not an element node. The existing test was bogus as it doesn't actually run the controller and just clones the template content in the test instead. You need to instantiate a new Stimulus application within the shadow DOM for controllers to work in there.
- The second commit allows the teleport target to be within the shadow DOM (and prioritises that before falling back to looking in the `document`).
- The final commit is a rehash of #11819. We now instantiate the dialog under the `div.w-userbar` element (which has a corresponding position class e.g. `w-userbar--top-left`). This is now possible thanks to the previous commit. With the dialog instantiated there, we could adjust the existing styles to take into account the positioning class so that the horizontal properties are properly inverted.

## Screenshot

<img width="949" alt="image" src="https://github.com/user-attachments/assets/dec112d4-55fb-42a0-aa45-71469b499e58" />
