### PR TITLE
Improve linked documentation for Page.move()

### DIFF
--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -440,7 +440,7 @@ See also [django-treebeard](inv:treebeard:std:doc#index)'s [node API](inv:treebe
     .. method:: move(new_parent, pos=None)
 
         Move a page and all its descendants to a new parent.
-        See :meth:`django-treebeard <treebeard.mp_tree.MP_Node.move>` for more information.
+        See :meth:`django-treebeard <treebeard.models.Node.move>` for more information.
 
 
     .. automethod:: create_alias


### PR DESCRIPTION
Treebeard's [documentation for `MP_Node.move()`](https://django-treebeard.readthedocs.io/en/stable/mp_tree.html#treebeard.mp_tree.MP_Node.move) is very short and not particularly useful imo. In particular it doesn't explain the possible values of the `pos` argument.

I think it'd be more useful to link to the general [`Node.move()` documentation](https://django-treebeard.readthedocs.io/en/stable/api.html#treebeard.models.Node.move) which has that information.