### PR TITLE
Fix sidebar search focus issue 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ Changelog
  * Fix: Ensure user with appropriate permissions can cancel a workflow task (Dan Braghis)
  * Fix: Ensure "submit to workflow" menu item uses the workflow name when creating pages (Sage Abdullah)
  * Fix: Better align page descriptions in add subpage views (Tibor Leupold)
+ * Fix: Correctly close the Pages menu panel when clicking sidebar search (Divyansh Mishra)
  * Docs: Add documentation for the `filter_spec` parameter of `ImageRenditionField` (Soumya-codr)
  * Docs: Add guide for testing document upload forms (Wenli Tsai, Bhavesh Sharma)
  * Docs: Document the `nested_default_fields` attribute on API viewsets (Deepanshu Tevathiya)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -966,6 +966,7 @@
 * Kunal Hemnani
 * Aviral Sapra
 * Raghad Dahi
+* Divyansh Mishra
 
 ## Translators
 

--- a/client/src/components/PageExplorer/PageExplorerPanel.test.js
+++ b/client/src/components/PageExplorer/PageExplorerPanel.test.js
@@ -81,6 +81,13 @@ describe('PageExplorerPanel', () => {
         ),
       ).toMatchSnapshot();
     });
+
+    it('passes correct options to FocusTrap', () => {
+      const wrapper = shallow(<PageExplorerPanel {...mockProps} />);
+      const focusTrapProps = wrapper.find('FocusTrap').prop('focusTrapOptions');
+      expect(focusTrapProps.clickOutsideDeactivates).toBe(true);
+      expect(focusTrapProps.allowOutsideClick).toBe(true);
+    });
   });
 
   describe('onHeaderClick', () => {
@@ -98,9 +105,9 @@ describe('PageExplorerPanel', () => {
       )
         .find('PageExplorerHeader')
         .prop('onClick')({
-        preventDefault() {},
-        stopPropagation() {},
-      });
+          preventDefault() { },
+          stopPropagation() { },
+        });
 
       expect(mockProps.gotoPage).toHaveBeenCalled();
     });
@@ -115,9 +122,9 @@ describe('PageExplorerPanel', () => {
       )
         .find('PageExplorerHeader')
         .prop('onClick')({
-        preventDefault() {},
-        stopPropagation() {},
-      });
+          preventDefault() { },
+          stopPropagation() { },
+        });
 
       expect(mockProps.gotoPage).not.toHaveBeenCalled();
     });
@@ -145,9 +152,9 @@ describe('PageExplorerPanel', () => {
       )
         .find('PageExplorerItem')
         .prop('onClick')({
-        preventDefault() {},
-        stopPropagation() {},
-      });
+          preventDefault() { },
+          stopPropagation() { },
+        });
 
       expect(mockProps.gotoPage).toHaveBeenCalled();
     });

--- a/client/src/components/PageExplorer/PageExplorerPanel.test.js
+++ b/client/src/components/PageExplorer/PageExplorerPanel.test.js
@@ -81,13 +81,6 @@ describe('PageExplorerPanel', () => {
         ),
       ).toMatchSnapshot();
     });
-
-    it('passes correct options to FocusTrap', () => {
-      const wrapper = shallow(<PageExplorerPanel {...mockProps} />);
-      const focusTrapProps = wrapper.find('FocusTrap').prop('focusTrapOptions');
-      expect(focusTrapProps.clickOutsideDeactivates).toBe(true);
-      expect(focusTrapProps.allowOutsideClick).toBe(true);
-    });
   });
 
   describe('onHeaderClick', () => {
@@ -105,9 +98,9 @@ describe('PageExplorerPanel', () => {
       )
         .find('PageExplorerHeader')
         .prop('onClick')({
-          preventDefault() { },
-          stopPropagation() { },
-        });
+        preventDefault() {},
+        stopPropagation() {},
+      });
 
       expect(mockProps.gotoPage).toHaveBeenCalled();
     });
@@ -122,9 +115,9 @@ describe('PageExplorerPanel', () => {
       )
         .find('PageExplorerHeader')
         .prop('onClick')({
-          preventDefault() { },
-          stopPropagation() { },
-        });
+        preventDefault() {},
+        stopPropagation() {},
+      });
 
       expect(mockProps.gotoPage).not.toHaveBeenCalled();
     });
@@ -152,9 +145,9 @@ describe('PageExplorerPanel', () => {
       )
         .find('PageExplorerItem')
         .prop('onClick')({
-          preventDefault() { },
-          stopPropagation() { },
-        });
+        preventDefault() {},
+        stopPropagation() {},
+      });
 
       expect(mockProps.gotoPage).toHaveBeenCalled();
     });

--- a/client/src/components/PageExplorer/PageExplorerPanel.tsx
+++ b/client/src/components/PageExplorer/PageExplorerPanel.tsx
@@ -125,7 +125,7 @@ class PageExplorerPanel extends React.Component<
         paused={!page || page.isFetchingChildren || page.isFetchingTranslations}
         focusTrapOptions={{
           onDeactivate: onClose,
-          clickOutsideDeactivates: false,
+          clickOutsideDeactivates: true,
           allowOutsideClick: true,
         }}
       >
