### PR TITLE
Fixes #13044: added space before colon in French localization for LocaleController and added test

### DIFF
--- a/client/src/controllers/LocaleController.test.js
+++ b/client/src/controllers/LocaleController.test.js
@@ -138,4 +138,26 @@ describe('LocaleController', () => {
     );
     expect(select).toMatchSnapshot();
   });
+
+  it('should correctly apply French spacing rules to localized time zone labels', async () => {
+  document.documentElement.lang = 'fr-FR';
+  await setup(/* html */ `
+    <select
+      name="locale-current_time_zone"
+      data-controller="w-init w-locale"
+      data-action="w-init:ready->w-locale#localizeTimeZoneOptions"
+      data-w-locale-server-time-zone-param="Europe/Paris"
+    >
+    </select>
+  `);
+  
+    expect(select.getAttribute('data-controller')).toEqual('w-locale');
+    const selected = select.selectedOptions[0];
+    expect(selected).toBeTruthy();
+    expect(selected.value).toEqual('');
+    expect(selected.textContent).toBe(
+      'Use server time zone: UTC+1 (heure normale d’Europe centrale)'
+    );
+    expect(select).toMatchSnapshot();
+  });
 });

--- a/client/src/controllers/LocaleController.ts
+++ b/client/src/controllers/LocaleController.ts
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus';
+import { gettext } from '../utils/gettext';
 
 /**
  * Localizes elements in the current locale.
@@ -58,7 +59,10 @@ export class LocaleController extends Controller<HTMLSelectElement> {
       if (!timeZone) return;
       const localized = LocaleController.getTZLabel(timeZone);
       const option = opt;
-      option.textContent = `${option.textContent}: ${localized}`;
+      const template = gettext('%s: %s');
+      option.textContent = template
+        .replace('%s', option.textContent ?? '')
+        .replace('%s', localized);
     });
   }
 }


### PR DESCRIPTION
## Description

This PR updates the `LocaleController` to support localization of time zone option labels using a translatable `gettext('%s: %s')`.

### Changes

- Removed:
  ```ts
  option.textContent = `${option.textContent}: ${localized}`;

- Replaced with:
  ```ts
    const template = gettext('%s: %s');
    option.textContent = template
      .replace('%s', option.textContent ?? '')
      .replace('%s', localized);

- Added a new test in LocaleController.test.js to verify this change.

### Why
This change fixes the formatting issue for French localization by enabling proper spacing and translation of the colon separator.

Fixes #13044
