### PR TITLE
Fix duplicate width descriptors in image srcset (#12389)

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1209,7 +1209,16 @@ class ResponsiveImage:
             # No point in using width descriptors if there is a single image.
             return renditions_list[0].url
 
-        return ", ".join([f"{r.url} {r.width}w" for r in renditions_list])
+        # Filter out duplicate widths to ensure valid HTML srcset
+        # Exception: width=0 (missing images) should not be deduplicated
+        seen_widths = set()
+        unique_renditions = []
+        for rendition in renditions_list:
+            if rendition.width == 0 or rendition.width not in seen_widths:
+                seen_widths.add(rendition.width)
+                unique_renditions.append(rendition)
+
+        return ", ".join([f"{r.url} {r.width}w" for r in unique_renditions])
 
     def __html__(self):
         attrs = self.attrs or {}


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #12389

### Description

<!-- Please describe the problem you're fixing. -->

When using `{% picture %}` with renditions larger than the source image, multiple renditions end up with identical widths (capped at source size), creating duplicate width descriptors in the srcset. For example, requesting `fill-2048x1152` and `fill-1536x864` from a 1024px image results in both having `1024w`, which fails HTML validation.

Fixed by updating `ResponsiveImage.get_width_srcset()` to deduplicate widths before building the srcset string, as suggested by @thibaudcolas in the issue thread. The method now tracks seen widths and keeps only the first occurrence of each unique width.

Added test `test_get_width_srcset_filters_duplicate_widths` that verifies duplicate widths are filtered out and first occurrences are preserved. 
I manually verified the fix resolves the HTML validation errors. 
The HTML passes validation on the [W3C Nu HTML Checker](https://validator.w3.org/nu/#textarea)

All existing tests pass.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None
