### PR TITLE
Only apply `WAGTAIL_CHECK_TEMPLATE_NUMBER_FORMAT` for Wagtail templates

### DIFF
--- a/wagtail/admin/tests/api/test_renderer_classes.py
+++ b/wagtail/admin/tests/api/test_renderer_classes.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 
 from wagtail.admin.api.views import PagesAdminAPIViewSet
+from wagtail.test.numberformat import ignore_numberformat
 from wagtail.test.utils import WagtailTestUtils
 
 
@@ -62,9 +63,10 @@ class TestPagesAdminAPIRendererClasses(WagtailTestUtils, TestCase):
 
     def test_api_response_returns_html_with_html_accept_header(self):
         """Test that API returns HTML when HTML is explicitly requested via Accept header."""
-        response = self.client.get(
-            reverse("wagtailadmin_api:pages:listing"), HTTP_ACCEPT="text/html"
-        )
+        with ignore_numberformat(["rest_framework/base.html"]):
+            response = self.client.get(
+                reverse("wagtailadmin_api:pages:listing"), HTTP_ACCEPT="text/html"
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/html; charset=utf-8")

--- a/wagtail/api/v2/tests/test_renderer_classes.py
+++ b/wagtail/api/v2/tests/test_renderer_classes.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 
 from wagtail.api.v2.views import BaseAPIViewSet
+from wagtail.test.numberformat import ignore_numberformat
 from wagtail.test.utils import WagtailTestUtils
 
 
@@ -60,9 +61,10 @@ class TestBaseAPIViewSetRendererClasses(WagtailTestUtils, TestCase):
 
     def test_api_response_returns_html_with_html_accept_header(self):
         """Test that API returns HTML when HTML is explicitly requested via Accept header."""
-        response = self.client.get(
-            reverse("wagtailapi_v2:pages:listing"), HTTP_ACCEPT="text/html"
-        )
+        with ignore_numberformat(["rest_framework/base.html"]):
+            response = self.client.get(
+                reverse("wagtailapi_v2:pages:listing"), HTTP_ACCEPT="text/html"
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/html; charset=utf-8")
@@ -74,10 +76,11 @@ class TestBaseAPIViewSetRendererClasses(WagtailTestUtils, TestCase):
 
     def test_api_response_returns_html_with_browser_accept_header(self):
         """Test that API returns HTML when accessed with typical browser Accept headers."""
-        response = self.client.get(
-            reverse("wagtailapi_v2:pages:listing"),
-            HTTP_ACCEPT="text/html,application/xhtml+xml,application/xml;q=0.9",
-        )
+        with ignore_numberformat(["rest_framework/base.html"]):
+            response = self.client.get(
+                reverse("wagtailapi_v2:pages:listing"),
+                HTTP_ACCEPT="text/html,application/xhtml+xml,application/xml;q=0.9",
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/html; charset=utf-8")

--- a/wagtail/tests/test_tests.py
+++ b/wagtail/tests/test_tests.py
@@ -4,12 +4,13 @@ import unittest
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.template import Context, Template
-from django.test import TestCase
+from django.template import Context, Origin, Template
+from django.test import SimpleTestCase, TestCase
 
 from wagtail.admin.tests.test_contentstate import content_state_equal
 from wagtail.models import PAGE_MODEL_CLASSES, Page, Site
 from wagtail.test.dummy_external_storage import DummyExternalStorage
+from wagtail.test.numberformat import ignore_numberformat
 from wagtail.test.testapp.models import (
     BusinessChild,
     BusinessIndex,
@@ -470,12 +471,67 @@ class TestDummyExternalStorage(WagtailTestUtils, TestCase):
     settings.WAGTAIL_CHECK_TEMPLATE_NUMBER_FORMAT,
     "Number formatting functions have not been patched",
 )
-class TestPatchedNumberFormat(TestCase):
+class TestPatchedNumberFormat(SimpleTestCase):
     def test_outputting_number_directly_is_disallowed(self):
         context = Context({"num": 42})
-        template = Template("the answer is {{ num }}")
-        with self.assertRaises(ImproperlyConfigured):
-            template.render(context)
+        template_name = "wagtailcore/tests/some_template.html"
+        external_template_name = "external_package/other_template.html"
+        templates = [
+            Template("the answer is {{ num }}"),
+            Template(
+                "the answer is {{ num }}",
+                origin=Origin(
+                    name=f"/some/path/{template_name}",
+                    template_name=template_name,
+                ),
+            ),
+            Template(
+                "the answer is {{ num }}",
+                origin=Origin(
+                    name=f"/some/path/{external_template_name}",
+                    template_name=external_template_name,
+                ),
+            ),
+        ]
+        for template in templates:
+            with (
+                self.subTest(template=template),
+                self.assertRaises(ImproperlyConfigured),
+            ):
+                template.render(context)
+
+    def test_ignore_numberformat(self):
+        context = Context({"num": 4815162342})
+        template_name = "external_package/some_template.html"
+        with ignore_numberformat([template_name]):
+            ignored_template = Template(
+                "the answer is {{ num }}",
+                origin=Origin(
+                    name=f"/some/path/{template_name}",
+                    template_name=template_name,
+                ),
+            )
+
+            self.assertEqual(
+                ignored_template.render(context),
+                "the answer is 4815162342",
+            )
+            with self.settings(USE_THOUSAND_SEPARATOR=True):
+                self.assertEqual(
+                    ignored_template.render(context),
+                    "the answer is 4,815,162,342",
+                )
+
+            # But other templates should still raise
+            other_template = Template(
+                "the answer is {{ num }}",
+                origin=Origin(
+                    name="/some/path/important/tests/some_template.html",
+                    template_name="important/tests/some_template.html",
+                ),
+            )
+            with self.assertRaises(ImproperlyConfigured):
+                other_template.render(context)
 
     def test_outputting_number_via_intcomma(self):
         context = Context({"num": 9000})


### PR DESCRIPTION
Some tests originally added in #13284 couldn't pass because they were rendering numbers in the DRF templates, which don't use explicit `|localize`/`|unlocalize` filters.

This PR tweaks the `WAGTAIL_CHECK_TEMPLATE_NUMBER_FORMAT` patches to only enforce the formatting in templates starting with `wagtail`, so templates in other packages aren't affected.

Not sure if we do want this, though. There might be cases where we reuse templates from e.g. django itself or django-filter and we might want to explicitly format the number in the context before passing it to the template...