### PR TITLE
Use correct converter depending on pk type for ModelViewSet

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
  * Resize overly large avatar images on upload (Harshit Ranjan)
  * Add natural keys for `Page` and `Collection` models (Samya Aggarwal)
  * Add Loom oEmbed provider (Nick Ivons)
+ * Add `ModelViewSet.pk_path_converter` with defaults for `IntegerField` and `UUIDField` primary keys (Seb Corbin)
  * Fix: Do not try to resolve locale during fixture load (Jake Howard, Seb Corbin)
  * Fix: Gracefully handle oEmbed responses with a non-200 status or missing type (Shivam Kumar, Bhavesh Sharma)
  * Fix: Keep action button labelled as "Publish" rather than "Schedule to publish" if go-live date has passed (Vishrut Ramraj)

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -87,6 +87,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
       :attr:`~django.db.models.Options.verbose_name_plural`.
 
    .. autoattribute:: add_to_reference_index
+   .. autoattribute:: pk_path_converter
    .. autoattribute:: ordering
    .. autoattribute:: sort_order_field
       :annotation: = UNDEFINED

--- a/docs/releases/7.3.md
+++ b/docs/releases/7.3.md
@@ -17,6 +17,7 @@ depth: 1
  * Resize overly large avatar images on upload (Harshit Ranjan)
  * Add natural keys for `Page` and `Collection` models (Samya Aggarwal)
  * Add Loom oEmbed provider (Nick Ivons)
+ * Add [`ModelViewSet.pk_path_converter`](ModelViewSet.pk_path_converter) with defaults for `IntegerField` and `UUIDField` primary keys (Seb Corbin)
 
 ### Bug fixes
 

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -91,6 +91,19 @@ class TestModelViewSetGroup(WagtailTestUtils, TestCase):
         self.assertNotContains(response, reverse("blockcounts_streammodel:index"))
 
 
