### PR TITLE
13411 image tags object fit

### DIFF
--- a/docs/advanced_topics/images/focal_points.md
+++ b/docs/advanced_topics/images/focal_points.md
@@ -9,7 +9,7 @@ Focal points can be defined manually by a Wagtail user, or automatically by usin
 
 ## Using `focus` attributes on template tags
 
-When using the various image template tags, you can set the `focus` attribute to add information about the image's focal point to the output `<img>` HTML tag. There are a few different values you can supply.
+When using the various image template tags, you can set the `focus` attribute to add information about the image's focal point to the output `<img>` HTML tag. There are a few different values you can supply to control the resulting HTML.
 
 ### Using `data-focus-position-*` attributes
 
@@ -52,39 +52,23 @@ Might render HTML like:
 <img src="/media/my-image.width-1024.jpg" style="object-position: 50% 50%;">
 ```
 
-### Using `<style>` elements
+This is compatible with all major browsers, but the `style` attribute can cause problems if you are using a [content security policy][csp].
 
-Finally, you set `object-position` via a separate `<style>` element by passing `focus="style-tag"` to the template tag. For example, the template:
+### Handling CSP with `<style>` elements
 
-```html+django
-{% image page.image width-1024 focus="style-tag" %}
-```
-
-Might render HTML like:
-
-```html
-<img src="/media/my-image.width-1024.jpg" id="abc123">
-<style type="text/css">
-    #wagtail-image-abc123 { object-position: 50% 50%; }
-</style>
-```
-
-The `id` attribute will be set to a random value unless you manually pass one into the template tag.
-
-**If you are using a content security policy,** you can pass a nonce with `focus="nonce-<value>"`. For example, the template:
+If you are using a [content-security-policy][csp] to protect against XSS attacks involving CSS, you can manually set `object-position` via an inline `<style>` element with a nonce you control:
 
 ```html+django
 <meta http-equiv="Content-Security-Policy" content="style-src 'nonce-xyz456';">
 
-{% image page.image width-1024 focus="nonce-xyz456" %}
-```
-
-Might render HTML like:
-
-```html
-<img src="/media/my-image.width-1024.jpg" id="abc123">
+{% image page.image width-1024 id="my-image" %}
 <style type="text/css" nonce="xyz456">
-    #wagtail-image-abc123 { object-position: 50% 50%; }
+    #my-image {
+        {% image page.image original as image_info %}
+        object-position:
+            {{ image_info.background_position_x }}
+            {{ image_info.background_position_y }};
+    }
 </style>
 ```
 
@@ -124,3 +108,6 @@ You can access the focal point in the template by accessing the `.focal_point` a
     {% endif %}
 />
 ```
+
+
+[csp]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP

--- a/docs/advanced_topics/images/focal_points.md
+++ b/docs/advanced_topics/images/focal_points.md
@@ -7,6 +7,87 @@ This is used by the `fill` filter to focus the cropping on the subject, and avoi
 
 Focal points can be defined manually by a Wagtail user, or automatically by using face or feature detection.
 
+## Using `focus` attributes on template tags
+
+When using the various image template tags, you can set the `focus` attribute to add information about the image's focal point to the output `<img>` HTML tag. There are a few different values you can supply.
+
+### Using `data-focus-position-*` attributes
+
+By default, the focal point will be set as percentages on two `data-focus-position-{x,y}` attributes on the image. You can also set this behavior explicitly with `focus="data-attr"` on the template tag. For example, the template:
+
+```html+django
+{% image page.image width-1024 focus="data-attr" %}
+```
+
+Might render HTML like:
+
+```html
+<img src="/media/my-image.width-1024.jpg" data-focus-position-x="50%" data-focus-position-y="50%">
+```
+
+In newer browsers, you can use the CSS `attr()` function to read these and set `object-position`. For example:
+
+```css
+img {
+    width: 400px;
+    height: 200px;
+    object-fit: cover;
+    object-position:
+        attr(data-focus-position-x type(<length-percentage>), 50%)
+        attr(data-focus-position-y type(<length-percentage>), 50%);
+}
+```
+
+### Using `style` attributes
+
+You can also set `object-position` via a `style` attribute directly on the image by passing `focus="style-attr"` to the template tag. For example, the template:
+
+```html+django
+{% image page.image width-1024 focus="style-attr" %}
+```
+
+Might render HTML like:
+
+```html
+<img src="/media/my-image.width-1024.jpg" style="object-position: 50% 50%;">
+```
+
+### Using `<style>` elements
+
+Finally, you set `object-position` via a separate `<style>` element by passing `focus="style-tag"` to the template tag. For example, the template:
+
+```html+django
+{% image page.image width-1024 focus="style-tag" %}
+```
+
+Might render HTML like:
+
+```html
+<img src="/media/my-image.width-1024.jpg" id="abc123">
+<style type="text/css">
+    #wagtail-image-abc123 { object-position: 50% 50%; }
+</style>
+```
+
+The `id` attribute will be set to a random value unless you manually pass one into the template tag.
+
+**If you are using a content security policy,** you can pass a nonce with `focus="nonce-<value>"`. For example, the template:
+
+```html+django
+<meta http-equiv="Content-Security-Policy" content="style-src 'nonce-xyz456';">
+
+{% image page.image width-1024 focus="nonce-xyz456" %}
+```
+
+Might render HTML like:
+
+```html
+<img src="/media/my-image.width-1024.jpg" id="abc123">
+<style type="text/css" nonce="xyz456">
+    #wagtail-image-abc123 { object-position: 50% 50%; }
+</style>
+```
+
 (rendition_background_position_style)=
 
 ## Setting the `background-position` inline style based on the focal point

