### PR TITLE
Increase footer z-index to avoid Draftail toolbar overlap

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Changelog
  * Fix: Ignore hidden error messages in minimap & `CountController` default `findValue` (Sage Abdullah)
  * Fix: Change default ordering for `UserViewSet` to `User.USERNAME_FIELD` to support default ordering ordering with custom User models that may not have a `name` field (Lynwee)
  * Fix: Ensure starter tests in the project template pass (Lasse Schmieding)
+ * Fix: Ensure fixed RichText toolbar shows under footer actions (Maciek Baron)
  * Docs: Fix cross-reference links to the TypeDoc-generated docs (Sage Abdullah)
  * Docs: Refine readthedocs' search indexing for releases and client-side code (Sage Abdullah)
  * Docs: Fix incorrect link to third party site in advanced topics (Yousef Al-Hadhrami (Yemeni))

--- a/client/scss/components/_footer.scss
+++ b/client/scss/components/_footer.scss
@@ -8,7 +8,7 @@
   margin-top: $mobile-nice-padding;
   margin-inline-start: $mobile-nice-padding;
   margin-inline-end: $mobile-nice-padding;
-  z-index: 20;
+  z-index: theme('zIndex.footer-actions');
 
   @include media-breakpoint-up(sm) {
     margin-top: 0;

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -112,6 +112,7 @@ module.exports = {
           'inset-inline-start, padding-inline-start, width, transform, margin-top, min-height',
       },
       zIndex: {
+        'footer-actions': '32',
         'minimap': '80',
         'header': '100',
         'sidebar': '110',

--- a/docs/releases/7.2.md
+++ b/docs/releases/7.2.md
@@ -28,6 +28,7 @@ depth: 1
  * Ignore hidden error messages in minimap & `CountController` default `findValue` (Sage Abdullah)
  * Change default ordering for `UserViewSet` to `User.USERNAME_FIELD` to support default ordering ordering with custom User models that may not have a `name` field (Lynwee)
  * Ensure starter tests in the project template pass (Lasse Schmieding)
+ * Ensure fixed RichText toolbar shows under footer actions (Maciek Baron)
 
 ### Documentation
 


### PR DESCRIPTION
This PR addresses #13299.

Draftail's focused toolbar has a `z-index` of 31, which is higher than the footer's `z-index` of 20.

I have increased the value to 32.

I performed manual testing and the footer is rendered behind modals and any other overlays. Things I tested:
* Picker modals
* Right hand side info panel
* Date pickers
* Floating Draftail toolbar
* Top dropdown menu