### PR TITLE
updated docs for before/after delete & publish

### DIFF
--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -682,7 +682,7 @@ def before_create_page(request, parent_page, page_class):
 
 Do something after a `Page` object is deleted. Uses the same behavior as `after_create_page`.
 
-This hook runs only when deleting a page through the deletion view at /admin/pages/<id>/delete/. It will not run when deleting pages through other routes, such as bulk actions (see [after_bulk_action](https://docs.wagtail.org/en/stable/reference/hooks.html#after-bulk-action) for implementing such hook for bulk actions). If you wish to perform some action on any page deletion, regardless of how the deletion was performed, it may be more appropriate to use Django's [post_delete](https://docs.djangoproject.com/en/5.2/ref/signals/#post-delete) signal.
+This hook runs only when deleting the page through the deletion view at `/admin/pages/<id>/delete/`. It will not run when deleting pages through other routes, such as bulk actions (see [](after_bulk_action) for implementing such hook for bulk actions). If you wish to perform some action on any page deletion, regardless of how the deletion was performed, it may be more appropriate to use Django's [post_delete](https://docs.djangoproject.com/en/stable/ref/signals/#post-delete) signal.
 
 (before_delete_page)=
 
@@ -711,7 +711,7 @@ def before_delete_page(request, page):
         return redirect('wagtailadmin_pages:delete', page.pk)
 ```
 
-This hook runs only when deleting a page through the deletion view at /admin/pages/<id>/delete/. It will not run when deleting pages through other routes, such as bulk actions (see [before_bulk_action](https://docs.wagtail.org/en/stable/reference/hooks.html#before-bulk-action) for implementing such hooks for bulk actions). If you wish to perform some action on any page deletion, regardless of how the deletion was performed, it may be more appropriate to use Django's [pre_delete](https://docs.djangoproject.com/en/5.2/ref/signals/#pre-delete) signal.
+This hook runs only when deleting the page through the deletion view at `/admin/pages/<id>/delete/`. It will not run when deleting pages through other routes, such as bulk actions (see [](before_bulk_action) for implementing such hooks for bulk actions). If you wish to perform some action on any page deletion, regardless of how the deletion was performed, it may be more appropriate to use Django's [pre_delete](https://docs.djangoproject.com/en/stable/ref/signals/#pre-delete) signal.
 
 (after_edit_page)=
 
@@ -735,7 +735,7 @@ Do something with a `Page` object after it has been published via page create vi
 
 The function does not have to return anything, but if an object with a `status_code` property is returned, Wagtail will use it as a response object and skip the rest of the view.
 
-This hook runs only when published via page create view or page edit view. It will not run when publishing pages through other routes, such as bulk actions (see [after_bulk_action](https://docs.wagtail.org/en/stable/reference/hooks.html#after-bulk-action) for implementing such hook for bulk actions). If you wish to perform some action on any page published, regardless of how the publication was performed, it may be more appropriate to use Django's [post_save](https://docs.djangoproject.com/en/5.2/ref/signals/#post-save) signal.
+This hook runs only when published via the page create view or the page edit view. It will not run when publishing pages through other routes, such as bulk actions (see [](after_bulk_action) for implementing such hook for bulk actions). If you wish to perform some action on any page published, regardless of how the publication was performed, it may be more appropriate to use Django's [post_save](https://docs.djangoproject.com/en/stable/ref/signals/#post-save) signal.
 
 (before_publish_page)=
 
@@ -745,7 +745,7 @@ Do something with a `Page` object before it has been published via page create v
 
 The function does not have to return anything, but if an object with a `status_code` property is returned, Wagtail will use it as a response object and skip the rest of the view.
 
-This hook runs only when published via page create view or page edit view. It will not run when publishing pages through other routes, such as bulk actions (see [before_bulk_action](https://docs.wagtail.org/en/stable/reference/hooks.html#before-bulk-action) for implementing such hook for bulk actions). If you wish to perform some action on any page published, regardless of how the publication was performed, it may be more appropriate to use Django's [pre_save](https://docs.djangoproject.com/en/5.2/ref/signals/#pre-save) signal.
+This hook runs only when published via the page create view or the page edit view. It will not run when publishing pages through other routes, such as bulk actions (see [](before_bulk_action) for implementing such hook for bulk actions). If you wish to perform some action on any page published, regardless of how the publication was performed, it may be more appropriate to use Django's [pre_save](https://docs.djangoproject.com/en/stable/ref/signals/#pre-save) signal.
 
 (after_unpublish_page)=
 
@@ -755,7 +755,7 @@ Called after unpublish action in "unpublish" view passing in the request and the
 
 The function does not have to return anything, but if an object with a `status_code` property is returned, Wagtail will use it as a response object and skip the rest of the view.
 
-This hook runs only while unpublishing through “unpublish” view. It will not run when publishing pages through other routes, such as bulk actions (see [Bulk actions](https://docs.wagtail.org/en/stable/reference/hooks.html#bulk-actions) for implementing such hook for bulk actions). If you wish to perform some action on any page published, regardless of how the publication was performed, it may be more appropriate to use Django's [signals](https://docs.djangoproject.com/en/5.2/ref/signals/#signals).
+This hook runs only while unpublishing through the “unpublish” view. It will not run when publishing pages through other routes, such as bulk actions (see [](bulk_actions) for implementing such hook for bulk actions). If you wish to perform some action on any page published, regardless of how the publication was performed, it may be more appropriate to use Django's [signals](https://docs.djangoproject.com/en/stable/ref/signals/#signals).
 
 (before_unpublish_page)=
 
@@ -765,7 +765,7 @@ Called before unpublish action in "unpublish" view passing in the request and th
 
 The function does not have to return anything, but if an object with a `status_code` property is returned, Wagtail will use it as a response object and skip the rest of the view.
 
-This hook runs only while unpublishing through “unpublish” view. It will not run when publishing pages through other routes, such as bulk actions (see [Bulk actions](https://docs.wagtail.org/en/stable/reference/hooks.html#bulk-actions) for implementing such hook for bulk actions). If you wish to perform some action on any page published, regardless of how the publication was performed, it may be more appropriate to use Django's [signals](https://docs.djangoproject.com/en/5.2/ref/signals/#signals).
+This hook runs only while unpublishing through the “unpublish” view. It will not run when publishing pages through other routes, such as bulk actions (see [](bulk_actions) for implementing such hook for bulk actions). If you wish to perform some action on any page published, regardless of how the publication was performed, it may be more appropriate to use Django's [signals](https://docs.djangoproject.com/en/stable/ref/signals/#signals).
 
 (after_copy_page)=
 
@@ -787,7 +787,7 @@ Uses the same behavior as `before_create_page`.
 
 Do something with a `Page` object after it has been moved passing in the request and page object. Uses the same behavior as `after_create_page`.
 
-This hook runs only while page moved through “move page” view. It will not run when publishing pages through other routes, such as bulk actions (see [Bulk actions](https://docs.wagtail.org/en/stable/reference/hooks.html#bulk-actions) for implementing such hook for bulk actions). If you wish to perform some action on any page published, regardless of how the publication was performed, it may be more appropriate to use Django's [signals](https://docs.djangoproject.com/en/5.2/ref/signals/#signals).
+This hook runs only while the page moved through the “move page” view. It will not run when publishing pages through other routes, such as bulk actions (see [](bulk_actions) for implementing such hook for bulk actions). If you wish to perform some action on any page published, regardless of how the publication was performed, it may be more appropriate to use Django's [signals](https://docs.djangoproject.com/en/stable/ref/signals/#signals).
 
 (before_move_page)=
 
@@ -797,7 +797,7 @@ Called at the beginning of the "move page" view passing in the request, the page
 
 Uses the same behavior as `before_create_page`.
 
-This hook runs only at the beginning of the “move page” view. It will not run when publishing pages through other routes, such as bulk actions (see [Bulk actions](https://docs.wagtail.org/en/stable/reference/hooks.html#bulk-actions) for implementing such hook for bulk actions). If you wish to perform some action on any page published, regardless of how the publication was performed, it may be more appropriate to use Django's [signals](https://docs.djangoproject.com/en/5.2/ref/signals/#signals).
+This hook runs only at the beginning of the the “move page” view. It will not run when publishing pages through other routes, such as bulk actions (see [](bulk_actions) for implementing such hook for bulk actions). If you wish to perform some action on any page published, regardless of how the publication was performed, it may be more appropriate to use Django's [signals](https://docs.djangoproject.com/en/stable/ref/signals/#signals).
 
 (before_convert_alias_page)=
 


### PR DESCRIPTION
This PR solves the issue #13392
Updated docs for `before_delete_page`, `after_delete_page`, `before_publish_page`, and `after_publish_page` hooks with the instruction that it does not run while bulk actions.
