### PR TITLE
Fix crash when using `FieldPanel` and `TitleFieldPanel` with `read_only=True`

### DIFF
--- a/wagtail/admin/panels/field_panel.py
+++ b/wagtail/admin/panels/field_panel.py
@@ -401,7 +401,7 @@ class FieldPanel(Panel):
             opts.update(
                 {
                     "fieldName": self.field_name,
-                    "widget": self.bound_field.field.widget,
+                    "widget": self.bound_field and self.bound_field.field.widget,
                 }
             )
             return opts

--- a/wagtail/admin/panels/title_field_panel.py
+++ b/wagtail/admin/panels/title_field_panel.py
@@ -53,11 +53,10 @@ class TitleFieldPanel(FieldPanel):
             "keyup->w-sync#apply",
         ]
 
-        def get_context_data(self, parent_context=None):
-            field = self.bound_field.field
-            if field and not self.read_only:
-                field.widget.attrs.update(**self.get_attrs())
-            return super().get_context_data(parent_context)
+        def get_editable_context_data(self):
+            if self.bound_field:
+                self.bound_field.field.widget.attrs.update(**self.get_attrs())
+            return super().get_editable_context_data()
 
         def get_attrs(self):
             """

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -997,6 +997,10 @@ class TestFieldPanel(TestCase):
                 # Help text should still be rendered, too
                 self.assertIn("Not required if event is on a single day", result)
 
+                # No widget should be passed to telepath
+                js_widget = bound_panel.js_opts()["widget"]
+                self.assertIsNone(js_widget)
+
     def test_format_value_for_display_with_choicefield(self):
         result = self.read_only_audience_panel.format_value_for_display(
             self.event.audience

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -2410,6 +2410,18 @@ class TestTitleFieldPanel(WagtailTestUtils, TestCase):
         attrs = html.find("input").attrs
         self.assertEqual(attrs["data-w-sync-target-value"], "")
 
+    def test_form_with_readonly_title_field_panel(self):
+        html = self.get_edit_handler_html(
+            ObjectList([TitleFieldPanel("title", read_only=True), FieldPanel("slug")]),
+            instance=EventPage(),
+        )
+
+        panel = html.select_one(".w-panel.title")
+        self.assertIsNotNone(panel)
+        input = panel.select_one("input")
+        self.assertIsNone(input)
+        self.assertIsNone(html.select_one("[data-controller~='w-sync']"))
+
     def test_not_using_apply_actions_if_live(self):
         """
         If the Page (or any model) has `live = True`, do not apply the actions by default.


### PR DESCRIPTION
Fixes #13212.

The first commit should probably be backported to 6.3, 7.0, and 7.1 if we consider that to be a "crashing bug", thus covered by our "active support" policy outlined in #13311. However, since `TitleFieldPanel` was introduced in 5.1 and not 6.3/7.0/7.1, and the crashing only happens for an opt-in feature that's quite uncommon (the docs don't explicitly state `read_only` support in `TitleFieldPanel`), I'm happy to consider that a missing feature.

The second commit only applies to 7.1+.