### PR TITLE
Showing warning/info in the keyboard_shortcuts dialog

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Reorganize keyboard shortcuts into better categories with an ordering from most common to most specific (Dhruvi Patel)
  * Add `max_value` of 100 (%) for the `closeness` field in Image URL Generator form (LB (Ben) Johnston)
  * Add reordering support to generic model and snippet listing views (Joey Jurjens, Sage Abdullah)
+ * Add messaging within the keyboard shortcuts dialog to indicate when keyboard shortcuts are disabled or how to disable them via user preferences (Pravin Kamble)
  * Fix: Use the correct method of resolving the file storage dynamically for FileField usage in images & documents (Amir Mahmoodi)
  * Fix: Ensure the add comment keyboard shortcut is disabled when keyboard shortcuts are disabled in user preferences (Dhruvi Patel)
  * Fix: Use model name when ordering by page type in page listings (Sage Abdullah)

--- a/docs/releases/7.2.md
+++ b/docs/releases/7.2.md
@@ -27,6 +27,7 @@ This feature was developed by Joey Jurjens and Sage Abdullah.
  * Allow deep contentpath for comments on fields other than StreamField (Lasse Schmieding, Sébastien Corbin, Joel William, Sage Abdullah)
  * Reorganize keyboard shortcuts into better categories with an ordering from most common to most specific (Dhruvi Patel)
  * Add `max_value` of 100 (%) for the `closeness` field in Image URL Generator form (LB (Ben) Johnston)
+ * Add messaging within the keyboard shortcuts dialog to indicate when keyboard shortcuts are disabled or how to disable them via user preferences (Pravin Kamble)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/shared/keyboard_shortcuts_dialog.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/keyboard_shortcuts_dialog.html
@@ -1,5 +1,15 @@
 {% load wagtailadmin_tags i18n %}
+{% fragment as account_link %}<a class="w-underline" href="{% url 'wagtailadmin_account' %}">{% trans 'account' %}</a>{% endfragment %}
 {% dialog icon_name="keyboard" classname="w-keyboard-shortcuts" id="keyboard-shortcuts-dialog" title=_("Keyboard shortcuts") %}
+    {% if not keyboard_shortcuts_enabled %}
+        {% help_block status="warning" %}
+            <p>
+                {% blocktrans trimmed %}
+                    Keyboard shortcuts are currently disabled; manage your {{ account_link }} to enable them.
+                {% endblocktrans %}
+            </p>
+        {% endhelp_block %}
+    {% endif %}
     <table class="w-w-full">
         <caption class="w-sr-only">
             {% trans "All keyboard shortcuts" %}
@@ -28,4 +38,13 @@
             {% endfor %}
         {% endblock %}
     </table>
