### PR TITLE
Bump codecov action to v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -453,7 +453,7 @@ jobs:
           include-hidden-files: true
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           flags: backend
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Our coverage action has been silently failing intermittently because we use the legacy tokenless upload mechanism in v3.

There was a back and forth with upgrading to v4 (see https://github.com/wagtail/wagtail/pull/12305) due to an issue on Codecov's side: https://github.com/codecov/codecov-action/issues/1548

It seems to have been fixed in v5, so let's see if this works.

The repo already has the `CODECOV_TOKEN` secret. Additionally, for forks, see https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token:

> Codecov does not require a token for an upload when either of the following conditions are true:
> - the repository is public and the organization has disabled token authentication for public repositories
or
> - the repository is public and the upload is for a commit that is on an "unprotected" branch (like `forkname:main`)

I believe ours fall into the second condition.

Also, as per https://docs.codecov.com/docs/codecov-tokens#legacy-upload-methods, the legacy method may be removed in the future, so it's a good thing to upgrade.
