### PR TITLE
Improve userbar and previews support for headless setups

### DIFF
--- a/client/src/controllers/PreviewController.test.js
+++ b/client/src/controllers/PreviewController.test.js
@@ -1,6 +1,29 @@
 import { Application } from '@hotwired/stimulus';
+import axe from 'axe-core';
 import { ProgressController } from './ProgressController';
 import { PreviewController } from './PreviewController';
+import { wagtailPreviewPlugin } from '../includes/previewPlugin';
+
+jest.mock('axe-core', () => {
+  const originalAxe = jest.requireActual('axe-core');
+  return {
+    ...originalAxe,
+    run: jest.fn(),
+    utils: {
+      ...originalAxe.utils,
+      sendCommandToFrame: jest.fn(),
+    },
+  };
+});
+
+function mockAxeResults(runResults, contentChecksResults) {
+  axe.run.mockResolvedValueOnce(runResults);
+  axe.utils.sendCommandToFrame.mockImplementationOnce(
+    (frame, options, callback) => {
+      callback(contentChecksResults);
+    },
+  );
+}
 
 jest.useFakeTimers();
 jest.spyOn(global, 'setTimeout');
@@ -91,6 +114,49 @@ describe('PreviewController', () => {
     </select>
   `;
 
+  const axeConfig = {
+    context: { include: ['main'] },
+    options: {},
+    messages: {
+      'heading-order': {
+        error_name: 'Incorrect heading hierarchy',
+        help_text: 'Avoid skipping levels',
+      },
+    },
+    spec: {},
+  };
+
+  const checksSidePanel = /* html */ `
+    <button type="button" data-side-panel-toggle="checks">
+      <div data-side-panel-toggle-counter></div>
+    </button>
+    <div data-side-panel="checks">
+      <h2 id="side-panel-checks-title">Checks</h2>
+      <template id="w-a11y-result-row-template">
+        <div data-a11y-result-row>
+          <h3>
+            <span data-a11y-result-name></span>
+          </h3>
+          <div data-a11y-result-help></div>
+          <button
+            data-a11y-result-selector
+            type="button"
+            aria-label="Show issue"
+          >
+            <span data-a11y-result-selector-text></span>
+          </button>
+        </div>
+      </template>
+      <h3>Word count: <span data-content-word-count>-</span></h3>
+      <h3>Reading time: <span data-content-reading-time>-</span></h3>
+      <h3>Issues found: <span data-a11y-result-count>-</span></h3>
+      <div data-checks-panel></div>
+    </div>
+    <script type="application/json" id="accessibility-axe-configuration">
+      ${JSON.stringify(axeConfig)}
+    </script>
+  `;
+
   beforeAll(() => {
     Object.keys(events).forEach((name) => {
       document.addEventListener(`${identifier}:${name}`, pushEvent);
@@ -111,9 +177,6 @@ describe('PreviewController', () => {
       <form method="POST" data-edit-form>
         <input type="text" id="id_title" name="title" value="My Page" />
       </form>
-      <div data-side-panel="checks">
-        <h2 id="side-panel-checks-title">Checks</h2>
-      </div>
       <div data-side-panel="preview">
         <h2 id="side-panel-preview-title">Preview</h2>
         <div
@@ -286,6 +349,10 @@ describe('PreviewController', () => {
     await Promise.resolve();
 
     await expectIframeReloaded(expectedUrl);
+
+    // If content checks are enabled, there are a few more promises to resolve
+    await jest.runOnlyPendingTimersAsync();
+
     expect(events).toMatchObject({
       update: [expect.any(Event)],
       json: [expect.any(Event)],
@@ -1560,6 +1627,370 @@ describe('PreviewController', () => {
         ready: [expect.any(Event)],
         updated: [expect.any(Event), expect.any(Event), expect.any(Event)],
       });
+    });
+  });
+
+  describe('content checks', () => {
+    const mockViolations = [
+      {
+        id: 'landmark-complementary-is-top-level',
+        impact: 'moderate',
+        tags: ['cat.semantics', 'best-practice'],
+        description:
+          'Ensure the complementary landmark or aside is at top level',
+        help: 'Aside should not be contained in another landmark',
+        helpUrl:
+          'https://dequeuniversity.com/rules/axe/4.10/landmark-complementary-is-top-level?application=axeAPI',
+        nodes: [
+          {
+            any: [
+              {
+                id: 'landmark-is-top-level',
+                data: {
+                  role: null,
+                },
+                relatedNodes: [],
+                impact: 'moderate',
+                message: 'The null landmark is contained in another landmark.',
+              },
+            ],
+            all: [],
+            none: [],
+            impact: 'moderate',
+            html: '<aside><div><div><h4>Origin</h4><p>United States (New England)</p></div><div><h4>Type</h4><p>Yeast bread</p></div></div></aside>',
+            target: ['#w-preview-iframe', 'aside'],
+            failureSummary:
+              'Fix any of the following:\n  The null landmark is contained in another landmark.',
+          },
+        ],
+      },
+      {
+        id: 'heading-order',
+        impact: 'moderate',
+        tags: ['cat.semantics', 'best-practice'],
+        description: 'Ensure the order of headings is semantically correct',
+        help: 'Heading levels should only increase by one',
+        helpUrl:
+          'https://dequeuniversity.com/rules/axe/4.10/heading-order?application=axeAPI',
+        nodes: [
+          {
+            any: [
+              {
+                id: 'heading-order',
+                data: null,
+                relatedNodes: [],
+                impact: 'moderate',
+                message: 'Heading order invalid',
+              },
+            ],
+            all: [],
+            none: [],
+            impact: 'moderate',
+            html: '<h4>Origin</h4>',
+            target: ['#w-preview-iframe', 'div:nth-child(1) > h4'],
+            failureSummary:
+              'Fix any of the following:\n  Heading order invalid',
+          },
+        ],
+      },
+    ];
+
+    beforeEach(() => {
+      // We log accessibility violations to the console as errors,
+      // mock it to avoid cluttering the test output.
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      document.body.insertAdjacentHTML('beforeend', checksSidePanel);
+    });
+
+    afterEach(() => {
+      // eslint-disable-next-line no-console
+      console.error.mockRestore();
+      // Ensure disconnect() is called before the next test so that the window's
+      // event listeners are removed
+      document.body.innerHTML = '';
+    });
+
+    it('should run content checks on the preview and render the results', async () => {
+      mockAxeResults(
+        { violations: mockViolations },
+        { wordCount: 123, readingTime: 7 },
+      );
+
+      await initializeOpenedPanel();
+
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledWith(
+        'axe.run results',
+        mockViolations,
+      );
+
+      await Promise.resolve();
+
+      const toggleCounter = document.querySelector(
+        '[data-side-panel-toggle-counter]',
+      );
+      expect(toggleCounter.textContent.trim()).toEqual('2');
+
+      const wordCount = document.querySelector('[data-content-word-count]');
+      expect(wordCount.textContent.trim()).toEqual('123');
+
+      const readingTime = document.querySelector('[data-content-reading-time]');
+      expect(readingTime.textContent.trim()).toEqual('7 mins');
+
+      const panelCounter = document.querySelector('[data-a11y-result-count]');
+      expect(panelCounter.textContent.trim()).toEqual('2');
+
+      const checksPanel = document.querySelector('[data-checks-panel]');
+      const resultRows = checksPanel.querySelectorAll('[data-a11y-result-row]');
+
+      // Note: The sorting algorithm does not work on the preview panel because
+      // the logic does not access the iframe's DOM to compare the nodes, so it
+      // ends up comparing the iframe itself, thus
+      expect(resultRows.length).toEqual(2);
+
+      // Should allow custom error message and help text from the config instead
+      // of Axe's defaults
+      expect(
+        resultRows[0]
+          .querySelector('[data-a11y-result-name]')
+          .textContent.trim(),
+      ).toEqual('Incorrect heading hierarchy');
+      expect(
+        resultRows[0]
+          .querySelector('[data-a11y-result-help]')
+          .textContent.trim(),
+      ).toEqual('Avoid skipping levels');
+      // Should strip out the #w-preview-iframe selector
+      expect(
+        resultRows[0]
+          .querySelector('[data-a11y-result-selector]')
+          .textContent.trim(),
+      ).toEqual('div:nth-child(1) > h4');
+
+      // Should use Axe's error message and help text
+      expect(
+        resultRows[1]
+          .querySelector('[data-a11y-result-name]')
+          .textContent.trim(),
+      ).toEqual('Aside should not be contained in another landmark');
+      expect(
+        resultRows[1]
+          .querySelector('[data-a11y-result-help]')
+          .textContent.trim(),
+      ).toEqual('Ensure the complementary landmark or aside is at top level');
+      // Should strip out the #w-preview-iframe selector
+      const selector = resultRows[1].querySelector(
+        '[data-a11y-result-selector]',
+      );
+      expect(selector.textContent.trim()).toEqual('aside');
+
+      mockWindow({ open: jest.fn() });
+
+      // Click the selector link to open the result in a new tab
+      selector.click();
+
+      // Run all timers and promises
+      await jest.runAllTimersAsync();
+
+      // Should open the result in a new tab with the correct URL
+      const absoluteUrl = `http://localhost${url}`;
+      expect(window.open).toHaveBeenCalledWith(absoluteUrl, absoluteUrl);
+    });
+
+    it('should not throw an error if content metrics plugin fails to return the results', async () => {
+      mockAxeResults({ violations: mockViolations }, null);
+
+      await initializeOpenedPanel();
+
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledWith(
+        'axe.run results',
+        mockViolations,
+      );
+
+      await Promise.resolve();
+
+      const toggleCounter = document.querySelector(
+        '[data-side-panel-toggle-counter]',
+      );
+      expect(toggleCounter.textContent.trim()).toEqual('2');
+
+      const wordCount = document.querySelector('[data-content-word-count]');
+      expect(wordCount.textContent.trim()).toEqual('-');
+
+      const readingTime = document.querySelector('[data-content-reading-time]');
+      expect(readingTime.textContent.trim()).toEqual('-');
+
+      const panelCounter = document.querySelector('[data-a11y-result-count]');
+      expect(panelCounter.textContent.trim()).toEqual('2');
+
+      const checksPanel = document.querySelector('[data-checks-panel]');
+      const resultRows = checksPanel.querySelectorAll('[data-a11y-result-row]');
+
+      // Should still render accessibility results
+      expect(resultRows.length).toEqual(2);
+    });
+
+    it('should re-run content checks when the window gets a message event with w-userbar:axe-ready', async () => {
+      let violations = [];
+
+      mockAxeResults({ violations }, {});
+      await initializeOpenedPanel();
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledTimes(0);
+
+      violations = mockViolations;
+      mockAxeResults({ violations }, { wordCount: 456, readingTime: 14 });
+
+      // A non-Wagtail message event should not trigger the checks
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { something: { foo: 'bar' } },
+        }),
+      );
+      await jest.runAllTimersAsync();
+
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledTimes(0);
+
+      // A Wagtail message event that is unrelated should not trigger the checks
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { wagtail: { type: 'w-userbar:other' } },
+        }),
+      );
+      await jest.runAllTimersAsync();
+
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledTimes(0);
+
+      // Simulate the Wagtail userbar sending the axe-ready event to indicate
+      // that it just finished running the accessibility checks and the
+      // PreviewController should re-run the checks
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { wagtail: { type: 'w-userbar:axe-ready' } },
+        }),
+      );
+      await jest.runAllTimersAsync();
+
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledWith(
+        'axe.run results',
+        mockViolations,
+      );
+      // eslint-disable-next-line no-console
+      console.error.mockClear();
+
+      // Mock two long-running checks
+      violations = [mockViolations[1]];
+      const newViolations = [mockViolations[0]];
+      mockAxeResults(
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({ violations });
+          }, 5_000);
+        }),
+        {},
+      );
+      mockAxeResults(
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({ violations: newViolations });
+          }, 15_000);
+        }),
+        {},
+      );
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { wagtail: { type: 'w-userbar:axe-ready' } },
+        }),
+      );
+      await jest.advanceTimersByTimeAsync(4_000);
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledTimes(0);
+
+      // If an event is dispatched while the checks are still running,
+      // it will be queued and processed after the current check finishes
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { wagtail: { type: 'w-userbar:axe-ready' } },
+        }),
+      );
+      await jest.advanceTimersByTimeAsync(5_000);
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledWith('axe.run results', violations);
+
+      await jest.advanceTimersByTimeAsync(7_000);
+
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledTimes(2);
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledWith(
+        'axe.run results',
+        newViolations,
+      );
+    });
+
+    it('should clean up event listeners on disconnect', async () => {
+      mockAxeResults({ violations: [] }, {});
+      const panel = document.querySelector('[data-side-panel="checks"]');
+      const element = document.querySelector('[data-controller="w-preview"]');
+      const spies = [
+        jest.spyOn(panel, 'addEventListener'),
+        jest.spyOn(panel, 'removeEventListener'),
+        jest.spyOn(window, 'addEventListener'),
+        jest.spyOn(window, 'removeEventListener'),
+      ];
+
+      await initializeOpenedPanel();
+
+      const controller = application.getControllerForElementAndIdentifier(
+        element,
+        identifier,
+      );
+
+      expect(window.addEventListener).toHaveBeenCalledWith(
+        'message',
+        controller.runChecks,
+      );
+      expect(panel.addEventListener).toHaveBeenCalledWith(
+        'show',
+        controller.activatePreview,
+      );
+      expect(panel.addEventListener).toHaveBeenCalledWith(
+        'hide',
+        controller.deactivatePreview,
+      );
+
+      element.removeAttribute('data-controller');
+      await jest.runAllTimersAsync();
+
+      expect(window.removeEventListener).toHaveBeenCalledWith(
+        'message',
+        controller.runChecks,
+      );
+      expect(panel.removeEventListener).toHaveBeenCalledWith(
+        'show',
+        controller.activatePreview,
+      );
+      expect(panel.removeEventListener).toHaveBeenCalledWith(
+        'hide',
+        controller.deactivatePreview,
+      );
+
+      spies.forEach((spy) => spy.mockRestore());
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/client/src/controllers/PreviewController.test.js
+++ b/client/src/controllers/PreviewController.test.js
@@ -1992,5 +1992,47 @@ describe('PreviewController', () => {
       // eslint-disable-next-line no-console
       expect(console.error).toHaveBeenCalledTimes(0);
     });
+
+    describe('custom axe configuration', () => {
+      it('should convert axe context config for the preview iframe', async () => {
+        mockAxeResults({ violations: [] }, {});
+        await initializeOpenedPanel();
+        expect(axe.run).toHaveBeenCalledWith(
+          {
+            include: {
+              fromFrames: ['#w-preview-iframe', 'main'],
+            },
+          },
+          axeConfig.options,
+        );
+      });
+
+      it('should respect context.exclude', async () => {
+        const config = document.getElementById(
+          'accessibility-axe-configuration',
+        );
+        config.innerHTML = JSON.stringify({
+          ...axeConfig,
+          context: {
+            include: ['#main'],
+            exclude: ['[data-ignored]'],
+          },
+        });
+
+        mockAxeResults({ violations: [] }, {});
+        await initializeOpenedPanel();
+        expect(axe.run).toHaveBeenCalledWith(
+          {
+            include: {
+              fromFrames: ['#w-preview-iframe', '#main'],
+            },
+            exclude: {
+              fromFrames: ['#w-preview-iframe', '[data-ignored]'],
+            },
+          },
+          axeConfig.options,
+        );
+      });
+    });
   });
 });

