### PR TITLE
Add concurrent index for fast wagtailcore_revision lookup (#13547)

### DIFF
--- a/wagtail/migrations/0097_add_revision_lookup_index.py
+++ b/wagtail/migrations/0097_add_revision_lookup_index.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtailcore", "0096_referenceindex_referenceindex_source_object_and_more"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS wagtailcore_revision_content_lookup
+                ON wagtailcore_revision (base_content_type_id, object_id, created_at DESC);
+            """,
+            reverse_sql="""
+                DROP INDEX CONCURRENTLY IF EXISTS wagtailcore_revision_content_lookup;
+            """,
+        ),
+    ]


### PR DESCRIPTION
This PR adds a concurrent index on wagtailcore_revision
(base_content_type_id, object_id, created_at DESC) to speed up queries.

- Production-safe migration (uses RunSQL with CONCURRENTLY)
- No changes to models.py
- Issue reference: #13547
