### PR TITLE
bump django-tasks to 0.11.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
             postgres: 'postgres:15'
             experimental: true
             install_extras: |
-              pip install "django-tasks>=0.9,<0.10"
+              pip install "django-tasks>=0.9,<0.12"
           - python: '3.14'
             django: 'git+https://github.com/django/django.git@main#egg=Django'
             psycopg: 'psycopg>=3.1.8'
@@ -119,7 +119,7 @@ jobs:
             postgres: 'postgres:latest'
             parallel: '--parallel'
             install_extras: |
-              pip install "django-tasks>=0.9,<0.10"
+              pip install "django-tasks>=0.9,<0.12"
     services:
       postgres:
         image: ${{ matrix.postgres || 'postgres:12' }}

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,6 +53,7 @@ Changelog
  * Maintenance: Refactor CreateView/EditView validation logic to support non-form validation (Matt Westcott)
  * Maintenance: Formalized support for Django 6.0 (Pravin Kamble)
  * Maintenance: Add `no-jquery` ESLint plugin to start final deprecation of jQuery (LB (Ben) Johnston)
+ * Maintenance: Upgrade to django-tasks 0.11.0 for Django 6.0 and Python 3.11 compatibility (Guilhem Saurel)
 
 
 7.2.1 (26.11.2025)

--- a/docs/releases/7.3.md
+++ b/docs/releases/7.3.md
@@ -86,6 +86,7 @@ This feature was developed by Thibaud Colas.
  * Refactor CreateView/EditView validation logic to support non-form validation (Matt Westcott)
  * Formalized support for Django 6.0 (Pravin Kamble)
  * Add `no-jquery` ESLint plugin to start final deprecation of jQuery (LB (Ben) Johnston)
+ * Upgrade to django-tasks 0.11.0 for Django 6.0 and Python 3.11 compatibility (Guilhem Saurel)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "anyascii>=0.1.5",
   "telepath>=0.3.1,<1",
   "laces>=0.1,<0.2",
-  "django-tasks>=0.8,<0.10",
+  "django-tasks>=0.8,<0.12",
   "modelsearch>=1.1,<1.2",
 ]
 


### PR DESCRIPTION
Hi,

In python 3.11, django-tasks > 0.8.1 and < 0.11.0 is broken: https://github.com/RealOrangeOne/django-tasks/issues/223

Also, django-tasks < 0.10.0 is not compatible with django >= 6: https://github.com/RealOrangeOne/django-tasks/issues/208

So I'm not sure how to correctly specify this all in pyproject.toml, but I think we should at least *allow* django-tasks 0.11.0.