### PR TITLE
Set `aria-invalid` on StreamField widgets input when there is an error

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -57,6 +57,7 @@
  * Fix: Update the start project template to align with Django's recommendation to have the `django.middleware.security.SecurityMiddleware` first (Brylie Christopher Oxley)
  * Fix: Ensure keyboard usage will correctly focus on new comments, including replies, when the side panel is open or closed (Dhruvi Patel)
  * Fix: Handle `help_text` kwarg in `FloatBlock` (Nick Smith)
+ * Fix: Set `aria-invalid` on StreamField widgets input when there is an error (Sage Abdullah)
  * Docs: Add missing tag library imports to footer template code in tutorial (Dimaco)
  * Docs: Improve documentation around securing user-uploaded files (Jake Howard)
  * Docs: Introduce search_fields in a dedicated tutorial section instead of the introduction (Matt Westcott)

--- a/client/src/components/StreamField/blocks/FieldBlock.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.js
@@ -122,6 +122,12 @@ export class FieldBlock {
       .querySelectorAll('.error-message')
       .forEach((element) => element.remove());
 
+    // The widget knows exactly where the <input> is, so we let it handle the
+    // invalid state to e.g. set the aria-invalid attribute. Use optional
+    // chaining as custom widgets may not have implemented this method, or the
+    // widget itself may have failed to render in the first place.
+    this.widget?.setInvalid?.(!!error);
+
     if (error) {
       this.field.classList.add('w-field--error');
       errorContainer.querySelector('.icon').removeAttribute('hidden');

--- a/client/src/components/StreamField/blocks/FieldBlock.test.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.test.js
@@ -19,6 +19,7 @@ let constructor = (
 let setState = (_widgetName, _state) => {};
 let getState = (_widgetName) => {};
 let getValue = (_widgetName) => {};
+let setInvalid = (_widgetName, _invalid) => {};
 let focus = (_widgetName) => {};
 
 class DummyWidgetDefinition {
@@ -59,6 +60,9 @@ class DummyWidgetDefinition {
       focus() {
         focus(widgetName);
       },
+      setInvalid(invalid) {
+        setInvalid(widgetName, invalid);
+      },
       idForLabel: id,
     };
   }
@@ -78,6 +82,7 @@ describe('telepath: wagtail.blocks.FieldBlock', () => {
     setState = jest.fn();
     getState = jest.fn();
     getValue = jest.fn();
+    setInvalid = jest.fn();
     focus = jest.fn();
 
     // Define a test block
@@ -171,6 +176,17 @@ describe('telepath: wagtail.blocks.FieldBlock', () => {
       ],
     });
     expect(document.body.innerHTML).toMatchSnapshot();
+  });
+
+  test('setError() calls widget.setInvalid()', () => {
+    boundBlock.setError({
+      messages: ['Field shall not pass.', 'Field must not be suspicious.'],
+    });
+    expect(setInvalid).toHaveBeenCalledTimes(1);
+    expect(setInvalid).toHaveBeenCalledWith('The widget', true);
+    boundBlock.setError();
+    expect(setInvalid).toHaveBeenCalledTimes(2);
+    expect(setInvalid).toHaveBeenCalledWith('The widget', false);
   });
 });
 

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -55,6 +55,14 @@ class BoundWidget {
     this.input.value = state;
   }
 
