### PR TITLE
Rename "Settings" to "Settings Models"

### DIFF
--- a/docs/reference/contrib/settings.md
+++ b/docs/reference/contrib/settings.md
@@ -1,4 +1,4 @@
-# Settings
+# Settings Models
 
 The `wagtail.contrib.settings` module allows you to define models that hold
 settings which are either common across all site records or specific to each site.


### PR DESCRIPTION
There's currently two pages in the documentation called "Settings":

- https://docs.wagtail.org/en/6.3/reference/contrib/settings.html
- https://docs.wagtail.org/en/6.3/reference/settings.html

When searching Google for "Wagtail Settings" the document for the settings contrib module comes up first, and the document describing the Django settings doesn't show up at all. I think most people searching for this would expect the second document to show up.

This PR renames the first one to "Settings Models" which should hopefully make the second document more relevant.