### PR TITLE
Fix filter dropdown clipping with long option labels

### DIFF
--- a/client/scss/components/_drilldown.scss
+++ b/client/scss/components/_drilldown.scss
@@ -68,6 +68,13 @@
   max-width: calc(260px - theme('spacing.4'));
 }
 
+.w-drilldown__submenu select {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+
 .w-drilldown__submenu .w-field__label {
   @apply w-label-1;
   margin-bottom: theme('spacing.3');


### PR DESCRIPTION
Fixes #13616

### Description

Long option labels in the filter sidebar caused native `<select>` elements to size themselves wider than their field wrapper, which resulted in the right border being clipped.

This change constrains the `<select>` to the width of its field wrapper, preventing intrinsic width expansion and eliminating the clipping without modifying panel overflow behavior or expanding the sidebar.

### AI usage

Used AI assistance for debugging guidance and help navigating Git workflows and repository structure. The code change itself was implemented manually.

