### PR TITLE
Fix frontend coverage upload to codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+
+orbs:
+  codecov: codecov/codecov@5.4.3
 
 jobs:
   backend:
@@ -58,7 +61,6 @@ jobs:
       - run: npm run build-storybook
       - run: npm run lint --loglevel silent
       - run: npm run test:unit:coverage -- --runInBand
-      - run: bash <(curl -s https://codecov.io/bash) -F frontend
 
   ui_tests:
     docker:
@@ -139,7 +141,12 @@ workflows:
   test:
     jobs:
       - backend
-      - frontend
+      - frontend:
+          post-steps:
+            - codecov/upload:
+                # For PRs, add `pr-xxx:` prefix to indicate unprotected branch
+                branch: ${CIRCLE_PR_NUMBER:+pr-$CIRCLE_PR_NUMBER:$CIRCLE_BRANCH}
+                flags: frontend
       - ui_tests:
           requires:
             - frontend


### PR DESCRIPTION
Our frontend coverage upload [has been failing silently](https://app.circleci.com/pipelines/github/wagtail/wagtail/24105/workflows/a4c72f17-8549-4e36-a2b1-2acb92372b3d/jobs/67100/parallel-runs/0/steps/0-110) because we're still using the [legacy upload method](https://docs.codecov.com/docs/codecov-tokens#legacy-upload-methods). This PR updates it to use the [official CircleCI Orb (actions-equivalent) for Codecov](https://circleci.com/developer/orbs/orb/codecov/codecov).