### PR TITLE
Ensure 'Go to first error' button shows up for errors in StreamField blocks

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -46,6 +46,7 @@ Changelog
  * Fix: Prevent error when iterating over specific tasks with missing models (Lasse Schmieding)
  * Fix: Ensure `TableBlock` header dropdown default option can be translated (arpitmak)
  * Fix: Fix missing cache key prefix when removing cached redirect files (Heric Libong)
+ * FIx: Ensure the go to first error button works as expected for StreamField errors (Sage Abdullah)
  * Docs: Fix cross-reference links to the TypeDoc-generated docs (Sage Abdullah)
  * Docs: Refine readthedocs' search indexing for releases and client-side code (Sage Abdullah)
  * Docs: Fix incorrect link to third party site in advanced topics (Yousef Al-Hadhrami (Yemeni))

--- a/docs/releases/7.2.md
+++ b/docs/releases/7.2.md
@@ -69,6 +69,7 @@ Thank you to Dhruvi Patel for implementing this as part of the [Google Summer of
  * Prevent error when iterating over specific tasks with missing models (Lasse Schmieding)
  * Ensure `TableBlock` header dropdown default option can be translated (arpitmak)
  * Fix missing cache key prefix when removing cached redirect files (Heric Libong)
+ * Ensure the go to first error button works as expected for StreamField errors (Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -32,7 +32,7 @@
                                         type="button"
                                         class="button button-small button-secondary w-hidden w-ml-2.5"
                                         data-controller="w-count w-focus"
-                                        data-action="click->w-focus#focus"
+                                        data-action="click->w-focus#focus wagtail:panel-init@document->w-count#count"
                                         data-w-count-active-class="!w-inline-block"
                                         data-w-count-find-value=":not([hidden]):is(.error-message,.help-critical)"
                                         data-w-focus-target-value=":not([hidden]):is(.error-message,.help-critical)"

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -558,6 +558,10 @@ class TestPageCreation(WagtailTestUtils, TestCase):
         buttons = message.find_all("button")
         self.assertEqual(len(buttons), 1)
         self.assertEqual(buttons[0].attrs["data-controller"], "w-count w-focus")
+        self.assertEqual(
+            set(buttons[0].attrs["data-action"].split()),
+            {"click->w-focus#focus", "wagtail:panel-init@document->w-count#count"},
+        )
         self.assertIn("Go to the first error", buttons[0].get_text())
 
         # Check that a form error was raised
@@ -790,6 +794,10 @@ class TestPageCreation(WagtailTestUtils, TestCase):
         buttons = message.find_all("button")
         self.assertEqual(len(buttons), 1)
         self.assertEqual(buttons[0].attrs["data-controller"], "w-count w-focus")
+        self.assertEqual(
+            set(buttons[0].attrs["data-action"].split()),
+            {"click->w-focus#focus", "wagtail:panel-init@document->w-count#count"},
+        )
         self.assertIn("Go to the first error", buttons[0].get_text())
 
         # Check that a form error was raised

--- a/wagtail/contrib/settings/tests/site_specific/test_admin.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_admin.py
@@ -146,6 +146,10 @@ class TestSiteSettingCreateView(SiteSettingTestMixin, BaseTestSiteSettingView):
         buttons = message.find_all("button")
         self.assertEqual(len(buttons), 1)
         self.assertEqual(buttons[0].attrs["data-controller"], "w-count w-focus")
+        self.assertEqual(
+            set(buttons[0].attrs["data-action"].split()),
+            {"click->w-focus#focus", "wagtail:panel-init@document->w-count#count"},
+        )
         self.assertIn("Go to the first error", buttons[0].get_text())
 
         # the field errors should indicate that two fields were required
@@ -378,6 +382,10 @@ class TestSiteSettingEditView(SiteSettingTestMixin, BaseTestSiteSettingView):
         buttons = message.find_all("button")
         self.assertEqual(len(buttons), 1)
         self.assertEqual(buttons[0].attrs["data-controller"], "w-count w-focus")
+        self.assertEqual(
+            set(buttons[0].attrs["data-action"].split()),
+            {"click->w-focus#focus", "wagtail:panel-init@document->w-count#count"},
+        )
         self.assertIn("Go to the first error", buttons[0].get_text())
 
         # the field errors should indicate that two fields were required

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -1013,6 +1013,10 @@ class TestSnippetCreateView(WagtailTestUtils, TestCase):
         buttons = message.find_all("button")
         self.assertEqual(len(buttons), 1)
         self.assertEqual(buttons[0].attrs["data-controller"], "w-count w-focus")
+        self.assertEqual(
+            set(buttons[0].attrs["data-action"].split()),
+            {"click->w-focus#focus", "wagtail:panel-init@document->w-count#count"},
+        )
         self.assertIn("Go to the first error", buttons[0].get_text())
 
         # field specific error should be shown
@@ -2024,6 +2028,10 @@ class TestSnippetEditView(BaseTestSnippetEditView):
         buttons = message.find_all("button")
         self.assertEqual(len(buttons), 1)
         self.assertEqual(buttons[0].attrs["data-controller"], "w-count w-focus")
+        self.assertEqual(
+            set(buttons[0].attrs["data-action"].split()),
+            {"click->w-focus#focus", "wagtail:panel-init@document->w-count#count"},
+        )
         self.assertIn("Go to the first error", buttons[0].get_text())
 
         # the error should only appear once: against the field, not in the header message
@@ -6022,6 +6030,10 @@ class TestSnippetViewWithCustomPrimaryKey(WagtailTestUtils, TestCase):
         buttons = message.find_all("button")
         self.assertEqual(len(buttons), 1)
         self.assertEqual(buttons[0].attrs["data-controller"], "w-count w-focus")
+        self.assertEqual(
+            set(buttons[0].attrs["data-action"].split()),
+            {"click->w-focus#focus", "wagtail:panel-init@document->w-count#count"},
+        )
         self.assertIn("Go to the first error", buttons[0].get_text())
 
         # the errors should appear against the fields with issues


### PR DESCRIPTION
Fixes #13517.

Not sure if this is the best fix, but it does work pretty well.

The `wagtail:panel-init` event is dispatched by the `initCollapsiblePanel` function:

https://github.com/wagtail/wagtail/blob/4c15c1f33f6d18f0374c73fbe1d59ee109347756/client/src/includes/panels.ts#L89-L96

When rendering StreamField blocks, Wagtail will render the block before calling the `initCollapsibleFunction`:

https://github.com/wagtail/wagtail/blob/4c15c1f33f6d18f0374c73fbe1d59ee109347756/client/src/components/StreamField/blocks/BaseSequenceBlock.js#L212-L220

The rendering process will recurse through the descendants of the block, so the `wagtail:init-panel` event will be dispatched in a depth-first order.

This means by the time the `wagtail:init-panel` event is dispatched for the collapsible panel of the top-level StreamField, the innermost block that have an error will already be rendered, thus the `w-count#count` call will find the error message element.

## Note

For some reason on Chrome, the scrolling doesn't always work initially if the error element is in a different tab. The scrolling seems to stop after a few pixels. See the first click in the following clip:

https://github.com/user-attachments/assets/d3f20a48-9d22-4231-be21-32d15bf7b778

After the first switch to the other tab, subsequent clicks on the button will correctly scroll to the error element.

This seems to be a Chrome bug (or maybe something with my setup), as I couldn't replicate it on Firefox or Safari. Adding a 100ms `setTimeout()` to the `forceFocus` util seems to work, but that's not ideal. I'd say we leave it for now...