### PR TITLE
Add support for cache invalidation using Bunny CDN

### DIFF
--- a/docs/reference/contrib/frontendcache.md
+++ b/docs/reference/contrib/frontendcache.md
@@ -232,6 +232,23 @@ WAGTAILFRONTENDCACHE = {
 
 Another option that can be set is `SUBSCRIPTION_ID`. By default the first encountered subscription will be used, but if your credential has access to more subscriptions, you should set this to an explicit value.
 
+### Bunny CDN
+
+Firstly, you need to register an account with Bunny if you haven't already got one. You can do this here: [Bunny Sign up](https://dash.bunny.net/auth/register). Then, grab your API key from [your account settings](https://dash.bunny.net/account/settings).
+
+Add an item into the `WAGTAILFRONTENDCACHE` and set the `BACKEND` parameter to `wagtail.contrib.frontend_cache.backends.BunnyBackend` and `ACCESS_KEY` to your API key:
+
+```python
+# settings.py
+
+WAGTAILFRONTENDCACHE = {
+    'bunny': {
+        'BACKEND': 'wagtail.contrib.frontend_cache.backends.BunnyBackend',
+        'ACCESS_KEY': 'your-access-key',
+    },
+}
+```
+
 (frontendcache_multiple_backends)=
 
 ## Multiple backends

--- a/wagtail/contrib/frontend_cache/backends/__init__.py
+++ b/wagtail/contrib/frontend_cache/backends/__init__.py
@@ -1,5 +1,6 @@
 from .base import *  # noqa
 from .azure import *  # noqa
+from .bunny import *  # noqa
 from .http import *  # noqa
 from .cloudflare import *  # noqa
 from .cloudfront import *  # noqa

--- a/wagtail/contrib/frontend_cache/backends/bunny.py
+++ b/wagtail/contrib/frontend_cache/backends/bunny.py
@@ -1,0 +1,49 @@
+import logging
+
+import requests
+from django.core.exceptions import ImproperlyConfigured
+
+from .base import BaseBackend
+
+logger = logging.getLogger("wagtail.frontendcache")
+
+
+__all__ = ["BunnyBackend"]
+
+
+class BunnyBackend(BaseBackend):
+    PURGE_API_URL = "https://api.bunny.net/purge"
+
+    def __init__(self, params):
+        if "ACCESS_KEY" not in params:
+            raise ImproperlyConfigured(
+                "The Bunny backend requires ACCESS_KEY to be specified"
+            )
+
+        super().__init__(params)
+
+        # Since Bunny's API doesn't support batch purging,
+        # create a session to avoid the handshake overhead for each request.
+        self.session = requests.Session()
+
+        self.session.headers["AccessKey"] = params["ACCESS_KEY"]
+
+    def purge(self, url):
+        try:
+            response = self.session.post(
+                self.PURGE_API_URL, params={"url": url, "async": "true"}
+            )
+
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            try:
+                response_json = e.response.json()
+            except ValueError:
+                response_json = {}
+
+            logger.exception(
+                "Couldn't purge %r from cache. HTTPError: %d. Message: %s",
+                url,
+                e.response.status_code,
+                response_json.get("Message", ""),
+            )


### PR DESCRIPTION
This PR supports using [Bunny](https://bunny.net/) for cache invalidation.

Relevant API docs: https://docs.bunny.net/reference/purgepublic_indexpost