+  setInvalid(invalid) {
+    if (invalid) {
+      this.input.setAttribute('aria-invalid', 'true');
+    } else {
+      this.input.removeAttribute('aria-invalid');
+    }
+  }
+
   getTextLabel(opts) {
     const val = this.getValue();
     if (typeof val !== 'string') return null;
@@ -181,6 +189,18 @@ class BoundRadioSelect {
     for (let i = 0; i < inputs.length; i += 1) {
       inputs[i].checked = state.includes(inputs[i].value);
     }
+  }
+
+  setInvalid(invalid) {
+    this.element
+      .querySelectorAll(`input[name="${this.name}"]`)
+      .forEach((input) => {
+        if (invalid) {
+          input.setAttribute('aria-invalid', 'true');
+        } else {
+          input.removeAttribute('aria-invalid');
+        }
+      });
   }
 
   focus() {
@@ -352,6 +372,14 @@ class BoundDraftailWidget {
     this.input.draftailEditor.onChange(editorState);
   }
 
+  setInvalid(invalid) {
+    if (invalid) {
+      this.input.setAttribute('aria-invalid', 'true');
+    } else {
+      this.input.removeAttribute('aria-invalid');
+    }
+  }
+
   getTextLabel(opts) {
     const maxLength = opts && opts.maxLength;
     if (!this.input.value) return '';
@@ -511,6 +539,13 @@ class BaseDateTimeWidget extends Widget {
       },
       setState(state) {
         element.value = state;
+      },
+      setInvalid(invalid) {
+        if (invalid) {
+          element.setAttribute('aria-invalid', 'true');
+        } else {
+          element.removeAttribute('aria-invalid');
+        }
       },
       focus(opts) {
         // focusing opens the date picker, so don't do this if it's a 'soft' focus

--- a/client/src/entrypoints/admin/telepath/widgets.test.js
+++ b/client/src/entrypoints/admin/telepath/widgets.test.js
@@ -61,6 +61,17 @@ describe('telepath: wagtail.widgets.Widget', () => {
     expect(document.querySelector('input').value).toBe('The new Value');
   });
 
+  test('setInvalid() sets aria-invalid attribute', () => {
+    boundWidget.setInvalid(true);
+    expect(document.querySelector('input').getAttribute('aria-invalid')).toBe(
+      'true',
+    );
+    boundWidget.setInvalid(false);
+    expect(
+      document.querySelector('input').getAttribute('aria-invalid'),
+    ).toBeNull();
+  });
+
   test('focus() focuses the text input', () => {
     boundWidget.focus();
     expect(document.activeElement).toBe(document.querySelector('input'));
@@ -205,6 +216,27 @@ describe('telepath: wagtail.widgets.RadioSelect', () => {
     boundWidget.setState(['coffee']);
     expect(document.querySelector('input[value="tea"]').checked).toBe(false);
     expect(document.querySelector('input[value="coffee"]').checked).toBe(true);
+  });
+
+  test('setInvalid() sets aria-invalid attribute', () => {
+    boundWidget.setInvalid(true);
+    expect(
+      document.querySelector('input[value="tea"]').getAttribute('aria-invalid'),
+    ).toBe('true');
+    expect(
+      document
+        .querySelector('input[value="coffee"]')
+        .getAttribute('aria-invalid'),
+    ).toBe('true');
+    boundWidget.setInvalid(false);
+    expect(
+      document.querySelector('input[value="tea"]').getAttribute('aria-invalid'),
+    ).toBeNull();
+    expect(
+      document
+        .querySelector('input[value="coffee"]')
+        .getAttribute('aria-invalid'),
+    ).toBeNull();
   });
 
   test('focus() focuses the text input', () => {
@@ -620,6 +652,13 @@ describe('telepath: wagtail.widgets.DraftailRichTextArea', () => {
     expect(retrievedState).toStrictEqual(NEW_STATE);
   });
 
+  test('setInvalid() sets aria-invalid attribute', () => {
+    boundWidget.setInvalid(true);
+    expect(inputElement.getAttribute('aria-invalid')).toBe('true');
+    boundWidget.setInvalid(false);
+    expect(inputElement.getAttribute('aria-invalid')).toBeNull();
+  });
+
   test('focus() focuses the text input', () => {
     // focus happens on a timeout, so use a mock to make it happen instantly
     jest.useFakeTimers();
@@ -713,6 +752,17 @@ describe('telepath: wagtail.widgets.DateInput', () => {
     expect(document.querySelector('input').value).toBe('2021-01-20');
   });
 
+  test('setInvalid() sets aria-invalid attribute', () => {
+    boundWidget.setInvalid(true);
+    expect(document.querySelector('input').getAttribute('aria-invalid')).toBe(
+      'true',
+    );
+    boundWidget.setInvalid(false);
+    expect(
+      document.querySelector('input').getAttribute('aria-invalid'),
+    ).toBeNull();
+  });
+
   test('focus() focuses the input', () => {
     boundWidget.focus();
     expect(document.activeElement).toBe(document.querySelector('input'));
@@ -773,6 +823,17 @@ describe('telepath: wagtail.widgets.TimeInput', () => {
   test('setState() changes the current state', () => {
     boundWidget.setState('12:34');
     expect(document.querySelector('input').value).toBe('12:34');
+  });
+
+  test('setInvalid() sets aria-invalid attribute', () => {
+    boundWidget.setInvalid(true);
+    expect(document.querySelector('input').getAttribute('aria-invalid')).toBe(
+      'true',
+    );
+    boundWidget.setInvalid(false);
+    expect(
+      document.querySelector('input').getAttribute('aria-invalid'),
+    ).toBeNull();
   });
 
   test('focus() focuses the input', () => {
@@ -837,6 +898,17 @@ describe('telepath: wagtail.widgets.DateTimeInput', () => {
   test('setState() changes the current state', () => {
     boundWidget.setState('2021-01-20 12:34');
     expect(document.querySelector('input').value).toBe('2021-01-20 12:34');
+  });
+
+  test('setInvalid() sets aria-invalid attribute', () => {
+    boundWidget.setInvalid(true);
+    expect(document.querySelector('input').getAttribute('aria-invalid')).toBe(
+      'true',
+    );
+    boundWidget.setInvalid(false);
+    expect(
+      document.querySelector('input').getAttribute('aria-invalid'),
+    ).toBeNull();
   });
 
   test('focus() focuses the input', () => {

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -77,6 +77,7 @@ Thank you to Joel William for implementing this as part of the [Google Summer of
  * Update the start project template to align with Django's recommendation to have the `django.middleware.security.SecurityMiddleware` first (Brylie Christopher Oxley)
  * Ensure keyboard usage will correctly focus on new comments, including replies, when the side panel is open or closed (Dhruvi Patel)
  * Handle `help_text` kwarg in `FloatBlock` (Nick Smith)
+ * Set `aria-invalid` on StreamField widgets input when there is an error (Sage Abdullah)
 
 ### Documentation
 


### PR DESCRIPTION
Fixes #10300.

Example with `EmbedBlock` as mentioned in the issue:

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/c89977e8-f3ee-4c54-b5f7-b7a5d90c489c" />
