### PR TITLE
feat: meta description empty content check

### DIFF
--- a/client/src/includes/a11y-result.test.ts
+++ b/client/src/includes/a11y-result.test.ts
@@ -4,6 +4,7 @@ import {
   WagtailAxeConfiguration,
   addCustomChecks,
   checkImageAltText,
+  checkMetaDescription,
   getA11yReport,
 } from './a11y-result';
 
@@ -116,6 +117,48 @@ describe('checkImageAltText edge cases', () => {
     const image = document.createElement('img');
     expect(checkImageAltText(image, options)).toBe(true);
   });
+});
+
+describe('checkMetaDescription', () => {
+  afterEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  const testCases = [
+    {
+      description: 'tag does not exist',
+      html: '',
+      expected: true,
+    },
+    {
+      description: 'tag has valid content',
+      html: '<meta name="description" content="A valid description.">',
+      expected: true,
+    },
+    {
+      description: 'content is an empty string',
+      html: '<meta name="description" content="">',
+      expected: false,
+    },
+    {
+      description: 'content is only whitespace',
+      html: '<meta name="description" content="   ">',
+      expected: false,
+    },
+    {
+      description: 'tag has no content attribute',
+      html: '<meta name="description">',
+      expected: false,
+    },
+  ];
+
+  test.each(testCases)(
+    'should return $expected when the meta description $description',
+    ({ html, expected }) => {
+      document.head.innerHTML = html;
+      expect(checkMetaDescription(document.documentElement)).toBe(expected);
+    },
+  );
 });
 
 jest.mock('axe-core', () => ({

--- a/client/src/includes/a11y-result.ts
+++ b/client/src/includes/a11y-result.ts
@@ -95,12 +95,27 @@ export const checkImageAltText = (
 };
 
 /**
+ * Custom rule for checking meta description. Checks if <meta name="description"> is empty.
+ * Only raises an issue if the tag is present and empty.
+ * To be used in Axe custom checks.
+ */
+export const checkMetaDescription = (node: HTMLElement) => {
+  // node is the full HTML document
+  const metaDescription = node.querySelector('meta[name="description"]');
+
+  if (!metaDescription) return true;
+
+  const content = metaDescription?.getAttribute('content') || '';
+  return content.trim().length > 0;
+};
+
+/**
  * Defines custom Axe rules, mapping each check to its corresponding JavaScript function.
  * This object holds the custom checks that will be added to the Axe configuration.
  */
 export const customChecks = {
   'check-image-alt-text': checkImageAltText,
-  // Add other custom checks here
+  'check-meta-description': checkMetaDescription,
 };
 
 /**

--- a/docs/advanced_topics/accessibility_considerations.md
+++ b/docs/advanced_topics/accessibility_considerations.md
@@ -135,6 +135,7 @@ By default, the checker includes the following rules to find common accessibilit
 -   `link-name`: `<a>` link elements must always have a text label.
 -   `p-as-heading`: This rule checks for paragraphs that are styled as headings. Paragraphs should not be styled as headings, as they don’t help users who rely on headings to navigate content.
 -   `alt-text-quality`: A custom rule ensures that image alt texts don't contain anti-patterns like file extensions and underscores.
+-   `meta-description`: This rule checks if the `<meta name="description">` tag is present and not empty.
 
 To customize how the checker is run (such as what rules to test), you can define a custom subclass of {class}`~wagtail.admin.userbar.AccessibilityItem` and override the attributes to your liking. Then, swap the instance of the default `AccessibilityItem` with an instance of your custom class via the [`construct_wagtail_userbar`](construct_wagtail_userbar) hook.
 

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -465,6 +465,9 @@ class TestAccessibilityCheckerConfig(WagtailTestUtils, TestCase):
                     "id": "check-image-alt-text",
                     "options": {"pattern": "\\.[a-z]{1,4}$|_"},
                 },
+                {
+                    "id": "check-meta-description",
+                },
             ]
 
             # Add via method
@@ -507,6 +510,14 @@ class TestAccessibilityCheckerConfig(WagtailTestUtils, TestCase):
                             "enabled": True,
                         },
                         {
+                            "id": "meta-description",
+                            "impact": "moderate",
+                            "selector": "html",
+                            "tags": ["best-practice"],
+                            "all": ["check-meta-description"],
+                            "enabled": True,
+                        },
+                        {
                             "id": "link-text-quality",
                             "impact": "serious",
                             "selector": "a",
@@ -519,6 +530,9 @@ class TestAccessibilityCheckerConfig(WagtailTestUtils, TestCase):
                         {
                             "id": "check-image-alt-text",
                             "options": {"pattern": "\\.[a-z]{1,4}$|_"},
+                        },
+                        {
+                            "id": "check-meta-description",
                         },
                         {
                             "id": "check-link-text",

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -41,7 +41,7 @@ class AccessibilityItem(BaseItem):
 
     #: A list of CSS selector(s) to test specific parts of the page.
     #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/context.md#the-include-property>`__.
-    axe_include = ["body"]
+    axe_include = ["html"]
 
     #: A list of CSS selector(s) to exclude specific parts of the page from testing.
     #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/context.md#exclude-elements-from-test>`__.
@@ -64,6 +64,7 @@ class AccessibilityItem(BaseItem):
         "link-name",
         "p-as-heading",
         "alt-text-quality",
+        "meta-description",
     ]
 
     #: A dictionary that maps axe-core rule IDs to a dictionary of rule options,
@@ -85,6 +86,14 @@ class AccessibilityItem(BaseItem):
             # If omitted, defaults to True and overrides configs in `axe_run_only`.
             "enabled": True,
         },
+        {
+            "id": "meta-description",
+            "impact": "moderate",
+            "selector": "html",
+            "tags": ["best-practice"],
+            "all": ["check-meta-description"],
+            "enabled": True,
+        },
     ]
 
     #: A list to add custom Axe checks or override their properties.
@@ -94,6 +103,9 @@ class AccessibilityItem(BaseItem):
         {
             "id": "check-image-alt-text",
             "options": {"pattern": "\\.(avif|gif|jpg|jpeg|png|svg|webp)$|_"},
+        },
+        {
+            "id": "check-meta-description",
         },
     ]
 
@@ -136,6 +148,12 @@ class AccessibilityItem(BaseItem):
         "alt-text-quality": {
             "error_name": _("Image alt text has inappropriate pattern"),
             "help_text": _("Use meaningful text"),
+        },
+        "meta-description": {
+            "error_name": _("Meta description tag is empty"),
+            "help_text": _(
+                "Add a concise meta description for better accessibility and SEO."
+            ),
         },
     }
 


### PR DESCRIPTION
- #12252

## Description

Added `meta-description` for checking the content isn't empty for the page meta description.

## Visuals

<img width="353" height="375" alt="image" src="https://github.com/user-attachments/assets/fb81f6d7-8758-4597-afe4-9d3622dd5ab7" />

<img width="596" height="175" alt="image" src="https://github.com/user-attachments/assets/bef5b834-34c5-47ec-9189-8fe38508ef86" />


