### PR TITLE
PublishMenuItem: don't show "schedule" if go_live_at is in the past

### DIFF
--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.forms import Media
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
@@ -89,7 +90,9 @@ class PublishMenuItem(ActionMenuItem):
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)
         page = context.get("page")
-        context["is_scheduled"] = page and page.go_live_at
+        context["is_scheduled"] = (
+            page and page.go_live_at and page.go_live_at > timezone.now()
+        )
         context["is_revision"] = context["view"] == "revisions_revert"
         return context
 


### PR DESCRIPTION
Fixes #13548

It's a very simple fix, would be nice to have it backported to the 7.0 LTS :pray: 
