### PR TITLE
Handle missing "value" attribute on log_actions._active when calling deactivate

### DIFF
--- a/wagtail/log_actions.py
+++ b/wagtail/log_actions.py
@@ -63,7 +63,10 @@ def activate(log_context):
 
 
 def deactivate():
-    del _active.value
+    try:
+        del _active.value
+    except AttributeError:
+        pass
 
 
 def get_active_log_context():

--- a/wagtail/tests/test_audit_log.py
+++ b/wagtail/tests/test_audit_log.py
@@ -10,6 +10,7 @@ from django.test import TestCase
 from django.utils import timezone
 from freezegun import freeze_time
 
+from wagtail import log_actions
 from wagtail.log_actions import LogActionRegistry
 from wagtail.log_actions import registry as log_registry
 from wagtail.models import (
@@ -656,3 +657,11 @@ class TestAuditLogHooks(WagtailTestUtils, TestCase):
             self.assertEqual(
                 log_actions.get_action_label("test.custom_action"), "Custom action"
             )
+
+    def test_deactivate_attr_error(self):
+        # Ensure that deactivating the log context does not raise an AttributeError
+        # if it has not been activated.
+        # https://github.com/wagtail/wagtail/issues/13208
+        self.assertFalse(hasattr(log_actions._active, "value"))
+        log_actions.deactivate()
+        # No exception should be raised here


### PR DESCRIPTION
Handles a missing "value" attribute on `log_actions._active` when calling `log_actions.deactivate()`

Closes #13208 

_Please describe the problem you're fixing here. Include the issue number, if applicable._
