### PR TITLE
feat: optimized project template dockerfile using multi-stage build

### DIFF
--- a/wagtail/project_template/Dockerfile
+++ b/wagtail/project_template/Dockerfile
@@ -1,20 +1,7 @@
 # Use an official Python runtime based on Debian 12 "bookworm" as a parent image.
-FROM python:3.12-slim-bookworm
+FROM python:3.12-slim-bookworm AS builder
 
-# Add user that will be used in the container.
-RUN useradd wagtail
-
-# Port used by this container to serve HTTP.
-EXPOSE 8000
-
-# Set environment variables.
-# 1. Force Python stdout and stderr streams to be unbuffered.
-# 2. Set PORT variable that is used by Gunicorn. This should match "EXPOSE"
-#    command.
-ENV PYTHONUNBUFFERED=1 \
-    PORT=8000
-
-# Install system packages required by Wagtail and Django.
+# Install build dependencies
 RUN apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-recommends \
     build-essential \
     libpq-dev \
@@ -24,12 +11,43 @@ RUN apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-r
     libwebp-dev \
  && rm -rf /var/lib/apt/lists/*
 
-# Install the application server.
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY requirements.txt /
+RUN pip install --no-cache-dir -r /requirements.txt
 RUN pip install "gunicorn==20.0.4"
 
-# Install the project requirements.
-COPY requirements.txt /
-RUN pip install -r /requirements.txt
+# Runtime stage
+
+FROM python:3.12-slim-bookworm AS runtime
+
+# Add user that will be used in the container.
+RUN useradd wagtail
+
+
+# Replaced build-essential/-dev with libpq5, libmariadb3.
+# Install system packages required by Wagtail and Django.
+RUN apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-recommends \
+    libpq5 \
+    libmariadb3 \
+    libjpeg62-turbo \
+    zlib1g \
+    libwebp7 \
+ && rm -rf /var/lib/apt/lists/*
+
+
+COPY --from=builder /opt/venv /opt/venv
+ 
+ # Set environment variables.
+# 1. Force Python stdout and stderr streams to be unbuffered.
+# 2. Set PORT variable that is used by Gunicorn. This should match "EXPOSE"
+#    command.
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PORT=8000 \
+    PATH="/opt/venv/bin:$PATH"
+
 
 # Use /app folder as a directory where the source code is stored.
 WORKDIR /app
@@ -38,6 +56,7 @@ WORKDIR /app
 # uses SQLite, the folder needs to be owned by the user that
 # will be writing to the database file.
 RUN chown wagtail:wagtail /app
+
 
 # Copy the source code of the project into the container.
 COPY --chown=wagtail:wagtail . .
@@ -48,13 +67,17 @@ USER wagtail
 # Collect static files.
 RUN python manage.py collectstatic --noinput --clear
 
+# Port used by this container to serve HTTP.
+EXPOSE 8000
+
 # Runtime command that executes when "docker run" is called, it does the
 # following:
-#   1. Migrate the database.
-#   2. Start the application server.
-# WARNING:
-#   Migrating database at the same time as starting the server IS NOT THE BEST
-#   PRACTICE. The database should be migrated manually or using the release
-#   phase facilities of your hosting platform. This is used only so the
-#   Wagtail instance can be started with a simple "docker run" command.
-CMD set -xe; python manage.py migrate --noinput; gunicorn {{ project_name }}.wsgi:application
+    #   1. Migrate the database.
+    #   2. Start the application server.
+    # WARNING:
+        #   Migrating database at the same time as starting the server IS NOT THE BEST
+        #   PRACTICE. The database should be migrated manually or using the release
+        #   phase facilities of your hosting platform. This is used only so the
+        #   Wagtail instance can be started with a simple "docker run" command.
+        CMD ["/bin/sh", "-c", "set -xe; python manage.py migrate --noinput; gunicorn {{ project_name }}.wsgi:application"]
+        


### PR DESCRIPTION
Fixes #13199 
Improves the project template Dockerfile to be production-ready by implementing a multi-stage build.

## Improvements
- **Size Reduction:** The image size is reduced by ~54% (from 620MB to 283MB).
- **Security:** Removed build-essential (GCC) and dev headers from the final runtime image to reduce the attack surface.

## Verification
<img width="635" height="51" alt="image" src="https://github.com/user-attachments/assets/b1ccf444-3071-4b6f-bbf5-32cbab994c6b" />

## Note
It does not yet solve the database migrations mixed with application serving. I have retained this behavior in this PR.

My goal was to treat this as a pure optimization update (reducing image bloat) without breaking the existing experience for developers using docker run. However, if the maintainers prefer to decouple the migrations in this update to strictly follow production best practices, I am happy to make that change!