### PR TITLE
Fix dropdown width not adjusting to content

### DIFF
--- a/client/scss/components/_drilldown.scss
+++ b/client/scss/components/_drilldown.scss
@@ -1,6 +1,8 @@
 .w-drilldown__contents {
   max-height: min(480px, 70vh);
   overflow-y: auto;
+  width: auto !important;
+  min-width: 300px;
 }
 
 .w-drilldown .w-drilldown__toggle {
@@ -64,13 +66,17 @@
   // and reduce the default margin-bottom.
   margin-top: theme('spacing.2');
   margin-bottom: theme('spacing.2');
-  // Force fields to stay within the width of the drilldown.
-  max-width: calc(260px - theme('spacing.4'));
 }
 
 .w-drilldown__submenu .w-field__label {
   @apply w-label-1;
   margin-bottom: theme('spacing.3');
+}
+
+.w-drilldown__submenu select {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box; /* Prevents padding from triggering scrollbars */
 }
 
 .w-drilldown__count {

--- a/client/scss/overrides/_vendor.tippy.scss
+++ b/client/scss/overrides/_vendor.tippy.scss
@@ -45,10 +45,16 @@
 
 .tippy-box[data-theme='drilldown'] {
   @apply w-rounded w-bg-surface-page w-text-inherit w-shadow-md;
-  width: 300px;
+  // Let the dropdown grow to the width of its content.
+  max-width: none !important;
 
   .tippy-content {
     @apply w-p-0;
+  }
+
+  .w-dropdown__content {
+    width: fit-content;
+    min-width: 100%;
   }
 }
 


### PR DESCRIPTION
The filter dropdown's width was fixed, preventing it from adjusting to wider content like long collection names. This change allows the dropdown container to resize based on its content. Fixes #13616.