### PR TITLE
GenAI policy - forbid the use of LLMs for lying via stock phrases

### DIFF
--- a/docs/contributing/general_guidelines.md
+++ b/docs/contributing/general_guidelines.md
@@ -20,6 +20,7 @@ We ask that if you use generative AI for your contribution, you include a discla
 
 - Entire work (code changes, documentation update, pull request descriptions) are LLM-generated without there being a clear understanding of the solution implementation from the contributor.
 - Responding to questions asked during code review by pasting those questions into an LLM
+- Allowing an LLM to make unchecked false statements through the use of stock phrases, such as claiming to have manually tested a bugfix, or claiming to have experience of an issue through a real-world project
 
 We will close those pull requests and issues that are unproductive, so we can focus our limited maintainer capacity elsewhere.
 


### PR DESCRIPTION
If an issue or PR description or reply is entirely LLM generated, as opposed to being written by a human with LLM assistance, it will tend to include fictitious details picked up from its training on genuine Github conversations, such as "I have manually tested this fix" or "I have real-world experience of this issue". Add this to the list of unacceptable uses.
