### PR TITLE
JSDoc - Full clean up, formatting & malformed fixes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -78,7 +78,7 @@ Changelog
  * Docs: Add documentation for how to group blocks within the StreamField picker (Gaurav Verma)
  * Docs: Clarify the user bar does not have moderation features (Sage Abdullah)
  * Docs: Add experimental documentation for admin UI components and client-side code (Sage Abdullah)
- * Docs: Clean up JSDoc documentation comments, update spelling where suitable (LB (Ben) Johnston)
+ * Docs: Clean up JSDoc documentation comments, syntax, and update spelling where suitable (LB (Ben) Johnston)
  * Maintenance: Refactor `get_embed` to remove `finder` argument which was only used for mocking in unit tests (Jigyasu Rajput)
  * Maintenance: Simplify handling of `None` values in `TypedTableBlock` (Jigyasu Rajput)
  * Maintenance: Remove squash.io configuration (Sage Abdullah)

--- a/client/src/components/ChooserWidget/ImageChooserWidget.js
+++ b/client/src/components/ChooserWidget/ImageChooserWidget.js
@@ -2,6 +2,19 @@
 
 import { Chooser, ChooserFactory } from '.';
 
+/**
+ * A state object representing the chosen image.
+ * @typedef {object} ImageChosenState if an image is chosen
+ * @property {number} id The ID of the chosen image.
+ * @property {string} edit_url The URL to edit the chosen image.
+ * @property {string} title The title of the chosen image.
+ * @property {object} preview Preview details of the chosen image.
+ * @property {string} preview.url The URL of the preview image.
+ * @property {string} preview.width The width of the preview image.
+ * @property {string} preview.height The height of the preview image.
+ * @property {string} default_alt_text The default alt text for the image.
+ */
+
 export class ImageChooser extends Chooser {
   chooserModalClass = ImageChooserModal;
 
@@ -16,15 +29,7 @@ export class ImageChooser extends Chooser {
    * Constructs the initial state of the chooser from the rendered (static) HTML.
    * The state is either null (no image chosen) or an object containing the image details.
    *
-   * @returns {Object|null} The initial state of the chooser. If an image is chosen,
-   * the state object contains the following properties:
-   * - id: {number} The ID of the chosen image.
-   * - edit_url: {string} The URL to edit the chosen image.
-   * - title: {string} The title of the chosen image.
-   * - preview: {Object} An object containing the preview details of the chosen image:
-   *   - url: {string} The URL of the preview image.
-   *   - width: {string} The width of the preview image.
-   *   - height: {string} The height of the preview image.
+   * @returns {ImageChosenState|null} The initial state of the chooser or null if no image is chosen.
    */
   getStateFromHTML() {
     const state = super.getStateFromHTML();

--- a/client/src/components/ChooserWidget/index.js
+++ b/client/src/components/ChooserWidget/index.js
@@ -2,8 +2,10 @@ import { ChooserModal } from '../../includes/chooserModal';
 
 export class Chooser extends EventTarget {
   chooserModalClass = ChooserModal;
-  titleStateKey = 'title'; // key used in the 'state' dictionary to hold the human-readable title
-  editUrlStateKey = 'edit_url'; // key used in the 'state' dictionary to hold the URL of the edit page
+  /** Key used in the 'state' dictionary to hold the human-readable title. */
+  titleStateKey = 'title';
+  /** Key used in the 'state' dictionary to hold the URL of the edit page. */
+  editUrlStateKey = 'edit_url';
 
   constructor(id, opts = {}) {
     super();
@@ -41,15 +43,15 @@ export class Chooser extends EventTarget {
     );
   }
 
+  /**
+   * Construct initial state of the chooser from the rendered (static) HTML.
+   * State is either null (= no item chosen) or a dict of id, title and edit_url.
+   *
+   * The result returned from the chooser modal (see get_chosen_response_data in
+   * wagtail.admin.views.generic.chooser.ChosenView) is a superset of this, and can therefore be
+   * passed directly to chooser.setState.
+   */
   getStateFromHTML() {
-    /*
-        Construct initial state of the chooser from the rendered (static) HTML.
-        State is either null (= no item chosen) or a dict of id, title and edit_url.
-
-        The result returned from the chooser modal (see get_chosen_response_data in
-        wagtail.admin.views.generic.chooser.ChosenView) is a superset of this, and can therefore be
-        passed directly to chooser.setState.
-        */
     if (this.input.value) {
       const state = {
         id: this.input.value,
@@ -212,16 +214,12 @@ export class ChooserFactory {
     this.modal.open(options, callback);
   }
 
-  /**
-   * Retrieve the widget object corresponding to the given HTML ID
-   */
+  /** Retrieve the widget object corresponding to the given HTML ID. */
   getById(id) {
     return document.getElementById(`${id}-chooser`).widget;
   }
 
-  /**
-   * Retrieve the widget object corresponding to the given HTML name
-   */
+  /** Retrieve the widget object corresponding to the given HTML name. */
   getByName(name, container) {
     const input = container.querySelector(`input[name="${name}"]`);
     return this.getById(input.id);

--- a/client/src/components/ComboBox/ComboBox.tsx
+++ b/client/src/components/ComboBox/ComboBox.tsx
@@ -105,7 +105,7 @@ export default function ComboBox<ComboBoxOption extends ComboBoxItem>({
     },
     selectedItem: null,
 
-    // Call onSelect only on item click and enter key press events
+    /** Call onSelect only on item click and enter key press events */
     onSelectedItemChange: (changes) => {
       const changeType = changes.type;
       switch (changeType) {

--- a/client/src/components/ComboBox/findMatches.ts
+++ b/client/src/components/ComboBox/findMatches.ts
@@ -1,5 +1,7 @@
-// Language-sensitive string comparison.
-// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator.
+/**
+ * Language-sensitive string comparison.
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator.
+ */
 const collator = new Intl.Collator(undefined, {
   usage: 'search',
   sensitivity: 'base',
@@ -7,10 +9,10 @@ const collator = new Intl.Collator(undefined, {
 });
 
 /**
- * Whether a string contains a subsring, with case-insensitive, locale-insensitive search.
- * See https://github.com/adobe/react-spectrum/blob/70e769acf639fc4ef3a704cb8fad81349cb4137a/packages/%40react-aria/i18n/src/useFilter.ts#L57.
- * See also https://github.com/arty-name/locale-index-of,
- * and https://github.com/tc39/ecma402/issues/506.
+ * Whether a string contains a substring, with case-insensitive, locale-insensitive search.
+ * @see https://github.com/adobe/react-spectrum/blob/70e769acf639fc4ef3a704cb8fad81349cb4137a/packages/%40react-aria/i18n/src/useFilter.ts#L57
+ * @see https://github.com/arty-name/locale-index-of
+ * @see https://github.com/tc39/ecma402/issues/506
  */
 export const contains = (string: string, substring: string) => {
   if (substring.length === 0) {

--- a/client/src/components/CommentApp/state/comments.ts
+++ b/client/src/components/CommentApp/state/comments.ts
@@ -27,11 +27,13 @@ export interface CommentReply {
   author: Author | null;
   date: number;
   deleted: boolean;
-  // There are three variables used for text
-  // text is the canonical text, that will be output to the form
-  // newText stores the edited version of the text until it is saved
-  // originalText stores the text upon reply creation, and is
-  // used to check whether existing replies have been edited
+  /**
+   * There are three variables used for text
+   * text is the canonical text, that will be output to the form
+   * newText stores the edited version of the text until it is saved
+   * originalText stores the text upon reply creation, and is
+   * used to check whether existing replies have been edited
+   */
   text: string;
   originalText: string;
   newText: string;
@@ -95,11 +97,13 @@ export interface Comment {
   replies: Map<number, CommentReply>;
   newReply: string;
   remoteReplyCount: number;
-  // There are three variables used for text
-  // text is the canonical text, that will be output to the form
-  // newText stores the edited version of the text until it is saved
-  // originalText stores the text upon comment creation, and is
-  // used to check whether existing comments have been edited
+  /**
+   * There are three variables used for text
+   * text is the canonical text, that will be output to the form
+   * newText stores the edited version of the text until it is saved
+   * originalText stores the text upon comment creation, and is
+   * used to check whether existing comments have been edited
+   */
   text: string;
   originalText: string;
   newText: string;
@@ -160,7 +164,7 @@ export interface CommentsState {
   forceFocus: boolean;
   focusedComment: number | null;
   pinnedComment: number | null;
-  // This is redundant, but stored for efficiency as it will change only as the app adds its loaded comments
+  /** This is redundant, but stored for efficiency as it will change only as the app adds its loaded comments */
   remoteCommentCount: number;
 }
 

--- a/client/src/components/CommentApp/utils/layout.ts
+++ b/client/src/components/CommentApp/utils/layout.ts
@@ -1,9 +1,12 @@
 import type { Annotation } from './annotation';
 import { getOrDefault } from './maps';
 
-const GAP = 20.0; // Gap between comments in pixels
-const TOP_MARGIN = 100.0; // Spacing from the top to the first comment in pixels
-const OFFSET = -50; // How many pixels from the annotation position should the comments be placed?
+/** Gap between comments in pixels. */
+const GAP = 20.0;
+/** Spacing from the top to the first comment in pixels. */
+const TOP_MARGIN = 100.0;
+/** How many pixels from the annotation position should the comments be placed? */
+const OFFSET = -50;
 
 export class LayoutController {
   commentElements: Map<number, HTMLElement> = new Map();

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
@@ -352,7 +352,7 @@ function findCommentStyleRanges(
   callback: (start: number, end: number) => void,
   filterFn?: (metadata: CharacterMetadata) => boolean,
 ) {
-  // Find comment style ranges that do not overlap an existing entity
+  /** Find comment style ranges that do not overlap an existing entity */
   const filterFunction =
     filterFn ||
     ((metadata: CharacterMetadata) => metadata.getStyle().some(styleIsComment));

--- a/client/src/components/Draftail/DraftUtils.js
+++ b/client/src/components/Draftail/DraftUtils.js
@@ -1,6 +1,6 @@
 /**
  * Returns collection of currently selected blocks.
- * See https://github.com/jpuri/draftjs-utils/blob/e81c0ae19c3b0fdef7e0c1b70d924398956be126/js/block.js#L19.
+ * @see https://github.com/jpuri/draftjs-utils/blob/e81c0ae19c3b0fdef7e0c1b70d924398956be126/js/block.js#L19.
  */
 const getSelectedBlocksList = (editorState) => {
   const selectionState = editorState.getSelection();
@@ -18,7 +18,7 @@ const getSelectedBlocksList = (editorState) => {
 
 /**
  * Returns the currently selected text in the editor.
- * See https://github.com/jpuri/draftjs-utils/blob/e81c0ae19c3b0fdef7e0c1b70d924398956be126/js/block.js#L106.
+ * @see https://github.com/jpuri/draftjs-utils/blob/e81c0ae19c3b0fdef7e0c1b70d924398956be126/js/block.js#L106.
  */
 export const getSelectionText = (editorState) => {
   const selection = editorState.getSelection();

--- a/client/src/components/Draftail/commands/InsertBlock.js
+++ b/client/src/components/Draftail/commands/InsertBlock.js
@@ -5,9 +5,9 @@ import { splitState } from '../CommentableEditor/CommentableEditor';
  * Definition for a command in the Draftail context menu that inserts a block.
  *
  * @param {BoundDraftailWidget} widget - the bound Draftail widget
- * @param {Object} blockDef - block definition for the block to be inserted
- * @param {Object} addSibling - capability descriptors from the containing block's capabilities definition
- * @param {Object} split - capability descriptor from the containing block's capabilities definition
+ * @param {object} blockDef - block definition for the block to be inserted
+ * @param {object} addSibling - capability descriptors from the containing block's capabilities definition
+ * @param {object} split - capability descriptor from the containing block's capabilities definition
  */
 export class DraftailInsertBlockCommand {
   constructor(widget, blockDef, addSibling, split) {

--- a/client/src/components/Draftail/commands/Split.js
+++ b/client/src/components/Draftail/commands/Split.js
@@ -6,7 +6,7 @@ import { gettext } from '../../../utils/gettext';
  * Definition for a command in the Draftail context menu that inserts a block.
  *
  * @param {BoundDraftailWidget} widget - the bound Draftail widget
- * @param {Object} split - capability descriptor from the containing block's capabilities definition
+ * @param {object} split - capability descriptor from the containing block's capabilities definition
  */
 export class DraftailSplitCommand {
   constructor(widget, split) {

--- a/client/src/components/Draftail/controls/MaxLength.tsx
+++ b/client/src/components/Draftail/controls/MaxLength.tsx
@@ -6,9 +6,9 @@ import { gettext } from '../../../utils/gettext';
 
 /**
  * Count characters in a string, with special processing to account for astral symbols in UCS-2,
- * matching the behaviour of HTML-native maxlength. See:
- * - https://mathiasbynens.be/notes/javascript-unicode
- * - https://github.com/RadLikeWhoa/Countable/blob/master/Countable.js#L29
+ * matching the behavior of HTML-native maxlength. See:
+ * @see https://mathiasbynens.be/notes/javascript-unicode
+ * @see https://github.com/RadLikeWhoa/Countable/blob/master/Countable.js#L29
  */
 export const countCharacters = (text: string) => {
   if (text) {

--- a/client/src/components/Draftail/decorators/Link.js
+++ b/client/src/components/Draftail/decorators/Link.js
@@ -22,7 +22,9 @@ const getEmailAddress = (mailto) => mailto.replace('mailto:', '').split('?')[0];
 const getPhoneNumber = (tel) => tel.replace('tel:', '').split('?')[0];
 const getDomainName = (url) => url.replace(/(^\w+:|^)\/\//, '').split('/')[0];
 
-// Determines how to display the link based on its type: page, mail, anchor or external.
+/**
+ * Determines how to display the link based on its type: page, mail, anchor or external.
+ */
 export const getLinkAttributes = (data) => {
   const url = data.url || null;
   let icon;
@@ -56,7 +58,7 @@ export const getLinkAttributes = (data) => {
 };
 
 /**
- * See https://docs.djangoproject.com/en/4.0/_modules/django/core/validators/#EmailValidator.
+ * @see https://docs.djangoproject.com/en/4.0/_modules/django/core/validators/#EmailValidator
  */
 // Compared to Django, changed to remove start and end of string checks.
 const djangoUser =
@@ -72,7 +74,7 @@ const djangoEmail = new RegExp(
 );
 
 /**
- * See https://docs.djangoproject.com/en/4.0/_modules/django/core/validators/#URLValidator.
+ * @see https://docs.djangoproject.com/en/4.0/_modules/django/core/validators/#URLValidator
  */
 const urlPattern = /(?:http|ftp)s?:\/\/[^\s]+/;
 

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -128,7 +128,7 @@ export const wrapWagtailIcon = (type) => {
 /**
  * Initializes the DraftailEditor for a given field.
  * @param {string} selector
- * @param {Object} originalOptions
+ * @param {object} originalOptions
  * @param {Element} currentScript
  */
 const initEditor = (selector, originalOptions, currentScript) => {

--- a/client/src/components/InlinePanel/index.js
+++ b/client/src/components/InlinePanel/index.js
@@ -7,13 +7,13 @@ import { ExpandingFormset } from '../ExpandingFormset';
  * Attaches behavior for an InlinePanel where inner panels can be created,
  * removed and re-ordered.
  *
- * @param {Object} opts
+ * @param {object} opts
  * @param {string} opts.formsetPrefix
  * @param {boolean?} opts.canOrder
  * @param {string} opts.emptyChildFormPrefix
  * @param {number} opts.maxForms
- * @param {function} opts.onAdd
- * @returns {Object}
+ * @param {Function} opts.onAdd
+ * @returns {object}
  */
 export class InlinePanel extends ExpandingFormset {
   constructor(opts, initControls = true) {

--- a/client/src/components/Portal/Portal.tsx
+++ b/client/src/components/Portal/Portal.tsx
@@ -6,7 +6,7 @@ import { createPortal } from 'react-dom';
 /**
  * A Portal component which automatically closes itself
  * when certain events happen outside.
- * See https://reactjs.org/docs/portals.html.
+ * @see https://reactjs.org/docs/portals.html
  */
 class Portal extends Component<{
   closeOnClick: boolean;

--- a/client/src/components/Sidebar/SidebarPanel.tsx
+++ b/client/src/components/Sidebar/SidebarPanel.tsx
@@ -28,7 +28,7 @@ export const SidebarPanel: React.FunctionComponent<SidebarPanelProps> = ({
   }
 
   const style = {
-    // See https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors.
+    /** @see https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors */
     ['--z-index' as any]: zIndex,
   };
 

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -53,7 +53,7 @@ class ListChild extends BaseSequenceChild {
 /**
  * Represents a position in the DOM where a new list item can be inserted.
  *
- * @description
+ * @remarks
  * This renders a + button. Later, these could also be used to represent drop zones for drag+drop reordering.
  */
 class InsertPosition extends BaseInsertionControl {

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -30,7 +30,7 @@ class StreamChild extends BaseSequenceChild {
   /**
    * wrapper for a block inside a StreamBlock, handling StreamBlock-specific metadata
    * such as id
-   * @returns {Object} - The state of the child block
+   * @returns {object} - The state of the child block
    */
   getState() {
     return {

--- a/client/src/controllers/ActionController.ts
+++ b/client/src/controllers/ActionController.ts
@@ -99,9 +99,11 @@ export class ActionController extends Controller<
     csrftokenElement.value = WAGTAIL_CONFIG.CSRF_TOKEN;
     formElement.appendChild(csrftokenElement);
 
-    /** If continue is false, pass the current URL as the next param
+    /**
+     * If continue is false, pass the current URL as the next param
      * so that the user is redirected back to the current page instead
-     * of continuing to the submitted page */
+     * of continuing to the submitted page
+     */
     if (!this.continueValue) {
       const nextElement = document.createElement('input');
       nextElement.type = 'hidden';

--- a/client/src/controllers/CleanController.ts
+++ b/client/src/controllers/CleanController.ts
@@ -46,7 +46,7 @@ export class CleanController extends Controller<HTMLInputElement> {
    * @event CleanController#applied
    * @type {CustomEvent}
    * @property {string} name - `w-slug:applied` | `w-clean:applied`
-   * @property {Object} detail
+   * @property {object} detail
    * @property {string} detail.action - The action that was applied (e.g. 'urlify' or 'slugify').
    * @property {string} detail.cleanValue - The the cleaned value that is applied.
    * @property {string} detail.sourceValue - The original value.

--- a/client/src/controllers/CloneController.ts
+++ b/client/src/controllers/CloneController.ts
@@ -8,8 +8,10 @@ type AddOptions = {
   clear?: boolean;
   /** Content for the message, HTML not supported. */
   text?: string;
-  /** Clone template type (found using data-type on template targets).
-   * e.g. Message status level based on Django's message types. */
+  /**
+   * Clone template type (found using data-type on template targets).
+   * e.g. Message status level based on Django's message types.
+   */
   type?: 'success' | 'error' | 'warning' | string;
 };
 

--- a/client/src/controllers/DropdownController.ts
+++ b/client/src/controllers/DropdownController.ts
@@ -9,6 +9,7 @@ import { hideTooltipOnEsc } from './TooltipController';
 const hideTooltipOnBreadcrumbsChange = {
   name: 'hideTooltipOnBreadcrumbAndCollapse',
   fn({ hide }: Instance) {
+    /** Hides the tooltip when breadcrumbs expand or collapse. */
     function onBreadcrumbExpandAndCollapse() {
       hide();
     }
@@ -102,8 +103,10 @@ export class DropdownController extends Controller<HTMLElement> {
     theme: { default: 'dropdown' as TippyTheme, type: String },
   };
 
-  // Hide on click *inside* the dropdown. Differs from tippy's hideOnClick
-  // option for outside clicks that defaults to true and we don't yet expose it.
+  /**
+   * Hide on click *inside* the dropdown. Differs from tippy's hideOnClick
+   * option for outside clicks that defaults to true and we don't yet expose it.
+   */
   declare readonly hideOnClickValue: boolean;
   declare readonly keepMountedValue: boolean;
   declare readonly offsetValue: [number, number];

--- a/client/src/controllers/FocusController.ts
+++ b/client/src/controllers/FocusController.ts
@@ -6,7 +6,7 @@ import { forceFocus } from '../utils/forceFocus';
  * Allows a target element (either via `href` or the targetValue as a selector) to be focused.
  * If the element does not have a `tabindex` attribute, it will be added and removed when the element loses focus.
  *
- * @description
+ * @remarks
  * Useful for the skip link functionality, which appears at the top left corner of the admin when the tab button is clicked.
  * Used to provide an accessible skip button for keyboard control so that users can
  * easily navigate to the main content without having to navigate a long list of navigation links.

--- a/client/src/controllers/FormsetController.ts
+++ b/client/src/controllers/FormsetController.ts
@@ -71,8 +71,10 @@ export class FormsetController extends Controller<HTMLElement> {
   declare readonly minFormsInputTarget: HTMLInputElement;
   /** Hidden input to read for the value for max forms. */
   declare readonly maxFormsInputTarget: HTMLInputElement;
-  /** Target element that has the template content to clone for new forms.
-   * `__prefix__` will be replaced with the next formIndex value upon creation. */
+  /**
+   * Target element that has the template content to clone for new forms.
+   * `__prefix__` will be replaced with the next formIndex value upon creation.
+   */
   declare readonly templateTarget: HTMLTemplateElement;
   /** Hidden input to track the total forms (including deleted) for POST request and initial reading. */
   declare readonly totalFormsInputTarget: HTMLInputElement;
@@ -123,6 +125,8 @@ export class FormsetController extends Controller<HTMLElement> {
   /**
    * Find the event's target's closest child target and remove it by
    * removing the 'child' target and adding a 'child-removed' target.
+   *
+   * @throws {Error} If the child form target for the event target cannot be found.
    */
   delete(event: Event) {
     const target = this.childTargets.find((child) =>
@@ -172,6 +176,8 @@ export class FormsetController extends Controller<HTMLElement> {
   /**
    * When removed, add the class and update the total count.
    * Also update the DELETE input for this form.
+   *
+   * @throws {Error} If the DELETE input target cannot be found within the removed form.
    */
   childTargetDisconnected(target: HTMLElement) {
     const deletedClasses = this.deletedClasses;

--- a/client/src/controllers/KeyboardController.ts
+++ b/client/src/controllers/KeyboardController.ts
@@ -15,7 +15,7 @@ import 'mousetrap/plugins/global-bind/mousetrap-global-bind';
  * <button type="button" data-controller="w-kbd" data-w-kbd-key="[">Trigger me with the <kbd>[</kbd> key.</button>
  * ```
  *
- * @example - use `mod` for `ctrl` on Windows and `cmd` on MacOS
+ * @example - use 'mod' for 'ctrl' on Windows and 'cmd' on MacOS
  * ```html
  * <button type="button" data-controller="w-kbd" data-w-kbd-key="mod+s">Trigger me with <kbd>ctrl+p</kbd> on Windows or <kbd>cmd+p</kbd> on MacOS.</button>
  * ```

--- a/client/src/controllers/LocaleController.ts
+++ b/client/src/controllers/LocaleController.ts
@@ -34,7 +34,6 @@ export class LocaleController extends Controller<HTMLSelectElement> {
   }
 
   /**
-   *
    * @param timeZone An IANA time zone string
    * @returns formatted time zone name in the current locale with short and long
    * labels, e.g. `"GMT+7 (Western Indonesia Time)"`

--- a/client/src/controllers/PreviewController.ts
+++ b/client/src/controllers/PreviewController.ts
@@ -53,13 +53,13 @@ const PREVIEW_UNAVAILABLE_WIDTH = 375;
  *
  * @event PreviewController#json
  * @type {CustomEvent}
- * @property {Object} detail
+ * @property {object} detail
  * @property {PreviewDataResponse} detail.data - The response data that indicates whether the submitted data was valid and whether the preview is available.
  * @property {string} name - `w-preview:json`
  *
  * @event PreviewController#error
  * @type {CustomEvent}
- * @property {Object} detail
+ * @property {object} detail
  * @property {Error} detail.error - The error object that was thrown.
  * @property {string} name - `w-preview:error`
  *
@@ -75,7 +75,7 @@ const PREVIEW_UNAVAILABLE_WIDTH = 375;
  * @event PreviewController#content
  * @type {CustomEvent}
  * @property {string} name - `w-preview:content`
- * @property {Object} detail
+ * @property {object} detail
  * @property {ExtractedContent} detail.content - The extracted content from the preview iframe.
  * @property {ContentMetrics} detail.metrics - The calculated metrics of the preview content.
  *
@@ -129,9 +129,11 @@ export class PreviewController extends Controller<HTMLElement> {
 
   /** The main preview `<iframe>` that is currently displayed. */
   declare readonly iframeTarget: HTMLIFrameElement;
-  /** All preview `<iframes>` that are currently in the DOM.
+  /**
+   * All preview `<iframe>`s that are currently in the DOM.
    * This contains the currently displayed `<iframe>` and may also contain
-   * the new `<iframe>` that will replace the current one. */
+   * the new `<iframe>` that will replace the current one.
+   */
   declare readonly iframeTargets: HTMLIFrameElement[];
   /** Preview mode `<select>` element. */
   declare readonly modeTarget: HTMLSelectElement;
@@ -147,8 +149,10 @@ export class PreviewController extends Controller<HTMLElement> {
 
   // Values
 
-  /** Interval in milliseconds when the form is checked for changes.
-   * Also used as the debounce duration for the update request. */
+  /**
+   * Interval in milliseconds when the form is checked for changes.
+   * Also used as the debounce duration for the update request.
+   */
   declare readonly autoUpdateIntervalValue: number;
   /** Key for storing the last selected device size in localStorage. */
   declare readonly deviceLocalStorageKeyValue: string;
@@ -156,8 +160,10 @@ export class PreviewController extends Controller<HTMLElement> {
   declare readonly deviceWidthPropertyValue: string;
   /** CSS property for the current width of the panel, to maintain the device scaling. */
   declare readonly panelWidthPropertyValue: string;
-  /** URL for rendering the preview, defaults to `urlValue`.
-   * Useful for headless setups where the front-end may be hosted at a different URL. */
+  /**
+   * URL for rendering the preview, defaults to `urlValue`.
+   * Useful for headless setups where the front-end may be hosted at a different URL.
+   */
   declare renderUrlValue: string;
   /** URL for updating the preview data. Also used for rendering the preview if `renderUrlValue` is unset. */
   declare readonly urlValue: string;
@@ -188,10 +194,13 @@ export class PreviewController extends Controller<HTMLElement> {
   declare contentChecksEnabled: boolean;
   /** Main editor form. */
   declare editForm: HTMLFormElement;
-  /** ResizeObserver to observe when the panel is resized
-   * so we can maintain the device size scaling. */
+  /**
+   * ResizeObserver to observe when the panel is resized
+   * so we can maintain the device size scaling.
+   */
   declare resizeObserver: ResizeObserver;
-  /** Side panel element of the preview panel, i.e. the element with the
+  /**
+   * Side panel element of the preview panel, i.e. the element with the
    * `data-side-panel` attribute. Useful for listening to show/hide events.
    * Normally, this is the parent element of the controller element.
    */
@@ -199,8 +208,10 @@ export class PreviewController extends Controller<HTMLElement> {
 
   // Instance variables with initial values set here
 
-  /** Whether the preview is ready for further updates.
+  /**
+   * Whether the preview is ready for further updates.
    *
+   * @remarks
    * The preview data is stored in the session, which means:
    *
    * - After logging out and logging back in, the session is cleared, so the
@@ -238,7 +249,8 @@ export class PreviewController extends Controller<HTMLElement> {
    */
   ready = false;
 
-  /** Whether the preview is currently available. This is used to distinguish
+  /**
+   * Whether the preview is currently available. This is used to distinguish
    * whether we are rendering a preview or the "Preview is not available"
    * screen. So even if the preview is currently outdated, this is still `true`
    * as long as the preview data is available and the preview is rendered (e.g.
@@ -246,7 +258,8 @@ export class PreviewController extends Controller<HTMLElement> {
    */
   available = true;
 
-  /** Serialized form payload to be compared in between intervals to determine
+  /**
+   * Serialized form payload to be compared in between intervals to determine
    * whether an update should be performed. Note that we currently do not handle
    * file inputs.
    */
@@ -258,13 +271,15 @@ export class PreviewController extends Controller<HTMLElement> {
   /** Interval for the auto-update. */
   updateInterval: ReturnType<typeof setOptionalInterval> = null;
 
-  /** Promise for the current update request. This is resolved as soon as the
+  /**
+   * Promise for the current update request. This is resolved as soon as the
    * update request is successful, so the preview iframe may not have been
    * fully reloaded.
    */
   updatePromise: Promise<boolean> | null = null;
 
-  /** Promise for the current content checks request. This resolved when both
+  /**
+   * Promise for the current content checks request. This resolved when both
    * the content checks and the accessibility checks are completed. Useful for
    * queueing the checks, as Axe does not allow concurrent runs.
    */
@@ -948,8 +963,7 @@ export class PreviewController extends Controller<HTMLElement> {
   /**
    * Extracts the rendered content from the preview iframe via an Axe plugin.
    * @param options Options object for extracting the content. Supported options:
-   * - `targetElement`: CSS selector for the element to extract content from.
-   *   Defaults to `main, [role="main"]`.
+   * - `targetElement`: CSS selector for the element to extract content from. Defaults to `main, [role="main"]`.
    * @returns An `ExtractedContent` object with `lang`, `innerText`, and `innerHTML` properties.
    */
   async extractContent(options?: ContentExtractorOptions) {

--- a/client/src/controllers/RevealController.ts
+++ b/client/src/controllers/RevealController.ts
@@ -63,9 +63,9 @@ export class RevealController extends Controller<HTMLElement> {
   declare readonly contentTargets: HTMLElement[];
   /** Global selector string to be used to determine the container to add the mouseleave listener to. */
   declare readonly peekTargetValue: string;
-  /**  Local storage key to be used to backup the open state of this controller, this can be unique or shared across multiple controllers, it uses the controller identifier for the base.If not provided, the controller will not attempt to store the state to local storage. */
+  /** Local storage key to be used to backup the open state of this controller, this can be unique or shared across multiple controllers, it uses the controller identifier for the base.If not provided, the controller will not attempt to store the state to local storage. */
   declare readonly storageKeyValue: string;
-  /**  Toggle button element(s) to have their classes and aria attributes updated. */
+  /** Toggle button element(s) to have their classes and aria attributes updated. */
   declare readonly toggleTargets: HTMLButtonElement[];
 
   cleanUpPeekListener?: () => void;

--- a/client/src/controllers/SessionController.ts
+++ b/client/src/controllers/SessionController.ts
@@ -22,8 +22,8 @@ interface PingResponse {
  * Manage an editing session by indicating the presence of the user and handling
  * cases when there are multiple users editing the same content.
  *
+ * @remarks
  * This controller defines the following behaviors:
- *
  * - Dispatching a ping event periodically, which can be utilized by other
  *   controllers to keep the session alive or indicate presence.
  * - Dispatching an event indicating the visibility state of the document.

--- a/client/src/controllers/TagController.ts
+++ b/client/src/controllers/TagController.ts
@@ -12,7 +12,7 @@ declare global {
 /**
  * Attach the jQuery tagit UI to the controlled element.
  *
- * See https://github.com/aehlke/tag-it
+ * @see https://github.com/aehlke/tag-it
  *
  * @example
  * ```html

--- a/client/src/controllers/TeleportController.ts
+++ b/client/src/controllers/TeleportController.ts
@@ -97,11 +97,12 @@ export class TeleportController extends Controller<HTMLTemplateElement> {
 
   /**
    * Returns a fresh copy of the DocumentFragment from the controlled element.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Node/cloneNode (returns the same type)
+   * @see https://github.com/microsoft/TypeScript/issues/283 (TypeScript will return as Node, incorrectly)
    */
   get templateFragment() {
     const content = this.element.content;
-    // https://developer.mozilla.org/en-US/docs/Web/API/Node/cloneNode (returns the same type)
-    // https://github.com/microsoft/TypeScript/issues/283 (TypeScript will return as Node, incorrectly)
     const templateFragment = content.cloneNode(true) as typeof content;
 
     // HACK:

--- a/client/src/controllers/TooltipController.ts
+++ b/client/src/controllers/TooltipController.ts
@@ -8,6 +8,7 @@ export const hideTooltipOnEsc = {
   name: 'hideOnEsc',
   defaultValue: true,
   fn({ hide }: Instance) {
+    /** Hides the tooltip when escape key is pressed. */
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
         hide();

--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -20,11 +20,11 @@ window.StimulusModule = StimulusModule;
  * interface to access the Stimulus application instance and base
  * React components.
  *
- * @type {Object} wagtail
- * @property {Object} app - Wagtail's Stimulus application instance.
- * @property {Object} components - Exposed components as globals for third-party reuse.
- * @property {Object} components.Icon - Icon React component.
- * @property {Object} components.Portal - Portal React component.
+ * @type {object} wagtail
+ * @property {object} app - Wagtail's Stimulus application instance.
+ * @property {object} components - Exposed components as globals for third-party reuse.
+ * @property {object} components.Icon - Icon React component.
+ * @property {object} components.Portal - Portal React component.
  */
 const wagtail = window.wagtail || {};
 

--- a/client/src/entrypoints/admin/draftail.js
+++ b/client/src/entrypoints/admin/draftail.js
@@ -8,14 +8,15 @@ import draftail, {
 } from '../../components/Draftail/index';
 
 /**
- * Entry point loaded when the Draftail editor is in use.
+ * Entrypoint loaded when the Draftail editor is in use.
+ *
+ * @remarks
+ * This file is included and run when there's a DraftailRichTextArea widget in the response.
+ * Normally this is only included once in the initial page load, but it may be included
+ * more than once when there's an AJAX response that includes the widget, e.g. in choosers.
+ * Ensure we only run the initialization code once.
+ * @see https://github.com/wagtail/wagtail/issues/12002
  */
-
-// This file is included and run when there's a DraftailRichTextArea widget in the response.
-// Normally this is only included once in the initial page load, but it may be included
-// more than once when there's an AJAX response that includes the widget, e.g. in choosers.
-// Ensure we only run the initialization code once.
-// https://github.com/wagtail/wagtail/issues/12002
 if (!window.Draftail || !window.draftail) {
   // Expose Draftail package as a global.
   window.Draftail = Draftail;

--- a/client/src/entrypoints/admin/modal-workflow.js
+++ b/client/src/entrypoints/admin/modal-workflow.js
@@ -6,21 +6,21 @@ import { gettext } from '../../utils/gettext';
 /**
  * ModalWorkflow - A framework for modal popups that are loaded via AJAX.
  *
- * @description
+ * @remarks
  * Allows navigation to other subpages to happen within the modal.
  * Supports returning a response to the calling page, which may happen after several navigation steps.
  *
  * @param {object} opts
  * @param {string} opts.url - A URL to the view that will be loaded into the dialog.
- *   If not provided and `dialogId` is given, the dialog component's `data-url` attribute is used instead.
- * @param {string=} opts.dialogId - The id of the dialog component to use instead of the Bootstrap modal.
- * @param {Object.<string, function>=} opts.responses - A object of callbacks to be called when the modal content calls `modal.respond(callbackName, params)`
- * @param {Object.<string, function>=} opts.onload - A object of callbacks to be called when loading a step of the workflow.
- *   The 'step' field in the response identifies the callback to call, passing it the
- *   modal object and response data as arguments.
- * @param {HTMLElement=} opts.triggerElement - Element that triggered the modal.
- *   It will be disabled while the modal is shown.
- *   If not provided, defaults to `document.activeElement` (which may not work as expected in Safari).
+ * If not provided and `dialogId` is given, the dialog component's `data-url` attribute is used instead.
+ * @param {string?} opts.dialogId - The id of the dialog component to use instead of the Bootstrap modal.
+ * @param {object} opts.responses - An object of callbacks to be called when the modal content calls `modal.respond(callbackName, params)`
+ * @param {object} opts.onload - An object whose keys are step names and values are callbacks to be called when loading a step of the workflow.
+ * The 'step' field in the response identifies the callback to call, passing it the
+ * modal object and response data as arguments.
+ * @param {HTMLElement?} opts.triggerElement - Element that triggered the modal.
+ * It will be disabled while the modal is shown.
+ * If not provided, defaults to `document.activeElement` (which may not work as expected in Safari).
  * @returns {object}
  */
 function ModalWorkflow(opts) {

--- a/client/src/entrypoints/admin/page-chooser-modal.js
+++ b/client/src/entrypoints/admin/page-chooser-modal.js
@@ -79,8 +79,10 @@ const PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
       }
     }
 
-    /* Set up behavior of choose-page links in the newly-loaded search results,
-    to pass control back to the calling page */
+    /**
+     * Set up behavior of choose-page links in the newly-loaded search results,
+     * to pass control back to the calling page.
+     */
     function ajaxifySearchResults() {
       // eslint-disable-next-line func-names
       $('.page-results a.choose-page', modal.body).on('click', function () {

--- a/client/src/entrypoints/contrib/table_block/table.test.js
+++ b/client/src/entrypoints/contrib/table_block/table.test.js
@@ -73,7 +73,9 @@ describe('telepath: wagtail.widgets.TableInput', () => {
   let renderMock;
   let updateSettingsMock;
 
-  // Call this to render the table block with the current settings
+  /**
+   * Call this to render the table block with the current settings
+   */
   const render = () => {
     // Create a placeholder to render the widget
     document.body.innerHTML = '<div id="placeholder"></div>';

--- a/client/src/includes/bulk-actions.js
+++ b/client/src/includes/bulk-actions.js
@@ -244,6 +244,10 @@ function addBulkActionListeners() {
   });
 }
 
+/**
+ * Rebinds event listeners for bulk actions.
+ * This is useful when the page content changes dynamically, such as after an AJAX request.
+ */
 function rebindBulkActionsEventListeners() {
   // when deselecting all checkbox, simply hide the footer for smooth transition
   document.querySelectorAll(BULK_ACTION_SELECT_ALL_CHECKBOX).forEach((el) => {

--- a/client/src/includes/dateTimeChooser.js
+++ b/client/src/includes/dateTimeChooser.js
@@ -1,12 +1,14 @@
 /**
  * Helper functions for initializing date and time chooser inputs using jQuery datetimepicker.
  * These are made available in the `window` scope by entrypoints/admin/date-time-chooser.js,
- * and depend on jquery and jquery.datetimepicker.js having been loaded.
+ * and depend on jQuery and jquery.datetimepicker.js having been loaded.
  */
 
 import $ from 'jquery';
 
-// Compare two date objects. Ignore minutes and seconds.
+/**
+ * Compare two date objects. Ignore minutes and seconds.
+ */
 export function dateEqual(x, y) {
   return (
     x.getDate() === y.getDate() &&
@@ -28,6 +30,11 @@ export function hideCurrent(current, input) {
   }
 }
 
+/**
+ * Initializes the date chooser.
+ * @param {string} id
+ * @param {object} opts
+ */
 export function initDateChooser(id, opts) {
   if (window.dateTimePickerTranslations) {
     $('#' + id).datetimepicker(
@@ -63,6 +70,11 @@ export function initDateChooser(id, opts) {
   }
 }
 
+/**
+ * Initializes the time chooser.
+ * @param {string} id
+ * @param {object} opts
+ */
 export function initTimeChooser(id, opts) {
   if (window.dateTimePickerTranslations) {
     $('#' + id).datetimepicker(
@@ -95,6 +107,11 @@ export function initTimeChooser(id, opts) {
   }
 }
 
+/**
+ * Initializes the date and time chooser.
+ * @param {string} id
+ * @param {object} opts
+ */
 export function initDateTimeChooser(id, opts) {
   if (window.dateTimePickerTranslations) {
     $('#' + id).datetimepicker(

--- a/client/src/includes/previewPlugin.ts
+++ b/client/src/includes/previewPlugin.ts
@@ -2,10 +2,13 @@ import axe, { AxePlugin } from 'axe-core';
 
 /**
  * Axe plugin registry for interaction between the page editor and the live preview.
+ *
+ * @remarks
  * Compared to other aspects of Axe and other plugins,
  * - The parent frame only triggers execution of the plugin’s logic in the one frame.
  * - The preview frame only executes the plugin’s logic, it doesn’t go through its own frames.
- * See https://github.com/dequelabs/axe-core/blob/master/doc/plugins.md.
+ *
+ * @see https://github.com/dequelabs/axe-core/blob/master/doc/plugins.md
  */
 export const wagtailPreviewPlugin: AxePlugin = {
   id: 'wagtailPreview',

--- a/client/src/includes/sidePanel.js
+++ b/client/src/includes/sidePanel.js
@@ -1,5 +1,9 @@
 import { ngettext } from '../utils/gettext';
 
+/**
+ * Initializes the side panel functionality.
+ * This includes opening and closing the side panel, resizing it, and managing its state.
+ */
 export default function initSidePanel() {
   const sidePanelWrapper = document.querySelector('[data-form-side]');
 
@@ -23,9 +27,11 @@ export default function initSidePanel() {
     return { minWidth, maxWidth, width, range, percentage };
   };
 
-  // We force the slider input to have dir="ltr" in the HTML so that the slider
-  // works the same way across Safari, Chrome and Firefox. Here, we correct the
-  // percentage value to follow the direction set on the root <html> element.
+  /**
+   * We force the slider input to have dir="ltr" in the HTML so that the slider
+   * works the same way across Safari, Chrome and Firefox. Here, we correct the
+   * percentage value to follow the direction set on the root <html> element.
+   */
   const getDirectedPercentage = (value) =>
     document.documentElement.dir === 'rtl' ? value : 100 - value;
 

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Entry point for the wagtail package.
+ * Entrypoint for the wagtail package.
  * Re-exports components and other modules via a cleaner API.
  */
 

--- a/client/src/tokens/breakpoints.js
+++ b/client/src/tokens/breakpoints.js
@@ -1,11 +1,7 @@
-/** @typedef {{
- sm: string;
- md: string;
- lg: string;
- xl: string;
-}} Breakpoints */
-
-/** @type {Breakpoints} */
+/**
+ * @typedef {{ sm: string; md: string; lg: string; xl: string }} Breakpoints
+ * @type {Breakpoints}
+ */
 const breakpoints = {
   sm: '50em', // 800px
   md: '56.25em', // 900px

--- a/client/src/tokens/colorThemes.js
+++ b/client/src/tokens/colorThemes.js
@@ -1,21 +1,15 @@
-/** @typedef {{
-    value: string;
-    bgUtility: string;
-    textUtility: string;
-    cssVariable: string;
-}} Token */
+/**
+ * @typedef {{ value: string; bgUtility: string; textUtility: string; cssVariable: string; }} Token
+ *
+ * @typedef {{ [token: string]: Token; }} CategoryTokens
+ *
+ * @typedef {{ label: string; tokens: CategoryTokens; }} ThemeCategory
+ */
 
-/** @typedef {{
-    [token: string]: Token;
-}} CategoryTokens */
-
-/** @typedef {{
-    label: string;
-    tokens: CategoryTokens;
-}} ThemeCategory */
-
-// The focus outline color is defined without reusing a named color variable
-// because it shouldn’t be reused for anything else in the UI.
+/**
+ * The focus outline color is defined without reusing a named color variable
+ * because it shouldn’t be reused for anything else in the UI.
+ */
 const focusToken = {
   value: '#00A885',
   bgUtility: 'w-bg-focus',

--- a/client/src/tokens/colors.js
+++ b/client/src/tokens/colors.js
@@ -1,20 +1,10 @@
-/** @typedef {{
-    hex: string;
-    hsl: string;
-    bgUtility: string;
-    textUtility: string;
-    cssVariable: string;
-    usage: string;
-    contrastText: string;
-}} Shade */
-
-/** @typedef {{
-    [jsName: string | number]: Shade;
-}} Hues */
-
-/** @typedef {{
-    [jsName: string]: Hues;
-}} Colors */
+/**
+ * @typedef {{ hex: string; hsl: string; bgUtility: string; textUtility: string; cssVariable: string; usage: string; contrastText: string; }} Shade
+ *
+ * @typedef {{ [jsName: string | number]: Shade; }} Hues
+ *
+ * @typedef {{ [jsName: string]: Hues; }} Colors
+ */
 
 /** @type {Colors} */
 const staticColors = {

--- a/client/src/utils/actions.ts
+++ b/client/src/utils/actions.ts
@@ -7,8 +7,10 @@ interface Action<N, P, M> {
   meta?: M;
 }
 
-// Stolen from the following project (had a 18kb footprint at the time).
-// https://github.com/acdlite/redux-actions/blob/79c68635fb1524c1b1cf8e2398d4b099b53ca8de/src/createAction.js
+/**
+ * Stolen from the following project (had a 18kb footprint at the time).
+ * @see https://github.com/acdlite/redux-actions/blob/79c68635fb1524c1b1cf8e2398d4b099b53ca8de/src/createAction.js
+ */
 export function createAction<N extends string, T extends any[], P, M>(
   type: N,
   actionCreator?: (...args: T) => P,

--- a/client/src/utils/contentPath.ts
+++ b/client/src/utils/contentPath.ts
@@ -3,14 +3,14 @@ const WAGTAIL_DIRECTIVE_DELIMITER = ':w:';
 /**
  * Extract the Wagtail directives from the URL fragment.
  *
- * This follows the algorithm described in
- * https://wicg.github.io/scroll-to-text-fragment/#extracting-the-fragment-directive
- * for extracting the fragment directive from the URL fragment, with a few
- * differences:
+ * @see https://wicg.github.io/scroll-to-text-fragment/#extracting-the-fragment-directive
+ *
+ * @remarks
+ * This follows the algorithm described above, o extract the fragment directive from the URL fragment,
+ * with a few differences:
  * - We use a :w: delimiter instead of the proposed :~: delimiter.
  * - We don't remove our directive from the URL fragment.
  *
- * @param rawFragment The raw fragment (hash) from the URL,
  * @returns a string of Wagtail directives, if any, in the style of URL search parameters.
  *
  * @example window.location.hash = '#:w:contentpath=abc1.d2e.3f'
@@ -23,6 +23,7 @@ const WAGTAIL_DIRECTIVE_DELIMITER = ':w:';
  * // getWagtailDirectives() === 'contentpath=abc1.d2e.3f&unknown=123&unknown=456'
  */
 export function getWagtailDirectives() {
+  // The raw fragment (hash) from the URL
   const rawFragment = window.location.hash;
   const position = rawFragment.indexOf(WAGTAIL_DIRECTIVE_DELIMITER);
   if (position === -1) return '';

--- a/client/src/utils/gettext.ts
+++ b/client/src/utils/gettext.ts
@@ -1,13 +1,13 @@
 /**
- * Translation / Internationalisation utilities based on Django's `JavaScriptCatalogView`
+ * Translation / Internationalization utilities based on Django's `JavaScriptCatalogView`
  *
- * https://docs.djangoproject.com/en/stable/topics/i18n/translation/#module-django.views.i18n
+ * @see https://docs.djangoproject.com/en/stable/topics/i18n/translation/#module-django.views.i18n
  */
 
 /**
  * The gettext function behaves similarly to the standard gettext interface within Django.
  *
- * https://docs.djangoproject.com/en/stable/topics/i18n/translation/#gettext
+ * @see https://docs.djangoproject.com/en/stable/topics/i18n/translation/#gettext
  *
  * @param {string} text
  * @returns {string}
@@ -25,7 +25,7 @@ export function gettext(text: string): string {
 /**
  * The ngettext function provides an interface to pluralize words and phrases.
  *
- * https://docs.djangoproject.com/en/stable/topics/i18n/translation/#ngettext
+ * @see https://docs.djangoproject.com/en/stable/topics/i18n/translation/#ngettext
  *
  * @param {string} singular
  * @param {string} plural
@@ -52,7 +52,7 @@ export function ngettext(
 }
 
 /**
- * https://docs.djangoproject.com/en/stable/topics/i18n/translation/#get-format
+ * @see https://docs.djangoproject.com/en/stable/topics/i18n/translation/#get-format
  */
 export type FormatType =
   | 'DATE_FORMAT'
@@ -74,7 +74,7 @@ export type FormatType =
  * The getFormat function has access to the configured i18n formatting settings and
  * can retrieve the format string for a given setting name.
  *
- * https://docs.djangoproject.com/en/stable/topics/i18n/translation/#get-format
+ * @see https://docs.djangoproject.com/en/stable/topics/i18n/translation/#get-format
  *
  * @param {FormatType} formatType
  * @returns {str}
@@ -99,7 +99,7 @@ export function getFormat(formatType: FormatType): string {
  * This can be used to store strings in global variables that should stay in the base
  * language (because they might be used externally) and will be translated later.
  *
- * https://docs.djangoproject.com/en/stable/topics/i18n/translation/#gettext_noop
+ * @see https://docs.djangoproject.com/en/stable/topics/i18n/translation/#gettext_noop
  *
  * @param {string} text
  * @returns {string}
@@ -118,7 +118,7 @@ export function gettextNoop(text: string): string {
  * The pluralIdx function works in a similar way to the pluralize template filter,
  * determining if a given count should use a plural form of a word or not.
  *
- * https://docs.djangoproject.com/en/stable/topics/i18n/translation/#pluralidx
+ * @see https://docs.djangoproject.com/en/stable/topics/i18n/translation/#pluralidx
  *
  * @param {number} count
  * @returns {boolean}

--- a/client/src/utils/message.ts
+++ b/client/src/utils/message.ts
@@ -32,15 +32,17 @@ export interface GetScrollPosition {
 }
 
 /**
+ * For simplicity, the same message type is used for both purposes instead of
+ * creating separate message types. This allows the CMS to pass over the message
+ * received from the old iframe to the new iframe as-is.
+ *
+ * @remarks
  * Indicates two things:
  * 1. The current window (i.e. the old preview iframe) is sending its scroll
  *    position to the recipient window (i.e. CMS).
  * 2. The current window (i.e. the CMS) is instructing the recipient window
  *    (i.e. the new preview iframe) to set its scroll position to the given
  *    coordinates.
- * For simplicity, the same message type is used for both purposes instead of
- * creating separate message types. This allows the CMS to pass over the message
- * received from the old iframe to the new iframe as-is.
  */
 export interface SetScrollPosition extends MessageWithOrigin {
   type: 'w-preview:set-scroll-position';

--- a/client/src/utils/performance.js
+++ b/client/src/utils/performance.js
@@ -9,7 +9,11 @@ if (process.env.NODE_ENV !== 'production') {
    */
   perfMiddleware = () => {
     /* eslint-disable no-console */
-    // `next` is a function that takes an 'action' and sends it through to the 'reducers'.
+    /**
+     * @param {Function} next - The next middleware in the chain.
+     * @returns {Function} A function that takes an 'action'
+     * and sends it through to the 'reducers'.
+     */
     const middleware = (next) => (action) => {
       let result;
 

--- a/client/src/utils/text.ts
+++ b/client/src/utils/text.ts
@@ -1,7 +1,7 @@
 /**
  * Escapes provided HTML.
  *
- * https://stackoverflow.com/questions/6234773/can-i-escape-html-special-chars-in-javascript
+ * @see https://stackoverflow.com/questions/6234773/can-i-escape-html-special-chars-in-javascript
  *
  * @param {string} unsafe - raw HTML to be made safe
  * @returns {string}

--- a/client/src/utils/version.js
+++ b/client/src/utils/version.js
@@ -48,8 +48,10 @@ class VersionNumber {
     return this.preReleaseStep !== null;
   }
 
-  /*
+  /**
    * Check if preReleaseStep of this versionNumber is behind another versionNumber's.
+   *
+   * @throws {CanOnlyComparePreReleaseVersionsError} If either version is not a pre-release.
    */
   isPreReleaseStepBehind(that) {
     if (!this.isPreRelease() || !that.isPreRelease()) {
@@ -68,7 +70,7 @@ class VersionNumber {
     return false;
   }
 
-  /*
+  /**
    * Get VersionDeltaType that this version is behind the other version passed in.
    */
   howMuchBehind(that) {

--- a/client/storybook/StimulusWrapper.tsx
+++ b/client/storybook/StimulusWrapper.tsx
@@ -9,6 +9,7 @@ import { initStimulus } from '../src/includes/initStimulus';
  * each time.
  *
  * @example
+ * ```jsx
  * import { StimulusWrapper } from '../storybook/StimulusWrapper';
  * const Template = ({ debug }) =>
  *   <StimulusWrapper
@@ -17,6 +18,7 @@ import { initStimulus } from '../src/includes/initStimulus';
  *   >
  *     <form data-controller="w-something" />
  *   </StimulusWrapper>
+ * ```
  */
 export class StimulusWrapper extends React.Component<{
   debug?: boolean;

--- a/client/storybook/main.js
+++ b/client/storybook/main.js
@@ -12,10 +12,12 @@ module.exports = {
     options: {},
   },
 
-  // Redefine Babel config to allow TypeScript class fields `declare`.
-  // See https://github.com/storybookjs/storybook/issues/12479.
-  // The resulting configuration is closer to Wagtail’s Webpack + TypeScript setup,
-  // preventing other potential issues with JS transpilation differences.
+  /**
+   * Redefine Babel config to allow TypeScript class fields `declare`.
+   * @see https://github.com/storybookjs/storybook/issues/12479.
+   * The resulting configuration is closer to Wagtail’s Webpack + TypeScript setup,
+   * preventing other potential issues with JS transpilation differences.
+   */
   babel: async (options) => ({
     ...options,
     plugins: [],

--- a/client/storybook/stories.d.ts
+++ b/client/storybook/stories.d.ts
@@ -1,4 +1,7 @@
-// See https://stackoverflow.com/questions/44678315/how-to-import-markdown-md-file-in-typescript.
+/**
+ * @see https://stackoverflow.com/questions/44678315/how-to-import-markdown-md-file-in-typescript.
+ */
+
 declare module '*.md';
 declare module '*.html';
 

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -136,9 +136,8 @@ module.exports = {
     scrollbarThin,
     /**
      * forced-colors media query for Windows High-Contrast mode support
-     * See:
-     * - https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors
-     * - https://github.com/tailwindlabs/tailwindcss/blob/v3.0.23/src/corePlugins.js#L168-L171
+     * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors
+     * @see https://github.com/tailwindlabs/tailwindcss/blob/v3.0.23/src/corePlugins.js#L168-L171
      */
     plugin(({ addVariant }) => {
       addVariant('forced-colors', '@media (forced-colors: active)');

--- a/client/tests/adapter.js
+++ b/client/tests/adapter.js
@@ -17,7 +17,8 @@ window.scrollTo = jest.fn();
 /** Mock scrollIntoView on elements, this is not provided by JSDom */
 Element.prototype.scrollIntoView = jest.fn();
 
-/** Mock console.warn to filter out warnings from React due to Draftail legacy Component API usage.
+/**
+ * Mock console.warn to filter out warnings from React due to Draftail legacy Component API usage.
  * Draftail/Draft-js is unlikely to support these and the warnings are not useful for unit test output.
  */
 /* eslint-disable no-console */

--- a/client/tests/mock-fetch.js
+++ b/client/tests/mock-fetch.js
@@ -2,7 +2,9 @@
 global.fetch = jest.fn();
 global.Headers = jest.fn();
 
-// Helper to mock a success JSON response.
+/**
+ * Helper to mock a success JSON response.
+ */
 fetch.mockResponseSuccessJSON = (body) => {
   fetch.mockImplementationOnce(() =>
     Promise.resolve({
@@ -14,7 +16,9 @@ fetch.mockResponseSuccessJSON = (body) => {
   );
 };
 
-// Helper to mock a success text response.
+/**
+ * Helper to mock a success text response.
+ */
 fetch.mockResponseSuccessText = (body) => {
   fetch.mockImplementationOnce(() =>
     Promise.resolve({
@@ -26,7 +30,9 @@ fetch.mockResponseSuccessText = (body) => {
   );
 };
 
-// Helper to mock a failure response.
+/**
+ * Helper to mock a failure response.
+ */
 fetch.mockResponseFailure = () => {
   fetch.mockImplementationOnce(() =>
     Promise.resolve({
@@ -46,7 +52,9 @@ fetch.mockResponseCrash = () => {
   );
 };
 
-// Helper to mock a timeout response.
+/**
+ * Helper to mock a timeout response.
+ */
 fetch.mockResponseTimeout = () => {
   fetch.mockImplementationOnce(() => {
     const timeout = 1000;

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -7,7 +7,6 @@
  * Those variables usually come from the back-end via templates.
  * See /wagtailadmin/templates/wagtailadmin/admin_base.html.
  */
-
 const wagtailConfig = {
   ADMIN_API: {
     DOCUMENTS: '/admin/api/main/documents/',

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -2,7 +2,9 @@ const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-// Generates a path to the output bundle to be loaded in the browser.
+/**
+ * Generates a path to the output bundle to be loaded in the browser.
+ */
 const getOutputPath = (app, folder, filename) => {
   const exceptions = {
     'documents': 'wagtaildocs',

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -130,7 +130,7 @@ For more details, see the documentation on [enabling the user bar](headless_user
  * Add documentation for how to [group blocks within the StreamField picker](block_grouping) (Gaurav Verma)
  * Clarify the user bar does not have moderation features (Sage Abdullah)
  * Add experimental documentation for admin UI components and client-side code (Sage Abdullah)
- * Clean up JSDoc documentation comments, update spelling where suitable (LB (Ben) Johnston)
+ * Clean up JSDoc documentation comments, syntax, and update spelling where suitable (LB (Ben) Johnston)
 
 ### Maintenance
 

--- a/wagtail/images/static_src/wagtailimages/js/add-multiple.js
+++ b/wagtail/images/static_src/wagtailimages/js/add-multiple.js
@@ -98,11 +98,13 @@ $(function () {
      * filename (with extension) as the title is preserved.
      *
      * @example
+     * ```js
      * document.addEventListener('wagtail:images-upload', function(event) {
      *   // remove file extension
      *   var newTitle = (event.detail.data.title || '').replace(/\.[^.]+$/, '');
      *   event.detail.data.title = newTitle;
      * });
+     * ```
      *
      * @param {HtmlElement[]} form
      * @returns {{name: 'string', value: *}[]}


### PR DESCRIPTION
This PR introduces a wide range of baseline formatting and structure fixes for JSDoc so we can better leverage documentation output.

This does NOT introduce linting for JSDoc but was informed by an Eslint plugin that I have extensively used across different projects for work - https://github.com/gajus/eslint-plugin-jsdoc

There are a lot of changes, but none of them change a single line of functional code, only refine the JSDoc syntax, positioning and usage.

This PR builds on https://github.com/wagtail/wagtail/pull/13245 and https://github.com/wagtail/wagtail/pull/13246 .

With this PR (and the related ones) in place, I feel we will have a really solid start for the 7.1 documentation approach using JSDoc, hence I will flag this for `7.1`. This also reduces the TypeDoc build warnings from 81 to 75.

### Eslint config used

I did not use any 'default', otherwise there will be hundreds of fixes and it may not be what we want, I tried to optimise for a reasonable 'cleanup' without extensive efforts. Letting us also rely on our migration to TypeScript so we do not have to redeclare types that are already in TS.

Note that this is NOT the same as the TSDoc linter, this produced 100s of warnings that could be addressed in the future, it was more about ensuring there's a baseline of the existence of JSDoc with a basic set of syntax.

The goal is that we could probably introduce this to our linter AFTER this PR merges and only have 1 or 2 files to fix up later. We may also want to consider `warn` not `error` for some of these as they can get a bit loud in the editor if you are just drafting together some code as a WIP.

```
  // ...
  plugins: ['@typescript-eslint', 'jsdoc'],
  // ...
  rules: {
    // ...
    'jsdoc/check-access': 'error',
    'jsdoc/check-alignment': 'error',
    'jsdoc/check-indentation': ['error', { excludeTags: ['remarks'] }],
    'jsdoc/check-line-alignment': 'error',
    'jsdoc/check-param-names': 'error',
    'jsdoc/check-property-names': 'error',
    'jsdoc/check-syntax': 'error',
    'jsdoc/check-tag-names': 'error',
    'jsdoc/check-types': 'error',
    'jsdoc/check-values': 'error',
    'jsdoc/empty-tags': 'error',
    'jsdoc/multiline-blocks': 'error',
    'jsdoc/no-bad-blocks': 'error',
    'jsdoc/no-blank-block-descriptions': 'error',
    'jsdoc/no-blank-blocks': 'error',
    'jsdoc/no-defaults': 'error',
    'jsdoc/no-multi-asterisks': 'error',
    'jsdoc/require-jsdoc': ['warn', { publicOnly: true }],
    'jsdoc/require-throws': 'error',
    'jsdoc/valid-types': 'error',
    // ...
```

With a less strict version in `files: ['client/src/components/**'],` to turn off requiring JSDoc ` 'jsdoc/require-jsdoc': 'off'`, and a more strict requirement in Stimulus Controllers to enforce adding examples to the root class declaration `'jsdoc/require-example': ['warn', { contexts: ['ClassDeclaration'] }],`.
