### PR TITLE
Fix SnippetChooserViewSet.widget_class to return a class instead of instance #13596

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changelog
 
 * Set `FieldPanel(required_on_save=True)` for `AbstractFormField`'s `field_type` field (Alex Tomkins)
 * Handle pasting of multiple tags separated by newlines or commas (Matthias Brück)
+* Fix: Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
 
 
 7.4 LTS (05.05.2026)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
 * Set `FieldPanel(required_on_save=True)` for `AbstractFormField`'s `field_type` field (Alex Tomkins)
 * Handle pasting of multiple tags separated by newlines or commas (Matthias Brück)
 * Fix: Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
+* Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
 
 
 7.4 LTS (05.05.2026)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -973,6 +973,7 @@
 * Seoyoung Kang
 * Vishal Shukla
 * Sanjok Karki
+* Amrinder Singh
 
 ## Translators
 

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -225,6 +225,20 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. automethod:: get_chooser_admin_base_path
 ```
 
+## SnippetChooserViewSet
+
+```{eval-rst}
+.. autoclass:: wagtail.snippets.views.chooser.SnippetChooserViewSet
+
+   .. autoattribute:: choose_view_class
+   .. autoattribute:: choose_results_view_class
+   .. autoattribute:: chosen_view_class
+   .. autoattribute:: chosen_multiple_view_class
+   .. autoattribute:: create_view_class
+   .. autoattribute:: base_widget_class
+   .. autoattribute:: widget_class
+```
+
 ## SnippetViewSetGroup
 
 ```{eval-rst}

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -19,7 +19,7 @@ depth: 1
 
 ### Bug fixes
 
- * ...
+ * Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
 
 ### Documentation
 
@@ -61,5 +61,9 @@ For additional details on these changes, see:
 ## Upgrade considerations - deprecation of old functionality
 
 ## Upgrade considerations - changes affecting Wagtail customizations
+
+### `SnippetChooserViewSet.widget_class` is now a class
+
+The `SnippetChooserViewSet.widget_class` attribute now correctly returns a widget class instead of an instance, consistent with [`ChooserViewSet.widget_class`](wagtail.admin.viewsets.chooser.ChooserViewSet.widget_class). This change may require updates to any customizations that relied on the previous behavior, such as an override in a `SnippetChooserViewSet` subclass that uses `super().widget_class`.
 
 ## Upgrade considerations - changes to undocumented internals

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -23,7 +23,7 @@ depth: 1
 
 ### Documentation
 
- * ...
+ * Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
 
 ### Maintenance
 
@@ -64,6 +64,6 @@ For additional details on these changes, see:
 
 ### `SnippetChooserViewSet.widget_class` is now a class
 
-The `SnippetChooserViewSet.widget_class` attribute now correctly returns a widget class instead of an instance, consistent with [`ChooserViewSet.widget_class`](wagtail.admin.viewsets.chooser.ChooserViewSet.widget_class). This change may require updates to any customizations that relied on the previous behavior, such as an override in a `SnippetChooserViewSet` subclass that uses `super().widget_class`.
+The [`SnippetChooserViewSet.widget_class`](wagtail.snippets.views.chooser.SnippetChooserViewSet.widget_class) attribute now correctly returns a widget class instead of an instance, consistent with [`ChooserViewSet.widget_class`](wagtail.admin.viewsets.chooser.ChooserViewSet.widget_class). This change may require updates to any customizations that relied on the previous behavior, such as an override in a `SnippetChooserViewSet` subclass that uses `super().widget_class`.
 
 ## Upgrade considerations - changes to undocumented internals

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -314,6 +314,22 @@ class TestSnippetChooserPanelWithIcon(BaseSnippetViewSetTests):
         self.assertEqual(response_json["result"]["string"], "New snippet")
 
 
