### PR TITLE
Formalize callable default support in all StreamField blocks

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,7 +37,7 @@
  * Add support for opt-in collapsible `StructBlock`s (Sage Abdullah)
  * Add `form_attrs` support to all StreamField blocks (Sage Abdullah)
  * Update project template documentation to include testing instructions and include starting test file in template (Aditya (megatrron))
- * Add support for `preview_value` and `default` in `Block` meta options as callables for dynamic previews within StreamField (Ziyao Yan)
+ * Add support for `preview_value` and `default` in `Block` meta options as callables for dynamic previews within StreamField (Ziyao Yan, Sage Abdullah)
  * Fix: Handle lazy translation strings as `preview_value` for `RichTextBlock` (Seb Corbin)
  * Fix: Fix handling of newline-separated choices in form builder when using non-windows newline characters (Baptiste Mispelon)
  * Fix: Ensure `WAGTAILADMIN_LOGIN_URL` is respected when logging out of the admin (Antoine Rodriguez, Ramon de Jezus)

--- a/docs/reference/streamfield/blocks.md
+++ b/docs/reference/streamfield/blocks.md
@@ -37,7 +37,7 @@ body = StreamField([
 All block definitions accept the following optional keyword arguments or `Meta` class attributes:
 
 -   `default`
-    -   The default value that a new 'empty' block should receive.
+    -   The default value (or a callable that returns the value) that a new 'empty' block should receive.
 -   `label`
     -   The label to display in the editor interface when referring to this block - defaults to a prettified version of the block name (or, in a context where no name is assigned - such as within a `ListBlock` - the empty string).
 -   `icon`
@@ -47,16 +47,24 @@ All block definitions accept the following optional keyword arguments or `Meta` 
 -   `group`
     -   The group used to categorize this block. Any blocks with the same group name will be shown together in the editor interface with the group name as a heading.
 
+```{versionadded} 7.1
+The `default` can now be defined as a callable.
+```
+
 (block_preview_arguments)=
 
 [StreamField blocks can have previews](configuring_block_previews) that will be shown inside the block picker. To accommodate the feature, all block definitions also accept the following options:
 
 -   `preview_value`
-    -   The placeholder value that will be used for rendering the preview. See {meth}`~wagtail.blocks.Block.get_preview_value` for more details.
+    -   The placeholder value (or a callable that returns the value) that will be used for rendering the preview. See {meth}`~wagtail.blocks.Block.get_preview_value` for more details.
 -   `preview_template`
     -   The template that is used to render the preview. See {meth}`~wagtail.blocks.Block.get_preview_template` for more details.
 -   `description`
     -   The description of the block to be shown to editors. See {meth}`~wagtail.blocks.Block.get_description` for more details.
+
+```{versionadded} 7.1
+The `preview_value` can now be defined as a callable.
+```
 
 All block definitions have the following methods and properties that can be overridden:
 

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -78,7 +78,7 @@ For more details, see the documentation on [enabling the user bar](headless_user
  * Add API for extracting preview page content (Sage Abdullah)
  * Add `form_attrs` support to all StreamField blocks (Sage Abdullah)
  * Update project template documentation to include testing instructions and include starting test file in template (Aditya (megatrron))
- * Add support for `preview_value` and `default` in `Block` meta options as callables for [dynamic previews within StreamField](configuring_block_previews) (Ziyao Yan)
+ * Add support for `preview_value` and `default` in `Block` meta options as callables for [dynamic previews within StreamField](configuring_block_previews) (Ziyao Yan, Sage Abdullah)
 
 ### Bug fixes
 

--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -619,20 +619,25 @@ class QuoteBlock(blocks.StructBlock):
 ```
 
 
-Alternatively, the `preview` attribute can be defined as a callable.
+Alternatively, the `preview_value` can be defined as a callable.
 
 ```{code-block} python
-:emphasize-lines: 8
-from datetime import datetime
+:emphasize-lines: 9
+from django.utils import timezone
 from wagtail.blocks import DateBlock, StreamBlock
+
 
 class MyStreamBlock(StreamBlock):
     # ... other blocks
     date_block = DateBlock(
         icon="calendar",
-        preview_value=lambda: datetime.now(),
+        preview_value=timezone.now,
         preview_template="blocks/date_block_preview.html",
     )
+```
+
+```{versionadded} 7.1
+The `preview_value` can now be defined as a callable.
 ```
 
 (streamfield_global_preview_template)=

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -155,7 +155,7 @@ class Block(metaclass=BaseBlock):
         """
         Return this block's default value (conventionally found in self.meta.default),
         converted to the value type expected by this block. If the default is a callable
-        (e.g., a function or lambda), it will be evaluated at runtime. This caters for
+        (e.g. a function), it will be evaluated at runtime. This caters for
         the case where that value type is not something that can be expressed statically at
         model definition time (e.g. something like StructValue which incorporates a
         pointer back to the block definition object).
@@ -315,10 +315,9 @@ class Block(metaclass=BaseBlock):
         """
         Return the placeholder value that will be used for rendering the block's
         preview. By default, the value is the ``preview_value`` from the block's
-        options if provided. If it's a callable, it will be invoked at runtime to
-        allow dynamic preview values, otherwise the ``default`` is used as fallback.
-        This method can also be overridden to provide a dynamic preview value, such as
-        from the database.
+        options if provided. If it's a callable, it will be evaluated at runtime.
+        If ``preview_value`` is not provided, the ``default`` is used as fallback.
+        This method can also be overridden to provide a dynamic preview value.
         """
         if hasattr(self.meta, "preview_value"):
             value = self.meta.preview_value

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -151,6 +151,9 @@ class Block(metaclass=BaseBlock):
         """
         return BoundBlock(self, value, prefix=prefix, errors=errors)
 
+    def _evaluate_callable(self, value):
+        return value() if callable(value) else value
+
     def get_default(self):
         """
         Return this block's default value (conventionally found in self.meta.default),
@@ -160,9 +163,7 @@ class Block(metaclass=BaseBlock):
         model definition time (e.g. something like StructValue which incorporates a
         pointer back to the block definition object).
         """
-        default = getattr(self.meta, "default", None)
-        if callable(default):
-            default = default()
+        default = self._evaluate_callable(getattr(self.meta, "default", None))
         return self.normalize(default)
 
     def clean(self, value):
@@ -320,9 +321,7 @@ class Block(metaclass=BaseBlock):
         This method can also be overridden to provide a dynamic preview value.
         """
         if hasattr(self.meta, "preview_value"):
-            value = self.meta.preview_value
-            if callable(value):
-                value = value()
+            value = self._evaluate_callable(self.meta.preview_value)
             return self.normalize(value)
         return self.get_default()
 

--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -773,7 +773,7 @@ class RawHTMLBlock(FieldBlock):
         super().__init__(**kwargs)
 
     def get_default(self):
-        return self.normalize(self.meta.default or "")
+        return self.normalize(self._evaluate_callable(self.meta.default or ""))
 
     def to_python(self, value):
         return mark_safe(value)

--- a/wagtail/blocks/struct_block.py
+++ b/wagtail/blocks/struct_block.py
@@ -133,12 +133,11 @@ class BaseStructBlock(Block):
         rather than a StructValue; for consistency, we need to convert it to a StructValue
         for StructBlock to work with
         """
+        default = self._evaluate_callable(self.meta.default)
 
         return self.normalize(
             {
-                name: self.meta.default[name]
-                if name in self.meta.default
-                else block.get_default()
+                name: default[name] if name in default else block.get_default()
                 for name, block in self.child_blocks.items()
             }
         )

--- a/wagtail/embeds/blocks.py
+++ b/wagtail/embeds/blocks.py
@@ -30,15 +30,16 @@ class EmbedValue:
 
 class EmbedBlock(blocks.URLBlock):
     def get_default(self):
+        default = self._evaluate_callable(self.meta.default)
         # Allow specifying the default for an EmbedBlock as either an EmbedValue or a string (or None).
-        if not self.meta.default:
+        if not default:
             return None
-        elif isinstance(self.meta.default, EmbedValue):
-            return self.meta.default
+        elif isinstance(default, EmbedValue):
+            return default
         else:
             # assume default has been passed as a string
             return EmbedValue(
-                self.meta.default,
+                default,
                 getattr(self.meta, "max_width", None),
                 getattr(self.meta, "max_height", None),
             )

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -1013,6 +1013,13 @@ class TestEmbedBlock(TestCase):
         self.assertIsInstance(block5.get_default(), EmbedValue)
         self.assertEqual(block5.get_default().url, "http://www.example.com/foo")
 
+        def callable_default():
+            return EmbedValue("http://www.example.com/foo")
+
+        block6 = EmbedBlock(default=callable_default)
+        self.assertIsInstance(block6.get_default(), EmbedValue)
+        self.assertEqual(block6.get_default().url, "http://www.example.com/foo")
+
     @responses.activate
     def test_clean_required(self):
         self.set_up_embed_response()


### PR DESCRIPTION
I wanted to raise this in a review for #13196, but I was too late to the party =)

The handling for callable `default` added in that PR was incomplete. The `RawHTMLBlock`, `EmbedBlock`, and `StructBlock` classes override the base `Block.get_default()`, so the normalization of callables must be taken into account there as well. It was also missing tests and docs outside of the `preview_value` context.

I refactored the bit where it does "call the value if it's a callable otherwise leave it as-is" into a separate method `_evaluate_callable()` to avoid repetition. I wanted to name it `_normalize_callable()` but I'm afraid it'd cause confusion with `normalize()`. Also, for all intents and purposes, this method could've been a utility function outside of the `Block` class, but I opted to keep it close for now.

Happy to hear any feedback or alternative approaches. I'm not 100% sure about this hence I didn't submit a full review in time on that previous PR.