+class TestAdminURLs(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.user = self.login()
+
+    def test_cannot_reverse_mismatched_converter_value(self):
+        with self.assertRaises(NoReverseMatch):
+            reverse("streammodel:edit", kwargs={"pk": "123abc"})
+
+    def test_404_on_mismatched_converter_value(self):
+        response = self.client.get("/admin/streammodel/edit/123abc/")
+        self.assertEqual(response.status_code, 404)
+
+
 class TestTemplateConfiguration(WagtailTestUtils, TestCase):
     def setUp(self):
         self.user = self.login()

--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -516,7 +516,7 @@ class ChosenViewMixin(ModelLookupMixin):
 
     def get(self, request, pk):
         try:
-            item = self.get_object(unquote(pk))
+            item = self.get_object(unquote(str(pk)))
         except ObjectDoesNotExist:
             raise Http404
 

--- a/wagtail/admin/views/generic/ordering.py
+++ b/wagtail/admin/views/generic/ordering.py
@@ -19,7 +19,7 @@ class ReorderView(PermissionCheckedMixin, View):
         return self.model._default_manager.all().order_by(self.sort_order_field)
 
     def post(self, request, *args, **kwargs):
-        item_to_move = get_object_or_404(self.model, pk=unquote(kwargs.get("pk")))
+        item_to_move = get_object_or_404(self.model, pk=unquote(str(kwargs.get("pk"))))
 
         try:
             # Position is an index in the list of items,

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -2,8 +2,10 @@ from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
+from django.db import models
 from django.forms.models import modelform_factory
 from django.urls import path
+from django.urls.converters import get_converters
 from django.utils.functional import cached_property
 from django.utils.text import capfirst
 
@@ -128,6 +130,24 @@ class ModelViewSet(ViewSet):
     @property
     def permission_policy(self):
         return ModelPermissionPolicy(self.model)
+
+    @cached_property
+    def pk_path_converter(self):
+        """
+        :ref:`Path converter <topics/http/urls:path converters>` to use for
+        the model's primary key in URL patterns. Defaults to ``"int"`` for
+        ``IntegerField``, ``"uuid"`` for ``UUIDField``, and ``"str"`` for all
+        other types.
+
+        .. versionadded:: 7.3
+           The ``pk_path_converter`` property was added.
+        """
+        if isinstance(self.model_opts.pk, models.UUIDField):
+            return "uuid"
+        if isinstance(self.model_opts.pk, models.IntegerField):
+            return "int"
+        # Default to string if unknown
+        return "str"
 
     @cached_property
     def name(self):
@@ -649,38 +669,44 @@ class ModelViewSet(ViewSet):
         hooks.register("register_permissions", self.get_permissions_to_register)
 
     def get_urlpatterns(self):
+        conv = self.pk_path_converter
         urlpatterns = [
             path("", self.index_view, name="index"),
             path("results/", self.index_results_view, name="index_results"),
             path("new/", self.add_view, name="add"),
-            path("edit/<str:pk>/", self.edit_view, name="edit"),
-            path("delete/<str:pk>/", self.delete_view, name="delete"),
-            path("history/<str:pk>/", self.history_view, name="history"),
+            path(f"edit/<{conv}:pk>/", self.edit_view, name="edit"),
+            path(f"delete/<{conv}:pk>/", self.delete_view, name="delete"),
+            path(f"history/<{conv}:pk>/", self.history_view, name="history"),
             path(
-                "history-results/<str:pk>/",
+                f"history-results/<{conv}:pk>/",
                 self.history_results_view,
                 name="history_results",
             ),
-            path("usage/<str:pk>/", self.usage_view, name="usage"),
+            path(f"usage/<{conv}:pk>/", self.usage_view, name="usage"),
         ]
 
         if self.reorder_view_enabled:
             urlpatterns.append(
-                path("reorder/<str:pk>/", self.reorder_view, name="reorder")
+                path(f"reorder/<{conv}:pk>/", self.reorder_view, name="reorder")
             )
 
         if self.inspect_view_enabled:
             urlpatterns.append(
-                path("inspect/<str:pk>/", self.inspect_view, name="inspect")
+                path(f"inspect/<{conv}:pk>/", self.inspect_view, name="inspect")
             )
 
         if self.copy_view_enabled:
-            urlpatterns.append(path("copy/<str:pk>/", self.copy_view, name="copy"))
+            urlpatterns.append(path(f"copy/<{conv}:pk>/", self.copy_view, name="copy"))
 
         return urlpatterns
 
     def on_register(self):
         super().on_register()
+        if self.pk_path_converter not in get_converters():
+            raise ImproperlyConfigured(
+                f"{self.__class__.__name__}.pk_path_converter is not a "
+                "registered path converter"
+            )
         self.register_admin_url_finder()
         self.register_reference_index()
         self.register_permissions()

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -1044,16 +1044,17 @@ class SnippetViewSet(ModelViewSet):
         )
 
     def get_urlpatterns(self):
