### PR TITLE
Implement scroll restoration for cross-domain preview iframes

### DIFF
--- a/client/src/utils/message.ts
+++ b/client/src/utils/message.ts
@@ -1,0 +1,73 @@
+/**
+ * A message that includes the sender's origin, so the CMS can use the correct
+ * origin when responding to the message, without requiring developers to
+ * specify the expected origin wherever necessary (e.g. in the userbar).
+ */
+interface MessageWithOrigin {
+  origin: string;
+}
+
+/**
+ * Indicates Axe in the userbar is ready for another run.
+ */
+export interface AxeReady {
+  type: 'w-userbar:axe-ready';
+}
+
+/**
+ * Indicates this window (i.e. the new preview iframe) is requesting the target
+ * window (i.e. the CMS) to restore the scroll position of a previous window to
+ * this window.
+ */
+export interface RequestScroll extends MessageWithOrigin {
+  type: 'w-preview:request-scroll';
+}
+
+/**
+ * Indicates this window (i.e. the CMS) is requesting the recipient window's
+ * (i.e. the old preview iframe) scroll position.
+ */
+export interface GetScrollPosition {
+  type: 'w-preview:get-scroll-position';
+}
+
+/**
+ * Indicates two things:
+ * 1. The current window (i.e. the old preview iframe) is sending its scroll
+ *    position to the recipient window (i.e. CMS).
+ * 2. The current window (i.e. the CMS) is instructing the recipient window
+ *    (i.e. the new preview iframe) to set its scroll position to the given
+ *    coordinates.
+ * For simplicity, the same message type is used for both purposes instead of
+ * creating separate message types. This allows the CMS to pass over the message
+ * received from the old iframe to the new iframe as-is.
+ */
+export interface SetScrollPosition extends MessageWithOrigin {
+  type: 'w-preview:set-scroll-position';
+  x: number;
+  y: number;
+}
+
+export type WagtailMessage =
+  | AxeReady
+  | RequestScroll
+  | GetScrollPosition
+  | SetScrollPosition;
+
+/**
+ * Parses a message event that may contain a Wagtail message.
+ * @param event The message event to check for a Wagtail message.
+ * @returns The Wagtail message if it exists, or null if it does not.
+ */
+export function getWagtailMessage(event: MessageEvent): WagtailMessage | null {
+  if (
+    !(
+      event.type === 'message' &&
+      typeof event.data === 'object' &&
+      'wagtail' in event.data
+    )
+  )
+    return null;
+
+  return event.data.wagtail;
+}

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -3,7 +3,7 @@
 <template id="wagtail-userbar-template">
     {# In preview panels, we still render the userbar UI, but hidden by default. #}
     <aside {% if request.in_preview_panel %}hidden{% endif %}>
-        <div class="w-userbar w-userbar--{{ position|default:'bottom-right' }} {% admin_theme_classname %}" data-wagtail-userbar data-wagtail-userbar-origin="{{ origin }}" part="userbar">
+        <div class="w-userbar w-userbar--{{ position|default:'bottom-right' }} {% admin_theme_classname %}" data-wagtail-userbar data-wagtail-userbar-origin="{{ origin|default:"" }}" part="userbar">
             {% block css %}
                 <link rel="stylesheet" href="{% absolute_static 'wagtailadmin/css/core.css' %}">
                 {# For headless userbar: the contents of the hook also need absolute URLs #}


### PR DESCRIPTION
Just like #13164, you can use these to test:

- the `api` branch in bakerydemo: https://github.com/wagtail/bakerydemo/tree/api
- bakerydemo-nextjs: https://github.com/wagtail/bakerydemo-nextjs/
- Ensure Wagtail is accessed from http://localhost:8000. If you want to change it, make sure to set the `WAGTAILADMIN_BASE_URL` setting accordingly, as the code relies on that setting for the userbar to work.

Note that this only works with wagtail-headless-preview's `REDIRECT_ON_PREVIEW` setting set to `True`. If it's set to false, it uses multi-layered iframes, which makes the cross-frame communication more difficult as the middle layer will have to include both the logic that's supposed to be in the `PreviewController` and the one in the userbar. I don't think that's worth implementing.