### PR TITLE
Lower default AVIF encoding quality from 80 to 73. Fix #13432

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Add `ModelViewSet.pk_path_converter` with defaults for `IntegerField` and `UUIDField` primary keys (Seb Corbin)
  * Improve accessibility for sidebar menu with visual active (expanded) menu item indicators (Vignesh Shivhare)
  * Add `before_edit_setting` / `after_edit_setting` hooks (Baptiste Mispelon)
+ * Lower default AVIF encoding quality from 80 to 73 (Thibaud Colas)
  * Fix: Do not try to resolve locale during fixture load (Jake Howard, Seb Corbin)
  * Fix: Gracefully handle oEmbed responses with a non-200 status or missing type (Shivam Kumar, Bhavesh Sharma)
  * Fix: Keep action button labelled as "Publish" rather than "Schedule to publish" if go-live date has passed (Vishrut Ramraj)

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -446,7 +446,7 @@ Change the global default for WebP image encoding quality (default: 80).
 WAGTAILIMAGES_AVIF_QUALITY = 65
 ```
 
-Change the global default for AVIF image encoding quality (default: 80).
+Change the global default for AVIF image encoding quality (default: 73).
 
 ### `WAGTAILIMAGES_HEIC_QUALITY`
 

--- a/docs/releases/7.3.md
+++ b/docs/releases/7.3.md
@@ -11,7 +11,6 @@ depth: 1
 
 ## What's new
 
-
 ### Other features
 
  * Resize overly large avatar images on upload (Harshit Ranjan)
@@ -20,6 +19,7 @@ depth: 1
  * Add [`ModelViewSet.pk_path_converter`](ModelViewSet.pk_path_converter) with defaults for `IntegerField` and `UUIDField` primary keys (Seb Corbin)
  * Improve accessibility for sidebar menu with visual active (expanded) menu item indicators (Vignesh Shivhare)
  * Add [`before_edit_setting`](before_edit_setting) / [`after_edit_setting`](after_edit_setting) hooks (Baptiste Mispelon)
+ * Lower default AVIF encoding quality from 80 to 73 (Thibaud Colas)
 
 ### Bug fixes
 
@@ -66,6 +66,10 @@ depth: 1
 ### Loading of fixtures containing models referencing `Locale`
 
 Previously, when loading fixtures of Page models or other models extending `TranslatableMixin`, missing `locale_id` values would be automatically filled with the default Locale. This could break the setup of TransactionTestCase, and so this functionality has now been removed. Fixtures must now specify an explicit `locale_id` value.
+
+### New default AVIF quality
+
+The `WAGTAILIMAGES_AVIF_QUALITY` default quality for AVIF image conversions has been lowered from 80 to 73, to provide more comparable perceptual quality to the JPEG default of 85, at smaller file sizes. If your site sets `WAGTAILIMAGES_JPEG_QUALITY` lower or higher than the default of 85, consider setting `WAGTAILIMAGES_AVIF_QUALITY` to a correspondingly lower or higher value to maintain consistent quality across formats.
 
 ## Upgrade considerations - deprecation of old functionality
 

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -474,7 +474,7 @@ representing the color you would like to use:
 
 ## Image quality
 
-Wagtail's JPEG image quality settings default to 85 (which is quite high). AVIF and WebP default to 80.
+Wagtail's JPEG image quality settings default to 85 (which is quite high). WebP defaults to 80, AVIF defaults to 73.
 This can be changed either globally or on a per-tag basis.
 
 ### Changing globally

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1139,7 +1139,7 @@ class Filter:
                 elif "avif-quality" in env:
                     quality = env["avif-quality"]
                 else:
-                    quality = getattr(settings, "WAGTAILIMAGES_AVIF_QUALITY", 80)
+                    quality = getattr(settings, "WAGTAILIMAGES_AVIF_QUALITY", 73)
                 return willow.save_as_avif(output, quality=quality)
             elif output_format == "heic":
                 # Allow changing of HEIC compression quality. Safari is the only browser that supports HEIC,

--- a/wagtail/images/tests/test_image_operations.py
+++ b/wagtail/images/tests/test_image_operations.py
@@ -762,7 +762,7 @@ class TestAvifQualityFilter(TestCase):
         with patch("PIL.Image.Image.save") as save:
             fil.run(image, f)
 
-        save.assert_called_with(f, "AVIF", quality=80)
+        save.assert_called_with(f, "AVIF", quality=73)
 
     def test_avif_quality_filter(self):
         fil = Filter(spec="width-400|avifquality-40|format-avif")


### PR DESCRIPTION
See #13432 for rationale on the change and proposed value.