### PR TITLE
Update UserViewSet, set its ordering field's default value is User.USERNAME_FIELD

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ Changelog
  * Fix: Use model name when ordering by page type in page listings (Sage Abdullah)
  * Fix: Prevent error from default `update_fields` parameter on `Page.asave()` (Tosinibikunle)
  * Fix: Ignore hidden error messages in minimap & `CountController` default `findValue` (Sage Abdullah)
+ * Fix: Change default ordering for `UserViewSet` to `User.USERNAME_FIELD` to support default ordering ordering with custom User models that may not have a `name` field (Lynwee)
  * Docs: Fix cross-reference links to the TypeDoc-generated docs (Sage Abdullah)
  * Docs: Refine readthedocs' search indexing for releases and client-side code (Sage Abdullah)
  * Docs: Fix incorrect link to third party site in advanced topics (Yousef Al-Hadhrami (Yemeni))

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -906,6 +906,7 @@
 * Yousef Al-Hadhrami (Yemeni)
 * Hunzlah Malik
 * Tosinibikunle
+* Lynwee
 
 ## Translators
 

--- a/docs/releases/7.2.md
+++ b/docs/releases/7.2.md
@@ -25,6 +25,7 @@ depth: 1
  * Use model name when ordering by page type in page listings (Sage Abdullah)
  * Prevent error from default `update_fields` parameter on `Page.asave()` (Tosinibikunle)
  * Ignore hidden error messages in minimap & `CountController` default `findValue` (Sage Abdullah)
+ * Change default ordering for `UserViewSet` to `User.USERNAME_FIELD` to support default ordering ordering with custom User models that may not have a `name` field (Lynwee)
 
 ### Documentation
 

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -2789,6 +2789,10 @@ class TestUserViewSet(TestCase):
         self.assertIs(viewset.get_form_class(for_update=False), CustomUserCreationForm)
         self.assertIs(viewset.get_form_class(for_update=True), CustomUserEditForm)
 
+    def test_get_viewset_cls_custom_and_check_ordering(self):
+        viewset_cls = get_viewset_cls(self.app_config, "user_viewset")
+        self.assertEqual(viewset_cls.ordering, get_user_model().USERNAME_FIELD)
+
     def test_get_viewset_cls_custom_form_invalid_value(self):
         with unittest.mock.patch.object(
             self.app_config, "user_viewset", new="asdfasdf"

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -345,7 +345,7 @@ class HistoryView(generic.HistoryView):
 class UserViewSet(ModelViewSet):
     icon = "user"
     model = User
-    ordering = "name"
+    ordering = User.USERNAME_FIELD
     add_to_reference_index = False
     filterset_class = UserFilterSet
     menu_name = "users"


### PR DESCRIPTION
In wagtail 7.1.*, `UserViewSet` has a field `ordering`, it works in function `order_queryset`. And by default, it will sort user model with fields `last_name` and `first_name`.

However in some apps,  user model is customised and these two fields may doesn't exist.  Then it will raise an exception when users open users menu in admin page. Then the developers have to do some fix.

I think we can update `UserViewSet.ordering`'s default value, make it respect the `User.USERNAME_FIELD`, so in such situations, wagtail admin page can work as expected.

Please consider to accept this PR.


### The new test can pass with latest code:    
<img width="1074" height="832" alt="image" src="https://github.com/user-attachments/assets/6d719889-d6ac-4a72-994a-a2d0aa153342" />

### The new test fails with man branch's code:    
<img width="2784" height="1170" alt="image" src="https://github.com/user-attachments/assets/cb303f71-4bc8-4d18-9164-52b2f99731d5" />

