### PR TITLE
Add note about current django-tasks behaviour to 6.4 release notes

### DIFF
--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -237,6 +237,10 @@ In this new release, validation is now applied on these fields, existing forms w
 
 ### Background tasks run at end of current transaction
 
+```{note}
+The behaviour described here no longer applies as of `django-tasks` 0.10. Tasks are now enqueued immediately (and executed immediately if `ImmediateBackend` is in use), and the `ENQUEUE_ON_COMMIT` setting is no longer available.
+```
+
 In the default configuration, tasks managed by `django-tasks` (see above) run during the request-response cycle, as before. However, they are now deferred until the current transaction (if any) is committed. If [`ATOMIC_REQUESTS`](inv:django:std:setting#DATABASE-ATOMIC_REQUESTS) is set to `True`, this will be at the end of the request. This may lead to a change of behaviour on views that expect to see the results of these tasks immediately, such as a view that creates a page and then performs a search query to retrieve it. To restore the previous behaviour, set `"ENQUEUE_ON_COMMIT": False` in the `TASKS` setting:
 
 ```python


### PR DESCRIPTION
The previously described enqueue-on-commit behaviour no longer applies as of django-tasks 0.10.
