### PR TITLE
Fix code example for construct_wagtail_userbar hook

### DIFF
--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -895,7 +895,7 @@ class UserbarPuppyLinkItem:
 
 @hooks.register('construct_wagtail_userbar')
 def add_puppy_link_item(request, items, page):
-    return items.append( UserbarPuppyLinkItem() )
+    items.append(UserbarPuppyLinkItem())
 ```
 
 If you intend to use icons in your actions, you'll have to declare them by overriding the [userbar template](custom_icons_userbar).


### PR DESCRIPTION
While browsing the documentation for hooks, I found two small issues in the example code for the `construct_wagtail_userbar` hook:

First it uses a `return` statement which doesn't make much sense since `list.append()` doesn't return anything. Wagtail doesn't make use of the return value for that hook either ([source](https://github.com/wagtail/wagtail/blob/f6f6bb80b002c4a9a7ddd52ba7c6e4ec9134f83d/wagtail/admin/userbar.py#L295)).

Second, it has some extra spaces around parentheses which isn't very usual in Python code (and indeed, no other code example in the file use that format).