### PR TITLE
Handle preserve-svg for multiple renditions

### DIFF
--- a/docs/advanced_topics/images/renditions.md
+++ b/docs/advanced_topics/images/renditions.md
@@ -54,6 +54,8 @@ The return value is a dictionary of renditions keyed by the specifications that 
 }
 ```
 
+If any specification contains the `preserve-svg` directive, the resulting dictionary key will be the final filter specification used for the rendition (omitting the `preserve-svg` directive, and any non-SVG-safe operations in the case that the image is an SVG) rather than the one originally passed. This may result in multiple specifications in the list resolving to the same final value - for example, if the list contains `width-400|format-jpeg|preserve-svg` and `width-400|format-webp|preserve-svg`, these will both reduce to `width-400` when applied to an SVG image. In this case, the return value will have fewer items than the original list.
+
 (caching_image_renditions)=
 
 ## Caching image renditions

--- a/wagtail/images/jinja2tags.py
+++ b/wagtail/images/jinja2tags.py
@@ -4,7 +4,6 @@ from jinja2.ext import Extension
 from .models import Filter, Picture, ResponsiveImage
 from .shortcuts import get_rendition_or_not_found, get_renditions_or_not_found
 from .templatetags.wagtailimages_tags import image_url
-from .utils import to_svg_safe_spec
 
 
 def image(image, filterspec, **attrs):
@@ -16,10 +15,6 @@ def image(image, filterspec, **attrs):
             "filter specs in 'image' tag may only contain A-Z, a-z, 0-9, dots, hyphens, pipes and underscores. "
             "(given filter: {})".format(filterspec)
         )
-
-    preserve_svg = "preserve-svg" in filterspec.split("|")
-    if preserve_svg and image.is_svg():
-        filterspec = to_svg_safe_spec(filterspec)
 
     rendition = get_rendition_or_not_found(image, filterspec)
 
@@ -39,10 +34,6 @@ def srcset_image(image, filterspec, **attrs):
             "(given filter: {})".format(filterspec)
         )
 
-    preserve_svg = "preserve-svg" in filterspec.split("|")
-    if preserve_svg and image.is_svg():
-        filterspec = to_svg_safe_spec(filterspec)
-
     specs = Filter.expand_spec(filterspec)
     renditions = get_renditions_or_not_found(image, specs)
 
@@ -58,10 +49,6 @@ def picture(image, filterspec, **attrs):
             "filter specs in 'picture' tag may only contain A-Z, a-z, 0-9, dots, hyphens, curly braces, commas, pipes and underscores. "
             "(given filter: {})".format(filterspec)
         )
-
-    preserve_svg = "preserve-svg" in filterspec.split("|")
-    if preserve_svg and image.is_svg():
-        filterspec = to_svg_safe_spec(filterspec)
 
     specs = Filter.expand_spec(filterspec)
     renditions = get_renditions_or_not_found(image, specs)

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -501,6 +501,31 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         except AttributeError:
             pass
 
+    def clean_filter_for_svg(self, filter: Filter) -> Filter:
+        """
+        Given a Filter object, check if its spec contains a 'preserve-svg' directive. If so,
+        remove it from the spec (along with any rasterising operations, in the case that this
+        image is an SVG) and return a new Filter object with the cleaned spec.
+        """
+        spec_elements = filter.spec.split("|")
+        if "preserve-svg" in spec_elements:
+            # remove 'preserve-svg' from filter specs for all image types
+            clean_spec = "|".join(
+                item for item in spec_elements if item != "preserve-svg"
+            )
+            if not clean_spec:
+                # no formatting directives were included in filter
+                raise InvalidFilterSpecError(
+                    "Filter should include at least one formatting directive other than 'preserve-svg'"
+                )
+            if self.is_svg():
+                # remove rasterizing directives
+                clean_spec = to_svg_safe_spec(clean_spec)
+
+            return Filter(spec=clean_spec)
+
+        return filter
+
     def get_rendition(self, filter: Filter | str) -> AbstractRendition:
         """
         Returns a ``Rendition`` instance with a ``file`` field value (an
@@ -519,22 +544,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
                 "Unrecognised filter format - string or Filter instance expected"
             )
 
-        spec_elements = filter.spec.split("|")
-        if "preserve-svg" in spec_elements:
-            # remove 'preserve-svg' from filter specs for all image types
-            clean_spec = "|".join(
-                item for item in spec_elements if item != "preserve-svg"
-            )
-            if not clean_spec:
-                # no formatting directives were included in filter
-                raise InvalidFilterSpecError(
-                    "Filter should include at least one formatting directive other than 'preserve-svg'"
-                )
-            if self.is_svg():
-                # remove rasterizing directives
-                clean_spec = to_svg_safe_spec(clean_spec)
-
-            filter = Filter(spec=clean_spec)
+        filter = self.clean_filter_for_svg(filter)
 
         try:
             rendition = self.find_existing_rendition(filter)
@@ -599,12 +609,17 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         model will be returned.
         """
         Rendition = self.get_rendition_model()
-        # We don’t support providing mixed Filter and string arguments in the same call.
-        if isinstance(filters[0], str):
-            filters = [Filter(spec) for spec in dict.fromkeys(filters).keys()]
+
+        clean_filters = []
+        for filter in filters:
+            if isinstance(filter, str):
+                filter = Filter(spec=filter)
+
+            filter = self.clean_filter_for_svg(filter)
+            clean_filters.append(filter)
 
         # Remove duplicate filters from the list while preserving order
-        filters = list(dict.fromkeys(filters))
+        filters = list(dict.fromkeys(clean_filters))
 
         # Find existing renditions where possible
         renditions = self.find_existing_renditions(*filters)

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -519,19 +519,22 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
                 "Unrecognised filter format - string or Filter instance expected"
             )
 
-        if "preserve-svg" in filter.spec:
+        spec_elements = filter.spec.split("|")
+        if "preserve-svg" in spec_elements:
             # remove 'preserve-svg' from filter specs for all image types
-            filter.spec = "|".join(
-                item for item in filter.spec.split("|") if item != "preserve-svg"
+            clean_spec = "|".join(
+                item for item in spec_elements if item != "preserve-svg"
             )
-            if not filter.spec:
+            if not clean_spec:
                 # no formatting directives were included in filter
                 raise InvalidFilterSpecError(
                     "Filter should include at least one formatting directive other than 'preserve-svg'"
                 )
             if self.is_svg():
                 # remove rasterizing directives
-                filter.spec = to_svg_safe_spec(filter.spec)
+                clean_spec = to_svg_safe_spec(clean_spec)
+
+            filter = Filter(spec=clean_spec)
 
         try:
             rendition = self.find_existing_rendition(filter)

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -600,6 +600,9 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         if isinstance(filters[0], str):
             filters = [Filter(spec) for spec in dict.fromkeys(filters).keys()]
 
+        # Remove duplicate filters from the list while preserving order
+        filters = list(dict.fromkeys(filters))
+
         # Find existing renditions where possible
         renditions = self.find_existing_renditions(*filters)
 
@@ -1157,6 +1160,14 @@ class Filter:
             return ""
 
         return hashlib.sha1(vary_string.encode("utf-8")).hexdigest()[:8]
+
+    def __eq__(self, value):
+        if isinstance(value, Filter):
+            return self.spec == value.spec
+        return False
+
+    def __hash__(self):
+        return hash(self.spec)
 
 
 class ResponsiveImage:

--- a/wagtail/images/templatetags/wagtailimages_tags.py
+++ b/wagtail/images/templatetags/wagtailimages_tags.py
@@ -7,7 +7,6 @@ from wagtail.images.shortcuts import (
     get_rendition_or_not_found,
     get_renditions_or_not_found,
 )
-from wagtail.images.utils import to_svg_safe_spec
 from wagtail.images.views.serve import generate_image_url
 
 register = template.Library()
@@ -30,7 +29,6 @@ def image(parser, token):
     error_messages = []
 
     multi_rendition = tag_name != "image"
-    preserve_svg = False
 
     for bit in bits:
         if bit == "as":
@@ -42,8 +40,6 @@ def image(parser, token):
             else:
                 # more than one item exists after 'as' - reject as invalid
                 error_messages.append("More than one variable name after 'as'")
-        elif bit == "preserve-svg":
-            preserve_svg = True
         else:
             try:
                 name, value = bit.split("=")
@@ -87,7 +83,6 @@ def image(parser, token):
             filter_specs,
             attrs=attrs,
             output_var_name=output_var_name,
-            preserve_svg=preserve_svg,
         )
     else:
         errors = "; ".join(error_messages)
@@ -110,17 +105,13 @@ class ImageNode(template.Node):
         filter_specs,
         output_var_name=None,
         attrs={},
-        preserve_svg=False,
     ):
         self.image_expr = image_expr
         self.output_var_name = output_var_name
         self.attrs = attrs
         self.filter_specs = filter_specs
-        self.preserve_svg = preserve_svg
 
-    def get_filter(self, preserve_svg=False):
-        if preserve_svg:
-            return Filter(to_svg_safe_spec(self.filter_specs))
+    def get_filter(self):
         return Filter(spec="|".join(self.filter_specs))
 
     def validate_image(self, context):
@@ -149,7 +140,7 @@ class ImageNode(template.Node):
 
         rendition = get_rendition_or_not_found(
             image,
-            self.get_filter(preserve_svg=self.preserve_svg and image.is_svg()),
+            self.get_filter(),
         )
 
         if self.output_var_name:
@@ -165,10 +156,8 @@ class ImageNode(template.Node):
 
 
 class SrcsetImageNode(ImageNode):
-    def get_filters(self, preserve_svg=False):
+    def get_filters(self):
         filter_specs = Filter.expand_spec(self.filter_specs)
-        if preserve_svg:
-            return [Filter(to_svg_safe_spec(f)) for f in filter_specs]
         return [Filter(spec=f) for f in filter_specs]
 
     def render(self, context):
@@ -177,7 +166,7 @@ class SrcsetImageNode(ImageNode):
         if not image:
             return ""
 
-        specs = self.get_filters(preserve_svg=self.preserve_svg and image.is_svg())
+        specs = self.get_filters()
         renditions = get_renditions_or_not_found(image, specs)
 
         if self.output_var_name:
@@ -202,7 +191,7 @@ class PictureNode(SrcsetImageNode):
 
         renditions = get_renditions_or_not_found(
             image,
-            self.get_filters(preserve_svg=self.preserve_svg and image.is_svg()),
+            self.get_filters(),
         )
 
         if self.output_var_name:

--- a/wagtail/images/tests/test_jinja2_svg.py
+++ b/wagtail/images/tests/test_jinja2_svg.py
@@ -4,6 +4,7 @@ from wagtail.images.models import Image
 from wagtail.images.tests.utils import (
     get_test_image_file,
     get_test_image_file_svg,
+    get_test_image_filename,
 )
 from wagtail.test.utils import WagtailTestUtils
 
@@ -41,9 +42,12 @@ class TestJinja2SVGSupport(WagtailTestUtils, TestCase):
         html = self.render(
             '{{ image(img, "width-200|format-webp") }}', {"img": self.raster_image}
         )
+        filename = get_test_image_filename(self.raster_image, "width-200.format-webp")
 
-        self.assertIn('width="200"', html)
-        self.assertIn(".webp", html)  # Format conversion applied
+        self.assertHTMLEqual(
+            html,
+            f'<img src="{filename}" width="200" height="150" alt="Test raster image">',
+        )
 
     def test_image_with_svg_without_preserve(self):
         """Test that without preserve-svg, SVGs get all operations (which would fail in production)."""
@@ -55,61 +59,73 @@ class TestJinja2SVGSupport(WagtailTestUtils, TestCase):
     def test_image_with_svg_with_preserve(self):
         """Test that with preserve-svg filter, SVGs only get safe operations."""
         html = self.render(
-            '{{ image(img, "width-200|format-webp|preserve-svg") }}',
+            '{{ image(img, "width-45|format-webp|preserve-svg") }}',
             {"img": self.svg_image},
         )
+        filename = get_test_image_filename(self.svg_image, "width-45")
 
-        # Check the SVG is preserved
-        self.assertIn(".svg", html)
-        self.assertNotIn(".webp", html)
+        self.assertHTMLEqual(
+            html,
+            f'<img src="{filename}" width="45.0" height="45.0" alt="Test SVG image">',
+        )
 
     def test_srcset_image_with_svg_preserve(self):
         """Test that preserve-svg works with srcset_image function."""
         html = self.render(
-            '{{ srcset_image(img, "width-{200,400}|format-webp|preserve-svg", sizes="100vw") }}',
+            '{{ srcset_image(img, "width-{35,55}|format-webp|preserve-svg", sizes="100vw") }}',
             {"img": self.svg_image},
         )
+        filename35 = get_test_image_filename(self.svg_image, "width-35")
+        filename55 = get_test_image_filename(self.svg_image, "width-55")
 
-        # Should preserve SVG format
-        self.assertIn(".svg", html)
-        self.assertNotIn(".webp", html)
+        self.assertHTMLEqual(
+            html,
+            f"""
+                <img sizes="100vw" src="{filename35}"
+                    srcset="{filename35} 35.0w, {filename55} 55.0w" width="35.0" height="35.0"
+                    alt="Test SVG image">
+            """,
+        )
 
     def test_picture_with_svg_preserve(self):
         """Test that preserve-svg works with picture function."""
         html = self.render(
-            '{{ picture(img, "format-{avif,webp,jpeg}|width-400|preserve-svg") }}',
+            '{{ picture(img, "format-{avif,webp,jpeg}|width-85|preserve-svg") }}',
             {"img": self.svg_image},
         )
-
-        # Should preserve SVG format
-        self.assertIn(".svg", html)
-        self.assertNotIn(".webp", html)
-        self.assertNotIn(".avif", html)
-        self.assertNotIn(".jpeg", html)
+        filename = get_test_image_filename(self.svg_image, "width-85")
+        self.assertHTMLEqual(
+            html,
+            f"""
+                <picture>
+                    <img src="{filename}" alt="Test SVG image" width="85.0" height="85.0">
+                </picture>
+            """,
+        )
 
     def test_preserve_svg_with_multiple_operations(self):
         """Test preserve-svg with multiple operations, some safe, some unsafe for SVGs."""
         html = self.render(
-            '{{ image(img, "width-300|height-200|format-webp|fill-100x100|jpegquality-80|preserve-svg") }}',
+            '{{ image(img, "width-300|height-200|format-webp|max-100x100|jpegquality-80|preserve-svg") }}',
             {"img": self.svg_image},
         )
-
-        # Should preserve SVG format
-        self.assertIn(".svg", html)
-        self.assertNotIn(".webp", html)
-        self.assertNotIn("jpegquality-80", html)
+        filename = get_test_image_filename(
+            self.svg_image, "width-300.height-200.max-100x100"
+        )
+        self.assertHTMLEqual(
+            html,
+            f'<img src="{filename}" alt="Test SVG image" width="100.0" height="100.0">',
+        )
 
     def test_preserve_svg_with_custom_attributes(self):
         """Test preserve-svg works with custom HTML attributes."""
         html = self.render(
-            '{{ image(img, "width-200|format-webp|preserve-svg", class="my-image", alt="Custom alt") }}',
+            '{{ image(img, "width-66|format-webp|preserve-svg", class="my-image", alt="Custom alt") }}',
             {"img": self.svg_image},
         )
+        filename = get_test_image_filename(self.svg_image, "width-66")
 
-        # Check custom attributes are present
-        self.assertIn('class="my-image"', html)
-        self.assertIn('alt="Custom alt"', html)
-
-        # SVG should be preserved
-        self.assertNotIn(".webp", html)
-        self.assertIn(".svg", html)
+        self.assertHTMLEqual(
+            html,
+            f'<img src="{filename}" class="my-image" alt="Custom alt" width="66.0" height="66.0">',
+        )

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -1013,6 +1013,47 @@ class TestRenditions(TestCase):
         with self.assertRaises(AttributeError):
             self.svg_image.get_rendition(Filter("width-400|bgcolor-000|format-jpeg"))
 
+    def test_image_get_renditions_preserve_svg(self):
+        renditions = self.image.get_renditions(
+            "width-400|bgcolor-000|format-jpeg|preserve-svg",
+            "width-200|bgcolor-000|format-jpeg|preserve-svg",
+        )
+        filename1 = get_test_image_filename(
+            self.image, "width-400.bgcolor-000.format-jpeg"
+        )
+        filename2 = get_test_image_filename(
+            self.image, "width-200.bgcolor-000.format-jpeg"
+        )
+
+        # no directives stripped except 'preserve-svg'
+        # (which is stripped from both the dictionary key and the resulting rendition)
+        self.assertEqual(
+            renditions["width-400|bgcolor-000|format-jpeg"].filter_spec,
+            "width-400|bgcolor-000|format-jpeg",
+        )
+        self.assertEqual(renditions["width-400|bgcolor-000|format-jpeg"].url, filename1)
+
+        self.assertEqual(
+            renditions["width-200|bgcolor-000|format-jpeg"].filter_spec,
+            "width-200|bgcolor-000|format-jpeg",
+        )
+        self.assertEqual(renditions["width-200|bgcolor-000|format-jpeg"].url, filename2)
+
+    def test_svg_get_renditions_preserve_svg(self):
+        renditions = self.svg_image.get_renditions(
+            "width-400|bgcolor-000|format-jpeg|preserve-svg",
+            "width-200|bgcolor-000|format-jpeg|preserve-svg",
+        )
+        filename1 = get_test_image_filename(self.svg_image, "width-400")
+        filename2 = get_test_image_filename(self.svg_image, "width-200")
+
+        # all non-SVG-safe directives stripped (from both the dictionary key and the resulting rendition)
+        self.assertEqual(renditions["width-400"].filter_spec, "width-400")
+        self.assertEqual(renditions["width-400"].url, filename1)
+
+        self.assertEqual(renditions["width-200"].filter_spec, "width-200")
+        self.assertEqual(renditions["width-200"].url, filename2)
+
 
 @override_settings(
     CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}

--- a/wagtail/images/tests/test_templatetags.py
+++ b/wagtail/images/tests/test_templatetags.py
@@ -483,3 +483,54 @@ class PictureTagTestCase(ImagesTestCase):
             </picture>
         """
         self.assertHTMLEqual(rendered, expected)
+
+    def test_preserve_svg_with_raster_image(self):
+        filenames = [
+            get_test_image_filename(self.image, "width-180.format-avif"),
+            get_test_image_filename(self.image, "width-360.format-avif"),
+            get_test_image_filename(self.image, "width-180.format-jpeg"),
+            get_test_image_filename(self.image, "width-360.format-jpeg"),
+        ]
+
+        rendered = self.render(
+            '{% picture myimage width-{180,360} format-{avif,jpeg} preserve-svg sizes="100vw" %}',
+            {"myimage": self.image},
+        )
+        expected = f"""
+            <picture>
+            <source srcset="{filenames[0]} 180w, {filenames[1]} 360w" sizes="100vw" type="image/avif">
+            <img
+                sizes="100vw"
+                src="{filenames[2]}"
+                srcset="{filenames[2]} 180w, {filenames[3]} 360w"
+                alt="Test image"
+                width="180"
+                height="135"
+            >
+            </picture>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    def test_preserve_svg_with_svg_image(self):
+        filenames = [
+            get_test_image_filename(self.svg_image, "width-40"),
+            get_test_image_filename(self.svg_image, "width-80"),
+        ]
+
+        rendered = self.render(
+            '{% picture myimage width-{40,80} format-{avif,jpeg} preserve-svg sizes="100vw" %}',
+            {"myimage": self.svg_image},
+        )
+        expected = f"""
+            <picture>
+            <img
+                sizes="100vw"
+                src="{filenames[0]}"
+                srcset="{filenames[0]} 40.0w, {filenames[1]} 80.0w"
+                alt="Test SVG image"
+                width="40.0"
+                height="40.0"
+            >
+            </picture>
+        """
+        self.assertHTMLEqual(rendered, expected)

--- a/wagtail/images/tests/test_templatetags.py
+++ b/wagtail/images/tests/test_templatetags.py
@@ -109,11 +109,13 @@ class ImageNodeTestCase(TestCase):
         for image, filter_specs, expected in params:
             with self.subTest(img=image, filter_specs=filter_specs, expected=expected):
                 context = {"image": image, "image_node": "fake_value"}
-                node = ImageNode(Variable("image"), filter_specs, preserve_svg=True)
-                node.render(context)
-                self.assertEqual(
-                    node.get_filter(preserve_svg=image.is_svg()).spec, expected
+                node = ImageNode(
+                    Variable("image"),
+                    filter_specs + ["preserve-svg"],
+                    output_var_name="rendition",
                 )
+                node.render(context)
+                self.assertEqual(context["rendition"].filter_spec, expected)
 
 
 class ImagesTestCase(TestCase):

--- a/wagtail/images/utils.py
+++ b/wagtail/images/utils.py
@@ -133,7 +133,6 @@ def to_svg_safe_spec(filter_specs):
         x
         for x in filter_specs
         if any(x.startswith(prefix) for prefix in svg_preserving_specs)
-        and x != "preserve-svg"
     ]
 
     # If no safe operations remain, use 'original'


### PR DESCRIPTION
Fixes #11570 and some latent bugs / cleanup following #12011 and #13016.

#12011 implemented handling of the `preserve-svg` directive within `AbstractImage.get_rendition` but did not address `get_renditions`. As a result, the `picture` and `image_srcset` tags (both Django and Jinja2 versions) were still reliant on their own special-case logic for handling `preserve-svg`, which was somewhat buggy (for example, the jinja2 tags failed to strip out `preserve-svg` when passed a non-SVG image).

`get_renditions` now fully handles `preserve-svg`, which has some subtle implications for the method's semantics, as identified in #11570 - if a filter spec is cleaned as a result of applying `preserve-svg`, the dict key in the return value will be the cleaned version rather than the originally passed one. In turn, this means that if multiple specs resolve to the same value after cleaning (such as `width-400|format-webp|preserve-svg` and `width-400|format-jpeg|preserve-svg` reducing to `width-400`), these will be collapsed into a single key.

This happens to be the desired behaviour as far as the `<picture>` tag is concerned (because if a tag would normally be offering webp and jpeg as alternatives, but is passed an svg source image, we want it to output a single image source rather than two identical choices) but may be unintuitive for other scenarios, so this has been noted in the docs.

With `get_rendition` and `get_renditions` both robustly handling the `preserve-svg` directive, we can now remove the special-case handling from the tag libraries once and for all.