### PR TITLE
Prevent error when iterating over specific tasks

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changelog
  * Fix: Change default ordering for `UserViewSet` to `User.USERNAME_FIELD` to support default ordering ordering with custom User models that may not have a `name` field (Lynwee)
  * Fix: Ensure starter tests in the project template pass (Lasse Schmieding)
  * Fix: Ensure fixed RichText toolbar shows under footer actions (Maciek Baron)
+ * Fix: Prevent error when iterating over specific tasks with missing models (Lasse Schmieding)
  * Docs: Fix cross-reference links to the TypeDoc-generated docs (Sage Abdullah)
  * Docs: Refine readthedocs' search indexing for releases and client-side code (Sage Abdullah)
  * Docs: Fix incorrect link to third party site in advanced topics (Yousef Al-Hadhrami (Yemeni))

--- a/docs/releases/7.2.md
+++ b/docs/releases/7.2.md
@@ -30,6 +30,7 @@ depth: 1
  * Change default ordering for `UserViewSet` to `User.USERNAME_FIELD` to support default ordering ordering with custom User models that may not have a `name` field (Lynwee)
  * Ensure starter tests in the project template pass (Lasse Schmieding)
  * Ensure fixed RichText toolbar shows under footer actions (Maciek Baron)
+ * Prevent error when iterating over specific tasks with missing models (Lasse Schmieding)
 
 ### Documentation
 

--- a/wagtail/query.py
+++ b/wagtail/query.py
@@ -725,7 +725,11 @@ class SpecificIterable(ModelIterable):
                     "This is most likely because a database migration has removed "
                     "the relevant table or record since the item was created:\n{}".format(
                         [
-                            {"id": p.id, "title": p.title, "type": p.content_type}
+                            {
+                                "id": p.id,
+                                "title": getattr(p, "title", str(p)),
+                                "type": p.content_type,
+                            }
                             for p in generic_items.values()
                         ]
                     ),
@@ -774,7 +778,8 @@ class DeferredSpecificIterable(ModelIterable):
                 warnings.warn(
                     "A specific version of the following object could not be returned "
                     "because the specific model is not present on the active "
-                    f"branch: <{obj.__class__.__name__} id='{obj.id}' title='{obj.title}' "
+                    f"branch: <{obj.__class__.__name__} id='{obj.id}' "
+                    f"title='{getattr(obj, 'title', str(obj))}' "
                     f"type='{obj.content_type}'>",
                     category=RuntimeWarning,
                 )


### PR DESCRIPTION
Fixes #13376 by removing access of `title`, which does not exist for `Task`.

Alternatively could add a title to Task, or make the title show up in the warning conditional on existence of the attribute?