### PR TITLE
Fix: Make TypedTableBlock content searchable using get_searchable_content

### DIFF
--- a/docs/releases/next.rst
+++ b/docs/releases/next.rst
@@ -1,0 +1,4 @@
+Bug Fixes
+=========
+
+Fixed a bug where ``TypedTableBlock`` content was not searchable due to missing ``get_searchable_content()`` implementation.

--- a/wagtail/contrib/typed_table_block/blocks.py
+++ b/wagtail/contrib/typed_table_block/blocks.py
@@ -297,6 +297,26 @@ class BaseTypedTableBlock(Block):
             return value.render_as_block(context)
         else:
             return ""
+        
+
+    def get_searchable_content(self, value):
+        """ Used to extract all the content from the table cells"""
+
+        content = []
+        if value:
+            for row in value.row_data:
+                for col, cell in zip(value.columns, row["values"]):
+                    block = col["block"]
+
+                    try:
+                        block_content = block.get_searchable_content(cell)
+                    except AttributeError:
+                        block_content = [str(cell)] if cell is not None else []
+
+                    if not block_content and cell is not None:
+                        block_content = [str(cell)]
+                    content.extend(block_content)
+        return content
 
     class Meta:
         default = None
@@ -305,6 +325,7 @@ class BaseTypedTableBlock(Block):
 
 class TypedTableBlock(BaseTypedTableBlock, metaclass=DeclarativeSubBlocksMetaclass):
     pass
+        
 
 
 class TypedTableBlockAdapter(Adapter):

--- a/wagtail/contrib/typed_table_block/tests.py
+++ b/wagtail/contrib/typed_table_block/tests.py
@@ -345,6 +345,30 @@ class TestTableBlock(TestCase):
             },
         )
 
+    def test_get_searchable_block(self):
+        block  =  TypedTableBlock([
+            ('name', blocks.CharBlock()),
+            ('quantity', blocks.IntegerBlock())
+
+        ])
+
+        table_data = {
+            'columns':[
+                {'type':'name', 'heading':'Fruit'},
+                {'type':'quantity', 'heading':'qty'}
+            ],
+            'rows':[
+                {'values':['Apple',5]},
+                {'values':['Banana',10]}
+            ],
+
+            'caption':'Fruit Stock'
+        }
+
+        value = block.to_python(table_data)
+        content = block.get_searchable_content(value)
+
+        self.assertEqual(content, ['Apple', '5', 'Banana', '10'])
 
 class TestBlockDefinitionLookup(TestCase):
     def test_block_lookup(self):


### PR DESCRIPTION
### Fix summary

Fixed an issue where 'TypeTableBlock' content and also values inside the table cells was not showing up in the search results due to the absence of the 'get_searchable_content()' method.

### Changed made 

 - Implemented 'get_searchable_content()' in 'BaseTypedTableBlock' 
 - Ensures all the cell values including Charblock and Intblock are enabled in search results.
 - All existing and newly added tests pass after the get_searchable_content() implementation.
 - Confirmed via pytest wagtail/contrib/typed_table_block/tests.py.

### Related Issue

Fixes: #13156 