### PR TITLE
Fix publish flow so failed publishes don’t wipe scheduled pages

### DIFF
--- a/wagtail/actions/publish_revision.py
+++ b/wagtail/actions/publish_revision.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.utils import timezone
 
 from wagtail.log_actions import log
@@ -99,6 +100,7 @@ class PublishRevisionAction:
             ):
                 workflow_state.cancel(user=self.user)
 
+    @transaction.atomic
     def _publish_revision(
         self,
         revision: Revision,


### PR DESCRIPTION
## Context

I ran into a case where a publish failed, but something still changed in the database.

Right now, publishing clears `approved_go_live_at` on existing revisions before the page is actually saved as live. If that save fails (validation error, slug conflict, etc.), the publish stops — but the scheduled revision has already been cleared and is gone.

From the editor’s side, it just looks like a failed publish. Under the hood, a scheduled page quietly disappeared.

---

## What this does

This makes the publish flow atomic.

* The core publish logic now runs inside a transaction, so clearing scheduled revisions, saving the page, and post-publish hooks all succeed or fail together
* The publish view is wrapped in `transaction.atomic()` as well, matching `save_action()`

If a publish fails, scheduled revisions are left untouched.

---

## Outcome

* No silent loss of scheduled content
* Publishing behaves the way editors expect
* No change for successful publishes

Small change, but it prevents a pretty painful failure mode.