### PR TITLE
Eliminate use of _WAGTAILSEARCH_FORCE_AUTO_UPDATE

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Maintenance: Updated NPM packages (LB (Ben) Johnston)
  * Maintenance: Rationalize front-end linting tasks and run concurrently (LB (Ben) Johnston)
  * Maintenance: Add a basic set of Storybook stories for the Stimulus Autosize controller (LB (Ben) Johnston)
+ * Maintenance: Remove use of `_WAGTAILSEARCH_FORCE_AUTO_UPDATE` in search tests (Matt Westcott)
 
 
 7.2 (05.11.2025)

--- a/docs/releases/7.3.md
+++ b/docs/releases/7.3.md
@@ -34,6 +34,7 @@ depth: 1
  * Updated NPM packages (LB (Ben) Johnston)
  * Rationalize front-end linting tasks and run concurrently (LB (Ben) Johnston)
  * Add a basic set of Storybook stories for the Stimulus Autosize controller (LB (Ben) Johnston)
+ * Remove use of `_WAGTAILSEARCH_FORCE_AUTO_UPDATE` in search tests (Matt Westcott)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -27,6 +27,7 @@ from wagtail.images.models import (
 )
 from wagtail.images.rect import Rect
 from wagtail.models import Collection, GroupCollectionPermission, Page, ReferenceIndex
+from wagtail.search.backends import get_search_backend
 from wagtail.test.dummy_external_storage import (
     DummyExternalStorage,
     DummyExternalStorageFile,
@@ -1274,20 +1275,11 @@ class TestIssue573(TestCase):
         image.get_rendition("fill-800x600")
 
 
-@override_settings(_WAGTAILSEARCH_FORCE_AUTO_UPDATE=["elasticsearch"])
 class TestIssue613(WagtailTestUtils, TestCase):
-    def get_elasticsearch_backend(self):
-        from django.conf import settings
-
-        from wagtail.search.backends import get_search_backend
-
+    def setUp(self):
         if "elasticsearch" not in settings.WAGTAILSEARCH_BACKENDS:
             raise unittest.SkipTest("No elasticsearch backend active")
 
-        return get_search_backend("elasticsearch")
-
-    def setUp(self):
-        self.search_backend = self.get_elasticsearch_backend()
         self.login()
 
         management.call_command(
@@ -1352,16 +1344,27 @@ class TestIssue613(WagtailTestUtils, TestCase):
         # https://github.com/wagtail/wagtailsearch/commit/53a98169bccc3cef5b234944037f2b3f78efafd4 .
         # If this turns out to be necessary after all, you might want to compare how wagtail.tests.test_page_search.PageSearchTests does it.
 
-        # Add an image with some tags
-        image = self.add_image(tags="hello")
-        self.search_backend.refresh_indexes()
+        backend_conf = settings.WAGTAILSEARCH_BACKENDS["elasticsearch"].copy()
+        backend_conf["AUTO_UPDATE"] = True
+        with self.settings(
+            WAGTAILSEARCH_BACKENDS={
+                "elasticsearch": backend_conf,
+            }
+        ):
+            search_backend = get_search_backend("elasticsearch")
 
-        # Search for it by tag
-        results = self.search_backend.search("hello", Image)
+            # Add an image with some tags
+            image = self.add_image(tags="hello")
 
-        # Check
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].id, image.id)
+            # TODO: remove this when https://github.com/kaedroho/django-modelsearch/pull/40 is merged and released
+            search_backend.refresh_indexes()
+
+            # Search for it by tag
+            results = search_backend.search("hello", Image)
+
+            # Check
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0].id, image.id)
 
     def test_issue_613_on_edit(self):
         # Note to future developer troubleshooting this test...
@@ -1370,16 +1373,27 @@ class TestIssue613(WagtailTestUtils, TestCase):
         # https://github.com/wagtail/wagtailsearch/commit/53a98169bccc3cef5b234944037f2b3f78efafd4 .
         # If this turns out to be necessary after all, you might want to compare how wagtail.tests.test_page_search.PageSearchTests does it.
 
-        # Add an image with some tags
-        image = self.edit_image(tags="hello")
-        self.search_backend.refresh_indexes()
+        backend_conf = settings.WAGTAILSEARCH_BACKENDS["elasticsearch"].copy()
+        backend_conf["AUTO_UPDATE"] = True
+        with self.settings(
+            WAGTAILSEARCH_BACKENDS={
+                "elasticsearch": backend_conf,
+            }
+        ):
+            search_backend = get_search_backend("elasticsearch")
 
-        # Search for it by tag
-        results = self.search_backend.search("hello", Image)
+            # Add an image with some tags
+            image = self.edit_image(tags="hello")
 
-        # Check
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].id, image.id)
+            # TODO: remove this when https://github.com/kaedroho/django-modelsearch/pull/40 is merged and released
+            search_backend.refresh_indexes()
+
+            # Search for it by tag
+            results = search_backend.search("hello", Image)
+
+            # Check
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0].id, image.id)
 
 
 class TestIssue312(TestCase):


### PR DESCRIPTION
Tests were making use of the secret `_WAGTAILSEARCH_FORCE_AUTO_UPDATE` setting to selectively enable AUTO_UPDATE on the elasticsearch backend for individual tests. Somehow this setting still exists in django-modelsearch, and it probably shouldn't :-) Rewrite these to patch the value of WAGTAILSEARCH_BACKENDS instead.