### PR TITLE
Allow `Block.preview_value` and `default` to be callables for dynamic previews

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@
  * Add support for opt-in collapsible `StructBlock`s (Sage Abdullah)
  * Add `form_attrs` support to all StreamField blocks (Sage Abdullah)
  * Update project template documentation to include testing instructions and include starting test file in template (Aditya (megatrron))
+ * Add support for `preview_value` and `default` in `Block` meta options as callables for dynamic previews within StreamField (Ziyao Yan)
  * Fix: Handle lazy translation strings as `preview_value` for `RichTextBlock` (Seb Corbin)
  * Fix: Fix handling of newline-separated choices in form builder when using non-windows newline characters (Baptiste Mispelon)
  * Fix: Ensure `WAGTAILADMIN_LOGIN_URL` is respected when logging out of the admin (Antoine Rodriguez, Ramon de Jezus)

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -78,6 +78,7 @@ For more details, see the documentation on [enabling the user bar](headless_user
  * Add API for extracting preview page content (Sage Abdullah)
  * Add `form_attrs` support to all StreamField blocks (Sage Abdullah)
  * Update project template documentation to include testing instructions and include starting test file in template (Aditya (megatrron))
+ * Add support for `preview_value` and `default` in `Block` meta options as callables for [dynamic previews within StreamField](configuring_block_previews) (Ziyao Yan)
 
 ### Bug fixes
 

--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -618,6 +618,23 @@ class QuoteBlock(blocks.StructBlock):
         return {"text": quote.text, "source": quote.source}
 ```
 
+
+Alternatively, the `preview` attribute can be defined as a callable.
+
+```{code-block} python
+:emphasize-lines: 8
+from datetime import datetime
+from wagtail.blocks import DateBlock, StreamBlock
+
+class MyStreamBlock(StreamBlock):
+    # ... other blocks
+    date_block = DateBlock(
+        icon="calendar",
+        preview_value=lambda: datetime.now(),
+        preview_template="blocks/date_block_preview.html",
+    )
+```
+
 (streamfield_global_preview_template)=
 
 ### Overriding the global preview template

--- a/wagtail/admin/tests/test_block_preview.py
+++ b/wagtail/admin/tests/test_block_preview.py
@@ -97,13 +97,22 @@ class TestStreamFieldBlockPreviewView(WagtailTestUtils, TestCase):
         self.assertEqual(main.text.strip(), "None")
 
     def test_preview_value_falls_back_to_default(self):
-        block = blocks.IntegerBlock(default=42)
-        response = self.get(block)
-        self.assertEqual(response.status_code, 200)
-        soup = self.get_soup(response.content)
-        main = soup.select_one("main")
-        self.assertIsNotNone(main)
-        self.assertEqual(main.text.strip(), "42")
+        def callable_default():
+            return 42
+
+        cases = [
+            ("static", blocks.IntegerBlock(default=42)),
+            ("callable", blocks.IntegerBlock(default=callable_default)),
+        ]
+
+        for via, block in cases:
+            with self.subTest(via=via):
+                response = self.get(block)
+                self.assertEqual(response.status_code, 200)
+                soup = self.get_soup(response.content)
+                main = soup.select_one("main")
+                self.assertIsNotNone(main)
+                self.assertEqual(main.text.strip(), "42")
 
     def test_preview_template(self):
         class PreviewTemplateViaMeta(blocks.Block):
@@ -143,6 +152,10 @@ class TestStreamFieldBlockPreviewView(WagtailTestUtils, TestCase):
                 self.assertEqual(custom_js["src"], "/static/js/custom.js")
 
     def test_preview_value(self):
+        @staticmethod
+        def preview_callable():
+            return "Hello, world!"
+
         class PreviewValueViaMeta(blocks.Block):
             class Meta:
                 preview_value = "Hello, world!"
@@ -151,9 +164,14 @@ class TestStreamFieldBlockPreviewView(WagtailTestUtils, TestCase):
             def get_preview_value(self):
                 return "Hello, world!"
 
+        class PreviewValueViaCallableMeta(blocks.Block):
+            class Meta:
+                preview_value = preview_callable
+
         cases = [
             ("meta", PreviewValueViaMeta()),
             ("method", PreviewValueViaMethod()),
+            ("meta_callable", PreviewValueViaCallableMeta()),
             ("kwarg", blocks.Block(preview_value="Hello, world!")),
             ("localized", blocks.Block(preview_value=_("Hello, world!"))),
             (


### PR DESCRIPTION
### Description
This PR implements [#13094](https://github.com/wagtail/wagtail/issues/13094), proposed by @laymonage.

It adds support for specifying `Meta.preview_value` and `Meta.default` as callables (with no arguments), following the convention used by Django model field defaults. This allows for dynamic values (e.g. database lookups, timestamps) without requiring subclassing or eager evaluation.

This also aligns with some of the use cases discussed in [#7992](https://github.com/wagtail/wagtail/issues/7992).

### Demo of the use case mentioned by [#7992](https://github.com/wagtail/wagtail/issues/7992).
With the demo block code below, we can dynamically generate the datetime without overriding `get_preview_value()`:
```
class BlockQuote(StructBlock):
    text = TextBlock()
    attribute_name = CharBlock(blank=True, required=False, label="e.g. Mary Berry")

    class Meta:
        icon = "openquote"
        template = "blocks/blockquote.html"
        preview_value = staticmethod(lambda: {
            "text": f"This preview was generated at {datetime.now().strftime('%H:%M:%S')}",
            "attribute_name": "Preview system"
        })
        description = "test block showing"
```

![ScreenRecording2025-07-02at8 55 42AM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/71ce61c4-1f97-434e-be6a-a36f81bd3dda)


### Test cases
Added for `test_preview_value_falls_back_to_default` and `test_preview_value `



