### PR TITLE
Update formatting for PageQuerySet.prefetch_related reference

### DIFF
--- a/docs/reference/pages/queryset_reference.md
+++ b/docs/reference/pages/queryset_reference.md
@@ -287,20 +287,20 @@ menu_items = homepage.get_children().live().in_menu()
 
     .. automethod:: prefetch_related
 
-        #### Performance considerations
+        .. note::
 
-        Typical usage of `prefetch_related()` results in an additional database query
-        being executed for each of the provided `lookups`. However, when combined with
-        `for_specific_subqueries=True`, this additional number of database queries is
-        multiplied for each specific type in the result. If you are only fetching
-        a small number of objects, or the type-variance of results is likely to be high,
-        the additional overhead of making these additional queries could actually have a
-        negative impact on performance.
+            Typical usage of ``prefetch_related()`` results in an additional database query
+            being executed for each of the provided ``lookups``. However, when combined with
+            ``for_specific_subqueries=True``, this additional number of database queries is
+            multiplied for each specific type in the result. If you are only fetching
+            a small number of objects, or the type-variance of results is likely to be high,
+            the additional overhead of making these additional queries could actually have a
+            negative impact on performance.
 
-        Using `prefetch_related()` with `for_specific_subqueries=True` should be reserved
-        for cases where a large number of results is needed, or the type-variance is
-        retricted in some way. For example, when rendering a list of child pages where
-        `allow_subtypes` is set on the parent, limiting the results to a small number of
-        page types. Or, where the `type()` or `not_type()` filters have been applied to
-        restrict the queryset to a small number of specific types.
+            Using ``prefetch_related()`` with ``for_specific_subqueries=True`` should be reserved
+            for cases where a large number of results is needed, or the type-variance is
+            restricted in some way. For example, when rendering a list of child pages where
+            ``allow_subtypes`` is set on the parent, limiting the results to a small number of
+            page types. Or, where the ``type()`` or ``not_type()`` filters have been applied to
+            restrict the queryset to a small number of specific types.
 ```


### PR DESCRIPTION
Update the formatting for the `PageQuerySet.prefetch_related` reference documentation as this does not appear to be rendering quite correctly. I guess this is because it uses markdown syntax is used within an `eval-rst` block.

https://docs.wagtail.org/en/stable/reference/pages/queryset_reference.html#wagtail.query.PageQuerySet.prefetch_related

I moved the contents to a note, which seemed to me to be similar to other usages on this page of the docs, although it does lose that the note is related to performance considerations. It would also be possible to use a restructured text heading instead if that is preferable.