### PR TITLE
Fix saving of empty values in EmbedBlock

### DIFF
--- a/wagtail/embeds/blocks.py
+++ b/wagtail/embeds/blocks.py
@@ -87,8 +87,11 @@ class EmbedBlock(blocks.URLBlock):
 
     def normalize(self, value):
         if isinstance(value, EmbedValue):
-            return value
-        return EmbedValue(value)
+            return value if value.url else None
+        elif value:
+            return EmbedValue(value)
+        else:
+            return None
 
     class Meta:
         icon = "media"

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -1019,12 +1019,14 @@ class TestEmbedBlock(TestCase):
 
         block = EmbedBlock()
 
-        cleaned_value = block.clean(EmbedValue("https://www.youtube.com/watch/"))
+        cleaned_value = block.clean(
+            block.normalize(EmbedValue("https://www.youtube.com/watch/"))
+        )
         self.assertIsInstance(cleaned_value, EmbedValue)
         self.assertEqual(cleaned_value.url, "https://www.youtube.com/watch/")
 
         with self.assertRaisesMessage(ValidationError, ""):
-            block.clean(None)
+            block.clean(block.normalize(None))
 
     @responses.activate
     def test_clean_non_required(self):
@@ -1032,11 +1034,13 @@ class TestEmbedBlock(TestCase):
 
         block = EmbedBlock(required=False)
 
-        cleaned_value = block.clean(EmbedValue("https://www.youtube.com/watch/"))
+        cleaned_value = block.clean(
+            block.normalize(EmbedValue("https://www.youtube.com/watch/"))
+        )
         self.assertIsInstance(cleaned_value, EmbedValue)
         self.assertEqual(cleaned_value.url, "https://www.youtube.com/watch/")
 
-        cleaned_value = block.clean(None)
+        cleaned_value = block.clean(block.normalize(None))
         self.assertIsNone(cleaned_value)
 
     @responses.activate
@@ -1046,9 +1050,17 @@ class TestEmbedBlock(TestCase):
         non_required_block = EmbedBlock(required=False)
 
         with self.assertRaises(ValidationError):
-            non_required_block.clean(EmbedValue("http://no-oembed-here.com/something"))
+            non_required_block.clean(
+                non_required_block.normalize(
+                    EmbedValue("http://no-oembed-here.com/something")
+                )
+            )
 
         required_block = EmbedBlock()
 
         with self.assertRaises(ValidationError):
-            required_block.clean(EmbedValue("http://no-oembed-here.com/something"))
+            required_block.clean(
+                non_required_block.normalize(
+                    EmbedValue("http://no-oembed-here.com/something")
+                )
+            )

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -895,6 +895,24 @@ class TestEmbedTag(TestCase):
 
 
 class TestEmbedBlock(TestCase):
+    def set_up_embed_response(self):
+        responses.get(
+            url="https://www.youtube.com/oembed",
+            match=[
+                matchers.query_param_matcher(
+                    {"url": "https://www.youtube.com/watch/", "format": "json"}
+                ),
+            ],
+            json={
+                "type": "something",
+                "url": "http://www.example.com",
+                "title": "test_title",
+                "width": "640",
+                "height": "480",
+                "html": "<h1>Hello world!</h1>",
+            },
+        )
+
     def test_deserialize(self):
         """
         Deserialising the JSONish value of an EmbedBlock (a URL) should give us an EmbedValue
@@ -920,12 +938,12 @@ class TestEmbedBlock(TestCase):
         serialized_empty_val = block.get_prep_value(None)
         self.assertEqual(serialized_empty_val, "")
 
-    @patch("wagtail.embeds.embeds.get_embed")
-    def test_render(self, get_embed):
-        get_embed.return_value = Embed(html="<h1>Hello world!</h1>")
+    @responses.activate
+    def test_render(self):
+        self.set_up_embed_response()
 
         block = EmbedBlock()
-        block_val = block.to_python("http://www.example.com/foo")
+        block_val = block.to_python("https://www.youtube.com/watch/")
 
         temp = template.Template("embed: {{ embed }}")
         context = template.Context({"embed": block_val})
@@ -934,17 +952,14 @@ class TestEmbedBlock(TestCase):
         # Check that the embed was in the returned HTML
         self.assertIn("<h1>Hello world!</h1>", result)
 
-        # Check that get_embed was called correctly
-        get_embed.assert_any_call("http://www.example.com/foo", None, None)
-
-    @patch("wagtail.embeds.embeds.get_embed")
-    def test_render_within_structblock(self, get_embed):
+    @responses.activate
+    def test_render_within_structblock(self):
         """
         When rendering the value of an EmbedBlock directly in a template
         (as happens when accessing it as a child of a StructBlock), the
         proper embed output should be rendered, not the URL.
         """
-        get_embed.return_value = Embed(html="<h1>Hello world!</h1>")
+        self.set_up_embed_response()
 
         block = blocks.StructBlock(
             [
@@ -954,7 +969,7 @@ class TestEmbedBlock(TestCase):
         )
 
         block_val = block.to_python(
-            {"title": "A test", "embed": "http://www.example.com/foo"}
+            {"title": "A test", "embed": "https://www.youtube.com/watch/"}
         )
 
         temp = template.Template("embed: {{ self.embed }}")
@@ -962,9 +977,6 @@ class TestEmbedBlock(TestCase):
         result = temp.render(context)
 
         self.assertIn("<h1>Hello world!</h1>", result)
-
-        # Check that get_embed was called correctly
-        get_embed.assert_any_call("http://www.example.com/foo", None, None)
 
     def test_value_from_form(self):
         """