+        conv = self.pk_path_converter
         urlpatterns = [
             path("", self.index_view, name="list"),
             path("results/", self.index_results_view, name="list_results"),
             path("add/", self.add_view, name="add"),
-            path("edit/<str:pk>/", self.edit_view, name="edit"),
-            path("delete/<str:pk>/", self.delete_view, name="delete"),
-            path("usage/<str:pk>/", self.usage_view, name="usage"),
-            path("history/<str:pk>/", self.history_view, name="history"),
+            path(f"edit/<{conv}:pk>/", self.edit_view, name="edit"),
+            path(f"delete/<{conv}:pk>/", self.delete_view, name="delete"),
+            path(f"usage/<{conv}:pk>/", self.usage_view, name="usage"),
+            path(f"history/<{conv}:pk>/", self.history_view, name="history"),
             path(
-                "history-results/<str:pk>/",
+                f"history-results/<{conv}:pk>/",
                 self.history_results_view,
                 name="history_results",
             ),
@@ -1061,22 +1062,22 @@ class SnippetViewSet(ModelViewSet):
 
         if self.reorder_view_enabled:
             urlpatterns += [
-                path("reorder/<str:pk>/", self.reorder_view, name="reorder")
+                path(f"reorder/<{conv}:pk>/", self.reorder_view, name="reorder")
             ]
 
         if self.copy_view_enabled:
-            urlpatterns += [path("copy/<str:pk>/", self.copy_view, name="copy")]
+            urlpatterns += [path(f"copy/<{conv}:pk>/", self.copy_view, name="copy")]
 
         if self.inspect_view_enabled:
             urlpatterns += [
-                path("inspect/<str:pk>/", self.inspect_view, name="inspect")
+                path(f"inspect/<{conv}:pk>/", self.inspect_view, name="inspect")
             ]
 
         if self.preview_enabled:
             urlpatterns += [
                 path("preview/", self.preview_on_add_view, name="preview_on_add"),
                 path(
-                    "preview/<str:pk>/",
+                    f"preview/<{conv}:pk>/",
                     self.preview_on_edit_view,
                     name="preview_on_edit",
                 ),
@@ -1086,7 +1087,7 @@ class SnippetViewSet(ModelViewSet):
             if self.preview_enabled:
                 urlpatterns += [
                     path(
-                        "history/<str:pk>/revisions/<int:revision_id>/view/",
+                        f"history/<{conv}:pk>/revisions/<int:revision_id>/view/",
                         self.revisions_view,
                         name="revisions_view",
                     )
@@ -1094,7 +1095,7 @@ class SnippetViewSet(ModelViewSet):
 
             urlpatterns += [
                 path(
-                    "history/<str:pk>/revisions/<int:revision_id>/revert/",
+                    f"history/<{conv}:pk>/revisions/<int:revision_id>/revert/",
                     self.revisions_revert_view,
                     name="revisions_revert",
                 ),
@@ -1108,43 +1109,43 @@ class SnippetViewSet(ModelViewSet):
         if self.draftstate_enabled:
             urlpatterns += [
                 path(
-                    "history/<str:pk>/revisions/<int:revision_id>/unschedule/",
+                    f"history/<{conv}:pk>/revisions/<int:revision_id>/unschedule/",
                     self.revisions_unschedule_view,
                     name="revisions_unschedule",
                 ),
-                path("unpublish/<str:pk>/", self.unpublish_view, name="unpublish"),
+                path(f"unpublish/<{conv}:pk>/", self.unpublish_view, name="unpublish"),
             ]
 
         if self.locking_enabled:
             urlpatterns += [
-                path("lock/<str:pk>/", self.lock_view, name="lock"),
-                path("unlock/<str:pk>/", self.unlock_view, name="unlock"),
+                path(f"lock/<{conv}:pk>/", self.lock_view, name="lock"),
+                path(f"unlock/<{conv}:pk>/", self.unlock_view, name="unlock"),
             ]
 
         if self.workflow_enabled:
             urlpatterns += [
                 path(
-                    "workflow/action/<str:pk>/<slug:action_name>/<int:task_state_id>/",
+                    f"workflow/action/<{conv}:pk>/<slug:action_name>/<int:task_state_id>/",
                     self.workflow_action_view,
                     name="workflow_action",
                 ),
                 path(
-                    "workflow/collect_action_data/<str:pk>/<slug:action_name>/<int:task_state_id>/",
+                    f"workflow/collect_action_data/<{conv}:pk>/<slug:action_name>/<int:task_state_id>/",
                     self.collect_workflow_action_data_view,
                     name="collect_workflow_action_data",
                 ),
                 path(
-                    "workflow/confirm_cancellation/<str:pk>/",
+                    f"workflow/confirm_cancellation/<{conv}:pk>/",
                     self.confirm_workflow_cancellation_view,
                     name="confirm_workflow_cancellation",
                 ),
                 path(
-                    "workflow_history/<str:pk>/",
+                    f"workflow_history/<{conv}:pk>/",
                     self.workflow_history_view,
                     name="workflow_history",
                 ),
                 path(
-                    "workflow_history/<str:pk>/detail/<int:workflow_state_id>/",
+                    f"workflow_history/<{conv}:pk>/detail/<int:workflow_state_id>/",
                     self.workflow_history_detail_view,
                     name="workflow_history_detail",
                 ),
@@ -1153,7 +1154,7 @@ class SnippetViewSet(ModelViewSet):
             if self.preview_enabled:
                 urlpatterns += [
                     path(
-                        "workflow/preview/<str:pk>/<int:task_id>/",
+                        f"workflow/preview/<{conv}:pk>/<int:task_id>/",
                         self.workflow_preview_view,
                         name="workflow_preview",
                     ),


### PR DESCRIPTION
This prevents 500 errors when accessing urls with a too permissive converter for pk.

How to reproduce:
 - create ModelViewSet for a model with an `IntegerField` (default `AutoField`) or an `UUIDField` as pk
 - try to access a view with a bad pk, that cannot be converted by the ORM, e.g. /admin/snippets/mysnippet/edit/foo/

[Related discussion](https://github.com/wagtail/wagtail/discussions/13424)
