### PR TITLE
remove mention of wagtailtrans, since it's obsolete

### DIFF
--- a/docs/advanced_topics/i18n.md
+++ b/docs/advanced_topics/i18n.md
@@ -670,20 +670,14 @@ GitHub: [https://github.com/wagtail/wagtail-localize](https://github.com/wagtail
 
 ## Alternative internationalization approach: wagtail-modeltranslation
 
-While Wagtail now offers official multi-language support, it follows a specific
-"page-per-language" philosophy. 
-For developers seeking a different architectural pattern,
-[wagtail-modeltranslation](https://github.com/infoportugal/wagtail-modeltranslation) 
-remains a robust and viable alternative.
+While Wagtail now offers official multi-language support, it follows a "one page tree per language" philosophy. Therefore a website can have vastly different language trees. Wagtail-localize has options to keep pages in-sync to a certain extent.
 
-Instead of duplicating pages across the site tree, it allows for field-level translation.
+For developers seeking a different architectural pattern, [wagtail-modeltranslation](https://github.com/infoportugal/wagtail-modeltranslation) remains a robust and viable alternative:
+
+Instead of duplicating pages across the site tree, it allows for field-level translation based on [django-modeltranslation](https://github.com/deschler/django-modeltranslation).
 This approach keeps all languages within a single database record by adding translated fields
 directly to the model, which can be preferable for sites requiring a unified tree structure
 or simpler synchronization of non-translatable content.
-
-For a comparison of these options, see SaaS Hammer's blog post
-[How to support multi-language in Wagtail CMS](https://saashammer.com/blog/how-support-multi-language-wagtail-cms/).
-Please note that while the conceptual comparison remains useful, the article is now over four years old.
 
 ## Wagtail admin translations
 


### PR DESCRIPTION
Updating the docs.

Removed mention of obsolete wagtailtrans.
Elevate the mention of wagtail-modeltrans, since it's the only viable alternative.
