### PR TITLE
Automatically register settings models with ReferenceIndex and update…

### DIFF
--- a/docs/advanced_topics/reference_index.md
+++ b/docs/advanced_topics/reference_index.md
@@ -22,11 +22,9 @@ The reference index does not require any further configuration. However there ar
 
 A model can be registered for reference indexing by adding code to `apps.py` in the app where the model is defined:
 
-#### Settings Models and Reference Index
+#### Settings models
 
-As of Wagtail 6.4.1, any model registered as a setting (using `@register_setting` and inheriting from `BaseSiteSetting` or `BaseGenericSetting`) is automatically registered with the reference index. This means references from settings models are tracked, and attempts to delete referenced objects (with `on_delete=PROTECT`) will be blocked in the admin, with a clear error message.
-
-**Note:** Models not registered with the reference index will raise a `ProtectedError` when deleting referenced objects, and this error may not be handled gracefully in the admin UI.
+Setting models registered with `@register_setting` (subclasses of `BaseSiteSetting` or `BaseGenericSetting`) are registered automatically. Their references are tracked and deletions of protected related objects are blocked cleanly. Models not registered with the index raise a raw `ProtectedError` on deleting protected related objects.
 
 ```python
 from django.apps import AppConfig

--- a/docs/reference/contrib/settings.md
+++ b/docs/reference/contrib/settings.md
@@ -28,11 +28,9 @@ Create a model that inherits from either:
 
 and register it using the `register_setting` decorator:
 
-**Reference Index Integration**
+**Reference index**
 
-Settings models registered with `@register_setting` are automatically tracked by Wagtail’s reference index. This ensures that references from settings to other objects (such as snippets, images, or pages) are managed correctly, and deletion of referenced objects is prevented if `on_delete=PROTECT` is used.
-
-You do not need to manually register settings models with the reference index.
+Setting models registered with `@register_setting` are tracked automatically. References to other objects (pages, snippets, images, documents, etc.) are detected so deletions of protected objects are blocked. No manual registration is required.
 
 ```python
 from django.db import models


### PR DESCRIPTION
- Settings models ([BaseSiteSetting](https://reimagined-doodle-5g4jvqx9px772pv46.github.dev/), [BaseGenericSetting](https://reimagined-doodle-5g4jvqx9px772pv46.github.dev/)) are now automatically registered with the ReferenceIndex when registered as settings.
- Updated documentation to clarify ReferenceIndex integration and ProtectedError handling for settings models.
- No manual registration required for settings models.

Closes #12947 and related issues.