### PR TITLE
Update `django-tasks` to `0.8`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "anyascii>=0.1.5",
   "telepath>=0.3.1,<1",
   "laces>=0.1,<0.2",
-  "django-tasks>=0.7,<0.8",
+  "django-tasks>=0.8,<0.9",
 ]
 
 [project.urls]


### PR DESCRIPTION
[`0.8.x`](https://github.com/RealOrangeOne/django-tasks/releases/tag/0.8.0) has a lot of useful changes it'd be great to get out into Wagtail 7.1.