### PR TITLE
Preserving the format while uploading the avatar

### DIFF
--- a/wagtail/admin/forms/account.py
+++ b/wagtail/admin/forms/account.py
@@ -150,16 +150,18 @@ class AvatarPreferencesForm(forms.ModelForm):
             new_width = int(width * (target_size / height))
 
         resized_image = image.resize((new_width, new_height))
-        
+
         orig_format = image.format or "JPEG"
 
         output = io.BytesIO()
         resized_image.save(output, format=image.format)
         output.seek(0)
 
-        new_ext = "jpg" if orig_format.upper() in ("JPEG", "JPG") else orig_format.lower()
+        new_ext = (
+            "jpg" if orig_format.upper() in ("JPEG", "JPG") else orig_format.lower()
+        )
         content_type = f"image/{'jpeg' if new_ext == 'jpg' else new_ext}"
-        
+
         base_name, _ = os.path.splitext(file.name)
         filename = f"{base_name}.{new_ext}"
 

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -739,16 +739,16 @@ class TestAccountUploadAvatar(WagtailTestUtils, TestCase, TestAccountSectionUtil
     def create_image_file(self, size=(800, 800), color="red", name="test.png"):
         img = Image.new("RGB", size, color=color)
         img_byte_arr = io.BytesIO()
-        
-        ext = name.split('.')[-1].upper()
+
+        ext = name.split(".")[-1].upper()
         if ext == "JPG":
             ext = "JPEG"
-        
+
         img.save(img_byte_arr, format=ext)
         img_byte_arr.seek(0)
-        
+
         content_type = f"image/{ext.lower()}" if ext != "JPEG" else "image/jpeg"
-        
+
         return SimpleUploadedFile(
             name=name, content=img_byte_arr.read(), content_type=content_type
         )
@@ -886,7 +886,6 @@ class TestAccountUploadAvatar(WagtailTestUtils, TestCase, TestAccountSectionUtil
         self.assertAlmostEqual(original_ratio, new_ratio, places=2)
 
     def test_avatar_preserves_original_format(self):
-        
         # Test JPG format
         jpg_file = self.create_image_file(size=(500, 500), name="test.jpg")
         form = AvatarPreferencesForm(files={"avatar": jpg_file})


### PR DESCRIPTION
Builds on the PR #13515, and commit 4c15c1f33f6d18f0374c73fbe1d59ee109347756  where the avatar resize logic forced PNG output regardless of the uploaded format. This change preserves the original image format (e.g., JPG → JPG) during processing, avoiding unnecessary file size inflation.

I ran a test (using a 2000x2000  JPG at ~4.5MB orignal)

| Format   | Size   |
|-----------|--------|
| Original  | 4.5 MB |
| PNG       | 353 KB |
| JPG       | 41 KB  |
