### PR TITLE
Temporarily use wagtailmodelsearch package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "telepath>=0.3.1,<1",
   "laces>=0.1,<0.2",
   "django-tasks>=0.8,<0.10",
-  "modelsearch@https://releases.wagtail.io/modelsearch/modelsearch-1.1b0-py3-none-any.whl",
+  "wagtailmodelsearch==1.1b1",
 ]
 
 [project.urls]

--- a/wagtail/search/apps.py
+++ b/wagtail/search/apps.py
@@ -1,5 +1,5 @@
 from django.utils.translation import gettext_lazy as _
-from modelsearch.apps import ModelSearchAppConfig
+from wagtailmodelsearch.apps import ModelSearchAppConfig
 
 
 class WagtailSearchAppConfig(ModelSearchAppConfig):

--- a/wagtail/search/backends/__init__.py
+++ b/wagtail/search/backends/__init__.py
@@ -1,1 +1,1 @@
-from modelsearch.backends import *  # noqa: F403
+from wagtailmodelsearch.backends import *  # noqa: F403

--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -1,1 +1,1 @@
-from modelsearch.backends.base import *  # noqa: F403
+from wagtailmodelsearch.backends.base import *  # noqa: F403

--- a/wagtail/search/backends/database/__init__.py
+++ b/wagtail/search/backends/database/__init__.py
@@ -1,1 +1,1 @@
-from modelsearch.backends.database import *  # noqa: F403
+from wagtailmodelsearch.backends.database import *  # noqa: F403

--- a/wagtail/search/backends/database/fallback.py
+++ b/wagtail/search/backends/database/fallback.py
@@ -1,1 +1,1 @@
-from modelsearch.backends.database.fallback import *  # noqa: F403
+from wagtailmodelsearch.backends.database.fallback import *  # noqa: F403

--- a/wagtail/search/backends/database/mysql/mysql.py
+++ b/wagtail/search/backends/database/mysql/mysql.py
@@ -1,1 +1,1 @@
-from modelsearch.backends.database.mysql.mysql import *  # noqa: F403
+from wagtailmodelsearch.backends.database.mysql.mysql import *  # noqa: F403

--- a/wagtail/search/backends/database/mysql/query.py
+++ b/wagtail/search/backends/database/mysql/query.py
@@ -1,1 +1,1 @@
-from modelsearch.backends.database.mysql.query import *  # noqa: F403
+from wagtailmodelsearch.backends.database.mysql.query import *  # noqa: F403

--- a/wagtail/search/backends/database/postgres/postgres.py
+++ b/wagtail/search/backends/database/postgres/postgres.py
@@ -1,1 +1,1 @@
-from modelsearch.backends.database.postgres.postgres import *  # noqa: F403
+from wagtailmodelsearch.backends.database.postgres.postgres import *  # noqa: F403

--- a/wagtail/search/backends/database/postgres/query.py
+++ b/wagtail/search/backends/database/postgres/query.py
@@ -1,1 +1,1 @@
-from modelsearch.backends.database.postgres.query import *  # noqa: F403
+from wagtailmodelsearch.backends.database.postgres.query import *  # noqa: F403

--- a/wagtail/search/backends/database/postgres/weights.py
+++ b/wagtail/search/backends/database/postgres/weights.py
@@ -1,1 +1,1 @@
-from modelsearch.backends.database.postgres.weights import *  # noqa: F403
+from wagtailmodelsearch.backends.database.postgres.weights import *  # noqa: F403

--- a/wagtail/search/backends/database/sqlite/query.py
+++ b/wagtail/search/backends/database/sqlite/query.py
@@ -1,1 +1,1 @@
-from modelsearch.backends.database.sqlite.query import *  # noqa: F403
+from wagtailmodelsearch.backends.database.sqlite.query import *  # noqa: F403

--- a/wagtail/search/backends/database/sqlite/sqlite.py
+++ b/wagtail/search/backends/database/sqlite/sqlite.py
@@ -1,1 +1,1 @@
-from modelsearch.backends.database.sqlite.sqlite import *  # noqa: F403
+from wagtailmodelsearch.backends.database.sqlite.sqlite import *  # noqa: F403

