### PR TITLE
Fix snippet-string-primary-key test to avoid dependence on database collation order

### DIFF
--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -6072,9 +6072,9 @@ class TestSnippetViewWithCustomPrimaryKey(WagtailTestUtils, TestCase):
 
         snippets = StandardSnippetWithCustomPrimaryKey.objects.all()
         self.assertEqual(snippets.count(), 3)
-        self.assertEqual(
-            snippets.order_by("snippet_id").last().snippet_id, "snippet_id_edited"
-        )
+        # Saving with a new primary key creates a new instance
+        self.assertTrue(snippets.filter(snippet_id="snippet_id_edited").exists())
+        self.assertTrue(snippets.filter(snippet_id="snippet/01").exists())
 
     def test_create(self):
         response = self.create(


### PR DESCRIPTION
Through a series of unfortunate edits 8 years ago (4adf3ebc5d0f4fc86ac429cd1cde39fa4be2342f followed by 418af66f014d118c264091a32f5501f9be63692e), we accidentally ended up with the test TestSnippetViewWithCustomPrimaryKey.test_edit being sensitive to the relative ordering of the strings `snippet/01` and `snippet_id_edited`, which apparently isn't the same in ASCII as in Postgres's `en_US.UTF-8` collation, and has therefore started breaking on my machine.

This test doesn't really need to order anything (it's just checking that a new snippet has been created with the passed ID alongside the one previously being edited) so rewrite it to not do that.
