### PR TITLE
Add `max_value` of 100 (%) for the Image URL Generator form

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Add keyboard shortcut (`/`) to activate and focus on the search input in the sidebar (Dhruvi Patel)
  * Allow deep contentpath for comments on fields other than StreamField (Lasse Schmieding, Sébastien Corbin, Joel William, Sage Abdullah)
  * Reorganize keyboard shortcuts into better categories with an ordering from most common to most specific (Dhruvi Patel)
+ * Add `max_value` of 100 (%) for the `closeness` field in Image URL Generator form (LB (Ben) Johnston)
  * Fix: Use the correct method of resolving the file storage dynamically for FileField usage in images & documents (Amir Mahmoodi)
  * Fix: Ensure the add comment keyboard shortcut is disabled when keyboard shortcuts are disabled in user preferences (Dhruvi Patel)
  * Fix: Use model name when ordering by page type in page listings (Sage Abdullah)

--- a/docs/releases/7.2.md
+++ b/docs/releases/7.2.md
@@ -19,6 +19,7 @@ depth: 1
  * Add keyboard shortcut (`/`) to activate and focus on the search input in the sidebar (Dhruvi Patel)
  * Allow deep contentpath for comments on fields other than StreamField (Lasse Schmieding, Sébastien Corbin, Joel William, Sage Abdullah)
  * Reorganize keyboard shortcuts into better categories with an ordering from most common to most specific (Dhruvi Patel)
+ * Add `max_value` of 100 (%) for the `closeness` field in Image URL Generator form (LB (Ben) Johnston)
 
 ### Bug fixes
 

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -235,6 +235,7 @@ class URLGeneratorForm(forms.Form):
     closeness = forms.IntegerField(
         label=_("Closeness"),
         min_value=0,
+        max_value=100,
         initial=0,
         widget=forms.NumberInput(
             attrs={

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -3888,6 +3888,13 @@ class TestURLGeneratorView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
             response.content,
         )
 
+        soup = self.get_soup(response.content)
+        form = soup.select_one("main form")
+        closeness = form.select_one("input[name=closeness]")
+        self.assertIsNotNone(closeness)
+        self.assertEqual(closeness.get("min"), "0")
+        self.assertEqual(closeness.get("max"), "100")
+
     def test_get_bad_permissions(self):
         """
         This tests that the view returns a "permission denied" redirect if a user without correct


### PR DESCRIPTION
Improve UX by not allowing the closeness field to get greater than what's available.

A small change but just helps users that may use keyboard control or the 'spinner' buttons and create values that do not do anything.

Note that the filter spec will cap this value at `100` so larger values will not break anything, but I thought it might be a nice small improvement.

<img width="1705" height="880" alt="Screenshot 2025-09-07 at 4 35 41 PM" src="https://github.com/user-attachments/assets/d5000925-ab42-4aab-a4af-fedc14469db0" />

