### PR TITLE
Reorder middleware to prioritize SecurityMiddleware

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -51,6 +51,7 @@
  * Fix: Only enable ManifestStaticFilesStorage in production settings, to aid test running (M. Sumair Khokhar)
  * Fix: Update `BooleanColumn` icons so they can be distinguished without relying on color (Sage Abdullah)
  * Fix: Do not delete default homepage by ID in home app migration (Matt Westcott)
+ * Fix: Update the start project template to align with Django's recommendation to have the `django.middleware.security.SecurityMiddleware` first (Brylie Christopher Oxley)
  * Docs: Add missing tag library imports to footer template code in tutorial (Dimaco)
  * Docs: Improve documentation around securing user-uploaded files (Jake Howard)
  * Docs: Introduce search_fields in a dedicated tutorial section instead of the introduction (Matt Westcott)

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -66,6 +66,7 @@ The [](../reference/contrib/settings) app now allows permission over site settin
  * Only enable ManifestStaticFilesStorage in production settings, to aid test running (M. Sumair Khokhar)
  * Update `BooleanColumn` icons so they can be distinguished without relying on color (Sage Abdullah)
  * Do not delete default homepage by ID in home app migration (Matt Westcott)
+ * Update the start project template to align with Django's recommendation to have the `django.middleware.security.SecurityMiddleware` first (Brylie Christopher Oxley)
 
 ### Documentation
 

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -49,13 +49,13 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "django.middleware.security.SecurityMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
 ]
 


### PR DESCRIPTION
Closes #13198

Place SecurityMiddleware at the top of the middleware list to enhance application security.