### PR TITLE
Fix reorder button hooks and update related tests

### DIFF
--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -249,21 +249,21 @@ class TestPageListingMoreButtonsHooks(TestButtonsHooks):
             if button.is_shown(user=editor)
         ]
         self.assertEqual(
-            len([button for button in buttons if button.label == "Sort menu order"]), 0
+            len([button for button in buttons if button.label == "Order page manually"]), 0
         )
 
         # Test with a user with publish permission
         publisher = self.create_user(username="publisher", password="password")
         publisher.groups.add(Group.objects.get(name="Moderators"))
 
-        # page_listing_more_button generator yields `Sort menu order button`
+        # page_listing_more_button generator yields `Order page manually button`
         buttons = [
             button
             for button in page_listing_more_buttons(page, user=publisher)
             if button.is_shown(user=publisher)
         ]
         reorder_button = next(
-            button for button in buttons if button.label == "Sort menu order"
+            button for button in buttons if button.label == "Order page manually"
         )
 
         self.assertEqual(reorder_button.url, "/admin/pages/%d/?ordering=ord" % page.id)

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -341,7 +341,7 @@ class PageListingHistoryButton(PageMenuItem):
 
 
 class PageListingSortMenuOrderButton(PageMenuItem):
-    label = _("Sort menu order")
+    label = _("Order page manually")
     icon_name = "list-ul"
 
     def is_shown(self, user):


### PR DESCRIPTION
Fixes #13484

This PR improves the clarity and consistency of page action labels related to reordering in the Wagtail admin.

Previously, the action was labeled “Sort menu order”, but the functionality applied more broadly — allowing manual ordering of pages, snippets, and other objects. This mismatch created confusion, especially since users could manually reorder items beyond just menu contexts.

This change updates the wording to “Order manually”, making the action clearer, more accurate, and aligned with what the feature actually does across the admin interface.

What’s changed?

Renamed misleading reordering actions to better reflect actual behavior

Improved UX clarity and reduced ambiguity for editors


Before

<img width="1440" height="900" alt="Screenshot 2026-01-25 at 11 24 56 PM" src="https://github.com/user-attachments/assets/47317f9c-ed50-485e-ab18-9805f84c96ce" />

After

<img width="1440" height="900" alt="Screenshot 2026-01-25 at 11 24 19 PM" src="https://github.com/user-attachments/assets/ffb461ac-098c-4c73-9e20-18180e44f3a4" />

