### PR TITLE
Improved Image Listing Layout Switcher

### DIFF
--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -396,6 +396,7 @@
 .w-layout-toggle-button-left {
   border-start-end-radius: theme('borderRadius.sm');
   border-end-end-radius: theme('borderRadius.sm');
+  margin-inline-start: -1px;
 }
 
 .w-layout-toggle-button {
@@ -408,6 +409,7 @@
   display: flex;
   background-color: theme('backgroundColor.surface-header');
   border: 1px solid theme('borderColor.border-field-default');
+  transition: background-color 0.2s ease;
 
   input[type='radio'] {
     position: absolute;
@@ -423,15 +425,13 @@
     width: theme('fontSize.16');
     height: theme('fontSize.16');
     color: theme('colors.text-meta');
-  }
-
-  &.w-layout-toggle-button-right + .w-layout-toggle-button-left {
-    border-inline-start: 1px solid theme('borderColor.border-field-default');
-    margin-inline-start: -1px;
+    transition: color 0.2s ease;
   }
 
   &:hover {
     background-color: theme('colors.surface-field');
+    border-color: theme('colors.border-field-hover');
+    z-index: 2;
   }
 
   &:has(input[type='radio']:checked),

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -388,13 +388,14 @@
   }
 }
 
-.w-layout-toggle-button-right{
-  border-top-left-radius: theme('borderRadius.sm');
-  border-bottom-left-radius: theme('borderRadius.sm');
+.w-layout-toggle-button-right {
+  border-start-start-radius: theme('borderRadius.sm');
+  border-end-start-radius: theme('borderRadius.sm');
 }
-.w-layout-toggle-button-left{
-  border-top-right-radius: theme('borderRadius.sm');
-  border-bottom-right-radius: theme('borderRadius.sm');
+
+.w-layout-toggle-button-left {
+  border-start-end-radius: theme('borderRadius.sm');
+  border-end-end-radius: theme('borderRadius.sm');
 }
 
 .w-layout-toggle-button {
@@ -408,7 +409,7 @@
   background-color: theme('backgroundColor.surface-header');
   border: 1px solid theme('borderColor.border-field-default');
 
-  input[type="radio"] {
+  input[type='radio'] {
     position: absolute;
     opacity: 0;
     width: 100%;
@@ -421,30 +422,35 @@
   .icon {
     width: theme('fontSize.16');
     height: theme('fontSize.16');
+    color: theme('colors.text-meta');
   }
 
   &.w-layout-toggle-button-right + .w-layout-toggle-button-left {
-    border-left: 1px solid theme('borderColor.border-field-default');
-    margin-left: -1px; 
+    border-inline-start: 1px solid theme('borderColor.border-field-default');
+    margin-inline-start: -1px;
   }
 
   &:hover {
     background-color: theme('colors.surface-field');
   }
 
-  &:has(input[type="radio"]:checked),
-  input[type="radio"]:checked + & {
+  &:has(input[type='radio']:checked),
+  input[type='radio']:checked + & {
     background-color: theme('colors.surface-field');
   }
-  &:has(input[type="radio"]:checked) .icon {
+
+  &:has(input[type='radio']:checked) .icon {
     color: theme('colors.text-link-default');
+
+    @media (prefers-color-scheme: light) {
+      color: theme('colors.primary.DEFAULT');
+    }
   }
-  
+
   &:focus {
     @include focus-outline;
     z-index: 1;
   }
-  
 }
 
 .w-layout-switch-control {

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -388,22 +388,71 @@
   }
 }
 
+.w-layout-toggle-button-right{
+  border-top-left-radius: theme('borderRadius.sm');
+  border-bottom-left-radius: theme('borderRadius.sm');
+}
+.w-layout-toggle-button-left{
+  border-top-right-radius: theme('borderRadius.sm');
+  border-bottom-right-radius: theme('borderRadius.sm');
+}
+
 .w-layout-toggle-button {
+  position: relative;
+  width: theme('spacing.10');
+  height: 100%;
+  padding: 0;
   align-items: center;
   justify-content: center;
   display: flex;
+  background-color: theme('backgroundColor.surface-header');
+  border: 1px solid theme('borderColor.border-field-default');
 
-  [type='checkbox'] {
-    width: theme('spacing.10');
-    height: theme('spacing.10');
-    opacity: 0;
+  input[type="radio"] {
     position: absolute;
-    inset: 0;
+    opacity: 0;
+    width: 100%;
+    height: 100%;
     margin: 0;
-    border: 0;
+    cursor: pointer;
+    z-index: 1;
   }
 
-  &:focus-within:has(:focus-visible) {
-    @include focus-outline;
+  .icon {
+    width: theme('fontSize.16');
+    height: theme('fontSize.16');
   }
+
+  &.w-layout-toggle-button-right + .w-layout-toggle-button-left {
+    border-left: 1px solid theme('borderColor.border-field-default');
+    margin-left: -1px; 
+  }
+
+  &:hover {
+    background-color: theme('colors.surface-field');
+  }
+
+  &:has(input[type="radio"]:checked),
+  input[type="radio"]:checked + & {
+    background-color: theme('colors.surface-field');
+  }
+  &:has(input[type="radio"]:checked) .icon {
+    color: theme('colors.text-link-default');
+  }
+  
+  &:focus {
+    @include focus-outline;
+    z-index: 1;
+  }
+  
+}
+
+.w-layout-switch-control {
+  position: relative;
+  width: theme('spacing.20');
+  height: theme('spacing.10');
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/wagtail/images/templates/wagtailimages/images/index.html
+++ b/wagtail/images/templates/wagtailimages/images/index.html
@@ -8,9 +8,6 @@
 
 {% block slim_header %}
     {% fragment as extra_form_fields %}
-        <div id="layout-toggle-button">
-            {% include "wagtailimages/images/layout_toggle_button.html" %}
-        </div>
         {% rawformattedfield label_text=_("Sort by") id_for_label="order_images_by" sr_only_label=True %}
             <select id="order_images_by" name="ordering">
                 {% for ordering, ordering_text in ORDERING_OPTIONS.items %}
@@ -18,6 +15,9 @@
                 {% endfor %}
             </select>
         {% endrawformattedfield %}
+        <div id="layout-toggle-switcher">
+            {% include "wagtailimages/images/layout_toggle_button.html" %}
+        </div>
     {% endfragment %}
     {% include "wagtailimages/images/image_listing_header.html" with breadcrumbs_items=breadcrumbs_items side_panels=side_panels history_url=history_url title=header_title search_url=index_results_url search_form=search_form filters=filters buttons=header_buttons icon_name=header_icon extra_form_fields=extra_form_fields only %}
 {% endblock %}

--- a/wagtail/images/templates/wagtailimages/images/index_results.html
+++ b/wagtail/images/templates/wagtailimages/images/index_results.html
@@ -4,7 +4,7 @@
 
 {% block before_results %}
     {{ block.super }}
-    <template data-controller="w-teleport" data-w-teleport-target-value="#layout-toggle-button" data-w-teleport-reset-value="true">
+    <template data-controller="w-teleport" data-w-teleport-target-value="#layout-toggle-switcher" data-w-teleport-reset-value="true">
         {% include "wagtailimages/images/layout_toggle_button.html" %}
     </template>
 {% endblock %}

--- a/wagtail/images/templates/wagtailimages/images/layout_toggle_button.html
+++ b/wagtail/images/templates/wagtailimages/images/layout_toggle_button.html
@@ -1,10 +1,12 @@
 {% load wagtailadmin_tags i18n %}
 
-<label class="w-slim-header-action-button w-layout-toggle-button">
-    {% if layout == "list" %}
+<div class="w-layout-switch-control">
+    <label class="w-layout-toggle-button w-layout-toggle-button-right" tabindex="0">
         {% icon name="grid" %}
-    {% else %}
-        {% icon name="list-ul" %}
-    {% endif %}
-    <input type="checkbox" aria-label="{% translate 'Toggle layout' %}" name="layout" value="list" {% if layout == "list" %}checked{% endif %} data-controller="w-tooltip" data-w-tooltip-content-value="{% translate 'Toggle layout' %}">
-</label>
+        <input type="radio" aria-label="{% translate 'Grid layout' %}" name="layout" value="grid" {% if layout == "grid" %}checked{% endif %} data-controller="w-tooltip" data-w-tooltip-content-value="{% translate 'Grid layout' %}">
+    </label>
+    <label class="w-layout-toggle-button w-layout-toggle-button-left" tabindex="0">
+    {% icon name="list-ul" %}
+        <input type="radio" aria-label="{% translate 'List layout' %}" name="layout" value="list" {% if layout == "list" %}checked{% endif %} data-controller="w-tooltip" data-w-tooltip-content-value="{% translate 'List layout' %}">
+    </label>
+</div>


### PR DESCRIPTION
Fix for #13233

This PR adds UX improvements over the image listing layout toggle button added in #13172

<img width="1175" height="686" alt="Screenshot From 2025-09-01 16-14-24" src="https://github.com/user-attachments/assets/a8e316de-0b18-4ae7-b305-cef88a135b53" />

<img width="1175" height="686" alt="Screenshot From 2025-09-01 16-14-15" src="https://github.com/user-attachments/assets/9eaf4ffc-f0e5-40c2-8f0a-d4ca60f553a0" />

