### PR TITLE
Docs: replace insecure HTTP links with HTTPS

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
  * Docs: Add documentation for the `filter_spec` parameter of `ImageRenditionField` (Soumya-codr)
  * Docs: Add guide for testing document upload forms (Wenli Tsai, Bhavesh Sharma)
  * Docs: Document the `nested_default_fields` attribute on API viewsets (Deepanshu Tevathiya)
+ * Docs: Replace `http` with `https` in example URLs (Kunal Gupta)
  * Maintenance: Removed support for Django 4.2
  * Maintenance: Fix LocaleController test failures caused by differing timezone representations between Node versions (Saptami, Matt Westcott)
  * Maintenance: Fix frontend coverage upload to Codecov (Sage Abdullah)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -942,6 +942,7 @@
 * Kacper Walęga
 * Deepanshu Tevathiya
 * Serkan Korkusuz
+* Kunal Gupta
 
 ## Translators
 

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -304,7 +304,7 @@ This would add the following to the JSON:
         "id": 45529,
         "meta": {
             "type": "wagtailimages.Image",
-            "detail_url": "http://www.example.com/api/v2/images/12/",
+            "detail_url": "https://www.example.com/api/v2/images/12/",
             "download_url": "/media/images/a_test_image.jpg",
             "tags": []
         },
