### PR TITLE
refactor background_position_style into x & y methods

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ Changelog
  * Refactor userbar rendering to better support headless websites (Sage Abdullah)
  * Add type-to-confirm step when deleting large numbers of pages through bulk actions (Rachel Smith)
  * Add `NoFutureDateValidator` to validate against dates in the future (Talha Rizwan)
+ * Extract separate `background_position_x` and `background_position_y` properties from `AbstractRendition.background_position_style` (Chiemezuo Akujobi)
  * Fix: Handle lazy translation strings as `preview_value` for `RichTextBlock` (Seb Corbin)
  * Fix: Fix handling of newline-separated choices in form builder when using non-windows newline characters (Baptiste Mispelon)
  * Fix: Ensure `WAGTAILADMIN_LOGIN_URL` is respected when logging out of the admin (Antoine Rodriguez, Ramon de Jezus)

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -40,6 +40,7 @@ The [](../reference/contrib/settings) app now allows permission over site settin
  * Refactor userbar rendering to better support headless websites (Sage Abdullah)
  * Add type-to-confirm step when deleting large numbers of pages through bulk actions (Rachel Smith)
  * Add [`NoFutureDateValidator`](date_field_validation) to validate against dates in the future (Talha Rizwan)
+ * Extract separate `background_position_x` and `background_position_y` properties from `AbstractRendition.background_position_style` (Chiemezuo Akujobi)
 
 ### Bug fixes
 

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1400,13 +1400,53 @@ class AbstractRendition(ImageFileMixin, models.Model):
             <div style="background-image: url('{{ image.url }}'); {{ image.background_position_style }}">
             </div>
         """
+        horz = self.background_position_x
+        vert = self.background_position_y
+        return f"background-position: {horz} {vert};"
+
+    @property
+    def background_position_x(self):
+        """
+        Returns the horizontal background position as a percentage string.
+
+        This positions the rendition horizontally according to the focal point's x coordinate.
+        If no focal point is set, defaults to 50% (center).
+
+        Returns:
+            str: The horizontal position as a percentage (e.g., "25%")
+
+        This can be passed as a data attribute to then be used in JavaScript to set the `background-position-x` CSS property instead of using inline styles.
+            <div class="my-bg-image" data-background-position-x="{{ image.background_position_x }}">
+            </div>
+        """
         focal_point = self.focal_point
         if focal_point:
             horz = int((focal_point.x * 100) // self.width)
-            vert = int((focal_point.y * 100) // self.height)
-            return f"background-position: {horz}% {vert}%;"
+            return f"{horz}%"
         else:
-            return "background-position: 50% 50%;"
+            return "50%"
+
+    @property
+    def background_position_y(self):
+        """
+        Returns the vertical background position as a percentage string.
+
+        This positions the rendition vertically according to the focal point's y coordinate.
+        If no focal point is set, defaults to 50% (center).
+
+        Returns:
+            str: The vertical position as a percentage (e.g., "25%")
+
+        This can be passed as a data attribute to then be used in JavaScript to set the `background-position-y` CSS property instead of using inline styles.
+            <div class="my-bg-image" data-background-position-y="{{ image.background_position_y }}">
+            </div>
+        """
+        focal_point = self.focal_point
+        if focal_point:
+            vert = int((focal_point.y * 100) // self.height)
+            return f"{vert}%"
+        else:
+            return "50%"
 
     def img_tag(self, extra_attributes={}):
         attrs = self.attrs_dict.copy()

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -908,6 +908,10 @@ class TestRenditions(TestCase):
             rendition.background_position_style, "background-position: 15% 41%;"
         )
 
+        # Individual background position properties
+        self.assertEqual(rendition.background_position_x, "15%")
+        self.assertEqual(rendition.background_position_y, "41%")
+
     def test_background_position_style_default(self):
         # Generate a rendition that's half the size of the original
         rendition = self.image.get_rendition("width-320")
@@ -915,6 +919,10 @@ class TestRenditions(TestCase):
         self.assertEqual(
             rendition.background_position_style, "background-position: 50% 50%;"
         )
+
+        # Individual background position properties
+        self.assertEqual(rendition.background_position_x, "50%")
+        self.assertEqual(rendition.background_position_y, "50%")
 
     @override_settings()
     def test_rendition_storage_setting_absent(self):


### PR DESCRIPTION
This is the first part of the fix for #12939 
It is part of a series of issues being addressed for the CSP compatibility GSoC 2025 project.

## Summary of Changes:
This refactors (but not removes) the AbstractRendition's `background_position_style`, which returns a CSS string to be set in-line, into two methods: `background_position_x` and `background_position_y`.
These two methods return percentage strings that can then be passed as data attributes and accessed in the CSS via the [attr() CSS function](https://developer.mozilla.org/en-US/docs/Web/CSS/attr)

## Missing changes:
* Documentation for new usage