### PR TITLE
Fix #11801: Exclude embed iframes from accessibility checker

### DIFF
--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -386,11 +386,29 @@ class TestAccessibilityCheckerConfig(WagtailTestUtils, TestCase):
                         ".sr-only",
                         # Should include the default exclude selectors
                         {"fromShadowDom": ["wagtail-userbar"]},
+                        ".responsive-object iframe",
                         # Override via method
                         "[data-please-ignore]",
                     ],
                 },
             )
+
+    def test_default_excludes_embed_iframes(self):
+        """
+        Test that embed iframes are excluded by default to prevent
+        cross-origin security errors that break Axe.
+        Regression test for https://github.com/wagtail/wagtail/issues/11801
+        """
+        config = self.get_config()
+        self.assertEqual(
+            config["context"]["exclude"],
+            [
+                # Default exclude for the userbar
+                {"fromShadowDom": ["wagtail-userbar"]},
+                # Default exclude for embed iframes (fix for #11801)
+                ".responsive-object iframe",
+            ],
+        )
 
     def test_custom_run_only_and_rules_per_request(self):
         class CustomRunOnlyAccessibilityItem(AccessibilityItem):

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -48,7 +48,11 @@ class AccessibilityItem(BaseItem):
     axe_exclude = []
 
     # Make sure that the userbar is not tested.
-    _axe_default_exclude = [{"fromShadowDom": ["wagtail-userbar"]}]
+    # Also exclude embed iframes to prevent cross-origin security errors that break Axe.
+    _axe_default_exclude = [
+        {"fromShadowDom": ["wagtail-userbar"]},
+        ".responsive-object iframe",
+    ]
 
     #: A list of `axe-core tags <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#axe-core-tags>`_
     #: or a list of `axe-core rule IDs <https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md>`_


### PR DESCRIPTION
## Description

Fixes #11801

When [EmbedBlock](cci:2://file:///c:/Users/Legion%205%20Pro/wagtail/wagtail/embeds/blocks.py:30:0-97:22) content (YouTube, Vimeo, etc.) was added to a page, the accessibility checker would stop working and no longer report genuine accessibility issues. This was caused by Axe encountering `SecurityError` exceptions when trying to scan cross-origin iframes.

## Changes

- Updated `AccessibilityItem._axe_default_exclude` in [wagtail/admin/userbar.py](cci:7://file:///c:/Users/Legion%205%20Pro/wagtail/wagtail/admin/userbar.py:0:0-0:0) to exclude `.responsive-object iframe` elements
- Added regression test [test_default_excludes_embed_iframes](cci:1://file:///c:/Users/Legion%205%20Pro/wagtail/wagtail/admin/tests/test_userbar.py:395:4-410:9) 
- Updated existing [test_custom_context](cci:1://file:///c:/Users/Legion%205%20Pro/wagtail/wagtail/admin/tests/test_userbar.py:365:4-393:13) test to expect the new default exclusion

## Testing

- All 37 tests in `wagtail.admin.tests.test_userbar` pass
-  New regression test verifies embed iframes are excluded by default
-  Other accessibility checks (heading hierarchy, empty headings, etc.) continue to work

## Rationale

The `.responsive-object` class is used by Wagtail's embed frontend template to wrap all embedded content, so this selector specifically targets embed iframes while allowing legitimate iframes elsewhere to still be checked by Axe.