### PR TITLE
WIP: Set semgrep rules for inline styles

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -80,3 +80,21 @@ rules:
       See https://docs.wagtail.org/en/latest/contributing/translations.html#marking-strings-for-translation for more information.
     languages: [javascript, typescript]
     severity: ERROR
+  - id: no-inline-html-styles
+    message: |
+      Do not use inline styles in HTML.
+      Use CSS classes or Stimulus attributes instead.
+    languages: [html]
+    severity: ERROR
+    patterns:
+      - pattern: <$TAG ... style="$STYLE_CONTENT" ...>
+  - id: no-setattribute-style
+    message: |
+      Avoid setting inline styles using `element.setAttribute('style', ...)`.
+      This approach triggers Content Security Policy (CSP) violations with strict
+      policies and leads to unmaintainable CSS. Prefer adding/removing CSS classes
+      or using framework-specific styling solutions.
+    languages: [javascript, typescript]
+    severity: ERROR
+    patterns:
+      - pattern: $ELEMENT.setAttribute('style', $STYLE_STRING)


### PR DESCRIPTION
In line with the 2025 GSoC project for CSP compatibility, one of the proactive attempts at preventing CSP violations in the codebase that has been explored is the possibility of creating rules in the `semgrep.yml` to spot said violations. This PR approaches the topic using inline styles as a prototype.