### PR TITLE
Preserve listing search and filter parameters when redirecting from bulk actions

### DIFF
--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -19,7 +19,6 @@ from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.formats import get_format
 from django.utils.html import avoid_wrapping, json_script
-from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.timesince import timesince
 from django.utils.translation import gettext_lazy as _
@@ -40,7 +39,6 @@ from wagtail.admin.utils import (
     get_keyboard_key_labels_from_request,
     get_latest_str,
     get_user_display_name,
-    get_valid_next_url_from_request,
 )
 from wagtail.admin.views.bulk_action.registry import bulk_action_registry
 from wagtail.admin.views.pages.utils import get_breadcrumbs_items_for_page
@@ -509,18 +507,14 @@ def bulk_action_choices(context, app_label, model_name):
     bulk_action_more_list = bulk_actions_list[4:]
     bulk_actions_list = bulk_actions_list[:4]
 
-    next_url = get_valid_next_url_from_request(context["request"])
-    if not next_url:
-        next_url = context["request"].path
-
+    # These buttons are not re-rendered after AJAX search and filters are applied,
+    # so don't include a 'next' parameter and let the JS construct it later.
     bulk_action_buttons = [
         ListingButton(
             action.display_name,
             reverse(
                 "wagtail_bulk_action", args=[app_label, model_name, action.action_type]
-            )
-            + "?"
-            + urlencode({"next": next_url}),
+            ),
             attrs={"aria-label": action.aria_label, "data-bulk-action-button": ""},
             priority=action.action_priority,
             classname=" ".join(action.classes | {"bulk-action-btn"}),
@@ -539,9 +533,7 @@ def bulk_action_choices(context, app_label, model_name):
                     url=reverse(
                         "wagtail_bulk_action",
                         args=[app_label, model_name, action.action_type],
-                    )
-                    + "?"
-                    + urlencode({"next": next_url}),
+                    ),
                     attrs={
                         "aria-label": action.aria_label,
                         "data-bulk-action-button": "",

--- a/wagtail/admin/tests/pages/test_custom_listing.py
+++ b/wagtail/admin/tests/pages/test_custom_listing.py
@@ -35,3 +35,11 @@ class TestCustomListing(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertContains(response, "Event pages")
         self.assertNotContains(response, "Christmas")
         self.assertContains(response, "Saint Patrick")
+
+        # Should render bulk action buttons
+        soup = self.get_soup(response.content)
+        bulk_actions = soup.select("[data-bulk-action-button]")
+        self.assertTrue(bulk_actions)
+        # 'next' parameter is constructed client-side later based on filters state
+        for action in bulk_actions:
+            self.assertNotIn("next=", action["href"])

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -93,12 +93,16 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
             count=3,
         )
 
+        # Should render bulk actions markup
         bulk_actions_js = versioned_static("wagtailadmin/js/bulk-actions.js")
-        self.assertContains(
-            response,
-            f'<script defer src="{bulk_actions_js}"></script>',
-            html=True,
-        )
+        soup = self.get_soup(response.content)
+        script = soup.select_one(f"script[src='{bulk_actions_js}']")
+        self.assertIsNotNone(script)
+        bulk_actions = soup.select("[data-bulk-action-button]")
+        self.assertTrue(bulk_actions)
+        # 'next' parameter is constructed client-side later based on filters state
+        for action in bulk_actions:
+            self.assertNotIn("next=", action["href"])
 
     def test_explore_results(self):
         explore_results_url = reverse(

--- a/wagtail/admin/tests/pages/test_page_search.py
+++ b/wagtail/admin/tests/pages/test_page_search.py
@@ -6,6 +6,7 @@ from django.test import TransactionTestCase
 from django.urls import reverse
 from django.utils.http import urlencode
 
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.models import Page
 from wagtail.test.testapp.models import EventIndex, SimplePage, SingleEventPage
 from wagtail.test.utils import WagtailTestUtils
@@ -338,3 +339,17 @@ class TestPageSearch(WagtailTestUtils, TransactionTestCase):
                     response,
                     f"{url}?q=&amp;content_type=tests.eventindex",
                 )
+
+    def test_bulk_action_rendered(self):
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        # Should render bulk actions markup
+        bulk_actions_js = versioned_static("wagtailadmin/js/bulk-actions.js")
+        soup = self.get_soup(response.content)
+        script = soup.select_one(f"script[src='{bulk_actions_js}']")
+        self.assertIsNotNone(script)
+        bulk_actions = soup.select("[data-bulk-action-button]")
+        self.assertTrue(bulk_actions)
+        # 'next' parameter is constructed client-side later based on filters state
+        for action in bulk_actions:
+            self.assertNotIn("next=", action["href"])

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -27,6 +27,7 @@ from wagtail.admin.forms import WagtailAdminModelForm
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.menu import admin_menu
 from wagtail.admin.panels import FieldPanel, ObjectList, get_edit_handler
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.widgets.button import Button, ButtonWithDropdown, ListingButton
 from wagtail.blocks.field_block import FieldBlockAdapter
 from wagtail.coreutils import get_dummy_request
@@ -509,6 +510,20 @@ class TestSnippetListView(WagtailTestUtils, TestCase):
             """,
             html=True,
         )
+
+    def test_bulk_action_rendered(self):
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        # Should render bulk actions markup
+        bulk_actions_js = versioned_static("wagtailadmin/js/bulk-actions.js")
+        soup = self.get_soup(response.content)
+        script = soup.select_one(f"script[src='{bulk_actions_js}']")
+        self.assertIsNotNone(script)
+        bulk_actions = soup.select("[data-bulk-action-button]")
+        self.assertTrue(bulk_actions)
+        # 'next' parameter is constructed client-side later based on filters state
+        for action in bulk_actions:
+            self.assertNotIn("next=", action["href"])
 
 
 @override_settings(WAGTAIL_I18N_ENABLED=True)

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -460,6 +460,20 @@ class TestUserIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
             "Show profile",
         )
 
+    def test_bulk_action_rendered(self):
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        # Should render bulk actions markup
+        bulk_actions_js = versioned_static("wagtailadmin/js/bulk-actions.js")
+        soup = self.get_soup(response.content)
+        script = soup.select_one(f"script[src='{bulk_actions_js}']")
+        self.assertIsNotNone(script)
+        bulk_actions = soup.select("[data-bulk-action-button]")
+        self.assertTrue(bulk_actions)
+        # 'next' parameter is constructed client-side later based on filters state
+        for action in bulk_actions:
+            self.assertNotIn("next=", action["href"])
+
 
 class TestUserIndexResultsView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #13472 and fixes #13253, closes #13474, closes #13554, and closes #13351.

The backend code of bulk actions views already have the mechanisms to redirect to the `next` parameter. However, the `next` parameter added to the URL for taking the user to the bulk actions view is constructed using `request.path`, which does not include query parameters:

https://github.com/wagtail/wagtail/blob/0445dead5c6d58bf7e72c6afe059fdbfe1e938d8/wagtail/admin/templatetags/wagtailadmin_tags.py#L512-L523

Unfortunately, even if we update that code to use `get_full_path()` (which does include the parameters), the buttons are only rendered on initial page load. This means the URL doesn't get updated when search and filters are applied via AJAX.

Note that the URL of the button isn't the final URL used for taking the user to the bulk actions view. The client-side code of bulk actions will modify it to append the `id` and `childOf` params according to the current selection, **along with the current parameters** and use that as the final URL:

https://github.com/wagtail/wagtail/blob/0445dead5c6d58bf7e72c6afe059fdbfe1e938d8/client/src/includes/bulk-actions.js#L179-L199

However, the reason why it's passing the current parameters to the bulk action view is so that the query parameters can be preserved when the user has opted to "select all items in the current listing". This is used in `get_all_objects_in_listing_query` methods, such as:

https://github.com/wagtail/wagtail/blob/0445dead5c6d58bf7e72c6afe059fdbfe1e938d8/wagtail/admin/views/pages/bulk_actions/page_bulk_action.py#L17-L38

Unfortunately, as can be seen above, it only takes into account the "search" `q` parameter, and not any filters. This is a separate issue, see #12853.

Anyway, the reason I mentioned it is that the query parameters passed to the bulk action view for that mechanism has led to misdirections on how the issue with `next` parameter should be fixed. Instead of making sure the `next` value is correctly constructed in the first place, people have been reconstructing the URL using the query parameters made available by that mechanism. See #13474, #13554, #13351.

This PR takes a different approach by making sure the `next` parameter uses the current client-side URL, along with any query parameters pre-encoded, so that the server can just use that for the redirect response.