### PR TITLE
Fix rendering of StructBlock with custom form templates

### DIFF
--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -31,15 +31,24 @@ export class StructBlock {
     }
 
     if (blockDef.meta.formTemplate) {
-      let dom = $(container);
-      $(placeholder).replaceWith(dom);
-
-      if (this.blockDef.collapsible) {
-        dom = this.#initializeCollapsiblePanel(dom, prefix);
-      }
-
       const html = blockDef.meta.formTemplate.replace(/__PREFIX__/g, prefix);
-      dom.append(html);
+
+      let dom;
+      if (container) {
+        // Replace the placeholder with the collapsible panel container so it's
+        // mounted to the DOM and can be initialized.
+        dom = $(container);
+        $(placeholder).replaceWith(dom);
+        // Initialize the collapsible panel and append the form template HTML
+        // to the content area of the collapsible panel.
+        dom = this.#initializeCollapsiblePanel(dom, prefix);
+        dom.append(html);
+      } else {
+        // Collapsible panel is handled by the parent block, so just
+        // replace the placeholder with the form template HTML.
+        dom = $(html);
+        $(placeholder).replaceWith(dom);
+      }
 
       const blockErrors = initialError?.blockErrors || {};
       this.blockDef.childBlockDefs.forEach((childBlockDef) => {

--- a/client/src/components/StreamField/blocks/StructBlock.test.js
+++ b/client/src/components/StreamField/blocks/StructBlock.test.js
@@ -818,3 +818,127 @@ describe('telepath: wagtail.blocks.StructBlock in stream block', () => {
     );
   });
 });
+
+describe('telepath: wagtail.blocks.StructBlock with formTemplate in stream block', () => {
+  let boundBlock;
+
+  beforeEach(() => {
+    // Setup test blocks - StreamBlock[StructBlock[StreamBlock[FieldBlock], FieldBlock]]
+    const innerStreamDef = new StreamBlockDefinition(
+      'inner_stream',
+      [
+        [
+          '',
+          [
+            new FieldBlockDefinition(
+              'test_block_a',
+              new DummyWidgetDefinition('Block A Widget'),
+              {
+                label: 'Test Block A',
+                required: false,
+                icon: 'pilcrow',
+                classname:
+                  'w-field w-field--char_field w-field--admin_auto_height_text_input',
+              },
+            ),
+          ],
+        ],
+      ],
+      {},
+      {
+        label: 'Inner Stream',
+        required: false,
+        icon: 'placeholder',
+        classname: null,
+        helpText: '',
+        helpIcon: '',
+        maxNum: null,
+        minNum: null,
+        blockCounts: {},
+        strings: {
+          MOVE_UP: 'Move up',
+          MOVE_DOWN: 'Move down',
+          DRAG: 'Drag',
+          DELETE: 'Delete',
+          DUPLICATE: 'Duplicate',
+          ADD: 'Add',
+        },
+      },
+    );
+
+    const structBlockDef = new StructBlockDefinition(
+      'struct_block',
+      [
+        innerStreamDef,
+        new FieldBlockDefinition(
+          'test_block_b',
+          new DummyWidgetDefinition('Block A Widget'),
+          {
+            label: 'Test Block B',
+            required: false,
+            icon: 'pilcrow',
+            classname: '',
+          },
+        ),
+      ],
+      {
+        label: 'Heading block',
+        required: false,
+        icon: 'title',
+        classname: 'struct-block',
+        helpText: 'use <strong>lots</strong> of these',
+        helpIcon: '<svg></svg>',
+        formTemplate: `<div class="custom-form-template">
+          <p>here comes the first field:</p>
+          <div data-structblock-child="inner_stream"></div>
+          <p>and here is the second:</p>
+          <div data-structblock-child="test_block_b"></div>
+        </div>`,
+      },
+    );
+
+    const blockDef = new StreamBlockDefinition(
+      '',
+      [['', [structBlockDef]]],
+      {},
+      {
+        label: '',
+        required: true,
+        icon: 'placeholder',
+        classname: null,
+        helpText: 'use <strong>plenty</strong> of these',
+        helpIcon: '<svg></svg>',
+        maxNum: null,
+        minNum: null,
+        blockCounts: {},
+        strings: {
+          MOVE_UP: 'Move up',
+          MOVE_DOWN: 'Move down',
+          DRAG: 'Drag',
+          DELETE: 'Delete',
+          DUPLICATE: 'Duplicate',
+          ADD: 'Add',
+        },
+      },
+    );
+
+    // Render it
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      {
+        type: 'struct_block',
+        id: 'struct-block-1',
+        value: {
+          inner_stream: [
+            { type: 'test_block_a', id: 'very-nested-1', value: 'foobar' },
+          ],
+          test_block_b: 'hello, world',
+        },
+      },
+    ]);
+  });
+
+  test('it renders correctly', () => {
+    expect(document.body.innerHTML).toMatchSnapshot();
+  });
+});