--- a/wagtail/search/backends/database/sqlite/utils.py
+++ b/wagtail/search/backends/database/sqlite/utils.py
@@ -1,1 +1,1 @@
-from modelsearch.backends.database.sqlite.utils import *  # noqa: F403
+from wagtailmodelsearch.backends.database.sqlite.utils import *  # noqa: F403

--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -1,11 +1,11 @@
-from modelsearch.backends.elasticsearch7 import *  # noqa: F403
-from modelsearch.backends.elasticsearch7 import (
+from wagtailmodelsearch.backends.elasticsearch7 import *  # noqa: F403
+from wagtailmodelsearch.backends.elasticsearch7 import (
     Elasticsearch7AutocompleteQueryCompiler as _Elasticsearch7AutocompleteQueryCompiler,
 )
-from modelsearch.backends.elasticsearch7 import (
+from wagtailmodelsearch.backends.elasticsearch7 import (
     Elasticsearch7SearchBackend as _Elasticsearch7SearchBackend,
 )
-from modelsearch.backends.elasticsearch7 import (
+from wagtailmodelsearch.backends.elasticsearch7 import (
     Elasticsearch7SearchQueryCompiler as _Elasticsearch7SearchQueryCompiler,
 )
 

--- a/wagtail/search/backends/elasticsearch8.py
+++ b/wagtail/search/backends/elasticsearch8.py
@@ -1,11 +1,11 @@
-from modelsearch.backends.elasticsearch8 import *  # noqa: F403
-from modelsearch.backends.elasticsearch8 import (
+from wagtailmodelsearch.backends.elasticsearch8 import *  # noqa: F403
+from wagtailmodelsearch.backends.elasticsearch8 import (
     Elasticsearch8AutocompleteQueryCompiler as _Elasticsearch8AutocompleteQueryCompiler,
 )
-from modelsearch.backends.elasticsearch8 import (
+from wagtailmodelsearch.backends.elasticsearch8 import (
     Elasticsearch8SearchBackend as _Elasticsearch8SearchBackend,
 )
-from modelsearch.backends.elasticsearch8 import (
+from wagtailmodelsearch.backends.elasticsearch8 import (
     Elasticsearch8SearchQueryCompiler as _Elasticsearch8SearchQueryCompiler,
 )
 

--- a/wagtail/search/backends/elasticsearch9.py
+++ b/wagtail/search/backends/elasticsearch9.py
@@ -1,11 +1,11 @@
-from modelsearch.backends.elasticsearch9 import *  # noqa: F403
-from modelsearch.backends.elasticsearch9 import (
+from wagtailmodelsearch.backends.elasticsearch9 import *  # noqa: F403
+from wagtailmodelsearch.backends.elasticsearch9 import (
     Elasticsearch9AutocompleteQueryCompiler as _Elasticsearch9AutocompleteQueryCompiler,
 )
-from modelsearch.backends.elasticsearch9 import (
+from wagtailmodelsearch.backends.elasticsearch9 import (
     Elasticsearch9SearchBackend as _Elasticsearch9SearchBackend,
 )
-from modelsearch.backends.elasticsearch9 import (
+from wagtailmodelsearch.backends.elasticsearch9 import (
     Elasticsearch9SearchQueryCompiler as _Elasticsearch9SearchQueryCompiler,
 )
 

--- a/wagtail/search/backends/opensearch2.py
+++ b/wagtail/search/backends/opensearch2.py
@@ -1,11 +1,11 @@
-from modelsearch.backends.opensearch2 import *  # noqa: F403
-from modelsearch.backends.opensearch2 import (
+from wagtailmodelsearch.backends.opensearch2 import *  # noqa: F403
+from wagtailmodelsearch.backends.opensearch2 import (
     OpenSearch2AutocompleteQueryCompiler as _OpenSearch2AutocompleteQueryCompiler,
 )
-from modelsearch.backends.opensearch2 import (
+from wagtailmodelsearch.backends.opensearch2 import (
     OpenSearch2SearchBackend as _OpenSearch2SearchBackend,
 )
-from modelsearch.backends.opensearch2 import (
+from wagtailmodelsearch.backends.opensearch2 import (
     OpenSearch2SearchQueryCompiler as _OpenSearch2SearchQueryCompiler,
 )
 

--- a/wagtail/search/backends/opensearch3.py
+++ b/wagtail/search/backends/opensearch3.py
@@ -1,11 +1,11 @@
-from modelsearch.backends.opensearch3 import *  # noqa: F403
-from modelsearch.backends.opensearch3 import (
+from wagtailmodelsearch.backends.opensearch3 import *  # noqa: F403
+from wagtailmodelsearch.backends.opensearch3 import (
     OpenSearch3AutocompleteQueryCompiler as _OpenSearch3AutocompleteQueryCompiler,
 )
-from modelsearch.backends.opensearch3 import (
+from wagtailmodelsearch.backends.opensearch3 import (
     OpenSearch3SearchBackend as _OpenSearch3SearchBackend,
 )
-from modelsearch.backends.opensearch3 import (
+from wagtailmodelsearch.backends.opensearch3 import (
     OpenSearch3SearchQueryCompiler as _OpenSearch3SearchQueryCompiler,
 )
 

--- a/wagtail/search/index.py
+++ b/wagtail/search/index.py
@@ -1,1 +1,1 @@
-from modelsearch.index import *  # noqa: F403
+from wagtailmodelsearch.index import *  # noqa: F403

--- a/wagtail/search/management/commands/update_index.py
+++ b/wagtail/search/management/commands/update_index.py
@@ -1,1 +1,1 @@
-from modelsearch.management.commands.rebuild_modelsearch_index import *  # noqa: F403
+from wagtailmodelsearch.management.commands.rebuild_modelsearch_index import *  # noqa: F403

--- a/wagtail/search/management/commands/wagtail_update_index.py
+++ b/wagtail/search/management/commands/wagtail_update_index.py
@@ -1,1 +1,1 @@
-from modelsearch.management.commands.rebuild_modelsearch_index import *  # noqa: F403
+from wagtailmodelsearch.management.commands.rebuild_modelsearch_index import *  # noqa: F403

--- a/wagtail/search/models.py
+++ b/wagtail/search/models.py
@@ -1,6 +1,9 @@
 from django.db import models
 from django.db.models import OneToOneField
-from modelsearch.abstract_models import AbstractIndexEntry, AbstractSQLiteFTSIndexEntry
+from wagtailmodelsearch.abstract_models import (
+    AbstractIndexEntry,
+    AbstractSQLiteFTSIndexEntry,
+)
 
 # We import abstract models from the modelsearch app and define concrete implementations here in the
 # wagtail.search app. This preserves backwards compatibility for existing Wagtail projects that have

--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -1,1 +1,1 @@
-from modelsearch.query import *  # noqa: F403
+from wagtailmodelsearch.query import *  # noqa: F403

--- a/wagtail/search/queryset.py
+++ b/wagtail/search/queryset.py
@@ -1,1 +1,1 @@
-from modelsearch.queryset import *  # noqa: F403
+from wagtailmodelsearch.queryset import *  # noqa: F403

--- a/wagtail/search/signal_handlers.py
+++ b/wagtail/search/signal_handlers.py
@@ -1,1 +1,1 @@
-from modelsearch.signal_handlers import *  # noqa: F403
+from wagtailmodelsearch.signal_handlers import *  # noqa: F403

--- a/wagtail/search/tasks.py
+++ b/wagtail/search/tasks.py
@@ -1,1 +1,1 @@
-from modelsearch.tasks import *  # noqa: F403
+from wagtailmodelsearch.tasks import *  # noqa: F403

--- a/wagtail/search/utils.py
+++ b/wagtail/search/utils.py
@@ -1,1 +1,1 @@
-from modelsearch.utils import *  # noqa: F403
+from wagtailmodelsearch.utils import *  # noqa: F403


### PR DESCRIPTION
To allow the 7.2 release candidate to go ahead, I uploaded a beta package of django-modelsearch to a URL on releases.wagtail.io and specified this in the dependencies in c777a577a75cc31ec4282041f107a1f85a11b9fd - however, PyPI will not accept a package with a non-PyPI dependency. To get around this, I have now temporarily published a fork named `wagtailmodelsearch` on PyPI - this also uses the module name `wagtailmodelsearch` instead of `modelsearch`, to avoid any name clashes once we switch back to django-modelsearch (at which point people who tried the RC will potentially have both packages in their environments).