### PR TITLE
document block preview`is_previewable`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,6 +38,7 @@ Changelog
  * Fix: Fix type hints for `register_filter_adapter_class` parameters (Sébastien Corbin)
  * Fix: Use correct URL when redirecting back to the listing after filtering and deleting form submissions (Sage Abdullah)
  * Docs: Use tuple instead of set in `UniqueConstraint` examples for a custom rendition model to avoid spurious migrations (Alec Baron)
+ * Docs: Document how to turn off StreamField block previews (Shlomo Markowitz)
 
 7.0 LTS (06.05.2025)
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/reference/streamfield/blocks.md
+++ b/docs/reference/streamfield/blocks.md
@@ -58,7 +58,7 @@ All block definitions accept the following optional keyword arguments or `Meta` 
 -   `description`
     -   The description of the block to be shown to editors. See {meth}`~wagtail.blocks.Block.get_description` for more details.
 
-All block definitions have the following methods that can be overridden:
+All block definitions have the following methods and properties that can be overridden:
 
 ```{eval-rst}
 .. autoclass:: wagtail.blocks.Block
@@ -69,6 +69,7 @@ All block definitions have the following methods that can be overridden:
     .. automethod:: wagtail.blocks.Block.get_preview_context
     .. automethod:: wagtail.blocks.Block.get_preview_template
     .. automethod:: wagtail.blocks.Block.get_description
+    .. autoattribute:: wagtail.blocks.Block.is_previewable
 ```
 
 (field_block_types)=

--- a/docs/releases/7.0.1.md
+++ b/docs/releases/7.0.1.md
@@ -19,6 +19,7 @@ depth: 1
 ### Documentation
 
  * Use tuple instead of set in `UniqueConstraint` examples for a custom rendition model to avoid spurious migrations (Alec Baron)
+ * Document how to [turn off StreamField block previews](turning_off_block_previews) (Shlomo Markowitz)
 
 ### Maintenance
 

--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -596,6 +596,20 @@ For more details on overriding templates, see Django's guide on [](inv:django#ho
 
 The global `wagtailcore/shared/block_preview.html` override will be used for all blocks by default. If you want to use a different template for a particular block, you can still specify `preview_template`, which will take precedence.
 
+(turning_off_block_previews)=
+
+### Turning off previews for a specific block
+
+To turn off previews for a block, set {attr}`is_previewable = False <wagtail.blocks.Block.is_previewable>` on the block class.
+
+```{code-block} python
+:emphasize-lines: 3
+
+class ConfigBlock(blocks.StructBlock):
+    ...
+    is_previewable = False
+```
+
 ## Customizations
 
 All block types implement a common API for rendering their front-end and form representations, and storing and retrieving values to and from the database. By subclassing the various block classes and overriding these methods, all kinds of customizations are possible, from modifying the layout of StructBlock form fields to implementing completely new ways of combining blocks. For further details, see [](custom_streamfield_blocks).

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -324,14 +324,14 @@ class Block(metaclass=BaseBlock):
 
     @cached_property
     def is_previewable(self):
-        # To prevent showing a broken preview if the block preview has not been
-        # configured, consider the block to be previewable if either:
-        # - a specific preview template is configured for the block
-        # - a preview value is provided and the global template has been overridden
-        # which are the intended ways to configure block previews.
-        #
-        # If a block is made previewable by other means, the `is_previewable`
-        # property should be overridden to return `True`.
+        """
+        Determine whether the block is previewable in the block picker. By
+        default, it automatically detects when a custom template is used or the
+        :ref:`the global preview template <streamfield_global_preview_template>`
+        is overridden and a preview value is provided. If the block is
+        previewable by other means, override this property to return ``True``.
+        To turn off previews for the block, set it to ``False``.
+        """
         has_specific_template = (
             hasattr(self.meta, "preview_template")
             or self.__class__.get_preview_template is not Block.get_preview_template


### PR DESCRIPTION
add documentation on  how to disable block previews for specific block types.
