### PR TITLE
Use correct URL when redirecting back to the listing after filtering and deleting form submissions

### DIFF
--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -553,15 +553,39 @@ class TestFormsSubmissionsList(WagtailTestUtils, TestCase):
         self.assertEqual(len(response.context["data_rows"]), 1)
 
     def test_list_submissions_filtering_range(self):
-        response = self.client.get(
-            reverse("wagtailforms:list_submissions", args=(self.form_page.id,)),
-            {"date_from": "12/31/2013", "date_to": "01/02/2014"},
-        )
+        url = reverse("wagtailforms:list_submissions", args=(self.form_page.id,))
+        params = {"date_from": "12/31/2013", "date_to": "01/02/2014"}
+        response = self.client.get(url, params)
 
         # Check response
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailforms/submissions_index.html")
         self.assertEqual(len(response.context["data_rows"]), 1)
+        soup = self.get_soup(response.content)
+        next_input = soup.select_one('input[name="next"]')
+        self.assertIsNotNone(next_input)
+        self.assertEqual(next_input["value"], f"{url}?{urlencode(params)}")
+
+    def test_list_submissions_filtering_results(self):
+        index_url = reverse("wagtailforms:list_submissions", args=(self.form_page.id,))
+        results_url = reverse(
+            "wagtailforms:list_submissions_results",
+            args=(self.form_page.id,),
+        )
+        params = {"date_from": "12/31/2013", "date_to": "01/02/2014"}
+        response = self.client.get(results_url, params)
+
+        # Check response
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateNotUsed(response, "wagtailforms/submissions_index.html")
+        self.assertTemplateUsed(response, "wagtailforms/list_submissions.html")
+        self.assertEqual(len(response.context["data_rows"]), 1)
+        soup = self.get_soup(response.content)
+        next_input = soup.select_one('input[name="next"]')
+        self.assertIsNotNone(next_input)
+        # The next URL should point to the index page (instead of results page)
+        # with the same query params to preserve the filter
+        self.assertEqual(next_input["value"], f"{index_url}?{urlencode(params)}")
 
     def test_list_submissions_pagination(self):
         self.make_list_submissions()

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -506,6 +506,12 @@ class TestFormsSubmissionsList(WagtailTestUtils, TestCase):
         # check display of list values within form submissions
         self.assertContains(response, "foo, baz")
 
+    def test_list_submissions_with_non_form_page(self):
+        # Accessing a submissions list view with the root page (non-form page)
+        response = self.client.get(reverse("wagtailforms:list_submissions", args=(2,)))
+        # Should raise 404 instead of a 500 error
+        self.assertEqual(response.status_code, 404)
+
     def test_list_submissions_after_filter_form_submissions_for_user_hook(self):
         # Hook forbids to delete form submissions for everyone
         def construct_forms_for_user(user, queryset):

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -5,6 +5,7 @@ from django.contrib.admin.utils import quote
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.forms import CheckboxSelectMultiple
+from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils.functional import classproperty
@@ -24,6 +25,7 @@ from wagtail.admin.views.generic import PermissionCheckedMixin
 from wagtail.admin.views.generic.base import BaseListingView
 from wagtail.admin.views.mixins import SpreadsheetExportMixin
 from wagtail.admin.views.pages.listing import PageFilterSet, PageListingMixin
+from wagtail.contrib.forms.models import FormMixin
 from wagtail.contrib.forms.utils import get_form_types, get_forms_for_user
 from wagtail.models import Page
 from wagtail.permissions import page_permission_policy
@@ -33,6 +35,8 @@ def get_submissions_list_view(request, *args, **kwargs):
     """Call the form page's list submissions view class"""
     page_id = kwargs.get("page_id")
     form_page = get_object_or_404(Page, id=page_id).specific
+    if not isinstance(form_page, FormMixin):
+        raise Http404
     return form_page.serve_submissions_list_view(request, *args, **kwargs)
 
 

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -363,5 +363,5 @@ class SubmissionsListView(SpreadsheetExportMixin, BaseListingView):
                 }
             )
 
-        context["next_url"] = self.request.get_full_path()
+        context["next_url"] = f"{self.get_index_url()}?{self.request.GET.urlencode()}"
         return context


### PR DESCRIPTION
Fixes #13132.

Haven't verified but it's likely a regression in #12017. Since that's a new feature in 6.3, which is LTS, I think we should backport the first commit there too. Not sure if it warrants a release on its own though.

Not sure if we should backport to 6.4, but there's already a pending bugfix in 6.4.x #12924, so we might as well get a release out with this fix.

The second commit is something I discovered while testing. It's only an issue if you manually enter the URL with the id of a non-form page, so I don't mind if we don't backport that fix.