### PR TITLE
Add a basic set of Storybook stories for the Stimulus Autosize controller

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Changelog
  * Maintenance: Dropped support for Django 5.1
  * Maintenance: Updated NPM packages (LB (Ben) Johnston)
  * Maintenance: Rationalize front-end linting tasks and run concurrently (LB (Ben) Johnston)
+ * Maintenance: Add a basic set of Storybook stories for the Stimulus Autosize controller (LB (Ben) Johnston)
 
 
 7.2 (05.11.2025)

--- a/client/src/controllers/AutosizeController.stories.js
+++ b/client/src/controllers/AutosizeController.stories.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { StimulusWrapper } from '../../storybook/StimulusWrapper';
+import { AutosizeController } from './AutosizeController';
+
+export default {
+  title: 'Stimulus / AutosizeController',
+  argTypes: {
+    value: {
+      control: 'text',
+      defaultValue: '',
+    },
+    debug: {
+      control: 'boolean',
+      defaultValue: false,
+    },
+  },
+};
+
+const definitions = [
+  {
+    identifier: 'w-autosize',
+    controllerConstructor: AutosizeController,
+  },
+];
+
+const Template = ({ value = '', debug = false }) => (
+  <StimulusWrapper debug={debug} definitions={definitions}>
+    <textarea data-controller="w-autosize" defaultValue={value} />
+  </StimulusWrapper>
+);
+
+export const EmptyTextarea = Template.bind({});
+
+export const FilledTextarea = Template.bind({});
+
+FilledTextarea.args = {
+  value:
+    'This is a filled textarea, it should autosize to fit its content. Wagtail ipsum dolor sit flap, perching by the riverside with elegant wiggle. Tiny steps, gentle dips, and endless tail-bobs bring joy to every puddle. Curabitur chirp elit, sed flutter magna finibus et song. Praesent feathers shimmer in early light; nullam breeze dapibus whisper across soft meadow moss. Etiam wagtailus curious, hopping between stones and stories, always following ripples where sunlight dances.',
+};

--- a/docs/releases/7.3.md
+++ b/docs/releases/7.3.md
@@ -33,6 +33,7 @@ depth: 1
  * Dropped support for Django 5.1
  * Updated NPM packages (LB (Ben) Johnston)
  * Rationalize front-end linting tasks and run concurrently (LB (Ben) Johnston)
+ * Add a basic set of Storybook stories for the Stimulus Autosize controller (LB (Ben) Johnston)
 
 
 ## Upgrade considerations - changes affecting all projects


### PR DESCRIPTION
Small change, adds a missing Storybook story for the Autosize controller.