### PR TITLE
Fix ChooseParentView skip logic for multi-language sites

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
 * Make `Button` component render a `<button>` element when no URL is supplied (Nayeli De Jesus, LB (Ben Johnston), Sage Abdullah)
 * Fix: Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
 * Fix: Prevent an error when approving a workflow that has been cancelled in a different session (Kailesh)
+* Fix: Accommodate multilingual sites in skipping the "choose parent" step when creating a new page from a flat page listing (Amrinder Singh)
 * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
 * Maintenance: Rename `request` argument to `cache_object` in `Page._get_site_root_paths()` for correctness (Kailesh)
 

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -22,6 +22,7 @@ depth: 1
 
  * Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
  * Prevent an error when approving a workflow that has been cancelled in a different session (Kailesh)
+ * Accommodate multilingual sites in skipping the "choose parent" step when creating a new page from a flat page listing (Amrinder Singh)
 
 ### Documentation
 

--- a/wagtail/admin/tests/pages/test_parent_page_chooser_view.py
+++ b/wagtail/admin/tests/pages/test_parent_page_chooser_view.py
@@ -1,10 +1,10 @@
 from unittest import mock
 
 from django.contrib.auth.models import Group, Permission
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
-from wagtail.models import GroupPagePermission, Page
+from wagtail.models import GroupPagePermission, Locale, Page
 from wagtail.test.testapp.models import BusinessIndex, EventIndex, EventPage, SimplePage
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
@@ -164,6 +164,99 @@ class TestParentPageChooserView(AdminTemplateTestUtils, WagtailTestUtils, TestCa
         )
 
 
+@override_settings(WAGTAIL_I18N_ENABLED=True)
+class TestParentPageChooserViewWithLocale(
+    AdminTemplateTestUtils, WagtailTestUtils, TestCase
+):
+    fixtures = ["test.json"]
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.login()
+        self.view_url = reverse("event_pages:choose_parent")
+        self.fr_locale = Locale.objects.create(language_code="fr")
+        self.en_event_index = EventIndex.objects.first()
+        self.fr_event_index = self.en_event_index.copy_for_translation(
+            self.fr_locale, copy_parents=True
+        )
+
+    def test_skip_if_only_one_valid_parent_with_locale_filter(self):
+        with mock.patch.object(EventPage, "allowed_parent_page_models") as mock_method:
+            mock_method.return_value = [EventIndex]
+            self.assertEqual(EventPage.allowed_parent_page_models(), [EventIndex])
+            response = self.client.get(self.view_url + "?locale=fr")
+
+        self.assertRedirects(
+            response,
+            reverse(
+                "wagtailadmin_pages:add",
+                args=("tests", "eventpage", self.fr_event_index.pk),
+            ),
+        )
+
+    def test_skip_if_only_one_valid_parent_with_default_locale(self):
+        with mock.patch.object(EventPage, "allowed_parent_page_models") as mock_method:
+            mock_method.return_value = [EventIndex]
+            self.assertEqual(EventPage.allowed_parent_page_models(), [EventIndex])
+            response = self.client.get(self.view_url)
+
+        self.assertRedirects(
+            response,
+            reverse(
+                "wagtailadmin_pages:add",
+                args=("tests", "eventpage", self.en_event_index.pk),
+            ),
+        )
+
+    def test_show_chooser_when_multiple_parents_in_same_locale(self):
+        # Create a second EventIndex in the default locale
+        root_page = Page.objects.get(depth=1)
+        second_event_index = EventIndex(title="Second Events", slug="second-events")
+        root_page.add_child(instance=second_event_index)
+
+        with mock.patch.object(EventPage, "allowed_parent_page_models") as mock_method:
+            mock_method.return_value = [EventIndex]
+            self.assertEqual(EventPage.allowed_parent_page_models(), [EventIndex])
+            response = self.client.get(self.view_url + "?locale=en")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/choose_parent.html")
+
+    def test_invalid_locale_returns_404(self):
+        with mock.patch.object(EventPage, "allowed_parent_page_models") as mock_method:
+            mock_method.return_value = [EventIndex]
+            self.assertEqual(EventPage.allowed_parent_page_models(), [EventIndex])
+            response = self.client.get(self.view_url + "?locale=invalid")
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_form_submission_with_locale(self):
+        form_data = {
+            "parent_page": self.fr_event_index.pk,
+        }
+
+        response = self.client.post(self.view_url + "?locale=fr", form_data)
+        self.assertRedirects(
+            response,
+            reverse(
+                "wagtailadmin_pages:add",
+                args=("tests", "eventpage", self.fr_event_index.pk),
+            ),
+        )
+
+    @override_settings(WAGTAIL_I18N_ENABLED=False)
+    def test_locale_param_ignored_when_i18n_disabled(self):
+        with mock.patch.object(EventPage, "allowed_parent_page_models") as mock_method:
+            mock_method.return_value = [EventIndex]
+            self.assertEqual(EventPage.allowed_parent_page_models(), [EventIndex])
+            response = self.client.get(self.view_url + "?locale=fr")
+
+        # There are still two EventIndex pages (one in each locale),
+        # so the chooser should be shown and the locale param should be ignored
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/choose_parent.html")
+
+
 class TestGenericParentPageChooserView(TestParentPageChooserView):
     def setUp(self):
         super().setUp()
