### PR TITLE
Move MANIFEST.in settings into pyproject.toml and delete MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,0 @@
-include LICENSE *.rst *.txt *.md
-graft wagtail
-prune **/__pycache__
-prune **/static_src
-global-exclude *.py[co]
-global-exclude *.stories.js
-global-exclude *.stories.tsx
-recursive-exclude wagtail/ *.md
-global-exclude .gitignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,5 +107,32 @@ ignore_path = ["_build", "docs/_build"]
 [tool.setuptools.packages.find]
 include = ["wagtail*"]
 
+
+[tool.setuptools.package-data]
+# https://setuptools.pypa.io/en/latest/userguide/datafiles.html
+
+"wagtail" = ["**/*"]
+"*" = [ ".dockerignore",]
+
+[tool.setuptools.data-files]
+"." = [
+  "AGENTS.md",
+  "CHANGELOG.txt",
+  "CODE_OF_CONDUCT.md",
+  "CONTRIBUTORS.md",
+  "SPONSORS.md",
+]
+
+[tool.setuptools.exclude-package-data]
+"wagtail" = [
+    "*.md",
+    "*.stories.js",
+    "*.stories.tsx",
+    "*.py[co]",
+    "static_src/**",
+    "**/static_src/**"
+]
+
+
 [tool.setuptools.dynamic]
 version = { attr = "wagtail.__version__" }


### PR DESCRIPTION
I updated the packaging setup so we don’t need MANIFEST.in anymore.
All the include/exclude rules are now inside pyproject.toml, using the newer setuptools way.

This keeps things in one place and is easier to maintain.

For reference:
https://setuptools.pypa.io/en/latest/userguide/datafiles.html