### PR TITLE
Docs: Replace TODO comment in custom embed finder example

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Docs: Document the `nested_default_fields` attribute on API viewsets (Deepanshu Tevathiya)
  * Docs: Replace `http` with `https` in example URLs (Kunal Gupta)
  * Docs: Use `pathlib.Path` for settings in "Integrating into Django" documentation (Kunal Gupta)
+ * Docs: Clarify example of how to implement custom embed finders (Naman Sharma S)
  * Maintenance: Removed support for Django 4.2
  * Maintenance: Fix LocaleController test failures caused by differing timezone representations between Node versions (Saptami, Matt Westcott)
  * Maintenance: Fix frontend coverage upload to Codecov (Sage Abdullah)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -943,6 +943,7 @@
 * Deepanshu Tevathiya
 * Serkan Korkusuz
 * Kunal Gupta
+* Naman Sharma S
 
 ## Translators
 

--- a/docs/advanced_topics/embeds.md
+++ b/docs/advanced_topics/embeds.md
@@ -293,8 +293,8 @@ class ExampleFinder(EmbedFinder):
 
         This is the part that may make requests to external APIs.
         """
-        # Perform the request to your embed provider's API
-        # Parse the response and extract the embed information
+        # TODO: Perform the request to your embed provider's API
+        # Parse the response and return the embed information
 
         return {
             'title': "Title of the content",

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -29,6 +29,7 @@ Wagtail 7.4 is designated a Long Term Support (LTS) release. Long Term Support r
  * Document the `nested_default_fields` attribute on API viewsets (Deepanshu Tevathiya)
  * Replace `http` with `https` in example URLs (Kunal Gupta)
  * Use `pathlib.Path` for settings in "Integrating into Django" documentation (Kunal Gupta)
+ * Clarify example of how to implement custom embed finders (Naman Sharma S)
 
 ### Maintenance
 


### PR DESCRIPTION
### Description

This PR updates the custom embed finder example in `docs/advanced_topics/embeds.md` by replacing a TODO comment with clear, descriptive guidance.

Previously, the example `ExampleFinder` class contained a TODO placeholder inside the `find_embed` method, which left the expected behaviour unclear for readers following the documentation. As this is presented as an instructional example, leaving implementation details unresolved can be confusing.

The TODO has been replaced with brief comments outlining the two key steps involved: making a request to the embed provider’s API and extracting the relevant embed information from the response. This keeps the example intentionally high-level while making it more useful and self-explanatory.

### AI usage

AI assistance was used to help identify the documentation issue and draft the initial wording of the change.
