### PR TITLE
Fix #13803: Ensure Draftail selects correct element when field name matches panel content ID suffix

### DIFF
--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -315,7 +315,7 @@ class BoundDraftailWidget {
 
     if (shouldInitEditor) {
       const [, setOptions] = initEditor(
-        '#' + this.input.id,
+        this.input.tagName.toLowerCase() + '#' + this.input.id, // Use tag name + ID selector to ensure uniqueness
         this.getFullOptions(),
         document.currentScript,
       );

--- a/client/src/components/Draftail/index.test.js
+++ b/client/src/components/Draftail/index.test.js
@@ -118,7 +118,7 @@ describe('Draftail', () => {
           </div>
         `;
 
-        draftail.initEditor('#description', {});
+        draftail.initEditor('input#description', {});
 
         expect(
           document.querySelector('[name="last"]').draftailEditor,
@@ -136,7 +136,7 @@ describe('Draftail', () => {
         `;
 
         draftail.initEditor(
-          '#description',
+          'input#description',
           {},
           document.querySelector('[data-draftail-script]'),
         );
@@ -154,7 +154,7 @@ describe('Draftail', () => {
         `;
 
         draftail.initEditor(
-          '#description',
+          'input#description',
           {},
           document.querySelector('[data-draftail-script]'),
         );
@@ -162,6 +162,38 @@ describe('Draftail', () => {
         expect(
           document.querySelector('#description').draftailEditor,
         ).toBeDefined();
+      });
+
+      it('handles field name overlapping with panel content ID using tag selector', () => {
+        window.draftail = draftail;
+        document.body.innerHTML = `
+          <div id="content">
+            <div>
+              <input id="content" value="null" />
+            </div>
+          </div>
+        `;
+
+        draftail.initEditor('input#content', {});
+
+        expect(
+          document.querySelector('input#content').draftailEditor,
+        ).toBeDefined();
+      });
+
+      it('fails when field name overlaps with panel content ID without tag selector', () => {
+        window.draftail = draftail;
+        document.body.innerHTML = `
+          <div id="content">
+            <div>
+              <input id="content" value="null" />
+            </div>
+          </div>
+        `;
+
+        expect(() => {
+          draftail.initEditor('#content', {});
+        }).toThrow(SyntaxError);
       });
     });
   });


### PR DESCRIPTION
Fixes #13803: Following the change that made StructBlocks collapsible in v7.1.x, Draftail editors fail to render in nested `StructBlock` configurations when a field name, for example _"content"_, collides with a collapsible panel's hardcoded content ID. In those cases `document.querySelector('#<id>')` could select the parent `<div>` instead of the intended `<input>`, causing JSON parsing errors during editor initialization.

The solution makes the selector more specific so the editor targets the input element directly.