### PR TITLE
Add oembed provider for Loom

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changelog
 
  * Resize overly large avatar images on upload (Harshit Ranjan)
  * Add natural keys for `Page` and `Collection` models (Samya Aggarwal)
+ * Add Loom oEmbed provider (Nick Ivons)
  * Fix: Do not try to resolve locale during fixture load (Jake Howard, Seb Corbin)
  * Fix: Gracefully handle oEmbed responses with a non-200 status or missing type (Shivam Kumar, Bhavesh Sharma)
  * Docs: Recommend running `purge_embeds` after an embed provider changes policies (Paul Souders)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -919,6 +919,7 @@
 * Paul Souders
 * Samya Aggarwal
 * Bhavesh Sharma
+* Nick Ivons
 
 ## Translators
 

--- a/docs/releases/7.3.md
+++ b/docs/releases/7.3.md
@@ -16,6 +16,7 @@ depth: 1
 
  * Resize overly large avatar images on upload (Harshit Ranjan)
  * Add natural keys for `Page` and `Collection` models (Samya Aggarwal)
+ * Add Loom oEmbed provider (Nick Ivons)
 
 ### Bug fixes
 

--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -291,6 +291,13 @@ kinomap = {
     ],
 }
 
+loom = {
+    "endpoint": "https://www.loom.com/v1/oembed",
+    "urls": [
+        r"^https?://(?:www\.)?loom\.com/share/.+$",
+    ],
+}
+
 major_league_gaming = {
     "endpoint": "http://tv.majorleaguegaming.com/oembed",
     "urls": [
@@ -667,6 +674,7 @@ all_providers = [
     justin_tv,
     kickstarter,
     kinomap,
+    loom,
     major_league_gaming,
     meetup,
     minoto,


### PR DESCRIPTION
Adds an oembed provider for Loom.

Sample documentation here: https://dev.loom.com/docs/embed-sdk/api

Test embeddable url: https://www.loom.com/share/0281766fa2d04bb788eaf19e65135184