### PR TITLE
Refine TypeDoc deployment setup

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,6 +20,13 @@ sphinx:
   configuration: docs/conf.py
   fail_on_warning: True
 search:
+  ignore:
+    # Ignore TypeDoc-generated docs as they can be noisy,
+    # use TypeDoc's search mechanism for those pages instead.
+    - reference/ui/client/*
   ranking:
-    releases/*: -1
+    # Group release notes at the bottom of the search results instead of mixing
+    # them with other pages.
+    releases/*: -10
+    # Except for the upgrading guide, which should have the normal rank.
     releases/upgrading.html: 0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,14 @@ StandaloneHTMLBuilder.supported_image_types = ["image/gif", "image/png"]
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
+# Relative path to the root of the documentation, used for linking to the
+# Typedoc-generated sub-docs. RTD allows optional language and version.
+base_path = ""
+if rtd_lang := os.environ.get("READTHEDOCS_LANGUAGE", ""):
+    base_path += f"/{rtd_lang}"
+if rtd_version := os.environ.get("READTHEDOCS_VERSION", ""):
+    base_path += f"/{rtd_version}"
+
 html_theme = "sphinx_wagtail_theme"
 html_theme_path = [sphinx_wagtail_theme.get_html_theme_path()]
 
@@ -191,12 +199,15 @@ myst_url_schemes = {
     "http": None,
     "mailto": None,
     "client": {
-        "url": "/reference/ui/client/{{path}}.html#{{fragment}}",
+        "url": "%s/reference/ui/client/{{path}}.html#{{fragment}}" % base_path,
         "title": "{{path}}",
         "classes": ["pre"],
     },
     "controller": {
-        "url": "/reference/ui/client/classes/controllers_{{path}}.{{path}}.html#{{fragment}}",
+        "url": (
+            "%s/reference/ui/client/classes/controllers_{{path}}.{{path}}.html#{{fragment}}"
+            % base_path
+        ),
         "title": "{{path}}",
         "classes": ["pre"],
     },

--- a/docs/extending/editor_api.md
+++ b/docs/extending/editor_api.md
@@ -13,7 +13,7 @@ const data = new FormData(editForm);
 
 ## The preview panel
 
-The preview panel is powered by the [`PreviewController`](../reference/ui/client/classes/controllers_PreviewController.PreviewController.html){.external} and its instance can be accessed using the [`wagtail.app.queryController`](../reference/ui/client/classes/includes_initStimulus.WagtailApplication#querycontroller){.external} function. The `PreviewController` provides methods to control the preview, such as extracting the previewed content and running content checks. Refer to the `PreviewController` documentation for more details.
+The preview panel is powered by the [`PreviewController`](controller:PreviewController) and its instance can be accessed using the [`wagtail.app.queryController`](client:classes/includes_initStimulus.WagtailApplication#querycontroller) function. The `PreviewController` provides methods to control the preview, such as extracting the previewed content and running content checks. Refer to the `PreviewController` documentation for more details.
 
 ```javascript
 const previewController = window.wagtail.app.queryController('w-preview');

--- a/docs/reference/ui/components.md
+++ b/docs/reference/ui/components.md
@@ -24,7 +24,7 @@ This document provides a reference for Wagtail's user interface (UI) components,
    :no-contents-entry:
 ```
 
-A dialog to display information in a modal dialog. It is powered by the [`DialogController`](./client/classes/controllers_DialogController.DialogController.html){.external} (`w-dialog`). To create a dialog, you can use the `{% dialog %}` and `{% enddialog %}` template tags.
+A dialog to display information in a modal dialog. It is powered by the [`DialogController`](controller:DialogController) (`w-dialog`). To create a dialog, you can use the `{% dialog %}` and `{% enddialog %}` template tags.
 
 ```html+django
 {% dialog icon_name="globe" title="Dialog with critical error" id="my-dialog" subtitle="This is a testing subtitle" message_status="critical" message_heading="There was an issue with the thing" message_description="This is a subtext for the message" %}
@@ -79,7 +79,7 @@ Arguments for the `{% dialog_toggle %}` tag:
    :no-contents-entry:
 ```
 
-A dropdown menu to display a list of actions or options. It is powered by the [`DropdownController`](./client/classes/controllers_DropdownController.DropdownController.html){.external} (`w-dropdown`). To create a dropdown, you can use the `{% dropdown %}` and `{% enddropdown %}` template tags.
+A dropdown menu to display a list of actions or options. It is powered by the [`DropdownController`](controller:DropdownController) (`w-dropdown`). To create a dropdown, you can use the `{% dropdown %}` and `{% enddropdown %}` template tags.
 
 ```html+django
 {% dropdown toggle_icon="dots-horizontal" toggle_aria_label="Actions" %}
@@ -145,7 +145,7 @@ Only the `button` argument is required, the rest are optional.
 
 ## Tooltip
 
-A tooltip that can be attached to an HTML element to display additional information on hover or focus. It is powered by the [`TooltipController`](./client/classes/controllers_TooltipController.TooltipController.html){.external} (`w-tooltip`). To add a tooltip, attach the `w-tooltip` controller to an element and specify the properties using data attributes.
+A tooltip that can be attached to an HTML element to display additional information on hover or focus. It is powered by the [`TooltipController`](controller:TooltipController) (`w-tooltip`). To add a tooltip, attach the `w-tooltip` controller to an element and specify the properties using data attributes.
 
 ```html
 <button


### PR DESCRIPTION
- Fix `myst_url_schemes` for TypeDoc-generated docs to take into account the language and version slugs on RTD.
- Ignore TypeDoc-generated docs from RTD's search index (fixes #13305) and further reduce the ranking of release notes so they are more likely to be grouped together at the bottom.