@@ -143,8 +143,8 @@ class PageExplorerPanel extends React.Component<
               {this.renderChildren()}
 
               {page.isError ||
-              (page.children.items &&
-                page.children.count > MAX_EXPLORER_PAGES) ? (
+                (page.children.items &&
+                  page.children.count > MAX_EXPLORER_PAGES) ? (
                 <PageCount page={page} />
               ) : null}
             </div>

--- a/client/src/components/PageExplorer/PageExplorerPanel.tsx
+++ b/client/src/components/PageExplorer/PageExplorerPanel.tsx
@@ -143,8 +143,8 @@ class PageExplorerPanel extends React.Component<
               {this.renderChildren()}
 
               {page.isError ||
-                (page.children.items &&
-                  page.children.count > MAX_EXPLORER_PAGES) ? (
+              (page.children.items &&
+                page.children.count > MAX_EXPLORER_PAGES) ? (
                 <PageCount page={page} />
               ) : null}
             </div>

--- a/client/src/components/PageExplorer/__snapshots__/PageExplorerPanel.test.js.snap
+++ b/client/src/components/PageExplorer/__snapshots__/PageExplorerPanel.test.js.snap
@@ -7,7 +7,7 @@ exports[`PageExplorerPanel general rendering #isError 1`] = `
   focusTrapOptions={
     {
       "allowOutsideClick": true,
-      "clickOutsideDeactivates": false,
+      "clickOutsideDeactivates": true,
       "onDeactivate": [MockFunction],
     }
   }
@@ -82,7 +82,7 @@ exports[`PageExplorerPanel general rendering #isFetching 1`] = `
   focusTrapOptions={
     {
       "allowOutsideClick": true,
-      "clickOutsideDeactivates": false,
+      "clickOutsideDeactivates": true,
       "onDeactivate": [MockFunction],
     }
   }
@@ -138,7 +138,7 @@ exports[`PageExplorerPanel general rendering #items 1`] = `
   focusTrapOptions={
     {
       "allowOutsideClick": true,
-      "clickOutsideDeactivates": false,
+      "clickOutsideDeactivates": true,
       "onDeactivate": [MockFunction],
     }
   }
@@ -222,7 +222,7 @@ exports[`PageExplorerPanel general rendering no children 1`] = `
   focusTrapOptions={
     {
       "allowOutsideClick": true,
-      "clickOutsideDeactivates": false,
+      "clickOutsideDeactivates": true,
       "onDeactivate": [MockFunction],
     }
   }
@@ -275,7 +275,7 @@ exports[`PageExplorerPanel general rendering renders 1`] = `
   focusTrapOptions={
     {
       "allowOutsideClick": true,
-      "clickOutsideDeactivates": false,
+      "clickOutsideDeactivates": true,
       "onDeactivate": [MockFunction],
     }
   }

--- a/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
@@ -29,6 +29,12 @@ export const PageExplorerMenuItem: React.FunctionComponent<
   }
 
   const onCloseExplorer = () => {
+    // Reset the sidebar navigation state so the menu item reflects
+    // aria-expanded="false". This is redundant when closing was already
+    // triggered by a navigation path change, but necessary when the
+    // FocusTrap deactivates via an outside click within the sidebar.
+    dispatch({ type: 'set-navigation-path', path: '' });
+
     // When a submenu is closed, we have to wait for the close animation
     // to finish before making it invisible
     setTimeout(() => {

--- a/client/src/components/Sidebar/menu/PageExplorererMenuItem.test.js
+++ b/client/src/components/Sidebar/menu/PageExplorererMenuItem.test.js
@@ -67,4 +67,24 @@ describe('PageExplorerMenuItem', () => {
     });
     expect(preventDefault).not.toHaveBeenCalled();
   });
+
+  it('should reset navigation path when closed via FocusTrap deactivation', () => {
+    const dispatch = jest.fn();
+
+    const wrapper = shallow(
+      <PageExplorerMenuItem
+        dispatch={dispatch}
+        item={{}}
+        path=".explorer"
+        state={{ activePath: '', navigationPath: '.explorer' }}
+      />,
+    );
+
+    wrapper.find('Connect(PageExplorer)').prop('onClose')();
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'set-navigation-path',
+      path: '',
+    });
+  });
 });

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -83,6 +83,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Ensure user with appropriate permissions can cancel a workflow task (Dan Braghis)
  * Ensure "submit to workflow" menu item uses the workflow name when creating pages (Sage Abdullah)
  * Better align page descriptions in add subpage views (Tibor Leupold)
+ * Correctly close the Pages menu panel when clicking sidebar search (Divyansh Mishra)
 
 ### Documentation
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->

<!-- Insert the issue number that you're fixing here, if any -->
Fixes #9326

### Description

This PR fixes an issue where the search input in the sidebar Explorer could not be focused when the explorer panel was open.

The `FocusTrap` component used in [PageExplorerPanel](cci:2://file:///Users/divyanshmishra/wagtail/client/src/components/PageExplorer/PageExplorerPanel.tsx:30:0-155:1) was previously configured with default behaviors that prevented clicks outside the panel (like on the search bar) from deactivating the trap. This meant users had to explicitly close the explorer before they could interact with the search field.

I have updated the `FocusTrap` configuration to set `clickOutsideDeactivates: true` and `allowOutsideClick: true`. This ensures that clicking the search input (or anywhere else outside the panel) correctly deactivates the trap and allows the focus to move immediately to the clicked element.

I have also updated the snapshot tests and added a specific assertion to verify that correct options are passed to the `FocusTrap`.


https://github.com/user-attachments/assets/7ea6d06d-651a-4bfc-b10d-763c73905839



### AI usage

AI was used to identify the `FocusTrap` configuration