### PR TITLE
update semgrep and enable parallel scanning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,8 @@ repos:
     hooks:
       - id: djhtml
   - repo: https://github.com/semgrep/semgrep
-    rev: v1.132.0
+    # NOTE: Keep in sync with dependencies in pyproject.toml
+    rev: v1.150.0
     hooks:
       - id: semgrep
         files: \.(js|ts|tsx|html|py)$

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Maintenance: Removed support for Django 4.2
  * Maintenance: Fix LocaleController test failures caused by differing timezone representations between Node versions (Saptami, Matt Westcott)
  * Maintenance: Fix frontend coverage upload to Codecov (Sage Abdullah)
+ * Maintenance: Update semgrep to 1.150.0 (Pravin Kamble)
 
 
 7.3 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -33,6 +33,7 @@ Wagtail 7.4 is designated a Long Term Support (LTS) release. Long Term Support r
  * Removed support for Django 4.2
  * Fix LocaleController test failures caused by differing timezone representations between Node versions (Saptami, Matt Westcott)
  * Fix frontend coverage upload to Codecov (Sage Abdullah)
+ * Update semgrep to 1.150.0 (Pravin Kamble)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,11 @@ testing = [
   "responses>=0.25,<1",
   # For coverage and PEP8 linting
   "coverage>=3.7.0",
+  # NOTE: Keep linters in sync with .pre-commit-config.yaml
   "doc8==1.1.2",
   "ruff==0.9.6",
   # For enforcing string formatting mechanism in source files
-  "semgrep==1.132.0",
+  "semgrep==1.150.0",
   # For templates linting
   "curlylint==0.13.1",
   # For template indenting


### PR DESCRIPTION
- Upgraded Semgrep to `v1.149.0 `
- enabled parallel scanning with `--jobs 4` to speed up the pre-commit runs.

https://github.com/semgrep/semgrep/releases/tag/v1.149.0