### PR TITLE
Add unit test for `SubmitController` error handling

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Changelog
  * Maintenance: Rationalize front-end linting tasks and run concurrently (LB (Ben) Johnston)
  * Maintenance: Add a basic set of Storybook stories for the Stimulus Autosize controller (LB (Ben) Johnston)
  * Maintenance: Remove use of `_WAGTAILSEARCH_FORCE_AUTO_UPDATE` in search tests (Matt Westcott)
+ * Maintenance: Add unit test for `SubmitController` error handling (LB (Ben) Johnston)
 
 
 7.2 (05.11.2025)

--- a/client/src/controllers/SubmitController.test.js
+++ b/client/src/controllers/SubmitController.test.js
@@ -53,4 +53,31 @@ describe('SubmitController', () => {
     expect(submit).toHaveBeenCalled();
     expect(lastFormCalled).toEqual(document.getElementById('form'));
   });
+
+  it('should throw an error if there is no form associated with the controlled element', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    document.body.innerHTML = `
+    <div id="form">
+      <input type="text" data-controller="w-submit" data-action="change->w-submit#submit" />
+    </div>`;
+
+    await Promise.resolve(); // wait for the controller to initialize
+
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    const input = document.querySelector('input');
+
+    input.dispatchEvent(new CustomEvent('change'));
+
+    expect(errorSpy).toHaveBeenCalledTimes(3);
+    const [[, message, error]] = errorSpy.mock.calls;
+
+    expect(message).toEqual('Error invoking action "change->w-submit#submit"');
+    expect(error.message).toEqual(
+      'w-submit controlled element must be part of a <form />',
+    );
+
+    errorSpy.mockRestore();
+  });
 });

--- a/docs/releases/7.3.md
+++ b/docs/releases/7.3.md
@@ -35,6 +35,7 @@ depth: 1
  * Rationalize front-end linting tasks and run concurrently (LB (Ben) Johnston)
  * Add a basic set of Storybook stories for the Stimulus Autosize controller (LB (Ben) Johnston)
  * Remove use of `_WAGTAILSEARCH_FORCE_AUTO_UPDATE` in search tests (Matt Westcott)
+ * Add unit test for `SubmitController` error handling (LB (Ben) Johnston)
 
 
 ## Upgrade considerations - changes affecting all projects


### PR DESCRIPTION
Adds a unit test for the `SubmitController` when an error should throw.

A small improvement to the test case coverage of the Stimulus controllers.