### PR TITLE
SwapController - Clean up JSDoc, ordering of values & form resolving

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -61,6 +61,7 @@ Changelog
  * Maintenance: Support skipping transaction unit tests with a tag (Sage Abdullah)
  * Maintenance: Remove unreachable code in wagtail.py (Oluwagbeminiyi Agbedejobi)
  * Maintenance: Upgrade django-treebeard dependency to 4.8-5.x (Samir Shah)
+ * Maintenance: Clean up JSDoc & ordering of values in `SwapController` (LB (Ben Johnston))
 
 
 7.3.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/controllers/SwapController.test.js
+++ b/client/src/controllers/SwapController.test.js
@@ -45,13 +45,15 @@ describe('SwapController', () => {
 
       document.body.innerHTML = `
       <div id="listing-results"></div>
-      <input
-        id="search"
-        type="text"
-        name="q"
-        data-controller="w-swap"
-        data-w-swap-target-value=""
-      />`;
+      <form>
+        <input
+          id="search"
+          type="text"
+          name="q"
+          data-controller="w-swap"
+          data-w-swap-target-value=""
+        />
+      </form>`;
 
       // trigger next browser render cycle
       await Promise.resolve();
@@ -68,14 +70,16 @@ describe('SwapController', () => {
 
       document.body.innerHTML = `
       <div id="listing-results"></div>
-      <input
-        id="search"
-        type="text"
-        name="q"
-        data-controller="w-swap"
-        data-w-swap-src-value="path/to/search"
-        data-w-swap-target-value="#resultX"
-      />`;
+      <form>
+        <input
+          id="search"
+          type="text"
+          name="q"
+          data-controller="w-swap"
+          data-w-swap-src-value="path/to/search"
+          data-w-swap-target-value="#resultX"
+        />
+      </form>`;
 
       // trigger next browser render cycle
       await Promise.resolve();
@@ -94,13 +98,15 @@ describe('SwapController', () => {
 
       document.body.innerHTML = `
       <div id="results"></div>
-      <input
-        id="search"
-        type="text"
-        name="q"
-        data-controller="w-swap"
-        data-w-swap-target-value="#results"
-      />`;
+      <form>
+        <input
+          id="search"
+          type="text"
+          name="q"
+          data-controller="w-swap"
+          data-w-swap-target-value="#results"
+        />
+      </form>`;
 
       // trigger next browser render cycle
       await Promise.resolve();
@@ -731,13 +737,16 @@ describe('SwapController', () => {
   describe('performing a content update via actions on a controlled button without a form', () => {
     beforeEach(() => {
       document.body.innerHTML = `
-      <button
-        id="clear"
-        data-controller="w-swap"
-        data-action="w-swap#replaceLazy"
-        data-w-swap-src-value="/admin/custom/results/?type=bar"
-        data-w-swap-target-value="#results"
-      >Clear owner filter</button>
+      <div id="not-a-form">
+        <button
+          id="clear"
+          type="button"
+          data-controller="w-swap"
+          data-action="w-swap#replaceLazy"
+          data-w-swap-src-value="/admin/custom/results/?type=bar"
+          data-w-swap-target-value="#results"
+        >Clear owner filter</button>
+      </div>
       <div id="results"></div>
       `;
     });

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -105,6 +105,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Support skipping transaction unit tests with a tag (Sage Abdullah)
  * Remove unreachable code in wagtail.py (Oluwagbeminiyi Agbedejobi)
  * Upgrade django-treebeard dependency to 4.8-5.x (Samir Shah)
+ * Clean up JSDoc & ordering of values in `SwapController` (LB (Ben Johnston))
 
 
 ## Upgrade considerations - changes affecting all projects


### PR DESCRIPTION
While working on using `SwapController` in other places in the admin (Image URL generator), I saw that this controller needs a bit of a clean up.

This PR adds consistent type declarations, JSDoc and fixes up a few edge cases in unit tests to round out test coverage. It also fixes a potential edge case but where the resolved `form` would not match correctly.

## Full details

- Use consistent alpha sorting of all values, plus type declarations
- Update values to readonly if they are not meant to be changed by controller logic
- Use consistent sentence structures for JSDoc
- Add JSDoc where practical to all values and methods
- Fix small typo in example JSDoc
- Refine `formElement` to resolve test coverage issue & clean up resolving for missed edge case where the controlled element may not be a form.
  - We technically support the controlled element being an input OR a form, but the code would not resolve the `form` if the controlled element was an input. This did not break any existing code but was found after I saw that test coverage for this was missing.