@@ -314,7 +314,7 @@ This would add the following to the JSON:
     },
     "feed_image_thumbnail": {
         "url": "/media/images/a_test_image.fill-100x100.jpg",
-        "full_url": "http://www.example.com/media/images/a_test_image.fill-100x100.jpg",
+        "full_url": "https://www.example.com/media/images/a_test_image.fill-100x100.jpg",
         "width": 100,
         "height": 100,
         "alt": "image alt text"
@@ -336,7 +336,7 @@ The `filter_spec` parameter in `ImageRenditionField` determines how the image wi
 Common examples include:
 
 ```python
-# Square crop and fill  
+# Square crop and fill
 APIField('thumbnail', serializer=ImageRenditionField('fill-300x300', source='image'))
 
 # Maintain aspect ratio with maximum dimensions

--- a/docs/advanced_topics/api/v2/usage.md
+++ b/docs/advanced_topics/api/v2/usage.md
@@ -52,7 +52,7 @@ Content-Type: application/json
             "id": 1,
             "meta": {
                 "type": "app_name.ModelName",
-                "detail_url": "http://api.example.com/api/v2/endpoint_name/1/"
+                "detail_url": "https://api.example.com/api/v2/endpoint_name/1/"
             },
             "field": "value"
         },
@@ -60,7 +60,7 @@ Content-Type: application/json
             "id": 2,
             "meta": {
                 "type": "app_name.ModelName",
-                "detail_url": "http://api.example.com/api/v2/endpoint_name/2/"
+                "detail_url": "https://api.example.com/api/v2/endpoint_name/2/"
             },
             "field": "different value"
         }
@@ -99,8 +99,8 @@ Content-Type: application/json
             "id": 1,
             "meta": {
                 "type": "blog.BlogPage",
-                "detail_url": "http://api.example.com/api/v2/pages/1/",
-                "html_url": "http://www.example.com/blog/my-blog-post/",
+                "detail_url": "https://api.example.com/api/v2/pages/1/",
+                "html_url": "https://www.example.com/blog/my-blog-post/",
                 "slug": "my-blog-post",
                 "first_published_at": "2016-08-30T16:52:00Z"
             },
@@ -284,8 +284,8 @@ Content-Type: application/json
             "id": 10,
             "meta": {
                 "type": "standard.StandardPage",
-                "detail_url": "http://api.example.com/api/v2/pages/10/",
-                "html_url": "http://www.example.com/about/",
+                "detail_url": "https://api.example.com/api/v2/pages/10/",
+                "html_url": "https://www.example.com/about/",
                 "slug": "about",
                 "first_published_at": "2016-08-30T16:52:00Z"
             },
@@ -322,8 +322,8 @@ Content-Type: application/json
             "id": 3,
             "meta": {
                 "type": "blog.BlogIndexPage",
-                "detail_url": "http://api.example.com/api/v2/pages/3/",
-                "html_url": "http://www.example.com/blog/",
+                "detail_url": "https://api.example.com/api/v2/pages/3/",
+                "html_url": "https://www.example.com/blog/",
                 "slug": "blog",
                 "first_published_at": "2016-09-21T13:54:00Z"
             },
@@ -333,8 +333,8 @@ Content-Type: application/json
             "id": 10,
             "meta": {
                 "type": "standard.StandardPage",
-                "detail_url": "http://api.example.com/api/v2/pages/10/",
-                "html_url": "http://www.example.com/about/",
+                "detail_url": "https://api.example.com/api/v2/pages/10/",
+                "html_url": "https://www.example.com/about/",
                 "slug": "about",
                 "first_published_at": "2016-08-30T16:52:00Z"
             },
@@ -435,8 +435,8 @@ Content-Type: application/json
             "id": 10,
             "meta": {
                 "type": "standard.StandardPage",
-                "detail_url": "http://api.example.com/api/v2/pages/10/",
-                "html_url": "http://www.example.com/usa-page/",
+                "detail_url": "https://api.example.com/api/v2/pages/10/",
+                "html_url": "https://www.example.com/usa-page/",
                 "slug": "usa-page",
                 "first_published_at": "2016-08-30T16:52:00Z",
                 "locale": "en-us"
@@ -469,8 +469,8 @@ Content-Type: application/json
             "id": 11,
             "meta": {
                 "type": "standard.StandardPage",
-                "detail_url": "http://api.example.com/api/v2/pages/11/",
-                "html_url": "http://www.example.com/gb-page/",
+                "detail_url": "https://api.example.com/api/v2/pages/11/",
+                "html_url": "https://www.example.com/gb-page/",
                 "slug": "gb-page",
                 "first_published_at": "2016-08-30T16:52:00Z",
                 "locale": "en-gb"
@@ -481,8 +481,8 @@ Content-Type: application/json
             "id": 12,
             "meta": {
                 "type": "standard.StandardPage",
-                "detail_url": "http://api.example.com/api/v2/pages/12/",
-                "html_url": "http://www.example.com/fr-page/",
+                "detail_url": "https://api.example.com/api/v2/pages/12/",
+                "html_url": "https://www.example.com/fr-page/",
                 "slug": "fr-page",
                 "first_published_at": "2016-08-30T16:52:00Z",
                 "locale": "fr"

--- a/docs/advanced_topics/performance.md
+++ b/docs/advanced_topics/performance.md
@@ -64,7 +64,7 @@ When using a queryset to render a list of images or objects with images, you can
 
 ## Frontend caching proxy
 
-Many websites use a frontend cache such as [Varnish](https://varnish-cache.org/), [Squid](http://www.squid-cache.org/), [Cloudflare](https://www.cloudflare.com/) or [CloudFront](https://aws.amazon.com/cloudfront/) to support high volumes of traffic with excellent response times. The downside of using a frontend cache though is that they don't respond well to updating content and will often keep an old version of a page cached after it has been updated.
+Many websites use a frontend cache such as [Varnish](https://varnish-cache.org/), [Squid](https://www.squid-cache.org/), [Cloudflare](https://www.cloudflare.com/) or [CloudFront](https://aws.amazon.com/cloudfront/) to support high volumes of traffic with excellent response times. The downside of using a frontend cache though is that they don't respond well to updating content and will often keep an old version of a page cached after it has been updated.
 
 Wagtail supports being [integrated](frontend_cache_purging) with many CDNs, so it can inform them when a page changes, so the cache can be cleared immediately and users see the changes sooner.
 
@@ -82,7 +82,7 @@ When using the [`{% pageurl %}`](pageurl_tag) or [`{% fullpageurl %}`](fullpageu
 
 ## Search
 
-Wagtail has strong support for [Elasticsearch](https://www.elastic.co) - both in the editor interface and for users of your site - but can fall back to a database search if Elasticsearch isn't present. Elasticsearch is faster and more powerful than the Django ORM for text search, so we recommend installing it or using a hosted service like [Searchly](http://www.searchly.com/).
+Wagtail has strong support for [Elasticsearch](https://www.elastic.co) - both in the editor interface and for users of your site - but can fall back to a database search if Elasticsearch isn't present. Elasticsearch is faster and more powerful than the Django ORM for text search, so we recommend installing it or using a hosted service like [Searchly](https://www.searchly.com/).
 
 For details on configuring Wagtail for Elasticsearch, see [](wagtailsearch_backends_elasticsearch).
 

--- a/docs/getting_started/integrating_into_django.md
+++ b/docs/getting_started/integrating_into_django.md
@@ -69,7 +69,7 @@ WAGTAIL_SITE_NAME = 'My Example Site'
 Add a `WAGTAILADMIN_BASE_URL` - this is the base URL used by the Wagtail admin site. It is typically used for generating URLs to include in notification emails:
 
 ```python
-WAGTAILADMIN_BASE_URL = 'http://example.com'
+WAGTAILADMIN_BASE_URL = 'https://example.com'
 ```
 
 If this setting is not present, Wagtail will fall back to `request.site.root_url` or to the hostname of the request. Although this setting is not strictly required, it is highly recommended because leaving it out may produce unusable URLs in notification emails.

--- a/docs/reference/contrib/routablepage.md
+++ b/docs/reference/contrib/routablepage.md
@@ -29,12 +29,12 @@ INSTALLED_APPS = [
 To use `RoutablePageMixin`, you need to make your class inherit from both {class}`wagtail.contrib.routable_page.models.RoutablePageMixin` and {class}`wagtail.models.Page`, then define some view methods and decorate them with `path` or `re_path`.
 
 These view methods behave like ordinary Django view functions, and must return an `HttpResponse` object.
-You may use the `RoutablePageMixing.render` method to override the context and template that the default page rendering would use.  
+You may use the `RoutablePageMixing.render` method to override the context and template that the default page rendering would use.
 If you want to create a more custom response, you may want to use `django.shortcuts.render`.
 
 The `path` and `re_path` decorators from `wagtail.contrib.routable_page.models.path` are similar to [the Django `django.urls` `path` and `re_path` functions](inv:django#topics/http/urls). The former allows the use of plain paths and converters while the latter lets you specify your URL patterns as regular expressions.
 
-```{warning} 
+```{warning}
 Punctuation is currently [not supported](https://github.com/wagtail/wagtail/issues/3653) in `path` or `re_path` patterns.
 ```
 
@@ -150,7 +150,7 @@ This method only returns the part of the URL within the page. To get the full UR
 '/events/year/2015/'
 
 >>> event_page.full_url + event_page.reverse_subpage('events_for_year', args=(2015, ))
-'http://example.com/events/year/2015/'
+'https://example.com/events/year/2015/'
 ```
 
 ### Changing route names

--- a/docs/reference/contrib/sitemaps.md
+++ b/docs/reference/contrib/sitemaps.md
@@ -68,16 +68,16 @@ sitemap will look like:
 
 For tools like Google Search Tools to properly index your site, you need to set
 a valid, crawlable hostname. If you change the site's hostname from
-`localhost` to `mysite.com`, `sitemap.xml` will contain the correct URLs:
+`localhost` to `mysite.com`, `sitemap.xml` will contain the correct URLs. If you
+change the site's port to `443`, the `https` scheme will be used:
 
 ```xml
 <url>
-    <loc>http://mysite.com/about/</loc>
+    <loc>https://mysite.com/about/</loc>
     <lastmod>2015-09-26</lastmod>
 </url>
 ```
 
-If you change the site's port to `443`, the `https` scheme will be used.
 Find out more about [working with Sites](site_model_ref).
 
 ## Customizing

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -909,7 +909,7 @@ from wagtail.admin.ui.components import Component
 
 class UserbarPuppyLinkItem(Component):
     def render_html(self, parent_context):
-        return '<li><a href="http://cuteoverload.com/tag/puppehs/" ' \
+        return '<li><a href="https://unsplash.com/s/photos/puppies" ' \
             + 'target="_parent" role="menuitem" class="action">Puppies!</a></li>'
 
 @hooks.register('construct_wagtail_userbar')

--- a/docs/reference/jinja2.md
+++ b/docs/reference/jinja2.md
@@ -40,7 +40,7 @@ In Django templates, `self` can be used to refer to the current page, stream blo
 
 ### `fullpageurl()`
 
-Generate an absolute URL (`http://example.com/foo/bar/`) for a Page instance:
+Generate an absolute URL (`https://example.com/foo/bar/`) for a Page instance:
 
 ```html+jinja
 <meta property="og:url" content="{{ fullpageurl(page) }}" />

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -33,7 +33,7 @@ This document contains reference information for the model classes inside the `w
 
         This is used for constructing the page's URL.
 
-        For example: ``http://domain.com/blog/[my-slug]/``
+        For example: ``https://domain.com/blog/[my-slug]/``
 
     .. attribute:: content_type
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -17,7 +17,7 @@ This is the human-readable name of your Wagtail install which welcomes users upo
 ### `WAGTAILADMIN_BASE_URL`
 
 ```python
-WAGTAILADMIN_BASE_URL = 'http://example.com'
+WAGTAILADMIN_BASE_URL = 'https://example.com'
 ```
 
 This is the base URL used by the Wagtail admin site. It is used for generating absolute URLs to the admin, such as in notification emails and the user bar. This setting must not include the admin path (`/admin`) or a trailing slash.
@@ -640,7 +640,7 @@ Allows the default `LoginForm` to be extended with extra fields.
 ### `WAGTAILADMIN_LOGIN_URL`
 
 ```python
-WAGTAILADMIN_LOGIN_URL = 'http://example.com/login/'
+WAGTAILADMIN_LOGIN_URL = 'https://example.com/login/'
 ```
 
 This specifies the URL to redirect when a user attempts to access a Wagtail admin page without being logged in. If omitted, Wagtail will fall back to using the standard login view (typically `/admin/login/`).
@@ -852,7 +852,7 @@ For full documentation on API configuration, including these settings, see [](ap
 ### `WAGTAILAPI_BASE_URL`
 
 ```python
-WAGTAILAPI_BASE_URL = 'http://api.example.com/'
+WAGTAILAPI_BASE_URL = 'https://api.example.com/'
 ```
 
 Required when using frontend cache invalidation, used to generate absolute URLs to document files and invalidating the cache.

--- a/docs/releases/0.5.rst
+++ b/docs/releases/0.5.rst
@@ -21,7 +21,7 @@ The image uploader UI has been improved to allow multiple images to be uploaded 
 Image feature detection
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Wagtail can now apply face and feature detection on images using `OpenCV <http://opencv.org/>`_, and use this to intelligently crop images.
+Wagtail can now apply face and feature detection on images using `OpenCV <https://opencv.org/>`_, and use this to intelligently crop images.
 
 :ref:`image_feature_detection`
 

--- a/docs/releases/1.0.rst
+++ b/docs/releases/1.0.rst
@@ -229,7 +229,7 @@ This has now been changed to add some ``meta`` information:
         "id": 1,
         "meta": {
             "type": "wagtailimages.Image",
-            "detail_url": "http://api.example.com/api/v1/images/1/"
+            "detail_url": "https://api.example.com/api/v1/images/1/"
         }
     }
 

--- a/docs/releases/1.4.rst
+++ b/docs/releases/1.4.rst
@@ -60,7 +60,7 @@ The ``Document`` model can now be overridden using the new ``WAGTAILDOCS_DOCUMEN
 Removed django-compressor dependency
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Wagtail no longer depends on the `django-compressor <http://django-compressor.readthedocs.org/>`_ library. While we highly recommend compressing and bundling the CSS and JavaScript on your sites, using django-compressor places additional installation and configuration demands on the developer, so this has now been made optional.
+Wagtail no longer depends on the `django-compressor <https://django-compressor.readthedocs.org/>`_ library. While we highly recommend compressing and bundling the CSS and JavaScript on your sites, using django-compressor places additional installation and configuration demands on the developer, so this has now been made optional.
 
 
 Minor features

--- a/docs/releases/1.5.rst
+++ b/docs/releases/1.5.rst
@@ -181,7 +181,7 @@ If you need the old behavior back, where SSL certificates are not verified for y
         }
     }
 
