### PR TITLE
Sync comment icon with title border line

### DIFF
--- a/client/scss/components/forms/_title.scss
+++ b/client/scss/components/forms/_title.scss
@@ -40,7 +40,9 @@
     }
 
     // Avoid calling attention to the field _unless_ it’s in one of those states.
-    &:not(:hover, :focus, :placeholder-shown, [aria-invalid='true']) {
+    &:not(:hover, :focus, :placeholder-shown, [aria-invalid='true'],
+    :has(~ :is(.w-field__comment-button:hover, .w-field__comment-button:focus-within, .w-field__comment-button--focused, .w-field__comment-button--add:hover, .w-field__comment-button--reveal:hover))
+    ) {
       // Hide w/ transparency to preserve border size and show it in forced-colors mode.
       border-color: transparent;
     }


### PR DESCRIPTION
Fixes #9202 

The comment icon is now synced with the title border line.

**Before:**

https://github.com/user-attachments/assets/a52df763-41a5-4906-ad10-1d6ee6ec8df4

**After:**

https://github.com/user-attachments/assets/d1ec650c-a8c6-4843-8968-e6f7b05c1e26


