### PR TITLE
Fix crash when previewing a form page with an empty field_type form field

### DIFF
--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -93,6 +93,8 @@ class AbstractFormField(Orderable):
     field_type = models.CharField(
         verbose_name=_("field type"), max_length=16, choices=FORM_FIELD_CHOICES
     )
+    # field_type must be populated for previews to build the form field.
+    field_type.required_on_save = True
     required = models.BooleanField(verbose_name=_("required"), default=True)
     choices = models.TextField(
         verbose_name=_("choices"),

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -2272,6 +2272,29 @@ class TestPreview(WagtailTestUtils, TestCase):
                 self.assertEqual(response.status_code, 200)
                 self.assertTemplateUsed(response, template)
 
+    def test_empty_field_type_does_not_crash_preview(self):
+        preview_url = reverse(
+            "wagtailadmin_pages:preview_on_add",
+            args=("tests", "formpage", self.homepage.pk),
+        )
+
+        response = self.client.post(
+            preview_url,
+            {**self.post_data, "form_fields-0-field_type": ""},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(
+            response.content.decode(),
+            {"is_valid": False, "is_available": False},
+        )
+
+        response = self.client.get(preview_url)
+
+        self.assertContains(
+            response,
+            "Preview cannot display due to validation errors.",
+        )
+
 
 class TestFormPageCreate(WagtailTestUtils, TestCase):
     def setUp(self):


### PR DESCRIPTION
Regression in 9eac93a5654e5dddab932e2b1eca960652e231c0. Fixes #13369.

This should be backported to 7.0 (active support, LTS) and 7.1 (active support).