### PR TITLE
fix: first_published_at save updated value on save draft

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/human_readable_date.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/human_readable_date.html
@@ -1,12 +1,10 @@
 {% load wagtailadmin_tags i18n %}
 
-{% if date %}
-    <button type="button" class="w-human-readable-date" data-controller="w-tooltip" data-w-tooltip-content-value="{{ date|date:tooltip_format }}" data-w-tooltip-placement-value="{{ placement }}">
-        <time class="w-human-readable-date__date" datetime="{{ date|date:"c" }}">
-            {{ date|timesince_simple|capfirst }}
-        </time>
-        {% if description %}
-            <span class="w-human-readable-date__description">{{ description }}</span>
-        {% endif %}
-    </button>
-{% endif %}
+<button type="button" class="w-human-readable-date" data-controller="w-tooltip" data-w-tooltip-content-value="{{ date|date:tooltip_format }}" data-w-tooltip-placement-value="{{ placement }}">
+    <time class="w-human-readable-date__date" datetime="{{ date|date:"c" }}">
+        {{ date|timesince_simple|capfirst }}
+    </time>
+    {% if description %}
+        <span class="w-human-readable-date__description">{{ description }}</span>
+    {% endif %}
+</button>

--- a/wagtail/admin/templates/wagtailadmin/shared/human_readable_date.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/human_readable_date.html
@@ -1,10 +1,12 @@
 {% load wagtailadmin_tags i18n %}
 
-<button type="button" class="w-human-readable-date" data-controller="w-tooltip" data-w-tooltip-content-value="{{ date|date:tooltip_format }}" data-w-tooltip-placement-value="{{ placement }}">
-    <time class="w-human-readable-date__date" datetime="{{ date|date:"c" }}">
-        {{ date|timesince_simple|capfirst }}
-    </time>
-    {% if description %}
-        <span class="w-human-readable-date__description">{{ description }}</span>
-    {% endif %}
-</button>
+{% if date %}
+    <button type="button" class="w-human-readable-date" data-controller="w-tooltip" data-w-tooltip-content-value="{{ date|date:tooltip_format }}" data-w-tooltip-placement-value="{{ placement }}">
+        <time class="w-human-readable-date__date" datetime="{{ date|date:"c" }}">
+            {{ date|timesince_simple|capfirst }}
+        </time>
+        {% if description %}
+            <span class="w-human-readable-date__description">{{ description }}</span>
+        {% endif %}
+    </button>
+{% endif %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1355,9 +1355,16 @@ def keyboard_shortcuts_dialog(context):
 
 @register.inclusion_tag("wagtailadmin/shared/human_readable_date.html")
 def human_readable_date(date, description=None, placement="top"):
+    if not isinstance(date, (datetime.datetime, datetime.date)):
+        return {
+            "date": None,
+            "description": description,
+            "placement": placement,
+            "tooltip_format": "",
+        }
     if isinstance(date, datetime.datetime):
         tooltip_format = getattr(settings, "DATETIME_FORMAT", "N j, Y, P")
-    elif isinstance(date, datetime.date):
+    else:
         tooltip_format = getattr(settings, "DATE_FORMAT", "N j, Y")
     return {
         "date": date,

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -1965,20 +1965,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         obj.latest_revision_id = self.latest_revision_id
         obj.latest_revision_created_at = self.latest_revision_created_at
 
-        if "first_published_at" not in content:
+        if obj.first_published_at is None:
             obj.first_published_at = self.first_published_at
-        else:
-            revision_first_published_at = content.get("first_published_at")
-            if isinstance(revision_first_published_at, str):
-                revision_first_published_at = models.DateTimeField().to_python(
-                    revision_first_published_at
-                )
-            if self.first_published_at is None:
-                obj.first_published_at = revision_first_published_at
-            elif revision_first_published_at != self.first_published_at:
-                obj.first_published_at = revision_first_published_at
-            else:
-                obj.first_published_at = self.first_published_at
 
         obj.translation_key = self.translation_key
         obj.locale_id = self.locale_id

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -1964,7 +1964,22 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         obj.locked_at = self.locked_at
         obj.latest_revision_id = self.latest_revision_id
         obj.latest_revision_created_at = self.latest_revision_created_at
-        obj.first_published_at = self.first_published_at
+
+        if "first_published_at" not in content:
+            obj.first_published_at = self.first_published_at
+        else:
+            revision_first_published_at = content.get("first_published_at")
+            if isinstance(revision_first_published_at, str):
+                revision_first_published_at = models.DateTimeField().to_python(
+                    revision_first_published_at
+                )
+            if self.first_published_at is None:
+                obj.first_published_at = revision_first_published_at
+            elif revision_first_published_at != self.first_published_at:
+                obj.first_published_at = revision_first_published_at
+            else:
+                obj.first_published_at = self.first_published_at
+
         obj.translation_key = self.translation_key
         obj.locale_id = self.locale_id
         obj.alias_of_id = self.alias_of_id


### PR DESCRIPTION
issue tracking #13142 

In the settings tab, modifying the .first_published_at field and then saving as draft was ending up not saving the modified value. But it was working fine for publish.
<img width="497" alt="Screenshot 2025-06-04 at 12 06 26 AM" src="https://github.com/user-attachments/assets/44e5789b-d56e-4266-8870-fe09fddf8b98" />


Issue is now fixed for "Save draft".
I'll fix the tests, once i'll get a feedback on this