### PR TITLE
Use the current host for building absolute URLs in the user bar

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Fix: Ensure starter tests in the project template pass (Lasse Schmieding)
  * Fix: Ensure fixed RichText toolbar shows under footer actions (Maciek Baron)
  * Fix: Prevent error when iterating over specific tasks with missing models (Lasse Schmieding)
+ * Fix: Better support userbar loading on multi-site through site hosts (Sage Abdullah)
  * Docs: Fix cross-reference links to the TypeDoc-generated docs (Sage Abdullah)
  * Docs: Refine readthedocs' search indexing for releases and client-side code (Sage Abdullah)
  * Docs: Fix incorrect link to third party site in advanced topics (Yousef Al-Hadhrami (Yemeni))

--- a/docs/releases/7.1.2.md
+++ b/docs/releases/7.1.2.md
@@ -14,6 +14,7 @@ depth: 1
 ### Bug fixes
 
  * Allow `label_format` to be set to an empty string to hide the block summary label (Sage Abdullah)
+ * Better support userbar loading on multi-site through site hosts (Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -5,7 +5,8 @@
     <aside {% if request.in_preview_panel %}hidden{% endif %}>
         <div class="w-userbar w-userbar--{{ position|default:'bottom-right' }} {% admin_theme_classname %}" data-wagtail-userbar data-wagtail-userbar-origin="{{ origin|default:"" }}" part="userbar">
             {% block css %}
-                <link rel="stylesheet" href="{% absolute_static 'wagtailadmin/css/core.css' %}">
+                {% versioned_static 'wagtailadmin/css/core.css' as core_css_url %}
+                <link rel="stylesheet" href="{% build_absolute_url core_css_url %}">
                 {# For headless userbar: the contents of the hook also need absolute URLs #}
                 {% hook_output 'insert_global_admin_css' %}
             {% endblock %}
@@ -44,7 +45,9 @@
 </template>
 <wagtail-userbar></wagtail-userbar>
 {% block js %}
-    <script src="{% absolute_static 'wagtailadmin/js/vendor.js' %}"></script>
-    <script src="{% absolute_static 'wagtailadmin/js/userbar.js' %}"></script>
+    {% versioned_static 'wagtailadmin/js/vendor.js' as vendor_js_url %}
+    {% versioned_static 'wagtailadmin/js/userbar.js' as userbar_js_url %}
+    <script src="{% build_absolute_url vendor_js_url %}"></script>
+    <script src="{% build_absolute_url userbar_js_url %}"></script>
 {% endblock %}
 <!-- end Wagtail user bar embed code -->

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_admin.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_admin.html
@@ -2,8 +2,8 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block item_content %}
-    {% base_url_setting default="" as base_url %}
-    <a href="{{ base_url }}{% url 'wagtailadmin_home' %}" target="_parent" role="menuitem">
+    {% url 'wagtailadmin_home' as admin_home_url %}
+    <a href="{% build_absolute_url admin_home_url %}" target="_parent" role="menuitem">
         {% icon name="key" classname="w-action-icon" %}
         {% trans 'Go to Wagtail admin' %}
     </a>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_add.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_add.html
@@ -2,8 +2,8 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block item_content %}
-    {% base_url_setting default="" as base_url %}
-    <a href="{{ base_url }}{% url 'wagtailadmin_pages:add_subpage' self.page.id %}" target="_parent" role="menuitem">
+    {% url 'wagtailadmin_pages:add_subpage' self.page.id as add_url %}
+    <a href="{% build_absolute_url add_url %}" target="_parent" role="menuitem">
         {% icon name="plus" classname="w-action-icon" %}
         {% trans 'Add a child page' %}
     </a>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_edit.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_edit.html
@@ -2,8 +2,8 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block item_content %}
-    {% base_url_setting default="" as base_url %}
-    <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' self.page.id %}" target="_parent" role="menuitem">
+    {% url 'wagtailadmin_pages:edit' self.page.id as edit_url %}
+    <a href="{% build_absolute_url edit_url %}" target="_parent" role="menuitem">
         {% icon name="edit" classname="w-action-icon" %}
         {% trans 'Edit this page' %}
     </a>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_explore.html
