### PR TITLE
Update core JS config files with ESM & types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,7 @@
+/**
+ * @see https://eslint.org/docs/user-guide/configuring
+ * @type {import('eslint').Linter.Config}
+ */
 module.exports = {
   extends: [
     '@wagtail/eslint-config-wagtail',
@@ -15,7 +19,7 @@ module.exports = {
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-use-before-define': ['error'],
+    '@typescript-eslint/no-use-before-define': 'error',
     // it is often helpful to pull out logic to class methods that may not use `this`
     'class-methods-use-this': 'off',
     'import/extensions': [

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,8 @@
 /**
  * @see https://prettier.io/docs/en/options.html
+ * @type {import("prettier").Config}
  */
-module.exports = {
+const config = {
   arrowParens: 'always',
   bracketSameLine: false,
   bracketSpacing: true,
@@ -15,3 +16,5 @@ module.exports = {
   semi: true,
   singleQuote: true,
 };
+
+export default config;

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,4 +1,8 @@
-module.exports = {
+/**
+ * @see https://stylelint.io/user-guide/configure/
+ * @type {import('stylelint').Config}
+ */
+const config = {
   extends: '@wagtail/stylelint-config-wagtail',
   rules: {
     'scss/at-rule-no-unknown': [
@@ -86,3 +90,5 @@ module.exports = {
     'declaration-block-no-redundant-longhand-properties': null,
   },
 };
+
+export default config;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,11 @@
-const baseConfig = require('./client/tailwind.config');
+import baseConfig from './client/tailwind.config';
 
 /**
  * Tailwind config file for Wagtail itself.
+ * @see https://v3.tailwindcss.com/docs/configuration
+ * @type {import('tailwindcss').Config}
  */
-module.exports = {
+const config = {
   presets: [baseConfig],
   content: [
     './wagtail/**/*.{py,html,ts,tsx}',
@@ -21,3 +23,5 @@ module.exports = {
     preflight: false,
   },
 };
+
+export default config;


### PR DESCRIPTION
A small developer experience improvement, ensuring we can easily see type annotations for core configs and where possible move to the ESM approach.

- Stylelint - move to `.mjs` for opt in ESM & add type
- Prettier - move to ESM supported with `.js` & add type
- Tailwind - move to ESM supported with `.js` & add type
- Eslint - add type (ESM not supported until next version)
