### PR TITLE
Disable usage count ordering when searching on documents and images listing views

### DIFF
--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -118,7 +118,9 @@ class IndexView(generic.IndexView):
                 "usage_count",
                 label=_("Usage"),
                 width="16%",
-                sort_key="usage_count",
+                # Ordering by usage count not currently available when searching,
+                # due to https://github.com/wagtail/django-modelsearch/issues/51
+                sort_key="usage_count" if not self.is_searching else None,
             ),
         ]
         if self.filters and "collection_id" in self.filters.filters:

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -80,7 +80,13 @@ class IndexView(generic.IndexView):
         return getattr(settings, "WAGTAILIMAGES_INDEX_PAGE_SIZE", 30)
 
     def get_valid_orderings(self):
-        return self.ORDERING_OPTIONS
+        orderings = self.ORDERING_OPTIONS.copy()
+        if self.is_searching:
+            # Ordering by usage count not currently available when searching,
+            # due to https://github.com/wagtail/django-modelsearch/issues/51
+            orderings.pop("usage_count", None)
+            orderings.pop("-usage_count", None)
+        return orderings.keys()
 
     def get_base_queryset(self):
         # Get images (filtered by user permission)
@@ -172,7 +178,9 @@ class IndexView(generic.IndexView):
                 UsageCountColumn(
                     "usage_count",
                     label=_("Usage"),
-                    sort_key="usage_count",
+                    # Ordering by usage count not currently available when searching,
+                    # due to https://github.com/wagtail/django-modelsearch/issues/51
+                    sort_key="usage_count" if not self.is_searching else None,
                     width="16%",
                 ),
             ]


### PR DESCRIPTION
The "order by usage count" feature for images and documents added in 7.1 has a bug where if you try to order by usage count while searching at the same time, it'll crash with a 500 error because django-modelsearch/wagtailsearch doesn't support ordering by annotations.

This PR disables the ordering when you're searching, in similar fashion to #12784.

Note that developers can technically work around it by defining a `usage_count` property on the model and adding it as a `FilterField`. I'm not sure how reliable and performant it would be, since you'll have to make sure the index is updated whenever the usage count increases/decreases.

So it's probably not something that Wagtail should support out of the box, but I do wonder whether we should completely disable the ordering while searching, or support that kind of configuration e.g. by checking if there's a `FilterField` for `usage_count` on the model.