+    {% if keyboard_shortcuts_enabled %}
+        {% help_block status="info" %}
+            <p>
+                {% blocktrans trimmed %}
+                    Keyboard shortcuts are currently enabled; manage your {{ account_link }} to disable them.
+                {% endblocktrans %}
+            </p>
+        {% endhelp_block %}
+    {% endif %}
 {% enddialog %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1338,13 +1338,23 @@ def keyboard_shortcuts_dialog(context):
     appropriate shortcuts for the user's platform.
     Note: Shortcut keys are intentionally not translated.
     """
+    request = context.get("request")
+    keyboard_shortcuts_enabled = True
+
+    if request and getattr(request, "user", None):
+        profile = getattr(request.user, "wagtail_userprofile", None)
+        if profile is not None:
+            keyboard_shortcuts_enabled = bool(
+                getattr(profile, "keyboard_shortcuts", True)
+            )
 
     comments_enabled = get_comments_enabled()
-    user_agent = context["request"].headers.get("User-Agent", "")
+    user_agent = request.headers.get("User-Agent", "") if request else ""
     is_mac = re.search(r"Mac|iPod|iPhone|iPad", user_agent)
-    KEYS = get_keyboard_key_labels_from_request(context["request"])
+    KEYS = get_keyboard_key_labels_from_request(request) if request else {}
 
     return {
+        "keyboard_shortcuts_enabled": keyboard_shortcuts_enabled,
         "shortcuts": {
             # Translators: Shortcuts for admin common shortcuts that are available across the admin
             ("admin-common", _("Application")): [
@@ -1389,7 +1399,7 @@ def keyboard_shortcuts_dialog(context):
                 (_("Superscript"), f"{KEYS.MOD} + ."),
                 (_("Subscript"), f"{KEYS.MOD} + ,"),
             ],
-        }
+        },
     }
 
 

--- a/wagtail/admin/tests/test_keyboard_shortcuts.py
+++ b/wagtail/admin/tests/test_keyboard_shortcuts.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 
 from wagtail.admin.utils import get_keyboard_key_labels_from_request
 from wagtail.test.utils import WagtailTestUtils
+from wagtail.users.models import UserProfile
 
 
 class TestGetKeyboardKeyLabelsFromRequestUtil(TestCase):
@@ -65,7 +66,8 @@ class TestGetKeyboardKeyLabelsFromRequestUtil(TestCase):
 
 class TestKeyboardShortcutsDialog(WagtailTestUtils, TestCase):
     def setUp(self):
-        self.login()
+        self.test_user = self.create_test_user()
+        self.login(user=self.test_user)
 
     def test_keyboard_shortcuts_trigger_in_sidebar(self):
         response = self.client.get(reverse("wagtailadmin_home"))
@@ -151,6 +153,53 @@ class TestKeyboardShortcutsDialog(WagtailTestUtils, TestCase):
 
         self.assertNotIn("comments", shortcuts_dialog.prettify())
         self.assertNotIn("Ctrl + Alt + m", all_shortcuts_text)
+
+    def test_account_link_in_modal(self):
+        """
+        Test that the 'account' link fragment is correctly rendered in the
+        keyboard shortcuts modal.
+        """
+        response = self.client.get(reverse("wagtailadmin_home"))
+        self.assertEqual(response.status_code, 200)
+
+        soup = self.get_soup(response.content)
+        shortcuts_dialog = soup.select_one("#keyboard-shortcuts-dialog")
+        self.assertIsNotNone(shortcuts_dialog)
+
+        account_link = shortcuts_dialog.select_one("a[href$='account/']")
+        self.assertIsNotNone(account_link)
+        self.assertEqual(account_link.text.strip(), "account")
+        self.assertIn("w-underline", account_link.get("class", []))
+
+    def test_modal_shows_disabled_info_when_keyboard_shortcuts_disabled(self):
+        """
+        Modal should open and show warning if keyboard shortcuts are disabled.
+        """
+        profile = UserProfile.get_for_user(self.test_user)
+        profile.keyboard_shortcuts = False
+        profile.save()
+
+        response = self.client.get(reverse("wagtailadmin_home"))
+
+        soup = self.get_soup(response.content)
+        shortcuts_dialog = soup.select_one("#keyboard-shortcuts-dialog")
+        self.assertIn(
+            "Keyboard shortcuts are currently disabled", shortcuts_dialog.prettify()
+        )
+
+    def test_modal_shows_enabled_info_when_shortcuts_enabled(self):
+        """
+        Modal should show normal info when keyboard shortcuts are enabled.
+        """
+        profile = UserProfile.get_for_user(self.test_user)
+        response = self.client.get(reverse("wagtailadmin_home"))
+        soup = self.get_soup(response.content)
+        shortcuts_dialog = soup.select_one("#keyboard-shortcuts-dialog")
+
+        self.assertTrue(profile.keyboard_shortcuts)
+        self.assertIn(
+            "Keyboard shortcuts are currently enabled", shortcuts_dialog.prettify()
+        )
 
 
 class TestMacKeyboardShortcutsDialog(WagtailTestUtils, TestCase):


### PR DESCRIPTION
This PR addresses #13475 

Changes I have made.
1. I have removed the testcase when the modal is opening only when keyboard_shortcuts are enabled.
2. I have update the opening of modal by pressing "?" key irrespective of the keyboard shortcuts are enabled or not.
3.  Showing info when keyboard_shortcuts are enabled in modal
4. Showing warning when keyboard_shortcuts are disabled in modal.
5. I have added respective test for my changes.

Note: I took help of AI for writing `test_account_link_in_modal` function.
