### PR TITLE
Handle unpopulated sort_order_field in generic ReorderView

### DIFF
--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -2081,6 +2081,31 @@ class TestReorderView(WagtailTestUtils, TestCase):
         # of the last item, and the sort_order of the other items updated by -1
         self.assertOrder([(self.obj2, 3), (self.obj3, 8), (self.obj1, 9)])
 
+    def test_post_request_with_unset_self_position_sets_default_value(self):
+        self.obj1.sort_order = None
+        self.obj1.save()
+        response = self.client.post(self.get_url(self.obj1) + "?position=2")
+        self.assertEqual(response.status_code, 200)
+
+        # The item will have the sort_order set to 0
+        # and the other items are unaffected
+        self.assertOrder([(self.obj1, 2), (self.obj2, 4), (self.obj3, 9)])
+
+    def test_post_request_with_unset_other_positions_sets_default_value(self):
+        FeatureCompleteToy.objects.all().update(sort_order=None)
+        response = self.client.post(self.get_url(self.obj1) + "?position=1")
+        self.assertEqual(response.status_code, 200)
+
+        # The item will have the sort_order set to the position value
+        # and the other items are unaffected
+        self.assertEqual(FeatureCompleteToy.objects.get(pk=self.obj1.pk).sort_order, 1)
+        self.assertEqual(
+            FeatureCompleteToy.objects.get(pk=self.obj2.pk).sort_order, None
+        )
+        self.assertEqual(
+            FeatureCompleteToy.objects.get(pk=self.obj3.pk).sort_order, None
+        )
+
     def test_move_position_up(self):
         # Move obj3 to the first position
         response = self.client.post(self.get_url(self.obj3) + "?position=0")

--- a/wagtail/admin/views/generic/ordering.py
+++ b/wagtail/admin/views/generic/ordering.py
@@ -52,7 +52,12 @@ class ReorderView(PermissionCheckedMixin, View):
         sort_order_at_position = items[new_position][self.sort_order_field]
 
         with transaction.atomic():
-            if new_position < current_position:
+            if current_sort_order is None or sort_order_at_position is None:
+                # If either value is not set, we can't reliably reorder other items.
+                # This likely happens if the field has not been prepopulated.
+                # Use the desired position as the new sort_order_field value.
+                sort_order_at_position = new_position
+            elif new_position < current_position:
                 # We are moving the item up in the list, so we need to push down
                 # the items from the new position and below.
                 queryset.filter(


### PR DESCRIPTION
Incomplete follow-up to #13323. Related: #13483. There is a bit more work needed if we wanted to gracefully handle `NULL` in custom `sort_order_field`. Which happens if devs adopt the manual ordering feature without initializing their fields. Which probably can/will happen, but not sure how much support is warranted as it would lead to all sorts of unexpected behavior regardless of how it’s done.

- Current `main` will throw a `ValueError: Cannot use None as a query value`
- Proposed changes here would set the desired position for the item only if it doesn’t match its `current_position`, which is unreliable as databases sort `NULL` differently.

Feels a bit silly to have to worry about the behavior when sorting items to the position they already occupy, which I don’t think our sorting UI currently handles anyway(!). But I’d rather not add code that will work differently between DBs.