### PR TITLE
Return 403 for authenticated users without admin access

### DIFF
--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -147,6 +147,6 @@ def require_admin_access(view_func):
                 request, _("You do not have permission to access the admin.")
             )
 
-        return reject_request(request)
+        raise PermissionDenied
 
     return decorated_view


### PR DESCRIPTION
Fixes #13847

### Description
A normal authenticated user when login without the permission of the admin access previously were previously redirected to the login page by `require_admin_access`, even thoughthey were already logged in. 
This change updates the behavior to raise .  which reflects the 403 forbidden response.so it is reflets the failure of authentication.

### AI usage
No
