### PR TITLE
Fixed #13646 -- Add routablefullpageurl template tag

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Changelog
  * Preserve "Collapse all" button state when switching between editor tabs (Raghad Dahi)
  * Upgrade modelsearch to 1.3 (Matt Westcott)
  * Implement checker error highlights within the preview panel (Thibaud Colas)
+ * Add `routablefullpageurl` template tag (Pravin Kamble)
  * Add support for customizing page explorer views per page type using `PageViewSet` (Sage Abdullah)
  * Fix: Handle nested inline models when displaying object usage information (Sage Abdullah, Kacper Walęga, Tian Jie Wong)
  * Fix: Avoid duplicate `get_object()` DB query in API detail view (Siddheshwar Kadam)

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -70,6 +70,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Preserve "Collapse all" button state when switching between editor tabs (Raghad Dahi)
  * Refine hover / focus styles for title field’s comment button (Srishti Jaiswal)
  * Implement checker error highlights within the preview panel (Thibaud Colas)
+ * Add `routablefullpageurl` template tag (Pravin Kamble)
 
 ### Bug fixes
 

--- a/wagtail/contrib/routable_page/templatetags/wagtailroutablepage_tags.py
+++ b/wagtail/contrib/routable_page/templatetags/wagtailroutablepage_tags.py
@@ -26,3 +26,25 @@ def routablepageurl(context, page, url_name, *args, **kwargs):
     if not base_url.endswith("/"):
         base_url += "/"
     return base_url + routed_url
+
+
+@register.simple_tag(takes_context=True)
+def routablefullpageurl(context, page, url_name, *args, **kwargs):
+    """
+    ``routablefullpageurl`` is similar to ``routablepageurl``, but returns
+    the full absolute URL (including protocol and domain).
+    """
+    request = context.get("request")
+    base_url = page.get_full_url(request=request)
+
+    if not base_url:
+        return ""
+
+    routed_url = page.reverse_subpage(url_name, args=args, kwargs=kwargs)
+
+    if not base_url.endswith("/"):
+        base_url += "/"
+    if routed_url.startswith("/"):
+        routed_url = routed_url[1:]
+
+    return base_url + routed_url

--- a/wagtail/contrib/routable_page/templatetags/wagtailroutablepage_tags.py
+++ b/wagtail/contrib/routable_page/templatetags/wagtailroutablepage_tags.py
@@ -34,17 +34,9 @@ def routablefullpageurl(context, page, url_name, *args, **kwargs):
     ``routablefullpageurl`` is similar to ``routablepageurl``, but returns
     the full absolute URL (including protocol and domain).
     """
-    request = context.get("request")
+    request = context["request"]
     base_url = page.get_full_url(request=request)
-
-    if not base_url:
-        return ""
-
     routed_url = page.reverse_subpage(url_name, args=args, kwargs=kwargs)
-
     if not base_url.endswith("/"):
         base_url += "/"
-    if routed_url.startswith("/"):
-        routed_url = routed_url[1:]
-
     return base_url + routed_url

--- a/wagtail/contrib/routable_page/tests.py
+++ b/wagtail/contrib/routable_page/tests.py
@@ -7,6 +7,7 @@ from django.urls import path
 from django.urls.exceptions import NoReverseMatch
 
 from wagtail.contrib.routable_page.templatetags.wagtailroutablepage_tags import (
+    routablefullpageurl,
     routablepageurl,
 )
 from wagtail.models import Page, Site
@@ -505,6 +506,47 @@ class TestRoutablePageTemplateTagForSecondSiteAtDifferentRoot(TestCase):
     def test_templatetag_reverse_external_view_without_append_slash(self):
         with mock.patch("wagtail.models.pages.WAGTAIL_APPEND_SLASH", False):
             url = routablepageurl(
+                self.context, self.routable_page, "external_view", "joe-bloggs"
+            )
+            expected = (
+                "http://localhost/"
+                + self.routable_page.slug
+                + "/"
+                + "external/joe-bloggs/"
+            )
+
+        self.assertEqual(url, expected)
+
+
+class TestRoutableFullPageUrlTemplateTag(TestCase):
+    def setUp(self):
+        self.home_page = Page.objects.get(id=2)
+        self.routable_page = self.home_page.add_child(
+            instance=RoutablePageTest(
+                title="Routable Page",
+                live=True,
+            )
+        )
+
+        self.rf = RequestFactory()
+        self.request = self.rf.get(self.routable_page.url)
+        self.context = {"request": self.request}
+
+    def test_templatetag_reverse_index_route(self):
+        url = routablefullpageurl(self.context, self.routable_page, "index_route")
+        self.assertEqual(url, "http://localhost/%s/" % self.routable_page.slug)
+
+    def test_templatetag_reverse_archive_by_year_view(self):
+        url = routablefullpageurl(
+            self.context, self.routable_page, "archive_by_year", "2014"
+        )
+        self.assertEqual(
+            url, "http://localhost/%s/archive/year/2014/" % self.routable_page.slug
+        )
+
+    def test_templatetag_reverse_external_view_without_append_slash(self):
+        with mock.patch("wagtail.models.pages.WAGTAIL_APPEND_SLASH", False):
+            url = routablefullpageurl(
                 self.context, self.routable_page, "external_view", "joe-bloggs"
             )
             expected = (

--- a/wagtail/contrib/routable_page/tests.py
+++ b/wagtail/contrib/routable_page/tests.py
@@ -518,7 +518,7 @@ class TestRoutablePageTemplateTagForSecondSiteAtDifferentRoot(TestCase):
         self.assertEqual(url, expected)
 
 
-class TestRoutableFullPageUrlTemplateTag(TestCase):
+class TestRoutableFullPageURLTemplateTag(TestCase):
     def setUp(self):
         self.home_page = Page.objects.get(id=2)
         self.routable_page = self.home_page.add_child(


### PR DESCRIPTION

This PR fixes #13646 
Adds the `routablefullpageurl` template tag to provide absolute URLs for routable pages, consistent with the existing `fullpageurl tag`.

Thanks @thibaudcolas  for report.

