### PR TITLE
fixes #13117 - Added 'Edit' button to success message after copying page

### DIFF
--- a/wagtail/admin/tests/pages/test_copy_page.py
+++ b/wagtail/admin/tests/pages/test_copy_page.py
@@ -798,3 +798,65 @@ class TestPageCopy(WagtailTestUtils, TestCase):
 
         # Check if slug is hello-world-2
         self.assertContains(response, "copy-form-2")
+
+    def test_copy_page_success_msg_contains_edit_button(self):
+        post_data = {
+            "new_title": "Hello world 2",
+            "new_slug": "hello-world-2",
+            "new_parent_page": str(self.root_page.id),
+            "copy_subpages": False,
+            "publish_copies": False,
+            "alias": False,
+        }
+        response = self.client.post(
+            reverse("wagtailadmin_pages:copy", args=(self.test_page.id,)),
+            post_data,
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Check that the user was redirected to the parents explore page
+        self.assertRedirects(
+            response, reverse("wagtailadmin_explore", args=(self.root_page.id,))
+        )
+
+        # Get copy
+        page_copy = self.root_page.get_children().filter(slug="hello-world-2").first()
+        self.assertIsNotNone(page_copy)
+
+        # Check the "Edit" button present in success message
+        self.assertContains(
+            response, reverse("wagtailadmin_pages:edit", args=(page_copy.id,))
+        )
+        self.assertContains(response, ">Edit<")
+
+    def test_copy_page_success_msg_contains_edit_button_subpages(self):
+        post_data = {
+            "new_title": "Hello world 2",
+            "new_slug": "hello-world-2",
+            "new_parent_page": str(self.root_page.id),
+            "copy_subpages": True,
+            "publish_copies": False,
+            "alias": False,
+        }
+        response = self.client.post(
+            reverse("wagtailadmin_pages:copy", args=(self.test_page.id,)),
+            post_data,
+            follow=True,
+        )
+
+        # Check that the user was redirected to the parents explore page
+        self.assertRedirects(
+            response, reverse("wagtailadmin_explore", args=(self.root_page.id,))
+        )
+
+        # Get copy
+        page_copy = self.root_page.get_children().filter(slug="hello-world-2").first()
+        self.assertIsNotNone(page_copy)
+
+        # Check the "Edit" button present in success message
+        self.assertContains(
+            response, reverse("wagtailadmin_pages:edit", args=(page_copy.id,))
+        )
+        self.assertContains(response, ">Edit<")

--- a/wagtail/admin/views/pages/copy.py
+++ b/wagtail/admin/views/pages/copy.py
@@ -1,5 +1,6 @@
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
+from django.urls import reverse
 from django.utils.translation import gettext as _
 
 from wagtail import hooks
@@ -86,12 +87,24 @@ def copy(request, page_id):
                         "page_title": page.specific_deferred.get_admin_display_title(),
                         "subpages_count": new_page.get_descendants().count(),
                     },
+                    buttons=[
+                        messages.button(
+                            reverse("wagtailadmin_pages:edit", args=(new_page.id,)),
+                            _("Edit"),
+                        )
+                    ],
                 )
             else:
                 messages.success(
                     request,
                     _("Page '%(page_title)s' copied.")
                     % {"page_title": page.specific_deferred.get_admin_display_title()},
+                    buttons=[
+                        messages.button(
+                            reverse("wagtailadmin_pages:edit", args=(new_page.id,)),
+                            _("Edit"),
+                        )
+                    ],
                 )
 
             for fn in hooks.get_hooks("after_copy_page"):


### PR DESCRIPTION
Fixes: https://github.com/wagtail/wagtail/issues/13117

I have added 'Edit' button to success message that appears after copying a page.

![Screenshot from 2025-05-20 18-05-38](https://github.com/user-attachments/assets/7d0bb46d-1f58-4b32-8d62-4c8f26db6dea)
![Screenshot from 2025-05-20 18-06-36](https://github.com/user-attachments/assets/086bcc5d-3345-42b2-bf38-99a5876228dd)

I have performed manual and unit testing, let me know if any are changes needed in the unit tests.