@@ -1001,43 +1013,35 @@ class TestEmbedBlock(TestCase):
         self.assertIsInstance(block5.get_default(), EmbedValue)
         self.assertEqual(block5.get_default().url, "http://www.example.com/foo")
 
-    @patch("wagtail.embeds.embeds.get_embed")
-    def test_clean_required(self, get_embed):
-        get_embed.return_value = Embed(html="<h1>Hello world!</h1>")
+    @responses.activate
+    def test_clean_required(self):
+        self.set_up_embed_response()
 
         block = EmbedBlock()
 
-        cleaned_value = block.clean(
-            EmbedValue("https://www.youtube.com/watch?v=_U79Wc965vw")
-        )
+        cleaned_value = block.clean(EmbedValue("https://www.youtube.com/watch/"))
         self.assertIsInstance(cleaned_value, EmbedValue)
-        self.assertEqual(
-            cleaned_value.url, "https://www.youtube.com/watch?v=_U79Wc965vw"
-        )
+        self.assertEqual(cleaned_value.url, "https://www.youtube.com/watch/")
 
         with self.assertRaisesMessage(ValidationError, ""):
             block.clean(None)
 
-    @patch("wagtail.embeds.embeds.get_embed")
-    def test_clean_non_required(self, get_embed):
-        get_embed.return_value = Embed(html="<h1>Hello world!</h1>")
+    @responses.activate
+    def test_clean_non_required(self):
+        self.set_up_embed_response()
 
         block = EmbedBlock(required=False)
 
-        cleaned_value = block.clean(
-            EmbedValue("https://www.youtube.com/watch?v=_U79Wc965vw")
-        )
+        cleaned_value = block.clean(EmbedValue("https://www.youtube.com/watch/"))
         self.assertIsInstance(cleaned_value, EmbedValue)
-        self.assertEqual(
-            cleaned_value.url, "https://www.youtube.com/watch?v=_U79Wc965vw"
-        )
+        self.assertEqual(cleaned_value.url, "https://www.youtube.com/watch/")
 
         cleaned_value = block.clean(None)
         self.assertIsNone(cleaned_value)
 
-    @patch("wagtail.embeds.embeds.get_embed")
-    def test_clean_invalid_url(self, get_embed):
-        get_embed.side_effect = EmbedNotFoundException
+    @responses.activate
+    def test_clean_invalid_url(self):
+        # no response set up, so responses will raise a ConnectionError
 
         non_required_block = EmbedBlock(required=False)
 


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/13135

Since https://github.com/wagtail/wagtail/pull/12849, saving a StreamField through the standard admin edit form will apply `normalize` to the blocks before calling `clean`. However, `EmbedBlock.normalize` did not properly account for blank values, returning an `EmbedValue` with a blank `url` attribute, which `clean` fails on. Fix this to return None for blank values.

Tests for `EmbedBlock.clean` have been updated to run inputs through `EmbedBlock.normalize`, replicating what happens in a real form.