### PR TITLE
Added shortcut to focus on search bar

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
  * Removed support for Python 3.8 (Matt Westcott)
  * Add usage count filter to the admin image and document listings (Joel William)
  * Add keyboard shortcut (`?`) to activate the keyboard shortcuts dialog (Dhruvi Patel)
+ * Add keyboard shortcut (`/`) to activate and focus on the search input in the sidebar (Dhruvi Patel)
  * Fix: Use the correct method of resolving the file storage dynamically for FileField usage in images & documents (Amir Mahmoodi)
  * Fix: Ensure the add comment keyboard shortcut is disabled when keyboard shortcuts are disabled in user preferences (Dhruvi Patel)
  * Fix: Use model name when ordering by page type in page listings (Sage Abdullah)

--- a/client/src/components/Sidebar/modules/Search.tsx
+++ b/client/src/components/Sidebar/modules/Search.tsx
@@ -4,6 +4,7 @@ import Tippy from '@tippyjs/react';
 import { gettext } from '../../../utils/gettext';
 import Icon from '../../Icon/Icon';
 import { ModuleDefinition, SIDEBAR_TRANSITION_DURATION } from '../Sidebar';
+import { KeyboardAction } from '../../../controllers/KeyboardController';
 
 interface SearchInputProps {
   slim: boolean;
@@ -43,8 +44,15 @@ export const SearchInput: React.FunctionComponent<SearchInputProps> = ({
       role="search"
       className="w-h-[42px] w-relative w-box-border w-flex w-items-center w-justify-start w-flex-row w-flex-shrink-0"
       action={searchUrl}
+      aria-keyshortcuts="/"
       method="get"
       onSubmit={onSubmitForm}
+      data-controller="w-kbd"
+      // when in slim mode trigger the click action so the sidebar expands and focuses on the input,
+      // otherwise simply focus on the input as it will be visible.
+      data-w-kbd-action-value={
+        slim ? KeyboardAction.CLICK : KeyboardAction.FOCUS
+      }
     >
       <div className="w-flex w-flex-row w-items-center w-h-full">
         <Tippy
@@ -70,6 +78,7 @@ export const SearchInput: React.FunctionComponent<SearchInputProps> = ({
           hover:w-bg-transparent`}
             type="submit"
             aria-label={gettext('Search')}
+            data-w-kbd-target={slim ? 'element' : undefined}
             onClick={(e) => {
               if (slim) {
                 e.preventDefault();
@@ -116,6 +125,7 @@ export const SearchInput: React.FunctionComponent<SearchInputProps> = ({
           name="q"
           placeholder={gettext('Search')}
           ref={searchInput}
+          data-w-kbd-target={slim ? undefined : 'element'}
         />
       </div>
     </form>

--- a/client/src/controllers/KeyboardController.test.js
+++ b/client/src/controllers/KeyboardController.test.js
@@ -3,9 +3,16 @@ import Mousetrap from 'mousetrap';
 
 import { KeyboardController } from './KeyboardController';
 
+jest.mock('../utils/forceFocus', () => ({
+  forceFocus: jest.fn(),
+}));
+
+import { forceFocus } from '../utils/forceFocus';
+
 describe('KeyboardController', () => {
   let app;
   const buttonClickMock = jest.fn();
+  const inputSelectMock = jest.fn();
 
   /**
    * Simulates a keydown, keypress, and keyup event for the provided key.
@@ -41,6 +48,7 @@ describe('KeyboardController', () => {
 
   beforeAll(() => {
     HTMLButtonElement.prototype.click = buttonClickMock;
+    HTMLInputElement.prototype.select = inputSelectMock;
   });
 
   afterEach(() => {
@@ -217,6 +225,60 @@ describe('KeyboardController', () => {
       simulateKey({ key: 'j' });
 
       expect(buttonClickMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('focus action functionality', () => {
+    it('should focus on input element when action is set to focus', async () => {
+      expect(forceFocus).not.toHaveBeenCalled();
+
+      await setup(
+        `<input id="search" type="text" data-controller="w-kbd" data-w-kbd-key-value="/" data-w-kbd-action-value="focus">`,
+      );
+
+      simulateKey({ key: '/' });
+
+      expect(forceFocus).toHaveBeenCalledTimes(1);
+      expect(forceFocus).toHaveBeenCalledWith(
+        document.getElementById('search'),
+      );
+    });
+
+    it('should focus on target element when using element target', async () => {
+      await setup(
+        `
+      <div data-controller="w-kbd" data-w-kbd-key-value="/" data-w-kbd-action-value="focus">
+        <input id="target-input" type="text" data-w-kbd-target="element">
+      </div>
+      `,
+      );
+
+      simulateKey({ key: '/' });
+
+      expect(forceFocus).toHaveBeenCalledTimes(1);
+      expect(forceFocus).toHaveBeenCalledWith(
+        document.getElementById('target-input'),
+      );
+    });
+
+    it('should select text on target element when it has value', async () => {
+      await setup(
+        `
+      <div data-controller="w-kbd" data-w-kbd-key-value="/" data-w-kbd-action-value="focus">
+        <input id="target-input" type="text" data-w-kbd-target="element">
+      </div>
+      `,
+      );
+
+      const targetInput = document.getElementById('target-input');
+      targetInput.value = 'target text';
+
+      simulateKey({ key: '/' });
+
+      expect(forceFocus).toHaveBeenCalledTimes(1);
+      expect(forceFocus).toHaveBeenCalledWith(targetInput);
+      expect(inputSelectMock).toHaveBeenCalledTimes(1);
+      expect(inputSelectMock.mock.contexts).toEqual([targetInput]);
     });
   });
 });

--- a/client/src/controllers/KeyboardController.ts
+++ b/client/src/controllers/KeyboardController.ts
@@ -14,17 +14,17 @@ import { WAGTAIL_CONFIG } from '../config/wagtailConfig';
  *
  * @example
  * ```html
- * <button type="button" data-controller="w-kbd" data-w-kbd-key="[">Trigger me with the <kbd>[</kbd> key.</button>
+ * <button type="button" data-controller="w-kbd" data-w-kbd-key-value="[">Trigger me with the <kbd>[</kbd> key.</button>
  * ```
  *
  * @example - use 'mod' for 'ctrl' on Windows and 'cmd' on MacOS
  * ```html
- * <button type="button" data-controller="w-kbd" data-w-kbd-key="mod+s">Trigger me with <kbd>ctrl+p</kbd> on Windows or <kbd>cmd+p</kbd> on MacOS.</button>
+ * <button type="button" data-controller="w-kbd" data-w-kbd-key-value="mod+s">Trigger me with <kbd>ctrl+p</kbd> on Windows or <kbd>cmd+p</kbd> on MacOS.</button>
  * ```
  *
  * @example - use 'global' scope to allow the shortcut to work even when an input is focused
  * ```html
- * <button type="button" data-controller="w-kbd" data-w-kbd-key="mod+s" data-w-kbd-scope-value="global">Trigger me globally.</button>
+ * <button type="button" data-controller="w-kbd" data-w-kbd-key-value="mod+s" data-w-kbd-scope-value="global">Trigger me globally.</button>
  * ```
  *
  * @example - use aria-keyshortcuts (when the key string is compatible with Mousetrap's syntax)
@@ -35,7 +35,7 @@ import { WAGTAIL_CONFIG } from '../config/wagtailConfig';
  *
  * @example - use a target element to trigger the click on a different element
  * ```html
- * <section type="button" data-controller="w-kbd" data-w-kbd-key="[">
+ * <section type="button" data-controller="w-kbd" data-w-kbd-key-value="[">
  *   Trigger my button with the <kbd>[</kbd> key.
  *   <button type="button" id="my-button" data-w-kbd-target="element">My Button</button>
  * </section>

--- a/docs/releases/7.2.md
+++ b/docs/releases/7.2.md
@@ -16,6 +16,7 @@ depth: 1
 
  * Add usage count filter to the admin image and document listings (Joel William)
  * Add keyboard shortcut (`?`) to activate the keyboard shortcuts dialog (Dhruvi Patel)
+ * Add keyboard shortcut (`/`) to activate and focus on the search input in the sidebar (Dhruvi Patel)
 
 ### Bug fixes
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1353,6 +1353,7 @@ def keyboard_shortcuts_dialog(context):
                 (_("Preview"), f"{KEYS.MOD} + p"),
                 (_("Toggle sidebar"), "["),
                 (_("Toggle minimap"), "]"),
+                (_("Search"), "/"),
                 (_("Add or show comments"), f"{KEYS.CTRL} + {KEYS.ALT} + m")
                 if comments_enabled
                 else None,


### PR DESCRIPTION
- Added a shortcut to focus on the search field in the sidebar
- Updated the keyboard controller to support focus events
- Added related tests for the keyboard controller

This PR is part of the ongoing GSoC project.

<img width="651" height="365" alt="Screenshot from 2025-08-17 20-53-01" src="https://github.com/user-attachments/assets/2fbcc2ac-8e5e-4326-b24c-e816d8acb176" />
<img width="1283" height="711" alt="Screenshot from 2025-08-17 21-05-02" src="https://github.com/user-attachments/assets/3246c7c1-1b7b-4833-8609-ad771ddce829" />
