### PR TITLE
Fix comment notifications for comment-only actions and prevent save errors (#13446)

### DIFF
--- a/wagtail/admin/notifications.py
+++ b/wagtail/admin/notifications.py
@@ -1,0 +1,143 @@
+import logging
+
+from django.contrib.auth import get_user_model
+from django.db.models import Prefetch, Q
+
+from wagtail.admin.mail import send_notification
+from wagtail.models import (
+    COMMENTS_RELATION_NAME,
+    Comment,
+    CommentReply,
+    PageSubscription,
+)
+
+logger = logging.getLogger("wagtail.admin")
+
+
+def send_commenting_notifications(changes, page, editor):
+    """
+    Sends notifications about any changes to comments to anyone who is subscribed.
+    """
+    relevant_comment_ids = []
+    relevant_comment_ids.extend(comment.pk for comment in changes["resolved_comments"])
+    relevant_comment_ids.extend(
+        comment.pk for comment, replies in changes["new_replies"]
+    )
+
+    # Skip if no changes were made
+    # Note: We don't email about edited comments so ignore those here
+    if (
+        not changes["new_comments"]
+        and not changes["deleted_comments"]
+        and not changes["resolved_comments"]
+        and not changes["new_replies"]
+    ):
+        return
+
+    # Get global page comment subscribers
+    subscribers = PageSubscription.objects.filter(
+        page=page, comment_notifications=True
+    ).select_related("user")
+    global_recipient_users = [
+        subscriber.user for subscriber in subscribers if subscriber.user != editor
+    ]
+
+    # Get subscribers to individual threads
+    replies = CommentReply.objects.filter(comment_id__in=relevant_comment_ids)
+    comments = Comment.objects.filter(id__in=relevant_comment_ids)
+    thread_users = (
+        get_user_model()
+        .objects.exclude(pk=editor.pk)
+        .exclude(pk__in=subscribers.values_list("user_id", flat=True))
+        .filter(
+            Q(comment_replies__comment_id__in=relevant_comment_ids)
+            | Q(**{("%s__pk__in" % COMMENTS_RELATION_NAME): relevant_comment_ids})
+        )
+        .prefetch_related(
+            Prefetch("comment_replies", queryset=replies),
+            Prefetch(COMMENTS_RELATION_NAME, queryset=comments),
+        )
+    )
+
+    # Skip if no recipients
+    if not (global_recipient_users or thread_users):
+        return
+    thread_users = [
+        (
+            user,
+            set(
+                list(user.comment_replies.values_list("comment_id", flat=True))
+                + list(
+                    getattr(user, COMMENTS_RELATION_NAME).values_list("pk", flat=True)
+                )
+            ),
+        )
+        for user in thread_users
+    ]
+    mailed_users = set()
+
+    for current_user, current_threads in thread_users:
+        # We are trying to avoid calling send_notification for each user for performance reasons
+        # so group the users receiving the same thread notifications together here
+        if current_user in mailed_users:
+            continue
+        users = [current_user]
+        mailed_users.add(current_user)
+        for user, threads in thread_users:
+            if user not in mailed_users and threads == current_threads:
+                users.append(user)
+                mailed_users.add(user)
+        try:
+            send_notification(
+                users,
+                "updated_comments",
+                {
+                    "page": page,
+                    "editor": editor,
+                    "new_comments": [
+                        comment
+                        for comment in changes["new_comments"]
+                        if comment.pk in current_threads
+                    ],
+                    "resolved_comments": [
+                        comment
+                        for comment in changes["resolved_comments"]
+                        if comment.pk in current_threads
+                    ],
+                    "deleted_comments": [],
+                    "replied_comments": [
+                        {
+                            "comment": comment,
+                            "replies": replies,
+                        }
+                        for comment, replies in changes["new_replies"]
+                        if comment.pk in current_threads
+                    ],
+                },
+            )
+        except Exception:
+            # We don't want to fail the whole save if notifications fail
+            logger.exception("Failed to send comment notifications")
+
+    try:
+        send_notification(
+            global_recipient_users,
+            "updated_comments",
+            {
+                "page": page,
+                "editor": editor,
+                "new_comments": changes["new_comments"],
+                "resolved_comments": changes["resolved_comments"],
+                "deleted_comments": changes["deleted_comments"],
+                "replied_comments": [
+                    {
+                        "comment": comment,
+                        "replies": replies,
+                    }
+                    for comment, replies in changes["new_replies"]
+                ],
+            },
+        )
+    except Exception:
+        # We don't want to fail the whole save if notifications fail
+        logger.exception("Failed to send comment notifications")

--- a/wagtail/admin/tests/pages/test_comment_notifications.py
+++ b/wagtail/admin/tests/pages/test_comment_notifications.py
@@ -1,0 +1,139 @@
+from unittest import mock
+
+from django.core import mail
+from django.test import TestCase
+from django.urls import reverse
+
+from wagtail.models import (
+    Comment,
+    Page,
+    PageSubscription,
+)
+from wagtail.test.testapp.models import SimplePage
+from wagtail.test.utils import WagtailTestUtils
+
+
+class TestCommentNotifications(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.root_page = Page.objects.get(id=2)
+        self.child_page = SimplePage(
+            title="Hello world!",
+            slug="hello-world",
+            content="hello",
+        )
+        self.root_page.add_child(instance=self.child_page)
+        self.child_page.save_revision().publish()
+
+        self.user = self.login()
+
+    def test_comment_only_action_triggers_notification(self):
+        subscriber = self.create_user("subscriber")
+        PageSubscription.objects.create(
+            page=self.child_page, user=subscriber, comment_notifications=True
+        )
+
+        comment = Comment.objects.create(
+            page=self.child_page,
+            user=self.user,
+            text="Initial comment",
+            contentpath="title",
+        )
+
+        post_data = {
+            "title": "Hello world!",
+            "content": "hello",
+            "slug": "hello-world",
+            "comments-TOTAL_FORMS": "1",
+            "comments-INITIAL_FORMS": "1",
+            "comments-MIN_NUM_FORMS": "0",
+            "comments-0-resolved": "on",
+            "comments-0-id": str(comment.id),
+            "comments-0-contentpath": "title",
+            "comments-0-text": "Initial comment",
+            "comments-0-replies-TOTAL_FORMS": "0",
+            "comments-0-replies-INITIAL_FORMS": "0",
+        }
+
+        mail.outbox = []
+        self.client.post(
+            reverse("wagtailadmin_pages:edit", args=[self.child_page.id]), post_data
+        )
+
+        self.assertEqual(
+            len(mail.outbox), 1, "Notification was not sent for comment-only action"
+        )
+
+    def test_scoping_bug_fixed(self):
+        user_a = self.create_user("user_a")
+        user_b = self.create_user("user_b")
+
+        # User A is subscribed to thread 1
+        comment_1 = Comment.objects.create(
+            page=self.child_page, user=user_a, text="Thread 1", contentpath="title"
+        )
+        # User B is subscribed to thread 2
+        comment_2 = Comment.objects.create(
+            page=self.child_page, user=user_b, text="Thread 2", contentpath="title"
+        )
+
+        post_data = {
+            "title": "Hello world!",
+            "content": "hello",
+            "slug": "hello-world",
+            "comments-TOTAL_FORMS": "2",
+            "comments-INITIAL_FORMS": "2",
+            "comments-0-id": str(comment_1.id),
+            "comments-0-text": "Thread 1",
+            "comments-0-contentpath": "title",
+            "comments-0-replies-TOTAL_FORMS": "1",
+            "comments-0-replies-INITIAL_FORMS": "0",
+            "comments-0-replies-0-text": "Reply to 1",
+            "comments-1-id": str(comment_2.id),
+            "comments-1-text": "Thread 2",
+            "comments-1-contentpath": "title",
+            "comments-1-replies-TOTAL_FORMS": "1",
+            "comments-1-replies-INITIAL_FORMS": "0",
+            "comments-1-replies-0-text": "Reply to 2",
+        }
+
+        mail.outbox = []
+        self.client.post(
+            reverse("wagtailadmin_pages:edit", args=[self.child_page.id]), post_data
+        )
+
+        self.assertEqual(len(mail.outbox), 2)
+
+        email_a = next(e for e in mail.outbox if user_a.email in e.to)
+        email_b = next(e for e in mail.outbox if user_b.email in e.to)
+
+        self.assertIn("Reply to 1", email_a.body)
+        self.assertNotIn("Reply to 2", email_a.body)
+        self.assertIn("Reply to 2", email_b.body)
+        self.assertNotIn("Reply to 1", email_b.body)
+
+    @mock.patch("wagtail.admin.mail.get_connection")
+    def test_no_500_error_on_notification_failure(self, mock_get_connection):
+        mock_get_connection.side_effect = Exception("SMTP error")
+        subscriber = self.create_user("subscriber")
+        PageSubscription.objects.create(
+            page=self.child_page, user=subscriber, comment_notifications=True
+        )
+
+        post_data = {
+            "title": "Hello world!",
+            "content": "hello",
+            "slug": "hello-world",
+            "comments-TOTAL_FORMS": "1",
+            "comments-INITIAL_FORMS": "0",
+            "comments-0-text": "A test comment",
+            "comments-0-contentpath": "title",
+            "comments-0-replies-TOTAL_FORMS": "0",
+            "comments-0-replies-INITIAL_FORMS": "0",
+        }
+
+        response = self.client.post(
+            reverse("wagtailadmin_pages:edit", args=[self.child_page.id]), post_data
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(Comment.objects.filter(text="A test comment").exists())


### PR DESCRIPTION
Fixes #13446

### Problem
Comment notifications were not consistently sent in some cases, even when notifications were enabled.  
In particular:
- Comment-only actions (such as resolving a thread) did not trigger notifications.
- In some situations, notification sending errors could surface as a 500 response during page save.

### Cause
- Notification sending was gated behind `has_content_changes`, which does not account for comment-only actions.
- The notification dispatch logic did not clearly separate comment activity from page content changes.
- Errors raised while sending notifications were able to interrupt the save flow.

### Solution
This PR:
- Ensures comment-related actions can trigger notifications independently of page content changes.
- Makes notification dispatch more robust by isolating it from the page save lifecycle.
- Prevents notification failures from causing save errors.

### Tests
- Added/updated tests to cover comment-only actions triggering notifications.
- Verified notifications are sent correctly without impacting page saves.
- Existing test suite passes.

### Notes
This change is intended to be minimal and backward-compatible, focusing only on restoring expected notification behavior.