### PR TITLE
fix: embed url crash prevention

### DIFF
--- a/wagtail/embeds/blocks.py
+++ b/wagtail/embeds/blocks.py
@@ -81,6 +81,9 @@ class EmbedBlock(blocks.URLBlock):
             )
 
     def clean(self, value):
+        if not self.required and value in (None, "", EmbedValue("")):
+            return None
+
         if value is None or (isinstance(value, EmbedValue) and not value.url):
             raise ValidationError(_("Please enter a URL for this embed."))
         if isinstance(value, EmbedValue) and not value.html:

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -1035,6 +1035,17 @@ class TestEmbedBlock(TestCase):
         cleaned_value = block.clean(None)
         self.assertIsNone(cleaned_value)
 
+    def test_clean_empty_url(self):
+        """
+        EmbedBlock should raise ValidationError if the EmbedValue has an empty URL
+        """
+        block = EmbedBlock()
+
+        with self.assertRaisesMessage(
+            ValidationError, "Please enter a URL for this embed."
+        ):
+            block.clean(EmbedValue(""))
+
     @patch("wagtail.embeds.embeds.get_embed")
     def test_clean_invalid_url(self, get_embed):
         get_embed.side_effect = EmbedNotFoundException


### PR DESCRIPTION
tracking issue : #13135 

This PR fixes the save draft with an empty EmbedBlock to not cause a crash by adding appropriate validation.
Added a relevant test case for this.

On "Save Draft", with empty url in embed, this sort of validation will be activated:
<img width="972" alt="Screenshot 2025-05-30 at 1 57 52 PM" src="https://github.com/user-attachments/assets/6fe084ef-696f-4df6-9c15-40e7bcf1d59c" />
