### PR TITLE
refactor style-src to avoid unsafe-inline CSP

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ Changelog
  * Fix: Accept any string beginning with 'y' as confirmation for `import_redirects` command (Matt Westcott)
  * Fix: Fix error when accessing the submissions listing view with a non-form page (Sage Abdullah)
  * Fix: Replace inline styles with CSS classes in HTML files (Srishti Jaiswal)
+ * Fix: Refactor remaining inline styles to avoid unsafe-inline style-src CSP (Chiemezuo Akujobi)
  * Docs: Add missing tag library imports to footer template code in tutorial (Dimaco)
  * Maintenance: Refactor `get_embed` to remove `finder` argument which was only used for mocking in unit tests (Jigyasu Rajput)
  * Maintenance: Simplify handling of `None` values in `TypedTableBlock` (Jigyasu Rajput)

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -41,6 +41,7 @@ depth: 1
  * Accept any string beginning with 'y' as confirmation for `import_redirects` command (Matt Westcott)
  * Fix error when accessing the submissions listing view with a non-form page (Sage Abdullah)
  * Replace inline styles with CSS classes in HTML files (Srishti Jaiswal)
+ * Refactor remaining inline styles to avoid unsafe-inline style-src CSP (Chiemezuo Akujobi)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/shared/icons.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/icons.html
@@ -1,5 +1,5 @@
 {% spaceless %}
-    <div style="display: none">
+    <div hidden>
         <svg>
             <defs>
                 {{ icons|safe }}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotion_form.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotion_form.html
@@ -2,7 +2,7 @@
 
 {% fragment as id %}inline_child_{{ form.prefix }}{% endfragment %}
 {% fragment as panel_id %}{{ id }}-panel{% endfragment %}
-<div id="{{ id }}"{% if form.DELETE.value %} style="display: none;"{% endif %}>
+<div id="{{ id }}"{% if form.DELETE.value %} hidden {% endif %}>
 
     {% fragment as header_controls %}
         <button type="button" class="button button--icon text-replace" data-inline-panel-child-move-up>{% icon name="arrow-up" %}{% trans "Move up" %}</button>

--- a/wagtail/images/static_src/wagtailimages/js/focal-point-chooser.js
+++ b/wagtail/images/static_src/wagtailimages/js/focal-point-chooser.js
@@ -83,6 +83,11 @@ $(function () {
   var width = focalPointOriginal.width;
   var height = focalPointOriginal.height;
 
+  // To avoid an inline style in the HTML which violates CSP, max-width and
+  // max-height are passed as data attributes to then be set as CSS properties.
+  $chooser.css('max-height', $chooser.data('max-height'));
+  $chooser.css('max-width', $chooser.data('max-width'));
+
   $indicator.css('left', (left * 100) / original.width + '%');
   $indicator.css('top', (top * 100) / original.height + '%');
   $indicator.css('width', (width * 100) / original.width + '%');

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -29,7 +29,8 @@
 
             <div
                 class="focal-point-chooser"
-                style="max-width: {{ rendition.width|unlocalize }}px; max-height: {{ rendition.height|unlocalize }}px;"
+                data-max-width="{{ rendition.width|unlocalize }}px"
+                data-max-height="{{ rendition.height|unlocalize }}px"
                 data-focal-point-x="{{ image.focal_point_x|default_if_none:''|unlocalize }}"
                 data-focal-point-y="{{ image.focal_point_y|default_if_none:''|unlocalize }}"
                 data-focal-point-width="{{ image.focal_point_width|default_if_none:''|unlocalize }}"


### PR DESCRIPTION
Fixes #12937 

This PR addresses the remaining checkboxes for the umbrella PR (#12937).

Changes were tested with a local version of wagtail.org (in line with the eventual goal of adding strict CSP-compliance to it).