### PR TITLE
Added keyboard shortcut for minimap

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@
  * Extract separate `background_position_x` and `background_position_y` properties from `AbstractRendition.background_position_style` (Chiemezuo Akujobi)
  * Add support for translated string concatenation in the locale selector when switching between a model's language in the admin (Matt Westcott, Ellie Walsh-O'Neill)
  * Switch to check / cross icons for users’ active state in users listing (Sage Abdullah)
+ * Add a keyboard shortcut to easily toggle the visibility of the minimap side panel (Dhruvi Patel)
  * Fix: Handle lazy translation strings as `preview_value` for `RichTextBlock` (Seb Corbin)
  * Fix: Fix handling of newline-separated choices in form builder when using non-windows newline characters (Baptiste Mispelon)
  * Fix: Ensure `WAGTAILADMIN_LOGIN_URL` is respected when logging out of the admin (Antoine Rodriguez, Ramon de Jezus)

--- a/client/src/components/Minimap/Minimap.tsx
+++ b/client/src/components/Minimap/Minimap.tsx
@@ -222,6 +222,9 @@ const Minimap: React.FunctionComponent<MinimapProps> = ({
             className="w-minimap__toggle"
             // Not the most correct label, but matches side panels with similar toggles.
             aria-label={gettext('Toggle side panel')}
+            data-controller="w-kbd"
+            data-w-kbd-key-value="alt+]"
+            data-w-kbd-scope-value="global"
           >
             <Icon name="expand-right" />
           </button>

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -43,6 +43,7 @@ The [](../reference/contrib/settings) app now allows permission over site settin
  * Extract separate `background_position_x` and `background_position_y` properties from `AbstractRendition.background_position_style` (Chiemezuo Akujobi)
  * Add support for translated string concatenation in the locale selector when switching between a model's language in the admin (Matt Westcott, Ellie Walsh-O'Neill)
  * Switch to check / cross icons for users’ active state in users listing (Sage Abdullah)
+ * Add a keyboard shortcut to easily toggle the visibility of the minimap side panel (Dhruvi Patel)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/shared/keyboard_shortcuts_dialog.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/keyboard_shortcuts_dialog.html
@@ -17,10 +17,12 @@
                         <th class="w-h4" scope="rowgroup">{{ category.1 }}</th>
                     </tr>
                     {% for shortcut in shortcuts %}
-                        <tr class="w-keyboard_shortcuts__key">
-                            <th scope="row">{{ shortcut.0 }}</th>
-                            <td><kbd>{{ shortcut.1 }}</kbd></td>
-                        </tr>
+                        {% if shortcut %}
+                            <tr class="w-keyboard_shortcuts__key">
+                                <th scope="row">{{ shortcut.0 }}</th>
+                                <td><kbd>{{ shortcut.1 }}</kbd></td>
+                            </tr>
+                        {% endif %}
                     {% endfor %}
                 </tbody>
             {% endfor %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1328,15 +1328,10 @@ def keyboard_shortcuts_dialog(context):
             ("actions-model", _("Actions")): [
                 (_("Save changes"), f"{KEYS.MOD} + s"),
                 (_("Preview"), f"{KEYS.MOD} + p"),
-                (
-                    _("Add or show comments"),
-                    f"{KEYS.CTRL} + {KEYS.ALT} + m",
-                ),
-            ]
-            if comments_enabled
-            else [
-                (_("Save changes"), f"{KEYS.MOD} + s"),
-                (_("Preview"), f"{KEYS.MOD} + p"),
+                (_("Minimap"), f"{KEYS.ALT} + ]"),
+                (_("Add or show comments"), f"{KEYS.CTRL} + {KEYS.ALT} + m")
+                if comments_enabled
+                else None,
             ],
             ("rich-text-content", _("Text content")): [
                 (_("Insert or edit a link"), f"{KEYS.MOD} + k")


### PR DESCRIPTION
Added the keyboard shortcut for Minimap

This PR is part of GSoC 2025 Project.

I have kept action name as 'Minimap' in keyboard shortcut dialog, In the accessibility map button name is 'Toggle side panel', but in the Wagtail user guide for accessibility features it is 'Minimap' (https://guide.wagtail.org/en-latest/concepts/accessibility-features/#mini-map). I need your feedback for the same. 

![Screenshot from 2025-06-13 10-08-36](https://github.com/user-attachments/assets/d99f6254-2b79-4dbc-b5a1-d45d9cdb03a3)

Keyboard shortcut dialog after newly added shortcut.
![Screenshot from 2025-06-13 10-09-05](https://github.com/user-attachments/assets/4624137d-51a7-4eb3-bbd8-3d981ecade4f)

Unit testcase status for the javscript.

![Screenshot from 2025-06-13 10-23-13](https://github.com/user-attachments/assets/1fb796f3-c879-45bb-9c04-fa8091b4291f)
