### PR TITLE
[Feature] Add  include_root  flag to Pages Admin API

### DIFF
--- a/wagtail/admin/api/views.py
+++ b/wagtail/admin/api/views.py
@@ -69,7 +69,7 @@ class PagesAdminAPIViewSet(PagesAPIViewSet):
     detail_only_fields = []
 
     known_query_parameters = PagesAPIViewSet.known_query_parameters.union(
-        ["for_explorer", "has_children"]
+        ["for_explorer", "has_children", "include_root"]
     )
 
     @classmethod
@@ -100,9 +100,10 @@ class PagesAdminAPIViewSet(PagesAPIViewSet):
     def get_queryset(self):
         queryset = super().get_queryset()
 
-        # Hide root page
-        # TODO: Add "include_root" flag
-        queryset = queryset.exclude(depth=1).defer_streamfields().specific()
+        if self.request.GET.get("include_root") != "true":
+            queryset = queryset.exclude(depth=1)
+
+        queryset = queryset.defer_streamfields().specific()
 
         return queryset
 

--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -731,6 +731,24 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
         self.assertEqual(len(content["items"]), get_total_page_count())
 
 
+
+    def test_include_root(self):
+        response = self.get_response(include_root="true")
+        content = json.loads(response.content.decode("UTF-8"))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertIn(1, page_id_list)
+        self.assertEqual(content["meta"]["total_count"], get_total_page_count() + 1)
+
+    def test_include_root_false(self):
+        response = self.get_response(include_root="false")
+        content = json.loads(response.content.decode("UTF-8"))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertNotIn(1, page_id_list)
+        self.assertEqual(content["meta"]["total_count"], get_total_page_count())
+
+
 class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
     fixtures = ["demosite.json"]
 


### PR DESCRIPTION
This commit adds  to  in  and updates  to conditionally exclude the root page. Corresponding tests have been added to .

<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->

Fixes #13867


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #...

### Description

<!-- Please describe the problem you're fixing. -->
This PR adds an optional include_root query parameter to the Pages Admin API (wagtail.admin.api.views.PagesAdminAPIViewSet).

Current behavior (without this PR):

- The root page (Depth=1) is hardcoded to be excluded from the queryset.
- A TODO comment exists in wagtail/admin/api/views.py suggesting this flag.

New behavior:

- include_root=true: The root page is included in the results.
- include_root=false (or omitted): The root page is excluded (backward compatible).

Implementation details:

- Added include_root to known_query_parameters.
- Updated get_queryset to conditionally apply .exclude(depth=1).
- Added unit tests in wagtail/admin/tests/api/test_pages.py.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
I used an AI assistant to scan the codebase for TODO comments, which led to the discovery of this issue.