### PR TITLE
feat: submenu items using submenu_hook in ViewSet

### DIFF
--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -54,6 +54,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: menu_order
    .. autoattribute:: menu_item_class
    .. autoattribute:: add_to_admin_menu
+   .. autoattribute:: submenu_hook
    .. automethod:: get_menu_item
 ```
 

--- a/wagtail/admin/menu.py
+++ b/wagtail/admin/menu.py
@@ -240,6 +240,11 @@ class WagtailMenuRegisterableGroup(WagtailMenuRegisterable):
     menu_icon = "folder-open-inverse"
     add_to_admin_menu = True
 
+    #: Hook name used to collect submenu items for this group.
+    #: Any ``ViewSet`` with a matching ``menu_hook`` will be added
+    #: as a sub-item. Optional.
+    submenu_hook = None
+
     def __init__(self):
         """
         When initialising, instantiate the classes (or use the instances)
@@ -261,7 +266,10 @@ class WagtailMenuRegisterableGroup(WagtailMenuRegisterable):
     def get_menu_item(self, order=None):
         return SubmenuMenuItem(
             label=self.menu_label,
-            menu=Menu(items=self.get_submenu_items()),
+            menu=Menu(
+                register_hook_name=self.submenu_hook,
+                items=self.get_submenu_items(),
+            ),
             name=self.menu_name,
             icon_name=self.menu_icon,
             order=order if order is not None else self.menu_order,

--- a/wagtail/admin/tests/viewsets/test_base_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_base_viewset.py
@@ -15,6 +15,9 @@ class TestBaseViewSet(WagtailTestUtils, TestCase):
         self.assertContains(response, "Miscellaneous")
         self.assertContains(response, "The Calendar")
         self.assertContains(response, "The Greetings")
+        self.assertContains(response, "Submenu Hook Miscellaneous")
+        self.assertContains(response, "The Submenu Hook Calendar")
+        self.assertContains(response, "Submenu Hook Greetings")
 
     def test_calendar_index_view(self):
         url = reverse("calendar:index")
@@ -23,11 +26,25 @@ class TestBaseViewSet(WagtailTestUtils, TestCase):
         self.assertEqual(url, "/admin/calendar/")
         self.assertContains(response, f"{now.year} calendar")
 
+    def test_submenu_hook_calendar_view(self):
+        url = reverse("submenu_hook_calendar:index")
+        response = self.client.get(url)
+        now = timezone.now()
+        self.assertEqual(url, "/admin/submenu_hook_calendar/")
+        self.assertContains(response, f"{now.year} calendar")
+
     def test_calendar_month_view(self):
         url = reverse("calendar:month")
         response = self.client.get(url)
         now = timezone.now()
         self.assertEqual(url, "/admin/calendar/month/")
+        self.assertContains(response, f"{now.year}/{now.month} calendar")
+
+    def test_submenu_hook_calendar_month_view(self):
+        url = reverse("submenu_hook_calendar:month")
+        response = self.client.get(url)
+        now = timezone.now()
+        self.assertEqual(url, "/admin/submenu_hook_calendar/month/")
         self.assertContains(response, f"{now.year}/{now.month} calendar")
 
     def test_greetings_view(self):
@@ -38,6 +55,16 @@ class TestBaseViewSet(WagtailTestUtils, TestCase):
         response = self.client.get(url)
         self.assertEqual(url, "/admin/greetingz/")
         self.assertContains(response, "Greetings")
+        self.assertContains(response, "Welcome to this greetings page, Gordon Freeman!")
+
+    def test_submenu_hook_greetings_view(self):
+        self.user.first_name = "Gordon"
+        self.user.last_name = "Freeman"
+        self.user.save()
+        url = reverse("submenu_hook_greetings:index")
+        response = self.client.get(url)
+        self.assertEqual(url, "/admin/submenu_hook_greetingz/")
+        self.assertContains(response, "Submenu Hook Greetings")
         self.assertContains(response, "Welcome to this greetings page, Gordon Freeman!")
 
     def test_method_injection(self):

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -171,6 +171,73 @@ class MiscellaneousViewSetGroup(ViewSetGroup):
     menu_label = "Miscellaneous"
 
 
+class SubmenuHookCalendarViewSet(ViewSet):
+    menu_label = "The Submenu Hook Calendar"
+    icon = "date"
+    name = "submenu_hook_calendar"
+    template_name = "tests/misc/calendar.html"
+
+    def __init__(self, name=None, **kwargs):
+        super().__init__(name, **kwargs)
+        self.now = timezone.now()
+
+    def index(self, request):
+        calendar_html = calendar.HTMLCalendar().formatyear(self.now.year)
+        return render(
+            request,
+            self.template_name,
+            {
+                "calendar_html": calendar_html,
+                "page_title": f"{self.now.year} calendar",
+                "header_icon": self.icon,
+            },
+        )
+
+    def month(self, request):
+        calendar_html = calendar.HTMLCalendar().formatmonth(
+            self.now.year, self.now.month
+        )
+        return render(
+            request,
+            self.template_name,
+            {
+                "calendar_html": calendar_html,
+                "page_title": f"{self.now.year}/{self.now.month} calendar",
+                "header_icon": self.icon,
+            },
+        )
+
+    def get_urlpatterns(self):
+        return [
+            path("", self.index, name="index"),
+            path("month/", self.month, name="month"),
+        ]
+
+
+class SubmenuHookGreetingsViewSet(ViewSet):
+    menu_label = "Submenu Hook Greetings"
+    icon = "user"
+    url_namespace = "submenu_hook_greetings"
+    url_prefix = "submenu_hook_greetingz"
+    menu_hook = "register_submenu_greetings"
+
+    def index(self, request):
+        return render(
+            request,
+            "tests/misc/greetings.html",
+            {"page_title": "Submenu Hook Greetings", "header_icon": self.icon},
+        )
+
+    def get_urlpatterns(self):
+        return [path("", self.index, name="index")]
+
+
+class MiscellaneousSubmenuHookViewSetGroup(ViewSetGroup):
+    menu_label = "Submenu Hook Miscellaneous"
+    items = (SubmenuHookCalendarViewSet,)
+    submenu_hook = "register_submenu_greetings"
+
+
 class JSONStreamModelViewSet(ModelViewSet):
     name = "streammodel"
     model = JSONStreamModel

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -40,8 +40,10 @@ from wagtail.test.testapp.models import (
 )
 from wagtail.test.testapp.views import (
     JSONModelViewSetGroup,
+    MiscellaneousSubmenuHookViewSetGroup,
     MiscellaneousViewSetGroup,
     SearchTestModelViewSet,
+    SubmenuHookGreetingsViewSet,
     ToyViewSetGroup,
     animated_advert_chooser_viewset,
     event_page_listing_viewset,
@@ -255,6 +257,14 @@ def register_viewsets():
         MiscellaneousViewSetGroup(),
         JSONModelViewSetGroup(),
         SearchTestModelViewSet(name="searchtest"),
+    ]
+
+
+@hooks.register("register_admin_viewset")
+def register_submenu_hook_viewset():
+    return [
+        MiscellaneousSubmenuHookViewSetGroup(),
+        SubmenuHookGreetingsViewSet(),
     ]
 
 


### PR DESCRIPTION
- #13235
- Extends #13236

## Description 
This PR introduces support for collecting submenu items in a ViewSetGroup via a `submenu_hook`.
Instead of manually listing every ViewSet inside a group’s items, developers can now register additional viewsets from separate modules, and attach them to the group’s submenu by using a matching `menu_hook` name.

More detail #13235

## Remaining Tasks
- [ ] Add to the change logs