### PR TITLE
Add linting script to ensure that package.json & pre-commit package versions are in sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
       - run: npm run lint:js
       - run: npm run lint:css
       - run: npm run lint:format
+      - run: npm run lint:project
       - run: npm run test:unit:coverage -- --runInBand
       - run: bash <(curl -s https://codecov.io/bash) -F frontend
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ lint-client:
 	npm run lint:css --silent
 	npm run lint:js --silent
 	npm run lint:format --silent
+	npm run lint:project
 
 lint-docs:
 	doc8 docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,8 @@
         "typedoc-plugin-mdn-links": "^5.0.4",
         "typescript": "^5.8.3",
         "webpack": "^5.100.2",
-        "webpack-cli": "^5.1.4"
+        "webpack-cli": "^5.1.4",
+        "yaml": "^2.8.0"
       },
       "engines": {
         "node": ">=22"
@@ -10168,6 +10169,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -10455,6 +10466,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/cssnano/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/csso": {
@@ -18197,15 +18218,6 @@
         }
       }
     },
-    "node_modules/postcss-load-config/node_modules/yaml": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
-      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/postcss-loader": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-8.1.1.tgz",
@@ -22549,19 +22561,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/typedoc/node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -23675,13 +23674,16 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "typedoc": "^0.28.7",
     "typedoc-plugin-mdn-links": "^5.0.4",
     "typescript": "^5.8.3",
+    "yaml": "^2.8.0",
     "webpack": "^5.100.2",
     "webpack-cli": "^5.1.4"
   },
@@ -145,8 +146,9 @@
     "lint:js": "eslint --ext .js,.ts,.tsx --report-unused-disable-directives .",
     "lint:css": "stylelint **/*.scss",
     "lint:format": "prettier --check \"**/?(.)*.{css,scss,js,ts,tsx,json,yaml,yml}\"",
+    "lint:project": "node ./scripts/check-dependencies.mjs",
     "lint:ts": "tsc --noEmit",
-    "lint": "npm run lint:js && npm run lint:ts && npm run lint:css && npm run lint:format",
+    "lint": "npm run lint:js && npm run lint:ts && npm run lint:css && npm run lint:format && npm run lint:project",
     "test": "npm run test:unit",
     "test:unit": "jest",
     "test:unit:watch": "jest --watch",

--- a/scripts/check-dependencies.mjs
+++ b/scripts/check-dependencies.mjs
@@ -1,0 +1,53 @@
+/**
+ * Compares the `package.json` dev dependencies against the `.pre-commit-config.yaml`.
+ * Validating that any pre commit hook dependencies are in sync with the project packages.
+ */
+
+import fs from 'node:fs';
+import { parse } from 'yaml';
+
+import packageJson from '../package.json' with { type: 'json' };
+
+const PACKAGE_JSON = 'package.json';
+const PRE_COMMIT_PATH = 'pre-commit-config.yaml';
+
+const { devDependencies } = packageJson;
+const { repos: preCommitRepos } = parse(
+  fs.readFileSync('.' + PRE_COMMIT_PATH, 'utf8'),
+);
+
+// eslint-disable-next-line no-console
+console.info(`Checking package dependencies against ${PRE_COMMIT_PATH}.`);
+
+const errorMessages = [];
+
+preCommitRepos.forEach(({ hooks }) => {
+  hooks.forEach(({ id = '', additional_dependencies: dependencies = [] }) => {
+    if (!id || !dependencies?.length) return;
+
+    dependencies.forEach((dependency) => {
+      const preCommitVersion = dependency.split('@').at(-1);
+      const [packageName] = dependency.split(`@${preCommitVersion}`, 1);
+      const packageVersion = devDependencies[packageName];
+      if (packageVersion?.endsWith(preCommitVersion) || false) return;
+
+      errorMessages.push(
+        [
+          ' →',
+          `${PRE_COMMIT_PATH} [${packageName}: ${preCommitVersion}]`,
+          `${PACKAGE_JSON}: [${packageName}: ${packageVersion ?? 'not found'}]`,
+        ].join(' '),
+      );
+    });
+  });
+});
+
+if (errorMessages.length) {
+  throw new Error(
+    [
+      `The following '${PACKAGE_JSON}' dependencies are not in sync with '${PRE_COMMIT_PATH}':`,
+      ...errorMessages,
+      '',
+    ].join('\n'),
+  );
+}


### PR DESCRIPTION
A basic script to ensure that we keep the pre-commit hooks & the package.json files in sync.

Fixes https://github.com/wagtail/wagtail/issues/10755

This will not cover all scenarios of updates, sometimes the hook revision itself will need updating, but it should be enough for us to flag this common issue quickly in the CI.

Note: Pre-commit will likely never implement a `--dry-run` or `--check` flag to their CLI, as per https://github.com/pre-commit/pre-commit/issues/2785

### Example error output

#### Out of sync dependency in `package.json`

```
> wagtail@1.0.0 lint:project
> node ./scripts/check-dependencies.mjs

Checking package dependencies against pre-commit-config.yaml.
file:///.../wagtail/scripts/check-dependencies.mjs:46
  throw new Error(
        ^

Error: The following 'package.json' dependencies are not in sync with 'pre-commit-config.yaml':
 → pre-commit-config.yaml [eslint: 8.57.0] package.json: [eslint: ^9.0.0]

    at file:///.../wagtail/scripts/check-dependencies.mjs:46:9
    at ModuleJob.run (node:internal/modules/esm/module_job:268:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:543:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:116:5)

Node.js v22.11.0
```

#### Missing dependency in `package.json`

```
> wagtail@1.0.0 lint:project
> node ./scripts/check-dependencies.mjs

Checking package dependencies against pre-commit-config.yaml.
file:///.../wagtail/scripts/check-dependencies.mjs:46
  throw new Error(
        ^

Error: The following 'package.json' dependencies are not in sync with 'pre-commit-config.yaml':
 → pre-commit-config.yaml [eslint: 8.57.0] package.json: [eslint: not found]

    at file:///.../wagtail/scripts/check-dependencies.mjs:46:9
    at ModuleJob.run (node:internal/modules/esm/module_job:268:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:543:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:116:5)

Node.js v22.11.0
```