### PR TITLE
Refactor CreateView/EditView validation logic to support non-form validation

### DIFF
--- a/docs/releases/7.3.md
+++ b/docs/releases/7.3.md
@@ -74,3 +74,7 @@ Previously, when loading fixtures of Page models or other models extending `Tran
 ### Image URL generator changes
 
 The URL `wagtailimages:generate_url` and its associated view class `GenerateURLView` have been replaced. The new dynamic image URL generator UI uses Stimulus, with the URL `wagtailimages:url_generator_output` and the same `URLGeneratorView` as the page itself with async requests now returning HTML partials. Any overrides to those views or their template `wagtailimages/url_generator.html` will need to be adapted.
+
+### Refactored validation logic for generic model `CreateView` and `EditView`
+
+The form validation logic in `wagtail.admin.views.generic.models.CreateView` (aliased as `wagtail.admin.views.generic.CreateView`) and `wagtail.admin.views.generic.models.EditView` (aliased as `wagtail.admin.views.generic.EditView`) has been refactored to better support validation conditions not handled by the form object (such as formsets displayed alongside the form, or a 'locked' status on the model). Any user code that overrides the `post`, `form_valid`, `form_invalid` and/or `get_error_message` methods to implement additional validation will need to be updated. These views now implement a new method `is_valid(form)`, which by default delegates to `form.is_valid()`. To signal a validation error, this method should set the attribute `self.produced_error_message` to the desired error message string, and return `False`. For a generic validation error, this error message string can be obtained from `self.get_error_message()`.

--- a/wagtail/admin/forms/workflows.py
+++ b/wagtail/admin/forms/workflows.py
@@ -179,7 +179,7 @@ class WorkflowContentTypeForm(forms.Form):
 
     def __init__(self, *args, workflow=None, **kwargs):
         self.workflow = workflow
-        if workflow and "initial" not in kwargs:
+        if workflow and workflow.pk and "initial" not in kwargs:
             kwargs["initial"] = {"content_types": workflow.workflow_content_types.all()}
 
         super().__init__(*args, **kwargs)
@@ -206,7 +206,10 @@ class WorkflowContentTypeForm(forms.Form):
         existing_assignments = WorkflowContentType.objects.filter(
             content_type__in=content_types,
             workflow__active=True,
-        ).exclude(workflow=self.workflow)
+        )
+        if self.workflow.pk:
+            existing_assignments = existing_assignments.exclude(workflow=self.workflow)
+
         for assignment in existing_assignments:
             self.add_error(
                 "content_types",

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -184,6 +184,12 @@ class Create(CreateView):
     def get_form_class(self):
         return self.get_edit_handler().get_form_class()
 
+    def get_initial_form_instance(self):
+        # defining this method ensures that self.object is set to a new instance
+        # while constructing the form, making it available to get_pages_formset
+        # and get_content_type_form during is_valid
+        return self.model()
+
     def get_pages_formset(self):
         if self.request.method == "POST":
             return WorkflowPagesFormSet(
@@ -213,36 +219,41 @@ class Create(CreateView):
         context["media"] = form.media + bound_panel.media + pages_formset.media
         return context
 
+    def is_valid(self, form):
+        if not super().is_valid(form):
+            return False
+
+        self.pages_formset = self.get_pages_formset()
+        self.content_type_form = self.get_content_type_form()
+
+        if not self.pages_formset.is_valid() or not self.content_type_form.is_valid():
+            self.produced_error_message = self.get_error_message()
+            return False
+
+        return True
+
     def form_valid(self, form):
         self.form = form
 
         with transaction.atomic():
             self.object = self.save_instance()
 
-            pages_formset = self.get_pages_formset()
-            content_type_form = self.get_content_type_form()
-            if pages_formset.is_valid() and content_type_form.is_valid():
-                pages_formset.save()
-                content_type_form.save()
+            self.pages_formset.save()
+            self.content_type_form.save()
 
-                success_message = self.get_success_message(self.object)
-                if success_message is not None:
-                    messages.success(
-                        self.request,
-                        success_message,
-                        buttons=[
-                            messages.button(
-                                reverse(self.edit_url_name, args=(self.object.id,)),
-                                _("Edit"),
-                            )
-                        ],
-                    )
-                return redirect(self.get_success_url())
-
-            else:
-                transaction.set_rollback(True)
-
-        return self.form_invalid(form)
+            success_message = self.get_success_message(self.object)
+            if success_message is not None:
+                messages.success(
+                    self.request,
+                    success_message,
+                    buttons=[
+                        messages.button(
+                            reverse(self.edit_url_name, args=(self.object.id,)),
+                            _("Edit"),
+                        )
+                    ],
+                )
+            return redirect(self.get_success_url())
 
 
 class Edit(EditView):
@@ -326,42 +337,50 @@ class Edit(EditView):
     def get_enable_url(self):
         return reverse(self.enable_url_name, args=(self.object.pk,))
 
+    def is_valid(self, form):
+        if not super().is_valid(form):
+            return False
+
+        if self.object.active:
+            # Note: These are hidden when the workflow is inactive
+            self.pages_formset = self.get_pages_formset()
+            self.content_type_form = self.get_content_type_form()
+
+            if (
+                not self.pages_formset.is_valid()
+                or not self.content_type_form.is_valid()
+            ):
+                self.produced_error_message = self.get_error_message()
+                return False
+
+        return True
+
     @transaction.atomic()
     def form_valid(self, form):
         self.form = form
 
         with transaction.atomic():
             self.object = self.save_instance()
-            successful = True
 
-            # Save pages formset and content type form
-            # Note: These are hidden when the workflow is inactive
             if self.object.active:
-                pages_formset = self.get_pages_formset()
-                content_type_form = self.get_content_type_form()
-                if pages_formset.is_valid() and content_type_form.is_valid():
-                    pages_formset.save()
-                    content_type_form.save()
-                else:
-                    transaction.set_rollback(True)
-                    successful = False
+                # Save pages formset and content type form
+                # Note: These are hidden when the workflow is inactive
+                self.pages_formset.save()
+                self.content_type_form.save()
 
-            if successful:
-                success_message = self.get_success_message()
-                if success_message is not None:
-                    messages.success(
-                        self.request,
-                        success_message,
-                        buttons=[
-                            messages.button(
-                                reverse(self.edit_url_name, args=(self.object.id,)),
-                                _("Edit"),
-                            )
-                        ],
-                    )
-                return redirect(self.get_success_url())
-
-        return self.form_invalid(form)
+            success_message = self.get_success_message()
+            if success_message is not None:
+                messages.success(
+                    self.request,
+                    success_message,
+                    buttons=[
+                        messages.button(
+                            reverse(self.edit_url_name, args=(self.object.id,)),
+                            _("Edit"),
+                        )
+                    ],
+                )
+            return redirect(self.get_success_url())
 
 
 class Disable(DeleteView):


### PR DESCRIPTION
A rabbit-hole I went down while trying to implement `Accept: application/json` error responses for the snippet create/edit views for the autosave MVP, and figured would be best handled in its own PR...

The form validation logic we inherit from Django's `BaseCreateView` / `BaseUpdateView` is heavily coupled to the `form.is_valid()` method, meaning that we need to do some pretty messy things to accommodate validation conditions that arise outside of the form:

* `wagtail.admin.views.workflows` has a formset and secondary form alongside the primary one, which are validated within `form_valid` after the primary form has been saved, relying on transactions to roll this back in case of validation error
* `CreateEditViewOptionalFeaturesMixin` overrides `post` to check the model's `locked` flag, and then `get_error_message` has to repeat that logic because `form_invalid` has no knowledge of why we've ended up there...

To fix this, we introduce a new `is_valid(form)` method on the view, which by default calls `form.is_valid()` but can be overridden to add validation checks on any other state the view is holding on to. In the case of a validation error, it sets the attribute `self.produced_error_message` (unfortunately `self.error_message` was already taken by the template string for the validation error message...) to be picked up by `form_invalid`.