### PR TITLE
Refresh accessibility targets in contributing docs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -107,6 +107,7 @@ Changelog
  * Maintenance: Add overridable blocks in comments and checks side panel templates (Sage Abdullah)
  * Maintenance: Rewrite Tabs component frontend to use Stimulus and TypeScript (Sai Srikar Dumpeti, LB (Ben) Johnston, Sage Abdullah)
  * Maintenance: Upgrade django-tasks to 0.8.x (Jake Howard)
+ * Maintenance: Refresh accessibility targets in contributing docs (Thibaud Colas)
 
 
 7.0.2 (24.07.2025)

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -232,9 +232,9 @@ We want to make Wagtail accessible for users of a wide variety of assistive tech
 -   [NVDA](https://www.nvaccess.org/download/) on Windows with Firefox ESR
 -   [VoiceOver](https://support.apple.com/en-gb/guide/voiceover-guide/welcome/web) on macOS with Safari
 -   [Windows Magnifier](https://support.microsoft.com/en-gb/help/11542/windows-use-magnifier) and macOS Zoom
--   Windows Speech Recognition and macOS Dictation
--   Mobile [VoiceOver](https://support.apple.com/en-gb/guide/voiceover-guide/welcome/web) on iOS, or [TalkBack](https://support.google.com/accessibility/android/answer/6283677?hl=en-GB) on Android
--   Windows [High-contrast mode](https://support.microsoft.com/en-us/windows/use-high-contrast-mode-in-windows-10-fedc744c-90ac-69df-aed5-c8a90125e696)
+-   [Windows voice access](https://support.microsoft.com/en-gb/topic/use-voice-access-to-control-your-pc-author-text-with-your-voice-4dcd23ee-f1b9-4fd1-bacc-862ab611f55d) and [macOS Voice Control](https://support.apple.com/en-gb/102225)
+-   [iOS VoiceOver](https://support.apple.com/en-gb/guide/iphone/iph3e2e415f/ios), or [TalkBack](https://support.google.com/accessibility/android/answer/6283677?hl=en-GB) on Android
+-   [Windows Contrast themes](https://support.microsoft.com/en-us/windows/change-color-contrast-in-windows-fedc744c-90ac-69df-aed5-c8a90125e696)
 
 We aim for Wagtail to work in those environments. Our development standards ensure that the site is usable with other assistive technologies. In practice, testing with assistive technology can be a daunting task that requires specialized training – here are tools we rely on to help identify accessibility issues, to use during development and code reviews:
 

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -167,6 +167,7 @@ Thank you to Dhruvi Patel for implementing this as part of the [Google Summer of
  * Add overridable blocks in comments and checks side panel templates (Sage Abdullah)
  * Rewrite Tabs component frontend to use Stimulus and TypeScript (Sai Srikar Dumpeti, LB (Ben) Johnston, Sage Abdullah)
  * Upgrade django-tasks to 0.8.x (Jake Howard)
+ * Refresh accessibility targets in contributing docs (Thibaud Colas)
 
 ## Upgrade considerations - changes affecting Wagtail customizations
 


### PR DESCRIPTION
This is a light-touch refresh of our accessibility targets to keep them up-to-date with new versions of operating systems, without introducing new items.

- Windows Speech Recognition is now called "voice access"
- macOS Dictation is still relevant but really it’s Voice Control which matters most for accessibility
- Important for links to be clear iOS VoiceOver and macOS VoiceOver are different beasts.
- Windows high-contrast mode is now Contrast themes.

---

I still think this is the right set of targets for us to test with as an open source project, but there are other relevant ones we should consider for product design. For a future PR, things that didn’t make the cut but are still relevant:

- Narrator, as the built-in screen reader on Windows (but its usage statistics are very low)
- JAWS, as the most popular screen reader (but it costs a lot of money)
- Orca, as the most widely used screen reader on Linux (be great for us to have, but hard to test with
- ZoomText, as a popular magnifier - reader combo