### PR TITLE
Add proof-of-concept Renovate config for limited and secure dependencies

### DIFF
--- a/.renovate.json
+++ b/.renovate.json
@@ -1,24 +1,37 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":gitSignOff"],
-  "enabledManagers": ["pip_requirements", "pip_setup"],
+  "enabledManagers": ["poetry"],
   "rangeStrategy": "widen",
-  "prConcurrentLimit": 1,
+  "prConcurrentLimit": 2,
+  "dependencyDashboard": true,
+  "schedule": ["on the first day of the month"],
+
   "packageRules": [
     {
-      "matchPackageNames": ["Django", "Pillow", "requests"],
-      "updateTypes": ["minor", "patch"],
-      "groupName": "python-core-dependencies",
+      "description": "Group minor/patch updates for core production dependencies",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "core-dependencies-minor-patch",
       "labels": ["dependencies", "automated"],
-      "schedule": ["before 5am on monday"]
+      "automerge": true,
+      "automergeType": "branch"
     },
     {
-      "matchPackageNames": ["Django", "Pillow", "requests"],
+      "description": "Group minor/patch updates for optional dependencies (testing/docs)",
+      "matchDepTypes": ["devDependencies", "optionalDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "optional-dependencies-minor-patch",
+      "labels": ["dev-dependencies", "automated"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "description": "Handle major updates separately",
       "matchUpdateTypes": ["major"],
-      "matchDepTypes": ["dependencies"],
-      "labels": ["security", "automated"],
-      "enabled": true,
-      "prPriority": 1
+      "labels": ["breaking-change", "automated"],
+      "automerge": false,
+      "separateMajorIssue": true
     }
   ]
 }


### PR DESCRIPTION
This is a small proof-of-concept Renovate setup for Wagtail, as discussed in fixes #12897.

### What this setup does

- Automatically detects all Python dependencies from `pyproject.toml` (no need to list packages manually).  
- Groups **minor/patch updates** for **core dependencies** (like Django, Pillow, requests, and other production dependencies).  
- Groups **minor/patch updates** for **optional or dev dependencies** (testing/docs packages) separately.  
- **Major updates** are handled carefully: they create separate PRs for review and are **not automerged**.  
- PRs are labeled clearly (`dependencies`, `dev-dependencies`, `breaking-change`, `automated`) for easy identification.  
- Schedule: **first day of every month** to reduce noise.  
- Minor/patch updates **automerge** (safe changes), while major updates require maintainers’ review.

### Goal

Show how automated dependency updates could work for Wagtail safely and professionally. Maintainers can review, adjust schedules, or tweak rules as needed.  

### POC Repository

[https://github.com/p-r-a-v-i-n/renovate-poc](https://github.com/p-r-a-v-i-n/renovate-poc)  

### References

- [Poetry Manager](https://docs.renovatebot.com/modules/manager/poetry/#additional-information)  
- [PackageRules](https://docs.renovatebot.com/configuration-options/#packagerules)  
- [Scheduling](https://docs.renovatebot.com/key-concepts/scheduling/)
- [Schedule-montly](https://docs.renovatebot.com/presets-schedule/#schedulemonthly)
