### PR TITLE
Preserve filter query parameters when redirecting after bulk actions

### DIFF
--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_action.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_action.py
@@ -43,20 +43,24 @@ class TestBulkActionDispatcher(WagtailTestUtils, TestCase):
         draft2.save_revision()
 
         filters = {
-            "content_type": draft1.content_type_id,  
-            "q": "draft",                            
-            "status": "draft",                      
-            "p": "3",                              
+            "content_type": draft1.content_type_id,
+            "q": "draft",
+            "status": "draft",
+            "p": "3",
         }
 
         query = (
-            f"id={draft1.id}&id={draft2.id}"         
-            f"&action=publish"                       
-            f"&next=/admin/pages/"                   
-            + "".join(f"&{key}={value}" for key, value in filters.items())  
+            f"id={draft1.id}&id={draft2.id}"
+            f"&action=publish"
+            f"&next=/admin/pages/"
+            + "".join(f"&{key}={value}" for key, value in filters.items())
         )
 
-        url = reverse("wagtail_bulk_action", args=("wagtailcore", "page", "publish")) + "?" + query
+        url = (
+            reverse("wagtail_bulk_action", args=("wagtailcore", "page", "publish"))
+            + "?"
+            + query
+        )
         response = self.client.post(url, follow=True)
 
         final_url = response.redirect_chain[-1][0]
@@ -67,6 +71,3 @@ class TestBulkActionDispatcher(WagtailTestUtils, TestCase):
         self.assertNotIn("id=", final_url)
         self.assertNotIn("action=", final_url)
         self.assertNotIn("next=", final_url)
-
-        
-        

--- a/wagtail/admin/views/bulk_action/base_bulk_action.py
+++ b/wagtail/admin/views/bulk_action/base_bulk_action.py
@@ -37,17 +37,15 @@ class BulkAction(ABC, FormView):
     def __init__(self, request, model):
         self.request = request
         next_url = get_valid_next_url_from_request(request) or request.path
-        
-        query_params = request.GET.copy()
-        query_params.pop('id', None)    
-        query_params.pop('action', None)
-        query_params.pop('next', None)
 
-        
+        query_params = request.GET.copy()
+        query_params.pop("id", None)
+        query_params.pop("action", None)
+        query_params.pop("next", None)
+
         if query_params:
             next_url = f"{next_url}?{query_params.urlencode()}"
-        
-     
+
         self.next_url = next_url
         self.num_parent_objects = self.num_child_objects = 0
         if model in self.models:


### PR DESCRIPTION
Fixes: #13253

To fix this issue instead of using get_valid_next_url_from_request(), which only returns the path, we reconstruct the redirect URL from request.GET and preserve all user-applied filters. Temporary form parameters (id, action, next) are removed, as they are only relevant during form submission.

Video Demo

https://github.com/user-attachments/assets/cbe2f2ec-5009-4c1c-996b-ae4154f18648


A test is also included to ensure that all filter query parameters are retained and that only form metadata is removed.
