### PR TITLE
Image settings DX tweaks in documentation

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -412,13 +412,46 @@ Custom storage classes should subclass `django.core.files.storage.Storage`. See 
 ### `WAGTAILIMAGES_EXTENSIONS`
 
 ```python
-WAGTAILIMAGES_EXTENSIONS = ['png', 'jpg']
+WAGTAILIMAGES_EXTENSIONS = ['avif', 'svg']
 ```
 
 A list of allowed image extensions that will be validated during image uploading.
 If this isn't supplied, all of AVIF, GIF, JPG, JPEG, PNG, WEBP are allowed.
 Warning: this doesn't always ensure that the uploaded file is valid as files can
 be renamed to have an extension no matter what data they contain.
+
+### `WAGTAILIMAGES_JPEG_QUALITY`
+
+```python
+WAGTAILIMAGES_JPEG_QUALITY = 75
+```
+
+Change the global default for JPEG image encoding quality (default: 85).
+
+### `WAGTAILIMAGES_WEBP_QUALITY`
+
+```python
+WAGTAILIMAGES_WEBP_QUALITY = 70
+```
+
+Change the global default for WebP image encoding quality (default: 80).
+
+### `WAGTAILIMAGES_AVIF_QUALITY`
+
+```python
+WAGTAILIMAGES_AVIF_QUALITY = 65
+```
+
+Change the global default for AVIF image encoding quality (default: 80).
+
+### `WAGTAILIMAGES_HEIC_QUALITY`
+
+```python
+WAGTAILIMAGES_HEIC_QUALITY = 60
+```
+
+Change the global default for HEIC image encoding quality (default: 80).
+
 
 ## Documents
 

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -537,7 +537,7 @@ See [](image_renditions).
 Wagtail supports the use of Scalable Vector Graphics alongside raster images. To allow Wagtail users to upload and use SVG images, add "svg" to the list of allowed image extensions by configuring `WAGTAILIMAGES_EXTENSIONS`:
 
 ```python
-WAGTAILIMAGES_EXTENSIONS = ["gif", "jpg", "jpeg", "png", "webp", "svg"]
+WAGTAILIMAGES_EXTENSIONS = ["avif", "gif", "jpg", "jpeg", "png", "webp", "svg"]
 ```
 
 SVG images can be included in templates via the `image` template tag, as with raster images. However, operations that require SVG images to be rasterized are not currently supported. This includes direct format conversion, e.g. `format-webp`, and `bgcolor` directives. Crop and resize operations do not require rasterization, so may be used freely (see [](available_resizing_methods)).


### PR DESCRIPTION
Those are pretty small tweaks, attempting to make it more likely for developers to make advantage of available image optimizations: the AVIF format, and the quality settings.

Related: #12789, #13127 