### PR TITLE
Add docs for programmatic access to the editor's form element and the preview panel

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -91,6 +91,7 @@ Changelog
  * Docs: Add experimental documentation for admin UI components and client-side code (Sage Abdullah)
  * Docs: Clean up JSDoc documentation comments, syntax, and update spelling where suitable (LB (Ben) Johnston)
  * Docs: Add more examples of all images settings and include `avif` in `WAGTAILIMAGES_EXTENSIONS` example (Thibaud Colas)
+ * Docs: Add an example of using `data-edit-form` and interacting with the editor form and preview panel (Sage Abdullah)
  * Maintenance: Refactor `get_embed` to remove `finder` argument which was only used for mocking in unit tests (Jigyasu Rajput)
  * Maintenance: Simplify handling of `None` values in `TypedTableBlock` (Jigyasu Rajput)
  * Maintenance: Remove squash.io configuration (Sage Abdullah)

--- a/client/src/includes/initStimulus.ts
+++ b/client/src/includes/initStimulus.ts
@@ -5,7 +5,7 @@ import { Application } from '@hotwired/stimulus';
  * Wagtail's extension of the base Stimulus `Application` with additional
  * capabilities for convenience.
  */
-class WagtailApplication extends Application {
+export class WagtailApplication extends Application {
   /**
    * Returns the first Stimulus controller that matches the identifier.
    * @param identifier - The identifier of the controller to query.
@@ -17,13 +17,13 @@ class WagtailApplication extends Application {
    * const content = await controller?.extractContent();
    * ```
    */
-  queryController(identifier: string): Controller | null {
+  queryController<T extends Controller<Element>>(identifier: string) {
     return this.getControllerForElementAndIdentifier(
       document.querySelector(
         `[${this.schema.controllerAttribute}~="${identifier}"]`,
       )!,
       identifier,
-    );
+    ) as T | null;
   }
 
   /**
@@ -37,7 +37,7 @@ class WagtailApplication extends Application {
    * controllers.forEach((controller) => controller.reset());
    * ```
    */
-  queryControllerAll(identifier: string): Controller[] {
+  queryControllerAll<T extends Controller<Element>>(identifier: string): T[] {
     return Array.from(
       document.querySelectorAll(
         `[${this.schema.controllerAttribute}~="${identifier}"]`,
@@ -46,7 +46,7 @@ class WagtailApplication extends Application {
       .map((element) =>
         this.getControllerForElementAndIdentifier(element, identifier),
       )
-      .filter(Boolean) as Controller[];
+      .filter(Boolean) as T[];
   }
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -190,6 +190,16 @@ myst_url_schemes = {
     "https": None,
     "http": None,
     "mailto": None,
+    "client": {
+        "url": "/reference/ui/client/{{path}}.html#{{fragment}}",
+        "title": "{{path}}",
+        "classes": ["pre"],
+    },
+    "controller": {
+        "url": "/reference/ui/client/classes/controllers_{{path}}.{{path}}.html#{{fragment}}",
+        "title": "{{path}}",
+        "classes": ["pre"],
+    },
 }
 
 myst_enable_extensions = [

--- a/docs/extending/editor_api.md
+++ b/docs/extending/editor_api.md
@@ -1,0 +1,168 @@
+# Accessing the editor programmatically
+
+Wagtail's editor is built with various JavaScript components that can be interacted with programmatically. This document provides an overview of how to access and extend the editor's functionality.
+
+## The editor's `<form>` element
+
+The editor's main `<form>` element can be queried using the `data-edit-form` attribute. This is useful for attaching event listeners or manipulating the form programmatically, as well as getting the form's `FormData` representation.
+
+```javascript
+const editForm = document.querySelector('form[data-edit-form]');
+const data = new FormData(editForm);
+```
+
+## The preview panel
+
+The preview panel is powered by the [`PreviewController`](controller:PreviewController) and its instance can be accessed using the [`wagtail.app.queryController`](client:classes/includes_initStimulus.WagtailApplication#querycontroller) function. The `PreviewController` provides methods to control the preview, such as extracting the previewed content and running content checks. Refer to the `PreviewController` documentation for more details.
+
+```javascript
+const previewController = window.wagtail.app.queryController('w-preview');
+const content = await previewController?.extractContent();
+await previewController?.runContentChecks();
+```
+
+## Example: generating meta description
+
+Extracting the previewed content using the `PreviewController` can be useful for different use cases. One example is generating a meta description for the page using a Large Language Model (LLM). The following example demonstrates a [custom Stimulus controller](extending_client_side_stimulus) that uses an LLM from the browser's [Summarizer API](https://developer.mozilla.org/en-US/docs/Web/API/Summarizer) to generate the page's meta description.
+
+```javascript
+/* js/summarize.js */
+
+class SummarizeController extends window.StimulusModule.Controller {
+  static targets = ['suggest'];
+
+  static values = {
+    input: { default: '', type: String },
+  };
+
+  /** Only load the controller if the browser supports the Summarizer API. */
+  static get shouldLoad() {
+    return 'Summarizer' in window;
+  }
+
+  /** The previewed content's language. */
+  contentLanguage = document.documentElement.lang || 'en';
+  /** A cached Summarizer instance Promise to avoid recreating it unnecessarily. */
+  #summarizer = null;
+
+  /** Promise of a browser Summarizer instance. */
+  get summarizer() {
+    if (this.#summarizer) return this.#summarizer; // Return from cache
+    this.#summarizer = Summarizer.create({
+      // Change the Summarizer's configuration as needed
+      sharedContext: `A summary of a webpage's content, suitable for use as a meta description.`,
+      type: 'teaser',
+      length: 'short',
+      format: 'plain-text',
+      expectedInputLanguages: [this.contentLanguage],
+      outputLanguage: document.documentElement.lang,
+    });
+    return this.#summarizer;
+  }
+
+  connect() {
+    this.input = this.element.querySelector(this.inputValue);
+    this.renderFurniture();
+  }
+
+  renderFurniture() {
+    const prefix = this.element.closest('[id]').id;
+    const buttonId = `${prefix}-generate`;
+    const button = /* html */ `
+      <button
+        id="${buttonId}"
+        type="button"
+        data-summarize-target="suggest"
+        data-action="summarize#generate"
+        class="button"
+      >
+        Generate suggestions
+      </button>
+    `;
+    this.element.insertAdjacentHTML('beforeend', button);
+
+    this.outputArea = document.createElement('div');
+    this.element.append(this.outputArea);
+  }
+
+  renderSuggestion(suggestion) {
+    const template = document.createElement('template');
+    template.innerHTML = /* html */ `
+      <div>
+        <output for="${this.suggestTarget.id}">${suggestion}</output>
+        <button class="button button-small" type="button" data-action="summarize#useSuggestion">Use</button>
+      </div>
+    `;
+    this.outputArea.append(template.content.firstElementChild);
+  }
+
+  useSuggestion(event) {
+    this.input.value = event.target.previousElementSibling.textContent;
+  }
+
+  async summarize(text) {
+    const summarizer = await this.summarizer;
+    return summarizer.summarize(text);
+  }
+
+  async getPageContent() {
+    const previewController = window.wagtail.app.queryController('w-preview');
+    const { innerText, lang } = await previewController.extractContent();
+    this.contentLanguage = lang;
+    return innerText;
+  }
+
+  async generate() {
+    this.outputArea.innerHTML = '';
+    this.suggestTarget.textContent = 'Generating…';
+    this.suggestTarget.disabled = true;
+
+    const text = await this.getPageContent();
+    await Promise.allSettled(
+      [...Array(3).keys()].map(() =>
+        this.summarize(text)
+          .then((output) => this.renderSuggestion(output))
+          .catch((error) => {
+            console.error('Error generating suggestion:', error);
+          }),
+      ),
+    );
+
+    this.suggestTarget.disabled = false;
+    this.suggestTarget.textContent = 'Generate suggestions';
+  }
+}
+
+window.wagtail.app.register('summarize', SummarizeController);
+```
+
+The JavaScript file can be loaded to the editor using the `insert_editor_js` hook and attached to the `Page`'s `FieldPanel` for the `search_description` field:
+
+```python
+# myapp/wagtail_hooks.py
+from django.templatetags.static import static
+from django.utils.html import format_html_join
+from wagtail import hooks
+from wagtail.admin.panels import FieldPanel
+from wagtail.models import Page
+
+
+@hooks.register("insert_editor_js")
+def editor_js():
+    js_files = ["js/summarize.js"]
+    return format_html_join(
+        "\n",
+        '<script src="{}"></script>',
+        ((static(filename),) for filename in js_files),
+    )
+
+# Replace the default `FieldPanel` for `search_description`
+# with a custom one that uses the `summarize` controller.
+Page.promote_panels[0].args[0][-1] = FieldPanel(
+    "search_description",
+    attrs={
+        "data-controller": "summarize",
+        "data-summarize-input-value": "[name='search_description']",
+    },
+)
+```

--- a/docs/extending/extending_client_side.md
+++ b/docs/extending/extending_client_side.md
@@ -402,3 +402,7 @@ window.draftail.TooltipEntity;
 
 -   [](streamfield_widget_api)
 -   [](custom_streamfield_blocks_media)
+
+## Extending the editor
+
+-   [](editor_api)

--- a/docs/extending/extending_client_side.md
+++ b/docs/extending/extending_client_side.md
@@ -348,6 +348,8 @@ window.wagtail.app.register('word-count', WordCountController);
 
 You may want to avoid bundling Stimulus with your JavaScript output and treat the global as an external/alias module, refer to your build system documentation for instructions on how to do this.
 
+(extending_client_side_react)=
+
 ## Extending with React
 
 To customize or extend the [React](https://reactjs.org/) components, you may need to use React too, as well as other related libraries.
@@ -400,5 +402,3 @@ window.draftail.TooltipEntity;
 
 -   [](streamfield_widget_api)
 -   [](custom_streamfield_blocks_media)
-
-(extending_client_side_react)=

--- a/docs/extending/extending_client_side.md
+++ b/docs/extending/extending_client_side.md
@@ -63,7 +63,7 @@ The [Stimulus handbook](https://stimulus.hotwired.dev/handbook/introduction) is 
 
 Wagtail exposes two client-side globals for using Stimulus.
 
-1. `window.wagtail.app` the core admin Stimulus application instance.
+1. `window.wagtail.app` the core admin Stimulus [`WagtailApplication`](client:classes/includes_initStimulus.WagtailApplication) instance.
 2. `window.StimulusModule` Stimulus module as exported from `@hotwired/stimulus`.
 
 First, create a custom [Stimulus controller](https://stimulus.hotwired.dev/reference/controllers) that extends the base `window.StimulusModule.Controller` using [JavaScript class inheritance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes). If you are using a build tool you can import your base controller via `import { Controller } from '@hotwired/stimulus';`.

--- a/docs/extending/index.md
+++ b/docs/extending/index.md
@@ -26,6 +26,7 @@ custom_account_settings
 customizing_group_views
 custom_image_filters
 extending_client_side
+editor_api
 rich_text_internals
 extending_draftail
 custom_bulk_actions

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -148,6 +148,7 @@ Thank you to Dhruvi Patel for implementing this as part of the [Google Summer of
  * Add experimental documentation for admin [UI components and client-side code](ui_components) (Sage Abdullah)
  * Clean up JSDoc documentation comments, syntax, and update spelling where suitable (LB (Ben) Johnston)
  * Add more examples of all [images settings](wagtailimages_all_settings) and include `avif` in `WAGTAILIMAGES_EXTENSIONS` example (Thibaud Colas)
+ * Add an example of using `data-edit-form` and interacting with the editor form and preview panel (Sage Abdullah)
 
 ### Maintenance
 


### PR DESCRIPTION
Bonus example: generating meta description using the page's preview content.