### PR TITLE
Fix 'Empty string passed to getElementById()' warning on Firefox

### DIFF
--- a/client/src/includes/panels.ts
+++ b/client/src/includes/panels.ts
@@ -110,7 +110,9 @@ export function initCollapsiblePanels(
  * JS-rendered elements.
  */
 export function initAnchoredPanels(
-  anchorTarget = document.getElementById(window.location.hash.slice(1)),
+  anchorTarget = window.location.hash
+    ? document.getElementById(window.location.hash.slice(1))
+    : null,
 ) {
   const target = anchorTarget?.matches('[data-panel]')
     ? anchorTarget


### PR DESCRIPTION
Regression in 86610560e6fbaeaf34c3badc6cb69422d2420a36
