### PR TITLE
docs: add wagtailcore to list of apps using signal receivers

### DIFF
--- a/docs/reference/signals.md
+++ b/docs/reference/signals.md
@@ -1,5 +1,14 @@
 # Signals
 
+The following Wagtail apps define signal receivers:
+
+- wagtailcore
+- wagtailadmin
+- wagtaildocs
+- wagtailimages
+- wagtailusers
+
+
 Wagtail's [](revision_model_ref) and [](page_model_ref) implement [Signals](inv:django#topics/signals) from `django.dispatch`.
 Signals are useful for creating side-effects from page publish/unpublish events.
 


### PR DESCRIPTION
_Please describe the problem you're fixing here, including the issue number if any. For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md_
Adds `wagtailcore` to the list of apps that define signal receivers.

Closes #13623.
