### PR TITLE
Update Image/Embed tooltip styles to match the inline toolbar

### DIFF
--- a/client/src/components/Draftail/Tooltip/Tooltip.scss
+++ b/client/src/components/Draftail/Tooltip/Tooltip.scss
@@ -22,24 +22,19 @@ $tooltip-color-no: theme('colors.critical.100');
 }
 
 @mixin arrow--left {
-  margin-inline-start: $tooltip-arrow-spacing;
+  margin-inline-start: $tooltip-spacing;
   transform: translateY(-50%);
 
   &::before {
-    top: 50%;
-    inset-inline-end: 100%;
-    transform: translateY(-50%);
-    border-inline-end-color: $tooltip-chrome;
+    content: none;
   }
 }
 
 @mixin arrow--top-left {
-  margin-top: $tooltip-arrow-spacing;
+  margin-top: $tooltip-spacing;
 
   &::before {
-    bottom: 100%;
-    inset-inline-start: $tooltip-arrow-spacing;
-    border-bottom-color: $tooltip-chrome;
+    content: none;
   }
 }
 

--- a/client/src/components/Draftail/blocks/EmbedBlock.js
+++ b/client/src/components/Draftail/blocks/EmbedBlock.js
@@ -31,14 +31,14 @@ const EmbedBlock = (props) => {
         </a>
       ) : null}
       <button
-        className="button Tooltip__button"
+        className="button button-small Tooltip__button"
         type="button"
         onClick={onEditEntity}
       >
         {gettext('Edit')}
       </button>
       <button
-        className="button button-secondary no Tooltip__button"
+        className="button button-small button-secondary no Tooltip__button"
         onClick={onRemoveEntity}
       >
         {gettext('Delete')}

--- a/client/src/components/Draftail/blocks/ImageBlock.js
+++ b/client/src/components/Draftail/blocks/ImageBlock.js
@@ -21,14 +21,14 @@ const ImageBlock = (props) => {
       <p className="ImageBlock__alt">{altLabel}</p>
 
       <button
-        className="button Tooltip__button"
+        className="button button-small Tooltip__button"
         type="button"
         onClick={onEditEntity}
       >
         {gettext('Edit')}
       </button>
       <button
-        className="button button-secondary no Tooltip__button"
+        className="button button-small button-secondary no Tooltip__button"
         onClick={onRemoveEntity}
       >
         {gettext('Delete')}

--- a/client/src/components/Draftail/blocks/__snapshots__/EmbedBlock.test.js.snap
+++ b/client/src/components/Draftail/blocks/__snapshots__/EmbedBlock.test.js.snap
@@ -18,13 +18,13 @@ exports[`EmbedBlock no data 1`] = `
   src={null}
 >
   <button
-    className="button Tooltip__button"
+    className="button button-small Tooltip__button"
     type="button"
   >
     Edit
   </button>
   <button
-    className="button button-secondary no Tooltip__button"
+    className="button button-small button-secondary no Tooltip__button"
   >
     Delete
   </button>
@@ -58,13 +58,13 @@ exports[`EmbedBlock renders 1`] = `
     Test title
   </a>
   <button
-    className="button Tooltip__button"
+    className="button button-small Tooltip__button"
     type="button"
   >
     Edit
   </button>
   <button
-    className="button button-secondary no Tooltip__button"
+    className="button button-small button-secondary no Tooltip__button"
   >
     Delete
   </button>

--- a/client/src/components/Draftail/blocks/__snapshots__/ImageBlock.test.js.snap
+++ b/client/src/components/Draftail/blocks/__snapshots__/ImageBlock.test.js.snap
@@ -23,13 +23,13 @@ exports[`ImageBlock alt 1`] = `
     Alt text: “Test”
   </p>
   <button
-    className="button Tooltip__button"
+    className="button button-small Tooltip__button"
     type="button"
   >
     Edit
   </button>
   <button
-    className="button button-secondary no Tooltip__button"
+    className="button button-small button-secondary no Tooltip__button"
   >
     Delete
   </button>
@@ -59,13 +59,13 @@ exports[`ImageBlock no data 1`] = `
     Decorative image
   </p>
   <button
-    className="button Tooltip__button"
+    className="button button-small Tooltip__button"
     type="button"
   >
     Edit
   </button>
   <button
-    className="button button-secondary no Tooltip__button"
+    className="button button-small button-secondary no Tooltip__button"
   >
     Delete
   </button>
@@ -95,13 +95,13 @@ exports[`ImageBlock renders 1`] = `
     Decorative image
   </p>
   <button
-    className="button Tooltip__button"
+    className="button button-small Tooltip__button"
     type="button"
   >
     Edit
   </button>
   <button
-    className="button button-secondary no Tooltip__button"
+    className="button button-small button-secondary no Tooltip__button"
   >
     Delete
   </button>


### PR DESCRIPTION
## Description

Fixes #10670 - Update Image/Embed tooltip styles to match the styles of the inline toolbar.

This is a follow-up to #10639 which updated the Link/Document tooltips. Now the Image/Embed "MediaBlock" rich text tooltips receive the same treatment.

## Changes

### Tooltip.scss
- Updated `--left` and `--top-left` mixins to:
  - Remove the arrow by setting `content: none` on `::before`
  - Adjust spacing to use `$tooltip-spacing` instead of `$tooltip-arrow-spacing`

### ImageBlock.js & EmbedBlock.js
- Added `button-small` class to both Edit and Delete buttons for consistency with the inline toolbar

### Snapshots
- Updated 5 related snapshot tests

## Checklist from Issue
- [x] Remove the arrow
- [x] Tweak the spacing  
- [x] Make the buttons smaller

## Browser Testing

Tested in: Chrome (latest)

---

## AI Disclosure

This contribution was developed with AI assistance (Claude/Anthropic). The following steps were taken to verify correctness:

1. **Code analysis**: Reviewed PR #10639 as the reference implementation and applied the same pattern
2. **Test verification**: Ran `jest --updateSnapshot` - all 5 tests passed
3. **Pattern consistency**: Ensured changes follow the exact same approach as the Link/Document tooltip fix