### PR TITLE
Fix alias of draft page shows edit form

### DIFF
--- a/wagtail/actions/create_alias.py
+++ b/wagtail/actions/create_alias.py
@@ -120,6 +120,7 @@ class CreatePageAliasAction:
             "path",
             "index_entries",
             "postgres_index_entries",
+            "latest_revision",  # for page aliases do not have revisions
         ]
 
         update_attrs = {

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -2139,6 +2139,31 @@ class TestPageEdit(WagtailTestUtils, TestCase):
             html=True,
         )
 
+    def test_edit_alias_page_from_draft_page(self):
+        # Ensure we have at least one revision. This is what happens when creating
+        # a page via the admin. It is stored as latest_revision
+        self.unpublished_page.save_revision()
+        alias_page = self.unpublished_page.create_alias(update_slug="an-alias-page")
+        response = self.client.get(
+            reverse("wagtailadmin_pages:edit", args=[alias_page.id])
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/html; charset=utf-8")
+
+        self.assertNotContains(response, 'id="status-sidebar-live"')
+
+        # Check the edit_alias.html template was used instead
+        self.assertTemplateUsed(response, "wagtailadmin/pages/edit_alias.html")
+        original_page_edit_url = reverse(
+            "wagtailadmin_pages:edit", args=[self.unpublished_page.id]
+        )
+        self.assertContains(
+            response,
+            f'<a class="button button-secondary" href="{original_page_edit_url}">Edit original page</a>',
+            html=True,
+        )
+
     def test_post_edit_alias_page(self):
         alias_page = self.child_page.create_alias(update_slug="new-child-page")
 


### PR DESCRIPTION
See https://www.loom.com/share/9dee4dbdc2794dc9a9676df16c0f5d20

If you create an alias from a draft page and then go to edit it, you see the edit form (which the edit form for the source page) instead of the "This is an alias" message.
This is because `page.get_latest_revision_as_object()` will return the latest revision as an object. On pages, this is saved on `latest_revision`. As aliases cannot have revisions, I've updated `CreatePageAliasAction` to exclude `latest_revision`

Note that this broke somewhere between Wagtail 3.x and 4.x and it was not noticed.