### PR TITLE
Fix StreamField param name in docs

### DIFF
--- a/docs/reference/streamfield/blocks.md
+++ b/docs/reference/streamfield/blocks.md
@@ -9,7 +9,7 @@ This document details the block types provided by Wagtail for use in [StreamFiel
 ```
 
 ```{eval-rst}
-.. class:: wagtail.fields.StreamField(blocks, blank=False, min_num=None, max_num=None, block_counts=None, collapsed=False)
+.. class:: wagtail.fields.StreamField(block_types, blank=False, min_num=None, max_num=None, block_counts=None, collapsed=False)
 
    A model field for representing long-form content as a sequence of content blocks of various types. See :ref:`streamfield_topic`.
 


### PR DESCRIPTION
The name of the first argument of `StreamField.__init__()` is `block_types`, not `blocks`.

Source: https://github.com/wagtail/wagtail/blob/bd726f9f8c3ecf78513bc5315d285e066bdb2772/wagtail/fields.py#L111