### PR TITLE
Solution for oembed that raises KeyError: 'type' for hidden tweets

### DIFF
--- a/wagtail/embeds/finders/oembed.py
+++ b/wagtail/embeds/finders/oembed.py
@@ -64,6 +64,10 @@ class OEmbedFinder(EmbedFinder):
             oembed = r.json()
         except requests.RequestException:
             raise EmbedNotFoundException
+        
+        # Check if 'type' is missing
+        if "type" not in oembed:
+            raise EmbedNotFoundException("Missing 'type' in response")
 
         # Convert photos into HTML
         if oembed["type"] == "photo":


### PR DESCRIPTION
Though X follow oEmbed structure, there are some places where we get a JSON response that's not an embed. The issue #13524 reports this issue. What I've implemented is `raise_for_status()` method before converting into `json` and assigning it to `oembed` as suggested in the issue. 

Below is the video after implementing the solution. [Here](https://github.com/wagtail/wagtail/issues/13524#issuecomment-3476866579) is the video of the issue that persisted before with the same twitter url.

https://github.com/user-attachments/assets/cc7e0396-b998-45c4-bc47-5bedc0521b54

Additional edits that might be considered for more firm solution:

If we don't want to strictly apply the raise non-200 status solution here, what alternatively can be done is conditionally checking if fields required by oEmbed structure (like `type`, `version`, or such) is present in the `oembed` after assigning the `json` value to it or not, and then proceed towards the action based on the condition.
However, this solution might also end up following the same raise non-200 status solution for the mentioned issue basically, just with few more customization.