### PR TITLE
Improve grouped linting & fix npm scripts + add lint:ts to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,10 +56,7 @@ jobs:
           paths:
             - wagtail
       - run: npm run build-storybook
-      - run: npm run lint:js
-      - run: npm run lint:css
-      - run: npm run lint:format
-      - run: npm run lint:project
+      - run: npm run lint --loglevel silent
       - run: npm run test:unit:coverage -- --runInBand
       - run: bash <(curl -s https://codecov.io/bash) -F frontend
 

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,7 @@ lint-server:
 	semgrep --config .semgrep.yml --error .
 
 lint-client:
-	npm run lint:css --silent
-	npm run lint:js --silent
-	npm run lint:format --silent
-	npm run lint:project
+	npm run lint --loglevel silent
 
 lint-docs:
 	doc8 docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@wagtail/stylelint-config-wagtail": "^0.8.0",
         "autoprefixer": "^10.4.21",
         "babel-loader": "^9.2.1",
+        "concurrently": "^9.2.0",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^6.11.0",
         "cssnano": "^5.1.15",
@@ -9899,6 +9900,32 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz",
+      "integrity": "sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
     "node_modules/confbox": {
@@ -20111,6 +20138,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -20493,6 +20530,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/shortcss": {
@@ -22128,6 +22178,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/trim-newlines": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@wagtail/stylelint-config-wagtail": "^0.8.0",
     "autoprefixer": "^10.4.21",
     "babel-loader": "^9.2.1",
+    "concurrently": "^9.2.0",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^6.11.0",
     "cssnano": "^5.1.15",
@@ -105,9 +106,9 @@
     "typedoc": "^0.28.7",
     "typedoc-plugin-mdn-links": "^5.0.4",
     "typescript": "^5.8.3",
-    "yaml": "^2.8.0",
     "webpack": "^5.100.2",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^5.1.4",
+    "yaml": "^2.8.0"
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
@@ -139,16 +140,16 @@
   "scripts": {
     "start": "webpack --config ./client/webpack.config.js --mode development --progress --watch",
     "build": "webpack --config ./client/webpack.config.js --mode production",
+    "fix": "npm run @all -- 'npm:fix:*'",
     "fix:css": "stylelint --fix **/*.scss",
     "fix:js": "eslint --ext .js,.ts,.tsx --fix .",
-    "fix": "npm run fix:css && npm run fix:js",
     "format": "prettier --write \"**/?(.)*.{css,scss,js,ts,tsx,json,yaml,yml}\"",
+    "lint": "npm run @all -- 'npm:lint:*'",
     "lint:js": "eslint --ext .js,.ts,.tsx --report-unused-disable-directives .",
     "lint:css": "stylelint **/*.scss",
     "lint:format": "prettier --check \"**/?(.)*.{css,scss,js,ts,tsx,json,yaml,yml}\"",
     "lint:project": "node ./scripts/check-dependencies.mjs",
     "lint:ts": "tsc --noEmit",
-    "lint": "npm run lint:js && npm run lint:ts && npm run lint:css && npm run lint:format && npm run lint:project",
     "test": "npm run test:unit",
     "test:unit": "jest",
     "test:unit:watch": "jest --watch",
@@ -156,6 +157,7 @@
     "test:integration": "./client/tests/integration/node_modules/.bin/jest --config ./client/tests/integration/jest.config.js",
     "storybook": "storybook dev -c client/storybook -p 6006 --no-open --no-version-updates",
     "build-docs": "typedoc",
-    "build-storybook": "storybook build -c client/storybook"
+    "build-storybook": "storybook build -c client/storybook",
+    "@all": "concurrently --group --passthrough-arguments --prefix-colors auto --timings"
   }
 }


### PR DESCRIPTION
Currently our CI and Makefile linting script is NOT running `lint:ts`, which means developers could easily miss this only to see it fail for developers running locally.

This may have been initially intentional but as we migrate more towards TypeScript, it's important our Types are checked in the CI.

In addition, it's quite easy to miss sub-scripts being added as we have these maintained in multiple places (Makefile, CI config).

This PR introduces an improvement for both these issues by bringing in [Concurrently](https://github.com/open-cli-tools/concurrently) to allow for NPM scripts to run in parallel more easily.

### Example output

The `lint` scripts will all run in parallel and have a grouped, prefixed (with colours) output like this.

<img width="1093" height="668" alt="Screenshot 2025-08-07 at 6 16 49 AM" src="https://github.com/user-attachments/assets/2e32830a-7147-43da-9446-ebe48ebebbef" />


### Full details

- Raised initially in comment - https://github.com/wagtail/wagtail/pull/13228#discussion_r2241049588
- Set up `@all` command to share common concurrently options for commands.
- Migrate `npm run lint` & `npm run fix` to automatically pick up all sub-scripts with the same prefix, e.g. `lint:ts`. These will run in parallel and output a summary of timings.
- Update Makefile & CI config to run all linting (inc. TypeScript types) and use a more explicit NPM loglevel https://docs.npmjs.com/cli/v11/using-npm/config#shorthands-and-other-cli-niceties

