### PR TITLE
Fix textarea overflow in Comment component

### DIFF
--- a/client/src/components/CommentApp/components/Comment/style.scss
+++ b/client/src/components/CommentApp/components/Comment/style.scss
@@ -41,6 +41,7 @@ $box-padding: 20px;
     border: 1px solid theme('colors.border-field-default');
     border-radius: 5px;
     color: $color-box-text;
+    box-sizing: border-box;
 
     &::placeholder {
       color: theme('colors.text-placeholder');


### PR DESCRIPTION
## Description

Fixes #10233 - Box Overflow in Add New Comment - Wagtail Storybook

The textarea for adding new comments was overflowing its container due to missing `box-sizing: border-box`. The `.comment` container has a fixed width of 300px, and the textarea inside has `width: 100%` plus `padding: 12px` and `border: 1px`. Without `box-sizing: border-box`, the actual rendered width exceeded 300px, causing the overflow.

## Changes

Added `box-sizing: border-box` to the textarea CSS rule in `client/src/components/CommentApp/components/Comment/style.scss`.

```diff
  textarea {
    margin: 0;
    padding: 12px;
    width: 100%;
    background-color: theme('colors.surface-field');
    border: 1px solid theme('colors.border-field-default');
    border-radius: 5px;
    color: $color-box-text;
+   box-sizing: border-box;
```

## Testing

Verified in Storybook:
- ✅ "Add New Comment" story - textarea is now contained within the box
- ✅ Long text input wraps correctly without overflow
- ✅ "Comment" story - existing comments display correctly (no regression)
- ✅ "Comment From Someone With A Really Long Name" - layout unaffected

## Browser Testing

Tested in: Chrome (latest)

---

## AI Disclosure

This contribution was developed with AI assistance (Claude/Anthropic). The following steps were taken to verify correctness:

1. **Manual code review**: Analyzed the CSS box model issue and confirmed the root cause
2. **Storybook verification**: Ran Storybook locally and manually tested multiple comment-related stories
3. **Visual inspection**: Confirmed the textarea is properly contained within the comment box
4. **Regression testing**: Verified existing comment stories remain unaffected