### PR TITLE
Fix link in site settings permissions release note

### DIFF
--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -13,7 +13,7 @@ depth: 1
 
 ### Site setting permissions
 
-The [](settings) app now allows permission over site settings to be granted on a per-site basis. This makes it possible to give non-superuser accounts full control over the configuration of an individual site. This feature was developed by Matt Westcott.
+The [](../reference/contrib/settings) app now allows permission over site settings to be granted on a per-site basis. This makes it possible to give non-superuser accounts full control over the configuration of an individual site. This feature was developed by Matt Westcott.
 
 ### Other features
 


### PR DESCRIPTION
The docs build is failing because the `wagtail.contrib.settings` page doesn't have an explicit `settings` target for the "Settings" heading. If we want to link to the page for the app, we should use `../reference/contrib/settings` instead.

~~I opted to link to the `site_settings` target specifically, and remove the link to "Settings" so that we only link to the most relevant section instead of linking to the same page twice with different anchors.~~