### PR TITLE
Ensure MySQL test database is created with utf8mb4 charset and collation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "mysqlclient>=1.4,<2"
+          pip install mysqlclient
           pip install -e '.[testing]' --config-settings editable_mode=strict
           pip install "${{ matrix.django }}"
       - name: Test

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -49,8 +49,12 @@ if DATABASES["default"]["ENGINE"] == "sql_server.pyodbc":
 
 # explicitly set charset / collation to utf8 on mysql
 if DATABASES["default"]["ENGINE"] == "django.db.backends.mysql":
-    DATABASES["default"]["TEST"]["CHARSET"] = "utf8"
-    DATABASES["default"]["TEST"]["COLLATION"] = "utf8_general_ci"
+    DATABASES["default"]["OPTIONS"] = {
+        "charset": "utf8mb4",
+        "collation": "utf8mb4_general_ci",
+    }
+    DATABASES["default"]["TEST"]["CHARSET"] = "utf8mb4"
+    DATABASES["default"]["TEST"]["COLLATION"] = "utf8mb4_general_ci"
 
 
 SECRET_KEY = "not needed"


### PR DESCRIPTION
Some of our tests have been failing on MariaDB 11.4.6+, particularly ones that involve JSON lookups such as the form builder tests:

https://github.com/wagtail/wagtail/blob/034f71c43887e614802a9f643ace3b4976923df3/wagtail/contrib/forms/tests/test_models.py#L100-L106

It's likely that this was caused by how the following bug was fixed in MariaDB upstream: https://jira.mariadb.org/browse/MDEV-35614

It seems to go away after setting the charset on the `default` database's options as per https://github.com/wagtail/wagtail/issues/9477#issuecomment-1823599286. I'm using `utf8mb4_general_ci` to follow our previous `utf8_general_ci` collation, as well as [Django's recommendation for performance](https://docs.djangoproject.com/en/5.2/ref/databases/#collation-settings) since we probably don't need the accuracy of `utf8mb4_unicode_ci` in testing.

We can close (maybe) #2925 now?