--- a/client/src/components/StreamField/blocks/__snapshots__/StructBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StructBlock.test.js.snap
@@ -585,6 +585,79 @@ exports[`telepath: wagtail.blocks.StructBlock with collapsible panel setError sh
         </section></div>"
 `;
 
+exports[`telepath: wagtail.blocks.StructBlock with formTemplate in stream block it renders correctly 1`] = `
+"<div class="c-sf-help">
+          <div class="help">
+            use <strong>plenty</strong> of these
+          </div>
+        </div><div class="">
+        <input type="hidden" name="the-prefix-count" data-streamfield-stream-count="" value="1">
+        <div data-streamfield-stream-container=""><div>
+        <button type="button" title="Insert a block" class="c-sf-add-button">
+          <svg class="icon icon-plus" aria-hidden="true"><use href="#icon-plus"></use></svg>
+        </button>
+      </div><div data-streamfield-child="" data-contentpath="struct-block-1">
+        <input type="hidden" name="the-prefix-0-deleted" value="">
+        <input type="hidden" name="the-prefix-0-order" value="0">
+        <input type="hidden" name="the-prefix-0-type" value="struct_block">
+        <input type="hidden" name="the-prefix-0-id" value="struct-block-1">
+        <section class="w-panel w-panel--nested" id="block-struct-block-1-section" aria-labelledby="block-struct-block-1-heading" data-panel="">
+          <div class="w-panel__header">
+            <a class="w-panel__anchor w-panel__anchor--prefix" href="#block-struct-block-1-section" aria-labelledby="block-struct-block-1-heading" data-panel-anchor="">
+              <svg class="icon icon-link w-panel__icon" aria-hidden="true">
+                <use href="#icon-link"></use>
+              </svg>
+            </a>
+            <button class="w-panel__toggle" type="button" aria-label="Toggle section" aria-describedby="block-struct-block-1-heading" data-panel-toggle="" aria-controls="block-struct-block-1-content" aria-expanded="true">
+              <svg class="icon icon-title w-panel__icon" aria-hidden="true">
+                <use href="#icon-title"></use>
+              </svg>
+            </button>
+            <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-struct-block-1-heading" data-panel-heading="">
+              <span class="c-sf-block__type">Heading block</span>
+              
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-0-value-inner_stream-0-value</span>
+            </h2>
+            <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-struct-block-1-section" aria-labelledby="block-struct-block-1-heading">
+              <svg class="icon icon-link w-panel__icon" aria-hidden="true">
+                <use href="#icon-link"></use>
+              </svg>
+            </a>
+            <div class="w-panel__divider"></div>
+            <div class="w-panel__controls" data-panel-controls=""><button type="button" class="button button--icon text-replace white" data-streamfield-action="MOVE_UP" title="Move up" disabled="disabled">
+        <svg class="icon icon-arrow-up" aria-hidden="true">
+          <use href="#icon-arrow-up"></use>
+        </svg>
+      </button><button type="button" class="button button--icon text-replace white" data-streamfield-action="MOVE_DOWN" title="Move down" disabled="disabled">
+        <svg class="icon icon-arrow-down" aria-hidden="true">
+          <use href="#icon-arrow-down"></use>
+        </svg>
+      </button><button type="button" class="button button--icon text-replace white" data-streamfield-action="DRAG" title="Drag">
+        <svg class="icon icon-grip" aria-hidden="true">
+          <use href="#icon-grip"></use>
+        </svg>
+      </button><button type="button" class="button button--icon text-replace white" data-streamfield-action="DUPLICATE" title="Duplicate">
+        <svg class="icon icon-copy" aria-hidden="true">
+          <use href="#icon-copy"></use>
+        </svg>
+      </button><button type="button" class="button button--icon text-replace white" data-streamfield-action="DELETE" title="Delete">
+        <svg class="icon icon-bin" aria-hidden="true">
+          <use href="#icon-bin"></use>
+        </svg>
+      </button></div>
+          </div>
+          <div id="block-struct-block-1-content" class="w-panel__content">
+            
+          </div>
+        </section>
+      </div><div>
+        <button type="button" title="Insert a block" class="c-sf-add-button">
+          <svg class="icon icon-plus" aria-hidden="true"><use href="#icon-plus"></use></svg>
+        </button>
+      </div></div>
+      </div>"
+`;
+
 exports[`telepath: wagtail.blocks.StructBlock with formTemplate it renders correctly 1`] = `
 "<section class="w-panel w-panel--nested" id="the-prefix-section" aria-labelledby="the-prefix-heading" data-panel="">
           <div class="w-panel__header">

--- a/client/src/components/StreamField/blocks/__snapshots__/StructBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StructBlock.test.js.snap
@@ -647,7 +647,97 @@ exports[`telepath: wagtail.blocks.StructBlock with formTemplate in stream block 
       </button></div>
           </div>
           <div id="block-struct-block-1-content" class="w-panel__content">
-            
+            <div class="custom-form-template">
+          <p>here comes the first field:</p>
+          <div class="">
+        <input type="hidden" name="the-prefix-0-value-inner_stream-count" data-streamfield-stream-count="" value="1">
+        <div data-streamfield-stream-container=""><div>
+        <button type="button" title="Insert a block" class="c-sf-add-button">
+          <svg class="icon icon-plus" aria-hidden="true"><use href="#icon-plus"></use></svg>
+        </button>
+      </div><div data-streamfield-child="" data-contentpath="very-nested-1">
+        <input type="hidden" name="the-prefix-0-value-inner_stream-0-deleted" value="">
+        <input type="hidden" name="the-prefix-0-value-inner_stream-0-order" value="0">
+        <input type="hidden" name="the-prefix-0-value-inner_stream-0-type" value="test_block_a">
+        <input type="hidden" name="the-prefix-0-value-inner_stream-0-id" value="very-nested-1">
+        <section class="w-panel w-panel--nested" id="block-very-nested-1-section" aria-labelledby="block-very-nested-1-heading" data-panel="">
+          <div class="w-panel__header">
+            <a class="w-panel__anchor w-panel__anchor--prefix" href="#block-very-nested-1-section" aria-labelledby="block-very-nested-1-heading" data-panel-anchor="">
+              <svg class="icon icon-link w-panel__icon" aria-hidden="true">
+                <use href="#icon-link"></use>
+              </svg>
+            </a>
+            <button class="w-panel__toggle" type="button" aria-label="Toggle section" aria-describedby="block-very-nested-1-heading" data-panel-toggle="" aria-controls="block-very-nested-1-content" aria-expanded="true">
+              <svg class="icon icon-pilcrow w-panel__icon" aria-hidden="true">
+                <use href="#icon-pilcrow"></use>
+              </svg>
+            </button>
+            <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-very-nested-1-heading" data-panel-heading="">
+              <span class="c-sf-block__type">Test Block A</span>
+              
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-0-value-inner_stream-0-value</span>
+            </h2>
+            <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-very-nested-1-section" aria-labelledby="block-very-nested-1-heading">
+              <svg class="icon icon-link w-panel__icon" aria-hidden="true">
+                <use href="#icon-link"></use>
+              </svg>
+            </a>
+            <div class="w-panel__divider"></div>
+            <div class="w-panel__controls" data-panel-controls=""><button type="button" class="button button--icon text-replace white" data-streamfield-action="MOVE_UP" title="Move up" disabled="disabled">
+        <svg class="icon icon-arrow-up" aria-hidden="true">
+          <use href="#icon-arrow-up"></use>
+        </svg>
+      </button><button type="button" class="button button--icon text-replace white" data-streamfield-action="MOVE_DOWN" title="Move down" disabled="disabled">
+        <svg class="icon icon-arrow-down" aria-hidden="true">
+          <use href="#icon-arrow-down"></use>
+        </svg>
+      </button><button type="button" class="button button--icon text-replace white" data-streamfield-action="DRAG" title="Drag">
+        <svg class="icon icon-grip" aria-hidden="true">
+          <use href="#icon-grip"></use>
+        </svg>
+      </button><button type="button" class="button button--icon text-replace white" data-streamfield-action="DUPLICATE" title="Duplicate">
+        <svg class="icon icon-copy" aria-hidden="true">
+          <use href="#icon-copy"></use>
+        </svg>
+      </button><button type="button" class="button button--icon text-replace white" data-streamfield-action="DELETE" title="Delete">
+        <svg class="icon icon-bin" aria-hidden="true">
+          <use href="#icon-bin"></use>
+        </svg>
+      </button></div>
+          </div>
+          <div id="block-very-nested-1-content" class="w-panel__content">
+            <div class="w-field__wrapper" data-field-wrapper="">
+        <div class="w-field w-field--char_field w-field--admin_auto_height_text_input" data-field="">
+          <div class="w-field__errors" id="the-prefix-0-value-inner_stream-0-value-errors" data-field-errors="">
+            <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true" hidden=""><use href="#icon-warning"></use></svg>
+          </div>
+          <div class="w-field__help" id="the-prefix-0-value-inner_stream-0-value-helptext" data-field-help=""></div>
+          <div class="w-field__input" data-field-input="">
+            <p name="the-prefix-0-value-inner_stream-0-value" id="the-prefix-0-value-inner_stream-0-value">Block A Widget</p>
+          </div>
+        </div>
+      </div>
+          </div>
+        </section>
+      </div><div>
+        <button type="button" title="Insert a block" class="c-sf-add-button">
+          <svg class="icon icon-plus" aria-hidden="true"><use href="#icon-plus"></use></svg>
+        </button>
+      </div></div>
+      </div>
+          <p>and here is the second:</p>
+          <div class="w-field__wrapper" data-field-wrapper="">
+        <div class="" data-field="">
+          <div class="w-field__errors" id="the-prefix-0-value-test_block_b-errors" data-field-errors="">
+            <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true" hidden=""><use href="#icon-warning"></use></svg>
+          </div>
+          <div class="w-field__help" id="the-prefix-0-value-test_block_b-helptext" data-field-help=""></div>
+          <div class="w-field__input" data-field-input="">
+            <p name="the-prefix-0-value-test_block_b" id="the-prefix-0-value-test_block_b">Block A Widget</p>
+          </div>
+        </div>
+      </div>
+        </div>
           </div>
         </section>
       </div><div>


### PR DESCRIPTION
Fixes #13324. To test, apply this patch on top of latest bakerydemo `main`:

```diff
diff --git a/bakerydemo/base/blocks.py b/bakerydemo/base/blocks.py
index 224d4cc..03642f1 100644
--- a/bakerydemo/base/blocks.py
+++ b/bakerydemo/base/blocks.py
@@ -79,6 +79,7 @@ class HeadingBlock(StructBlock):
         template = "blocks/heading_block.html"
         preview_value = {"heading_text": "Healthy bread types", "size": "h2"}
         description = "A heading with level two, three, or four"
+        form_template = "custom_block.html"


 class ThemeSettingsBlock(StructBlock):
@@ -102,6 +103,7 @@ class ThemeSettingsBlock(StructBlock):
     class Meta:
         icon = "cog"
         label_format = "Theme: {theme}, Text size: {text_size}"
+        form_template = "custom_block.html"


 class BlockQuote(StructBlock):
diff --git a/bakerydemo/recipes/blocks.py b/bakerydemo/recipes/blocks.py
index 9e6be7b..1b09ce2 100644
--- a/bakerydemo/recipes/blocks.py
+++ b/bakerydemo/recipes/blocks.py
@@ -38,6 +38,7 @@ class RecipeStepBlock(StructBlock):
     class Meta:
         template = "blocks/recipe_step_block.html"
         icon = "tick"
+        form_template = "custom_block.html"


 class RecipeStreamBlock(StreamBlock):
diff --git a/bakerydemo/templates/custom_block.html b/bakerydemo/templates/custom_block.html
new file mode 100644
index 0000000..20440c4
--- /dev/null
+++ b/bakerydemo/templates/custom_block.html
@@ -0,0 +1,21 @@
+{% load wagtailadmin_tags  %}
+
+<div class="{{ classname }}">
+    {% if help_text %}
+        <span>
+            <div class="help">
+                {% icon name="help" classname="default" %}
+                {{ help_text }}
+            </div>
+        </span>
+    {% endif %}
+
+    {% for child in children.values %}
+        <div class="w-field" data-field data-contentpath="{{ child.block.name }}">
+            {% if child.block.label %}
+                <label class="w-field__label" {% if child.id_for_label %}for="{{ child.id_for_label }}"{% endif %}>{{ child.block.label }}{% if child.block.required %}<span class="w-required-mark">*</span>{% endif %}</label>
+            {% endif %}
+            {{ child.render_form }}
+        </div>
+    {% endfor %}
+</div>
```

Go to http://localhost:8000/admin/pages/81/edit/

1. In "Backstory", add a new heading block. Observe that the newly added block has no inputs rendered.
2. In "Backstory", add a new block quote. Observe that the nested settings block in the added block is correctly rendered.
3. In "Body", look for an existing or add a new "Steps list" block. Observe that the newly added block has no inputs rendered.

With this PR, 1 & 3 are fixed, and 2 remains working correctly. To be extra sure, try removing the custom `form_template = "custom_block.html"` in each block and make sure they still work (i.e. all of them are collapsible and they render the inputs correctly).