-See the `Elasticsearch-py documentation <http://elasticsearch-py.readthedocs.org/en/stable/#ssl-and-authentication>`_ for more configuration options.
+See the `Elasticsearch-py documentation <https://elasticsearch-py.readthedocs.org/en/stable/#ssl-and-authentication>`_ for more configuration options.
 
 
 Project template now imports ``settings.dev`` explicitly

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -27,6 +27,7 @@ Wagtail 7.4 is designated a Long Term Support (LTS) release. Long Term Support r
  * Add documentation for the `filter_spec` parameter of `ImageRenditionField` (Soumya-codr)
  * Add guide for testing document upload forms (Wenli Tsai, Bhavesh Sharma)
  * Document the `nested_default_fields` attribute on API viewsets (Deepanshu Tevathiya)
+ * Replace `http` with `https` in example URLs (Kunal Gupta)
 
 ### Maintenance
 

--- a/docs/topics/writing_templates.md
+++ b/docs/topics/writing_templates.md
@@ -195,7 +195,7 @@ For sites enforcing a Content Security Policy, you can override the `wagtailembe
 
 ### `pageurl`
 
-Takes a Page object and returns a relative URL (`/foo/bar/`) if within the same Site as the current page, or absolute (`http://example.com/foo/bar/`) if not.
+Takes a Page object and returns a relative URL (`/foo/bar/`) if within the same Site as the current page, or absolute (`https://example.com/foo/bar/`) if not.
 
 ```html+django
 {% load wagtailcore_tags %}
@@ -221,7 +221,7 @@ A `fallback` keyword argument can be provided - this can be a URL string, a name
 
 ### `fullpageurl`
 
-Takes a Page object and returns its absolute URL (`http://example.com/foo/bar/`).
+Takes a Page object and returns its absolute URL (`https://example.com/foo/bar/`).
 
 ```html+django
 {% load wagtailcore_tags %}


### PR DESCRIPTION

### Description

This PR updates several documentation links and example URLs to use HTTPS instead of HTTP.

### Examples of updates
- `http://www.searchly.com/` → `https://www.searchly.com/`
- `http://www.squid-cache.org/` → `https://www.squid-cache.org/`
- `http://example.com` → `https://example.com`

The changes are limited to documentation and do not introduce any functional or behavioral changes.
