### PR TITLE
Feature Add Report for Scheduled Pages

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/reports/scheduled_pages_results.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/scheduled_pages_results.html
@@ -1,0 +1,34 @@
+{% extends 'wagtailadmin/reports/base_page_report_results.html' %}
+{% load i18n wagtailadmin_tags %}
+
+{% block results %}
+    <table class="listing">
+        <thead>
+            <tr>
+                <th>{% trans "Page" %}</th>
+                <th>{% trans "Type" %}</th>
+                <th>{% trans "Scheduled by" %}</th>
+                <th>{% trans "Scheduled for" %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for page in object_list %}
+                <tr>
+                    <td class="title">
+                        <a href="{% url 'wagtailadmin_pages:edit' page.id %}">
+                            {{ page.get_admin_display_title }}
+                        </a>
+                    </td>
+                    <td>{{ page.content_type.model_class.get_verbose_name }}</td>
+                    <td>{{ page.get_latest_revision.user }}</td>
+                    <td>{{ page.get_latest_revision.approved_go_live_at|default:page.expire_at }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endblock %}
+
+
+{% block no_results_message %}
+    <p>{% trans "No scheduled page found." %}</p>
+{% endblock %}

--- a/wagtail/admin/urls/reports.py
+++ b/wagtail/admin/urls/reports.py
@@ -6,6 +6,7 @@ from wagtail.admin.views.reports.locked_pages import LockedPagesView
 from wagtail.admin.views.reports.page_types_usage import (
     PageTypesUsageReportView,
 )
+from wagtail.admin.views.reports.scheduled_pages import ScheduledPagesView
 from wagtail.admin.views.reports.workflows import WorkflowTasksView, WorkflowView
 
 app_name = "wagtailadmin_reports"
@@ -49,5 +50,15 @@ urlpatterns = [
         "page-types-usage/results/",
         PageTypesUsageReportView.as_view(results_only=True),
         name="page_types_usage_results",
+    ),
+    path(
+        "scheduled-pages/",
+        ScheduledPagesView.as_view(),
+        name="scheduled_pages",
+    ),
+    path(
+        "scheduled-pages/results/",
+        ScheduledPagesView.as_view(results_only=True),
+        name="scheduled_pages_results",
     ),
 ]

--- a/wagtail/admin/views/reports/scheduled_pages.py
+++ b/wagtail/admin/views/reports/scheduled_pages.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+
+from django.core.exceptions import PermissionDenied
+from django.utils.translation import gettext_lazy as _
+
+from wagtail.permissions import page_permission_policy
+
+from .base import PageReportView
+
+
+class ScheduledPagesView(PageReportView):
+    """Report showing pages scheduled for future publish or unpublish"""
+
+    results_template_name = "wagtailadmin/reports/scheduled_pages_results.html"
+    page_title = _("Scheduled Pages")
+    header_icon = "time"
+
+    def get_filename(self):
+        """Generate filename for XLSX export"""
+        return "scheduled-pages-report-{}".format(datetime.today().strftime("%Y-%m-%d"))
+
+    def get_queryset(self):
+        pages = (
+            page_permission_policy.instances_user_has_permission_for(
+                self.request.user, "publish"
+            )
+            .annotate_approved_schedule()
+            .filter(_approved_schedule=True)
+            .prefetch_related("content_type")
+            .order_by("-first_published_at")
+        )
+        self.queryset = pages
+        return super().get_queryset()
+
+    def dispatch(self, request, *args, **kwargs):
+        if not page_permission_policy.user_has_permission(request.user, "publish"):
+            raise PermissionDenied
+        return super().dispatch(request, *args, **kwargs)

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -862,6 +862,13 @@ class AgingPagesReportMenuItem(MenuItem):
         )
 
 
+class ScheduledPagesMenuItem(MenuItem):
+    def is_shown(self, request):
+        return page_permission_policy.user_has_any_permission(
+            request.user, ["add", "change", "publish"]
+        )
+
+
 class PageTypesReportMenuItem(MenuItem):
     def is_shown(self, request):
         return page_permission_policy.user_has_any_permission(
@@ -921,6 +928,17 @@ def register_aging_pages_report_menu_item():
         name="aging-pages",
         icon_name="time",
         order=1100,
+    )
+
+
+@hooks.register("register_reports_menu_item")
+def register_scheduled_pages_menu_item():
+    return ScheduledPagesMenuItem(
+        _("Scheduled pages"),
+        reverse("wagtailadmin_reports:scheduled_pages"),
+        name="scheduled-pages",
+        icon_name="time",
+        order=700,
     )
 
 


### PR DESCRIPTION
Fixes: #12919

### Changes Made

- `wagtail/admin/views/reports/scheduled_pages.py`: Report view listing all pages scheduled for publish/unpublish.
- `wagtail/admin/templates/wagtailadmin/reports/scheduled_pages_results.html`: Table showing page, type, scheduled by, and scheduled date/time.
- `wagtail/admin/wagtail_hooks.py`: Menu item under Report section.
- `wagtail/admin/urls/reports.py`: URL pattern for scheduled pages report.
- `wagtail/admin/tests/test_reports_views.py`: Added Test for ScheduledPage Permissions.

### Source
- Based on previous PR attempt at #8740. 
- Implementation follows the pattern of existing reports (`AgingPagesView`, `LockedPagesView`).

### Not Included (Future Commits)
- Dashboard/homepage panel.
- "Publish now" or "Publish all" action buttons.
- Advanced filters.
- Scheduled snippets support (can be added later).

These can added in future commits. I'll update it as i progress.

Please let me know, If there is some tweaks or modification required in my implementation.


### AI Usage

Used AI assist for the html template.