### PR TITLE
Add WAGTAILIMAGES_FORMAT_CONVERSIONS to the settings docs

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -456,6 +456,14 @@ WAGTAILIMAGES_HEIC_QUALITY = 60
 
 Change the global default for HEIC image encoding quality (default: 80).
 
+### `WAGTAILIMAGES_FORMAT_CONVERSIONS`
+
+```python
+WAGTAILIMAGES_FORMAT_CONVERSIONS = {}
+```
+
+See [](customizing_output_formats).
+
 ## Documents
 
 ### `WAGTAILDOCS_DOCUMENT_MODEL`


### PR DESCRIPTION
Hi,

The docs for Images settings don't include WAGTAILIMAGES_FORMAT_CONVERSIONS. This change adds that setting to the end of the list (maybe there's a better ordering?) and links to the Images docs.

- https://docs.wagtail.org/en/v7.1.2/reference/settings.html#images
- https://docs.wagtail.org/en/v7.1.2/advanced_topics/images/image_file_formats.html#customizing-output-formats

Here's the code that uses the setting: https://github.com/wagtail/wagtail/blob/4c15c1f33f6d18f0374c73fbe1d59ee109347756/wagtail/images/models.py#L1093

Thanks for taking the time to review this change,

David