--- a/wagtail/images/tests/test_templatetags.py
+++ b/wagtail/images/tests/test_templatetags.py
@@ -1,5 +1,3 @@
-import re
-
 from django.template import Context, Engine, TemplateSyntaxError, Variable
 from django.test import TestCase
 
@@ -273,52 +271,6 @@ class ImageTagTestCase(ImagesTestCase):
                     width="640"
                     style="border: 4px solid orange; object-position: 50% 50%;"
                 />""",
-        )
-
-    def test_focus_style_tag(self):
-        filename = self.image.get_rendition("original").url
-
-        rendered = self.render("{% image myimage original focus='style-tag' %}", {"myimage": self.image})
-
-        id_match = re.search(r'\sid="(wagtail-image-[a-z0-9]+)"', rendered)
-        self.assertIsInstance(id_match, re.Match, 'Generated HTML did not have a random "id" attribute')
-
-        image_id = id_match.group(1)
-        self.assertHTMLEqual(
-            rendered,
-            f"""
-                <img alt="Test image" height="480" src="{filename}" width="640" id="{image_id}" />
-                <style type="text/css">#{image_id} {{ object-position: 50% 50%; }}</style>
-            """,
-        )
-
-    def test_focus_nonce(self):
-        filename = self.image.get_rendition("original").url
-
-        rendered = self.render("{% image myimage original focus='nonce-abc123' %}", {"myimage": self.image})
-
-        id_match = re.search(r'\sid="(wagtail-image-[a-z0-9]+)"', rendered)
-        self.assertIsInstance(id_match, re.Match, 'Generated HTML did not have a random "id" attribute')
-
-        image_id = id_match.group(1)
-        self.assertHTMLEqual(
-            rendered,
-            f"""
-                <img alt="Test image" height="480" src="{filename}" width="640" id="{image_id}" />
-                <style type="text/css" nonce="abc123">#{image_id} {{ object-position: 50% 50%; }}</style>
-            """,
-        )
-
-    def test_focus_style_tag_with_existing_id(self):
-        filename = self.image.get_rendition("original").url
-
-        rendered = self.render("{% image myimage original focus='style-tag' id='custom-id' %}", {"myimage": self.image})
-        self.assertHTMLEqual(
-            rendered,
-            f"""
-                <img alt="Test image" height="480" src="{filename}" width="640" id="custom-id" />
-                <style type="text/css">#custom-id {{ object-position: 50% 50%; }}</style>
-            """,
         )
 
     def test_focus_unknown_type(self):


### PR DESCRIPTION
This is an attempt to solve #13411 by adding a `focus="<data-attr|syle-attr>"` attribute to the`{% image %}`, `{% srcset_image %}`, and `{% picture %}` template tags.

The basic idea here is that the `<img>` tags output by the template tags now always include some information about the focus point in a form that is readily usable as a CSS `<position>` value (so it can be used in `object-position`, `background-position`, `offset-position`, etc.). Exactly how that output works is controlled by setting a `focus="..."` attribute on the template tag with different values:

- `data-attr` (also the default behavior if you don’t set the attribute at all) adds `data-focus-position-x` and `data-focus-position-y` attributes to the `<img>`. Their values are CSS percentages, e.g. `"50%"`.

    For example:

    ```html+django
    {% image page.image width-1024 focus="data-attr" %}
    ```

    …renders:

    ```html
    <img src="/media/my-image.width-1024.jpg" data-focus-position-x="50%" data-focus-position-y="50%">
    ```

    - These names are kind of verbose! I wanted to include “position” in them to indicate that these are CSS position values, but maybe that’s not really necessary.
    - I made these include “%” in the value so there wouldn’t be confusion about whether they were percentages or absolute pixel positions on the image. But I could also make them just numbers if folks think that’s better. (Side note: the example CSS in the docs would also need to change to use `%` as the type instead of `type(<length-percentage>)`, e.g. `attr(data-focus-position-x %, 50%)`.)

- `style-attr` adds a `style` attribute that sets the `object-position` CSS property. If the template author has set their own `style` attribute, this just adds to the end of it.

    For example:

    ```html+django
    {% image page.image width-1024 focus="style-attr" %}
    ```

    …renders:

    ```html
    <img src="/media/my-image.width-1024.jpg" style="object-position: 50% 50%;">
    ```

- Any other value just gets passed on as a regular HTML attribute instead of being removed and replaced with something else like the above options. `focus` is not an actual attribute name in HTML, but my thinking here was to try not to get in the way of users setting their own arbitrary attributes or a potential future version of this attribute being added to HTML.

    That said, it might be better to raise an exception instead and/or to use a different name (over on the various WICG repos, W3C and WHATWG folks *seem* committed to not adding built-in attributes with dashes or underscores in the name, so maybe something like `set-focus` or `image-focus` or `focus-style` is the right way to go). Happy to make changes here.

- I originally had support for `style-tag` and `nonce-<value>`, which would output a separate `<style>` element, optionally with a `nonce` attribute for CSP support, but that implementation is kind of complicated. It’s convenient, but I ultimately figured it didn’t add enough to justify the code, so I pulled it out but included a description of how to do it manually in the docs.

    If you like that idea, though, you can see the implementation in the first commit. Just revert the second commit to get it back. It undoubtedly needs some refinement and introduces some other open questions (e.g. duplicated code from *blocks* for generating random IDs).

I’ve tried to add some clear documentation to the “focal points” page, so that might be a good overview: https://github.com/Mr0grog/wagtail/blob/c68e9516ee3fc690c7c3d7d78bc18b9133e0ac95/docs/advanced_topics/images/focal_points.md#using-focus-attributes-on-template-tags#using-focus-attributes-on-template-tags

