### PR TITLE
Add case-insensitive redirects option

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -912,6 +912,24 @@ Default is an empty list, there must be a list of languages to also purge the ur
 
 ## Redirects
 
+### `WAGTAIL_REDIRECTS_CASE_INSENSITIVE`
+
+(boolean, default `False`)
+
+When set to `True`, redirect matching becomes case-insensitive. This means a redirect created for `/ActionPlanOnBullying` will also match requests to `/actionplanonbullying`, `/ACTIONPLANONBULLYING`, or any other case variation.
+
+```python
+WAGTAIL_REDIRECTS_CASE_INSENSITIVE = True
+```
+
+This is particularly useful for large sites where users might type URLs with different capitalization, avoiding the need to create multiple redirect entries for the same path. For example, government websites with many campaign pages can create a single redirect that handles all case variations.
+
+When `False` (the default), redirects use exact case matching, maintaining backward compatibility with existing behavior.
+
+```{note}
+Case-insensitive matching applies to the entire path, including query strings. For example, `/Test?foo=Bar` will match `/test?foo=bar` when this setting is enabled.
+```
+
 ### `WAGTAIL_REDIRECTS_FILE_STORAGE`
 
 ```python

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -1,11 +1,13 @@
 from io import BytesIO
+from unittest import skipIf
+
 
 from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.test import TestCase, override_settings
 from django.db import connection
-from unittest import skipIf
 from django.urls import reverse
+
 from openpyxl.reader.excel import load_workbook
 
 from wagtail.admin.admin_url_finder import AdminURLFinder

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -691,9 +691,7 @@ class TestCaseInsensitiveRedirects(TestCase):
 
     def test_case_insensitive_redirect_to_page(self):
         """Different case variations all match the same redirect."""
-        redirect = models.Redirect(
-            old_path="/CaseMixed", redirect_link="/target-page/"
-        )
+        redirect = models.Redirect(old_path="/CaseMixed", redirect_link="/target-page/")
         redirect.save()
 
         test_cases = ["/casemixed", "/CASEMIXED", "/CaseMixed", "/CaSeMiXeD"]
@@ -754,9 +752,7 @@ class TestCaseSensitiveRedirects(TestCase):
 
     def test_case_sensitive_with_special_characters(self):
         """Special characters don't affect case sensitivity."""
-        redirect = models.Redirect(
-            old_path="/Test-Page_123", redirect_link="/target"
-        )
+        redirect = models.Redirect(old_path="/Test-Page_123", redirect_link="/target")
         redirect.save()
 
         response = self.client.get("/Test-Page_123/")
@@ -766,10 +762,7 @@ class TestCaseSensitiveRedirects(TestCase):
         response = self.client.get("/test-page_123/")
         self.assertEqual(response.status_code, 404)
 
-    @skipIf(
-        connection.vendor == "sqlite",
-        "SQLite uses case-insensitive collation"
-    )
+    @skipIf(connection.vendor == "sqlite", "SQLite uses case-insensitive collation")
     def test_case_sensitive_matching(self):
         """Case-sensitive matching works correctly on databases that support it."""
         redirect = models.Redirect(old_path="/CaseSensitive", redirect_link="/target")

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -1,13 +1,11 @@
 from io import BytesIO
 from unittest import skipIf
 
-
 from django.conf import settings
 from django.contrib.auth.models import Permission
-from django.test import TestCase, override_settings
 from django.db import connection
+from django.test import TestCase, override_settings
 from django.urls import reverse
-
 from openpyxl.reader.excel import load_workbook
 
 from wagtail.admin.admin_url_finder import AdminURLFinder

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -3,6 +3,8 @@ from io import BytesIO
 from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.test import TestCase, override_settings
+from django.db import connection
+from unittest import skipIf
 from django.urls import reverse
 from openpyxl.reader.excel import load_workbook
 
@@ -643,6 +645,144 @@ class TestRedirects(TestCase):
 
         # should default is_permanent to True
         self.assertIs(redirect.is_permanent, True)
+
+
+@override_settings(WAGTAIL_REDIRECTS_CASE_INSENSITIVE=True)
+class TestCaseInsensitiveRedirects(TestCase):
+    fixtures = ["test.json"]
+
+    def test_case_insensitive_redirect_matching(self):
+        """Redirects match regardless of case when setting is enabled."""
+        redirect = models.Redirect(
+            old_path="/ActionPlanOnBullying", redirect_link="/new-page"
+        )
+        redirect.save()
+
+        # Try different capitalizations - all should redirect
+        test_cases = [
+            "/ActionPlanOnBullying",
+            "/actionplanonbullying",
+            "/ACTIONPLANONBULLYING",
+            "/ActionPlanOnBullying/",
+            "/AcTiOnPlAnOnBuLlYiNg",
+        ]
+
+        for test_path in test_cases:
+            with self.subTest(path=test_path):
+                response = self.client.get(test_path)
+                self.assertRedirects(
+                    response,
+                    "/new-page",
+                    status_code=301,
+                    fetch_redirect_response=False,
+                )
+
+    def test_case_insensitive_with_query_string(self):
+        """Query strings work with case-insensitive matching."""
+        redirect = models.Redirect(
+            old_path="/TestPage?foo=bar", redirect_link="/target"
+        )
+        redirect.save()
+
+        response = self.client.get("/testpage/?foo=bar")
+        self.assertRedirects(
+            response, "/target", status_code=301, fetch_redirect_response=False
+        )
+
+    def test_case_insensitive_redirect_to_page(self):
+        """Different case variations all match the same redirect."""
+        redirect = models.Redirect(
+            old_path="/CaseMixed", redirect_link="/target-page/"
+        )
+        redirect.save()
+
+        test_cases = ["/casemixed", "/CASEMIXED", "/CaseMixed", "/CaSeMiXeD"]
+        for test_path in test_cases:
+            with self.subTest(path=test_path):
+                response = self.client.get(test_path)
+                self.assertRedirects(
+                    response,
+                    "/target-page/",
+                    status_code=301,
+                    fetch_redirect_response=False,
+                )
+
+    def test_case_insensitive_site_specific_redirect(self):
+        """Site-specific redirects respect case-insensitive setting."""
+        contact_page = Page.objects.get(url_path="/home/contact-us/")
+        site = Site.objects.create(
+            hostname="other.example.com", port=80, root_page=contact_page
+        )
+        redirect = models.Redirect(
+            old_path="/About", redirect_link="/about-page", site=site
+        )
+        redirect.save()
+
+        # Works on the right site
+        response = self.client.get("/about/", HTTP_HOST="other.example.com")
+        self.assertRedirects(
+            response, "/about-page", status_code=301, fetch_redirect_response=False
+        )
+
+        # Doesn't work on other sites
+        response = self.client.get("/about/", HTTP_HOST="localhost")
+        self.assertEqual(response.status_code, 404)
+
+
+class TestCaseSensitiveRedirects(TestCase):
+    """Default behavior remains case-sensitive for backward compatibility."""
+
+    fixtures = ["test.json"]
+
+    def test_case_sensitive_redirect_matching(self):
+        """By default, redirects only match exact case."""
+        redirect = models.Redirect(
+            old_path="/ActionPlanOnBullying", redirect_link="/new-page"
+        )
+        redirect.save()
+
+        # Exact match works
+        response = self.client.get("/ActionPlanOnBullying/")
+        self.assertRedirects(
+            response, "/new-page", status_code=301, fetch_redirect_response=False
+        )
+        # Different case returns 404
+        response = self.client.get("/actionplanonbullying/")
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get("/ACTIONPLANONBULLYING/")
+        self.assertEqual(response.status_code, 404)
+
+    def test_case_sensitive_with_special_characters(self):
+        """Special characters don't affect case sensitivity."""
+        redirect = models.Redirect(
+            old_path="/Test-Page_123", redirect_link="/target"
+        )
+        redirect.save()
+
+        response = self.client.get("/Test-Page_123/")
+        self.assertRedirects(
+            response, "/target", status_code=301, fetch_redirect_response=False
+        )
+        response = self.client.get("/test-page_123/")
+        self.assertEqual(response.status_code, 404)
+
+    @skipIf(
+        connection.vendor == "sqlite",
+        "SQLite uses case-insensitive collation"
+    )
+    def test_case_sensitive_matching(self):
+        """Case-sensitive matching works correctly on databases that support it."""
+        redirect = models.Redirect(old_path="/CaseSensitive", redirect_link="/target")
+        redirect.save()
+
+        response = self.client.get("/CaseSensitive")
+        self.assertRedirects(
+            response, "/target", status_code=301, fetch_redirect_response=False
+        )
+        response = self.client.get("/casesensitive")
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get("/CASESENSITIVE")
+        self.assertEqual(response.status_code, 404)
 
 
 @override_settings(


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #13085 

### Description

<!-- Please describe the problem you're fixing. -->

This adds a new `WAGTAIL_REDIRECTS_CASE_INSENSITIVE` setting that makes redirect matching case-insensitive when enabled.

**The problem:** Sites with marketing campaigns or public-facing URLs (like government websites) often use mixed-case paths like `/ActionPlanOnBullying` for readability. Right now, if someone types `/actionplanonbullying`, it won't redirect, instead you'd need to create separate redirect entries for every possible capitalization, which gets messy fast.

**What this does:** When you set `WAGTAIL_REDIRECTS_CASE_INSENSITIVE = True`, the redirect middleware uses case-insensitive matching (`__iexact` lookup) so a redirect for `/ActionPlanOnBullying` will match `/actionplanonbullying`, `/ACTIONPLANONBULLYING`, or any other case variation. It defaults to `False` so existing sites aren't affected.

I tested this manually by creating redirects with mixed case and trying different capitalizations and it works as expected. Also added tests to cover both the new case-insensitive mode and to make sure the default case-sensitive behavior still works.

**Note on tests:** One test (`test_case_sensitive_matching`) is skipped on SQLite because SQLite uses case-insensitive text collation by default, which makes it impossible to properly test case-sensitive matching in that environment. The test passes on PostgreSQL and other databases that support case-sensitive collation.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Used AI to help draft the documentation in settings.md.