### PR TITLE
Fix broken migration when ListBlock is defined with a child_block kwarg

### DIFF
--- a/wagtail/blocks/list_block.py
+++ b/wagtail/blocks/list_block.py
@@ -427,6 +427,7 @@ class ListBlock(Block):
                 child_block = kwargs.get("child_block")
                 if isinstance(child_block, Block):
                     block_id = lookup.add_block(child_block)
+                    kwargs = kwargs.copy()  # avoid mutating the original kwargs stored in self._constructor_args
                     kwargs["child_block"] = block_id
 
         return path, args, kwargs

--- a/wagtail/tests/test_streamfield.py
+++ b/wagtail/tests/test_streamfield.py
@@ -1115,6 +1115,54 @@ class TestDeconstructStreamFieldWithLookup(TestCase):
             },
         )
 
+    def test_deconstruct_with_listblock_with_child_block_kwarg_idempotence(self):
+        # See https://github.com/wagtail/wagtail/issues/13137. When a ListBlock is defined with
+        # a child_block keyword argument, its deconstruct_with_lookup method inserts that child
+        # block into the lookup to obtain an ID, and returns that ID as the child_block kwarg
+        # in its result. However, an implementation bug meant that this was mutating the kwargs
+        # dict stored in the block's _constructor_args attribute. As a result, subsequent calls
+        # to deconstruct_with_lookup (which happen routinely during makemigrations) would
+        # encounter the ID in child_block, leave it alone (because it isn't a block object as
+        # expected), and return that ID in the result without adding it to the lookup, messing
+        # up the ID sequence in the process.
+        field = StreamField(
+            [
+                ("heading", blocks.CharBlock(required=True)),
+                (
+                    "bullets",
+                    blocks.ListBlock(child_block=blocks.CharBlock(required=False)),
+                ),
+            ],
+            blank=True,
+        )
+        field.set_attributes_from_name("body")
+
+        expected_args = [
+            [
+                ("heading", 0),
+                ("bullets", 2),
+            ]
+        ]
+        expected_kwargs = {
+            "blank": True,
+            "block_lookup": {
+                0: ("wagtail.blocks.CharBlock", (), {"required": True}),
+                1: ("wagtail.blocks.CharBlock", (), {"required": False}),
+                2: ("wagtail.blocks.ListBlock", (), {"child_block": 1}),
+            },
+        }
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(name, "body")
+        self.assertEqual(path, "wagtail.fields.StreamField")
+        self.assertEqual(kwargs, expected_kwargs)
+        self.assertEqual(args, expected_args)
+
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(name, "body")
+        self.assertEqual(path, "wagtail.fields.StreamField")
+        self.assertEqual(kwargs, expected_kwargs)
+        self.assertEqual(args, expected_args)
+
     def test_deconstruct_with_listblock_subclass(self):
         # See https://github.com/wagtail/wagtail/issues/12164 - unlike StructBlock and StreamBlock,
         # ListBlock's deconstruct method doesn't reduce subclasses to the base ListBlock class.


### PR DESCRIPTION
Fixes #13137.

When a ListBlock is defined with a `child_block` keyword argument, its `deconstruct_with_lookup` method inserts that child block into the lookup to obtain an ID, and returns that ID as the `child_block` kwarg in its result. However, an implementation bug meant that this was mutating the kwargs dict stored in the block's `_constructor_args attribute`. As a result, subsequent calls to `deconstruct_with_lookup` (which happen routinely during `makemigrations`) would encounter the ID in `child_block`, leave it alone (because it isn't a block object as expected), and return that ID in the result without adding it to the lookup, messing up the ID sequence in the process.
