### PR TITLE
Refactor privacy-switch.js to replace jQuery with vanilla JS and add test coverage

### DIFF
--- a/client/src/entrypoints/admin/privacy-switch.js
+++ b/client/src/entrypoints/admin/privacy-switch.js
@@ -1,32 +1,49 @@
-/* global ModalWorkflow */
+import { domReady } from '../../utils/domReady';
+import { encodeForm } from '../../utils/encodeForm';
 
-import $ from 'jquery';
+/**
+ * Initializes the privacy switch functionality.
+ * Attaches event listeners to privacy trigger buttons to open the ModalWorkflow.
+ */
+function initPrivacySwitch() {
+  const privacyTriggers = document.querySelectorAll(
+    '[data-a11y-dialog-show="set-privacy"]',
+  );
 
-$(() => {
-  /* Interface to set permissions from the explorer / editor */
-  $('[data-a11y-dialog-show="set-privacy"]').on('click', function setPrivacy() {
-    ModalWorkflow({
-      dialogId: 'set-privacy',
-      url: this.getAttribute('data-url'),
-      onload: {
-        set_privacy(modal) {
-          $('form', modal.body).on('submit', function handleSubmit() {
-            modal.postForm(this.action, $(this).serialize());
-            return false;
-          });
+  privacyTriggers.forEach((trigger) => {
+    trigger.addEventListener('click', (event) => {
+      event.preventDefault();
+      const url = trigger.getAttribute('data-url');
+
+      window.ModalWorkflow({
+        dialogId: 'set-privacy',
+        url,
+        onload: {
+          set_privacy(modal) {
+            const form = modal.body.querySelector('form');
+            if (form) {
+              form.addEventListener('submit', (submitEvent) => {
+                submitEvent.preventDefault();
+                // Use getAttribute('action') to preserve relative URLs if needed, falling back to property
+                const actionUrl = form.getAttribute('action') || form.action;
+                modal.postForm(actionUrl, encodeForm(form));
+              });
+            }
+          },
+          set_privacy_done(modal, { is_public: isPublic }) {
+            document.dispatchEvent(
+              new CustomEvent('w-privacy:changed', {
+                bubbles: true,
+                cancelable: false,
+                detail: { isPublic },
+              }),
+            );
+            modal.close();
+          },
         },
-        set_privacy_done(modal, { is_public: isPublic }) {
-          document.dispatchEvent(
-            new CustomEvent('w-privacy:changed', {
-              bubbles: true,
-              cancelable: false,
-              detail: { isPublic },
-            }),
-          );
-          modal.close();
-        },
-      },
+      });
     });
-    return false;
   });
-});
+}
+
+domReady().then(initPrivacySwitch);

--- a/client/src/entrypoints/admin/privacy-switch.js
+++ b/client/src/entrypoints/admin/privacy-switch.js
@@ -5,14 +5,13 @@ import { encodeForm } from '../../utils/encodeForm';
  * Initializes the privacy switch functionality.
  * Attaches event listeners to privacy trigger buttons to open the ModalWorkflow.
  */
-function initPrivacySwitch() {
+domReady().then(() => {
   const privacyTriggers = document.querySelectorAll(
     '[data-a11y-dialog-show="set-privacy"]',
   );
 
   privacyTriggers.forEach((trigger) => {
-    trigger.addEventListener('click', (event) => {
-      event.preventDefault();
+    trigger.addEventListener('click', () => {
       const url = trigger.getAttribute('data-url');
 
       window.ModalWorkflow({
@@ -24,7 +23,6 @@ function initPrivacySwitch() {
             if (form) {
               form.addEventListener('submit', (submitEvent) => {
                 submitEvent.preventDefault();
-                // Use getAttribute('action') to preserve relative URLs if needed, falling back to property
                 const actionUrl = form.getAttribute('action') || form.action;
                 modal.postForm(actionUrl, encodeForm(form));
               });
@@ -44,6 +42,4 @@ function initPrivacySwitch() {
       });
     });
   });
-}
-
-domReady().then(initPrivacySwitch);
+});

--- a/client/src/entrypoints/admin/privacy-switch.js
+++ b/client/src/entrypoints/admin/privacy-switch.js
@@ -5,9 +5,8 @@ import { encodeForm } from '../../utils/encodeForm';
  * Initializes the privacy switch functionality.
  * Attaches event listeners to privacy trigger buttons to open the ModalWorkflow.
  */
-function initPrivacySwitch() {
+domReady().then(() => {
   function setPrivacy(event) {
-    event.preventDefault();
     const trigger = event.currentTarget;
     const url = trigger.getAttribute('data-url');
 
@@ -20,7 +19,6 @@ function initPrivacySwitch() {
           if (form) {
             form.addEventListener('submit', (submitEvent) => {
               submitEvent.preventDefault();
-              // Use getAttribute('action') to preserve relative URLs if needed, falling back to property
               const actionUrl = form.getAttribute('action') || form.action;
               modal.postForm(actionUrl, encodeForm(form));
             });
@@ -56,7 +54,4 @@ function initPrivacySwitch() {
   document.addEventListener('w-autosave:success', () => {
     bindPrivacySwitch();
   });
-}
-
-domReady().then(initPrivacySwitch);
-
+});

--- a/client/src/entrypoints/admin/privacy-switch.js
+++ b/client/src/entrypoints/admin/privacy-switch.js
@@ -1,19 +1,30 @@
-/* global ModalWorkflow */
+import { domReady } from '../../utils/domReady';
+import { encodeForm } from '../../utils/encodeForm';
 
-import $ from 'jquery';
+/**
+ * Initializes the privacy switch functionality.
+ * Attaches event listeners to privacy trigger buttons to open the ModalWorkflow.
+ */
+function initPrivacySwitch() {
+  function setPrivacy(event) {
+    event.preventDefault();
+    const trigger = event.currentTarget;
+    const url = trigger.getAttribute('data-url');
 
-$(() => {
-  /* Interface to set permissions from the explorer / editor */
-  function setPrivacy() {
-    ModalWorkflow({
+    window.ModalWorkflow({
       dialogId: 'set-privacy',
-      url: this.getAttribute('data-url'),
+      url,
       onload: {
         set_privacy(modal) {
-          $('form', modal.body).on('submit', function handleSubmit() {
-            modal.postForm(this.action, $(this).serialize());
-            return false;
-          });
+          const form = modal.body.querySelector('form');
+          if (form) {
+            form.addEventListener('submit', (submitEvent) => {
+              submitEvent.preventDefault();
+              // Use getAttribute('action') to preserve relative URLs if needed, falling back to property
+              const actionUrl = form.getAttribute('action') || form.action;
+              modal.postForm(actionUrl, encodeForm(form));
+            });
+          }
         },
         set_privacy_done(modal, { is_public: isPublic }) {
           document.dispatchEvent(
@@ -27,13 +38,25 @@ $(() => {
         },
       },
     });
-    return false;
   }
 
-  $('[data-a11y-dialog-show="set-privacy"]').on('click', setPrivacy);
+  function bindPrivacySwitch() {
+    const privacyTriggers = document.querySelectorAll(
+      '[data-a11y-dialog-show="set-privacy"]',
+    );
+
+    privacyTriggers.forEach((trigger) => {
+      trigger.addEventListener('click', setPrivacy);
+    });
+  }
+
+  bindPrivacySwitch();
 
   // Re-bind after side panel content is refreshed e.g. via autosave
-  $(document).on('w-autosave:success', () => {
-    $('[data-a11y-dialog-show="set-privacy"]').on('click', setPrivacy);
+  document.addEventListener('w-autosave:success', () => {
+    bindPrivacySwitch();
   });
-});
+}
+
+domReady().then(initPrivacySwitch);
+

--- a/client/src/entrypoints/admin/privacy-switch.test.js
+++ b/client/src/entrypoints/admin/privacy-switch.test.js
@@ -9,7 +9,7 @@ describe('privacy-switch entrypoint', () => {
 
   beforeEach(() => {
     document.body.innerHTML = `
-      <button data-a11y-dialog-show="set-privacy" data-url="/set-privacy/">Set privacy</button>
+      <button type="button" data-a11y-dialog-show="set-privacy" data-url="/set-privacy/">Set privacy</button>
     `;
 
     // Stub ModalWorkflow to capture options
@@ -36,11 +36,9 @@ describe('privacy-switch entrypoint', () => {
       bubbles: true,
       cancelable: true,
     });
-    const preventDefaultSpy = jest.spyOn(clickEvent, 'preventDefault');
 
     trigger.dispatchEvent(clickEvent);
 
-    expect(preventDefaultSpy).toHaveBeenCalled();
     expect(window.ModalWorkflow).toHaveBeenCalledTimes(1);
     expect(modalOptions.dialogId).toBe('set-privacy');
     expect(modalOptions.url).toBe('/set-privacy/');

--- a/client/src/entrypoints/admin/privacy-switch.test.js
+++ b/client/src/entrypoints/admin/privacy-switch.test.js
@@ -1,0 +1,84 @@
+// Mock domReady to ensure the callback runs immediately during tests
+jest.mock('../../utils/domReady', () => ({
+  domReady: () => Promise.resolve(),
+}));
+
+describe('privacy-switch entrypoint', () => {
+  let trigger;
+  let modalOptions;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <button data-a11y-dialog-show="set-privacy" data-url="/set-privacy/">Set privacy</button>
+    `;
+
+    // Stub ModalWorkflow to capture options
+    window.ModalWorkflow = jest.fn((opts) => {
+      modalOptions = opts;
+    });
+
+    // Import the module under test (after globals and DOM are ready)
+    jest.isolateModules(() => {
+      require('./privacy-switch');
+    });
+
+    trigger = document.querySelector('[data-a11y-dialog-show="set-privacy"]');
+  });
+
+  afterEach(() => {
+    modalOptions = undefined;
+    document.body.innerHTML = '';
+    delete window.ModalWorkflow;
+  });
+
+  it('should open the ModalWorkflow with the expected options on click', () => {
+    const clickEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = jest.spyOn(clickEvent, 'preventDefault');
+
+    trigger.dispatchEvent(clickEvent);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(window.ModalWorkflow).toHaveBeenCalledTimes(1);
+    expect(modalOptions.dialogId).toBe('set-privacy');
+    expect(modalOptions.url).toBe('/set-privacy/');
+    expect(typeof modalOptions.onload.set_privacy).toBe('function');
+    expect(typeof modalOptions.onload.set_privacy_done).toBe('function');
+  });
+
+  it('should wire form submit to modal.postForm in set_privacy', () => {
+    const form = document.createElement('form');
+    form.action = '/submit/';
+    document.body.appendChild(form);
+    const modal = { body: document.body, postForm: jest.fn() };
+
+    trigger.click();
+    modalOptions.onload.set_privacy(modal);
+
+    const submitEvent = new Event('submit', {
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = jest.spyOn(submitEvent, 'preventDefault');
+    form.dispatchEvent(submitEvent);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(modal.postForm).toHaveBeenCalledTimes(1);
+    expect(modal.postForm).toHaveBeenCalledWith('/submit/', expect.any(String));
+  });
+
+  it('should dispatch w-privacy:changed and close the modal in set_privacy_done', () => {
+    const close = jest.fn();
+    const modal = { close };
+    const listener = jest.fn();
+    document.addEventListener('w-privacy:changed', listener);
+
+    trigger.click();
+    modalOptions.onload.set_privacy_done(modal, { is_public: true });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/entrypoints/admin/privacy-switch.test.js
+++ b/client/src/entrypoints/admin/privacy-switch.test.js
@@ -79,4 +79,23 @@ describe('privacy-switch entrypoint', () => {
     expect(listener).toHaveBeenCalledTimes(1);
     expect(close).toHaveBeenCalledTimes(1);
   });
+
+  it('should re-bind triggers when w-autosave:success is dispatched', () => {
+    const newTrigger = document.createElement('button');
+    newTrigger.type = 'button';
+    newTrigger.setAttribute('data-a11y-dialog-show', 'set-privacy');
+    newTrigger.setAttribute('data-url', '/new-privacy/');
+    document.body.appendChild(newTrigger);
+
+    document.dispatchEvent(new CustomEvent('w-autosave:success'));
+
+    newTrigger.click();
+
+    expect(window.ModalWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dialogId: 'set-privacy',
+        url: '/new-privacy/',
+      }),
+    );
+  });
 });

--- a/client/src/utils/encodeForm.test.js
+++ b/client/src/utils/encodeForm.test.js
@@ -1,0 +1,33 @@
+import { encodeForm } from './encodeForm';
+
+describe('encodeForm', () => {
+  it('encodes standard text fields', () => {
+    const form = document.createElement('form');
+    form.innerHTML = `
+      <input type="text" name="username" value="wagtail">
+      <input type="text" name="role" value="developer">
+    `;
+    expect(encodeForm(form)).toBe('username=wagtail&role=developer');
+  });
+
+  it('encodes multiple values for the same name', () => {
+    const form = document.createElement('form');
+    form.innerHTML = `
+      <input type="checkbox" name="features" value="cms" checked>
+      <input type="checkbox" name="features" value="ecommerce" checked>
+    `;
+    expect(encodeForm(form)).toBe('features=cms&features=ecommerce');
+  });
+
+  it('encodes file inputs by their filename (legacy behavior)', () => {
+    const form = document.createElement('form');
+    // In JSDOM/Browser, an empty file input results in a File object with an empty name
+    form.innerHTML = '<input type="file" name="upload">';
+    expect(encodeForm(form)).toBe('upload=');
+  });
+
+  it('handles empty forms', () => {
+    const form = document.createElement('form');
+    expect(encodeForm(form)).toBe('');
+  });
+});

--- a/client/src/utils/encodeForm.ts
+++ b/client/src/utils/encodeForm.ts
@@ -1,0 +1,8 @@
+/**
+ * Encodes form data into a URL-encoded string (application/x-www-form-urlencoded).
+ * Replacement for jQuery's $(form).serialize()
+ */
+export const encodeForm = (form: HTMLFormElement): string => {
+  const formData = new FormData(form);
+  return new URLSearchParams(formData as any).toString();
+};

--- a/client/src/utils/encodeForm.ts
+++ b/client/src/utils/encodeForm.ts
@@ -2,7 +2,15 @@
  * Encodes form data into a URL-encoded string (application/x-www-form-urlencoded).
  * Replacement for jQuery's $(form).serialize()
  */
-export const encodeForm = (form: HTMLFormElement): string => {
+export function encodeForm(form: HTMLFormElement): string {
   const formData = new FormData(form);
-  return new URLSearchParams(formData as any).toString();
-};
+  const params = new URLSearchParams();
+
+  Array.from(formData.entries()).forEach(([key, value]) => {
+    const valueString =
+      typeof value === 'string' ? value : (value as File)?.name || '';
+    params.append(key, valueString);
+  });
+
+  return params.toString();
+}


### PR DESCRIPTION
This PR aims to solve issue #13606 by refactoring the privacy-switch.js entrypoint from jQuery to Vanilla JS. This PR also introduces a new test file privacy-switch.test.js to ensure the functionality is preserved.

## Screenshots

<img width="1910" height="1112" alt="image" src="https://github.com/user-attachments/assets/0bd19939-7696-474b-abf2-acb306d2313a" />

<img width="1914" height="1112" alt="image" src="https://github.com/user-attachments/assets/4a6e9e3f-dded-40a3-8f83-22fa7d8fabcf" />
