### PR TITLE
Bump django-modelcluster to 6.4.1 for Django 6.0 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: Run tests
           command: |
             export PYTHONUNBUFFERED=1
-            WAGTAIL_CHECK_TEMPLATE_NUMBER_FORMAT=1 python -u runtests.py --parallel=1
+            WAGTAIL_CHECK_TEMPLATE_NUMBER_FORMAT=1 python -u runtests.py --parallel=2
 
   frontend:
     docker:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,8 +107,6 @@ jobs:
             experimental: true
             install_extras: |
               pip install "django-tasks>=0.9,<0.10"
-              pip uninstall -y django-modelcluster
-              pip install "git+https://github.com/wagtail/django-modelcluster.git@main#egg=django-modelcluster"
           - python: '3.14'
             django: 'git+https://github.com/django/django.git@main#egg=Django'
             psycopg: 'psycopg>=3.1.8'
@@ -117,8 +115,6 @@ jobs:
             parallel: '--parallel'
             install_extras: |
               pip install "django-tasks>=0.9,<0.10"
-              pip uninstall -y django-modelcluster
-              pip install "git+https://github.com/wagtail/django-modelcluster.git@main#egg=django-modelcluster"
     services:
       postgres:
         image: ${{ matrix.postgres || 'postgres:12' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
   "Django>=4.2",
-  "django-modelcluster>=6.2.1,<7.0",
+  "django-modelcluster>=6.4.1,<7.0",
   "django-permissionedforms>=0.1,<1.0",
   "django-taggit>=5.0,<7",
   "django-treebeard>=4.5.1,<5.0",


### PR DESCRIPTION
Facepalm moment here...

Right at the start of the Django 6.0 development cycle, we made a fix to django-modelcluster to handle the deprecation of `get_prefetch_queryset`: https://github.com/wagtail/django-modelcluster/pull/198

We updated our Github Actions CI run for Django main (and later stable/6.0.x) to use the git main version of django-modelcluster, and promptly forgot about it.

Jump ahead to yesterday, Django 6.0 is released, and the current release of django-modelcluster is still incompatible with it. Cue CircleCI (which doesn't pin a specific version of Django) failing...

I've now released django-modelcluster 6.4.1 with the fix. Bumping the version in pyproject.toml isn't strictly needed, but that'll have the effect of clearing the cached environment on CircleCI.