@@ -2,8 +2,8 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block item_content %}
-    {% base_url_setting default="" as base_url %}
-    <a href="{{ base_url }}{% url 'wagtailadmin_explore' self.parent_page.id %}" target="_parent" role="menuitem">
+    {% url 'wagtailadmin_explore' self.parent_page.id as explore_url %}
+    <a href="{% build_absolute_url explore_url %}" target="_parent" role="menuitem">
         {% icon name="folder-open-inverse" classname="w-action-icon" %}
         {% trans 'Show in Explorer' %}
     </a>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -206,6 +206,18 @@ def admin_url_name(obj, action):
     return obj.snippet_viewset.get_url_name(action)
 
 
+@register.simple_tag(takes_context=True)
+def build_absolute_url(context, url):
+    """
+    Usage: {% build_absolute_url url %}
+    Returns the absolute URL of the given URL.
+    """
+    request = context.get("request")
+    if not request:
+        return url
+    return request.build_absolute_uri(url)
+
+
 @register.simple_tag
 def latest_str(obj):
     """

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -210,11 +210,14 @@ def admin_url_name(obj, action):
 def build_absolute_url(context, url):
     """
     Usage: {% build_absolute_url url %}
-    Returns the absolute URL of the given URL.
+    Returns the absolute URL of the given URL based on the request's host.
+    If the request doesn't exist in the context, falls back to
+    WAGTAILADMIN_BASE_URL as the base URL.
+    If the given URL is already absolute, returns it unchanged.
     """
     request = context.get("request")
     if not request:
-        return url
+        return urljoin(get_admin_base_url(), url)
     return request.build_absolute_uri(url)
 
 

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -8,7 +8,7 @@ from django.utils import translation
 from django.utils.translation import gettext
 
 from wagtail import hooks
-from wagtail.admin.templatetags.wagtailadmin_tags import absolute_static
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.userbar import AccessibilityItem, Userbar
 from wagtail.coreutils import get_dummy_request
 from wagtail.models import PAGE_TEMPLATE_VAR, Locale, Page, Site
@@ -66,7 +66,7 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
                 # Wagtail admin core CSS should be linked with absolute URL to
                 # ensure it works when loaded from a different domain
                 # (e.g. headless frontend)
-                absolute_static("wagtailadmin/css/core.css"),
+                f"http://localhost{versioned_static('wagtailadmin/css/core.css')}",
                 # Custom CSS must be changed appropriately if necessary
                 "/path/to/my/custom.css",
             ],
@@ -79,8 +79,8 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
                 # Wagtail vendor and userbar JS should be linked with absolute
                 # URL to ensure it works when loaded from a different domain
                 # (e.g. headless frontend)
-                absolute_static("wagtailadmin/js/vendor.js"),
-                absolute_static("wagtailadmin/js/userbar.js"),
+                f"http://localhost{versioned_static('wagtailadmin/js/vendor.js')}",
+                f"http://localhost{versioned_static('wagtailadmin/js/userbar.js')}",
             ],
         )
 

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -1,6 +1,5 @@
 import json
 
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Permission
 from django.template import Context, Template
 from django.test import TestCase, override_settings
@@ -136,9 +135,7 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
         # Should render the "Go to Wagtail admin" link using an absolute URL
         soup = self.get_soup(content)
         admin_url = reverse("wagtailadmin_home")
-        admin_link = soup.select_one(
-            f"a[href='{settings.WAGTAILADMIN_BASE_URL}{admin_url}']"
-        )
+        admin_link = soup.select_one(f"a[href='http://localhost{admin_url}']")
         self.assertIsNotNone(admin_link)
         self.assertEqual(admin_link.text.strip(), "Go to Wagtail admin")
 
@@ -156,16 +153,12 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
         soup = self.get_soup(content)
 
         edit_url = reverse("wagtailadmin_pages:edit", args=(self.homepage.id,))
-        edit_link = soup.select_one(
-            f"a[href='{settings.WAGTAILADMIN_BASE_URL}{edit_url}']"
-        )
+        edit_link = soup.select_one(f"a[href='http://localhost{edit_url}']")
         self.assertIsNotNone(edit_link)
         self.assertEqual(edit_link.text.strip(), "Edit this page")
 
         explore_url = reverse("wagtailadmin_explore", args=(self.parent_page.id,))
-        explore_link = soup.select_one(
-            f"a[href='{settings.WAGTAILADMIN_BASE_URL}{explore_url}']"
-        )
+        explore_link = soup.select_one(f"a[href='http://localhost{explore_url}']")
         self.assertIsNotNone(explore_link)
         self.assertEqual(explore_link.text.strip(), "Show in Explorer")
 
@@ -185,16 +178,12 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
         soup = self.get_soup(content)
 
         edit_url = reverse("wagtailadmin_pages:edit", args=(self.homepage.id,))
-        edit_link = soup.select_one(
-            f"a[href='{settings.WAGTAILADMIN_BASE_URL}{edit_url}']"
-        )
+        edit_link = soup.select_one(f"a[href='http://localhost{edit_url}']")
         self.assertIsNotNone(edit_link)
         self.assertEqual(edit_link.text.strip(), "Edit this page")
 
         explore_url = reverse("wagtailadmin_explore", args=(self.parent_page.id,))
-        explore_link = soup.select_one(
-            f"a[href='{settings.WAGTAILADMIN_BASE_URL}{explore_url}']"
-        )
+        explore_link = soup.select_one(f"a[href='http://localhost{explore_url}']")
         self.assertIsNotNone(explore_link)
         self.assertEqual(explore_link.text.strip(), "Show in Explorer")
 
@@ -221,9 +210,7 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
         # The explore link should still be visible
         soup = self.get_soup(content)
         explore_url = reverse("wagtailadmin_explore", args=(self.parent_page.id,))
-        explore_link = soup.select_one(
-            f"a[href='{settings.WAGTAILADMIN_BASE_URL}{explore_url}']"
-        )
+        explore_link = soup.select_one(f"a[href='http://localhost{explore_url}']")
         self.assertIsNotNone(explore_link)
         self.assertEqual(explore_link.text.strip(), "Show in Explorer")
 
@@ -718,7 +705,7 @@ class TestUserbarAddLink(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
 
         # page allows subpages, so the 'add page' button should show
-        expected_url = settings.WAGTAILADMIN_BASE_URL + (
+        expected_url = self.request.build_absolute_uri(
             reverse("wagtailadmin_pages:add_subpage", args=(self.event_index.id,))
         )
         needle = f"""
