### PR TITLE
Fix long form field label issue

### DIFF
--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -154,8 +154,21 @@ class AbstractFormField(Orderable):
 
         is_new = self.pk is None
         if is_new:
-            clean_name = self.get_field_clean_name()
-            self.clean_name = clean_name
+            base_name = self.get_field_clean_name()
+            self.clean_name = base_name
+
+            existing_names = set(
+                self.__class__.objects.filter(page_id=self.page_id).values_list(
+                    "clean_name", flat=True
+                )
+            )
+
+            MAXLEN = 64
+            counter = 1
+            while self.clean_name in existing_names:
+                suffix = f"_{counter}"
+                self.clean_name = base_name[: MAXLEN - len(suffix)].rstrip("_") + suffix
+                counter += 1
 
         super().save(*args, **kwargs)
 

--- a/wagtail/contrib/forms/tests/test_forms.py
+++ b/wagtail/contrib/forms/tests/test_forms.py
@@ -147,7 +147,7 @@ class TestFormBuilder(TestCase):
         self.assertIn("your_favourite_number", field_names)
         self.assertIn("your_favourite_text_editors", field_names)
         self.assertIn("your_favourite_python_ides", field_names)
-        self.assertIn("u03a5our_favourite_u03a1ython_ixd0e", field_names)
+        self.assertIn("ὕour_favourite_ρython_ïðè", field_names)
         self.assertIn("your_choices", field_names)
         self.assertIn("i_agree_to_the_terms_of_use", field_names)
         self.assertIn("a_hidden_field", field_names)
@@ -172,7 +172,7 @@ class TestFormBuilder(TestCase):
             form_class.base_fields["your_favourite_python_ides"], forms.ChoiceField
         )
         self.assertIsInstance(
-            form_class.base_fields["u03a5our_favourite_u03a1ython_ixd0e"],
+            form_class.base_fields["ὕour_favourite_ρython_ïðè"],
             forms.ChoiceField,
         )
         self.assertIsInstance(
@@ -188,7 +188,7 @@ class TestFormBuilder(TestCase):
             form_class.base_fields["your_message"].widget, forms.Textarea
         )
         self.assertIsInstance(
-            form_class.base_fields["u03a5our_favourite_u03a1ython_ixd0e"].widget,
+            form_class.base_fields["ὕour_favourite_ρython_ïðè"].widget,
             forms.RadioSelect,
         )
         self.assertIsInstance(
@@ -317,8 +317,8 @@ class TestFormBuilder(TestCase):
                 '<input type="text" name="your_favourite_python_ides" class="custom">',
             ),
             (
-                "u03a5our_favourite_u03a1ython_ixd0e",
-                '<input type="text" name="u03a5our_favourite_u03a1ython_ixd0e" class="custom">',
+                "ὕour_favourite_ρython_ïðè",
+                '<input type="text" name="ὕour_favourite_ρython_ïðè" class="custom">',
             ),
             (
                 "your_choices",

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -947,7 +947,7 @@ class TestFormsSubmissionsExport(WagtailTestUtils, TestCase):
         self.assertIn("こんにちは、世界", data_line)
 
     def test_list_submissions_csv_export_with_unicode_in_field(self):
-        FormField.objects.create(
+        field = FormField.objects.create(
             page=self.form_page,
             sort_order=2,
             label="Выберите самую любимую IDE для разработке на Python",
@@ -961,7 +961,7 @@ class TestFormsSubmissionsExport(WagtailTestUtils, TestCase):
             form_data={
                 "your_email": "unicode@example.com",
                 "your_message": "We don't need unicode here",
-                "u0412u044bu0431u0435u0440u0438u0442u0435_u0441u0430u043cu0443u044e_u043bu044eu0431u0438u043cu0443u044e_ide_u0434u043bu044f_u0440u0430u0437u0440u0430u0431u043eu0442u043au0435_u043du0430_python": "vim",
+                field.clean_name: "vim",
             },
         )
         unicode_form_submission.submit_time = "2014-01-02T12:00:00.000Z"
@@ -1153,7 +1153,7 @@ class TestCustomFormsSubmissionsExport(WagtailTestUtils, TestCase):
         self.assertIn("こんにちは、世界", data_line)
 
     def test_list_submissions_csv_export_with_unicode_in_field(self):
-        FormFieldWithCustomSubmission.objects.create(
+        field = FormFieldWithCustomSubmission.objects.create(
             page=self.form_page,
             sort_order=2,
             label="Выберите самую любимую IDE для разработке на Python",
@@ -1168,7 +1168,7 @@ class TestCustomFormsSubmissionsExport(WagtailTestUtils, TestCase):
             form_data={
                 "your-email": "unicode@example.com",
                 "your-message": "We don't need unicode here",
-                "u0412u044bu0431u0435u0440u0438u0442u0435_u0441u0430u043cu0443u044e_u043bu044eu0431u0438u043cu0443u044e_ide_u0434u043bu044f_u0440u0430u0437u0440u0430u0431u043eu0442u043au0435_u043du0430_python": "vim",
+                field.clean_name: "vim",
             },
         )
         unicode_form_submission.submit_time = "2014-01-02T12:00:00.000Z"

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -1,9 +1,9 @@
 from functools import lru_cache
 
 from django.contrib.contenttypes.models import ContentType
+from django.utils.text import slugify
 
 from wagtail import hooks
-from wagtail.coreutils import safe_snake_case
 from wagtail.models import get_page_models
 from wagtail.permissions import page_permission_policy
 
@@ -13,7 +13,15 @@ def get_field_clean_name(label):
     Converts a user entered field label to a string that is safe to use for both a
     HTML attribute (field's name) and a JSON key used internally to store the responses.
     """
-    return safe_snake_case(label)
+    name = slugify(label, allow_unicode=True).replace("-", "_")
+
+    if not name:
+        name = "field_name"
+
+    MAX_LEN = 64
+    clean_name = name[:MAX_LEN].rstrip("_")
+
+    return clean_name
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
### Changes
- `wagtail/contrib/forms/utils.py`: Added truncation logic to `get_field_clean_name()`
- `wagtail/contrib/forms/tests/test_models.py`:
  - Added TestCleanNameUtils with unit tests for the utility function
  - Added TestFormFieldCleanNameTruncate test verifying the fix avoids DataError

### Why?

Creating form fields with long labels in non-Latin characters like `Arabic`, causes a `DataError` when saving to the database. The `clean_name` field now has a `max_length=64` enforced by `get_field_clean_name()` as suggested, also avoids unecessary ascii-fy.

### Tests
- required unit tests are included in PR.

Fixes #13107 