### PR TITLE
Fix ImageBlock alt text prefilling logic after EventTarget migration

### DIFF
--- a/client/src/components/ChooserWidget/index.js
+++ b/client/src/components/ChooserWidget/index.js
@@ -86,7 +86,7 @@ export class Chooser extends EventTarget {
 
   setStateFromModalData(data) {
     this.setState(data);
-    this.dispatchEvent(new Event('chosen', data));
+    this.dispatchEvent(new CustomEvent('chosen', { detail: data }));
   }
 
   clear() {

--- a/client/src/entrypoints/images/image-block.js
+++ b/client/src/entrypoints/images/image-block.js
@@ -17,7 +17,7 @@ class ImageBlockDefinition extends window.wagtailStreamField.blocks
 
     const imageChooserWidget = block.childBlocks.image.widget;
     let lastDefaultAltText = initialState?.image?.default_alt_text || '';
-    imageChooserWidget.on('chosen', (data) => {
+    imageChooserWidget.addEventListener('chosen', ({ detail: data }) => {
       /* If the alt text field has not been changed from the previous image's default alt text
       (or the empty string, if there was no previous image), replace it with the new image's
       default alt text */


### PR DESCRIPTION
Fixes #13275. I've also double-checked the events dispatched by the classes migrated to `EventTarget` to see if there are any remaining `.on(...)` and incorrect `Event()` with data, and couldn't find any.


https://github.com/user-attachments/assets/b4b83653-7f9a-4a23-a903-5f42afae4a25

