### PR TITLE
Fix issue #13532: StreamBlock diffs show raw data instead of formatted labels

### DIFF
--- a/wagtail/admin/compare.py
+++ b/wagtail/admin/compare.py
@@ -308,6 +308,28 @@ class StreamBlockComparison(BaseSequenceBlockComparison):
     def get_block_comparisons(self):
         return self.get_block_comparisons_by_id()
 
+    def htmlvalue(self, val):
+        htmlvalues = []
+
+        for stream_child in self.get_blocks_from_value(val):
+            block = stream_child.block
+            label = block.label
+            comparison_class = get_comparison_class_for_block(block)
+
+            htmlvalues.append(
+                (
+                    label,
+                    comparison_class(
+                        block, True, True, stream_child.value, stream_child.value
+                    ).htmlvalue(stream_child.value),
+                )
+            )
+
+        return format_html(
+            "<dl>\n{}\n</dl>",
+            format_html_join("\n", "    <dt>{}</dt>\n    <dd>{}</dd>", htmlvalues),
+        )
+
 
 class ListBlockComparison(BaseSequenceBlockComparison):
     @staticmethod

--- a/wagtail/admin/tests/test_compare.py
+++ b/wagtail/admin/tests/test_compare.py
@@ -921,6 +921,40 @@ class TestStreamFieldComparison(TestCase):
         self.assertTrue(comparison.has_changed())
 
 
+class TestStreamBlockComparison(TestCase):
+    comparison_class = compare.StreamBlockComparison
+
+    def test_streamblock_comparison_htmlvalue(self):
+        field = StreamPage._meta.get_field("body")
+        stream_block = field.stream_block.child_blocks["books"]
+
+        stream_value = StreamValue(
+            stream_block,
+            [
+                ("title", "Test Title", "1"),
+                ("author", "Test Author", "2"),
+            ],
+        )
+
+        comparison = self.comparison_class(
+            stream_block,
+            True,
+            True,
+            stream_value,
+            stream_value,
+        )
+
+        result = comparison.htmlvalue(stream_value)
+
+        self.assertIsInstance(result, SafeString)
+        self.assertIn("<dl>", result)
+        self.assertIn("</dl>", result)
+        self.assertIn("<dt>Title</dt>", result)
+        self.assertIn("<dt>Author</dt>", result)
+        self.assertIn("<dd>Test Title</dd>", result)
+        self.assertIn("<dd>Test Author</dd>", result)
+
+
 class TestChoiceFieldComparison(TestCase):
     comparison_class = compare.ChoiceFieldComparison
 


### PR DESCRIPTION
## Description

Fix StreamBlock diffs in revision comparison to display structured field-by-field formatting with labels instead of concatenated plain text.

## Solution

Added `htmlvalue()` method to `StreamBlockComparison` class to override the base `BlockComparison.htmlvalue()` implementation. The new method iterates through stream block children and renders each block with its label using the appropriate comparison class, producing structured HTML output with `<dl>`, `<dt>`, and `<dd>` tags.

**Why this solution:**
- `StreamBlockComparison` was inheriting the default `BlockComparison.htmlvalue()` which uses `render_basic()` and extracts plain text, resulting in concatenated output
- The fix follows the same pattern as `StructBlockComparison.htmlvalue()` which already produces structured output

Fixes #13532


## Screenshots

Before: <img width="1227" height="182" alt="image" src="https://github.com/user-attachments/assets/61a41b39-82c2-431d-b1e9-3945db00909b" />
After: <img width="1059" height="757" alt="image" src="https://github.com/user-attachments/assets/ed7fef0a-2bd6-46ad-948f-97cdc0a3ae96" />