### PR TITLE
fix(button): render <button> element when no URL is defined (#13250)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changelog
 
 * Set `FieldPanel(required_on_save=True)` for `AbstractFormField`'s `field_type` field (Alex Tomkins)
 * Handle pasting of multiple tags separated by newlines or commas (Matthias Brück)
+* Make `Button` component render a `<button>` element when no URL is supplied (Nayeli De Jesus, LB (Ben Johnston), Sage Abdullah)
 * Fix: Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
 * Fix: Prevent an error when approving a workflow that has been cancelled in a different session (Kailesh)
 * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -975,6 +975,7 @@
 * Sanjok Karki
 * Amrinder Singh
 * Kailesh
+* Nayeli De Jesus
 
 ## Translators
 

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -16,6 +16,7 @@ depth: 1
 
  * Set `FieldPanel(required_on_save=True)` for `AbstractFormField`'s `field_type` field (Alex Tomkins)
  * Handle pasting of multiple tags separated by newlines or commas (Matthias Brück)
+ * Make `Button` component render a `<button>` element when no URL is supplied (Nayeli De Jesus, LB (Ben Johnston), Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/shared/button.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/button.html
@@ -1,7 +1,18 @@
 {% load wagtailadmin_tags %}
-<a href="{{ button.url }}" class="{{ button.classname }}" {{ button.base_attrs_string }}>
+
+{% fragment content %}
     {% if button.icon_name %}
         {% icon name=button.icon_name %}
     {% endif %}
     {{ button.label }}
-</a>
+{% endfragment %}
+
+{% if button.url %}
+    <a href="{{ button.url }}" class="{{ button.classname }}" {{ button.base_attrs_string }}>
+        {{ content }}
+    </a>
+{% else %}
+    <button class="{{ button.classname }}" {{ button.base_attrs_string }}>
+        {{ content }}
+    </button>
+{% endif %}

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -360,6 +360,63 @@ class TestPageHeaderButtonsHooks(TestButtonsHooks):
         self.assertFalse(add_subpage_button.is_shown(user=self.user))
 
 
+class TestButtonRendering(WagtailTestUtils, SimpleTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.link_button = Button(
+            "Go to URL",
+            "/url",
+            classname="class1 class2",
+            icon_name="globe",
+            attrs={"data-test": "value"},
+        )
+        cls.action_button = Button(
+            "Perform action",
+            classname="class3 class4",
+            icon_name="cog",
+            attrs={"data-action": "perform"},
+        )
+        cls.submit_button = Button(
+            "Submit form",
+            classname="class3 class4",
+            icon_name="cog",
+            attrs={"type": "submit", "data-action": "perform"},
+        )
+
+    def test_link_button_renders_as_anchor_tag(self):
+        html = self.link_button.render_html({})
+        soup = self.get_soup(html)
+        link = soup.select_one("a")
+        self.assertIsNotNone(link)
+        self.assertEqual(link.get("href"), "/url")
+        self.assertEqual(set(link.get("class")), {"class1", "class2"})
+        self.assertEqual(link.get("data-test"), "value")
+        icon = link.select_one("svg use[href='#icon-globe']")
+        self.assertIsNotNone(icon)
+
+    def test_action_button_renders_as_button_tag(self):
+        html = self.action_button.render_html({})
+        soup = self.get_soup(html)
+        button = soup.select_one("button")
+        self.assertIsNotNone(button)
+        self.assertEqual(button.get("type"), "button")
+        self.assertEqual(set(button.get("class")), {"class3", "class4"})
+        self.assertEqual(button.get("data-action"), "perform")
+        icon = button.select_one("svg use[href='#icon-cog']")
+        self.assertIsNotNone(icon)
+
+    def test_button_allows_submit_type(self):
+        html = self.submit_button.render_html({})
+        soup = self.get_soup(html)
+        button = soup.select_one("button")
+        self.assertIsNotNone(button)
+        self.assertEqual(button.get("type"), "submit")
+        self.assertEqual(set(button.get("class")), {"class3", "class4"})
+        self.assertEqual(button.get("data-action"), "perform")
+        icon = button.select_one("svg use[href='#icon-cog']")
+        self.assertIsNotNone(icon)
+
+
 class ButtonComparisonTestCase(SimpleTestCase):
     """Tests the comparison functions."""
 

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -24,18 +24,20 @@ class BaseButton(Component):
         attrs=None,
         priority=1000,
     ):
+        self.attrs = self.attrs.copy()
         if label:
             self.label = label
 
         if url:
             self.url = url
+        else:
+            self.attrs["type"] = "button"
 
         self.classname = classname
 
         if icon_name:
             self.icon_name = icon_name
 
-        self.attrs = self.attrs.copy()
         if attrs:
             self.attrs.update(attrs)
         self.priority = priority
@@ -105,7 +107,11 @@ class BaseButton(Component):
 
 
 class Button(BaseButton):
-    """Plain link button with a label and optional icon."""
+    """
+    Plain button with a label and optional icon.
+    If ``url`` is provided, it will be rendered as an ``<a>`` element;
+    otherwise, it will be rendered as a ``<button type="button">`` element.
+    """
 
     allow_in_dropdown = True
 


### PR DESCRIPTION
_Please describe the problem you're fixing here. Include the issue number, if applicable._

Wagtail’s default Button component always renders an anchor tag when a URL is provided, but does not support rendering a plain button element when no URL is set. This is limiting for cases where a button should trigger a POST request or open a dialog without navigating anywhere.

Fixes #13250 