### PR TITLE
Typed confirmation dialog added for bulk page delete

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_delete.html
@@ -50,7 +50,17 @@
     {% if items and not is_protected %}
         {% trans 'Yes, delete' as action_button_text %}
         {% trans "No, don't delete" as no_action_button_text %}
-        {% include 'wagtailadmin/bulk_actions/confirmation/form.html' with action_button_class="serious" %}
+        {% if type_to_confirm_before_delete %}
+            <form method="POST">
+                {% csrf_token %}
+                {% include "wagtailadmin/shared/dialog/confirm_site_name.html" with total_pages=total_page_count %}
+                <input type="hidden" name="next" value="{{ next }}">
+                <input type="submit" value="{{ action_button_text }}" class="button serious">
+                <a href="{% if next %}{{ next }}{% else %}{% url 'wagtailadmin_explore' page.get_parent.id %}{% endif %}" class="button button-secondary">{{ no_action_button_text }}</a>
+            </form>
+        {% else%}
+            {% include 'wagtailadmin/bulk_actions/confirmation/form.html' with action_button_class="serious" %}
+        {% endif %}
     {% else %}
         {% include 'wagtailadmin/bulk_actions/confirmation/go_back.html' %}
     {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
@@ -69,19 +69,8 @@
 
             <form action="{% url 'wagtailadmin_pages:delete' page.id %}" method="POST">
                 {% csrf_token %}
-                {% if confirm_before_delete %}
-                    <p id="id_confirm_site_name-warning" class="status-msg failure">
-                        {% blocktrans trimmed with total_pages=descendant_count|add:1|intcomma %}
-                            This action will delete total <b>{{ total_pages }}</b> pages.
-                        {% endblocktrans %}
-                    </p>
-                    <label class="w-label-3" for="id_confirm_site_name">
-                        {% blocktrans trimmed %}
-                            Please type <b>{{ wagtail_site_name }}</b> to confirm.
-                        {% endblocktrans %}
-                    </label>
-                    <input type="text" name="confirm_site_name" class="w-mb-4"
-                           id="id_confirm_site_name" aria-describedby="id_confirm_site_name-warning" required>
+                {% if type_to_confirm_before_delete %}
+                    {% include "wagtailadmin/shared/dialog/confirm_site_name.html" with total_pages=descendant_count|add:1 %}
                 {% endif %}
                 <input type="hidden" name="next" value="{{ next }}">
                 <input type="submit" value="{% trans 'Yes, delete it' %}" class="button serious">

--- a/wagtail/admin/templates/wagtailadmin/shared/dialog/confirm_site_name.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/dialog/confirm_site_name.html
@@ -1,0 +1,18 @@
+{% load i18n wagtailadmin_tags %}
+
+<p id="id_confirm_site_name-warning" class="status-msg failure">
+    {% blocktrans count counter=total_pages trimmed with total_pages_formatted=total_pages|intcomma %}
+        This action will delete <b>{{ total_pages_formatted }}</b> page in total.
+    {% plural %}
+        This action will delete <b>{{ total_pages_formatted }}</b> pages in total.
+    {% endblocktrans %}
+</p>
+
+<label class="w-label-3" for="id_confirm_site_name">
+    {% blocktrans trimmed %}
+        Please type <b>{{ wagtail_site_name }}</b> to confirm.
+    {% endblocktrans %}
+</label>
+
+<input type="text" name="confirm_site_name" class="w-mb-4"
+       id="id_confirm_site_name" aria-describedby="id_confirm_site_name-warning" required>

--- a/wagtail/admin/tests/pages/test_delete_page.py
+++ b/wagtail/admin/tests/pages/test_delete_page.py
@@ -83,7 +83,9 @@ class TestPageDelete(WagtailTestUtils, TestCase):
             reverse("wagtailadmin_pages:delete", args=(self.child_page.id,))
         )
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "This action will delete total <b>3</b> pages.")
+        self.assertContains(
+            response, "This action will delete <b>3</b> pages in total."
+        )
         self.assertContains(response, "Please type <b>mysite</b> to confirm.")
         self.assertContains(response, '<input type="text" name="confirm_site_name"')
         # deletion should not actually happen on GET
@@ -107,7 +109,9 @@ class TestPageDelete(WagtailTestUtils, TestCase):
         # One error messages should be returned
         messages = [m.message for m in response.context["messages"]]
         self.assertEqual(len(messages), 1)
-        self.assertContains(response, "This action will delete total <b>3</b> pages.")
+        self.assertContains(
+            response, "This action will delete <b>3</b> pages in total."
+        )
         self.assertContains(response, "Please type <b>mysite</b> to confirm.")
         self.assertContains(response, '<input type="text" name="confirm_site_name"')
         # Site should not be deleted

