### PR TITLE
Check `can_create_at` on `can_move_to` for `PagePermissionTester`

### DIFF
--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -2317,6 +2317,9 @@ class PagePermissionTester:
         ):
             return False
 
+        if not self.page.specific.can_create_at(destination):
+            return False
+
         # shortcut the trivial 'everything' / 'nothing' permissions
         if not self.user.is_active:
             return False


### PR DESCRIPTION
This PR fixes #13293.

(See issue for in-depth explanation of issue)

By adding a check of `can_create_at` on the `can_move_to`, we can prevent users from moving multiple child pages with `max_count_per_parent` under one parent. This will remove the option in the page picker under the /move route.