### PR TITLE
Modify site switch to use site str()

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
 * Set `FieldPanel(required_on_save=True)` for `AbstractFormField`'s `field_type` field (Alex Tomkins)
 * Handle pasting of multiple tags separated by newlines or commas (Matthias Brück)
 * Make `Button` component render a `<button>` element when no URL is supplied (Nayeli De Jesus, LB (Ben Johnston), Sage Abdullah)
+* Show site name in site switcher dropdown in site settings editor (Jack Morgan)
 * Fix: Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
 * Fix: Prevent an error when approving a workflow that has been cancelled in a different session (Kailesh)
 * Fix: Accommodate multilingual sites in skipping the "choose parent" step when creating a new page from a flat page listing (Amrinder Singh)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -978,6 +978,7 @@
 * Nayeli De Jesus
 * Sahil Kumar
 * Rob Brackett
+* Jack Morgan
 
 ## Translators
 

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -17,6 +17,7 @@ depth: 1
  * Set `FieldPanel(required_on_save=True)` for `AbstractFormField`'s `field_type` field (Alex Tomkins)
  * Handle pasting of multiple tags separated by newlines or commas (Matthias Brück)
  * Make `Button` component render a `<button>` element when no URL is supplied (Nayeli De Jesus, LB (Ben Johnston), Sage Abdullah)
+ * Show site name in site switcher dropdown in site settings editor (Jack Morgan)
 
 ### Bug fixes
 

--- a/wagtail/contrib/settings/forms.py
+++ b/wagtail/contrib/settings/forms.py
@@ -28,11 +28,7 @@ class SiteSwitchForm(forms.Form):
         self.fields["site"].choices = [
             (
                 self.get_change_url(site, model),
-                (
-                    site.hostname + " [{}]".format(_("default"))
-                    if site.is_default_site
-                    else site.hostname
-                ),
+                str(site),
             )
             for site in sites
         ]

--- a/wagtail/contrib/settings/tests/site_specific/test_forms.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_forms.py
@@ -5,27 +5,38 @@ from wagtail.models import Page, Site
 from wagtail.test.testapp.models import TestSiteSetting
 
 
-class TestSiteSwitchFromSiteOrdering(TestCase):
+class TestSiteSwitchFormOrdering(TestCase):
     def setUp(self):
         self.root_page = Page.objects.get(pk=2)
         Site.objects.all().delete()  # Drop the initial site.
 
-    def test_site_order_by_hostname(self):
+    def _create_sites(self):
+        # Standard site
         site_1 = Site.objects.create(hostname="charly.com", root_page=self.root_page)
+        # Site with default
         site_2 = Site.objects.create(
             hostname="bravo.com", root_page=self.root_page, is_default_site=True
         )
-        site_3 = Site.objects.create(hostname="alfa.com", root_page=self.root_page)
+        # Site with name
+        site_3 = Site.objects.create(
+            hostname="alfa.com", site_name="Alfa Website", root_page=self.root_page
+        )
+        # Site with non-standard port
+        site_4 = Site.objects.create(
+            hostname="alfa.com", port=5678, root_page=self.root_page
+        )
+        return site_1, site_2, site_3, site_4
+
+    def test_site_order_by_site_name_and_hostname(self):
+        site_1, site_2, site_3, site_4 = self._create_sites()
         form = SiteSwitchForm(site_1, TestSiteSetting, sites=Site.objects.all())
         expected_choices = [
-            (f"/admin/settings/tests/testsitesetting/{site_3.id}/", "alfa.com"),
+            (f"/admin/settings/tests/testsitesetting/{site_3.id}/", "Alfa Website"),
+            (f"/admin/settings/tests/testsitesetting/{site_4.id}/", "alfa.com:5678"),
             (
                 f"/admin/settings/tests/testsitesetting/{site_2.id}/",
                 "bravo.com [default]",
             ),
-            (
-                f"/admin/settings/tests/testsitesetting/{site_1.id}/",
-                "charly.com",
-            ),
+            (f"/admin/settings/tests/testsitesetting/{site_1.id}/", "charly.com"),
         ]
         self.assertEqual(form.fields["site"].choices, expected_choices)

--- a/wagtail/models/sites.py
+++ b/wagtail/models/sites.py
@@ -64,7 +64,17 @@ def get_site_for_hostname(hostname, port):
 
 class SiteManager(models.Manager):
     def get_queryset(self):
-        return super().get_queryset().order_by(Lower("hostname"))
+        return (
+            super()
+            .get_queryset()
+            .order_by(
+                Case(
+                    When(site_name="", then=Lower("hostname")),
+                    default=Lower("site_name"),
+                ),
+                Lower("hostname"),
+            )
+        )
 
     def get_by_natural_key(self, hostname, port):
         return self.get(hostname=hostname, port=port)

