### PR TITLE
Feat: validator to restrict future dates

### DIFF
--- a/docs/advanced_topics/customization/page_editing_interface.md
+++ b/docs/advanced_topics/customization/page_editing_interface.md
@@ -159,6 +159,60 @@ To unregister, call `unregister_image_format` with the string of the `name` of t
 Unregistering ``Format`` objects will cause errors when viewing or editing pages that reference them.
 ```
 
+(date_field_validation)=
+
+## Date Field Validation
+
+Wagtail provides some built-in validators for common date validation scenarios. These validators can be applied to `DateField` and `DateTimeField` instances to enforce specific constraints on date input.
+
+(no_future_date_validator)=
+
+### Preventing Future Dates
+
+The `NoFutureDateValidator` prevents users from entering dates in the future. This is particularly useful for fields that should only contain past or present dates, such as:
+
+- Birth dates
+- Historical event dates  
+- Publication dates for content that has already been published
+- Completion dates for finished projects
+
+```python
+from django.db import models
+from wagtail.fields import NoFutureDateValidator
+from wagtail.admin.panels import FieldPanel
+from wagtail.models import Page
+
+
+class EventPage(Page):
+    event_date = models.DateField(
+        validators=[NoFutureDateValidator()],
+        help_text="The date when this event occurred"
+    )
+    birth_date = models.DateField(
+        validators=[NoFutureDateValidator("Birth date cannot be in the future.")],
+        help_text="Person's date of birth"
+    )
+
+    content_panels = Page.content_panels + [
+        FieldPanel('event_date'),
+        FieldPanel('birth_date'),
+    ]
+```
+
+The validator also accepts an optional custom error message:
+
+```python
+# Using default message: "Date cannot be in the future."
+event_date = models.DateField(validators=[NoFutureDateValidator()])
+
+# Using custom message
+birth_date = models.DateField(
+    validators=[NoFutureDateValidator("Please enter a valid birth date.")]
+)
+```
+
+The validator will raise a validation error if the entered date is after today's date.
+
 (custom_edit_handler_forms)=
 
 ## Customizing generated forms

--- a/wagtail/tests/test_date_validators.py
+++ b/wagtail/tests/test_date_validators.py
@@ -1,0 +1,68 @@
+import datetime
+from unittest.mock import patch
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from wagtail.fields import NoFutureDateValidator
+
+
+class TestNoFutureDateValidator(TestCase):
+    def setUp(self):
+        self.validator = NoFutureDateValidator()
+
+    def test_validates_past_date(self):
+        """Past dates should pass validation"""
+        past_date = datetime.date.today() - datetime.timedelta(days=1)
+        # Should not raise ValidationError
+        self.validator(past_date)
+
+    def test_validates_today(self):
+        """Today's date should pass validation"""
+        today = datetime.date.today()
+        # Should not raise ValidationError
+        self.validator(today)
+
+    def test_rejects_future_date(self):
+        """Future dates should raise ValidationError"""
+        future_date = datetime.date.today() + datetime.timedelta(days=1)
+        with self.assertRaises(ValidationError) as cm:
+            self.validator(future_date)
+
+        self.assertEqual(cm.exception.code, "future_date")
+        self.assertEqual(str(cm.exception.message), "Date cannot be in the future.")
+
+    def test_validates_none_value(self):
+        """None values should pass validation (let required validation handle empty values)"""
+        # Should not raise ValidationError
+        self.validator(None)
+
+    def test_custom_message(self):
+        """Test custom error message"""
+        custom_message = "Custom future date error message"
+        validator = NoFutureDateValidator(message=custom_message)
+        future_date = datetime.date.today() + datetime.timedelta(days=1)
+
+        with self.assertRaises(ValidationError) as cm:
+            validator(future_date)
+
+        self.assertEqual(str(cm.exception.message), custom_message)
+
+    @patch("wagtail.fields.datetime")
+    def test_validates_with_mocked_today(self, mock_datetime):
+        """Test that validation uses the correct 'today' reference"""
+        # Mock today to be 2024-01-15
+        mock_today = datetime.date(2024, 1, 15)
+        mock_datetime.date.today.return_value = mock_today
+
+        # Test date exactly one day in the future
+        future_date = datetime.date(2024, 1, 16)
+        with self.assertRaises(ValidationError):
+            self.validator(future_date)
+
+        # Test date exactly 'today'
+        self.validator(mock_today)  # Should not raise
+
+        # Test past date
+        past_date = datetime.date(2024, 1, 14)
+        self.validator(past_date)  # Should not raise


### PR DESCRIPTION
Issue tracking #13113 

**Add a new validator that prevents future dates from being entered in date fields.**

This validator is useful for fields that should be in the past or present but never in the future, such as birth dates, historical event dates, or publication dates that have already occurred.

The validator:
- Extends Django's BaseValidator
- Provides a clear error message when a future date is entered
- Allows customization of the error message
- Handles None values gracefully (letting required validation handle empty values)
- Includes comprehensive test coverage

**Example Usage**:
<img width="578" alt="Screenshot 2025-06-13 at 12 07 24 PM" src="https://github.com/user-attachments/assets/643b4efe-d082-431d-b4c8-5193a5fd7e62" />


**Example Model Field**:
<img width="749" alt="Screenshot 2025-06-13 at 12 09 40 PM" src="https://github.com/user-attachments/assets/25f72cbd-a4f0-4bc5-90e1-5a50f3788403" />


I can further add documentation for this validator once i get a thumbs up.
