### PR TITLE
Added shortcut to open keyboard shortcut dialog

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changelog
 
  * Removed support for Python 3.8 (Matt Westcott)
  * Add usage count filter to the admin image and document listings (Joel William)
+ * Add keyboard shortcut (`?`) to activate the keyboard shortcuts dialog (Dhruvi Patel)
  * Fix: Use the correct method of resolving the file storage dynamically for FileField usage in images & documents (Amir Mahmoodi)
  * Fix: Ensure the add comment keyboard shortcut is disabled when keyboard shortcuts are disabled in user preferences (Dhruvi Patel)
  * Fix: Use model name when ordering by page type in page listings (Sage Abdullah)

--- a/docs/releases/7.2.md
+++ b/docs/releases/7.2.md
@@ -15,6 +15,7 @@ depth: 1
 ### Other features
 
  * Add usage count filter to the admin image and document listings (Joel William)
+ * Add keyboard shortcut (`?`) to activate the keyboard shortcuts dialog (Dhruvi Patel)
 
 ### Bug fixes
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1348,6 +1348,7 @@ def keyboard_shortcuts_dialog(context):
                 ),
             ],
             ("actions-model", _("Actions")): [
+                (_("Show keyboard shortcuts"), "?"),
                 (_("Save changes"), f"{KEYS.MOD} + s"),
                 (_("Preview"), f"{KEYS.MOD} + p"),
                 (_("Toggle sidebar"), "["),

--- a/wagtail/admin/tests/test_keyboard_shortcuts.py
+++ b/wagtail/admin/tests/test_keyboard_shortcuts.py
@@ -83,7 +83,8 @@ class TestKeyboardShortcutsDialog(WagtailTestUtils, TestCase):
                     "role": "button",
                     "data-a11y-dialog-show": "keyboard-shortcuts-dialog",
                     "data-action": "w-action#noop:prevent:stop",
-                    "data-controller": "w-action",
+                    "data-controller": "w-kbd w-action",
+                    "data-w-kbd-key-value": "?",
                 }
             ),
             sidebar_data,

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -986,7 +986,8 @@ def register_keyboard_shortcuts_menu_item():
             "role": "button",  # Ensure screen readers announce this as a button
             "data-a11y-dialog-show": "keyboard-shortcuts-dialog",
             "data-action": "w-action#noop:prevent:stop",
-            "data-controller": "w-action",
+            "data-controller": "w-kbd w-action",
+            "data-w-kbd-key-value": "?",
         },
         name="keyboard-shortcuts-trigger",
         url="#",


### PR DESCRIPTION
Added shortcut to open keyboard shortcut dialog

This project is part of GSoC project.

Feel free to suggest action name, I have kept it as 'Open keyboard shortcut help'.

<img width="650" height="416" alt="image" src="https://github.com/user-attachments/assets/87c6baf7-72a3-4a40-824a-e9e56728f563" />