+class TestSnippetChooserViewSetWidgetClass(SimpleTestCase):
+    def test_widget_class_returns_class(self):
+        chooser_viewset = FullFeaturedSnippet.snippet_viewset.chooser_viewset
+        widget_class = chooser_viewset.widget_class
+
+        self.assertIsInstance(widget_class, type)
+        self.assertTrue(issubclass(widget_class, AdminSnippetChooser))
+        self.assertEqual(widget_class.model, FullFeaturedSnippet)
+        self.assertEqual(widget_class.icon, "cog")
+
+        widget_instance = widget_class()
+        self.assertIsInstance(widget_instance, widget_class)
+        self.assertEqual(widget_instance.model, FullFeaturedSnippet)
+        self.assertEqual(widget_instance.icon, "cog")
+
+
 class TestAdminURLs(BaseSnippetViewSetTests):
     def test_default_url_namespace(self):
         snippet = Advert.objects.create(text="foo")

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -1,4 +1,3 @@
-from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.ui.tables import LiveStatusTagColumn
@@ -73,7 +72,4 @@ class SnippetChooserViewSet(ChooserViewSet):
     chosen_view_class = SnippetChosenView
     chosen_multiple_view_class = SnippetChosenMultipleView
     create_view_class = SnippetCreateView
-
-    @cached_property
-    def widget_class(self):
-        return AdminSnippetChooser(model=self.model, icon=self.icon)
+    base_widget_class = AdminSnippetChooser

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -67,9 +67,36 @@ class SnippetCreateView(CreateView):
 
 
 class SnippetChooserViewSet(ChooserViewSet):
+    """
+    A :class:`~wagtail.admin.viewsets.chooser.ChooserViewSet` subclass with
+    support for additional snippet-specific features.
+
+    All attributes and methods from ``ChooserViewSet`` are available.
+    """
+
     choose_view_class = ChooseView
+    """
+    The view class to use for the overall chooser modal;
+    must be a subclass of ``wagtail.snippets.views.chooser.ChooseView``.
+    """
     choose_results_view_class = ChooseResultsView
+    """
+    The view class used to render just the results panel within the chooser modal;
+    must be a subclass of ``wagtail.snippets.views.chooser.ChooseResultsView``.
+    """
     chosen_view_class = SnippetChosenView
+    """
+    The view class used after an item has been chosen;
+    must be a subclass of ``wagtail.snippets.views.chooser.SnippetChosenView``.
+    """
     chosen_multiple_view_class = SnippetChosenMultipleView
+    """
+    The view class used after multiple items have been chosen;
+    must be a subclass of ``wagtail.snippets.views.chooser.SnippetChosenMultipleView``.
+    """
     create_view_class = SnippetCreateView
+    """
+    The view class used to handle submissions of the 'create' form;
+    must be a subclass of ``wagtail.snippets.views.chooser.SnippetCreateView``.
+    """
     base_widget_class = AdminSnippetChooser

--- a/wagtail/snippets/widgets.py
+++ b/wagtail/snippets/widgets.py
@@ -15,8 +15,9 @@ class AdminSnippetChooser(BaseChooser):
     classname = "snippet-chooser"
     js_constructor = "SnippetChooser"
 
-    def __init__(self, model, **kwargs):
-        self.model = model
+    def __init__(self, model=None, **kwargs):
+        if model is not None:
+            self.model = model
         name = self.model._meta.verbose_name
         self.choose_one_text = _("Choose %(object)s") % {"object": name}
         self.choose_another_text = _("Choose another %(object)s") % {"object": name}


### PR DESCRIPTION
Fixes #13596

**Problem**
`SnippetChooserViewSet.widget_class` returns an `AdminSnippetChooser` instance instead of a class, unlike the base `ChooserViewSet` which uses `type()` to return a dynamically created class.

This breaks consistency with the parent class and could cause issues if code tries to instantiate `widget_class()`.

**Solution**
- Changed `widget_class` to use `type()` following the base `ChooserViewSet` pattern
- Made `model` parameter optional in `AdminSnippetChooser.__init__` so the dynamic class can be instantiated without arguments (falls back to class attribute)
- Added upgrade note for anyone relying on the old behavior

**Testing**
- 3 new tests for widget_class behavior
- All tests pass