### PR TITLE
Fix timefield serialize elasticsearch

### DIFF
--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -11,6 +11,7 @@ from django.utils.crypto import get_random_string
 from elasticsearch import VERSION as ELASTICSEARCH_VERSION
 from elasticsearch import Elasticsearch, NotFoundError
 from elasticsearch.helpers import bulk
+from datetime import time
 
 from wagtail.search.backends.base import (
     BaseSearchBackend,

--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -76,7 +76,7 @@ class Elasticsearch7Mapping:
         "SlugField": "string",
         "SmallIntegerField": "integer",
         "TextField": "string",
-        "TimeField": "date",
+        "TimeField": "keyword",
         "URLField": "string",
     }
 
@@ -270,6 +270,14 @@ class Elasticsearch7Mapping:
         edgengrams = []
         for field in self.model.get_search_fields():
             value = field.get_value(obj)
+
+            if isinstance(value, time):
+                value = value.strftime("%H:%M:%S") if value else None
+            elif isinstance(value, (list, tuple)):
+                value = [
+                    item.strftime("%H:%M:%S") if isinstance(item, time) else item
+                    for item in value
+                ]
 
             if isinstance(field, RelatedFields):
                 if isinstance(value, (models.Manager, models.QuerySet)):

--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -1,6 +1,7 @@
 import json
 from collections import OrderedDict
 from copy import deepcopy
+from datetime import time
 from urllib.parse import urlparse
 
 from django.db import DEFAULT_DB_ALIAS, models
@@ -11,7 +12,6 @@ from django.utils.crypto import get_random_string
 from elasticsearch import VERSION as ELASTICSEARCH_VERSION
 from elasticsearch import Elasticsearch, NotFoundError
 from elasticsearch.helpers import bulk
-from datetime import time
 
 from wagtail.search.backends.base import (
     BaseSearchBackend,

--- a/wagtail/test/search/models.py
+++ b/wagtail/test/search/models.py
@@ -135,3 +135,20 @@ class UnindexedBook(index.Indexed, models.Model):
     tags = TaggableManager()
 
     search_fields = []
+
+
+class EventPage(index.Indexed, models.Model):
+    """Test model for DateField and TimeField"""
+
+    title = models.CharField(max_length=255)
+    start_date = models.DateField()
+    start_time = models.TimeField(blank=True, null=True)
+
+    search_fields = [
+        index.SearchField("title"),
+        index.FilterField("start_date"),
+        index.FilterField("start_time"),
+    ]
+
+    def __str__(self):
+        return self.title


### PR DESCRIPTION
Issue Tracking: #13032 
Extension of PR : #13080 
Added tests to verify that TimeField serialization in elastic-search is now fixed.