### PR TITLE
Docs: add short note about rebuilding admin assets after upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ python manage.py createsuperuser
 python manage.py runserver
 ```
 
+⚠️ Admin frontend assets
+
+After upgrading Wagtail or switching branches, the admin UI may still load with
+outdated frontend assets, causing broken or inconsistent behavior.
+
+If you encounter unexpected admin issues, rebuild the assets:
+
+    npm install
+    npm run build
+    
 For detailed installation and setup docs, see [the getting started tutorial](https://docs.wagtail.org/en/stable/getting_started/tutorial.html).
 
 ### 👨‍👩‍👧‍👦 Who’s using it?


### PR DESCRIPTION
PR ISSUE:- Document need to rebuild admin assets after Wagtail upgrades #13686 
Adding a short note in the README to remind contributors to rebuild admin assets
(`npm install && npm run build`) would help avoid this confusion.