### PR TITLE
Fix typo in comments for spelling settings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,7 +166,7 @@ pygments_style = None
 # If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False
 
-# splhinxcontrib.spelling settings
+# sphinxcontrib.spelling settings
 
 spelling_lang = "en_GB"
 spelling_word_list_filename = "spelling_wordlist.txt"


### PR DESCRIPTION
This PR fixes a small typo in a comment in docs/conf.py (splhinxcontrib → sphinxcontrib).

No functional changes.
