### PR TITLE
Add concurrent index for fast wagtailcore_revision lookup (#13547)

### DIFF
--- a/wagtail/migrations/0097_add_revision_lookup_index.py
+++ b/wagtail/migrations/0097_add_revision_lookup_index.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtailcore", "0096_referenceindex_referenceindex_source_object_and_more"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS wagtailcore_revision_content_lookup
+                ON wagtailcore_revision (base_content_type_id, object_id, created_at DESC);
+            """,
+            reverse_sql="""
+                DROP INDEX CONCURRENTLY IF EXISTS wagtailcore_revision_content_lookup;
+            """,
+        ),
+    ]


### PR DESCRIPTION
Thanks for pointing this out!

You're right — CREATE INDEX CONCURRENTLY is PostgreSQL-only.
I missed the fact that Wagtail migrations must remain database-agnostic.

I’ll close this PR and look into alternative approaches that are compatible
with all supported databases, or a PostgreSQL-specific optimization if that
fits the project’s policy.

Thanks again for the clarification.
