### PR TITLE
Do not postMessage() in userbar if not in an iframe

### DIFF
--- a/client/src/includes/userbar.ts
+++ b/client/src/includes/userbar.ts
@@ -548,6 +548,8 @@ export class Userbar extends HTMLElement {
   }
 
   postMessage(message: WagtailMessage) {
+    // Don't post messages if this window is not in an iframe.
+    if (window.top === window) return;
     window.top?.postMessage({ wagtail: message }, this.origin);
   }
 


### PR DESCRIPTION
Missed this in c0b0ebe4a308a2517e05cb8325c86f1386b74533 (#13224).

We changed the approach so that the `PreviewController` waits for the userbar to send a `w-userbar:axe-ready` message to the parent window before triggering an Axe run from the editor. However, I forgot to ensure the `postMessage()` is only called if the window (where the userbar is in) is an iframe. On headless setups, this causes the userbar to `postMessage()` using the backend server's origin as the target, even when it's not actually in an iframe (thus `window.top` is the same window i.e. the frontend), resulting in an error message about mismatching origins.