### PR TITLE
Update add_to_django_project.md to add include, path and re_path imports

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -911,6 +911,7 @@
 * Lasse Schmieding
 * Shivam Kumar
 * Pravin Kamble
+* Martin Fitzpatrick
 
 ## Translators
 

--- a/docs/advanced_topics/add_to_django_project.md
+++ b/docs/advanced_topics/add_to_django_project.md
@@ -123,6 +123,7 @@ Wagtail requires several Django app modules, third-party apps, and defines sever
 
 ```python
 from django.contrib import admin
+from django.urls import include, path, re_path
 
 from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls


### PR DESCRIPTION
The code block for urls.py doesn't include the imports for `from django.urls import include, path, re_path`. 

While it might be assumed these imports are already there, depending on how the current `urls.py` is setup some (e.g. `re_path`) might not be imported.  