### PR TITLE
Fix filter button alignment on small screens

### DIFF
--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -174,4 +174,11 @@
       }
     }
   }
+
+  // Fix odd vertical alignment of filter button on small screens
+  @include media-breakpoint-down(sm) {
+    &__search-form {
+      align-items: flex-start;
+    }
+  }
 }


### PR DESCRIPTION
Fixes #12715

### Description

On listing pages with filters (e.g. Pages, Images, Documents), the filter button
appears oddly positioned on small screen widths due to flex alignment in
`.w-slim-header__search-form`.

This change adjusts the alignment at small viewport sizes so the filter button
remains visually aligned with the search input, without affecting wrapping,
overflow, breadcrumbs, or action buttons.

The layout remains unchanged on larger screens.

### Screenshots

**Pages listing – 640px width (after fix)**
  
<img width="951" height="430" alt="Screenshot 2026-01-30 181103" src="https://github.com/user-attachments/assets/5a5a732c-da28-48f8-8f20-90f30ebf668b" />


**Images listing – ~480px width (after fix)**  

<img width="943" height="423" alt="Screenshot 2026-01-30 181153" src="https://github.com/user-attachments/assets/25c753a3-4a44-4329-813b-e4870bbb2245" />


### AI usage

Used AI assistance for understanding the existing CSS structure and for guidance
on writing the pull request description.

