### PR TITLE
Fix #13662: Standardize form panel spacing

### DIFF
--- a/client/scss/components/_panel.scss
+++ b/client/scss/components/_panel.scss
@@ -174,7 +174,7 @@ $header-button-size: theme('spacing.6');
   border: 1px solid theme('colors.border-furniture');
   border-radius: 5px;
   margin-bottom: calc(
-    theme('spacing.4') + theme('spacing.4') * var(--w-density-factor)
+    theme('spacing.5') + theme('spacing.5') * var(--w-density-factor)
   );
 
   .w-panel__header {


### PR DESCRIPTION
 Problem:
 The Wagtail admin page editor had inconsistent vertical spacing between different types of form panels. Dashboard panels (`.w-panel--dashboard`) used a smaller margin-bottom of `theme('spacing.4')` (~16px) while regular panels (`.w-panel`) used `theme('spacing.5')` (~20px), creating an uneven visual rhythm that made the interface harder to scan.

Solution:
Updated the `.w-panel--dashboard` margin-bottom to use `theme('spacing.5')` to match the standard panel spacing. This ensures all panel types have consistent spacing throughout the page editor, creating a more polished and professional appearance.
 Both values continue to respect the `--w-density-factor` CSS variable for user-configurable spacing adjustments.
 
 Changes Made
-client/scss/components/_panel.scss :
 Changed `.w-panel--dashboard` margin-bottom from `theme('spacing.4')` to `theme('spacing.5')` on line 177

 Testing
 - Built the CSS assets successfully with `npm run build`
 - Verified the change compiles correctly

Fixes #13662  