### PR TITLE
Change handling of InlinePanel's label to work with other languages

### DIFF
--- a/docs/advanced_topics/customization/page_editing_interface.md
+++ b/docs/advanced_topics/customization/page_editing_interface.md
@@ -19,7 +19,7 @@ class BlogPage(Page):
     ]
     sidebar_content_panels = [
         FieldPanel('advert'),
-        InlinePanel('related_links', heading="Related links", label="Related link"),
+        InlinePanel('related_links'),
     ]
 
     edit_handler = TabbedInterface([

--- a/docs/reference/contrib/forms/customization.md
+++ b/docs/reference/contrib/forms/customization.md
@@ -31,7 +31,7 @@ class FormPage(AbstractEmailForm):
 
     content_panels = AbstractEmailForm.content_panels + [
         FieldPanel('intro'),
-        InlinePanel('custom_form_fields', label="Form fields"),
+        InlinePanel('custom_form_fields'),
         FieldPanel('thank_you_text'),
         MultiFieldPanel([
             FieldRowPanel([
@@ -80,7 +80,7 @@ class FormPage(AbstractEmailForm):
 
     content_panels = AbstractEmailForm.content_panels + [
         FieldPanel('intro'),
-        InlinePanel('form_fields', label="Form fields"),
+        InlinePanel('form_fields'),
         FieldPanel('thank_you_text'),
         MultiFieldPanel([
             FieldRowPanel([
@@ -139,7 +139,7 @@ class FormPage(AbstractEmailForm):
 
     content_panels = AbstractEmailForm.content_panels + [
         FieldPanel('intro'),
-        InlinePanel('form_fields', label="Form fields"),
+        InlinePanel('form_fields'),
         FieldPanel('thank_you_text'),
         MultiFieldPanel([
             FieldRowPanel([
@@ -212,7 +212,7 @@ class FormPage(AbstractEmailForm):
 
     content_panels = AbstractEmailForm.content_panels + [
         FieldPanel('intro'),
-        InlinePanel('form_fields', label="Form fields"),
+        InlinePanel('form_fields'),
         FieldPanel('thank_you_text'),
         MultiFieldPanel([
             FieldRowPanel([
@@ -305,7 +305,7 @@ class FormPage(AbstractEmailForm):
 
     content_panels = AbstractEmailForm.content_panels + [
         FieldPanel('intro'),
-        InlinePanel('form_fields', label="Form fields"),
+        InlinePanel('form_fields'),
         FieldPanel('thank_you_text'),
         MultiFieldPanel([
             FieldRowPanel([
@@ -447,7 +447,7 @@ class FormPage(AbstractEmailForm):
 
     content_panels = AbstractEmailForm.content_panels + [
         FieldPanel('intro'),
-        InlinePanel('form_fields', label="Form fields"),
+        InlinePanel('form_fields'),
         FieldPanel('thank_you_text'),
         MultiFieldPanel([
             FieldRowPanel([

--- a/docs/reference/contrib/forms/index.md
+++ b/docs/reference/contrib/forms/index.md
@@ -46,7 +46,7 @@ class FormPage(AbstractEmailForm):
 
     content_panels = AbstractEmailForm.content_panels + [
         FieldPanel('intro'),
-        InlinePanel('form_fields', label="Form fields"),
+        InlinePanel('form_fields'),
         FieldPanel('thank_you_text'),
         MultiFieldPanel([
             FieldRowPanel([

--- a/docs/topics/pages.md
+++ b/docs/topics/pages.md
@@ -54,7 +54,7 @@ class BlogPage(Page):
     content_panels = Page.content_panels + [
         FieldPanel('date'),
         FieldPanel('body'),
-        InlinePanel('related_links', heading="Related links", label="Related link"),
+        InlinePanel('related_links'),
     ]
 
     promote_panels = [
@@ -371,7 +371,7 @@ To add this to the admin interface, use the `InlinePanel` edit panel class:
 content_panels = [
     ...
 
-    InlinePanel('related_links', label="Related links"),
+    InlinePanel('related_links'),
 ]
 ```
 

--- a/docs/topics/snippets/features.md
+++ b/docs/topics/snippets/features.md
@@ -185,7 +185,7 @@ class Shirt(RevisionMixin, ClusterableModel):
         FieldPanel("name"),
         FieldPanel("colour"),
         FieldPanel("categories", widget=forms.CheckboxSelectMultiple),
-        InlinePanel("images", label="Images"),
+        InlinePanel("images"),
     ]
 
 

--- a/docs/topics/snippets/rendering.md
+++ b/docs/topics/snippets/rendering.md
@@ -111,7 +111,7 @@ class BookPage(Page):
     # ...
 
     content_panels = Page.content_panels + [
-        InlinePanel('advert_placements', label="Adverts"),
+        InlinePanel('advert_placements'),
         # ...
     ]
 ```

--- a/docs/tutorial/create_contact_page.md
+++ b/docs/tutorial/create_contact_page.md
@@ -53,7 +53,7 @@ class FormPage(AbstractEmailForm):
     content_panels = AbstractEmailForm.content_panels + [
         FormSubmissionsPanel(),
         FieldPanel('intro'),
-        InlinePanel('form_fields', label="Form fields"),
+        InlinePanel('form_fields'),
         FieldPanel('thank_you_text'),
         MultiFieldPanel([
             FieldRowPanel([

--- a/wagtail/admin/forms/workflows.py
+++ b/wagtail/admin/forms/workflows.py
@@ -307,7 +307,7 @@ def get_workflow_edit_handler():
                 FieldPanel("task", widget=AdminTaskChooser(show_clear_link=False)),
             ],
             heading=_("Add tasks to your workflow"),
-            label=_("Task"),
+            label=_("task"),
             icon="thumbtack",
         ),
     ]

--- a/wagtail/admin/panels/inline_panel.py
+++ b/wagtail/admin/panels/inline_panel.py
@@ -94,7 +94,7 @@ class InlinePanel(Panel):
         manager = getattr(self.model, self.relation_name)
         self.db_field = manager.rel
         if not self.label:
-            self.label = capfirst(self.db_field.related_model._meta.verbose_name)
+            self.label = self.db_field.related_model._meta.verbose_name
 
     def classes(self):
         return super().classes() + ["w-panel--nested"]

--- a/wagtail/admin/panels/inline_panel.py
+++ b/wagtail/admin/panels/inline_panel.py
@@ -27,7 +27,13 @@ class InlinePanel(Panel):
         super().__init__(*args, **kwargs)
         self.relation_name = relation_name
         self.panels = panels
-        self.heading = heading or label or capfirst(relation_name.replace("_", " "))
+        self.heading = (
+            heading
+            if heading
+            else capfirst(label)
+            if label
+            else capfirst(relation_name.replace("_", " "))
+        )
         self.label = label
         self.min_num = min_num
         self.max_num = max_num

--- a/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
@@ -35,7 +35,7 @@
 <div class="w-mb-4 -w-ml-4">
     {% block add_button %}
         <button type="button" class="button button-small button-secondary chooser__choose-button" id="id_{{ self.formset.prefix }}-ADD">
-            {% icon name=icon|default:"plus-inverse" %}{% blocktrans trimmed with label=self.label|lower %}Add {{ label }}{% endblocktrans %}
+            {% icon name=icon|default:"plus-inverse" %}{% blocktrans trimmed with label=self.label %}Add {{ label }}{% endblocktrans %}
         </button>
     {% endblock %}
 </div>

--- a/wagtail/admin/templates/wagtailadmin/panels/inline_panel_child.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/inline_panel_child.html
@@ -12,7 +12,7 @@
         <button type="button" class="button button--icon text-replace white" id="{{ child.form.DELETE.id_for_label }}-button" title="{% trans 'Delete' %}">{% icon name="bin" %}</button>
     {% endfragment %}
     {% fragment as heading %}
-        {{ self.label }}<span data-inline-panel-child-count></span>
+        {{ self.label|capfirst }}<span data-inline-panel-child-count></span>
     {% endfragment %}
     {% panel id=panel_id heading=heading heading_size="label" heading_level="3" header_controls=header_controls %}
         {% if child.form.non_field_errors %}

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -2461,6 +2461,8 @@ class TestChildRelationsOnSuperclass(WagtailTestUtils, TestCase):
         # Response should include an advert_placements formset labelled Adverts
         self.assertContains(response, "Adverts")
         self.assertContains(response, "id_advert_placements-TOTAL_FORMS")
+        # Expecting the add-button
+        self.assertContains(response, "Add advert")
 
     def test_post_create_form(self):
         post_data = {
@@ -2539,6 +2541,8 @@ class TestChildRelationsOnSuperclass(WagtailTestUtils, TestCase):
             '<input type="hidden" name="advert_placements-0-advert" value="1" id="id_advert_placements-0-advert">',
             html=True,
         )
+        # Expecting the add-button
+        self.assertContains(response, "Add advert")
 
     def test_post_edit_form(self):
         post_data = {

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -436,7 +436,7 @@ class TestPanelAttributes(WagtailTestUtils, TestCase):
                     [
                         InlinePanel(
                             "speakers",
-                            label="Speakers",
+                            label="speaker",
                             attrs={"data-panel-type": "inline"},
                         ),
                     ],
@@ -533,7 +533,7 @@ class TestTabbedInterface(WagtailTestUtils, TestCase):
                 ),
                 ObjectList(
                     [
-                        InlinePanel("speakers", label="Speakers"),
+                        InlinePanel("speakers", label="speaker"),
                     ],
                     heading="Speakers",
                 ),
@@ -748,7 +748,7 @@ class TestObjectList(TestCase):
                 FieldPanel("title", widget=forms.Textarea),
                 FieldPanel("date_from"),
                 FieldPanel("date_to"),
-                InlinePanel("speakers", label="Speakers"),
+                InlinePanel("speakers", label="speaker"),
             ],
             heading="Event details",
             classname="shiny",
@@ -1353,7 +1353,7 @@ class TestInlinePanel(WagtailTestUtils, TestCase):
             [
                 InlinePanel(
                     "speakers",
-                    label="Speakers",
+                    label="speaker",
                     classname="classname-for-speakers",
                     attrs={"data-controller": "test"},
                 )
@@ -1432,7 +1432,7 @@ class TestInlinePanel(WagtailTestUtils, TestCase):
             [
                 InlinePanel(
                     "speakers",
-                    label="Speakers",
+                    label="speaker",
                     panels=[
                         FieldPanel("first_name", widget=forms.Textarea),
                         FieldPanel("image"),
@@ -1519,7 +1519,7 @@ class TestInlinePanel(WagtailTestUtils, TestCase):
             [
                 InlinePanel(
                     "speakers",
-                    label="Speakers",
+                    label="speaker",
                     panels=[
                         FieldPanel("first_name", widget=forms.Textarea),
                         FieldPanel("image"),
@@ -1539,11 +1539,11 @@ class TestInlinePanel(WagtailTestUtils, TestCase):
 
     def test_invalid_inlinepanel_declaration(self):
         with self.ignore_deprecation_warnings():
-            self.assertRaises(TypeError, lambda: InlinePanel(label="Speakers"))
+            self.assertRaises(TypeError, lambda: InlinePanel(label="speaker"))
             self.assertRaises(
                 TypeError,
                 lambda: InlinePanel(
-                    EventPage, "speakers", label="Speakers", bacon="chunky"
+                    EventPage, "speakers", label="speaker", bacon="chunky"
                 ),
             )
 
@@ -1552,13 +1552,13 @@ class TestInlinePanel(WagtailTestUtils, TestCase):
         # Heading is the plural term, derived from the relation's related_name
         self.assertEqual(panel.heading, "Social links")
         # Label is the singular term, derived from the related model's verbose_name
-        self.assertEqual(panel.label, "Social link")
+        self.assertEqual(panel.label, "social link")
 
     def test_inline_panel_order_with_min_num(self):
         event_page = EventPage.objects.get(slug="christmas")
 
         speaker_object_list = ObjectList(
-            [InlinePanel("speakers", label="Speakers", min_num=2)]
+            [InlinePanel("speakers", label="speaker", min_num=2)]
         ).bind_to_model(EventPage)
 
         EventPageForm = speaker_object_list.get_form_class()
@@ -1595,7 +1595,7 @@ class TestNonOrderableInlinePanel(WagtailTestUtils, TestCase):
             [
                 InlinePanel(
                     "social_links",
-                    label="Social Links",
+                    label="social link",
                 )
             ]
         ).bind_to_model(PersonPage)
@@ -2270,7 +2270,7 @@ class TestPanelIcons(WagtailTestUtils, TestCase):
     def test_override_inlinepanel_icon(self):
         cases = [
             (
-                InlinePanel("carousel_items", label="Carousey", icon="cogs"),
+                InlinePanel("carousel_items", label="carousey", icon="cogs"),
                 "cogs",
             ),
             (

--- a/wagtail/contrib/settings/tests/generic/test_model.py
+++ b/wagtail/contrib/settings/tests/generic/test_model.py
@@ -119,5 +119,5 @@ class GenericSettingModelTestCase(GenericSettingsTestMixin, TestCase):
 
         self.assertEqual(
             str(ImportantPagesGenericSetting.load()),
-            "Important pages settings",
+            "important pages settings",
         )

--- a/wagtail/test/demosite/models.py
+++ b/wagtail/test/demosite/models.py
@@ -182,8 +182,8 @@ class HomePageRelatedLink(Orderable, AbstractRelatedLink):
 
 HomePage.content_panels = Page.content_panels + [
     FieldPanel("body"),
-    InlinePanel("carousel_items", label="Carousel items"),
-    InlinePanel("related_links", label="Related links"),
+    InlinePanel("carousel_items", label="carousel item"),
+    InlinePanel("related_links", label="related link"),
 ]
 
 
@@ -232,9 +232,9 @@ class StandardPageRelatedLink(Orderable, AbstractRelatedLink):
 
 StandardPage.content_panels = Page.content_panels + [
     FieldPanel("intro"),
-    InlinePanel("carousel_items", heading="Carousel items", label="Carousel item"),
+    InlinePanel("carousel_items", label="carousel item"),
     FieldPanel("body"),
-    InlinePanel("related_links", heading="Related links", label="Related link"),
+    InlinePanel("related_links", label="related link"),
 ]
 
 
@@ -276,7 +276,7 @@ class StandardIndexPageRelatedLink(Orderable, AbstractRelatedLink):
 
 StandardIndexPage.content_panels = Page.content_panels + [
     FieldPanel("intro"),
-    InlinePanel("related_links", label="Related links"),
+    InlinePanel("related_links", label="related link"),
 ]
 
 
@@ -347,8 +347,8 @@ class BlogEntryPageTag(TaggedItemBase):
 BlogEntryPage.content_panels = Page.content_panels + [
     FieldPanel("date"),
     FieldPanel("body"),
-    InlinePanel("carousel_items", label="Carousel items"),
-    InlinePanel("related_links", label="Related links"),
+    InlinePanel("carousel_items", label="carousel item"),
+    InlinePanel("related_links", label="related link"),
 ]
 
 
@@ -409,7 +409,7 @@ class BlogIndexPageRelatedLink(Orderable, AbstractRelatedLink):
 
 BlogIndexPage.content_panels = Page.content_panels + [
     FieldPanel("intro"),
-    InlinePanel("related_links", label="Related links"),
+    InlinePanel("related_links", label="related link"),
 ]
 
 
@@ -521,10 +521,10 @@ EventPage.content_panels = Page.content_panels + [
     FieldPanel("audience"),
     FieldPanel("cost"),
     FieldPanel("signup_link"),
-    InlinePanel("carousel_items", label="Carousel items"),
+    InlinePanel("carousel_items", label="carousel item"),
     FieldPanel("body"),
-    InlinePanel("speakers", label="Speakers"),
-    InlinePanel("related_links", label="Related links"),
+    InlinePanel("speakers", label="speaker"),
+    InlinePanel("related_links", label="related link"),
 ]
 
 
@@ -571,7 +571,7 @@ class EventIndexPageRelatedLink(Orderable, AbstractRelatedLink):
 
 EventIndexPage.content_panels = Page.content_panels + [
     FieldPanel("intro"),
-    InlinePanel("related_links", label="Related links"),
+    InlinePanel("related_links", label="related link"),
 ]
 
 
@@ -632,7 +632,7 @@ PersonPage.content_panels = Page.content_panels + [
     FieldPanel("biography"),
     FieldPanel("image"),
     MultiFieldPanel(ContactFieldsMixin.panels, "Contact"),
-    InlinePanel("related_links", label="Related links"),
+    InlinePanel("related_links", label="related link"),
 ]
 
 
@@ -690,5 +690,5 @@ class FormPage(AbstractForm):
     )
     api_fields = [APIField("form_fields")]
     content_panels = AbstractForm.content_panels + [
-        InlinePanel("form_fields", label="Form fields")
+        InlinePanel("form_fields", label="form field")
     ]

--- a/wagtail/test/testapp/migrations/0001_squashed_0073_revisablechildmodel_secret_text.py
+++ b/wagtail/test/testapp/migrations/0001_squashed_0073_revisablechildmodel_secret_text.py
@@ -546,7 +546,7 @@ class Migration(migrations.Migration):
                 ),
             ],
             options={
-                "verbose_name": "MTI Base page",
+                "verbose_name": "MTI base page",
             },
             bases=("wagtailcore.page",),
         ),
@@ -1958,8 +1958,8 @@ class Migration(migrations.Migration):
                 ("address", models.CharField(max_length=255, verbose_name="Address")),
             ],
             options={
-                "verbose_name": "Address",
-                "verbose_name_plural": "Addresses",
+                "verbose_name": "address",
+                "verbose_name_plural": "addresses",
             },
             bases=(wagtail.search.index.Indexed, models.Model),
         ),
@@ -1987,8 +1987,8 @@ class Migration(migrations.Migration):
                 ),
             ],
             options={
-                "verbose_name": "Person",
-                "verbose_name_plural": "Persons",
+                "verbose_name": "person",
+                "verbose_name_plural": "persons",
             },
             bases=("wagtailcore.page",),
         ),
@@ -2093,8 +2093,8 @@ class Migration(migrations.Migration):
                 ),
             ],
             options={
-                "verbose_name": "Tag",
-                "verbose_name_plural": "Tags",
+                "verbose_name": "tag",
+                "verbose_name_plural": "tags",
             },
         ),
         migrations.CreateModel(

--- a/wagtail/test/testapp/migrations/0025_alter_importantpagesgenericsetting_options.py
+++ b/wagtail/test/testapp/migrations/0025_alter_importantpagesgenericsetting_options.py
@@ -12,8 +12,8 @@ class Migration(migrations.Migration):
         migrations.AlterModelOptions(
             name="importantpagesgenericsetting",
             options={
-                "verbose_name": "Important pages settings",
-                "verbose_name_plural": "Important pages settings",
+                "verbose_name": "important pages settings",
+                "verbose_name_plural": "important pages settings",
             },
         ),
     ]

--- a/wagtail/test/testapp/migrations/0038_sociallink.py
+++ b/wagtail/test/testapp/migrations/0038_sociallink.py
@@ -44,8 +44,8 @@ class Migration(migrations.Migration):
                 ),
             ],
             options={
-                "verbose_name": "Social link",
-                "verbose_name_plural": "Social links",
+                "verbose_name": "social link",
+                "verbose_name_plural": "social links",
             },
             bases=(wagtail.search.index.Indexed, models.Model),
         ),

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -1841,7 +1841,7 @@ class MTIBasePage(Page):
     is_creatable = False
 
     class Meta:
-        verbose_name = "MTI Base page"
+        verbose_name = "MTI base page"
 
 
 class MTIChildPage(MTIBasePage):
@@ -1943,8 +1943,8 @@ class ImportantPagesGenericSetting(BaseGenericSetting):
     )
 
     class Meta:
-        verbose_name = _("Important pages settings")
-        verbose_name_plural = _("Important pages settings")
+        verbose_name = _("important pages settings")
+        verbose_name_plural = _("important pages settings")
 
 
 @register_setting(icon="tag")
@@ -2282,8 +2282,8 @@ class PersonPage(Page):
     ]
 
     class Meta:
-        verbose_name = "Person"
-        verbose_name_plural = "Persons"
+        verbose_name = "person"
+        verbose_name_plural = "persons"
 
 
 class Address(index.Indexed, ClusterableModel, Orderable):
@@ -2305,8 +2305,8 @@ class Address(index.Indexed, ClusterableModel, Orderable):
     ]
 
     class Meta:
-        verbose_name = "Address"
-        verbose_name_plural = "Addresses"
+        verbose_name = "address"
+        verbose_name_plural = "addresses"
 
 
 class AddressTag(TaggedItemBase):
@@ -2347,8 +2347,8 @@ class RestaurantTag(TagBase):
     free_tagging = False
 
     class Meta:
-        verbose_name = "Tag"
-        verbose_name_plural = "Tags"
+        verbose_name = "tag"
+        verbose_name_plural = "tags"
 
 
 class TaggedRestaurant(ItemBase):

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -267,7 +267,7 @@ class PageWithExcludedCopyField(Page):
         FieldPanel("special_field"),
         FieldPanel("content"),
         FieldPanel("special_stream"),
-        InlinePanel("special_notes", label="Special notes"),
+        InlinePanel("special_notes", label="special note"),
     ]
 
 
@@ -366,7 +366,7 @@ class EventPageSpeaker(TranslatableMixin, Orderable, LinkFields, ClusterableMode
         "last_name",
         "image",
         MultiFieldPanel(LinkFields.panels, "Link"),
-        InlinePanel("awards", label="Awards"),
+        InlinePanel("awards", label="award"),
     ]
 
     class Meta(TranslatableMixin.Meta, Orderable.Meta):
@@ -441,18 +441,18 @@ class EventPage(Page):
         FieldPanel("audience", help_text="Who this event is for"),
         "cost",
         "signup_link",
-        InlinePanel("carousel_items", label="Carousel items"),
+        InlinePanel("carousel_items", label="carousel item"),
         "body",
         InlinePanel(
             "speakers",
-            label="Speaker",
+            label="speaker",
             heading="Speaker lineup",
             help_text="Put the keynote speaker first",
         ),
-        InlinePanel("related_links", label="Related links"),
+        InlinePanel("related_links", label="related link"),
         "categories",
         # InlinePanel related model uses `pk` not `id`
-        InlinePanel("head_counts", label="Head Counts"),
+        InlinePanel("head_counts", label="head count"),
     ]
 
     promote_panels = [
@@ -614,7 +614,7 @@ class FormPage(AbstractEmailForm):
 
     content_panels = [
         TitleFieldPanel("title", classname="title"),
-        InlinePanel("form_fields", label="Form fields"),
+        InlinePanel("form_fields", label="form field"),
         MultiFieldPanel(
             [
                 FieldPanel("to_address"),
@@ -673,7 +673,7 @@ class JadeFormPage(AbstractEmailForm):
 
     content_panels = [
         TitleFieldPanel("title", classname="title"),
-        InlinePanel("form_fields", label="Form fields"),
+        InlinePanel("form_fields", label="form field"),
         MultiFieldPanel(
             [
                 FieldPanel("to_address"),
@@ -720,7 +720,7 @@ class FormPageWithRedirect(AbstractEmailForm):
     content_panels = [
         TitleFieldPanel("title", classname="title"),
         FieldPanel("thank_you_redirect_page"),
-        InlinePanel("form_fields", label="Form fields"),
+        InlinePanel("form_fields", label="form field"),
         MultiFieldPanel(
             [
                 FieldPanel("to_address"),
@@ -823,7 +823,7 @@ class FormPageWithCustomSubmission(AbstractEmailForm):
     content_panels = [
         TitleFieldPanel("title", classname="title"),
         FieldPanel("intro"),
-        InlinePanel("custom_form_fields", label="Form fields"),
+        InlinePanel("custom_form_fields", label="form field"),
         FieldPanel("thank_you_text"),
         MultiFieldPanel(
             [
@@ -894,7 +894,7 @@ class FormPageWithCustomSubmissionListView(AbstractEmailForm):
     content_panels = [
         TitleFieldPanel("title", classname="title"),
         FieldPanel("intro"),
-        InlinePanel("form_fields", label="Form fields"),
+        InlinePanel("form_fields", label="form field"),
         FieldPanel("thank_you_text"),
         MultiFieldPanel(
             [
@@ -1024,7 +1024,7 @@ class FormPageWithCustomFormBuilder(AbstractEmailForm):
 
     content_panels = [
         TitleFieldPanel("title", classname="title"),
-        InlinePanel("form_fields", label="Form fields"),
+        InlinePanel("form_fields", label="form field"),
         MultiFieldPanel(
             [
                 FieldPanel("to_address"),
@@ -1486,7 +1486,7 @@ class StandardIndex(Page):
         TitleFieldPanel("title", classname="title"),
         FieldPanel("seo_title"),
         FieldPanel("slug"),
-        InlinePanel("advert_placements", label="Adverts"),
+        InlinePanel("advert_placements", heading="Adverts", label="advert"),
     ]
 
     promote_panels = []
@@ -1494,7 +1494,7 @@ class StandardIndex(Page):
 
 class PromotionalPage(Page):
     content_panels = Page.content_panels + [
-        InlinePanel("advert_placements", label="Adverts", min_num=1),
+        InlinePanel("advert_placements", heading="Adverts", label="advert", min_num=1),
     ]
 
 
@@ -2331,8 +2331,8 @@ class SocialLink(index.Indexed, ClusterableModel):
     panels = ["url", "kind"]
 
     class Meta:
-        verbose_name = "Social link"
-        verbose_name_plural = "Social links"
+        verbose_name = "social link"
+        verbose_name_plural = "social links"
 
 
 class RestaurantPage(Page):


### PR DESCRIPTION
This change continues the work of #12556 and tries to fix the handling of the `InlinePanel`'s label, so it works with other languages (like german, see #13221 for details).

After fixing and adapting the tests I've also changed the test models to use consistent verbose names.

I've also adapted the documentation to use the minimal form of `InlinePanel(...)` to simplify the code.
I think in simple english code bases, you probably won't need `heading` and `label`, if the relation's name and the model already result in the correct forms. In multi-language projects, the model's verbose name should be translated, and only the `heading` has to be set to be properly translated.

Fixes #13221