@@ -762,7 +749,7 @@ class TestUserbarComponent(WagtailTestUtils, TestCase):
         items = soup.select("li")
         self.assertEqual(len(items), 2)
 
-        admin_url = f"{settings.WAGTAILADMIN_BASE_URL}{reverse('wagtailadmin_home')}"
+        admin_url = f"http://localhost{reverse('wagtailadmin_home')}"
         admin_item = items[0]
         admin_link = admin_item.select_one("a")
         self.assertIsNotNone(admin_link)
@@ -784,11 +771,10 @@ class TestUserbarComponent(WagtailTestUtils, TestCase):
         items = soup.select("li")
         self.assertEqual(len(items), 2)
 
-        admin_url = f"{settings.WAGTAILADMIN_BASE_URL}{reverse('wagtailadmin_home')}"
         admin_item = items[0]
         admin_link = admin_item.select_one("a")
         self.assertIsNotNone(admin_link)
-        self.assertEqual(admin_link.get("href"), admin_url)
+        self.assertEqual(admin_link.get("href"), reverse("wagtailadmin_home"))
         self.assertEqual(admin_link.text.strip(), "Go to Wagtail admin")
 
         accessibility_item = items[-1]
@@ -813,7 +799,7 @@ class TestUserbarComponent(WagtailTestUtils, TestCase):
         items = soup.select("li")
         self.assertEqual(len(items), 2)
 
-        admin_url = f"{settings.WAGTAILADMIN_BASE_URL}{reverse('wagtailadmin_home')}"
+        admin_url = f"http://localhost{reverse('wagtailadmin_home')}"
         admin_item = items[0]
         admin_link = admin_item.select_one("a")
         self.assertIsNotNone(admin_link)
@@ -844,7 +830,7 @@ class TestUserbarComponent(WagtailTestUtils, TestCase):
         self.assertEqual(len(links), 4)
         self.assertEqual(
             [link.get("href") for link in links],
-            [f"{settings.WAGTAILADMIN_BASE_URL}{url}" for url in expected_urls],
+            [f"http://localhost{url}" for url in expected_urls],
         )
 
         accessibility_button = soup.select_one("li button")

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -767,6 +767,13 @@ class TestUserbarComponent(WagtailTestUtils, TestCase):
     def test_render_no_request(self):
         rendered = Userbar().render_html({})
         soup = self.get_soup(rendered)
