### PR TITLE
Fix register_icons hook to pass accumulated icons to each hook

### DIFF
--- a/wagtail/admin/icons.py
+++ b/wagtail/admin/icons.py
@@ -1,5 +1,4 @@
 import hashlib
-import itertools
 import re
 from functools import lru_cache
 
@@ -13,8 +12,10 @@ icon_comment_pattern = re.compile(r"<!--.*?-->", re.DOTALL)
 
 @lru_cache(maxsize=None)
 def get_icons():
-    icon_hooks = hooks.get_hooks("register_icons")
-    all_icons = sorted(itertools.chain.from_iterable(hook([]) for hook in icon_hooks))
+    all_icons = []
+    for fn in hooks.get_hooks("register_icons"):
+        all_icons = fn(all_icons)
+    all_icons = sorted(all_icons)
     combined_icon_markup = ""
     for icon in all_icons:
         symbol = (


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/13190

On a side note, I find the way some hooks behave a bit inconsistent. There are hooks that follow a similar pattern—such as "passing a list to the hook function"—but differ in how they expect that list to be handled. In some cases, you’re expected to modify the list directly, while in others you return a new one. Here are a few examples of similar hooks that illustrate this inconsistency:
https://docs.wagtail.org/en/latest/reference/hooks.html#construct-homepage-panels
https://docs.wagtail.org/en/latest/reference/hooks.html#construct-main-menu
