### PR TITLE
Ignore hidden error messages in CountController default findValue

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Fix: Ensure the add comment keyboard shortcut is disabled when keyboard shortcuts are disabled in user preferences (Dhruvi Patel)
  * Fix: Use model name when ordering by page type in page listings (Sage Abdullah)
  * Fix: Prevent error from default `update_fields` parameter on `Page.asave()` (Tosinibikunle)
+ * Fix: Ignore hidden error messages in minimap & `CountController` default `findValue` (Sage Abdullah)
  * Docs: Fix cross-reference links to the TypeDoc-generated docs (Sage Abdullah)
  * Docs: Refine readthedocs' search indexing for releases and client-side code (Sage Abdullah)
  * Docs: Fix incorrect link to third party site in advanced topics (Yousef Al-Hadhrami (Yemeni))

--- a/client/src/components/Minimap/index.tsx
+++ b/client/src/components/Minimap/index.tsx
@@ -37,7 +37,7 @@ const createMinimapLink = (
   const ariaLevel = heading.getAttribute('aria-level');
   const headingLevel = `h${ariaLevel || heading.tagName[1] || 2}`;
   const errorCount = [].slice
-    .call(panel.querySelectorAll('.error-message'))
+    .call(panel.querySelectorAll(':not([hidden]):is(.error-message)'))
     .filter((err) => err.closest('[data-panel]') === panel).length;
 
   return {

--- a/client/src/controllers/CountController.test.js
+++ b/client/src/controllers/CountController.test.js
@@ -31,6 +31,8 @@ describe('CountController', () => {
       document.getElementById('items').innerHTML = `
       <li class="error-message"></li>
       <li class="help-critical"></li>
+      <li class="error-message" hidden></li>
+      <li class="help-critical" hidden></li>
       <li class="error-message"></li>`;
 
       document.dispatchEvent(new CustomEvent('recount'));

--- a/client/src/controllers/CountController.ts
+++ b/client/src/controllers/CountController.ts
@@ -1,7 +1,8 @@
 import { Controller } from '@hotwired/stimulus';
 import { ngettext } from '../utils/gettext';
 
-const DEFAULT_ERROR_SELECTOR = '.error-message,.help-critical';
+const DEFAULT_ERROR_SELECTOR =
+  ':not([hidden]):is(.error-message,.help-critical)';
 
 /**
  * Adds the ability for a controlled element to update the total count

--- a/docs/releases/7.2.md
+++ b/docs/releases/7.2.md
@@ -24,6 +24,7 @@ depth: 1
  * Ensure the add comment keyboard shortcut is disabled when keyboard shortcuts are disabled in user preferences (Dhruvi Patel)
  * Use model name when ordering by page type in page listings (Sage Abdullah)
  * Prevent error from default `update_fields` parameter on `Page.asave()` (Tosinibikunle)
+ * Ignore hidden error messages in minimap & `CountController` default `findValue` (Sage Abdullah)
 
 ### Documentation
 


### PR DESCRIPTION
Was working on https://github.com/wagtail/wagtail-ai/pull/94 and found that the default selector, which is used in a few places e.g. tabs, counts error message elements that are hidden.