### PR TITLE
Avoid deleting default homepage by ID in home app migration

### DIFF
--- a/wagtail/project_template/home/migrations/0002_create_homepage.py
+++ b/wagtail/project_template/home/migrations/0002_create_homepage.py
@@ -8,9 +8,14 @@ def create_homepage(apps, schema_editor):
     Site = apps.get_model("wagtailcore.Site")
     HomePage = apps.get_model("home.HomePage")
 
-    # Delete the default homepage
-    # If migration is run multiple times, it may have already been deleted
-    Page.objects.filter(id=2).delete()
+    # Delete the default homepage (of type Page) as created by wagtailcore.0002_initial_data,
+    # if it exists
+    page_content_type = ContentType.objects.get(
+        model="page", app_label="wagtailcore"
+    )
+    Page.objects.filter(
+        content_type=page_content_type, slug="home", depth=2
+    ).delete()
 
     # Create content type for homepage model
     homepage_content_type, __ = ContentType.objects.get_or_create(


### PR DESCRIPTION
Fixes #4235. It is not safe to assume that the default homepage created in wagtailcore.0002_initial_data will always have the ID 2 on all database configurations, so identify it based on slug, depth and content type instead.
