### PR TITLE
Updated missing link on an article on advanced topics docs to point to the new website

### DIFF
--- a/docs/advanced_topics/i18n.md
+++ b/docs/advanced_topics/i18n.md
@@ -678,8 +678,8 @@ fit your use case better:
 -   [Wagtailtrans](https://github.com/wagtail/wagtailtrans)
 -   [wagtail-modeltranslation](https://github.com/infoportugal/wagtail-modeltranslation)
 
-For a comparison of these options, see AccordBox's blog post
-[How to support multi-language in Wagtail CMS](https://www.accordbox.com/blog/how-support-multi-language-wagtail-cms/).
+For a comparison of these options, see SaasHammer's blog post
+[How to support multi-language in Wagtail CMS](https://saashammer.com/blog/how-support-multi-language-wagtail-cms/).
 
 ## Wagtail admin translations
 

--- a/docs/advanced_topics/i18n.md
+++ b/docs/advanced_topics/i18n.md
@@ -678,7 +678,7 @@ fit your use case better:
 -   [Wagtailtrans](https://github.com/wagtail/wagtailtrans)
 -   [wagtail-modeltranslation](https://github.com/infoportugal/wagtail-modeltranslation)
 
-For a comparison of these options, see SaasHammer's blog post
+For a comparison of these options, see SaaS Hammer's blog post
 [How to support multi-language in Wagtail CMS](https://saashammer.com/blog/how-support-multi-language-wagtail-cms/).
 
 ## Wagtail admin translations


### PR DESCRIPTION
AccordBox changed to SaasHammer

The article is about how to support multi-languae in wagtail. The original article can be found on 
https://web.archive.org/web/20231202193207/https://www.accordbox.com/blog/how-support-multi-language-wagtail-cms/
The new link is https://saashammer.com/blog/how-support-multi-language-wagtail-cms/