### PR TITLE
Enhance workflow tasks styling by setting a maximum width for task elements and adjusting the width of the tasks column in the admin view.

### DIFF
--- a/client/scss/components/_workflow-tasks.scss
+++ b/client/scss/components/_workflow-tasks.scss
@@ -11,6 +11,7 @@
     border-radius: 5px;
     color: theme('colors.text-link-default');
     min-width: $task-width;
+    max-width: 20ch;
     height: $task-height;
     margin: 7px;
     padding-inline-start: 9px;

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -138,7 +138,7 @@ class Index(IndexView):
             url_name="wagtailadmin_workflows:usage",
             width="15%",
         ),
-        WorkflowTasksColumn("tasks", label=_("Tasks")),
+        WorkflowTasksColumn("tasks", label=_("Tasks"), width="60%"),
     ]
     default_ordering = "name"
     search_fields = ["name"]


### PR DESCRIPTION
Fixes #13883

Workflows with tasks that have very long names can cause the “Tasks” column on /admin/workflows/list/ to expand disproportionately, squeezing the other columns and making the table look unbalanced.

This happens because the task name is styled for truncation (text-overflow: ellipsis) but the task “card” container had no max width, so long names could still increase the intrinsic width of the Tasks cell and force the column to grow.

This PR fixes the layout by:

Adding a max-width constraint to the workflow task “card” so long names truncate as intended.
Setting an explicit width for the Tasks column so the “Name” and “Used by” columns remain readable and consistent.
Screenshots are attached showing the listing before/after with long task names.

Before -> reproduce the BUG.
<img width="1718" height="749" alt="Screenshot From 2026-02-10 23-56-37" src="https://github.com/user-attachments/assets/9b34a498-017d-4cbd-a4e1-351093781ac6" />

After -> applying the fix.
<img width="1718" height="749" alt="Screenshot From 2026-02-10 23-58-31" src="https://github.com/user-attachments/assets/fe099604-55b2-4ef9-98b2-d2a2a4b2035d" />
