### PR TITLE
Sync comment icon with title border line

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Changelog
  * Use choice label when displaying choice fields in `SnippetViewSet`/`ModelViewSet`'s `list_display` (Srishti Jaiswal)
  * Add new content check `empty-meta-description` to validate meta description tags are not empty (Thibaud Colas)
  * Add `extractMetrics` method to `PreviewController` to retrieve content metrics from the preview panel (Thibaud Colas)
+ * Refine hover / focus styles for title field’s comment button (Srishti Jaiswal)
  * Preserve "Collapse all" button state when switching between editor tabs (Raghad Dahi)
  * Fix: Handle nested inline models when displaying object usage information (Sage Abdullah, Kacper Walęga, Tian Jie Wong)
  * Fix: Avoid duplicate `get_object()` DB query in API detail view (Siddheshwar Kadam)

--- a/client/scss/components/forms/_title.scss
+++ b/client/scss/components/forms/_title.scss
@@ -40,7 +40,21 @@
     }
 
     // Avoid calling attention to the field _unless_ it’s in one of those states.
-    &:not(:hover, :focus, :placeholder-shown, [aria-invalid='true']) {
+    &:not(
+      :hover,
+      :focus,
+      :placeholder-shown,
+      [aria-invalid='true'],
+      :has(
+        ~ :where(
+          .w-field__comment-button:hover,
+          .w-field__comment-button:focus-within,
+          .w-field__comment-button--focused,
+          .w-field__comment-button--add:hover,
+          .w-field__comment-button--reveal:hover
+        )
+      )
+    ) {
       // Hide w/ transparency to preserve border size and show it in forced-colors mode.
       border-color: transparent;
     }

--- a/client/scss/components/forms/_title.scss
+++ b/client/scss/components/forms/_title.scss
@@ -49,9 +49,7 @@
         ~ :where(
           .w-field__comment-button:hover,
           .w-field__comment-button:focus-within,
-          .w-field__comment-button--focused,
-          .w-field__comment-button--add:hover,
-          .w-field__comment-button--reveal:hover
+          .w-field__comment-button--focused
         )
       )
     ) {

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -58,6 +58,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Add new content check `empty-meta-description` to validate meta description tags are not empty (Thibaud Colas)
  * Add `extractMetrics` method to `PreviewController` to retrieve content metrics from the preview panel (Thibaud Colas)
  * Preserve "Collapse all" button state when switching between editor tabs (Raghad Dahi)
+ * Refine hover / focus styles for title field’s comment button (Srishti Jaiswal)
 
 ### Bug fixes
 


### PR DESCRIPTION
Fixes #9202 

The comment icon is now synced with the title border line.

**Before:**

https://github.com/user-attachments/assets/a52df763-41a5-4906-ad10-1d6ee6ec8df4

**After:**

https://github.com/user-attachments/assets/d1ec650c-a8c6-4843-8968-e6f7b05c1e26


