### PR TITLE
Ensure starter project tests pass

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Fix: Prevent error from default `update_fields` parameter on `Page.asave()` (Tosinibikunle)
  * Fix: Ignore hidden error messages in minimap & `CountController` default `findValue` (Sage Abdullah)
  * Fix: Change default ordering for `UserViewSet` to `User.USERNAME_FIELD` to support default ordering ordering with custom User models that may not have a `name` field (Lynwee)
+ * Fix: Ensure starter tests in the project template pass (Lasse Schmieding)
  * Docs: Fix cross-reference links to the TypeDoc-generated docs (Sage Abdullah)
  * Docs: Refine readthedocs' search indexing for releases and client-side code (Sage Abdullah)
  * Docs: Fix incorrect link to third party site in advanced topics (Yousef Al-Hadhrami (Yemeni))

--- a/docs/reference/project_template.md
+++ b/docs/reference/project_template.md
@@ -106,9 +106,10 @@ When you create a new project using `wagtail start`, there will be a set of basi
 
 These tests check:
 
--   If the _root `Page`_ (ID=1) is automatically created.
--   That the _home `Page`_ can be created as a child of the root page.
--   A placeholder test for other sub-pages, such as the `BlogIndexPage`, ready for implementation.
+- That the root `Page` (ID=1) is automatically created.
+- That a `HomePage` can be created as a child of the root page.
+- That the created `HomePage` is renderable.
+- That the created `HomePage` uses the `home/home_page.html` template.
 
 #### Running the tests
 

--- a/docs/releases/7.2.md
+++ b/docs/releases/7.2.md
@@ -27,6 +27,7 @@ depth: 1
  * Prevent error from default `update_fields` parameter on `Page.asave()` (Tosinibikunle)
  * Ignore hidden error messages in minimap & `CountController` default `findValue` (Sage Abdullah)
  * Change default ordering for `UserViewSet` to `User.USERNAME_FIELD` to support default ordering ordering with custom User models that may not have a `name` field (Lynwee)
+ * Ensure starter tests in the project template pass (Lasse Schmieding)
 
 ### Documentation
 

--- a/wagtail/project_template/home/tests.py
+++ b/wagtail/project_template/home/tests.py
@@ -1,7 +1,6 @@
-from django.urls import reverse
 from home.models import HomePage
 
-from wagtail.models import Page
+from wagtail.models import Page, Site
 from wagtail.test.utils import WagtailPageTestCase
 
 
@@ -30,14 +29,14 @@ class HomeTests(WagtailPageTestCase):
         """
         Create a homepage instance for testing.
         """
-        root_page = Page.objects.get(pk=1)
+        root_page = Page.get_first_root_node()
+        Site.objects.create(hostname="testsite", root_page=root_page, is_default_site=True)
         self.homepage = HomePage(title="Home")
         root_page.add_child(instance=self.homepage)
 
-    def test_homepage_status_code(self):
-        response = self.client.get(reverse("home"))
-        self.assertEqual(response.status_code, 200)
+    def test_homepage_is_renderable(self):
+        self.assertPageIsRenderable(self.homepage)
 
     def test_homepage_template_used(self):
-        response = self.client.get(reverse("home"))
+        response = self.client.get(self.homepage.url)
         self.assertTemplateUsed(response, "home/home_page.html")


### PR DESCRIPTION
Fixes #13417.  Update failing tests included in the project template and update the documentation.

To test the tests, I installed wagtail and created a project, then ran the tests. 

I was unsure if the tests should be changed / expanded to show off more of the test methods included in `WagtailPageTestCase`.