--- a/client/src/controllers/PreviewController.ts
+++ b/client/src/controllers/PreviewController.ts
@@ -787,8 +787,8 @@ export class PreviewController extends Controller<HTMLElement> {
     }
 
     this.contentChecksPromise = (async () => {
-      await runContentChecks();
       await runAccessibilityChecks(() => this.newTabTarget.click());
+      await runContentChecks();
       this.contentChecksPromise = null;
     })();
 

--- a/client/src/controllers/PreviewController.ts
+++ b/client/src/controllers/PreviewController.ts
@@ -332,13 +332,12 @@ export class PreviewController extends Controller<HTMLElement> {
     }
 
     // Ensure we only test within the preview iframe, but nonetheless with the correct selectors.
-    this.axeConfig.context = {
-      include: {
-        fromFrames: ['#w-preview-iframe'].concat(
-          (this.axeConfig.context as ContextObject).include as string[],
-        ),
-      },
-    } as ContextObject;
+    this.axeConfig.context.include = {
+      fromFrames: ['#w-preview-iframe'].concat(
+        this.axeConfig.context.include as string[],
+      ),
+    } as ContextObject['include'];
+
     if ((this.axeConfig.context.exclude as string[])?.length > 0) {
       this.axeConfig.context.exclude = {
         fromFrames: ['#w-preview-iframe'].concat(

--- a/client/src/includes/a11y-result.test.ts
+++ b/client/src/includes/a11y-result.test.ts
@@ -145,7 +145,7 @@ describe('getA11yReport', () => {
     };
     (axe.run as jest.Mock).mockResolvedValue(mockResults);
     const config: WagtailAxeConfiguration = {
-      context: 'body',
+      context: { include: ['body'] },
       options: {},
       messages: {},
       spec: {
@@ -169,7 +169,7 @@ describe('getA11yReport', () => {
     };
     (axe.run as jest.Mock).mockResolvedValue(mockResults);
     const config: WagtailAxeConfiguration = {
-      context: 'body',
+      context: { include: ['body'] },
       options: {},
       messages: {},
       spec: {

--- a/client/src/includes/a11y-result.ts
+++ b/client/src/includes/a11y-result.ts
@@ -1,13 +1,14 @@
 import axe, {
   AxeResults,
   ContextObject,
+  CrossTreeSelector,
   NodeResult,
   Result,
   RunOptions,
   Spec,
 } from 'axe-core';
 
-const toSelector = (str: string | string[]) =>
+const toSelector = (str: string | string[] | CrossTreeSelector[]) =>
   Array.isArray(str) ? str.join(' ') : str;
 
 const sortAxeNodes = (nodeResultA?: NodeResult, nodeResultB?: NodeResult) => {
@@ -203,7 +204,7 @@ export const renderA11yResults = (
         // Special-case when displaying accessibility results within the admin interface.
         const isInCMS = node.target[0] === '#w-preview-iframe';
         const selectorName = toSelector(
-          isInCMS ? node.target[1] : node.target[0],
+          node.target.filter((target) => target !== '#w-preview-iframe'),
         );
 
         const a11ySelector = currentA11yRow.querySelector(

--- a/client/src/includes/a11y-result.ts
+++ b/client/src/includes/a11y-result.ts
@@ -1,6 +1,6 @@
 import axe, {
   AxeResults,
-  ElementContext,
+  ContextObject,
   NodeResult,
   Result,
   RunOptions,
@@ -46,7 +46,7 @@ interface ErrorMessage {
   help_text: string;
 }
 export interface WagtailAxeConfiguration {
-  context: ElementContext;
+  context: ContextObject;
   options: RunOptions;
   messages: Record<string, ErrorMessage>;
   spec: Spec;

--- a/client/src/includes/userbar.ts
+++ b/client/src/includes/userbar.ts
@@ -343,15 +343,26 @@ export class Userbar extends HTMLElement {
     this.dialog = dialog;
     this.dialogBody = body;
 
+    const accessibilityTrigger = this.shadowRoot.getElementById(
+      'accessibility-trigger',
+    );
+
+    const toggleAxeResults = () => {
+      if (!this.dialog.shown) {
+        this.dialog.show();
+      } else {
+        this.dialog.hide();
+      }
+    };
+
+    accessibilityTrigger?.addEventListener('click', toggleAxeResults);
+
     await this.runAxe();
   }
 
   async runAxe() {
     if (!this.shadowRoot) return;
 
-    const accessibilityTrigger = this.shadowRoot.getElementById(
-      'accessibility-trigger',
-    );
     const config = getAxeConfiguration(this.shadowRoot);
 
     const accessibilityResultsBox = this.shadowRoot.querySelector(
@@ -367,7 +378,6 @@ export class Userbar extends HTMLElement {
       );
 
     if (
-      !accessibilityTrigger ||
       !config ||
       !accessibilityResultsBox ||
       !a11yRowTemplate ||
@@ -379,10 +389,15 @@ export class Userbar extends HTMLElement {
     // Collect content data from the live preview via Axe plugin for content metrics calculation
     const { results, a11yErrorsNumber } = await getA11yReport(config);
 
+    this.trigger.querySelector('[data-w-userbar-axe-count]')?.remove();
     if (results.violations.length) {
       const a11yErrorBadge = document.createElement('span');
       a11yErrorBadge.textContent = String(a11yErrorsNumber);
       a11yErrorBadge.classList.add('w-userbar-axe-count');
+      a11yErrorBadge.setAttribute(
+        'data-w-userbar-axe-count',
+        String(a11yErrorsNumber),
+      );
       this.trigger.appendChild(a11yErrorBadge);
     }
 
@@ -458,22 +473,12 @@ export class Userbar extends HTMLElement {
       });
     };
 
-    const toggleAxeResults = () => {
-      if (accessibilityResultsBox.getAttribute('aria-hidden') === 'true') {
-        this.dialog.show();
-
-        renderA11yResults(
-          this.dialogBody,
-          results,
-          config,
-          a11yRowTemplate,
-          onClickSelector,
-        );
-      } else {
-        this.dialog.hide();
-      }
-    };
-
-    accessibilityTrigger.addEventListener('click', toggleAxeResults);
+    renderA11yResults(
+      this.dialogBody,
+      results,
+      config,
+      a11yRowTemplate,
+      onClickSelector,
+    );
   }
 }

--- a/client/src/includes/userbar.ts
+++ b/client/src/includes/userbar.ts
@@ -23,6 +23,8 @@ Learn more about roving tabIndex: https://w3c.github.io/aria-practices/#kbd_rovi
 
 export class Userbar extends HTMLElement {
   declare trigger: HTMLElement;
+  declare dialog: A11yDialog;
+  declare dialogBody: HTMLElement;
 
   connectedCallback() {
     const template = document.querySelector<HTMLTemplateElement>(
@@ -309,6 +311,7 @@ export class Userbar extends HTMLElement {
 
   // Initialise Axe
   async initialiseAxe() {
+    // Collect content data from the live preview via Axe plugin for content metrics calculation
     if (!this.shadowRoot) return;
 
     axe.registerPlugin(wagtailPreviewPlugin);
@@ -336,11 +339,17 @@ export class Userbar extends HTMLElement {
       },
     );
 
-    const { body: modalBody, dialog: modal } = await modalReady;
+    const { dialog, body } = await modalReady;
+    this.dialog = dialog;
+    this.dialogBody = body;
 
-    // Collect content data from the live preview via Axe plugin for content metrics calculation
+    await this.runAxe();
+  }
 
-    const accessibilityTrigger = this.shadowRoot?.getElementById(
+  async runAxe() {
+    if (!this.shadowRoot) return;
+
+    const accessibilityTrigger = this.shadowRoot.getElementById(
       'accessibility-trigger',
     );
     const config = getAxeConfiguration(this.shadowRoot);
@@ -367,6 +376,7 @@ export class Userbar extends HTMLElement {
       return;
     }
 
+    // Collect content data from the live preview via Axe plugin for content metrics calculation
     const { results, a11yErrorsNumber } = await getA11yReport(config);
 
     if (results.violations.length) {
@@ -450,17 +460,17 @@ export class Userbar extends HTMLElement {
 
     const toggleAxeResults = () => {
       if (accessibilityResultsBox.getAttribute('aria-hidden') === 'true') {
-        modal.show();
+        this.dialog.show();
 
         renderA11yResults(
-          modalBody,
+          this.dialogBody,
           results,
           config,
           a11yRowTemplate,
           onClickSelector,
         );
       } else {
-        modal.hide();
+        this.dialog.hide();
       }
     };
 

--- a/client/src/includes/userbar.ts
+++ b/client/src/includes/userbar.ts
@@ -309,24 +309,10 @@ export class Userbar extends HTMLElement {
 
   // Initialise Axe
   async initialiseAxe() {
-    // Collect content data from the live preview via Axe plugin for content metrics calculation
+    if (!this.shadowRoot) return;
+
     axe.registerPlugin(wagtailPreviewPlugin);
     axe.plugins.wagtailPreview.add(contentMetricsPluginInstance);
-
-    const accessibilityTrigger = this.shadowRoot?.getElementById(
-      'accessibility-trigger',
-    );
-    const config = getAxeConfiguration(this.shadowRoot);
-    if (!this.shadowRoot || !accessibilityTrigger || !config) return;
-
-    const { results, a11yErrorsNumber } = await getA11yReport(config);
-
-    if (results.violations.length) {
-      const a11yErrorBadge = document.createElement('span');
-      a11yErrorBadge.textContent = String(a11yErrorsNumber);
-      a11yErrorBadge.classList.add('w-userbar-axe-count');
-      this.trigger.appendChild(a11yErrorBadge);
-    }
 
     const stimulus = Application.start(
       this.shadowRoot.firstElementChild as Element,
@@ -352,9 +338,13 @@ export class Userbar extends HTMLElement {
 
     const { body: modalBody, dialog: modal } = await modalReady;
 
-    // Disable TS linter check for legacy code in 3rd party `A11yDialog` element
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // Collect content data from the live preview via Axe plugin for content metrics calculation
+
+    const accessibilityTrigger = this.shadowRoot?.getElementById(
+      'accessibility-trigger',
+    );
+    const config = getAxeConfiguration(this.shadowRoot);
+
     const accessibilityResultsBox = this.shadowRoot.querySelector(
       '#accessibility-results',
     );
@@ -367,8 +357,23 @@ export class Userbar extends HTMLElement {
         '#w-a11y-result-outline-template',
       );
 
-    if (!accessibilityResultsBox || !a11yRowTemplate || !a11yOutlineTemplate) {
+    if (
+      !accessibilityTrigger ||
+      !config ||
+      !accessibilityResultsBox ||
+      !a11yRowTemplate ||
+      !a11yOutlineTemplate
+    ) {
       return;
+    }
+
+    const { results, a11yErrorsNumber } = await getA11yReport(config);
+
+    if (results.violations.length) {
+      const a11yErrorBadge = document.createElement('span');
+      a11yErrorBadge.textContent = String(a11yErrorsNumber);
+      a11yErrorBadge.classList.add('w-userbar-axe-count');
+      this.trigger.appendChild(a11yErrorBadge);
     }
 
     const innerErrorBadges = this.shadowRoot.querySelectorAll<HTMLSpanElement>(

--- a/client/src/includes/userbar.ts
+++ b/client/src/includes/userbar.ts
@@ -298,9 +298,15 @@ export class Userbar extends HTMLElement {
     // On initialisation, all menu items should be disabled for roving tab index
     resetItemsTabIndex();
 
-    document.addEventListener('DOMContentLoaded', async () => {
-      await this.initialiseAxe();
-    });
+    // The page may already be loaded, e.g. when the userbar is loaded via AJAX.
+    // In this case, we need to call the initialisation function immediately.
+    if (document.readyState === 'complete') {
+      this.initialiseAxe();
+    } else {
+      document.addEventListener('DOMContentLoaded', async () => {
+        await this.initialiseAxe();
+      });
+    }
   }
 
   /*

--- a/client/src/utils/debounce.ts
+++ b/client/src/utils/debounce.ts
@@ -30,7 +30,7 @@
 export const debounce = <A extends any[], R = any>(
   func: (...args: A) => R | Promise<R>,
   wait: number | null = 0,
-): { (...args: A): Promise<R>; cancel(): void } => {
+): DebouncedFunction<A, R> => {
   let timeoutId: number | undefined;
 
   const debounced = (...args: A) => {
@@ -59,5 +59,13 @@ export const debounce = <A extends any[], R = any>(
     window.clearTimeout(timeoutId);
   };
 
+  debounced.restore = () => func;
+
   return debounced;
+};
+
+export type DebouncedFunction<A extends any[], R = any> = {
+  (...args: A): Promise<R>;
+  cancel(): void;
+  restore(): (...args: A) => R | Promise<R>;
 };

--- a/wagtail/admin/templates/wagtailadmin/notifications/base.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/base.html
@@ -89,7 +89,7 @@
         <table width="600" border="0" align="center" class="mobile" cellspacing="0" cellpadding="0">
             <tr>
                 <td>
-                    {% block branding_logo %}<img width="100%" border="0" style="display: block;" alt="" src="{% notification_static 'wagtailadmin/images/email-header.jpg' %}" />{% endblock %}
+                    {% block branding_logo %}<img width="100%" border="0" style="display: block;" alt="" src="{% absolute_static 'wagtailadmin/images/email-header.jpg' %}" />{% endblock %}
                 </td>
             </tr>
         </table>

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -3,7 +3,7 @@
 <template id="wagtail-userbar-template">
     {# In preview panels, we still render the userbar UI, but hidden by default. #}
     <aside {% if request.in_preview_panel %}hidden{% endif %}>
-        <div class="w-userbar w-userbar--{{ position|default:'bottom-right' }} {% admin_theme_classname %}" data-wagtail-userbar part="userbar">
+        <div class="w-userbar w-userbar--{{ position|default:'bottom-right' }} {% admin_theme_classname %}" data-wagtail-userbar data-wagtail-userbar-origin="{{ origin }}" part="userbar">
             {% block css %}
                 {% versioned_static 'wagtailadmin/css/core.css' as core_css_url %}
                 <link rel="stylesheet" href="{% build_absolute_url core_css_url %}">

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -5,8 +5,7 @@
     <aside {% if request.in_preview_panel %}hidden{% endif %}>
         <div class="w-userbar w-userbar--{{ position|default:'bottom-right' }} {% admin_theme_classname %}" data-wagtail-userbar data-wagtail-userbar-origin="{{ origin }}" part="userbar">
             {% block css %}
-                {% versioned_static 'wagtailadmin/css/core.css' as core_css_url %}
-                <link rel="stylesheet" href="{% build_absolute_url core_css_url %}">
+                <link rel="stylesheet" href="{% absolute_static 'wagtailadmin/css/core.css' %}">
                 {# For headless userbar: the contents of the hook also need absolute URLs #}
                 {% hook_output 'insert_global_admin_css' %}
             {% endblock %}
@@ -45,9 +44,7 @@
 </template>
 <wagtail-userbar></wagtail-userbar>
 {% block js %}
-    {% versioned_static 'wagtailadmin/js/vendor.js' as vendor_js_url %}
-    {% versioned_static 'wagtailadmin/js/userbar.js' as userbar_js_url %}
-    <script src="{% build_absolute_url vendor_js_url %}"></script>
-    <script src="{% build_absolute_url userbar_js_url %}"></script>
+    <script src="{% absolute_static 'wagtailadmin/js/vendor.js' %}"></script>
+    <script src="{% absolute_static 'wagtailadmin/js/userbar.js' %}"></script>
 {% endblock %}
 <!-- end Wagtail user bar embed code -->

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_admin.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_admin.html
@@ -2,8 +2,8 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block item_content %}
-    {% url 'wagtailadmin_home' as admin_home_url %}
-    <a href="{% build_absolute_url admin_home_url %}" target="_parent" role="menuitem">
+    {% base_url_setting default="" as base_url %}
+    <a href="{{ base_url }}{% url 'wagtailadmin_home' %}" target="_parent" role="menuitem">
         {% icon name="key" classname="w-action-icon" %}
         {% trans 'Go to Wagtail admin' %}
     </a>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_add.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_add.html
@@ -2,8 +2,8 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block item_content %}
-    {% url 'wagtailadmin_pages:add_subpage' self.page.id as add_url %}
-    <a href="{% build_absolute_url add_url %}" target="_parent" role="menuitem">
+    {% base_url_setting default="" as base_url %}
+    <a href="{{ base_url }}{% url 'wagtailadmin_pages:add_subpage' self.page.id %}" target="_parent" role="menuitem">
         {% icon name="plus" classname="w-action-icon" %}
         {% trans 'Add a child page' %}
     </a>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_edit.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_edit.html
@@ -2,8 +2,8 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block item_content %}
-    {% url 'wagtailadmin_pages:edit' self.page.id as edit_url %}
-    <a href="{% build_absolute_url edit_url %}" target="_parent" role="menuitem">
+    {% base_url_setting default="" as base_url %}
+    <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' self.page.id %}" target="_parent" role="menuitem">
         {% icon name="edit" classname="w-action-icon" %}
         {% trans 'Edit this page' %}
     </a>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_explore.html
@@ -2,8 +2,8 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block item_content %}
-    {% url 'wagtailadmin_explore' self.parent_page.id as explore_url %}
-    <a href="{% build_absolute_url explore_url %}" target="_parent" role="menuitem">
+    {% base_url_setting default="" as base_url %}
+    <a href="{{ base_url }}{% url 'wagtailadmin_explore' self.parent_page.id %}" target="_parent" role="menuitem">
         {% icon name="folder-open-inverse" classname="w-action-icon" %}
         {% trans 'Show in Explorer' %}
     </a>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -205,18 +205,6 @@ def admin_url_name(obj, action):
     return obj.snippet_viewset.get_url_name(action)
 
 
-@register.simple_tag(takes_context=True)
-def build_absolute_url(context, url):
-    """
-    Usage: {% build_absolute_url url %}
-    Returns the absolute URL of the given URL.
-    """
-    request = context.get("request")
-    if not request:
-        return url
-    return request.build_absolute_uri(url)
-
-
 @register.simple_tag
 def latest_str(obj):
     """

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -13,7 +13,6 @@ from django.shortcuts import resolve_url as resolve_url_func
 from django.template import Context
 from django.template.base import token_kwargs
 from django.template.defaultfilters import stringfilter
-from django.templatetags.static import static
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils import timezone
@@ -679,12 +678,13 @@ def admin_theme_color_scheme(context):
 
 
 @register.simple_tag
-def notification_static(path):
+def absolute_static(path):
     """
-    Variant of the {% static %}` tag for use in notification emails - tries to form
-    a full URL using WAGTAILADMIN_BASE_URL if the static URL isn't already a full URL.
+    Variant of the {% versioned_static %}` tag for use in external systems, such as
+    notification emails. Tries to form a full URL using WAGTAILADMIN_BASE_URL
+    if the static URL isn't already a full URL.
     """
-    return urljoin(base_url_setting(), static(path))
+    return urljoin(base_url_setting(), versioned_static_func(path))
 
 
 @register.simple_tag

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -13,10 +13,10 @@ from freezegun import freeze_time
 
 from wagtail.admin.staticfiles import VERSION_HASH, versioned_static
 from wagtail.admin.templatetags.wagtailadmin_tags import (
+    absolute_static,
     avatar_url,
     i18n_enabled,
     locale_label_from_id,
-    notification_static,
     timesince_last_update,
     timesince_simple,
 )
@@ -83,36 +83,38 @@ class TestAvatarTemplateTag(WagtailTestUtils, TestCase):
         self.assertIn("custom-avatar", url)
 
 
-class TestNotificationStaticTemplateTag(SimpleTestCase):
+class TestAbsoluteStaticTemplateTag(SimpleTestCase):
     @override_settings(STATIC_URL="/static/")
-    def test_local_notification_static(self):
-        url = notification_static("wagtailadmin/images/email-header.jpg")
-        self.assertEqual(
-            "{}/static/wagtailadmin/images/email-header.jpg".format(
-                settings.WAGTAILADMIN_BASE_URL
-            ),
-            url,
+    def test_local_absolute_static(self):
+        url = absolute_static("wagtailadmin/images/email-header.jpg")
+        expected = (
+            rf"^{settings.WAGTAILADMIN_BASE_URL}/static/wagtailadmin/images/"
+            r"email-header.jpg\?v=(\w{8})$"
         )
+        self.assertRegex(url, expected)
 
     @override_settings(
         STATIC_URL="/static/", WAGTAILADMIN_BASE_URL="http://localhost:8000"
     )
-    def test_local_notification_static_baseurl(self):
-        url = notification_static("wagtailadmin/images/email-header.jpg")
-        self.assertEqual(
-            "http://localhost:8000/static/wagtailadmin/images/email-header.jpg", url
+    def test_local_absolute_static_baseurl(self):
+        url = absolute_static("wagtailadmin/images/email-header.jpg")
+        expected = (
+            r"^http://localhost:8000/static/wagtailadmin/images/"
+            r"email-header.jpg\?v=(\w{8})$"
         )
+        self.assertRegex(url, expected)
 
     @override_settings(
         STATIC_URL="https://s3.amazonaws.com/somebucket/static/",
         WAGTAILADMIN_BASE_URL="http://localhost:8000",
     )
-    def test_remote_notification_static(self):
-        url = notification_static("wagtailadmin/images/email-header.jpg")
-        self.assertEqual(
-            "https://s3.amazonaws.com/somebucket/static/wagtailadmin/images/email-header.jpg",
-            url,
+    def test_remote_absolute_static(self):
+        url = absolute_static("wagtailadmin/images/email-header.jpg")
+        expected = (
+            r"https://s3.amazonaws.com/somebucket/static/wagtailadmin/images/"
+            r"email-header.jpg\?v=(\w{8})$"
         )
+        self.assertRegex(url, expected)
 
 
 class TestVersionedStatic(SimpleTestCase):

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -8,7 +8,7 @@ from django.utils import translation
 from django.utils.translation import gettext
 
 from wagtail import hooks
-from wagtail.admin.staticfiles import versioned_static
+from wagtail.admin.templatetags.wagtailadmin_tags import absolute_static
 from wagtail.admin.userbar import AccessibilityItem, Userbar
 from wagtail.coreutils import get_dummy_request
 from wagtail.models import PAGE_TEMPLATE_VAR, Locale, Page, Site
@@ -66,7 +66,7 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
                 # Wagtail admin core CSS should be linked with absolute URL to
                 # ensure it works when loaded from a different domain
                 # (e.g. headless frontend)
-                f"http://localhost{versioned_static('wagtailadmin/css/core.css')}",
+                absolute_static("wagtailadmin/css/core.css"),
                 # Custom CSS must be changed appropriately if necessary
                 "/path/to/my/custom.css",
             ],
@@ -79,8 +79,8 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
                 # Wagtail vendor and userbar JS should be linked with absolute
                 # URL to ensure it works when loaded from a different domain
                 # (e.g. headless frontend)
-                f"http://localhost{versioned_static('wagtailadmin/js/vendor.js')}",
-                f"http://localhost{versioned_static('wagtailadmin/js/userbar.js')}",
+                absolute_static("wagtailadmin/js/vendor.js"),
+                absolute_static("wagtailadmin/js/userbar.js"),
             ],
         )
 

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -384,7 +384,7 @@ class TestAccessibilityCheckerConfig(WagtailTestUtils, TestCase):
                         # Override via class attribute
                         ".sr-only",
                         # Should include the default exclude selectors
-                        {"fromShadowDOM": ["wagtail-userbar"]},
+                        {"fromShadowDom": ["wagtail-userbar"]},
                         # Override via method
                         "[data-please-ignore]",
                     ],

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Permission
 from django.template import Context, Template
 from django.test import TestCase, override_settings
@@ -135,7 +136,9 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
         # Should render the "Go to Wagtail admin" link using an absolute URL
         soup = self.get_soup(content)
         admin_url = reverse("wagtailadmin_home")
-        admin_link = soup.select_one(f"a[href='http://localhost{admin_url}']")
+        admin_link = soup.select_one(
+            f"a[href='{settings.WAGTAILADMIN_BASE_URL}{admin_url}']"
+        )
         self.assertIsNotNone(admin_link)
         self.assertEqual(admin_link.text.strip(), "Go to Wagtail admin")
 
@@ -153,12 +156,16 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
         soup = self.get_soup(content)
 
         edit_url = reverse("wagtailadmin_pages:edit", args=(self.homepage.id,))
-        edit_link = soup.select_one(f"a[href='http://localhost{edit_url}']")
+        edit_link = soup.select_one(
+            f"a[href='{settings.WAGTAILADMIN_BASE_URL}{edit_url}']"
+        )
         self.assertIsNotNone(edit_link)
         self.assertEqual(edit_link.text.strip(), "Edit this page")
 
         explore_url = reverse("wagtailadmin_explore", args=(self.parent_page.id,))
-        explore_link = soup.select_one(f"a[href='http://localhost{explore_url}']")
+        explore_link = soup.select_one(
+            f"a[href='{settings.WAGTAILADMIN_BASE_URL}{explore_url}']"
+        )
         self.assertIsNotNone(explore_link)
         self.assertEqual(explore_link.text.strip(), "Show in Explorer")
 
@@ -178,12 +185,16 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
         soup = self.get_soup(content)
 
         edit_url = reverse("wagtailadmin_pages:edit", args=(self.homepage.id,))
-        edit_link = soup.select_one(f"a[href='http://localhost{edit_url}']")
+        edit_link = soup.select_one(
+            f"a[href='{settings.WAGTAILADMIN_BASE_URL}{edit_url}']"
+        )
         self.assertIsNotNone(edit_link)
         self.assertEqual(edit_link.text.strip(), "Edit this page")
 
         explore_url = reverse("wagtailadmin_explore", args=(self.parent_page.id,))
-        explore_link = soup.select_one(f"a[href='http://localhost{explore_url}']")
+        explore_link = soup.select_one(
+            f"a[href='{settings.WAGTAILADMIN_BASE_URL}{explore_url}']"
+        )
         self.assertIsNotNone(explore_link)
         self.assertEqual(explore_link.text.strip(), "Show in Explorer")
 
@@ -210,7 +221,9 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
         # The explore link should still be visible
         soup = self.get_soup(content)
         explore_url = reverse("wagtailadmin_explore", args=(self.parent_page.id,))
-        explore_link = soup.select_one(f"a[href='http://localhost{explore_url}']")
+        explore_link = soup.select_one(
+            f"a[href='{settings.WAGTAILADMIN_BASE_URL}{explore_url}']"
+        )
         self.assertIsNotNone(explore_link)
         self.assertEqual(explore_link.text.strip(), "Show in Explorer")
 
@@ -705,7 +718,7 @@ class TestUserbarAddLink(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
 
         # page allows subpages, so the 'add page' button should show
-        expected_url = self.request.build_absolute_uri(
+        expected_url = settings.WAGTAILADMIN_BASE_URL + (
             reverse("wagtailadmin_pages:add_subpage", args=(self.event_index.id,))
         )
         needle = f"""
@@ -749,7 +762,7 @@ class TestUserbarComponent(WagtailTestUtils, TestCase):
         items = soup.select("li")
         self.assertEqual(len(items), 2)
 
-        admin_url = f"http://localhost{reverse('wagtailadmin_home')}"
+        admin_url = f"{settings.WAGTAILADMIN_BASE_URL}{reverse('wagtailadmin_home')}"
         admin_item = items[0]
         admin_link = admin_item.select_one("a")
         self.assertIsNotNone(admin_link)
@@ -771,10 +784,11 @@ class TestUserbarComponent(WagtailTestUtils, TestCase):
         items = soup.select("li")
         self.assertEqual(len(items), 2)
 
+        admin_url = f"{settings.WAGTAILADMIN_BASE_URL}{reverse('wagtailadmin_home')}"
         admin_item = items[0]
         admin_link = admin_item.select_one("a")
         self.assertIsNotNone(admin_link)
-        self.assertEqual(admin_link.get("href"), reverse("wagtailadmin_home"))
+        self.assertEqual(admin_link.get("href"), admin_url)
         self.assertEqual(admin_link.text.strip(), "Go to Wagtail admin")
 
         accessibility_item = items[-1]
@@ -792,7 +806,7 @@ class TestUserbarComponent(WagtailTestUtils, TestCase):
         items = soup.select("li")
         self.assertEqual(len(items), 2)
 
-        admin_url = f"http://localhost{reverse('wagtailadmin_home')}"
+        admin_url = f"{settings.WAGTAILADMIN_BASE_URL}{reverse('wagtailadmin_home')}"
         admin_item = items[0]
         admin_link = admin_item.select_one("a")
         self.assertIsNotNone(admin_link)
@@ -823,7 +837,7 @@ class TestUserbarComponent(WagtailTestUtils, TestCase):
         self.assertEqual(len(links), 4)
         self.assertEqual(
             [link.get("href") for link in links],
-            [f"http://localhost{url}" for url in expected_urls],
+            [f"{settings.WAGTAILADMIN_BASE_URL}{url}" for url in expected_urls],
         )
 
         accessibility_button = soup.select_one("li button")

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -335,7 +335,7 @@ class ChecksSidePanel(BaseSidePanel):
 
     def get_axe_configuration(self):
         # Retrieve the Axe configuration from the userbar.
-        userbar_items = [AccessibilityItem()]
+        userbar_items = [AccessibilityItem(in_editor=True)]
         page = self.object if issubclass(self.model, Page) else None
         apply_userbar_hooks(self.request, userbar_items, page)
 

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -47,7 +47,7 @@ class AccessibilityItem(BaseItem):
     axe_exclude = []
 
     # Make sure that the userbar is not tested.
-    _axe_default_exclude = [{"fromShadowDOM": ["wagtail-userbar"]}]
+    _axe_default_exclude = [{"fromShadowDom": ["wagtail-userbar"]}]
 
     #: A list of `axe-core tags <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#axe-core-tags>`_
     #: or a list of `axe-core rule IDs <https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md>`_

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.admin.ui.components import Component
+from wagtail.admin.utils import get_admin_base_url
 from wagtail.coreutils import accepts_kwarg
 from wagtail.models import Revision
 from wagtail.models.pages import Page
@@ -365,6 +366,7 @@ class Userbar(Component):
             # Render the userbar items
             return {
                 "request": request,
+                "origin": get_admin_base_url(),
                 "items": rendered_items,
                 "position": self.position,
                 "page": self.object,

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -30,6 +30,10 @@ class AdminItem(BaseItem):
 class AccessibilityItem(BaseItem):
     """A userbar item that runs the accessibility checker."""
 
+    def __init__(self, in_editor=False):
+        super().__init__()
+        self.in_editor = in_editor
+
     #: The template to use for rendering the item.
     template = "wagtailadmin/userbar/item_accessibility.html"
 

--- a/wagtail/snippets/tests/test_preview.py
+++ b/wagtail/snippets/tests/test_preview.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from wagtail.admin.staticfiles import versioned_static
+from wagtail.admin.templatetags.wagtailadmin_tags import absolute_static
 from wagtail.admin.views.generic.preview import PreviewOnEdit
 from wagtail.test.testapp.models import (
     EventCategory,
@@ -324,10 +325,10 @@ class TestPreview(WagtailTestUtils, TestCase):
         )
         self.assertNotContains(response, versioned_static("wagtailadmin/js/icons.js"))
 
+    @override_settings(WAGTAILADMIN_BASE_URL="http://other.example.com:8000")
     def test_userbar_in_preview(self):
         self.client.post(self.preview_on_edit_url, self.post_data)
-        host = "other.example.com:8000"
-        response = self.client.get(self.preview_on_edit_url, headers={"host": host})
+        response = self.client.get(self.preview_on_edit_url)
 
         # Check the HTML response
         self.assertEqual(response.status_code, 200)
@@ -344,7 +345,7 @@ class TestPreview(WagtailTestUtils, TestCase):
         self.assertEqual(
             [link.get("href") for link in css_links],
             [
-                f"http://{host}{versioned_static('wagtailadmin/css/core.css')}",
+                absolute_static("wagtailadmin/css/core.css"),
                 "/path/to/my/custom.css",
             ],
         )
@@ -352,8 +353,8 @@ class TestPreview(WagtailTestUtils, TestCase):
         self.assertEqual(
             [script.get("src") for script in scripts],
             [
-                f"http://{host}{versioned_static('wagtailadmin/js/vendor.js')}",
-                f"http://{host}{versioned_static('wagtailadmin/js/userbar.js')}",
+                absolute_static("wagtailadmin/js/vendor.js"),
+                absolute_static("wagtailadmin/js/userbar.js"),
             ],
         )
 


### PR DESCRIPTION
To test, you can use:
- the `api` branch in bakerydemo: https://github.com/wagtail/bakerydemo/tree/api
- bakerydemo-nextjs: https://github.com/wagtail/bakerydemo-nextjs/
- Ensure Wagtail is accessed from http://localhost:8000. If you want to change it, make sure to set the `WAGTAILADMIN_BASE_URL` setting accordingly, as the code relies on that setting for the userbar to work.

Note that while I initially got the content checks to run when you navigate through the pages in the preview iframe's frontend, I've removed that feature because the userbar is no longer rendered outside of the dedicated preview route. (Clicking on a link to another page in the preview will take you to the live version of that page, so the userbar will be unmounted).