+        # Without a request provided, URLs should fall back to the
+        # WAGTAILADMIN_BASE_URL setting
+        base_url = "http://testserver"
+
+        userbar = soup.select_one("[data-wagtail-userbar]")
+        self.assertIsNotNone(userbar)
+        self.assertEqual(userbar.get("data-wagtail-userbar-origin"), base_url)
 
         items = soup.select("li")
         self.assertEqual(len(items), 2)
@@ -791,10 +798,8 @@ class TestUserbarComponent(WagtailTestUtils, TestCase):
 
         userbar = soup.select_one("[data-wagtail-userbar]")
         self.assertIsNotNone(userbar)
-        self.assertEqual(
-            userbar.get("data-wagtail-userbar-origin"),
-            settings.WAGTAILADMIN_BASE_URL,
-        )
+        # The origin should be based on the request's scheme and host information
+        self.assertEqual(userbar.get("data-wagtail-userbar-origin"), "http://localhost")
 
         items = soup.select("li")
         self.assertEqual(len(items), 2)
@@ -841,8 +846,8 @@ class TestUserbarComponent(WagtailTestUtils, TestCase):
         )
 
     @override_settings(WAGTAILADMIN_BASE_URL=None)
-    def test_render_without_admin_base_url_setting(self):
-        rendered = Userbar().render_html({"request": self.request})
+    def test_render_without_request_and_admin_base_url_setting(self):
+        rendered = Userbar().render_html({})
         soup = self.get_soup(rendered)
 
         userbar = soup.select_one("[data-wagtail-userbar]")

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -364,10 +364,15 @@ class Userbar(Component):
             # Remove any unrendered items
             rendered_items = [item for item in rendered_items if item]
 
+            if request:
+                origin = f"{request.scheme}://{request.get_host()}"
+            else:
+                origin = get_admin_base_url() or ""
+
             # Render the userbar items
             return {
                 "request": request,
-                "origin": get_admin_base_url(),
+                "origin": origin,
                 "items": rendered_items,
                 "position": self.position,
                 "page": self.object,

--- a/wagtail/snippets/tests/test_preview.py
+++ b/wagtail/snippets/tests/test_preview.py
@@ -6,7 +6,6 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from wagtail.admin.staticfiles import versioned_static
-from wagtail.admin.templatetags.wagtailadmin_tags import absolute_static
 from wagtail.admin.views.generic.preview import PreviewOnEdit
 from wagtail.test.testapp.models import (
     EventCategory,
@@ -325,10 +324,10 @@ class TestPreview(WagtailTestUtils, TestCase):
         )
         self.assertNotContains(response, versioned_static("wagtailadmin/js/icons.js"))
 
-    @override_settings(WAGTAILADMIN_BASE_URL="http://other.example.com:8000")
     def test_userbar_in_preview(self):
         self.client.post(self.preview_on_edit_url, self.post_data)
-        response = self.client.get(self.preview_on_edit_url)
+        host = "other.example.com:8000"
+        response = self.client.get(self.preview_on_edit_url, headers={"host": host})
 
         # Check the HTML response
         self.assertEqual(response.status_code, 200)
@@ -345,7 +344,7 @@ class TestPreview(WagtailTestUtils, TestCase):
         self.assertEqual(
             [link.get("href") for link in css_links],
             [
-                absolute_static("wagtailadmin/css/core.css"),
+                f"http://{host}{versioned_static('wagtailadmin/css/core.css')}",
                 "/path/to/my/custom.css",
             ],
         )
@@ -353,8 +352,8 @@ class TestPreview(WagtailTestUtils, TestCase):
         self.assertEqual(
             [script.get("src") for script in scripts],
             [
-                absolute_static("wagtailadmin/js/vendor.js"),
-                absolute_static("wagtailadmin/js/userbar.js"),
+                f"http://{host}{versioned_static('wagtailadmin/js/vendor.js')}",
+                f"http://{host}{versioned_static('wagtailadmin/js/userbar.js')}",
             ],
         )
 


### PR DESCRIPTION
Fixes #13414, see https://github.com/wagtail/wagtail/issues/13414#issuecomment-3314478932 for more details.