### PR TITLE
Handled user keyboard shortcut preference for comments shortcut 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changelog
 
  * Removed support for Python 3.8 (Matt Westcott)
  * Fix: Use the correct method of resolving the file storage dynamically for FileField usage in images & documents (Amir Mahmoodi)
+ * Fix: Ensure the add comment keyboard shortcut is disabled when keyboard shortcuts are disabled in user preferences (Dhruvi Patel)
  * Docs: Fix cross-reference links to the TypeDoc-generated docs (Sage Abdullah)
  * Docs: Refine readthedocs' search indexing for releases and client-side code (Sage Abdullah)
  * Maintenance: Test against Python 3.14 prerelease (Sage Abdullah)

--- a/client/src/controllers/KeyboardController.test.js
+++ b/client/src/controllers/KeyboardController.test.js
@@ -3,12 +3,6 @@ import Mousetrap from 'mousetrap';
 
 import { KeyboardController } from './KeyboardController';
 
-jest.mock('../config/wagtailConfig', () => ({
-  WAGTAIL_CONFIG: {
-    KEYBOARD_SHORTCUTS_ENABLED: true,
-  },
-}));
-
 describe('KeyboardController', () => {
   let app;
   const buttonClickMock = jest.fn();

--- a/client/src/controllers/KeyboardController.ts
+++ b/client/src/controllers/KeyboardController.ts
@@ -60,7 +60,7 @@ export class KeyboardController extends Controller<
   declare readonly elementTargets: (HTMLButtonElement | HTMLAnchorElement)[];
 
   /**
-   * If custom keyboard shortcuts are disabled by user in settings then controller will not be loaded
+   * If custom keyboard shortcuts are disabled by user in settings then controller will not be loaded.
    */
   static get shouldLoad() {
     return !!WAGTAIL_CONFIG.KEYBOARD_SHORTCUTS_ENABLED;

--- a/client/src/entrypoints/admin/comments.js
+++ b/client/src/entrypoints/admin/comments.js
@@ -1,6 +1,8 @@
 import { gettext } from '../../utils/gettext';
 import { initCommentApp } from '../../components/CommentApp/main';
 
+import { WAGTAIL_CONFIG } from '../../config/wagtailConfig';
+
 const KEYCODE_M = 77;
 
 /**
@@ -11,10 +13,15 @@ window.comments = (() => {
 
   /**
    * Returns true if the provided keyboard event is using the 'add/focus comment' keyboard
-   * shortcut
+   * shortcut and custom keyboard shortcuts enabled by user in settings.
    */
   function isCommentShortcut(e) {
-    return (e.ctrlKey || e.metaKey) && e.altKey && e.keyCode === KEYCODE_M;
+    return (
+      WAGTAIL_CONFIG.KEYBOARD_SHORTCUTS_ENABLED &&
+      (e.ctrlKey || e.metaKey) &&
+      e.altKey &&
+      e.keyCode === KEYCODE_M
+    );
   }
 
   function getContentPath(fieldNode) {

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -35,6 +35,7 @@ const wagtailConfig = {
     },
   ],
   ACTIVE_CONTENT_LOCALE: 'en',
+  KEYBOARD_SHORTCUTS_ENABLED: true,
 };
 
 const configScript = Object.assign(document.createElement('script'), {

--- a/docs/releases/7.2.md
+++ b/docs/releases/7.2.md
@@ -14,11 +14,12 @@ depth: 1
 
 ### Other features
 
- * ...
+ * Ensure
 
 ### Bug fixes
 
  * Use the correct method of resolving the file storage dynamically for FileField usage in images & documents (Amir Mahmoodi)
+ * Ensure the add comment keyboard shortcut is disabled when keyboard shortcuts are disabled in user preferences (Dhruvi Patel)
 
 ### Documentation
 


### PR DESCRIPTION
User keyboard shortcut preference for - Non stimulus shortcut
Updated default keyboard shortcut preference to stubs for tests

This PR is part of GSoC 2025 Project.

Let me know If I need to add tests for the change in comments.js


<img width="592" height="282" alt="Screenshot from 2025-08-07 22-14-43" src="https://github.com/user-attachments/assets/5b279f98-abe3-4afd-a35f-807c12b48b10" />
