### PR TITLE
Add a note about CSP for background image position styles. Fix #12939

### DIFF
--- a/docs/advanced_topics/images/focal_points.md
+++ b/docs/advanced_topics/images/focal_points.md
@@ -21,6 +21,8 @@ attribute on the rendition to position the rendition based on the focal point in
 </div>
 ```
 
+For sites enforcing a Content Security Policy, you can apply those styles via a `<style>` tag with a `nonce` attribute.
+
 ## Accessing the focal point in templates
 
 You can access the focal point in the template by accessing the `.focal_point` attribute of a rendition:


### PR DESCRIPTION
Fixes #12939. The simpler approach to addressing this issue, without incurring a lot of churn in Wagtail. In this case, the full code sample would be something like:

```html+django
{% image page.image width-1024 as image %}
<style nonce="{{request.csp_nonce}}">
#my-image-bg { background-image: url('{{ image.url }}'); {{ image.background_position_style }} }
</style>
<div id="my-image-bg">
</div>
```