--- a/wagtail/admin/views/pages/bulk_actions/delete.py
+++ b/wagtail/admin/views/pages/bulk_actions/delete.py
@@ -1,9 +1,11 @@
+from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
 from wagtail.admin.views.bulk_action.mixins import ReferenceIndexMixin
 from wagtail.admin.views.pages.bulk_actions.page_bulk_action import PageBulkAction
+from wagtail.admin.views.pages.utils import type_to_delete_confirmation
 
 
 class DeleteBulkAction(ReferenceIndexMixin, PageBulkAction):
@@ -22,6 +24,32 @@ class DeleteBulkAction(ReferenceIndexMixin, PageBulkAction):
             **super().object_context(page),
             "descendant_count": page.get_descendant_count(),
         }
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        pages = context.get("items", [])
+        # Count the total number of pages including descendants
+        total_page_count = len(pages) + sum(
+            page.get("descendant_count", 0) for page in pages
+        )
+        wagtail_site_name = getattr(settings, "WAGTAIL_SITE_NAME", "wagtail")
+        context.update(
+            {
+                "wagtail_site_name": wagtail_site_name,
+                "total_page_count": total_page_count,
+                # If the total page count exceeds this limit, then confirm before delete
+                "type_to_confirm_before_delete": total_page_count
+                >= getattr(settings, "WAGTAILADMIN_UNSAFE_PAGE_DELETION_LIMIT", 10),
+            }
+        )
+        return context
+
+    def post(self, request):
+        if type_to_delete_confirmation(request):
+            return super().post(request)
+        else:
+            # Re-render the confirmation page when site name verification fails
+            return self.render_to_response(self.get_context_data())
 
     @classmethod
     def execute_action(cls, objects, user=None, **kwargs):

--- a/wagtail/admin/views/pages/delete.py
+++ b/wagtail/admin/views/pages/delete.py
@@ -10,6 +10,7 @@ from wagtail import hooks
 from wagtail.actions.delete_page import DeletePageAction
 from wagtail.admin import messages
 from wagtail.admin.utils import get_valid_next_url_from_request
+from wagtail.admin.views.pages.utils import type_to_delete_confirmation
 from wagtail.models import Page, ReferenceIndex
 
 
@@ -45,15 +46,8 @@ def delete(request, page_id):
             if usage.is_protected:
                 raise PermissionDenied
 
-            continue_deleting = True
-            if (
-                request.POST.get("confirm_site_name")
-                and request.POST.get("confirm_site_name") != wagtail_site_name
-            ):
-                messages.error(
-                    request, f"Please type '{wagtail_site_name}' to confirm."
-                )
-                continue_deleting = False
+            continue_deleting = type_to_delete_confirmation(request)
+
             if continue_deleting:
                 parent_id = page.get_parent().id
                 # Delete the source page.
@@ -99,7 +93,7 @@ def delete(request, page_id):
             "usage_count": usage.count(),
             "is_protected": usage.is_protected,
             # if the number of pages ( child pages + current page) exceeds this limit, then confirm before delete.
-            "confirm_before_delete": (descendant_count + 1)
+            "type_to_confirm_before_delete": (descendant_count + 1)
             >= getattr(settings, "WAGTAILADMIN_UNSAFE_PAGE_DELETION_LIMIT", 10),
             "wagtail_site_name": wagtail_site_name,
             # note that while pages_to_delete may contain a mix of translated pages

--- a/wagtail/admin/views/pages/utils.py
+++ b/wagtail/admin/views/pages/utils.py
@@ -1,5 +1,8 @@
+from django.conf import settings
 from django.urls import reverse
 from django.utils.functional import cached_property
+
+from wagtail.admin import messages
 
 # Retain backwards compatibility for imports
 from wagtail.admin.utils import (  # noqa: F401
@@ -69,3 +72,19 @@ class GenericPageBreadcrumbsMixin:
             self.breadcrumbs_items
             + super().get_breadcrumbs_items()[-self.breadcrumbs_items_to_take :]
         )
+
+
+def type_to_delete_confirmation(request, context=None):
+    """
+    Checks if a user has correctly typed the site name to confirm page deletion
+    when using a confirmation dialog.
+    """
+    wagtail_site_name = getattr(settings, "WAGTAIL_SITE_NAME", "wagtail")
+    if (
+        request.POST.get("confirm_site_name")
+        and request.POST.get("confirm_site_name") != wagtail_site_name
+    ):
+        messages.error(request, f"Please type '{wagtail_site_name}' to confirm.")
+        return False
+
+    return True


### PR DESCRIPTION
Adds an optional type to confirm dialog box for bulk page deletion.

[This PR is to address issue #13073](https://github.com/wagtail/wagtail/issues/13073)

<img width="770" alt="Screenshot 2025-06-17 at 11 09 12" src="https://github.com/user-attachments/assets/f33542c6-2552-4999-b663-0f72a7ef45ee" />


