### PR TITLE
Fix avatar upload to resize large profile pictures

### DIFF
--- a/wagtail/admin/forms/account.py
+++ b/wagtail/admin/forms/account.py
@@ -1,6 +1,6 @@
 import io
-import warnings
 import os
+import warnings
 
 from django import forms
 from django.conf import settings
@@ -136,7 +136,7 @@ class AvatarPreferencesForm(forms.ModelForm):
 
         image = Image.open(file)
         width, height = image.size
-        
+
         if width <= 400 and height <= 400:
             return file
 

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -1,8 +1,6 @@
+import io
 import unittest
 import zoneinfo
-from PIL import Image
-import io
-
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -13,7 +11,9 @@ from django.core import mail
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
+from PIL import Image
 
+from wagtail.admin.forms.account import AvatarPreferencesForm
 from wagtail.admin.localization import (
     WAGTAILADMIN_PROVIDED_LANGUAGES,
     get_available_admin_languages,
@@ -22,7 +22,6 @@ from wagtail.admin.localization import (
 from wagtail.admin.views.account import AccountView, profile_tab
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.test.utils import WagtailTestUtils
-from wagtail.admin.forms.account import AvatarPreferencesForm
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 from wagtail.users.models import UserProfile
 
@@ -736,14 +735,15 @@ class TestAccountUploadAvatar(WagtailTestUtils, TestCase, TestAccountSectionUtil
         self.user = self.login()
         self.avatar = get_test_image_file()
         self.other_avatar = get_test_image_file()
-        
+
     def create_image_file(self, size=(800, 800), color="red", name="test.png"):
-        
         img = Image.new("RGB", size, color=color)
         img_byte_arr = io.BytesIO()
         img.save(img_byte_arr, format="PNG")
         img_byte_arr.seek(0)
-        return SimpleUploadedFile(name=name, content=img_byte_arr.read(), content_type="image/png")
+        return SimpleUploadedFile(
+            name=name, content=img_byte_arr.read(), content_type="image/png"
+        )
 
     def test_account_view(self):
         """
@@ -830,8 +830,7 @@ class TestAccountUploadAvatar(WagtailTestUtils, TestCase, TestAccountSectionUtil
         # Check the avatar was changed
         profile.refresh_from_db()
         self.assertTrue(profile.avatar)
-        
-        
+
     def test_avatar_resize_large_image(self):
         """Ensure that large uploaded images are resized to a maximum of 400x400."""
         uploaded_file = self.create_image_file(size=(800, 800), name="large_image.jpg")

--- a/wagtail/admin/tests/test_forms.py
+++ b/wagtail/admin/tests/test_forms.py
@@ -1,11 +1,7 @@
-import io
 
-from django.core.files.uploadedfile import SimpleUploadedFile
 from django.forms.fields import CharField
 from django.test import SimpleTestCase, TestCase
-from PIL import Image
 
-from wagtail.admin.forms.account import AvatarPreferencesForm
 from wagtail.admin.forms.auth import LoginForm, PasswordResetForm
 from wagtail.admin.forms.models import WagtailAdminModelForm
 from wagtail.test.testapp.models import Advert
@@ -71,6 +67,3 @@ class TestDeferRequiredFields(TestCase):
         form.defer_required_fields()
         form.restore_required_fields()
         self.assertFalse(form.is_valid())
-
-
-


### PR DESCRIPTION
# Description

This PR improves the user profile avatar upload functionality by ensuring that uploaded images are optimized before being saved. Currently, users can upload very large images, which may lead to unnecessary storage usage and slower page loads.

Fixes #12603 

## Changes include

- Automatically resize uploaded profile images if width or height exceeds 400px.
- Keep the original image if it is already ≤ 400px in both dimensions.
- Uses Pillow and the existing ImageTransform class to handle resizing.
- Added unit tests to verify that:
  - Large images are resized correctly.
  - Small images are not modified.
  - Images with width or height > 400px are resized proportionally.
  - Aspect ratio is preserved after resizing.