### PR TITLE
Fix #13128: Explicitly list allowed image extensions in accept attribute for single and multi image upload fields

### DIFF
--- a/wagtail/images/fields.py
+++ b/wagtail/images/fields.py
@@ -191,14 +191,13 @@ class WagtailImageField(ImageField):
             and "accept" not in widget.attrs
             and attrs.get("accept") == "image/*"
         ):
-            # File upload dialogs will often not allow selecting heic or avif if the accept attribute is
-            # given as "image/*" - we need to add explicit mimetypes for these
-            extra_mime_types = []
-            if "heic" in self.allowed_image_extensions:
-                extra_mime_types.append("image/heic")
-            if "avif" in self.allowed_image_extensions:
-                extra_mime_types.append("image/avif")
-            if extra_mime_types:
-                attrs["accept"] = ", ".join(["image/*"] + extra_mime_types)
+            # add explicit MIME TYPE for all allowed image extensions.
+            # This ensures the OS file upload picker only shows selectable image files
+            # that match the configured types
+            mime_types = [
+                f"image/{img_extension}"
+                for img_extension in self.allowed_image_extensions
+            ]
+            attrs["accept"] = ", ".join(mime_types)
 
         return attrs

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -26,6 +26,7 @@
                 <input
                     id="fileupload"
                     multiple
+                    accept="{{mime_types|join:', '}}"
                     name="files[]"
                     type="file"
                     data-accept-file-types="/\.({{ allowed_extensions|join:'|' }})$/i"

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1629,7 +1629,8 @@ class TestImageChooserView(WagtailTestUtils, TestCase):
         # upload file field should have an explicit 'accept' case for image/avif
         soup = self.get_soup(response_json["html"])
         self.assertEqual(
-            soup.select_one('input[type="file"]').get("accept"), "image/*, image/avif"
+            soup.select_one('input[type="file"]').get("accept"),
+            "image/avif, image/gif, image/jpg, image/jpeg, image/png, image/webp",
         )
 
     def test_simple_with_collection_nesting(self):
@@ -1655,7 +1656,7 @@ class TestImageChooserView(WagtailTestUtils, TestCase):
         soup = self.get_soup(response_json["html"])
         self.assertEqual(
             soup.select_one('input[type="file"]').get("accept"),
-            "image/*, image/heic, image/avif",
+            "image/gif, image/jpg, image/jpeg, image/png, image/webp, image/avif, image/heic",
         )
 
     @override_settings(WAGTAILIMAGES_EXTENSIONS=["gif", "jpg", "jpeg", "png", "webp"])
@@ -1667,7 +1668,10 @@ class TestImageChooserView(WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailimages/chooser/chooser.html")
 
         soup = self.get_soup(response_json["html"])
-        self.assertEqual(soup.select_one('input[type="file"]').get("accept"), "image/*")
+        self.assertEqual(
+            soup.select_one('input[type="file"]').get("accept"),
+            "image/gif, image/jpg, image/jpeg, image/png, image/webp",
+        )
 
     def test_choose_permissions(self):
         # Create group with access to admin and Chooser permission on one Collection, but not another.

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -2454,6 +2454,9 @@ class TestMultipleImageUploader(AdminTemplateTestUtils, WagtailTestUtils, TestCa
             file=get_test_image_file(),
         )
 
+    @override_settings(
+        WAGTAILIMAGES_EXTENSIONS=["gif", "jpg", "jpeg", "png", "webp", "avif", "heic"]
+    )
     def test_add(self):
         """
         This tests that the add view responds correctly on a GET request
@@ -2464,6 +2467,15 @@ class TestMultipleImageUploader(AdminTemplateTestUtils, WagtailTestUtils, TestCa
         # Check response
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailimages/multiple/add.html")
+
+        # Check input field's accept attribute explicitly
+        # lists the allowed images extensions
+        soup = self.get_soup(response.content)
+        upload_field = soup.select("input#fileupload").pop()
+        self.assertEqual(
+            upload_field.attrs["accept"],
+            "image/gif, image/jpg, image/jpeg, image/png, image/webp, image/avif, image/heic",
+        )
 
         # draftail should NOT be a standard JS include on this page
         # (see TestMultipleImageUploaderWithCustomImageModel - this confirms that form media

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -98,12 +98,15 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        allowed_extensions = get_allowed_image_extensions()
+        mime_types = [f"image/{ext}" for ext in allowed_extensions]
 
         context.update(
             {
                 "max_filesize": self.form.fields["file"].max_upload_size,
                 "max_title_length": self.form.fields["title"].max_length,
-                "allowed_extensions": get_allowed_image_extensions(),
+                "allowed_extensions": allowed_extensions,
+                "mime_types": mime_types,
                 "error_max_file_size": self.form.fields["file"].error_messages[
                     "file_too_large_unknown_size"
                 ],


### PR DESCRIPTION
This pull request address #13128 by updating the `accept` attribute of image upload fields.
Upload inputs previously used a generic `accept=image/* ` , which relied on broad MIME type filtering.
This update replaces that with an explicit list of allowed image extensions, based on WAGTAILIMAGES_EXTENSIONS setting.
For example, instead of:
 `<input type='file' accept='image/*'>`.
we now generate:
 `<input type='file' accept='image/jpeg, image/png, image/avif'>`.
This ensures the file picker only allows images that are explicitly listed by the wagtail setting above, improving file validation and user experience.

## SCREENSHOTS

### Settings Example
`WAGTAILIMAGES_EXTENSIONS = ["png"]`
![wagtailimages](https://github.com/user-attachments/assets/d948109b-79ee-4d5f-82a1-2337ab48edb3)

### Before
Single image upload:
![single-upload-before](https://github.com/user-attachments/assets/344e8d1a-f509-4fe1-9142-97b8866272d6)

Multiple image upload:
![multiple-upload-before](https://github.com/user-attachments/assets/4689c404-d9af-4ace-8346-ea1df82b52dc)
### After
Single image upload:
![single-upload-after](https://github.com/user-attachments/assets/675eec2d-87ba-4425-a338-ac2eeb7e8d2f)

Multiple image upload:
![multiple-upload-after](https://github.com/user-attachments/assets/dc0ed729-d22c-4015-a739-34070b3e0092)
