### PR TITLE
Indicate keyboard shortcuts enabled/disabled in admin dialog with Account link (Fixes #13475)

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/keyboard_shortcuts_dialog.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/keyboard_shortcuts_dialog.html
@@ -1,5 +1,23 @@
 {% load wagtailadmin_tags i18n %}
+{% fragment as account_link %}<a class="w-underline" href="{% url 'wagtailadmin_account' %}">{% trans 'Account' %}</a>{% endfragment %}
 {% dialog icon_name="keyboard" classname="w-keyboard-shortcuts" id="keyboard-shortcuts-dialog" title=_("Keyboard shortcuts") %}
+    {% if keyboard_shortcuts_enabled %}
+        {% help_block status="info" %}
+            <p>
+                {% blocktrans trimmed %}
+                    Keyboard shortcuts are currently enabled, manage your {{ account_link }} to disable them.
+                {% endblocktrans %}
+            </p>
+        {% endhelp_block %}
+    {% else %}
+        {% help_block status="warning" %}
+            <p>
+                {% blocktrans trimmed %}
+                    Keyboard shortcuts are currently disabled, manage your {{ account_link }} to enable them.
+                {% endblocktrans %}
+            </p>
+        {% endhelp_block %}
+    {% endif %}
     <table class="w-w-full">
         <caption class="w-sr-only">
             {% trans "All keyboard shortcuts" %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1339,12 +1339,22 @@ def keyboard_shortcuts_dialog(context):
     Note: Shortcut keys are intentionally not translated.
     """
 
+    request = context["request"]
+
+    user = getattr(context.get("request"), "user", None)
+    keyboard_shortcuts_enabled = (
+        user.wagtail_userprofile.keyboard_shortcuts
+        if hasattr(user, "wagtail_userprofile")
+        else True
+    )
+
     comments_enabled = get_comments_enabled()
-    user_agent = context["request"].headers.get("User-Agent", "")
+    user_agent = request.headers.get("User-Agent", "")
     is_mac = re.search(r"Mac|iPod|iPhone|iPad", user_agent)
-    KEYS = get_keyboard_key_labels_from_request(context["request"])
+    KEYS = get_keyboard_key_labels_from_request(request)
 
     return {
+        "keyboard_shortcuts_enabled": keyboard_shortcuts_enabled,
         "shortcuts": {
             # Translators: Shortcuts for admin common shortcuts that are available across the admin
             ("admin-common", _("Application")): [


### PR DESCRIPTION
This PR updates the Wagtail admin keyboard shortcuts dialog to clearly indicate whether keyboard shortcuts are enabled or disabled for the current user.

- Shows an info banner when shortcuts are enabled, with a link to the Account page to disable them.
- Shows a warning banner when shortcuts are disabled, with a link to the Account page to enable them.
- Adds/updates tests to cover both states and the Account link.

This resolves issue #13475.