### PR TITLE
Add visual indicator for page aliases in page tree 

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_alias_indicator.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_alias_indicator.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+{% load wagtailadmin_tags %}
+
+{% comment %}
+    Expects a variable 'page', a page object.
+    Tests whether that page is an alias, and if so, outputs an 'alias' indicator.
+{% endcomment %}
+
+{% if page.alias_of %}
+    <span
+        class="indicator"
+        title="{% blocktranslate with title=page.alias_of.get_admin_display_title %}Alias of {{ title }}{% endblocktranslate %}"
+    >
+        {% icon name="link" classname="initial" %}
+        <span class="w-sr-only">{% trans "Alias page" %}</span>
+    </span>
+{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -37,6 +37,7 @@
 
     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
     {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
+    {% include "wagtailadmin/pages/listing/_alias_indicator.html" with page=page %}
 </div>
 
 <ul class="actions">

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -915,6 +915,28 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
             reverse("wagtailadmin_pages:history", args=(page.id,)),
         )
 
+    def test_alias_page_shows_indicator(self):
+        """Test that alias pages display the alias indicator"""
+        # Create a source page
+        source_page = SimplePage(
+            title="Source Page",
+            slug="source-page",
+            content="Source content",
+        )
+        self.root_page.add_child(instance=source_page)
+
+        # Create an alias of the source page
+        alias_page = source_page.create_alias(update_slug="alias-page")
+
+        # Get explorer view
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=(self.root_page.id,))
+        )
+
+        # Check that alias indicator appears for alias page
+        self.assertContains(response, "Alias of Source Page")
+        self.assertContains(response, "Alias page")  # sr-only text
+
 
 class TestBreadcrumb(WagtailTestUtils, TestCase):
     fixtures = ["test.json"]

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -926,7 +926,7 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.root_page.add_child(instance=source_page)
 
         # Create an alias of the source page
-        alias_page = source_page.create_alias(update_slug="alias-page")
+        source_page.create_alias(update_slug="alias-page")
 
         # Get explorer view
         response = self.client.get(


### PR DESCRIPTION
Adds a link icon next to alias pages in the page explorer, making them easily identifiable at a glance.

Currently, editors must open the page detail view to verify if a page is an alias. This adds a subtle indicator following the same pattern as privacy and locked indicators.

Changes:
- Add [_alias_indicator.html](cci:7://file:///home/codxbrexx/OpenSource/wagtail/wagtail/admin/templates/wagtailadmin/pages/listing/_alias_indicator.html:0:0-0:0) template
- Integrate indicator into page title in explorer view  
- Add test coverage

The indicator uses the existing `.indicator` CSS class, shows a tooltip on hover ("Alias of [Page]"), and includes screen reader support.

Fixes #6916