### PR TITLE
Add note about when we close stale pull requests

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
 
  * Docs: Fix cross-reference links to the TypeDoc-generated docs (Sage Abdullah)
  * Docs: Refine readthedocs' search indexing for releases and client-side code (Sage Abdullah)
+ * Docs: Add section about closing stale pull requests to the issue tracking documentation (Thibaud Colas, Sage Abdullah, LB (Ben) Johnston)
 
 7.1 (04.08.2025)
 ~~~~~~~~~~~~~~~~

--- a/docs/contributing/issue_tracking.md
+++ b/docs/contributing/issue_tracking.md
@@ -40,6 +40,16 @@ Rebasing / squashing of pull requests is welcome, but not essential. When doing 
 
 Core team members working on Wagtail are expected to go through the same process with their own fork of the project.
 
+### Closing pull requests
+
+When pull requests become stale over time, we will close them to encourage others to take them on.
+
+As a general rule, this applies to pull requests that the contributor has indicated they cannot finish or have stalled (no response to questions or feedback) over more than two release cycles.
+
+Once a pull request is closed, any contributor can resume work on it at any time, with the same approach taken further, or with a different angle.
+
+Add a comment to the original issue with some context and what was needed for the pull request to be completed. If there is no original issue that the pull request was created against, consider creating an issue to summarize the bug or enhancement if suitable.
+
 ## Release schedule
 
 We aim to release a new version every 3 months. To keep to this schedule, we will tend to 'bump' issues and PRs to a future release where necessary, rather than let them delay the present one. For this reason, an issue being tagged under a particular release milestone should not be taken as any kind of guarantee that the feature will actually be shipped in that release.

--- a/docs/releases/7.1.1.md
+++ b/docs/releases/7.1.1.md
@@ -19,6 +19,7 @@ depth: 1
 
  * Fix cross-reference links to the TypeDoc-generated docs (Sage Abdullah)
  * Refine readthedocs' search indexing for releases and client-side code (Sage Abdullah)
+ * Add section about closing stale pull requests to the issue tracking documentation (Thibaud Colas, Sage Abdullah, LB (Ben) Johnston)
 
 ### Maintenance
 


### PR DESCRIPTION
Fixes #13308. Based on core team discussions, new wording to encourage us to do this more, while keeping some discretion case by case. The goal is to encourage momentum from contributors. It’s completely fine for people to move on, but more helpful for other contributors to have a clear signal on what is happening / when it’s ok to take over.