### PR TITLE
Fix/table comment highlighting

### DIFF
--- a/client/src/entrypoints/admin/comments.js
+++ b/client/src/entrypoints/admin/comments.js
@@ -100,11 +100,13 @@ window.comments = (() => {
 
     onFocus() {
       this.node.classList.add('w-field__comment-button--focused');
+      this.fieldNode.classList.add('w-field--comment-focused');
       this.node.ariaLabel = gettext('Unfocus comment');
     }
 
     onUnfocus() {
       this.node.classList.remove('w-field__comment-button--focused');
+      this.fieldNode.classList.remove('w-field--comment-focused');
       this.node.ariaLabel = gettext('Focus comment');
 
       // TODO: ensure comment is focused accessibly when this is clicked,

--- a/client/src/entrypoints/contrib/typed_table_block/__snapshots__/typed_table_block.test.js.snap
+++ b/client/src/entrypoints/contrib/typed_table_block/__snapshots__/typed_table_block.test.js.snap
@@ -38,7 +38,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock it renders cor
             </thead>
             <tbody><tr><td class="control-cell"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-row" aria-label="Insert row" title="Insert row">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
-      </button></td><td><div class="w-field__wrapper" data-field-wrapper="">
+      </button></td><td><div class="w-field__wrapper" data-field-wrapper="" data-contentpath="rows.0.values.0">
         <div class="w-field w-field--char_field w-field--text_input" data-field="">
           <div class="w-field__errors" id="mytable-cell-0-0-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true" hidden=""><use href="#icon-warning"></use></svg>
@@ -48,7 +48,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock it renders cor
             <p name="mytable-cell-0-0" id="mytable-cell-0-0">Block A widget</p>
           </div>
         </div>
-      </div></td><td><div class="w-field__wrapper" data-field-wrapper="">
+      </div></td><td><div class="w-field__wrapper" data-field-wrapper="" data-contentpath="rows.0.values.1">
         <div class="w-field w-field--char_field w-field--admin_auto_height_text_input" data-field="">
           <div class="w-field__errors" id="mytable-cell-0-1-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true" hidden=""><use href="#icon-warning"></use></svg>
@@ -62,7 +62,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock it renders cor
         <svg class="icon icon-bin icon" aria-hidden="true"><use href="#icon-bin"></use></svg>
       </button></td></tr><tr><td class="control-cell"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-row" aria-label="Insert row" title="Insert row">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
-      </button></td><td><div class="w-field__wrapper" data-field-wrapper="">
+      </button></td><td><div class="w-field__wrapper" data-field-wrapper="" data-contentpath="rows.1.values.0">
         <div class="w-field w-field--char_field w-field--text_input" data-field="">
           <div class="w-field__errors" id="mytable-cell-1-0-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true" hidden=""><use href="#icon-warning"></use></svg>
@@ -72,7 +72,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock it renders cor
             <p name="mytable-cell-1-0" id="mytable-cell-1-0">Block A widget</p>
           </div>
         </div>
-      </div></td><td><div class="w-field__wrapper" data-field-wrapper="">
+      </div></td><td><div class="w-field__wrapper" data-field-wrapper="" data-contentpath="rows.1.values.1">
         <div class="w-field w-field--char_field w-field--admin_auto_height_text_input" data-field="">
           <div class="w-field__errors" id="mytable-cell-1-1-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true" hidden=""><use href="#icon-warning"></use></svg>
@@ -144,7 +144,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError passe
             </thead>
             <tbody><tr><td class="control-cell"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-row" aria-label="Insert row" title="Insert row">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
-      </button></td><td><div class="w-field__wrapper" data-field-wrapper="">
+      </button></td><td><div class="w-field__wrapper" data-field-wrapper="" data-contentpath="rows.0.values.0">
         <div class="w-field w-field--char_field w-field--text_input" data-field="">
           <div class="w-field__errors" id="mytable-cell-0-0-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true" hidden=""><use href="#icon-warning"></use></svg>
@@ -154,7 +154,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError passe
             <p name="mytable-cell-0-0" id="mytable-cell-0-0">Block A widget</p>
           </div>
         </div>
-      </div></td><td><div class="w-field__wrapper" data-field-wrapper="">
+      </div></td><td><div class="w-field__wrapper" data-field-wrapper="" data-contentpath="rows.0.values.1">
         <div class="w-field w-field--char_field w-field--admin_auto_height_text_input w-field--error" data-field="">
           <div class="w-field__errors" id="mytable-cell-0-1-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true"><use href="#icon-warning"></use></svg>
@@ -168,7 +168,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError passe
         <svg class="icon icon-bin icon" aria-hidden="true"><use href="#icon-bin"></use></svg>
       </button></td></tr><tr><td class="control-cell"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-row" aria-label="Insert row" title="Insert row">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
-      </button></td><td><div class="w-field__wrapper" data-field-wrapper="">
+      </button></td><td><div class="w-field__wrapper" data-field-wrapper="" data-contentpath="rows.1.values.0">
         <div class="w-field w-field--char_field w-field--text_input" data-field="">
           <div class="w-field__errors" id="mytable-cell-1-0-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true" hidden=""><use href="#icon-warning"></use></svg>
@@ -178,7 +178,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError passe
             <p name="mytable-cell-1-0" id="mytable-cell-1-0">Block A widget</p>
           </div>
         </div>
-      </div></td><td><div class="w-field__wrapper" data-field-wrapper="">
+      </div></td><td><div class="w-field__wrapper" data-field-wrapper="" data-contentpath="rows.1.values.1">
         <div class="w-field w-field--char_field w-field--admin_auto_height_text_input" data-field="">
           <div class="w-field__errors" id="mytable-cell-1-1-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true" hidden=""><use href="#icon-warning"></use></svg>
@@ -250,7 +250,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError shows
             </thead>
             <tbody><tr><td class="control-cell"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-row" aria-label="Insert row" title="Insert row">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
-      </button></td><td><div class="w-field__wrapper" data-field-wrapper="">
+      </button></td><td><div class="w-field__wrapper" data-field-wrapper="" data-contentpath="rows.0.values.0">
         <div class="w-field w-field--char_field w-field--text_input" data-field="">
           <div class="w-field__errors" id="mytable-cell-0-0-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true" hidden=""><use href="#icon-warning"></use></svg>
@@ -260,7 +260,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError shows
             <p name="mytable-cell-0-0" id="mytable-cell-0-0">Block A widget</p>
           </div>
         </div>
-      </div></td><td><div class="w-field__wrapper" data-field-wrapper="">
+      </div></td><td><div class="w-field__wrapper" data-field-wrapper="" data-contentpath="rows.0.values.1">
         <div class="w-field w-field--char_field w-field--admin_auto_height_text_input" data-field="">
           <div class="w-field__errors" id="mytable-cell-0-1-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true" hidden=""><use href="#icon-warning"></use></svg>
@@ -274,7 +274,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError shows
         <svg class="icon icon-bin icon" aria-hidden="true"><use href="#icon-bin"></use></svg>
       </button></td></tr><tr><td class="control-cell"><button type="button" class="button button-secondary button-small button--icon text-replace prepend-row" aria-label="Insert row" title="Insert row">
         <svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg>
-      </button></td><td><div class="w-field__wrapper" data-field-wrapper="">
+      </button></td><td><div class="w-field__wrapper" data-field-wrapper="" data-contentpath="rows.1.values.0">
         <div class="w-field w-field--char_field w-field--text_input" data-field="">
           <div class="w-field__errors" id="mytable-cell-1-0-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true" hidden=""><use href="#icon-warning"></use></svg>
@@ -284,7 +284,7 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock setError shows
             <p name="mytable-cell-1-0" id="mytable-cell-1-0">Block A widget</p>
           </div>
         </div>
-      </div></td><td><div class="w-field__wrapper" data-field-wrapper="">
+      </div></td><td><div class="w-field__wrapper" data-field-wrapper="" data-contentpath="rows.1.values.1">
         <div class="w-field w-field--char_field w-field--admin_auto_height_text_input" data-field="">
           <div class="w-field__errors" id="mytable-cell-1-1-errors" data-field-errors="">
             <svg class="icon icon-warning w-field__errors-icon" aria-hidden="true" hidden=""><use href="#icon-warning"></use></svg>

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
@@ -224,6 +224,21 @@ describe('wagtail.contrib.typed_table_block.blocks.TypedTableBlock', () => {
     });
     expect(document.body.innerHTML).toMatchSnapshot();
   });
+
+  test('assigns data-contentpath to cells', () => {
+    const cells = document.querySelectorAll(
+      '[data-field-wrapper][data-contentpath]',
+    );
+    expect(cells.length).toBe(4); // 2 rows * 2 columns
+
+    // Row 0
+    expect(cells[0].dataset.contentpath).toBe('rows.0.values.0');
+    expect(cells[1].dataset.contentpath).toBe('rows.0.values.1');
+
+    // Row 1
+    expect(cells[2].dataset.contentpath).toBe('rows.1.values.0');
+    expect(cells[3].dataset.contentpath).toBe('rows.1.values.1');
+  });
 });
 
 describe('wagtail.contrib.typed_table_block.blocks.TypedTableBlock in StreamBlock', () => {


### PR DESCRIPTION
Fixes #13730

Summary

Comments added to rich text inside TypedTableBlock cells were not being highlighted after saving and reloading the page.

This happened because table cell containers were missing the data-contentpath attribute required by Wagtail’s commenting system to correctly restore and focus comment anchors. As a result, comments appeared detached from the content they were created on.

This PR ensures that each table cell exposes a stable and correct content path so comment anchors can be reliably restored.



Changes
	•	JavaScript
	•	Assign data-contentpath attributes (for example rows.0.values.0) to table cell containers in typed_table_block.js.
	•	Recalculate content paths when rows or columns are added, removed, or reordered to keep annotations in sync.
	•	CSS
	•	Apply comment focus highlighting to table cells using the .w-field--comment-focused state.
	•	Tests
	•	Add a regression test in typed_table_block.test.js to verify that table cells receive the correct data-contentpath.


Verification
	•	Manual
	•	Verified that commenting on text inside a table cell correctly highlights the cell.
	•	Confirmed that the highlight persists after saving and reloading the page.
	•	Automated
	•	Ran npm test client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js and confirmed all tests pass.


Notes

This change is intentionally limited to restoring correct comment highlighting for content within table cells and does not introduce commenting on the table block as a whole.


