### PR TITLE
Use browser built-in `EventTarget` instead of `events.EventEmitter`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -68,6 +68,7 @@
  * Maintenance: Add integrity & resolved checksums to package-lock.json (Sylvain Fankhauser)
  * Maintenance: Replace `SlugController` with more generic and reusable `CleanController` (LB (Ben) Johnston)
  * Maintenance: Remove outdated nginx / uWSGI example config files from `/etc` (LB (Ben) Johnston)
+ * Maintenance: Use browser built-in `EventTarget` instead of `events.EventEmitter` from Webpack (Sage Abdullah)
 
 
 7.0.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/components/ChooserWidget/index.js
+++ b/client/src/components/ChooserWidget/index.js
@@ -1,7 +1,6 @@
-import EventEmitter from 'events';
 import { ChooserModal } from '../../includes/chooserModal';
 
-export class Chooser extends EventEmitter {
+export class Chooser extends EventTarget {
   chooserModalClass = ChooserModal;
   titleStateKey = 'title'; // key used in the 'state' dictionary to hold the human-readable title
   editUrlStateKey = 'edit_url'; // key used in the 'state' dictionary to hold the URL of the edit page
@@ -85,7 +84,7 @@ export class Chooser extends EventEmitter {
 
   setStateFromModalData(data) {
     this.setState(data);
-    this.emit('chosen', data);
+    this.dispatchEvent(new Event('chosen', data));
   }
 
   clear() {

--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -2,7 +2,6 @@
 
 /* global $ */
 
-import EventEmitter from 'events';
 import { v4 as uuidv4 } from 'uuid';
 import Sortable from 'sortablejs';
 import { escapeHtml as h } from '../../../utils/text';
@@ -37,13 +36,13 @@ class ActionButton {
     $(container).append(this.dom);
 
     if (this.enableEvent) {
-      this.sequenceChild.on(this.enableEvent, () => {
+      this.sequenceChild.addEventListener(this.enableEvent, () => {
         this.enable();
       });
     }
 
     if (this.disableEvent) {
-      this.sequenceChild.on(this.disableEvent, () => {
+      this.sequenceChild.addEventListener(this.disableEvent, () => {
         this.disable();
       });
     }
@@ -114,7 +113,7 @@ class DeleteButton extends ActionButton {
   }
 }
 
-export class BaseSequenceChild extends EventEmitter {
+export class BaseSequenceChild extends EventTarget {
   constructor(
     blockDef,
     placeholder,
@@ -309,14 +308,14 @@ export class BaseSequenceChild extends EventEmitter {
   }
 
   enableDuplication() {
-    this.emit('enableDuplication');
+    this.dispatchEvent(new Event('enableDuplication'));
     if (this.block && this.block.setCapabilityOptions) {
       this.block.setCapabilityOptions('duplicate', { enabled: true });
     }
   }
 
   disableDuplication() {
-    this.emit('disableDuplication');
+    this.dispatchEvent(new Event('disableDuplication'));
     if (this.block && this.block.setCapabilityOptions) {
       this.block.setCapabilityOptions('duplicate', { enabled: false });
     }
@@ -335,19 +334,19 @@ export class BaseSequenceChild extends EventEmitter {
   }
 
   enableMoveUp() {
-    this.emit('enableMoveUp');
+    this.dispatchEvent(new Event('enableMoveUp'));
   }
 
   disableMoveUp() {
-    this.emit('disableMoveUp');
+    this.dispatchEvent(new Event('disableMoveUp'));
   }
 
   enableMoveDown() {
-    this.emit('enableMoveDown');
+    this.dispatchEvent(new Event('enableMoveDown'));
   }
 
   disableMoveDown() {
-    this.emit('disableMoveDown');
+    this.dispatchEvent(new Event('disableMoveDown'));
   }
 
   setIndex(newIndex) {

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -89,6 +89,7 @@ The [](../reference/contrib/settings) app now allows permission over site settin
  * Add integrity & resolved checksums to package-lock.json (Sylvain Fankhauser)
  * Replace `SlugController` with more generic and reusable `CleanController` (LB (Ben) Johnston)
  * Remove outdated nginx / uWSGI example config files from `/etc` (LB (Ben) Johnston)
+ * Use browser built-in `EventTarget` instead of `events.EventEmitter` from Webpack (Sage Abdullah)
 
 ## Upgrade considerations - changes affecting all projects
 


### PR DESCRIPTION
I don't see a reason why we use `EventEmitter` from `events` instead of the browser built-in `EventTarget`. We don't even have `events` in our dependencies list, it comes from webpack's dependencies.

Dropping this shaves 4KB from `vendor.js`.

Output of `du -cha *` inside `wagtail/admin/static/wagtailadmin/js`:

```diff
 8.0K	bulk-actions.js
 4.0K	chooser-modal.js
 4.0K	chooser-widget-telepath.js
 4.0K	chooser-widget.js
  52K	comments.js
 660K	core.js
 4.0K	core.js.LICENSE.txt
 4.0K	date-time-chooser.js
 288K	draftail.js
 4.0K	draftail.js.LICENSE.txt
 4.0K	filtered-select.js
 4.0K	icons.js
 4.0K	modal-workflow.js
 8.0K	page-chooser-modal.js
 4.0K	page-chooser-telepath.js
 4.0K	page-chooser.js
 4.0K	privacy-switch.js
  44K	sidebar.js
 4.0K	sidebar.js.LICENSE.txt
 4.0K	task-chooser-modal.js
 4.0K	task-chooser.js
 8.0K	telepath/telepath.js
  32K	telepath/blocks.js
 8.0K	telepath/widgets.js
  48K	telepath
 588K	userbar.js
 4.0K	userbar.js.LICENSE.txt
 4.0K	vendor/jquery-ui-1.13.2.min.js.LICENSE.txt
 4.0K	vendor/jquery-3.6.0.min.js.LICENSE.txt
 4.0K	vendor/jquery.datetimepicker.js.LICENSE.txt
  88K	vendor/jquery-3.6.0.min.js
  64K	vendor/jquery.datetimepicker.js
 252K	vendor/jquery-ui-1.13.2.min.js
 4.0K	vendor/bootstrap-modal.js
 8.0K	vendor/tag-it.js
  20K	vendor/jquery.fileupload.js
 4.0K	vendor/jquery.ba-throttle-debounce.min.js
 4.0K	vendor/bootstrap-transition.js
 4.0K	vendor/jquery.fileupload-process.js
 4.0K	vendor/jquery.iframe-transport.js
 464K	vendor
-356K	vendor.js
+352K	vendor.js
 4.0K	vendor.js.LICENSE.txt
  12K	wagtailadmin.js
 4.0K	workflow-action.js
 2.5M	total
```