@@ -180,3 +273,12 @@ class TestGenericParentPageChooserView(TestParentPageChooserView):
                 "label": "Event pages",
             }
         ]
+
+
+class TestGenericParentPageChooserViewWithLocale(TestParentPageChooserViewWithLocale):
+    def setUp(self):
+        super().setUp()
+        self.view_url = reverse(
+            "wagtailadmin_pages:choose_parent",
+            args=["tests", "eventpage"],
+        )

--- a/wagtail/admin/views/pages/choose_parent.py
+++ b/wagtail/admin/views/pages/choose_parent.py
@@ -10,11 +10,12 @@ from django.views.generic import FormView
 
 from wagtail.admin.forms.pages import ParentChooserForm
 from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
+from wagtail.admin.views.generic.mixins import LocaleMixin
 from wagtail.models import Page
 from wagtail.permissions import page_permission_policy
 
 
-class ChooseParentView(WagtailAdminTemplateMixin, FormView):
+class ChooseParentView(LocaleMixin, WagtailAdminTemplateMixin, FormView):
     template_name = "wagtailadmin/pages/choose_parent.html"
     model = Page
     index_url_name = None
@@ -36,6 +37,10 @@ class ChooseParentView(WagtailAdminTemplateMixin, FormView):
         allowed_parent_pages = Page.objects.filter(
             content_type__in=allowed_parent_page_content_types
         )
+
+        # Filter by locale if i18n is enabled
+        if self.locale:
+            allowed_parent_pages = allowed_parent_pages.filter(locale=self.locale)
 
         # Get queryset of pages where the user has permission to add subpages
         if user.is_superuser:


### PR DESCRIPTION
Fixes #12145

### Problem

On multi-language sites, clicking "Add page" from a `PageListingViewSet` always shows the parent chooser, even when there's only one valid parent page per locale.

This happens because `get_valid_parent_pages()` counts parents across all locales. So a site with `BlogIndexPage` in English + German (2 pages total) never triggers the skip logic, even though each locale only has 1 valid parent.

### Solution

Added locale filtering to `ChooseParentView`, following the existing `LocaleMixin` pattern:

- Added `i18n_enabled` and `locale` cached properties
- Filter `allowed_parent_pages` by current locale when i18n is enabled
- Uses `?locale=` param if provided, otherwise falls back to default locale
- Returns 404 for invalid locale codes
- Fully backward compatible when i18n is disabled

### Testing

- 6 new tests for i18n scenarios
- 1 test for backward compatibility  
- All 13 tests pass
- Manually verified on bakerydemo with English + German setup