### PR TITLE
Fix ParentalKey duplication bug in revisions (#13701)

### DIFF
--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -603,7 +603,8 @@ class EditView(
         try:
             with transaction.atomic():
                 self.page = self.form.save(commit=not self.page.live)
-                self.page.save_related()
+                if hasattr(self.page, 'save_related'):
+                    self.page.save_related()
                 self.subscription.save()
 
                 overwrite_revision_id = self.request.POST.get("overwrite_revision_id")

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -603,7 +603,7 @@ class EditView(
         try:
             with transaction.atomic():
                 self.page = self.form.save(commit=not self.page.live)
-                if hasattr(self.page, 'save_related'):
+                if hasattr(self.page, "save_related"):
                     self.page.save_related()
                 self.subscription.save()
 

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -603,6 +603,7 @@ class EditView(
         try:
             with transaction.atomic():
                 self.page = self.form.save(commit=not self.page.live)
+                self.page.save_related()
                 self.subscription.save()
 
                 overwrite_revision_id = self.request.POST.get("overwrite_revision_id")


### PR DESCRIPTION
### Description:
Fixes the issue where unpublishing and republishing a page with new ParentalKey child objects causes duplicates.

### Root Cause: 
Revisions were created before child objects were saved, leading to pk=null in serialized data.

### Fix: 
Added self.page.save_related() in the admin save action to ensure child objects are saved before save_revision().

### Testing: 
I verified the change prevents pk=null in revisions for new child objects.

Fixes #13701 
Pls review @gasman @thibaudcolas @laymonage 