### PR TITLE
Enable carryforward for Codecov flags

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,4 +11,10 @@ coverage:
       default:
         informational: true
 
-comment: off
+comment: false
+
+flags:
+  backend:
+    carryforward: true
+  frontend:
+    carryforward: true


### PR DESCRIPTION
This ensures that when coverage is not uploaded for a commit (e.g. a commit that only changes the docs will not have the backend coverage uploaded), the coverage information from a previous commit is retained.



### Description


See https://docs.codecov.com/docs/flags#carryforward-flags


### AI usage

None