### PR TITLE
Upload redundant latest.whl nightly build for ease of use with package managers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
  * Maintenance: Remove use of `_WAGTAILSEARCH_FORCE_AUTO_UPDATE` in search tests (Matt Westcott)
  * Maintenance: Add unit test for `SubmitController` error handling (LB (Ben) Johnston)
  * Maintenance: Improve nightly release upload scripts (Jake Howard)
+ * Maintenance: Upload redundant `latest.whl` nightly build for ease of use with package managers (Sage Abdullah)
 
 
 7.2.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/7.3.md
+++ b/docs/releases/7.3.md
@@ -42,6 +42,7 @@ depth: 1
  * Remove use of `_WAGTAILSEARCH_FORCE_AUTO_UPDATE` in search tests (Matt Westcott)
  * Add unit test for `SubmitController` error handling (LB (Ben) Johnston)
  * Improve nightly release upload scripts (Jake Howard)
+ * Upload redundant `latest.whl` nightly build for ease of use with package managers (Sage Abdullah)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/scripts/nightly/upload.py
+++ b/scripts/nightly/upload.py
@@ -20,6 +20,13 @@ s3.upload_file(
     "releases.wagtail.io",
     "nightly/dist/" + f.name,
 )
+# Redundant upload to a fixed filename for ease of use with package managers
+print("Uploading latest.whl")  # noqa: T201
+s3.upload_file(
+    str(f),
+    "releases.wagtail.io",
+    "nightly/dist/latest.whl",
+)
 
 print("Updating latest.json")  # noqa: T201
 
@@ -37,8 +44,8 @@ boto3.client("cloudfront").create_invalidation(
     DistributionId="E283SZ5CB4MDM0",
     InvalidationBatch={
         "Paths": {
-            "Quantity": 1,
-            "Items": ["/nightly/latest.json"],
+            "Quantity": 2,
+            "Items": ["/nightly/latest.json", "/nightly/dist/latest.whl"],
         },
         "CallerReference": str(uuid.uuid4()),
     },


### PR DESCRIPTION
This makes it easy for automations (e.g. tests of external packages) to install the nightly build, which is much faster than installing from source and does not require compiling the static assets themselves.