### PR TITLE
Remove todo notes for removing refresh_indexes in tests

### DIFF
--- a/wagtail/documents/tests/test_search.py
+++ b/wagtail/documents/tests/test_search.py
@@ -96,7 +96,6 @@ class TestIssue613(WagtailTestUtils, TestCase):
             # Add a document with some tags
             document = self.add_document(tags="hello")
 
-            # TODO: remove this when https://github.com/kaedroho/django-modelsearch/pull/40 is merged and released
             search_backend.refresh_indexes()
 
             # Search for it by tag
@@ -125,7 +124,6 @@ class TestIssue613(WagtailTestUtils, TestCase):
             # Add a document with some tags
             document = self.edit_document(tags="hello")
 
-            # TODO: remove this when https://github.com/kaedroho/django-modelsearch/pull/40 is merged and released
             search_backend.refresh_indexes()
 
             # Search for it by tag

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -1356,7 +1356,6 @@ class TestIssue613(WagtailTestUtils, TestCase):
             # Add an image with some tags
             image = self.add_image(tags="hello")
 
-            # TODO: remove this when https://github.com/kaedroho/django-modelsearch/pull/40 is merged and released
             search_backend.refresh_indexes()
 
             # Search for it by tag
@@ -1385,7 +1384,6 @@ class TestIssue613(WagtailTestUtils, TestCase):
             # Add an image with some tags
             image = self.edit_image(tags="hello")
 
-            # TODO: remove this when https://github.com/kaedroho/django-modelsearch/pull/40 is merged and released
             search_backend.refresh_indexes()
 
             # Search for it by tag


### PR DESCRIPTION
As per https://github.com/wagtail/django-modelsearch/pull/40 , we are not going ahead with this change in django-modelsearch and so tests (and any other code that needs to see indexing take effect immediately) must continue to call refresh_indexes.
