### PR TITLE
Move search_fields to the search section of the tutorial

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,6 +47,7 @@ Changelog
  * Fix: Ensure that draft changes to an editable `first_published_at` field are preserved on reloading (Talha Rizwan)
  * Docs: Add missing tag library imports to footer template code in tutorial (Dimaco)
  * Docs: Improve documentation around securing user-uploaded files (Jake Howard)
+ * Docs: Introduce search_fields in a dedicated tutorial section instead of the introduction (Matt Westcott)
  * Maintenance: Refactor `get_embed` to remove `finder` argument which was only used for mocking in unit tests (Jigyasu Rajput)
  * Maintenance: Simplify handling of `None` values in `TypedTableBlock` (Jigyasu Rajput)
  * Maintenance: Remove squash.io configuration (Sage Abdullah)

--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -359,9 +359,6 @@ from django.db import models
 from wagtail.models import Page
 from wagtail.fields import RichTextField
 
-# add this:
-from wagtail.search import index
-
 # keep the definition of BlogIndexPage model, and add the BlogPage model:
 
 class BlogPage(Page):
@@ -369,15 +366,8 @@ class BlogPage(Page):
     intro = models.CharField(max_length=250)
     body = RichTextField(blank=True)
 
-    search_fields = Page.search_fields + [
-        index.SearchField('intro'),
-        index.SearchField('body'),
-    ]
-
     content_panels = Page.content_panels + ["date", "intro", "body"]
 ```
-
-In the model above, you import `index` as this makes the model searchable. You then list fields that you want to be searchable for the user.
 
 You have to migrate your database again because of the new changes in your `models.py` file:
 
@@ -553,7 +543,6 @@ from modelcluster.fields import ParentalKey
 
 from wagtail.models import Page, Orderable
 from wagtail.fields import RichTextField
-from wagtail.search import index
 
 # ... Keep the definition of BlogIndexPage, update the content_panels of BlogPage, and add a new BlogPageGalleryImage model:
 
@@ -561,11 +550,6 @@ class BlogPage(Page):
     date = models.DateField("Post date")
     intro = models.CharField(max_length=250)
     body = RichTextField(blank=True)
-
-    search_fields = Page.search_fields + [
-        index.SearchField('intro'),
-        index.SearchField('body'),
-    ]
 
     content_panels = Page.content_panels + [
         "date", "intro", "body",
@@ -647,11 +631,6 @@ class BlogPage(Page):
         else:
             return None
 
-    search_fields = Page.search_fields + [
-        index.SearchField('intro'),
-        index.SearchField('body'),
-    ]
-
     content_panels = Page.content_panels + ["date", "intro", "body", "gallery_images"]
 ```
 
@@ -725,7 +704,6 @@ from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from wagtail.models import Page, Orderable
 from wagtail.fields import RichTextField
 from wagtail.admin.panels import MultiFieldPanel
-from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 
 class BlogPage(Page):
@@ -736,7 +714,7 @@ class BlogPage(Page):
     # Add this:
     authors = ParentalManyToManyField('blog.Author', blank=True)
 
-    # ... Keep the main_image method and search_fields definition. Modify your content_panels:
+    # ... Keep the main_image method. Modify your content_panels:
     content_panels = Page.content_panels + [
         MultiFieldPanel(["date", "authors"], heading="Blog information"),
         "intro", "body", "gallery_images"
@@ -760,7 +738,6 @@ from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from wagtail.models import Page, Orderable
 from wagtail.fields import RichTextField
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
-from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 
 class BlogPage(Page):
@@ -849,7 +826,6 @@ from taggit.models import TaggedItemBase
 from wagtail.models import Page, Orderable
 from wagtail.fields import RichTextField
 from wagtail.admin.panels import FieldPanel, InlinePanel, MultiFieldPanel
-from wagtail.search import index
 
 
 # ... Keep the definition of BlogIndexPage model and add a new BlogPageTag model
@@ -870,7 +846,7 @@ class BlogPage(Page):
     # Add this:
     tags = ClusterTaggableManager(through=BlogPageTag, blank=True)
 
-    # ... Keep the main_image method and search_fields definition. Then modify the content_panels:
+    # ... Keep the main_image method. Then modify the content_panels:
     content_panels = Page.content_panels + [
         MultiFieldPanel([
             "date",

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -65,6 +65,7 @@ The [](../reference/contrib/settings) app now allows permission over site settin
 
  * Add missing tag library imports to footer template code in tutorial (Dimaco)
  * Improve documentation around securing user-uploaded files (Jake Howard)
+ * Introduce search_fields in a dedicated tutorial section instead of the introduction (Matt Westcott)
 
 ### Maintenance
 

--- a/docs/tutorial/add_search.md
+++ b/docs/tutorial/add_search.md
@@ -88,4 +88,26 @@ Now, you want to display your search across your site. One way to do this is to 
 </header>
 ```
 
+You can now run searches and view results. However, the search currently only returns results for words found in the page title. To make other fields searchable, it is necessary to add them to the search index - see [](wagtailsearch_indexing). In `portfolio/models.py`, add the code below:
+
+```python
+# Add to the existing imports:
+from wagtail.search import index
+
+class PortfolioPage(Page):
+    # Keep the existing parent_page_types, body and content_panels definitions, and add:
+
+    search_fields = Page.search_fields + [
+        index.SearchField('body'),
+    ]
+```
+
+Now run the following command to rebuild the search index, now with the `body` field of `PortfolioPage` included:
+
+```sh
+python manage.py update_index
+```
+
+Searching will now return results for words found within the body text.
+
 Well done! You now have a fully deployable portfolio site. The next section of this tutorial will walk you through how to deploy your site.

--- a/docs/tutorial/add_search.md
+++ b/docs/tutorial/add_search.md
@@ -88,21 +88,22 @@ Now, you want to display your search across your site. One way to do this is to 
 </header>
 ```
 
-You can now run searches and view results. However, the search currently only returns results for words found in the page title. To make other fields searchable, it is necessary to add them to the search index - see [](wagtailsearch_indexing). In `portfolio/models.py`, add the code below:
+You can now run searches and view results. However, the search currently only returns results for words found in the page title. To make other fields searchable, it is necessary to add them to the search index - see [](wagtailsearch_indexing). In `blog/models.py`, add the code below:
 
 ```python
 # Add to the existing imports:
 from wagtail.search import index
 
-class PortfolioPage(Page):
-    # Keep the existing parent_page_types, body and content_panels definitions, and add:
+class BlogPage(Page):
+    # Keep the existing parent_page_types, fields, methods and content_panels definitions, and add:
 
     search_fields = Page.search_fields + [
+        index.SearchField('intro'),
         index.SearchField('body'),
     ]
 ```
 
-Now run the following command to rebuild the search index, now with the `body` field of `PortfolioPage` included:
+Now run the following command to rebuild the search index, now with the `body` field of `BlogPage` included:
 
 ```sh
 python manage.py update_index


### PR DESCRIPTION
Fixes #11563, supersedes #11623.

The initial tutorial includes a `search_fields` definition on BlogPage but only briefly explains it, and never makes use of it. By contrast, the extended tutorial does cover setting up search, but doesn't define `search_fields` on the new page types.

Remove `search_fields` from the initial tutorial, to keep it focused, and cover this in the "Add search to your site" section of the extended tutorial instead.
