### PR TITLE
Fix incorrect AppConfig class name reference in image docs

### DIFF
--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -340,7 +340,7 @@ class CustomImagesAppConfig(WagtailImagesAppConfig):
     default_attrs = {"decoding": "async", "loading": "lazy"}
 ```
 
-Then, replace `wagtail.images` in `settings.INSTALLED_APPS` with the path to `CustomUsersAppConfig`:
+Then, replace `wagtail.images` in `settings.INSTALLED_APPS` with the path to `CustomImagesAppConfig`:
 
 ```python
 INSTALLED_APPS = [


### PR DESCRIPTION
In the 'Adding default attributes to all images' section, the text referred to CustomUsersAppConfig instead of CustomImagesAppConfig. I have updated it to match the code example above it.