--- a/wagtail/tests/test_sites.py
+++ b/wagtail/tests/test_sites.py
@@ -90,7 +90,20 @@ class TestSiteOrdering(TestCase):
             [site_3.id, site_2.id, site_1.id],
         )
 
-    def test_site_order_by_hostname_site_name_irrelevant(self):
+    def test_site_order_by_site_name(self):
+        """Named sites are ordered by site_name, not hostname."""
+        site_1 = Site.objects.create(
+            hostname="zulu.com", site_name="Alpha", root_page=self.root_page
+        )
+        site_2 = Site.objects.create(
+            hostname="alfa.com", site_name="Zulu", root_page=self.root_page
+        )
+        self.assertEqual(
+            list(Site.objects.all().values_list("id", flat=True)),
+            [site_1.id, site_2.id],
+        )
+
+    def test_site_order_by_site_name_falls_back_to_hostname(self):
         site_1 = Site.objects.create(
             hostname="charly.com", site_name="X-ray", root_page=self.root_page
         )
@@ -102,7 +115,65 @@ class TestSiteOrdering(TestCase):
         )
         self.assertEqual(
             list(Site.objects.all().values_list("id", flat=True)),
-            [site_3.id, site_2.id, site_1.id],
+            [site_1.id, site_2.id, site_3.id],
+        )
+
+    def test_site_order_by_site_name_case_insensitive(self):
+        """site_name ordering is case-insensitive."""
+        site_1 = Site.objects.create(
+            hostname="c.com", site_name="alpha", root_page=self.root_page
+        )
+        site_2 = Site.objects.create(
+            hostname="b.com", site_name="Bravo", root_page=self.root_page
+        )
+        site_3 = Site.objects.create(
+            hostname="a.com", site_name="CHARLIE", root_page=self.root_page
+        )
+        self.assertEqual(
+            list(Site.objects.all().values_list("id", flat=True)),
+            [site_1.id, site_2.id, site_3.id],
+        )
+
+    def test_site_order_named_and_nameless_interleaved(self):
+        """Named and nameless sites are interleaved alphabetically."""
+        site_1 = Site.objects.create(
+            hostname="zulu.com", site_name="Alfa", root_page=self.root_page
+        )
+        site_2 = Site.objects.create(hostname="bravo.com", root_page=self.root_page)
+        site_3 = Site.objects.create(
+            hostname="alfa.com", site_name="Charlie", root_page=self.root_page
+        )
+        self.assertEqual(
+            list(Site.objects.all().values_list("id", flat=True)),
+            [site_1.id, site_2.id, site_3.id],
+        )
+
+    def test_site_order_site_name_hostname_tiebreaker(self):
+        """Sites with the same site_name are ordered by hostname."""
+        site_1 = Site.objects.create(
+            hostname="alpha.com", site_name="Shared Name", root_page=self.root_page
+        )
+        site_2 = Site.objects.create(
+            hostname="zulu.com", site_name="Shared Name", root_page=self.root_page
+        )
+        self.assertEqual(
+            list(Site.objects.all().values_list("id", flat=True)),
+            [site_1.id, site_2.id],
+        )
+
+    def test_site_order_site_name_prefix_collision_with_hostname(self):
+        """
+        A site_name that is a prefix of another site's hostname produces a
+        deterministic order. This is the case where Concat('site_name', 'hostname')
+        would generate identical sort keys for two different sites.
+        """
+        site_1 = Site.objects.create(
+            hostname="ar.com", site_name="be", root_page=self.root_page
+        )
+        site_2 = Site.objects.create(hostname="bear.com", root_page=self.root_page)
+        self.assertEqual(
+            list(Site.objects.all().values_list("id", flat=True)),
+            [site_1.id, site_2.id],
         )
 
 


### PR DESCRIPTION
## Description

The site switcher uses a custom string representation, which duplicates most of the logic from `Site.__str__()`. This switcher is shown on site settings pages.

This change reduces the code repetition, and improving the readability of choices for users. Other packages, such as wagtail menus, show both the site name and domain in their site switcher.

I've updated the tests to check the string representation is used, and that all sites are listed as options. The existing test checking order of sites has been removed, as I cannot find any reasoning for it, I can restore it if required.

### Useful links

- [Wagtail Site model .__str__() method](https://github.com/wagtail/wagtail/blob/23408a513f4b6754cea6bd0563dae4577dc68e3f/wagtail/models/sites.py#L122-L131)

### Screenshots

Before:

<img width="1696" height="334" alt="image" src="https://github.com/user-attachments/assets/5db27102-93a3-49aa-8b4c-cb327341e52f" />

After:

<img width="1696" height="336" alt="image" src="https://github.com/user-attachments/assets/89a274c4-6e2e-4433-8d8a-8bd5b67de913" />