### PR TITLE
Fix Unicode redirect matching for URL-encoded paths

### DIFF
--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -545,6 +545,24 @@ class TestRedirects(TestCase):
             response, "/redirectto", status_code=301, fetch_redirect_response=False
         )
 
+    def test_redirect_with_encoded_unicode_to_decoded_request(self):
+        # Test the bug scenario: redirect stored with URL-encoded unicode,
+        # but user navigates to the decoded version
+        # This uses Korean characters (로스트아크 = Lost Ark)
+        redirect = models.Redirect(
+            old_path="/games/%eb%a1%9c%ec%8a%a4%ed%8a%b8%ec%95%84%ed%81%ac",
+            redirect_link="/lost-ark",
+        )
+        redirect.save()
+
+        # Navigate using the decoded unicode URL
+        response = self.client.get("/games/로스트아크/")
+
+        # Should successfully redirect even though stored path is encoded
+        self.assertRedirects(
+            response, "/lost-ark", status_code=301, fetch_redirect_response=False
+        )
+
     def test_reject_null_characters(self):
         response = self.client.get("/test%00test/")
         self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
## Issue [#13357](https://github.com/wagtail/wagtail/issues/13357)
Fixes a bug where redirects with URL-encoded Unicode characters would not match incoming requests and return 404 errors instead of redirecting.
**Example:** Creating a redirect for `/games/%eb%a1%9c%ec%8a%a4%ed%8a%b8%ec%95%84%ed%81%ac` (Korean "로스트아크" / "Lost Ark") would fail to match when users navigated to the page.
## Root Cause
URL percent-encoding is case-sensitive in string comparison (`%eb` ≠ `%EB`), even though they are semantically equivalent per RFC 3986. When redirects were stored with lowercase hex encoding but Django normalized incoming requests to uppercase, the match would fail.
## Solution
1. **Normalize stored paths**: Updated `Redirect.normalise_path()` to convert percent-encoded paths to canonical uppercase hex form while preserving Unicode paths as-is
2. **Ensure normalization on save**: Override `Redirect.save()` to normalize `old_path` even when `full_clean()` isn't called
3. **Normalize incoming paths**: Updated redirect middleware to try matching against the normalized (decode-then-encode) version of incoming paths
4. **Added test coverage**: New test `test_redirect_with_encoded_unicode_to_decoded_request()` verifies the fix with Korean characters
## Testing
- All 54 existing redirect tests pass
- New test added for the specific bug scenario
- Backward compatible - no breaking changes
## AI Disclosure
> [!NOTE]  
> This pull request includes code written with the assistance of AI.
