### PR TITLE
Refactor target handling & match resolving in `RulesController`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
           - eslint@9.39.2
           - '@typescript-eslint/eslint-plugin@8.20.0'
           - '@typescript-eslint/parser@8.20.0'
-          - '@wagtail/eslint-config-wagtail@0.6.0-rc1.0'
+          - '@wagtail/eslint-config-wagtail@0.6.0'
           - 'eslint-plugin-no-jquery@3.1.1'
           - 'eslint-plugin-storybook@10.2.4'
   - repo: https://github.com/thibaudcolas/pre-commit-stylelint

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Changelog
  * Maintenance: Fix blank choice tests for Django 6.1 (Sage Abdullah)
  * Maintenance: Ignore `EMAIL_BACKEND` setting deprecation on Django 6.1 when running project template tests (Sage Abdullah)
  * Maintenance: Use uv with lockfile in CI configurations (Sage Abdullah)
+ * Maintenance: Add `one` and `not` match support to `RulesController` (LB (Ben Johnston))
 
 
 7.4.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/components/ComboBox/ComboBox.tsx
+++ b/client/src/components/ComboBox/ComboBox.tsx
@@ -184,7 +184,6 @@ export default function ComboBox<ComboBoxOption extends ComboBoxItem>({
     <div className="w-combobox-container">
       <div className="w-combobox">
         {/* downshift does the label-field association itself. */}
-        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
         <label {...getLabelProps()} className="w-sr-only">
           {label}
         </label>

--- a/client/src/controllers/RulesController.stories.js
+++ b/client/src/controllers/RulesController.stories.js
@@ -14,6 +14,9 @@ const definitions = [
   { identifier: 'w-rules', controllerConstructor: RulesController },
 ];
 
+/**
+ * Example of the `enable` target usage within the RulesController.
+ */
 const EnableTemplate = ({ debug = false }) => (
   <StimulusWrapper debug={debug} definitions={definitions}>
     <form
@@ -22,63 +25,87 @@ const EnableTemplate = ({ debug = false }) => (
       // avoid accidental submissions with preventing submit
       data-action="change->w-rules#resolve submit->w-rules#resolve:prevent"
     >
-      <div className="w-field__wrapper">
-        <label className="w-field__label" htmlFor="link-field">
-          Enter a link:
+      <fieldset>
+        <legend>
+          An example of <strong>enabling</strong> secondary fields based on the
+          primary fields having a value entered. Add a value to the email field
+          to disable the link label or add a value to the link field to disable
+          the email subject.
+        </legend>
+        <div className="w-field__wrapper">
+          <label className="w-field__label" htmlFor="link-field">
+            Enter a link:
+          </label>
           <div className="w-field">
             <div className="w-field__input">
               <input type="url" name="link" id="link-field" />
             </div>
           </div>
-        </label>
-      </div>
-      <div className="w-field__wrapper">
-        <label className="w-field__label" htmlFor="email-field">
-          Or enter an Email address:
+        </div>
+        <div className="w-field__wrapper">
+          <label className="w-field__label" htmlFor="email-field">
+            <strong>Or</strong> enter an Email address:
+          </label>
           <div className="w-field">
             <div className="w-field__input">
               <input type="email" name="email" id="email-field" />
             </div>
           </div>
-        </label>
-      </div>
-      <hr />
-      <div>
-        <label className="w-field__label" htmlFor="drink">
-          Enter an email subject:
+        </div>
+        <hr />
+        <div className="w-field__wrapper">
+          <label className="w-field__label" htmlFor="subject-field">
+            Enter an email subject:
+          </label>
           <div className="w-field">
             <div className="w-field__input">
               <input
                 type="text"
                 name="subject"
+                id="subject-field"
                 className="w-field__wrapper"
                 data-w-rules='{"link":""}'
                 data-w-rules-target="enable"
               />
             </div>
           </div>
-        </label>
-      </div>
-      <div className="w-field__wrapper">
-        <label className="w-field__label" htmlFor="subject-field">
-          Enter a link label:
+        </div>
+        <div className="w-field__wrapper">
+          <label className="w-field__label" htmlFor="link-label-field">
+            Enter a link label:
+          </label>
           <div className="w-field">
             <div className="w-field__input">
               <input
                 type="email"
                 name="subject"
-                id="subject-field"
+                id="link-label-field"
                 data-w-rules='{"email":""}'
                 data-w-rules-target="enable"
               />
             </div>
           </div>
-        </label>
+        </div>
+      </fieldset>
+      <div>
+        <p>Enter either a link or an email address, not both.</p>
+        {/* Additional example of using match values, only ONE field should be blank to submit. */}
+        <button
+          type="submit"
+          data-w-rules-target="enable"
+          data-w-rules={JSON.stringify({ link: '', email: '' })}
+          data-w-rules-match="one"
+        >
+          Submit
+        </button>
       </div>
     </form>
   </StimulusWrapper>
 );
 
+/**
+ * Example of the `show` target usage within the RulesController.
+ */
 const ShowTemplate = ({ debug = false }) => (
   <StimulusWrapper debug={debug} definitions={definitions}>
     <form
@@ -87,12 +114,18 @@ const ShowTemplate = ({ debug = false }) => (
       // avoid accidental submissions with preventing submit
       data-action="change->w-rules#resolve submit->w-rules#resolve:prevent"
     >
-      <div className="w-field__wrapper">
-        <label className="w-field__label" htmlFor="drink">
-          Choose your favorite drink:
-          <div className="w-field w-field--choice_field w-field--select">
+      <fieldset>
+        <legend>
+          An example of <strong>showing</strong> a second field based on the
+          value of the first field.
+        </legend>
+        <div className="w-field__wrapper">
+          <label className="w-field__label" htmlFor="drink">
+            Choose your favorite drink:
+          </label>
+          <div className="w-field w-field--select">
             <div className="w-field__input">
-              <select className="w-min-w-full" name="drink">
+              <select id="drink" className="w-min-w-full" name="drink">
                 <option value="">-------</option>
                 <option value="coffee">Coffee ☕</option>
                 <option value="tea">Tea 🍵</option>
@@ -101,22 +134,22 @@ const ShowTemplate = ({ debug = false }) => (
               </select>
             </div>
           </div>
-        </label>
-      </div>
-      <div
-        className="w-field__wrapper"
-        data-w-rules-target="show"
-        data-w-rules='{"drink":"other"}'
-      >
-        <label className="w-field__label" htmlFor="other">
-          Other
-          <div className="w-field w-field--choice_field w-field--select">
+        </div>
+        <div
+          className="w-field__wrapper"
+          data-w-rules-target="show"
+          data-w-rules='{"drink":"other"}'
+        >
+          <label className="w-field__label" htmlFor="other">
+            Other
+          </label>
+          <div className="w-field w-field--select">
             <div className="w-field__input">
-              <input type="text" name="other" />
+              <input type="text" name="other" id="other" />
             </div>
           </div>
-        </label>
-      </div>
+        </div>
+      </fieldset>
     </form>
   </StimulusWrapper>
 );

--- a/client/src/controllers/RulesController.ts
+++ b/client/src/controllers/RulesController.ts
@@ -3,6 +3,10 @@ import { Controller } from '@hotwired/stimulus';
 import { castArray } from '../utils/castArray';
 import { debounce } from '../utils/debounce';
 
+/**
+ * Enum for the different effects that can be applied to form controls,
+ * determined by the different controller targets and rules.
+ */
 enum Effect {
   Enable = 'enable',
   Show = 'show',
@@ -12,6 +16,13 @@ enum Match {
   All = 'all', // Default
   Any = 'any',
 }
+
+type RuleEntry = [string, string[]];
+
+type EffectHandler = (
+  target: FormControlElement | HTMLElement,
+  result: boolean,
+) => (() => void) | null;
 
 /**
  * Form control elements that can support the `disabled` attribute.
@@ -63,6 +74,13 @@ export class RulesController extends Controller<
 > {
   static targets = ['enable', 'show'];
 
+  static values = {
+    match: { default: Match.All, type: String },
+  };
+
+  /** The matching strategy to use for the rules, defaults to `all` and used as the fallback if not provided. */
+  declare readonly matchValue: Match;
+
   /** Targets will be enabled if the target's rule matches the scoped form data, otherwise will be disabled. */
   declare readonly enableTargets: FormControlElement[];
   /** True if there is at least one enable target, used to ensure rules do not run if not needed. */
@@ -72,34 +90,69 @@ export class RulesController extends Controller<
   /** True if there is at least one show target, used to ensure rules do not run if not needed. */
   declare readonly hasShowTarget: boolean;
 
-  declare form;
-  declare rulesCache: Record<
-    string,
-    { match: Match; rules: Array<[string, string[]]> }
-  >;
+  declare formCache: HTMLFormElement | null;
+  declare rulesCache: Record<string, RuleEntry[]>;
 
   initialize() {
     this.rulesCache = {};
     this.resolve = debounce(this.resolve.bind(this), 50);
-    this.form = this.findForm();
-  }
-
-  findForm() {
-    const element = this.element;
-    if (element instanceof HTMLFormElement) return element;
-    if ('form' in element) return element.form;
-    return element.closest('form');
   }
 
   /**
-   * Resolve the conditional targets based on the form data and the target(s)
-   * rule attributes and the controlled element's form data.
+   * Cache the form element found on the controller to avoid
+   * DOM thrashing when multiple resolves happen.
    */
-  resolve() {
-    if (!this.hasEnableTarget && !this.hasShowTarget) return;
+  get form() {
+    if (this.formCache) return this.formCache;
+    const element = this.element;
+    if (element instanceof HTMLFormElement) {
+      this.formCache = element;
+    } else {
+      const form = 'form' in element ? element.form : element.closest('form');
+      this.formCache = form;
+    }
+    if (this.formCache) return this.formCache;
+    throw new Error('Form not found.');
+  }
 
+  /**
+   * Effect targets grouped by effect type.
+   */
+  get effectTargets() {
+    return {
+      [Effect.Enable]: this.enableTargets,
+      [Effect.Show]: this.showTargets,
+    } as const;
+  }
+
+  /**
+   * Effect handlers to first determine if the effect needs to be applied,
+   * if it does, it will return a function to apply the effect.
+   */
+  get effectHandlers(): Record<Effect, EffectHandler> {
+    return {
+      [Effect.Enable]: (target, result) => {
+        if (!('disabled' in target)) return null;
+        if (result === !target.disabled) return null;
+        return () => {
+          target.disabled = !result;
+        };
+      },
+      [Effect.Show]: (target, result) => {
+        if (result === !target.hidden) return null;
+        return () => {
+          target.hidden = !result;
+        };
+      },
+    } as const;
+  }
+
+  /**
+   * Returns an object of match functions that will be used to match against
+   * the current state of the form data.
+   */
+  get matchers(): Record<Match, (rules: RuleEntry[]) => boolean> {
     const formData = new FormData(this.form);
-
     const checkFn = ([fieldName, allowedValues]) => {
       // Forms can have multiple values for the same field name
       const values = formData.getAll(fieldName);
@@ -108,49 +161,87 @@ export class RulesController extends Controller<
       return allowedValues.some((validValue) => values.includes(validValue));
     };
 
-    this.enableTargets.forEach((target) => {
-      const effect = Effect.Enable;
-      const { match, rules } = this.parseRules(target, effect);
+    return {
+      [Match.All]: (rules) => rules.every(checkFn),
+      [Match.Any]: (rules) => rules.some(checkFn),
+    };
+  }
 
-      const enable =
-        match === Match.Any ? rules.some(checkFn) : rules.every(checkFn);
+  /**
+   * Resolve the conditional targets based on the form data and the target(s)
+   * rule attributes and the controlled element's form data.
+   *
+   * For each effect target, determine the match type to use, parse the rules,
+   * run the matchers and apply the effect if needed.
+   *
+   * An `effect` event is dispatched before applying the effect,
+   * which can be cancelled to prevent the effect from being applied.
+   *
+   * Finally, a `resolved` event is dispatched after all effects have been processed.
+   */
+  resolve(event?: Event & { params?: { match?: Match } }) {
+    if (!this.hasEnableTarget && !this.hasShowTarget) return;
 
-      if (enable === !target.disabled) return;
+    const effectHandlers = this.effectHandlers;
+    const effectTargets = this.effectTargets;
+    const matchers = this.matchers;
 
-      const event = this.dispatch('effect', {
-        bubbles: true,
-        cancelable: true,
-        detail: { effect, enable },
-        target,
+    Object.entries(effectTargets).forEach(([effect, targets]) => {
+      targets.forEach((target) => {
+        const match = this.getMatchType(target, effect as Effect, event);
+        const rules = this.parseRules(target, effect as Effect);
+        const result = matchers[match](rules);
+        const apply = effectHandlers[effect](target, result);
+
+        if (!apply) return;
+
+        const effectEvent = this.dispatch('effect', {
+          bubbles: true,
+          cancelable: true,
+          detail: { effect, [effect]: result },
+          target,
+        });
+
+        if (effectEvent.defaultPrevented) return;
+
+        apply();
       });
-
-      if (event.defaultPrevented) return;
-
-      target.disabled = !enable;
-    });
-
-    this.showTargets.forEach((target) => {
-      const effect = Effect.Show;
-      const { match, rules } = this.parseRules(target, effect);
-
-      const show =
-        match === Match.Any ? rules.some(checkFn) : rules.every(checkFn);
-
-      if (show === !target.hidden) return;
-
-      const event = this.dispatch('effect', {
-        bubbles: true,
-        cancelable: true,
-        detail: { effect, show },
-        target,
-      });
-
-      if (event.defaultPrevented) return;
-
-      target.hidden = !show;
     });
 
     this.dispatch('resolved', { bubbles: true, cancelable: false });
+  }
+
+  /**
+   * Get the match type for the specified target, effect or event
+   * so that the most specific match value can be used for this rules
+   * resolving.
+   *
+   * First check the event for provided params, then the target element
+   * for attributes, finally the controller's match value with default
+   * and error handling for edge cases.
+   */
+  getMatchType(
+    target: Element,
+    effect: Effect = Effect.Enable,
+    { params = {} }: { params?: { match?: Match } } = {},
+  ): Match {
+    const identifier = this.identifier;
+    const matchValues = Object.values(Match);
+    return [
+      params.match,
+      target.getAttribute(`data-${identifier}-${effect}-match`) ||
+        target.getAttribute(`data-${identifier}-match`),
+      this.matchValue,
+      Match.All, // ensure there's always a default value if all others are blank
+    ].find((value): value is Match => {
+      if (!value || typeof value !== 'string') return false;
+      if (matchValues.includes(value as Match)) return true;
+      this.context.handleError(
+        new Error(`Invalid match value: '${value}'.`),
+        `Match value must be one of: '${matchValues.join("', '")}'.`,
+      );
+      return false;
+    })!;
   }
 
   /**
@@ -165,13 +256,9 @@ export class RulesController extends Controller<
    * When parsing the rule, assume an `Object.entries` format or convert an
    * object to this format. Then ensure each value is an array of strings
    * for consistent comparison to FormData values.
-   *
-   * Support an override of the match value, via a rule entry with a string that
-   * is an empty string, as this will not be a valid field `name`.
    */
-  parseRules(target: Element, effect: Effect = Effect.Enable) {
-    const emptyRules = { match: Match.All, rules: [] };
-    if (!target) return emptyRules;
+  parseRules(target: Element, effect: Effect = Effect.Enable): RuleEntry[] {
+    if (!target) return [];
 
     let attribute = `data-${this.identifier}-${effect}`;
     let rulesRaw = target.getAttribute(attribute);
@@ -181,7 +268,7 @@ export class RulesController extends Controller<
       rulesRaw = target.getAttribute(attribute);
     }
 
-    if (!rulesRaw) return emptyRules;
+    if (!rulesRaw) return [];
 
     const cachedRule = this.rulesCache[rulesRaw];
     if (cachedRule) return cachedRule;
@@ -195,37 +282,22 @@ export class RulesController extends Controller<
         error,
         `Unable to parse rule at the attribute '${attribute}'.`,
       );
-      return emptyRules;
+      return [];
     }
 
     const rules = (
       Array.isArray(parsedRules) ? parsedRules : Object.entries(parsedRules)
     )
       .filter(Array.isArray)
-      .map(([fieldName = '', validValues = ''] = []) => [
-        fieldName,
-        castArray(validValues).map(String),
-      ]) as Array<[string, string[]]>;
-
-    const [, [match = Match.All] = []] =
-      rules.find(([key]) => key === '') || [];
-
-    if (!Object.values(Match).includes(match as Match)) {
-      this.context.handleError(
-        new Error(`Invalid match value: '${match}'.`),
-        `Match value must be one of: '${Object.values(Match).join("', '")}'.`,
+      .filter(([key]) => key)
+      .map(
+        ([fieldName = '', validValues = ''] = []) =>
+          [fieldName, castArray(validValues).map(String)] as RuleEntry,
       );
-      return emptyRules;
-    }
 
-    const newRules = {
-      match: match as Match,
-      rules: rules.filter(([key]) => key),
-    };
+    this.rulesCache[rulesRaw] = rules;
 
-    this.rulesCache[rulesRaw] = newRules;
-
-    return newRules;
+    return rules;
   }
 
   /* Target disconnection & reconnection */

--- a/client/src/controllers/RulesController.ts
+++ b/client/src/controllers/RulesController.ts
@@ -12,9 +12,19 @@ enum Effect {
   Show = 'show',
 }
 
+/**
+ * Match values determine how rules are resolved from the form data
+ * to determine if the rule has been satisfied.
+ *
+ * @remarks
+ * Match values are inspired by JSON Schema's `allOf`, `anyOf`, `oneOf`, and `not` keywords,
+ * @see https://json-schema.org/understanding-json-schema/reference/combining
+ */
 enum Match {
   All = 'all', // Default
   Any = 'any',
+  Not = 'not',
+  One = 'one',
 }
 
 type RuleEntry = [string, string[]];
@@ -66,6 +76,17 @@ type FormControlElement =
  *     <option value="other">Other</option>
  *   </select>
  *   <input type="text" name="other-drink" data-w-rules-target="show" data-w-rules='{"fav-drink": ["other"]}'>
+ * </form>
+ * ```
+ *
+ * @example - Use match to apply different sets of rules
+ * <form data-controller="w-rules" data-action="change->w-rules#resolve">
+ *   <input type="file" id="avatar" name="avatar" accept="image/png, image/jpeg">
+ *   <input type="email" id="email" name="email" required>
+ *   <output name="summary" for="file email">
+ *     <span data-w-rules='{"avatar": [""], "email": [""]}' data-w-rules-match="not" data-w-rules-target="show">Your profile details are ready.</span>
+ *     <span data-w-rules='{"avatar": [""], "email": [""]}' data-w-rules-match="any" data-w-rules-target="show">Your profile details are missing.</span>
+ *   </output>
  * </form>
  * ```
  */
@@ -164,6 +185,8 @@ export class RulesController extends Controller<
     return {
       [Match.All]: (rules) => rules.every(checkFn),
       [Match.Any]: (rules) => rules.some(checkFn),
+      [Match.Not]: (rules) => rules.filter(checkFn).length === 0,
+      [Match.One]: (rules) => rules.filter(checkFn).length === 1,
     };
   }
 

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -40,6 +40,7 @@ depth: 1
  * Fix blank choice tests for Django 6.1 (Sage Abdullah)
  * Ignore `EMAIL_BACKEND` setting deprecation on Django 6.1 when running project template tests (Sage Abdullah)
  * Use uv with lockfile in CI configurations (Sage Abdullah)
+ * Add `one` and `not` match support to `RulesController` (LB (Ben Johnston))
 
 ## Upgrade considerations - removal of deprecated features from Wagtail 6.4 - 7.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "@types/sortablejs": "^1.15.9",
         "@typescript-eslint/eslint-plugin": "^8.20.0",
         "@typescript-eslint/parser": "^8.20.0",
-        "@wagtail/eslint-config-wagtail": "^0.6.0-rc1.0",
+        "@wagtail/eslint-config-wagtail": "^0.6.0",
         "@wagtail/stylelint-config-wagtail": "^0.8.0",
         "autoprefixer": "^10.4.21",
         "babel-loader": "^9.2.1",
@@ -6562,9 +6562,9 @@
       }
     },
     "node_modules/@wagtail/eslint-config-wagtail": {
-      "version": "0.6.0-rc1.0",
-      "resolved": "https://registry.npmjs.org/@wagtail/eslint-config-wagtail/-/eslint-config-wagtail-0.6.0-rc1.0.tgz",
-      "integrity": "sha512-5mUbcGmyQLIQ37fu4WVfi+kkX6/fw4UEU8ojZFKCmIVvvuVboLC+vbxKUPnUrMMbl2k2RY8niEDzAOC1qthkfQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wagtail/eslint-config-wagtail/-/eslint-config-wagtail-0.6.0.tgz",
+      "integrity": "sha512-JhvREzUT5dIAbMNceomK0gt8ICLM7jTMEeW7jVBo9Pz3/Olksl75sySGv+uZ2bVIAVmE5JCcqLdjNImea0DHDg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/sortablejs": "^1.15.9",
     "@typescript-eslint/eslint-plugin": "^8.20.0",
     "@typescript-eslint/parser": "^8.20.0",
-    "@wagtail/eslint-config-wagtail": "^0.6.0-rc1.0",
+    "@wagtail/eslint-config-wagtail": "^0.6.0",
     "@wagtail/stylelint-config-wagtail": "^0.8.0",
     "autoprefixer": "^10.4.21",
     "babel-loader": "^9.2.1",


### PR DESCRIPTION
This PR is intentionally split out as the final enabler to complete #11045 - setting up a robust `RulesController` that can be used beyond our internal admin use cases.

This refactors some of the existing `RulesController` code, adds unit tests and supports a more explicit `match` mechanism as a response to feedback on previous PRs. Adds two new `match` modes; `one` & `not`.

## Summary of changes

Each change is a discrete commit for easier reviewing.

1. Disable an ESLint rule in test/storybook files as it's not configured well - see https://github.com/wagtail/wagtail/issues/13378 (Update: This has since been fixed)
2. Refactor `RulesController` mechanism for referencing the nearest `form` element, minor improvement that just makes the code a bit easier to follow.
3. Enhance `RulesController` TypeScript & JSDoc to better reference common entities.
4. Refactor `RulesController` effect handling to avoid the large amounts of duplication between show/enable.
5. Refactor `RulesController` match code, this is to address the current awkward API where you had to pass the match value in via the rules with an empty string key, in response to [comment](https://github.com/wagtail/wagtail/pull/12667#discussion_r2269231623). Instead, we will support the match value being declared as the controller value, an action param or on the target element, similar to the rules. Finally, this also includes TWO new match values `not` & `one`, to complete the ability to have these rules match in more flexible ways.

This also includes a large amount of additional unit tests to cover event dispatching/cancelling, various combinations of the new match value approach and additional edge case checks. It also includes a large rework of the Storybook examples with added use cases and a better layout.

## How to test

This PR should not change the existing usage of `RulesController`, you can test these use cases as follows.

1. Within a page, access the privacy modal, check that switching between the privacy modes (e.g. password), should show/hide various fields that match the mode. As per https://github.com/wagtail/wagtail/pull/12667
2. Within a collection, access the privacy modal, check fields as above. As per https://github.com/wagtail/wagtail/pull/12667
3. Within the image URL generator, select various image filter options and check the width/height/closeness fields are disabled/enabled accordingly. As per https://github.com/wagtail/wagtail/pull/11202
