### PR TITLE
Set minimum target version for ruff to py310

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -6,7 +6,7 @@ exclude = [
   "migrations",
 ]
 line-length = 88
-target-version = "py39" # minimum target version
+target-version = "py310" # minimum target version
 
 [lint]
 # D100: Missing docstring in public module


### PR DESCRIPTION
Since Wagtail 7.2, Python 3.10 has been the minimum supported version
