### PR TITLE
Return 403 forbidden error when anonymous user try login without permission

### DIFF
--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -128,9 +128,6 @@ def require_admin_access(view_func):
     def decorated_view(request, *args, **kwargs):
         user = request.user
 
-        if user.is_anonymous:
-            return reject_request(request)
-
         if user.has_perms(["wagtailadmin.access_admin"]):
             try:
                 with LogContext(user=user):
@@ -142,11 +139,8 @@ def require_admin_access(view_func):
 
                 return permission_denied(request)
 
-        if not request.headers.get("x-requested-with") == "XMLHttpRequest":
-            messages.error(
-                request, _("You do not have permission to access the admin.")
-            )
-
+        # User doesn't have permission (includes anonymous users)
+        # Raise PermissionDenied to return 403 instead of redirecting
         raise PermissionDenied
 
     return decorated_view


### PR DESCRIPTION
Fixes #13847

### Description

The [require_admin_access]decorator was redirecting anonymous users to the login page when they attempted to access admin views without the `wagtailadmin.access_admin` permission. This behavior was inconsistent and provided poor UX, as it suggested users should log in when the real issue was lack of permission.

This PR changes the decorator to return HTTP 403 Forbidden for all users without the required permission, regardless of authentication status.

**Changes made:**
- Removed special handling for anonymous users that redirected to login page
- Simplified the decorator to raise `PermissionDenied` for all unauthorized access attempts
- Both anonymous and authenticated users without permission now receive the same 403 response

**Before:**
- Anonymous users → 302 redirect to `/admin/login/`
- Authenticated users without permission → 403 Forbidden

**After:**
- Anonymous users → 403 Forbidden
- Authenticated users without permission → 403 Forbidden

This provides clearer feedback to users and follows proper HTTP semantics.

### AI usage
No