### PR TITLE
Check if subpage models can be created in can_add_subpage

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Fix: Ensure `ImageBlock` alt text populates on choosing a new image after unchecking decorative state (Pratham Jaiswal)
  * Fix: Set `verbose_name_plural` for Query model in search promotions app (Saptami)
  * Fix: Truncate overly long task names in workflow admin view (Gaurav Takhi)
+ * Fix: Hide "Add child page" button when no child pages can be created as per `max_count` or `max_count_per_parent` (Lasse Schmieding)
  * Docs: Add documentation for the `filter_spec` parameter of `ImageRenditionField` (Soumya-codr)
  * Docs: Add guide for testing document upload forms (Wenli Tsai, Bhavesh Sharma)
  * Docs: Document the `nested_default_fields` attribute on API viewsets (Deepanshu Tevathiya)

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -27,6 +27,7 @@ Wagtail 7.4 is designated a Long Term Support (LTS) release. Long Term Support r
  * Ensure `ImageBlock` alt text populates on choosing a new image after unchecking decorative state (Pratham Jaiswal)
  * Set `verbose_name_plural` for Query model in search promotions app (Saptami)
  * Truncate overly long task names in workflow admin view (Gaurav Takhi)
+ * Hide "Add child page" button when no child pages can be created as per `max_count` or `max_count_per_parent` (Lasse Schmieding)
 
 ### Documentation
 

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -102,13 +102,12 @@ class TestPageCreation(WagtailTestUtils, TestCase):
         response = self.client.get(
             reverse("wagtailadmin_pages:add_subpage", args=(simple_parent_page.id,))
         )
-        self.assertEqual(response.status_code, 200)
-        # if there is no page_type available then this message should be shown.
-        self.assertContains(
-            response, "Sorry, you cannot create a page at this location."
-        )
-        self.assertNotContains(
-            response, "Choose which type of page you'd like to create."
+        # Raises a permission denied error
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse("wagtailadmin_home"))
+        self.assertEqual(
+            response.context["message"],
+            "Sorry, you do not have permission to access this area.",
         )
 
     def test_add_subpage_with_one_valid_subpage_type(self):

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -8,7 +8,7 @@ from wagtail.admin import widgets as wagtailadmin_widgets
 from wagtail.admin.wagtail_hooks import page_header_buttons, page_listing_more_buttons
 from wagtail.admin.widgets.button import Button
 from wagtail.models import Page
-from wagtail.test.testapp.models import SimplePage
+from wagtail.test.testapp.models import SimpleChildPage, SimplePage, SimpleParentPage
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.utils.deprecation import RemovedInWagtail80Warning
 
@@ -354,6 +354,24 @@ class TestPageHeaderButtonsHooks(TestButtonsHooks):
         )
         full_url = unpublish_base_url + "?" + urlencode({"next": next_url})
         self.assertEqual(unpublish_button.url, full_url)
+
+    def test_add_child_not_shown_when_no_subpage_type_available_to_create(self):
+        simple_parent_page = SimpleParentPage(
+            title="Simple parent",
+            slug="simple-parent",
+        )
+        self.root_page.add_child(instance=simple_parent_page)
+        simple_child_page = SimpleChildPage(
+            title="Simple child",
+            slug="simple-child",
+        )
+        simple_parent_page.add_child(instance=simple_child_page)
+
+        buttons = page_header_buttons(simple_parent_page, self.user, view_name="edit")
+        add_subpage_button = next(
+            button for button in buttons if button.label == "Add child page"
+        )
+        self.assertFalse(add_subpage_button.is_shown(user=self.user))
 
 
 class ButtonComparisonTestCase(SimpleTestCase):

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -2183,8 +2183,16 @@ class PagePermissionTester:
     def can_add_subpage(self):
         if not self.user.is_active:
             return False
+
         specific_class = self.page.specific_class
-        if specific_class is None or not specific_class.creatable_subpage_models():
+        if specific_class is None:
+            return False
+
+        creatable_subpage_models = specific_class.creatable_subpage_models()
+        if not any(
+            subpage_model.can_create_at(self.page)
+            for subpage_model in creatable_subpage_models
+        ):
             return False
         return self.user.is_superuser or ("add" in self.permissions)
 


### PR DESCRIPTION
Add a check in `can_add_subpage` to check if the allowed subpage models can be created under the parent.
This checks whether the constraints set by `max_count` and `max_count_per_parent` are set.

This change prevents the "Add child page buttons" showing, as suggested by @zerolab in #13286 .

## Comments & Questions
It does change the behaviour of trying to reach the subpage, throwing a `PermissionDenied` when trying to access the add page instead of showing an empty list. I think the message introduced in #8173 does not show anymore.
The message with the `PermissionDenied` isn't as descriptive as the previous message, so perhaps this is not as nice as it was before, although the links to reach this page are not present anymore.

There are similar checks for the `creatable_subpage_models` in the `PagePermissionTester` in the `can_copy_to` and the `can_publish_subpage` methods, perhaps they might also like to check the counts?