### PR TITLE
Add custom hook for group submenu

### DIFF
--- a/wagtail/admin/menu.py
+++ b/wagtail/admin/menu.py
@@ -262,7 +262,8 @@ class WagtailMenuRegisterableGroup(WagtailMenuRegisterable):
     def get_menu_item(self, order=None):
         return SubmenuMenuItem(
             label=self.menu_label,
-            menu=Menu(register_hook_name=self.submenu_hook, items=self.get_submenu_items()),
+            menu=Menu(register_hook_name=self.submenu_hook,
+                      items=self.get_submenu_items()),
             name=self.menu_name,
             icon_name=self.menu_icon,
             order=order if order is not None else self.menu_order,

--- a/wagtail/admin/menu.py
+++ b/wagtail/admin/menu.py
@@ -239,6 +239,7 @@ class WagtailMenuRegisterableGroup(WagtailMenuRegisterable):
 
     menu_icon = "folder-open-inverse"
     add_to_admin_menu = True
+
     submenu_hook = None
 
     def __init__(self):
@@ -262,8 +263,9 @@ class WagtailMenuRegisterableGroup(WagtailMenuRegisterable):
     def get_menu_item(self, order=None):
         return SubmenuMenuItem(
             label=self.menu_label,
-            menu=Menu(register_hook_name=self.submenu_hook,
-                      items=self.get_submenu_items()),
+            menu=Menu(
+                register_hook_name=self.submenu_hook, items=self.get_submenu_items()
+            ),
             name=self.menu_name,
             icon_name=self.menu_icon,
             order=order if order is not None else self.menu_order,

--- a/wagtail/admin/menu.py
+++ b/wagtail/admin/menu.py
@@ -239,6 +239,7 @@ class WagtailMenuRegisterableGroup(WagtailMenuRegisterable):
 
     menu_icon = "folder-open-inverse"
     add_to_admin_menu = True
+    submenu_hook = None
 
     def __init__(self):
         """
@@ -261,7 +262,7 @@ class WagtailMenuRegisterableGroup(WagtailMenuRegisterable):
     def get_menu_item(self, order=None):
         return SubmenuMenuItem(
             label=self.menu_label,
-            menu=Menu(items=self.get_submenu_items()),
+            menu=Menu(register_hook_name=self.submenu_hook, items=self.get_submenu_items()),
             name=self.menu_name,
             icon_name=self.menu_icon,
             order=order if order is not None else self.menu_order,


### PR DESCRIPTION
We are adding a hook to separate the creation of a group menu and the elements of that menu. It will be possible to create a group in one module, and add elements in any other modules using a hook. Related: #13235
