### PR TITLE
Prevent multiple child pages with `max_count_per_parent` being moved under one parent

### DIFF
--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -2317,6 +2317,10 @@ class PagePermissionTester:
         ):
             return False
 
+        # if the page cannot be created at the destination, it cannot be moved there
+        if not self.page.specific.can_create_at(destination):
+            return False
+
         # shortcut the trivial 'everything' / 'nothing' permissions
         if not self.user.is_active:
             return False


### PR DESCRIPTION
This PR fixes #13293 

(See issue for in-depth explanation of issue)

By adding a check of `can_create_at` on the `can_move_to` on `PagePermissionTester`, we can prevent users from moving multiple child pages with `max_count_per_parent` under one parent. This will remove the option in the page picker under the `/move` route.