### PR TITLE
Use model name when ordering by page type in page listings

### DIFF
--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -180,13 +180,15 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.root_page.add_child(instance=event_page)
 
         orderings = {
-            "content_type": (
-                [self.new_page.id, self.old_page.id, event_page.id],
-                "-content_type",
+            "content_type__model": (
+                # SimplePage, SingleEventPage, StandardIndex
+                [self.new_page.id, event_page.id, self.old_page.id],
+                "-content_type__model",
             ),
-            "-content_type": (
-                [event_page.id, self.old_page.id, self.new_page.id],
-                "content_type",
+            "-content_type__model": (
+                # StandardIndex, SingleEventPage, SimplePage
+                [self.old_page.id, event_page.id, self.new_page.id],
+                "content_type__model",
             ),
         }
         url = reverse("wagtailadmin_explore", args=(self.root_page.id,))

--- a/wagtail/admin/tests/test_filters.py
+++ b/wagtail/admin/tests/test_filters.py
@@ -75,7 +75,7 @@ class TestFilteredModelChoiceField(WagtailTestUtils, TestCase):
             users = FilteredModelChoiceField(
                 queryset=User.objects.order_by(User.USERNAME_FIELD),
                 filter_field="id_group",
-                filter_accessor=lambda user: user.groups.all(),
+                filter_accessor=lambda user: user.groups.all().order_by("name"),
             )
 
         form = UserForm()
@@ -83,7 +83,7 @@ class TestFilteredModelChoiceField(WagtailTestUtils, TestCase):
         expected_html = """
             <select name="users" data-widget="filtered-select" data-filter-field="id_group" required id="id_users">
                 <option value="" selected>---------</option>
-                <option value="{david}" data-filter-value="{musicians},{actors}">{david_username}</option>
+                <option value="{david}" data-filter-value="{actors},{musicians}">{david_username}</option>
                 <option value="{kevin}" data-filter-value="{actors}">{kevin_username}</option>
                 <option value="{morten}" data-filter-value="{musicians}">{morten_username}</option>
             </select>

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -152,7 +152,7 @@ class PageListingMixin:
             "type",
             label=_("Type"),
             accessor="page_type_display_name",
-            sort_key="content_type",
+            sort_key="content_type__model",
             width="12%",
         ),
         PageStatusColumn(


### PR DESCRIPTION
Ordering by content_type means ordering by its ID, which may not correspond to the alphabetical ordering of the model name being displayed to the user.

This isn't perfect either, as the actual model name may be different depending on verbose_name. However, verbose_name isn't stored on the database, so this is the closest we can get.

This fixes the tests against Django's `main` after https://github.com/django/django/pull/19723 which caused the ID ordering of our test page content types to no longer be what we expect.