### PR TITLE
Improve the workflow details popup

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
 * Handle pasting of multiple tags separated by newlines or commas (Matthias Brück)
 * Make `Button` component render a `<button>` element when no URL is supplied (Nayeli De Jesus, LB (Ben Johnston), Sage Abdullah)
 * Show site name in site switcher dropdown in site settings editor (Jack Morgan)
+* Improve clarity of different task states in workflow details dialog (Dan Braghis)
 * Fix: Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
 * Fix: Prevent an error when approving a workflow that has been cancelled in a different session (Kailesh)
 * Fix: Accommodate multilingual sites in skipping the "choose parent" step when creating a new page from a flat page listing (Amrinder Singh)

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -18,6 +18,7 @@ depth: 1
  * Handle pasting of multiple tags separated by newlines or commas (Matthias Brück)
  * Make `Button` component render a `<button>` element when no URL is supplied (Nayeli De Jesus, LB (Ben Johnston), Sage Abdullah)
  * Show site name in site switcher dropdown in site settings editor (Jack Morgan)
+ * Improve clarity of different task states in workflow details dialog (Dan Braghis)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/workflows/workflow_status.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/workflow_status.html
@@ -29,12 +29,28 @@
                             </div>
                         </div>
                     {% else %}
-                        {% if status == "in_progress" %}{% icon name="radio-full" classname="workflow-timeline__icon" title=status_display %}{% else %}{% icon name="radio-empty" classname="workflow-timeline__icon" title=status_display %}{% endif %}
+                        {% if status == "in_progress" %}
+                            {% icon name="radio-full" classname="workflow-timeline__icon" title=status_display %}
+                        {% elif status == "approved" %}
+                            {% icon name="circle-check" classname="workflow-timeline__icon" title=status_display %}
+                        {% elif status == "cancelled" %}
+                            {% icon name="circle-xmark" classname="workflow-timeline__icon" title=status_display %}
+                        {% elif status == "skipped" %}
+                            {% icon name="circle-full" classname="workflow-timeline__icon" title=status_display %}
+                        {% else %}
+                            {% icon name="radio-empty" classname="workflow-timeline__icon" title=status_display %}
+                        {% endif %}
                         {{ task.name }}
                         {% if task.task_state.finished_by %}
-                            {% blocktrans trimmed with approved_by=task.task_state.finished_by|user_display_name %}
-                                Approved by {{ approved_by }}
-                            {% endblocktrans %}
+                            {% if status == "cancelled" %}
+                                {% blocktrans trimmed with cancelled_by=task.task_state.finished_by|user_display_name %}
+                                    Cancelled by {{ cancelled_by }}
+                                {% endblocktrans %}
+                            {% else %}
+                                {% blocktrans trimmed with approved_by=task.task_state.finished_by|user_display_name %}
+                                    Approved by {{ approved_by }}
+                                {% endblocktrans %}
+                            {% endif %}
                         {% endif %}
                     {% endif %}
 
@@ -79,5 +95,4 @@
             {% endwith %}
         </div>
     {% endwith %}
-
 </div>

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -4547,19 +4547,68 @@ class TestPageWorkflowStatus(BasePageWorkflowTests):
 
         response = self.client.get(self.get_url("edit"))
         html = response.content.decode("utf-8")
+
+        self.assertContains(
+            response,
+            '<svg class="icon icon-circle-check workflow-timeline__icon" aria-hidden="true"><use href="#icon-circle-check"></use></svg>',
+            count=1,  # the "submitted" item
+            html=True,
+        )
+
         self.assertIn(
-            "In progress\n        </span>\n                        {}".format(
-                self.task_1.name
-            ),
+            f"In progress\n        </span>\n                        \n                        {self.task_1.name}",
             html,
         )
+
+        self.assertContains(
+            response,
+            '<svg class="icon icon-radio-full workflow-timeline__icon" aria-hidden="true"><use href="#icon-radio-full"></use></svg>',
+            count=1,
+            html=True,
+        )
+
         self.assertIn(
-            "Not started\n        </span>\n                        {}".format(
-                self.task_2.name
-            ),
+            f"Not started\n        </span>\n                        \n                        {self.task_2.name}",
             html,
+        )
+        self.assertContains(
+            response,
+            '<svg class="icon icon-radio-empty workflow-timeline__icon" aria-hidden="true"><use href="#icon-radio-empty"></use></svg>',
+            count=2,
+            html=True,
         )
         self.assertIn(self.get_url("history"), html)
+
+        # now approve
+        response = self.workflow_action("approve")
+        html = response.content.decode("utf-8")
+        self.assertIn(
+            f"Approved\n        </span>\n                        \n                        {self.task_1.name}",
+            html,
+        )
+        self.assertContains(
+            response,
+            '<svg class="icon icon-circle-check workflow-timeline__icon" aria-hidden="true"><use href="#icon-circle-check"></use></svg>',
+            count=2,  # the "submitted" item, and task 1
+            html=True,
+        )
+
+        self.assertIn(
+            f"In progress\n        </span>\n                        \n                        {self.task_2.name}",
+            html,
+        )
+        self.assertContains(
+            response,
+            '<svg class="icon icon-radio-full workflow-timeline__icon" aria-hidden="true"><use href="#icon-radio-full"></use></svg>',
+            count=1,
+            html=True,
+        )
+        self.assertContains(
+            response,
+            '<svg class="icon icon-radio-empty workflow-timeline__icon" aria-hidden="true"><use href="#icon-radio-empty"></use></svg>',
+            count=1,
+            html=True,
+        )
 
     def test_status_through_workflow_cycle(self):
         self.login(self.superuser)


### PR DESCRIPTION
### Description

This PR improves the workflow timeline show via the "View details" link in the information panel.

This only works with `WAGTAIL_WORKFLOW_REQUIRE_REAPPROVAL_ON_EDIT = False` (which is the default.

<details><summary>Screnshots</summary>

Approved task, before and after

<img width="2518" height="912" alt="task approved" src="https://github.com/user-attachments/assets/9c3ac201-bf52-49fd-ab40-e41d077b7c7c" />

Rejected task, before and after
<img width="2514" height="930" alt="task rejected" src="https://github.com/user-attachments/assets/3f045289-6a6c-47f1-b4c2-d3935cc96980" />

Cancelled task, before and after
<img width="2524" height="904" alt="task cancelled" src="https://github.com/user-attachments/assets/25d2dc07-19fe-4953-a5db-a73831295cec" />

Note: I am aware that this last one is not possible out of the box

</details> 

### AI usage

No AI was used.
