### PR TITLE
Improve active menu item visibility in sidebar

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
  * Add natural keys for `Page` and `Collection` models (Samya Aggarwal)
  * Add Loom oEmbed provider (Nick Ivons)
  * Add `ModelViewSet.pk_path_converter` with defaults for `IntegerField` and `UUIDField` primary keys (Seb Corbin)
+ * Improve accessibility for sidebar menu with visual active (expanded) menu item indicators (Vignesh Shivhare)
  * Fix: Do not try to resolve locale during fixture load (Jake Howard, Seb Corbin)
  * Fix: Gracefully handle oEmbed responses with a non-200 status or missing type (Shivam Kumar, Bhavesh Sharma)
  * Fix: Keep action button labelled as "Publish" rather than "Schedule to publish" if go-live date has passed (Vishrut Ramraj)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -925,6 +925,7 @@
 * Aman Bora
 * Ishtpreet Singh
 * Jashvirsingh Taak
+* Vignesh Shivhare
 
 ## Translators
 

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -5,6 +5,7 @@
   $root: &;
   @include transition(border-color $menu-transition-duration ease);
   position: relative;
+  border-inline-start: 2px solid transparent;
 
   &__link {
     @apply w-text-14 w-leading-none w-transition;
@@ -53,6 +54,7 @@
   &--active {
     @apply w-bg-surface-menu-item-active;
     text-shadow: -1px -1px 0 theme('colors.black-35');
+    border-inline-start-color: theme('colors.border-button-outline-default');
 
     > a {
       color: theme('colors.text-label-menus-active');

--- a/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
@@ -70,6 +70,7 @@ export const PageExplorerMenuItem: React.FunctionComponent<
   const className =
     'sidebar-menu-item sidebar-page-explorer-item' +
     (isActive ? ' sidebar-menu-item--active' : '') +
+    (isOpen ? ' sidebar-sub-menu-item--open' : '') +
     (isInSubMenu ? ' sidebar-menu-item--in-sub-menu' : '');
 
   const sidebarTriggerIconClassName =

--- a/client/src/components/Sidebar/menu/SubMenuItem.scss
+++ b/client/src/components/Sidebar/menu/SubMenuItem.scss
@@ -55,10 +55,6 @@
     overflow-y: auto;
   }
 
-  > ul > li {
-    border: 0;
-  }
-
   &__footer {
     margin: 0;
     padding: 0.9em 1.7em;
@@ -94,6 +90,9 @@
 
 .sidebar-sub-menu-item {
   &--open {
+    border-inline-start: 2px solid
+      theme('colors.border-interactive-more-contrast-dark-bg-hover');
+
     > a {
       text-shadow: -1px -1px 0 theme('colors.black-35');
     }

--- a/docs/releases/7.3.md
+++ b/docs/releases/7.3.md
@@ -18,6 +18,7 @@ depth: 1
  * Add natural keys for `Page` and `Collection` models (Samya Aggarwal)
  * Add Loom oEmbed provider (Nick Ivons)
  * Add [`ModelViewSet.pk_path_converter`](ModelViewSet.pk_path_converter) with defaults for `IntegerField` and `UUIDField` primary keys (Seb Corbin)
+ * Improve accessibility for sidebar menu with visual active (expanded) menu item indicators (Vignesh Shivhare)
 
 ### Bug fixes
 


### PR DESCRIPTION
This PR aims to solve issue **#12644** by improving the visual indication of the active sidebar menu item.
Previously, the active state relied only on subtle color changes, which made it difficult to distinguish.

### Changes made
- Added a solid left border indicator for .sidebar-menu-item--active using the theme token `theme('colors.border-button-outline-default')`
- Added a distinct left border to .sidebar-sub-menu-item--open using `theme('colors.border-interactive-more-contrast-dark-bg-hover')` to visually indicate expanded state.

###ScreenShots
<img width="785" height="494" alt="Screenshot 2025-11-25 131238" src="https://github.com/user-attachments/assets/d881226f-69e3-415f-a801-5d1d4fa361ea" />
<img width="781" height="493" alt="Screenshot 2025-11-25 131156" src="https://github.com/user-attachments/assets/f6894cc8-435c-448b-b48f-b5a0a8cdad54" />

If further adjustments are needed, I’ll be happy to make them.