### PR TITLE
Fix ImageBlock alt text not populating from decorative state

### DIFF
--- a/client/src/entrypoints/images/image-block.js
+++ b/client/src/entrypoints/images/image-block.js
@@ -20,8 +20,11 @@ class ImageBlockDefinition extends window.wagtailStreamField.blocks
     imageChooserWidget.addEventListener('chosen', ({ detail: data }) => {
       /* If the alt text field has not been changed from the previous image's default alt text
       (or the empty string, if there was no previous image), replace it with the new image's
-      default alt text */
-      if (altTextField.value === lastDefaultAltText) {
+      default alt text. Also populate if the field is empty (e.g., after switching from decorative). */
+      if (
+        altTextField.value === lastDefaultAltText ||
+        altTextField.value === ''
+      ) {
         altTextField.value = data.default_alt_text;
       }
       lastDefaultAltText = data.default_alt_text;


### PR DESCRIPTION
## Description

Fixes #12858 - ImageBlock Alt Text not populated when switching from decorative state.

When a user:
1. Creates an ImageBlock with "Decorative" checked
2. Saves
3. Returns and unchecks "Decorative"  
4. Chooses a new image

The alt text field was remaining empty instead of being populated with the new image's description.

## Root Cause

In `image-block.js`, the 'chosen' event handler only populates alt text if:
```javascript
altTextField.value === lastDefaultAltText
```

For a decorative image, `altTextField.value` is empty (`''`), while `lastDefaultAltText` contains the previous image's description. Since they don't match, the new image's description was never applied.

## Changes

Added condition to also populate alt text when the field is empty:

```diff
- if (altTextField.value === lastDefaultAltText) {
+ if (altTextField.value === lastDefaultAltText || altTextField.value === '') {
```

## Testing

- ✅ All existing tests pass (3/3)
- Covers the decorative→non-decorative transition case as described in the issue

---

## AI Disclosure

This contribution was developed with AI assistance (Claude/Anthropic). The following steps were taken to verify correctness:

1. **Code analysis**: Traced through the logic to understand why empty alt text wasn't being populated
2. **Test verification**: Ran `jest --testPathPattern=image` - all 3 tests passed
3. **Minimal change**: Single condition addition that directly addresses the issue