### PR TITLE
Fix workflow cancelled task

### DIFF
--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -286,7 +286,9 @@ class PageActionMenu:
             is_final_task = (
                 current_workflow_state and current_workflow_state.is_at_final_task
             )
-            if task:
+            if not task:
+                pass
+            else:
                 actions = task.get_actions(page, request.user)
                 workflow_menu_items = []
                 for name, label, launch_modal in actions:


### PR DESCRIPTION
This fixes an AttributeError that occurs when a workflow is cancelled in one browser
session and an approval action is attempted from another (stale) session.

In this scenario, `page.current_workflow_task` can be `None`, but the page action
menu construction assumed it was always present and attempted to call
`get_actions()` on it, resulting in a server error.

This change adds a defensive check to ensure the action menu is built safely
when no current workflow task exists, preventing the error and allowing the
request to fail gracefully.

Fixes #13856

