### PR TITLE
Replace myst_url_schemes links with relative external links

### DIFF
--- a/docs/extending/editor_api.md
+++ b/docs/extending/editor_api.md
@@ -13,7 +13,7 @@ const data = new FormData(editForm);
 
 ## The preview panel
 
-The preview panel is powered by the [`PreviewController`](controller:PreviewController) and its instance can be accessed using the [`wagtail.app.queryController`](client:classes/includes_initStimulus.WagtailApplication#querycontroller) function. The `PreviewController` provides methods to control the preview, such as extracting the previewed content and running content checks. Refer to the `PreviewController` documentation for more details.
+The preview panel is powered by the [`PreviewController`](../reference/ui/client/classes/controllers_PreviewController.PreviewController.html){.external} and its instance can be accessed using the [`wagtail.app.queryController`](../reference/ui/client/classes/includes_initStimulus.WagtailApplication#querycontroller){.external} function. The `PreviewController` provides methods to control the preview, such as extracting the previewed content and running content checks. Refer to the `PreviewController` documentation for more details.
 
 ```javascript
 const previewController = window.wagtail.app.queryController('w-preview');

--- a/docs/extending/extending_client_side.md
+++ b/docs/extending/extending_client_side.md
@@ -63,7 +63,7 @@ The [Stimulus handbook](https://stimulus.hotwired.dev/handbook/introduction) is 
 
 Wagtail exposes two client-side globals for using Stimulus.
 
-1. `window.wagtail.app` the core admin Stimulus [`WagtailApplication`](client:classes/includes_initStimulus.WagtailApplication) instance.
+1. `window.wagtail.app` the core admin Stimulus [`WagtailApplication`](../reference/ui/client/classes/includes_initStimulus.WagtailApplication){.external} instance.
 2. `window.StimulusModule` Stimulus module as exported from `@hotwired/stimulus`.
 
 First, create a custom [Stimulus controller](https://stimulus.hotwired.dev/reference/controllers) that extends the base `window.StimulusModule.Controller` using [JavaScript class inheritance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes). If you are using a build tool you can import your base controller via `import { Controller } from '@hotwired/stimulus';`.

--- a/docs/reference/ui/components.md
+++ b/docs/reference/ui/components.md
@@ -24,7 +24,7 @@ This document provides a reference for Wagtail's user interface (UI) components,
    :no-contents-entry:
 ```
 
-A dialog to display information in a modal dialog. It is powered by the [`DialogController`](controller:DialogController) (`w-dialog`). To create a dialog, you can use the `{% dialog %}` and `{% enddialog %}` template tags.
+A dialog to display information in a modal dialog. It is powered by the [`DialogController`](./client/classes/controllers_DialogController.DialogController.html){.external} (`w-dialog`). To create a dialog, you can use the `{% dialog %}` and `{% enddialog %}` template tags.
 
 ```html+django
 {% dialog icon_name="globe" title="Dialog with critical error" id="my-dialog" subtitle="This is a testing subtitle" message_status="critical" message_heading="There was an issue with the thing" message_description="This is a subtext for the message" %}
@@ -79,7 +79,7 @@ Arguments for the `{% dialog_toggle %}` tag:
    :no-contents-entry:
 ```
 
-A dropdown menu to display a list of actions or options. It is powered by the [`DropdownController`](controller:DropdownController) (`w-dropdown`). To create a dropdown, you can use the `{% dropdown %}` and `{% enddropdown %}` template tags.
+A dropdown menu to display a list of actions or options. It is powered by the [`DropdownController`](./client/classes/controllers_DropdownController.DropdownController.html){.external} (`w-dropdown`). To create a dropdown, you can use the `{% dropdown %}` and `{% enddropdown %}` template tags.
 
 ```html+django
 {% dropdown toggle_icon="dots-horizontal" toggle_aria_label="Actions" %}
@@ -145,7 +145,7 @@ Only the `button` argument is required, the rest are optional.
 
 ## Tooltip
 
-A tooltip that can be attached to an HTML element to display additional information on hover or focus. It is powered by the [`TooltipController`](controller:TooltipController) (`w-tooltip`). To add a tooltip, attach the `w-tooltip` controller to an element and specify the properties using data attributes.
+A tooltip that can be attached to an HTML element to display additional information on hover or focus. It is powered by the [`TooltipController`](./client/classes/controllers_TooltipController.TooltipController.html){.external} (`w-tooltip`). To add a tooltip, attach the `w-tooltip` controller to an element and specify the properties using data attributes.
 
 ```html
 <button


### PR DESCRIPTION
Quick fix for `myst_url_schemes` external links, which unfortunately don’t seem to be compatible with how Read the Docs generates URLs with language and version segments in the path.

I’ve converted the links to be relative URLs marked as `.external` for now (so MyST doesn’t attempt to parse the references), and will revisit after the release.