### PR TITLE
Small clarity fixes in the your first wagtail site tutorial docs.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,7 +24,7 @@ Changelog
  * Docs: Fix cross-reference links to the TypeDoc-generated docs (Sage Abdullah)
  * Docs: Refine readthedocs' search indexing for releases and client-side code (Sage Abdullah)
  * Docs: Fix incorrect link to third party site in advanced topics (Yousef Al-Hadhrami (Yemeni))
- * Docs: Fix incorrect import references in getting started tutorial (Hunzlah Malik)
+ * Docs: Fix incorrect import references and update steps for clarity in getting started tutorial (Hunzlah Malik, Pravin Kamble)
  * Docs: Fix code example for `construct_wagtail_userbar` (Baptiste Mispelon)
  * Docs: Add a note about CSP for background image position and responsive embed styles (Thibaud Colas, Chiemezuo Akujobi, Sage Abdullah)
  * Docs: Add guidance for AI-led contributions to contributor docs (Andrew Selzer)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -910,6 +910,7 @@
 * Andrew Selzer
 * Lasse Schmieding
 * Shivam Kumar
+* Pravin Kamble
 
 ## Translators
 

--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -359,7 +359,7 @@ from django.db import models
 from wagtail.models import Page
 from wagtail.fields import RichTextField
 
-# keep the definition of BlogIndexPage model, and add the BlogPage model:
+# Keep the BlogIndexPage model code as is, and add the BlogPage model:
 
 class BlogPage(Page):
     date = models.DateField("Post date")
@@ -404,7 +404,7 @@ URL of the blog this post is a part of.
 Now, go to your [admin interface](https://guide.wagtail.org/en-latest/concepts/wagtail-interfaces/#admin-interface) and create a few blog posts as children of `BlogIndexPage` by following these steps:
 
 1.  Click **Pages** from the Wagtail [Sidebar](https://guide.wagtail.org/en-latest/how-to-guides/find-your-way-around/#the-sidebar), and then click **Home**
-2.  Hover on **Blog** and click **Add child page**.
+2.  Hover over **Blog**, click the three-dot menu (⋯), then select **Add child page**.
 
 ![Page listing for Home page with the "Add Child Page" button highlighted in red](../_static/images/tutorial/tutorial_4a.png)
 

--- a/docs/releases/7.2.md
+++ b/docs/releases/7.2.md
@@ -45,7 +45,7 @@ This feature was developed by Joey Jurjens and Sage Abdullah.
  * Fix cross-reference links to the TypeDoc-generated docs (Sage Abdullah)
  * Refine readthedocs' search indexing for releases and client-side code (Sage Abdullah)
  * Fix incorrect link to third party site in advanced topics (Yousef Al-Hadhrami (Yemeni))
- * Fix incorrect import references in getting started tutorial (Hunzlah Malik)
+ * Fix incorrect import references and update steps for clarity in getting started tutorial (Hunzlah Malik, Pravin Kamble)
  * Fix code example for `construct_wagtail_userbar` (Baptiste Mispelon)
  * Add a note about CSP for background image position and responsive embed styles (Thibaud Colas, Chiemezuo Akujobi, Sage Abdullah)
  * Add guidance for AI-led contributions to contributor docs (Andrew Selzer)


### PR DESCRIPTION
I made two small documentation changes based on confusion I had while following the “[Blog index and posts](https://docs.wagtail.org/en/latest/getting_started/tutorial.html#blog-index-and-posts)” part of the tutorial

1. Adding the BlogPage model
  In this section, the comment about adding BlogPage was not very clear, and I accidentally replaced the BlogIndexPage  model instead of keeping it. The new wording makes it clear that the existing BlogIndexPage should stay, and BlogPage should be added below it.
2. Adding child pages
  The tutorial says to hover on “Blog” and click “Add child page”, but this option only appears after clicking the three dots. The updated text explains the correct steps.