### PR TITLE
Add support for `attrs` in `formattedfield` tag

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Maintenance: Migrate privacy switch modal field hiding to the Stimulus `RulesController` (LB (Ben) Johnston)
  * Maintenance: Add semgrep rules for inline styles and scripts (Chiemezuo Akujobi, Sage Abdullah)
  * Maintenance: Fix intermittent test failures caused by nondeterministic order in TestFilteredModelChoiceField (Sage Abdullah)
+ * Maintenance: Add support for `attrs` in `formattedfield` tag (LB (Ben) Johnston)
 
 
 7.1.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/7.2.md
+++ b/docs/releases/7.2.md
@@ -38,6 +38,7 @@ depth: 1
  * Migrate privacy switch modal field hiding to the Stimulus [`RulesController`](controller:RulesController) (LB (Ben) Johnston)
  * Add semgrep rules for inline styles and scripts (Chiemezuo Akujobi, Sage Abdullah)
  * Fix intermittent test failures caused by nondeterministic order in TestFilteredModelChoiceField (Sage Abdullah)
+ * Add support for `attrs` in `formattedfield` tag (LB (Ben) Johnston)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/admin/templates/wagtailadmin/shared/formatted_field.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/formatted_field.html
@@ -13,7 +13,7 @@
     A unified template for both use cases is messy, but it guarantees we are keeping form field styles the same everywhere.
 {% endcomment %}
 
-<div class="w-field__wrapper {{ classname }}"{% if wrapper_id %} id="{{ wrapper_id }}"{% endif %} data-field-wrapper>
+<div class="w-field__wrapper {{ classname }}"{% if wrapper_id %} id="{{ wrapper_id }}"{% endif %}{% if attrs %}{% include "wagtailadmin/shared/attrs.html" with attrs=attrs %}{% endif %}>
 
     {# Render custom label attributes if provided, or the bound field’s label attributes otherwise. #}
     {% if show_label %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1175,6 +1175,7 @@ def formattedfield(
     label_text=None,
     error_message_id=None,
     wrapper_id=None,
+    attrs=None,
 ):
     """
     Renders a form field in standard Wagtail admin layout.
@@ -1192,12 +1193,15 @@ def formattedfield(
     - `label_text` - Manually set this if the field’s HTML is hard-coded.
     - `error_message_id` - ID of the error message container element.
     - `wrapper_id` - ID of the overall wrapper element.
+    - `attrs` - Dict of additional HTML attributes to add to the field wrapper element, `data-field-wrapper` will be included by default.
     """
 
     label_for = id_for_label or (field and field.id_for_label) or ""
 
     context = {
         "classname": classname,
+        # Ensure data-field-wrapper is always present
+        "attrs": {**(attrs or {}), "data-field-wrapper": True},
         "show_label": show_label,
         "sr_only_label": sr_only_label,
         "icon": icon,


### PR DESCRIPTION
## Overview

In a similar goal to https://github.com/wagtail/wagtail/pull/13211 & https://github.com/wagtail/wagtail/pull/10629 - this PR adds the ability to pass `attrs` to the `formattedfield` template tag.

I have also included some basic tests for this tag as I could not find any, while adding tests for the `attrs` support.

## Additional context

I have intentionally **not** added the context passing of `attrs` to `formattedfieldfromcontext` as this has unintended side effects where the `attrs` may be passed down from Panel or other parent context.

This is hopefully a nice improvement to make this template tag and form field container usage even more flexible for the future. I originally needed this for changes for #11045 but ended up going in a different direction, I thought this stand-alone PR would still be good to submit though.