### PR TITLE
Provide client-side access to the editing form panel structure

### DIFF
--- a/client/src/components/ChooserWidget/index.js
+++ b/client/src/components/ChooserWidget/index.js
@@ -218,4 +218,12 @@ export class ChooserFactory {
   getById(id) {
     return document.getElementById(`${id}-chooser`).widget;
   }
+
+  /**
+   * retrieve the widget object corresponding to the given HTML name
+   */
+  getByName(name, container) {
+    const input = container.querySelector(`input[name="${name}"]`);
+    return this.getById(input.id);
+  }
 }

--- a/client/src/components/ExpandingFormset/index.js
+++ b/client/src/components/ExpandingFormset/index.js
@@ -14,7 +14,6 @@ export class ExpandingFormset {
     const addButton = $('#' + prefix + '-ADD');
     this.formContainer = $('#' + prefix + '-FORMS');
     this.totalFormsInput = $('#' + prefix + '-TOTAL_FORMS');
-    this.formCount = parseInt(this.totalFormsInput.val(), 10);
 
     const emptyFormElement = document.getElementById(
       prefix + '-EMPTY_FORM_TEMPLATE',
@@ -35,6 +34,10 @@ export class ExpandingFormset {
     }
   }
 
+  get formCount() {
+    return parseInt(this.totalFormsInput.val(), 10);
+  }
+
   /**
    * @param {object?} opts
    * @param {boolean?} opts.runCallbacks - (default: true) - if false, the onAdd and onInit callbacks will not be run
@@ -48,8 +51,7 @@ export class ExpandingFormset {
 
     this.formContainer.append(newFormHtml);
 
-    this.formCount += 1;
-    this.totalFormsInput.val(this.formCount);
+    this.totalFormsInput.val(this.formCount + 1);
 
     if (!('runCallbacks' in opts) || opts.runCallbacks) {
       if (this.opts.onAdd) this.opts.onAdd(formIndex);

--- a/client/src/components/ExpandingFormset/index.js
+++ b/client/src/components/ExpandingFormset/index.js
@@ -9,18 +9,12 @@ import $ from 'jquery';
  * @see `client/src/controllers/FormsetController.ts` for the future (WIP) implementation.
  */
 export class ExpandingFormset {
-  constructor(prefix, opts = {}) {
+  constructor(prefix, opts = {}, initControls = true) {
     this.opts = opts;
     const addButton = $('#' + prefix + '-ADD');
     this.formContainer = $('#' + prefix + '-FORMS');
     this.totalFormsInput = $('#' + prefix + '-TOTAL_FORMS');
     this.formCount = parseInt(this.totalFormsInput.val(), 10);
-
-    if (opts.onInit) {
-      for (let i = 0; i < this.formCount; i += 1) {
-        opts.onInit(i);
-      }
-    }
 
     const emptyFormElement = document.getElementById(
       prefix + '-EMPTY_FORM_TEMPLATE',
@@ -28,9 +22,17 @@ export class ExpandingFormset {
 
     this.emptyFormTemplate = emptyFormElement.innerHTML;
 
-    addButton.on('click', () => {
-      this.addForm();
-    });
+    if (initControls) {
+      if (opts.onInit) {
+        for (let i = 0; i < this.formCount; i += 1) {
+          opts.onInit(i);
+        }
+      }
+
+      addButton.on('click', () => {
+        this.addForm();
+      });
+    }
   }
 
   /**

--- a/client/src/components/InlinePanel/index.js
+++ b/client/src/components/InlinePanel/index.js
@@ -16,9 +16,9 @@ import { ExpandingFormset } from '../ExpandingFormset';
  * @returns {Object}
  */
 export class InlinePanel extends ExpandingFormset {
-  constructor(type, opts) {
+  constructor(opts) {
     super(opts.formsetPrefix, opts);
-    this.type = type;
+    this.type = opts.type;
     this.relationName = opts.relationName;
     this.formsElt = $('#' + opts.formsetPrefix + '-FORMS');
 

--- a/client/src/components/InlinePanel/index.js
+++ b/client/src/components/InlinePanel/index.js
@@ -352,4 +352,9 @@ export class InlinePanel extends ExpandingFormset {
       this.updateControlStates();
     }
   }
+
+  getPanelByName(name) {
+    if (name === this.relationName) return this;
+    return null;
+  }
 }

--- a/client/src/components/InlinePanel/index.js
+++ b/client/src/components/InlinePanel/index.js
@@ -16,46 +16,48 @@ import { ExpandingFormset } from '../ExpandingFormset';
  * @returns {Object}
  */
 export class InlinePanel extends ExpandingFormset {
-  constructor(opts) {
-    super(opts.formsetPrefix, opts);
+  constructor(opts, initControls = true) {
+    super(opts.formsetPrefix, opts, initControls);
     this.type = opts.type;
     this.prefix = opts.prefix;
     this.relationName = opts.relationName;
     this.formsElt = $('#' + opts.formsetPrefix + '-FORMS');
 
-    if (this.opts.canOrder) {
-      this.sortable = Sortable.create(this.formsElt.get(0), {
-        handle: '[data-inline-panel-child-drag]',
-        animation: 200,
-        onEnd: this.handleDragEnd.bind(this),
-        setData: (dataTransfer) => {
-          dataTransfer.setData(
-            'application/vnd.wagtail.type',
-            'inlinepanel-child',
-          );
-        },
+    if (initControls) {
+      if (this.opts.canOrder) {
+        this.sortable = Sortable.create(this.formsElt.get(0), {
+          handle: '[data-inline-panel-child-drag]',
+          animation: 200,
+          onEnd: this.handleDragEnd.bind(this),
+          setData: (dataTransfer) => {
+            dataTransfer.setData(
+              'application/vnd.wagtail.type',
+              'inlinepanel-child',
+            );
+          },
+        });
+      }
+
+      for (let i = 0; i < this.formCount; i += 1) {
+        const childPrefix = this.opts.emptyChildFormPrefix.replace(
+          /__prefix__/g,
+          i,
+        );
+        this.initChildControls(childPrefix);
+      }
+
+      this.updateControlStates();
+      // dispatch event for form ready
+      setTimeout(() => {
+        this.formsElt.get(0)?.dispatchEvent(
+          new CustomEvent('w-formset:ready', {
+            bubbles: true,
+            cancelable: false,
+            detail: { ...opts },
+          }),
+        );
       });
     }
-
-    for (let i = 0; i < this.formCount; i += 1) {
-      const childPrefix = this.opts.emptyChildFormPrefix.replace(
-        /__prefix__/g,
-        i,
-      );
-      this.initChildControls(childPrefix);
-    }
-
-    this.updateControlStates();
-    // dispatch event for form ready
-    setTimeout(() => {
-      this.formsElt.get(0)?.dispatchEvent(
-        new CustomEvent('w-formset:ready', {
-          bubbles: true,
-          cancelable: false,
-          detail: { ...opts },
-        }),
-      );
-    });
   }
 
   /**

--- a/client/src/components/InlinePanel/index.js
+++ b/client/src/components/InlinePanel/index.js
@@ -19,6 +19,7 @@ export class InlinePanel extends ExpandingFormset {
   constructor(opts) {
     super(opts.formsetPrefix, opts);
     this.type = opts.type;
+    this.prefix = opts.prefix;
     this.relationName = opts.relationName;
     this.formsElt = $('#' + opts.formsetPrefix + '-FORMS');
 

--- a/client/src/components/InlinePanel/index.js
+++ b/client/src/components/InlinePanel/index.js
@@ -16,8 +16,10 @@ import { ExpandingFormset } from '../ExpandingFormset';
  * @returns {Object}
  */
 export class InlinePanel extends ExpandingFormset {
-  constructor(opts) {
+  constructor(type, opts) {
     super(opts.formsetPrefix, opts);
+    this.type = type;
+    this.relationName = opts.relationName;
     this.formsElt = $('#' + opts.formsetPrefix + '-FORMS');
 
     if (this.opts.canOrder) {

--- a/client/src/components/InlinePanel/index.test.js
+++ b/client/src/components/InlinePanel/index.test.js
@@ -52,7 +52,7 @@ describe('InlinePanel', () => {
       canOrder: true,
     };
 
-    panel = new InlinePanel(options);
+    panel = new InlinePanel('InlinePanel', options);
 
     jest.runAllTimers();
   });

--- a/client/src/components/InlinePanel/index.test.js
+++ b/client/src/components/InlinePanel/index.test.js
@@ -52,7 +52,7 @@ describe('InlinePanel', () => {
       canOrder: true,
     };
 
-    panel = new InlinePanel('InlinePanel', options);
+    panel = new InlinePanel(options);
 
     jest.runAllTimers();
   });

--- a/client/src/components/MultipleChooserPanel/index.js
+++ b/client/src/components/MultipleChooserPanel/index.js
@@ -1,8 +1,8 @@
 import { InlinePanel } from '../InlinePanel';
 
 export class MultipleChooserPanel extends InlinePanel {
-  constructor(type, opts) {
-    super(type, opts);
+  constructor(opts) {
+    super(opts);
 
     this.chooserWidgetFactory = window.telepath.unpack(
       JSON.parse(

--- a/client/src/components/MultipleChooserPanel/index.js
+++ b/client/src/components/MultipleChooserPanel/index.js
@@ -1,7 +1,7 @@
 import { InlinePanel } from '../InlinePanel';
 
 export class MultipleChooserPanel extends InlinePanel {
-  constructor(opts) {
+  constructor(opts, initControls = true) {
     super(opts);
 
     this.chooserWidgetFactory = window.telepath.unpack(
@@ -11,26 +11,29 @@ export class MultipleChooserPanel extends InlinePanel {
       ),
     );
 
-    const openModalButton = document.getElementById(
-      `${opts.formsetPrefix}-OPEN_MODAL`,
-    );
-    openModalButton.addEventListener('click', () => {
-      this.chooserWidgetFactory.openModal(
-        (result) => {
-          result.forEach((item) => {
-            if (opts.maxForms && this.getChildCount() >= opts.maxForms) return;
-            this.addForm();
-            const formIndex = this.formCount - 1;
-            const formPrefix = `${opts.formsetPrefix}-${formIndex}`;
-            const chooserFieldId = `${formPrefix}-${opts.chooserFieldName}`;
-            const chooserWidget =
-              this.chooserWidgetFactory.getById(chooserFieldId);
-            chooserWidget.setStateFromModalData(item);
-          });
-        },
-        { multiple: true },
+    if (initControls) {
+      const openModalButton = document.getElementById(
+        `${opts.formsetPrefix}-OPEN_MODAL`,
       );
-    });
+      openModalButton.addEventListener('click', () => {
+        this.chooserWidgetFactory.openModal(
+          (result) => {
+            result.forEach((item) => {
+              if (opts.maxForms && this.getChildCount() >= opts.maxForms)
+                return;
+              this.addForm();
+              const formIndex = this.formCount - 1;
+              const formPrefix = `${opts.formsetPrefix}-${formIndex}`;
+              const chooserFieldId = `${formPrefix}-${opts.chooserFieldName}`;
+              const chooserWidget =
+                this.chooserWidgetFactory.getById(chooserFieldId);
+              chooserWidget.setStateFromModalData(item);
+            });
+          },
+          { multiple: true },
+        );
+      });
+    }
   }
 
   updateOpenModalButtonState() {

--- a/client/src/components/MultipleChooserPanel/index.js
+++ b/client/src/components/MultipleChooserPanel/index.js
@@ -1,8 +1,8 @@
 import { InlinePanel } from '../InlinePanel';
 
 export class MultipleChooserPanel extends InlinePanel {
-  constructor(opts) {
-    super(opts);
+  constructor(type, opts) {
+    super(type, opts);
 
     this.chooserWidgetFactory = window.telepath.unpack(
       JSON.parse(

--- a/client/src/components/Panel/index.js
+++ b/client/src/components/Panel/index.js
@@ -1,6 +1,6 @@
 export class Panel {
-  constructor(type) {
-    this.type = type;
+  constructor(opts) {
+    this.type = opts.type;
   }
 
   getPanelByName(/* name */) {
@@ -14,9 +14,9 @@ export class Panel {
 }
 
 export class PanelGroup extends Panel {
-  constructor(type, children) {
-    super(type);
-    this.children = children;
+  constructor(opts) {
+    super(opts);
+    this.children = opts.children;
   }
 
   getPanelByName(name) {
@@ -29,10 +29,10 @@ export class PanelGroup extends Panel {
 }
 
 export class FieldPanel extends Panel {
-  constructor(type, fieldName, widget) {
-    super(type);
-    this.fieldName = fieldName;
-    this.widget = widget;
+  constructor(opts) {
+    super(opts);
+    this.fieldName = opts.fieldName;
+    this.widget = opts.widget;
   }
 
   getBoundWidget() {

--- a/client/src/components/Panel/index.js
+++ b/client/src/components/Panel/index.js
@@ -1,6 +1,7 @@
 export class Panel {
   constructor(opts) {
     this.type = opts.type;
+    this.prefix = opts.prefix;
   }
 
   getPanelByName(/* name */) {
@@ -46,5 +47,10 @@ export class FieldPanel extends Panel {
   getPanelByName(name) {
     if (name === this.fieldName) return this;
     return null;
+  }
+
+  getErrorMessage() {
+    const errorContainer = document.getElementById(`${this.prefix}-errors`);
+    return errorContainer?.querySelector('.error-message')?.textContent?.trim();
   }
 }

--- a/client/src/components/Panel/index.js
+++ b/client/src/components/Panel/index.js
@@ -1,0 +1,51 @@
+export class Panel {
+  collectWidgets() {
+    /* Insert any widgets that this panel manages into the `collection` dict. */
+  }
+
+  getWidgets() {
+    /* Return a dict of widgets that this panel manages. */
+    const collection = {};
+    this.collectWidgets(collection);
+    return collection;
+  }
+}
+
+export class PanelGroup extends Panel {
+  constructor(children) {
+    super();
+    this.children = children;
+  }
+
+  collectWidgets(collection) {
+    /* Insert any widgets that this panel group manages into the `collection` dict. */
+    this.children.forEach((child) => {
+      child.collectWidgets(collection);
+    });
+  }
+}
+
+export class FieldPanel extends Panel {
+  constructor(fieldName, widget) {
+    super();
+    this.fieldName = fieldName;
+    this.widget = widget;
+  }
+
+  collectWidgets(collection) {
+    let boundWidget;
+    // Widget classes created before Wagtail 7.1 may not have a `getByName` method :-(
+    if (this.widget.getByName) {
+      try {
+        boundWidget = this.widget.getByName(this.fieldName, document.body);
+      } catch (error) {
+        if (error.name === 'InputNotFoundError') {
+          return; // Skip adding this widget if not found
+        }
+        throw error; // Re-throw other errors
+      }
+      // eslint-disable-next-line no-param-reassign
+      collection[this.fieldName] = boundWidget;
+    }
+  }
+}

--- a/client/src/components/Panel/index.js
+++ b/client/src/components/Panel/index.js
@@ -3,15 +3,13 @@ export class Panel {
     this.type = type;
   }
 
-  collectWidgets() {
-    /* Insert any widgets that this panel manages into the `collection` dict. */
-  }
+  getPanelByName(/* name */) {
+    /* Return any descendant panel (including self) that matches the given field or relation name,
+     * or null if there is no match
+     */
 
-  getWidgets() {
-    /* Return a dict of widgets that this panel manages. */
-    const collection = {};
-    this.collectWidgets(collection);
-    return collection;
+    // The base panel definition has no notion of descendants or a name of its own, so just return null
+    return null;
   }
 }
 
@@ -21,11 +19,12 @@ export class PanelGroup extends Panel {
     this.children = children;
   }
 
-  collectWidgets(collection) {
-    /* Insert any widgets that this panel group manages into the `collection` dict. */
-    this.children.forEach((child) => {
-      child.collectWidgets(collection);
-    });
+  getPanelByName(name) {
+    for (const child of this.children) {
+      const panel = child.getPanelByName(name);
+      if (panel) return panel;
+    }
+    return null;
   }
 }
 
@@ -44,20 +43,8 @@ export class FieldPanel extends Panel {
     return null;
   }
 
-  collectWidgets(collection) {
-    let boundWidget;
-    // Widget classes created before Wagtail 7.1 may not have a `getByName` method :-(
-    try {
-      boundWidget = this.getBoundWidget();
-    } catch (error) {
-      if (error.name === 'InputNotFoundError') {
-        return; // Skip adding this widget if not found
-      }
-      throw error; // Re-throw other errors
-    }
-    if (boundWidget) {
-      // eslint-disable-next-line no-param-reassign
-      collection[this.fieldName] = boundWidget;
-    }
+  getPanelByName(name) {
+    if (name === this.fieldName) return this;
+    return null;
   }
 }

--- a/client/src/components/Panel/index.js
+++ b/client/src/components/Panel/index.js
@@ -36,18 +36,26 @@ export class FieldPanel extends Panel {
     this.widget = widget;
   }
 
+  getBoundWidget() {
+    // Widget classes created before Wagtail 7.1 may not have a `getByName` method :-(
+    if (this.widget.getByName) {
+      return this.widget.getByName(this.fieldName, document.body);
+    }
+    return null;
+  }
+
   collectWidgets(collection) {
     let boundWidget;
     // Widget classes created before Wagtail 7.1 may not have a `getByName` method :-(
-    if (this.widget.getByName) {
-      try {
-        boundWidget = this.widget.getByName(this.fieldName, document.body);
-      } catch (error) {
-        if (error.name === 'InputNotFoundError') {
-          return; // Skip adding this widget if not found
-        }
-        throw error; // Re-throw other errors
+    try {
+      boundWidget = this.getBoundWidget();
+    } catch (error) {
+      if (error.name === 'InputNotFoundError') {
+        return; // Skip adding this widget if not found
       }
+      throw error; // Re-throw other errors
+    }
+    if (boundWidget) {
       // eslint-disable-next-line no-param-reassign
       collection[this.fieldName] = boundWidget;
     }

--- a/client/src/components/Panel/index.js
+++ b/client/src/components/Panel/index.js
@@ -1,4 +1,8 @@
 export class Panel {
+  constructor(type) {
+    this.type = type;
+  }
+
   collectWidgets() {
     /* Insert any widgets that this panel manages into the `collection` dict. */
   }
@@ -12,8 +16,8 @@ export class Panel {
 }
 
 export class PanelGroup extends Panel {
-  constructor(children) {
-    super();
+  constructor(type, children) {
+    super(type);
     this.children = children;
   }
 
@@ -26,8 +30,8 @@ export class PanelGroup extends Panel {
 }
 
 export class FieldPanel extends Panel {
-  constructor(fieldName, widget) {
-    super();
+  constructor(type, fieldName, widget) {
+    super(type);
     this.fieldName = fieldName;
     this.widget = widget;
   }

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -199,6 +199,7 @@ export class StreamBlock extends BaseSequenceBlock {
       `).insertBefore(dom);
     }
     this.container = dom;
+    this.element = dom.get(0);
 
     // StreamChild objects for the current (non-deleted) child blocks
     this.children = [];

--- a/client/src/components/Widget/index.js
+++ b/client/src/components/Widget/index.js
@@ -31,13 +31,20 @@ export const querySelectorIncludingSelf = (elementOrNodeList, selector) => {
   return null; // No matching element found
 };
 
+export class InputNotFoundError extends Error {
+  constructor(name) {
+    super(`No input found with name "${name}"`);
+    this.name = 'InputNotFoundError';
+  }
+}
+
 export class BoundWidget {
   constructor(elementOrNodeList, name, parentCapabilities) {
     // look for an input element with the given name
     const selector = `:is(input,select,textarea,button)[name="${name}"]`;
     this.input = querySelectorIncludingSelf(elementOrNodeList, selector);
     if (!this.input) {
-      throw new Error(`No input found with name "${name}"`);
+      throw new InputNotFoundError(name);
     }
 
     this.idForLabel = this.input.id;

--- a/client/src/components/Widget/index.js
+++ b/client/src/components/Widget/index.js
@@ -1,31 +1,43 @@
 import { setAttrs } from '../../utils/attrs';
 import { runInlineScripts } from '../../utils/runInlineScripts';
 
+export const querySelectorIncludingSelf = (elementOrNodeList, selector) => {
+  /**
+   * Given an element or a NodeList, return the first element that matches the selector.
+   * This can be the top-level element itself or a descendant.
+   */
+
+  // if elementOrNodeList not iterable, it must be a single element
+  const nodeList = elementOrNodeList.forEach
+    ? elementOrNodeList
+    : [elementOrNodeList];
+
+  for (let i = 0; i < nodeList.length; i += 1) {
+    const container = nodeList[i];
+    if (container.nodeType === Node.ELEMENT_NODE) {
+      // Check if the container itself matches the selector
+      if (container.matches(selector)) {
+        return container;
+      }
+
+      // If not, search within the container
+      const found = container.querySelector(selector);
+      if (found) {
+        return found;
+      }
+    }
+  }
+
+  return null; // No matching element found
+};
+
 export class BoundWidget {
   constructor(elementOrNodeList, name, idForLabel, parentCapabilities) {
-    // if elementOrNodeList not iterable, it must be a single element
-    const nodeList = elementOrNodeList.forEach
-      ? elementOrNodeList
-      : [elementOrNodeList];
-
-    // look for an input element with the given name, as either a direct element of nodeList
-    // or a descendant
+    // look for an input element with the given name
     const selector = `:is(input,select,textarea,button)[name="${name}"]`;
-
-    for (let i = 0; i < nodeList.length; i += 1) {
-      const element = nodeList[i];
-      if (element.nodeType === Node.ELEMENT_NODE) {
-        if (element.matches(selector)) {
-          this.input = element;
-          break;
-        } else {
-          const input = element.querySelector(selector);
-          if (input) {
-            this.input = input;
-            break;
-          }
-        }
-      }
+    this.input = querySelectorIncludingSelf(elementOrNodeList, selector);
+    if (!this.input) {
+      throw new Error(`No input found with name "${name}"`);
     }
 
     this.idForLabel = idForLabel;

--- a/client/src/components/Widget/index.js
+++ b/client/src/components/Widget/index.js
@@ -32,7 +32,7 @@ export const querySelectorIncludingSelf = (elementOrNodeList, selector) => {
 };
 
 export class BoundWidget {
-  constructor(elementOrNodeList, name, idForLabel, parentCapabilities) {
+  constructor(elementOrNodeList, name, parentCapabilities) {
     // look for an input element with the given name
     const selector = `:is(input,select,textarea,button)[name="${name}"]`;
     this.input = querySelectorIncludingSelf(elementOrNodeList, selector);
@@ -40,7 +40,7 @@ export class BoundWidget {
       throw new Error(`No input found with name "${name}"`);
     }
 
-    this.idForLabel = idForLabel;
+    this.idForLabel = this.input.id;
     this.parentCapabilities = parentCapabilities || new Map();
   }
 
@@ -84,9 +84,8 @@ export class BoundWidget {
 }
 
 export class Widget {
-  constructor(html, idPattern) {
+  constructor(html) {
     this.html = html;
-    this.idPattern = idPattern;
   }
 
   boundWidgetClass = BoundWidget;
@@ -100,7 +99,6 @@ export class Widget {
     options = {},
   ) {
     const html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
-    const idForLabel = this.idPattern.replace(/__ID__/g, id);
 
     /* write the HTML into a temp container to parse it into a node list */
     const tempContainer = document.createElement('div');
@@ -128,7 +126,6 @@ export class Widget {
     const boundWidget = new this.boundWidgetClass(
       childElements.length === 1 ? childElements[0] : childNodes,
       name,
-      idForLabel,
       parentCapabilities,
     );
     boundWidget.setState(initialState);
@@ -160,10 +157,10 @@ export class CheckboxInput extends Widget {
 }
 
 export class BoundRadioSelect {
-  constructor(element, name, idForLabel) {
+  constructor(element, name) {
     this.element = element;
     this.name = name;
-    this.idForLabel = idForLabel;
+    this.idForLabel = '';
     this.isMultiple = !!this.element.querySelector(
       `input[name="${name}"][type="checkbox"]`,
     );

--- a/client/src/components/Widget/index.js
+++ b/client/src/components/Widget/index.js
@@ -122,6 +122,11 @@ export class Widget {
     boundWidget.setState(initialState);
     return boundWidget;
   }
+
+  getByName(name, container) {
+    // eslint-disable-next-line new-cap
+    return new this.boundWidgetClass(container, name);
+  }
 }
 
 export class BoundCheckboxInput extends BoundWidget {

--- a/client/src/components/Widget/index.js
+++ b/client/src/components/Widget/index.js
@@ -2,14 +2,7 @@ import { setAttrs } from '../../utils/attrs';
 import { runInlineScripts } from '../../utils/runInlineScripts';
 
 export class BoundWidget {
-  constructor(
-    elementOrNodeList,
-    name,
-    idForLabel,
-    initialState,
-    parentCapabilities,
-    options,
-  ) {
+  constructor(elementOrNodeList, name, idForLabel, parentCapabilities) {
     // if elementOrNodeList not iterable, it must be a single element
     const nodeList = elementOrNodeList.forEach
       ? elementOrNodeList
@@ -36,9 +29,7 @@ export class BoundWidget {
     }
 
     this.idForLabel = idForLabel;
-    this.setState(initialState);
     this.parentCapabilities = parentCapabilities || new Map();
-    this.options = options;
   }
 
   getValue() {
@@ -122,14 +113,14 @@ export class Widget {
     }
 
     // eslint-disable-next-line new-cap
-    return new this.boundWidgetClass(
+    const boundWidget = new this.boundWidgetClass(
       childElements.length === 1 ? childElements[0] : childNodes,
       name,
       idForLabel,
-      initialState,
       parentCapabilities,
-      options,
     );
+    boundWidget.setState(initialState);
+    return boundWidget;
   }
 }
 
@@ -152,7 +143,7 @@ export class CheckboxInput extends Widget {
 }
 
 export class BoundRadioSelect {
-  constructor(element, name, idForLabel, initialState) {
+  constructor(element, name, idForLabel) {
     this.element = element;
     this.name = name;
     this.idForLabel = idForLabel;
@@ -160,7 +151,6 @@ export class BoundRadioSelect {
       `input[name="${name}"][type="checkbox"]`,
     );
     this.selector = `input[name="${name}"]:checked`;
-    this.setState(initialState);
   }
 
   getValue() {

--- a/client/src/components/Widget/index.js
+++ b/client/src/components/Widget/index.js
@@ -248,3 +248,32 @@ export class BoundSelect extends BoundWidget {
 export class Select extends Widget {
   boundWidgetClass = BoundSelect;
 }
+
+export class BlockWidget extends Widget {
+  constructor() {
+    // Pass an empty string as the HTML. This means we cannot generate new instances through `render`,
+    // but we're not making use of that - and the real HTML would embed the block definition as a data
+    // attribute, which could potentially be huge.
+    super('');
+  }
+
+  render() {
+    throw new Error('BlockWidget does not support rendering');
+  }
+
+  getByName(name, container) {
+    // Retrieve the block object that was stashed on the root element by BlockController
+    const rootElement = querySelectorIncludingSelf(container, `#${name}-root`);
+    if (!rootElement) {
+      throw new InputNotFoundError(name);
+    }
+    if (!rootElement.rootBlock) {
+      throw new Error(
+        `BlockWidget with name "${name}" does not have a root block attached.`,
+      );
+    }
+    // The API for block objects matches the one for widgets (getValue, getState, etc.),
+    // so we just return that in lieu of a BoundWidget.
+    return rootElement.rootBlock;
+  }
+}

--- a/client/src/components/Widget/index.test.js
+++ b/client/src/components/Widget/index.test.js
@@ -88,6 +88,13 @@ describe('Widget', () => {
     expect(input.getAttribute('aria-describedby')).toBe('some-id');
     expect(input.required).toBe(true);
   });
+
+  it('can be retrieved for an existing form element', () => {
+    document.body.innerHTML =
+      '<input type="text" name="surname" id="id_surname" value="Bobson">';
+    const otherBoundWidget = widgetDef.getByName('surname', document.body);
+    expect(otherBoundWidget.getValue()).toBe('Bobson');
+  });
 });
 
 describe('Widget with inline JS', () => {

--- a/client/src/components/Widget/index.test.js
+++ b/client/src/components/Widget/index.test.js
@@ -10,7 +10,6 @@ describe('Widget', () => {
 
     widgetDef = new Widget(
       '<input type="text" name="__NAME__" maxlength="255" id="__ID__">',
-      '__ID__',
     );
     boundWidget = widgetDef.render(
       document.getElementById('placeholder'),
@@ -29,7 +28,7 @@ describe('Widget', () => {
 
   test('it fails rendering if no input is found', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
-    const nonWidget = new Widget('<div>Not an input</div>', '__ID__');
+    const nonWidget = new Widget('<div>Not an input</div>');
     expect(() => {
       nonWidget.render(
         document.getElementById('placeholder'),
@@ -120,7 +119,6 @@ describe('Widget with inline JS', () => {
 
     widgetDef = new Widget(
       '<div><input type="text" name="__NAME__" maxlength="255" id="__ID__"><script>document.getElementById("__ID__").className = "custom-class";</script></div>',
-      '__ID__',
     );
     boundWidget = widgetDef.render(
       document.getElementById('placeholder'),
@@ -152,7 +150,6 @@ describe('Widget with multiple top-level nodes', () => {
 
     widgetDef = new Widget(
       '<!-- here comes a widget --><input type="text" name="__NAME__" maxlength="255" id="__ID__"><button data-button-state="idle">Click me</button><script>document.getElementById("__ID__").className = "custom-class";</script>',
-      '__ID__',
     );
     boundWidget = widgetDef.render(
       document.getElementById('placeholder'),
@@ -191,7 +188,6 @@ describe('RadioSelect', () => {
           <input type="radio" name="__NAME__" value="coffee" id="__ID___1"> Coffee</label>
         </li>
       </ul>`,
-      '__ID___0',
     );
     boundWidget = widgetDef.render(
       document.getElementById('placeholder'),
@@ -273,7 +269,6 @@ describe('RadioSelect for CheckboxSelectMultiple', () => {
           <input type="checkbox" name="__NAME__" value="blue" id="__ID___2"> Blue</label>
         </li>
       </ul>`,
-      '__ID___0',
     );
     boundWidget = widgetDef.render(
       document.getElementById('placeholder'),
@@ -315,7 +310,6 @@ describe('CheckboxInput', () => {
 
     const widgetDef = new CheckboxInput(
       '<input type="checkbox" name="__NAME__" id="__ID__">',
-      '__ID__',
     );
     boundWidget = widgetDef.render(
       document.getElementById('placeholder'),
@@ -365,7 +359,6 @@ describe('Select', () => {
         <option value="1">Option 1</option>
         <option value="2">Option 2</option>
       </select>`,
-      '__ID__',
     );
     boundWidget = widgetDef.render(
       document.getElementById('placeholder'),
@@ -417,7 +410,6 @@ describe('Select multiple', () => {
         <option value="green">Green</option>
         <option value="blue">Blue</option>
       </select>`,
-      '__ID__',
     );
     boundWidget = widgetDef.render(
       document.getElementById('placeholder'),

--- a/client/src/components/Widget/index.test.js
+++ b/client/src/components/Widget/index.test.js
@@ -27,6 +27,19 @@ describe('Widget', () => {
     expect(document.querySelector('input').value).toBe('The Value');
   });
 
+  test('it fails rendering if no input is found', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const nonWidget = new Widget('<div>Not an input</div>', '__ID__');
+    expect(() => {
+      nonWidget.render(
+        document.getElementById('placeholder'),
+        'the-name',
+        'the-id',
+        'The Value',
+      );
+    }).toThrow('No input found with name "the-name"');
+  });
+
   test('getValue() returns the current value', () => {
     expect(boundWidget.getValue()).toBe('The Value');
     document.querySelector('input').value = 'New Value';

--- a/client/src/controllers/BlockController.test.js
+++ b/client/src/controllers/BlockController.test.js
@@ -1,7 +1,7 @@
 import { Application } from '@hotwired/stimulus';
 import { BlockController } from './BlockController';
 
-const render = jest.fn();
+const render = jest.fn(() => ({ element: document.createElement('div') }));
 const unpack = jest.fn(() => ({ render }));
 window.telepath = { unpack };
 

--- a/client/src/controllers/BlockController.ts
+++ b/client/src/controllers/BlockController.ts
@@ -57,7 +57,13 @@ export class BlockController extends Controller<HTMLElement> {
     }
 
     const output = telepath.unpack(this.dataValue);
-    output.render(element, id, ...this.argumentsValue);
+    const rootBlock = output.render(element, id, ...this.argumentsValue);
+
+    // attach a reference to the top-level block to the root element, so that the BlockWidget
+    // JS class can retrieve it later
+    rootBlock.element.id = `${id}-root`;
+    rootBlock.element.rootBlock = rootBlock;
+
     this.dispatch('ready', { detail: { ...output }, cancelable: false });
   }
 }

--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -52,6 +52,11 @@ if (!window.telepath) {
 window.telepath.register('wagtail.panels.Panel', Panel);
 window.telepath.register('wagtail.panels.PanelGroup', PanelGroup);
 window.telepath.register('wagtail.panels.FieldPanel', FieldPanel);
+window.telepath.register('wagtail.panels.InlinePanel', InlinePanel);
+window.telepath.register(
+  'wagtail.panels.MultipleChooserPanel',
+  MultipleChooserPanel,
+);
 
 /**
  * Support legacy, undocumented, usage of `buildExpandingFormset` as a global function.

--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -48,6 +48,23 @@ if (!window.telepath) {
   window.telepath = new Telepath();
 }
 
+class Panel {}
+window.telepath.register('wagtail.panels.Panel', Panel);
+
+class PanelGroup {
+  constructor(children) {
+    this.children = children;
+  }
+}
+window.telepath.register('wagtail.panels.PanelGroup', PanelGroup);
+
+class FieldPanel {
+  constructor(fieldName) {
+    this.fieldName = fieldName;
+  }
+}
+window.telepath.register('wagtail.panels.FieldPanel', FieldPanel);
+
 /**
  * Support legacy, undocumented, usage of `buildExpandingFormset` as a global function.
  * @deprecated RemovedInWagtail80

--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -4,6 +4,7 @@ import Telepath from 'telepath-unpack';
 import { Icon, Portal } from '../..';
 import { ExpandingFormset } from '../../components/ExpandingFormset';
 import { coreControllerDefinitions } from '../../controllers';
+import { Panel, PanelGroup, FieldPanel } from '../../components/Panel';
 import { InlinePanel } from '../../components/InlinePanel';
 import { MultipleChooserPanel } from '../../components/MultipleChooserPanel';
 import { WAGTAIL_CONFIG } from '../../config/wagtailConfig';
@@ -48,21 +49,8 @@ if (!window.telepath) {
   window.telepath = new Telepath();
 }
 
-class Panel {}
 window.telepath.register('wagtail.panels.Panel', Panel);
-
-class PanelGroup {
-  constructor(children) {
-    this.children = children;
-  }
-}
 window.telepath.register('wagtail.panels.PanelGroup', PanelGroup);
-
-class FieldPanel {
-  constructor(fieldName) {
-    this.fieldName = fieldName;
-  }
-}
 window.telepath.register('wagtail.panels.FieldPanel', FieldPanel);
 
 /**

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -3,12 +3,14 @@ import {
   CheckboxInput,
   RadioSelect,
   Select,
+  BlockWidget,
 } from '../../../components/Widget';
 
 window.telepath.register('wagtail.widgets.Widget', Widget);
 window.telepath.register('wagtail.widgets.CheckboxInput', CheckboxInput);
 window.telepath.register('wagtail.widgets.RadioSelect', RadioSelect);
 window.telepath.register('wagtail.widgets.Select', Select);
+window.telepath.register('wagtail.widgets.BlockWidget', BlockWidget);
 
 class ValidationError {
   constructor(messages) {

--- a/client/src/entrypoints/admin/wagtailadmin.js
+++ b/client/src/entrypoints/admin/wagtailadmin.js
@@ -13,6 +13,14 @@ document.addEventListener('DOMContentLoaded', () => {
   initTabs();
   initSidePanel();
   initCollapsiblePanels();
+
+  const editHandlerElement = document.querySelector('[data-edit-handler]');
+  if (editHandlerElement) {
+    const editHandlerJson =
+      editHandlerElement.getAttribute('data-edit-handler');
+    const packedEditHandler = JSON.parse(editHandlerJson);
+    window.editHandler = window.telepath.unpack(packedEditHandler);
+  }
 });
 
 /**

--- a/docs/reference/streamfield/widget_api.md
+++ b/docs/reference/streamfield/widget_api.md
@@ -24,10 +24,9 @@ class FancyInputAdapter(WidgetAdapter):
     def js_args(self, widget):
         return [
             # Arguments typically include the widget's HTML representation
-            # and label ID rendered with __NAME__ and __ID__ placeholders,
-            # for use in the client-side render() method
+            # rendered with __NAME__ and __ID__ placeholders, for use in the
+            # client-side render() method
             widget.render('__NAME__', None, attrs={'id': '__ID__'}),
-            widget.id_for_label('__ID__'),
             widget.extra_options,
         ]
 

--- a/wagtail/admin/panels/base.py
+++ b/wagtail/admin/panels/base.py
@@ -328,4 +328,4 @@ class Panel:
             )
 
         def telepath_pack(self, context):
-            return ("wagtail.panels.Panel", [])
+            return ("wagtail.panels.Panel", [type(self.panel).__name__])

--- a/wagtail/admin/panels/base.py
+++ b/wagtail/admin/panels/base.py
@@ -5,6 +5,7 @@ from wagtail.admin.forms.models import (
     WagtailAdminDraftStateFormMixin,
     WagtailAdminModelForm,
 )
+from wagtail.admin.telepath import register as register_telepath_adapter
 from wagtail.admin.ui.components import Component
 from wagtail.blocks import StreamValue
 from wagtail.coreutils import safe_snake_case
@@ -223,6 +224,7 @@ class Panel:
 
         return value
 
+    @register_telepath_adapter
     class BoundPanel(Component):
         """
         A template component for a panel that has been associated with a model instance, form, and request.
@@ -324,3 +326,6 @@ class Panel:
                 self.request,
                 self.form.__class__.__name__,
             )
+
+        def telepath_pack(self, context):
+            return ("wagtail.panels.Panel", [])

--- a/wagtail/admin/panels/base.py
+++ b/wagtail/admin/panels/base.py
@@ -327,5 +327,12 @@ class Panel:
                 self.form.__class__.__name__,
             )
 
+        telepath_adapter_name = "wagtail.panels.Panel"
+
+        def js_opts(self):
+            return {
+                "type": type(self.panel).__name__,
+            }
+
         def telepath_pack(self, context):
-            return ("wagtail.panels.Panel", [type(self.panel).__name__])
+            return (self.telepath_adapter_name, [self.js_opts()])

--- a/wagtail/admin/panels/base.py
+++ b/wagtail/admin/panels/base.py
@@ -332,6 +332,7 @@ class Panel:
         def js_opts(self):
             return {
                 "type": type(self.panel).__name__,
+                "prefix": self.prefix,
             }
 
         def telepath_pack(self, context):

--- a/wagtail/admin/panels/field_panel.py
+++ b/wagtail/admin/panels/field_panel.py
@@ -393,4 +393,7 @@ class FieldPanel(Panel):
             )
 
         def telepath_pack(self, context):
-            return ("wagtail.panels.FieldPanel", [self.field_name])
+            return (
+                "wagtail.panels.FieldPanel",
+                [self.field_name, self.bound_field.field.widget],
+            )

--- a/wagtail/admin/panels/field_panel.py
+++ b/wagtail/admin/panels/field_panel.py
@@ -392,12 +392,14 @@ class FieldPanel(Panel):
                 self.form.__class__.__name__,
             )
 
-        def telepath_pack(self, context):
-            return (
-                "wagtail.panels.FieldPanel",
-                [
-                    type(self.panel).__name__,
-                    self.field_name,
-                    self.bound_field.field.widget,
-                ],
+        telepath_adapter_name = "wagtail.panels.FieldPanel"
+
+        def js_opts(self):
+            opts = super().js_opts()
+            opts.update(
+                {
+                    "fieldName": self.field_name,
+                    "widget": self.bound_field.field.widget,
+                }
             )
+            return opts

--- a/wagtail/admin/panels/field_panel.py
+++ b/wagtail/admin/panels/field_panel.py
@@ -395,5 +395,9 @@ class FieldPanel(Panel):
         def telepath_pack(self, context):
             return (
                 "wagtail.panels.FieldPanel",
-                [self.field_name, self.bound_field.field.widget],
+                [
+                    type(self.panel).__name__,
+                    self.field_name,
+                    self.bound_field.field.widget,
+                ],
             )

--- a/wagtail/admin/panels/field_panel.py
+++ b/wagtail/admin/panels/field_panel.py
@@ -9,6 +9,7 @@ from django.utils.text import capfirst
 
 from wagtail.admin import compare
 from wagtail.admin.forms.models import registry as model_field_registry
+from wagtail.admin.telepath import register as register_telepath_adapter
 from wagtail.blocks import BlockField
 
 from .base import Panel
@@ -148,6 +149,7 @@ class FieldPanel(Panel):
             self.model,
         )
 
+    @register_telepath_adapter
     class BoundPanel(Panel.BoundPanel):
         template_name = "wagtailadmin/panels/field_panel.html"
         # Default icons for common model field types,
@@ -389,3 +391,6 @@ class FieldPanel(Panel):
                 self.request,
                 self.form.__class__.__name__,
             )
+
+        def telepath_pack(self, context):
+            return ("wagtail.panels.FieldPanel", [self.field_name])

--- a/wagtail/admin/panels/group.py
+++ b/wagtail/admin/panels/group.py
@@ -159,11 +159,12 @@ class PanelGroup(Panel):
 
             return comparators
 
-        def telepath_pack(self, context):
-            return (
-                "wagtail.panels.PanelGroup",
-                [type(self.panel).__name__, self.visible_children],
-            )
+        telepath_adapter_name = "wagtail.panels.PanelGroup"
+
+        def js_opts(self):
+            opts = super().js_opts()
+            opts["children"] = self.visible_children
+            return opts
 
 
 class TabbedInterface(PanelGroup):

--- a/wagtail/admin/panels/group.py
+++ b/wagtail/admin/panels/group.py
@@ -1,6 +1,8 @@
 from django.forms import Media
 from django.utils.functional import cached_property
 
+from wagtail.admin.telepath import register as register_telepath_adapter
+
 from .base import Panel
 
 
@@ -97,6 +99,7 @@ class PanelGroup(Panel):
 
         return result
 
+    @register_telepath_adapter
     class BoundPanel(Panel.BoundPanel):
         @cached_property
         def children(self):
@@ -155,6 +158,9 @@ class PanelGroup(Panel):
                 comparators.extend(child.get_comparison())
 
             return comparators
+
+        def telepath_pack(self, context):
+            return ("wagtail.panels.PanelGroup", [self.children])
 
 
 class TabbedInterface(PanelGroup):

--- a/wagtail/admin/panels/group.py
+++ b/wagtail/admin/panels/group.py
@@ -160,7 +160,10 @@ class PanelGroup(Panel):
             return comparators
 
         def telepath_pack(self, context):
-            return ("wagtail.panels.PanelGroup", [self.visible_children])
+            return (
+                "wagtail.panels.PanelGroup",
+                [type(self.panel).__name__, self.visible_children],
+            )
 
 
 class TabbedInterface(PanelGroup):

--- a/wagtail/admin/panels/group.py
+++ b/wagtail/admin/panels/group.py
@@ -160,7 +160,7 @@ class PanelGroup(Panel):
             return comparators
 
         def telepath_pack(self, context):
-            return ("wagtail.panels.PanelGroup", [self.children])
+            return ("wagtail.panels.PanelGroup", [self.visible_children])
 
 
 class TabbedInterface(PanelGroup):

--- a/wagtail/admin/panels/inline_panel.py
+++ b/wagtail/admin/panels/inline_panel.py
@@ -1,4 +1,5 @@
 import functools
+import json
 
 from django import forms
 from django.forms.formsets import DELETION_FIELD_NAME, ORDERING_FIELD_NAME
@@ -174,7 +175,16 @@ class InlinePanel(Panel):
                 )
             ]
 
+        @property
+        def js_opts(self):
+            return {
+                "formsetPrefix": f"id_{self.formset.prefix}",
+                "emptyChildFormPrefix": self.empty_child.form.prefix,
+                "canOrder": self.formset.can_order,
+                "maxForms": self.formset.max_num,
+            }
+
         def get_context_data(self, parent_context=None):
             context = super().get_context_data(parent_context)
-            context["can_order"] = self.formset.can_order
+            context["options_json"] = json.dumps(self.js_opts)
             return context

--- a/wagtail/admin/panels/inline_panel.py
+++ b/wagtail/admin/panels/inline_panel.py
@@ -177,9 +177,11 @@ class InlinePanel(Panel):
                 )
             ]
 
-        @property
+        telepath_adapter_name = "wagtail.panels.InlinePanel"
+
         def js_opts(self):
             return {
+                "type": type(self.panel).__name__,
                 "formsetPrefix": f"id_{self.formset.prefix}",
                 "emptyChildFormPrefix": self.empty_child.form.prefix,
                 "canOrder": self.formset.can_order,
@@ -189,14 +191,5 @@ class InlinePanel(Panel):
 
         def get_context_data(self, parent_context=None):
             context = super().get_context_data(parent_context)
-            context["options_json"] = json.dumps(self.js_opts)
+            context["options_json"] = json.dumps(self.js_opts())
             return context
-
-        def telepath_pack(self, context):
-            return (
-                "wagtail.panels.InlinePanel",
-                [
-                    type(self.panel).__name__,
-                    self.js_opts,
-                ],
-            )

--- a/wagtail/admin/panels/inline_panel.py
+++ b/wagtail/admin/panels/inline_panel.py
@@ -7,6 +7,7 @@ from django.utils.functional import cached_property
 from django.utils.text import capfirst
 
 from wagtail.admin import compare
+from wagtail.admin.telepath import register as register_telepath_adapter
 
 from .base import Panel, get_form_for_model
 from .group import MultiFieldPanel
@@ -100,6 +101,7 @@ class InlinePanel(Panel):
     def classes(self):
         return super().classes() + ["w-panel--nested"]
 
+    @register_telepath_adapter
     class BoundPanel(Panel.BoundPanel):
         template_name = "wagtailadmin/panels/inline_panel.html"
 
@@ -182,9 +184,19 @@ class InlinePanel(Panel):
                 "emptyChildFormPrefix": self.empty_child.form.prefix,
                 "canOrder": self.formset.can_order,
                 "maxForms": self.formset.max_num,
+                "relationName": self.panel.relation_name,
             }
 
         def get_context_data(self, parent_context=None):
             context = super().get_context_data(parent_context)
             context["options_json"] = json.dumps(self.js_opts)
             return context
+
+        def telepath_pack(self, context):
+            return (
+                "wagtail.panels.InlinePanel",
+                [
+                    type(self.panel).__name__,
+                    self.js_opts,
+                ],
+            )

--- a/wagtail/admin/panels/inline_panel.py
+++ b/wagtail/admin/panels/inline_panel.py
@@ -193,3 +193,9 @@ class InlinePanel(Panel):
             context = super().get_context_data(parent_context)
             context["options_json"] = json.dumps(self.js_opts())
             return context
+
+        def telepath_pack(self, context):
+            # pass initControls = False so that we do not initialize controls while calling
+            # the constructor; this prevents attaching event handlers multiple times if the
+            # object is unpacked multiple times
+            return (self.telepath_adapter_name, [self.js_opts(), False])

--- a/wagtail/admin/panels/multiple_chooser_panel.py
+++ b/wagtail/admin/panels/multiple_chooser_panel.py
@@ -35,9 +35,14 @@ class MultipleChooserPanel(InlinePanel):
                     self.chooser_widget
                 )
 
+        @property
+        def js_opts(self):
+            opts = super().js_opts
+            opts["chooserFieldName"] = self.panel.chooser_field_name
+            return opts
+
         def get_context_data(self, parent_context=None):
             context = super().get_context_data(parent_context)
-            context["chooser_field_name"] = self.panel.chooser_field_name
             context["chooser_widget_definition"] = (
                 self.chooser_widget_telepath_definition
             )

--- a/wagtail/admin/panels/multiple_chooser_panel.py
+++ b/wagtail/admin/panels/multiple_chooser_panel.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import ImproperlyConfigured
 
 from wagtail.admin.telepath import JSContext
+from wagtail.admin.telepath import register as register_telepath_adapter
 
 from .inline_panel import InlinePanel
 
@@ -20,6 +21,7 @@ class MultipleChooserPanel(InlinePanel):
         kwargs["chooser_field_name"] = self.chooser_field_name
         return kwargs
 
+    @register_telepath_adapter
     class BoundPanel(InlinePanel.BoundPanel):
         template_name = "wagtailadmin/panels/multiple_chooser_panel.html"
 
@@ -51,3 +53,12 @@ class MultipleChooserPanel(InlinePanel):
         @property
         def media(self):
             return super().media + self.js_context.media
+
+        def telepath_pack(self, context):
+            return (
+                "wagtail.panels.MultipleChooserPanel",
+                [
+                    type(self.panel).__name__,
+                    self.js_opts,
+                ],
+            )

--- a/wagtail/admin/panels/multiple_chooser_panel.py
+++ b/wagtail/admin/panels/multiple_chooser_panel.py
@@ -37,9 +37,10 @@ class MultipleChooserPanel(InlinePanel):
                     self.chooser_widget
                 )
 
-        @property
+        telepath_adapter_name = "wagtail.panels.MultipleChooserPanel"
+
         def js_opts(self):
-            opts = super().js_opts
+            opts = super().js_opts()
             opts["chooserFieldName"] = self.panel.chooser_field_name
             return opts
 
@@ -53,12 +54,3 @@ class MultipleChooserPanel(InlinePanel):
         @property
         def media(self):
             return super().media + self.js_context.media
-
-        def telepath_pack(self, context):
-            return (
-                "wagtail.panels.MultipleChooserPanel",
-                [
-                    type(self.panel).__name__,
-                    self.js_opts,
-                ],
-            )

--- a/wagtail/admin/telepath/__init__.py
+++ b/wagtail/admin/telepath/__init__.py
@@ -18,8 +18,8 @@ registry = WagtailAdapterRegistry(telepath_js_path=None)
 JSContext = registry.js_context_class
 
 
-def register(adapter, cls):
-    registry.register(adapter, cls)
+def register(*args, **kwargs):
+    return registry.register(*args, **kwargs)
 
 
 def adapter(js_constructor, base=Adapter):

--- a/wagtail/admin/telepath/widgets.py
+++ b/wagtail/admin/telepath/widgets.py
@@ -18,7 +18,6 @@ class WidgetAdapter(Adapter):
     def js_args(self, widget):
         return [
             widget.render("__NAME__", None, attrs={"id": "__ID__"}),
-            widget.id_for_label("__ID__"),
         ]
 
     def get_media(self, widget):

--- a/wagtail/admin/telepath/widgets.py
+++ b/wagtail/admin/telepath/widgets.py
@@ -33,8 +33,7 @@ class WidgetAdapter(Adapter):
         )
 
 
-register(WidgetAdapter(), forms.widgets.Input)
-register(WidgetAdapter(), forms.Textarea)
+register(WidgetAdapter(), forms.widgets.Widget)
 
 
 class CheckboxInputAdapter(WidgetAdapter):

--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -29,6 +29,7 @@
         data-w-unsaved-confirmation-value="true"
         data-w-unsaved-force-value="{{ has_unsaved_changes|yesno:'true,false' }}"
         data-w-unsaved-watch-value="edits"
+        {% if edit_handler_json %} data-edit-handler="{{ edit_handler_json }}"{% endif %}
     >
         {% csrf_token %}
 

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -37,13 +37,6 @@
                 {# Reuse the footer container, but redefine the actions content down below to use component classes #}
             {% endblock %}
         </form>
-        <script>
-            const form = document.getElementById('page-edit-form');
-            const editHandlerJson = form.getAttribute('data-edit-handler');
-            const packedEditHandler = JSON.parse(editHandlerJson);
-            const editHandler = window.telepath.unpack(packedEditHandler);
-            console.log(editHandler.getWidgets());
-        </script>
     {% endblock %}
 {% endblock %}
 

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -25,6 +25,7 @@
             data-w-unsaved-confirmation-value="true"
             data-w-unsaved-force-value="{% if has_unsaved_changes %}true{% else %}false{% endif %}"
             data-w-unsaved-watch-value="edits{% if comments_enabled %} comments{% endif %}"
+            data-edit-handler="{{ edit_handler_json }}"
         >
             {% csrf_token %}
 
@@ -36,6 +37,13 @@
                 {# Reuse the footer container, but redefine the actions content down below to use component classes #}
             {% endblock %}
         </form>
+        <script>
+            const form = document.getElementById('page-edit-form');
+            const editHandlerJson = form.getAttribute('data-edit-handler');
+            const packedEditHandler = JSON.parse(editHandlerJson);
+            const editHandler = window.telepath.unpack(packedEditHandler);
+            console.log(editHandler);
+        </script>
     {% endblock %}
 {% endblock %}
 

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -42,7 +42,7 @@
             const editHandlerJson = form.getAttribute('data-edit-handler');
             const packedEditHandler = JSON.parse(editHandlerJson);
             const editHandler = window.telepath.unpack(packedEditHandler);
-            console.log(editHandler);
+            console.log(editHandler.getWidgets());
         </script>
     {% endblock %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
@@ -43,7 +43,7 @@
 {% block js_init %}
     <script>
         (function() {
-            var panel = new InlinePanel(JSON.parse("{{options_json|escapejs}}"));
+            var panel = new InlinePanel("InlinePanel", JSON.parse("{{options_json|escapejs}}"));
         })();
     </script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
@@ -43,7 +43,7 @@
 {% block js_init %}
     <script>
         (function() {
-            var panel = new InlinePanel("InlinePanel", JSON.parse("{{options_json|escapejs}}"));
+            var panel = new InlinePanel(JSON.parse("{{options_json|escapejs}}"));
         })();
     </script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
@@ -43,12 +43,7 @@
 {% block js_init %}
     <script>
         (function() {
-            var panel = new InlinePanel({
-                formsetPrefix: "id_{{ self.formset.prefix }}",
-                emptyChildFormPrefix: "{{ self.empty_child.form.prefix }}",
-                canOrder: {% if can_order %}true{% else %}false{% endif %},
-                maxForms: {{ self.formset.max_num|unlocalize }}
-            });
+            var panel = new InlinePanel(JSON.parse("{{options_json|escapejs}}"));
         })();
     </script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/panels/multiple_chooser_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/multiple_chooser_panel.html
@@ -14,13 +14,7 @@
 
     <script>
         (function() {
-            var panel = new MultipleChooserPanel({
-                formsetPrefix: "id_{{ self.formset.prefix }}",
-                emptyChildFormPrefix: "{{ self.empty_child.form.prefix }}",
-                canOrder: {% if can_order %}true{% else %}false{% endif %},
-                maxForms: {{ self.formset.max_num|unlocalize }},
-                chooserFieldName: "{{ chooser_field_name }}",
-            });
+            var panel = new MultipleChooserPanel(JSON.parse("{{options_json|escapejs}}"));
         })();
     </script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/panels/multiple_chooser_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/multiple_chooser_panel.html
@@ -14,7 +14,7 @@
 
     <script>
         (function() {
-            var panel = new MultipleChooserPanel("MultipleChooserPanel", JSON.parse("{{options_json|escapejs}}"));
+            var panel = new MultipleChooserPanel(JSON.parse("{{options_json|escapejs}}"));
         })();
     </script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/panels/multiple_chooser_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/multiple_chooser_panel.html
@@ -14,7 +14,7 @@
 
     <script>
         (function() {
-            var panel = new MultipleChooserPanel(JSON.parse("{{options_json|escapejs}}"));
+            var panel = new MultipleChooserPanel("MultipleChooserPanel", JSON.parse("{{options_json|escapejs}}"));
         })();
     </script>
 {% endblock %}

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -2248,7 +2248,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         # as when running it within the full test suite
         self.client.get(reverse("wagtailadmin_pages:edit", args=(self.event_page.id,)))
 
-        with self.assertNumQueries(35):
+        with self.assertNumQueries(36):
             self.client.get(
                 reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
             )
@@ -2261,7 +2261,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         # Warm up the cache as above.
         self.client.get(reverse("wagtailadmin_pages:edit", args=(self.event_page.id,)))
 
-        with self.assertNumQueries(40):
+        with self.assertNumQueries(41):
             self.client.get(
                 reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
             )

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -1415,7 +1415,7 @@ class TestInlinePanel(WagtailTestUtils, TestCase):
         )
 
         # rendered panel must include the JS initializer
-        self.assertIn("var panel = new InlinePanel({", result)
+        self.assertIn("var panel = new InlinePanel(", result)
 
         # rendered panel must have data-contentpath-disabled attribute by default
         self.assertIn("data-contentpath-disabled", result)
@@ -1505,7 +1505,7 @@ class TestInlinePanel(WagtailTestUtils, TestCase):
         )
 
         # render_js_init must provide the JS initializer
-        self.assertIn("var panel = new InlinePanel({", panel.render_html())
+        self.assertIn("var panel = new InlinePanel(", panel.render_html())
 
     @override_settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True)
     def test_no_thousand_separators_in_js(self):
@@ -1535,7 +1535,7 @@ class TestInlinePanel(WagtailTestUtils, TestCase):
             instance=event_page, form=form, request=self.request
         )
 
-        self.assertIn("maxForms: 1000", panel.render_html())
+        self.assertIn(r"\u0022maxForms\u0022: 1000", panel.render_html())
 
     def test_invalid_inlinepanel_declaration(self):
         with self.ignore_deprecation_warnings():
@@ -2144,7 +2144,9 @@ class TestMultipleChooserPanel(WagtailTestUtils, TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'name="gallery_images-TOTAL_FORMS"')
-        self.assertContains(response, 'chooserFieldName: "image"')
+        self.assertContains(
+            response, r"\u0022chooserFieldName\u0022: \u0022image\u0022"
+        )
 
 
 class TestMultipleChooserPanelGetComparison(TestCase):

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -20,6 +20,7 @@ from wagtail import hooks
 from wagtail.admin import messages
 from wagtail.admin.forms.models import WagtailAdminModelForm
 from wagtail.admin.models import EditingSession
+from wagtail.admin.telepath import JSContext
 from wagtail.admin.templatetags.wagtailadmin_tags import user_display_name
 from wagtail.admin.ui.editing_sessions import EditingSessionsModule
 from wagtail.admin.ui.tables import LiveStatusTagColumn, TitleColumn
@@ -183,6 +184,7 @@ class PanelMixin:
 
         form = context.get("form")
         panel = self.get_bound_panel(form)
+        edit_handler_json = None
 
         media = context.get("media", Media())
         if form:
@@ -190,10 +192,16 @@ class PanelMixin:
         if panel:
             media += panel.media
 
+            js_context = JSContext()
+            packed_edit_handler = js_context.pack(panel)
+            edit_handler_json = json.dumps(packed_edit_handler)
+            media += js_context.media
+
         context.update(
             {
                 "panel": panel,
                 "media": media,
+                "edit_handler_json": edit_handler_json,
             }
         )
 

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -1,3 +1,4 @@
+import json
 from urllib.parse import quote, urlencode
 
 from django.conf import settings
@@ -15,6 +16,7 @@ from django.views.generic.base import View
 
 from wagtail.admin import messages
 from wagtail.admin.action_menu import PageActionMenu
+from wagtail.admin.telepath import JSContext
 from wagtail.admin.ui.components import MediaContainer
 from wagtail.admin.ui.side_panels import (
     ChecksSidePanel,
@@ -452,7 +454,13 @@ class CreateView(WagtailAdminTemplateMixin, HookResponseMixin, View):
         )
         side_panels = self.get_side_panels()
 
-        media = MediaContainer([bound_panel, self.form, action_menu, side_panels]).media
+        js_context = JSContext()
+        packed_edit_handler = js_context.pack(bound_panel)
+        edit_handler_json = json.dumps(packed_edit_handler)
+
+        media = MediaContainer(
+            [bound_panel, self.form, action_menu, side_panels, js_context]
+        ).media
 
         context.update(
             {
@@ -460,6 +468,7 @@ class CreateView(WagtailAdminTemplateMixin, HookResponseMixin, View):
                 "page_class": self.page_class,
                 "parent_page": self.parent_page,
                 "edit_handler": bound_panel,
+                "edit_handler_json": edit_handler_json,
                 "action_menu": action_menu,
                 "side_panels": side_panels,
                 "form": self.form,

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -19,6 +19,7 @@ from wagtail.admin import messages
 from wagtail.admin.action_menu import PageActionMenu
 from wagtail.admin.mail import send_notification
 from wagtail.admin.models import EditingSession
+from wagtail.admin.telepath import JSContext
 from wagtail.admin.ui.components import MediaContainer
 from wagtail.admin.ui.editing_sessions import EditingSessionsModule
 from wagtail.admin.ui.side_panels import (
@@ -945,7 +946,13 @@ class EditView(WagtailAdminTemplateMixin, HookResponseMixin, View):
         action_menu = self.get_action_menu()
         side_panels = self.get_side_panels()
 
-        media = MediaContainer([bound_panel, self.form, action_menu, side_panels]).media
+        js_context = JSContext()
+        packed_edit_handler = js_context.pack(bound_panel)
+        edit_handler_json = json.dumps(packed_edit_handler)
+
+        media = MediaContainer(
+            [bound_panel, self.form, action_menu, side_panels, js_context]
+        ).media
 
         context.update(
             {
@@ -953,6 +960,7 @@ class EditView(WagtailAdminTemplateMixin, HookResponseMixin, View):
                 "page_for_status": self.page_for_status,
                 "content_type": self.page_content_type,
                 "edit_handler": bound_panel,
+                "edit_handler_json": edit_handler_json,
                 "errors_debug": self.errors_debug,
                 "action_menu": action_menu,
                 "side_panels": side_panels,

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -17,6 +17,7 @@ from django.utils.text import capfirst
 
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.telepath import JSContext
+from wagtail.admin.telepath import register as register_telepath_adapter
 from wagtail.utils.templates import template_is_overridden
 
 __all__ = [
@@ -654,6 +655,7 @@ class DeclarativeSubBlocksMetaclass(BaseBlock):
 # ========================
 
 
+@register_telepath_adapter
 class BlockWidget(forms.Widget):
     """Wraps a block object as a widget so that it can be incorporated into a Django form"""
 
@@ -734,6 +736,9 @@ class BlockWidget(forms.Widget):
 
     def value_omitted_from_data(self, data, files, name):
         return self.block_def.value_omitted_from_data(data, files, name)
+
+    def telepath_pack(self, context):
+        return ("wagtail.widgets.BlockWidget", [])
 
 
 class BlockField(forms.Field):


### PR DESCRIPTION
This PR makes a variable `window.editHandler` available on the page create view, page edit view, and all create/edit views extending PanelMixin (including snippets). This gives client-side code the ability to manipulate the form structure in various ways:

* navigating the panel tree via the `.children` attribute on group panel types
* retrieving the FieldPanel / InlinePanel for a given field name with `.getPanelByName("foo")`
* accessing the underlying widget for a FieldPanel with `getBoundWidget()`; however, this may not be reliable for third-party widgets if A) they already provide a telepath adapter (for use in StreamField) but do not implement the newly-added `getByName` method, or B) they do not provide a telepath adapter and the base `Widget` implementation (which looks for an `input` / `select` / `textarea` element matching by name) is insufficient
* notably, the widget returned for a StreamField is the top-level block of the stream, allowing further descent into the StreamField block tree
* getting / setting error messages for FieldPanel with `getErrorMessage()` / `setErrorMessage("foo")` (which also updates ARIA attributes on the input, where `getBoundWidget` is able to retrieve it)
* accesing the existing `InlinePanel` API, specifically `.addForm()`. Access to the child panels of InlinePanel is not yet implemented - I hope to implement this in a follow-up PR.