### PR TITLE
Refactor: Rename misleading 'request' parameter to 'cache_object' in _get_site_root_paths

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
 * Fix: Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
 * Fix: Prevent an error when approving a workflow that has been cancelled in a different session (Kailesh)
 * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
+* Maintenance: Rename `request` argument to `cache_object` in `Page._get_site_root_paths()` for correctness (Kailesh)
 
 
 7.4 LTS (05.05.2026)

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -28,7 +28,7 @@ depth: 1
 
 ### Maintenance
 
- * ...
+ * Rename `request` argument to `cache_object` in `Page._get_site_root_paths()` for correctness (Kailesh)
 
 ## Upgrade considerations - removal of deprecated features from Wagtail 6.4 - 7.3
 
@@ -68,3 +68,11 @@ For additional details on these changes, see:
 The [`SnippetChooserViewSet.widget_class`](wagtail.snippets.views.chooser.SnippetChooserViewSet.widget_class) attribute now correctly returns a widget class instead of an instance, consistent with [`ChooserViewSet.widget_class`](wagtail.admin.viewsets.chooser.ChooserViewSet.widget_class). This change may require updates to any customizations that relied on the previous behavior, such as an override in a `SnippetChooserViewSet` subclass that uses `super().widget_class`.
 
 ## Upgrade considerations - changes to undocumented internals
+
+### `request` argument to `Page._get_site_root_paths` is now `cache_object`
+
+The `request` argument to the undocumented method `Page._get_site_root_paths()` is renamed to `cache_object` to reflect the fact that it is not always a request object, but may be any object that can be used for caching purposes.
+
+If you pass `request` as a positional argument, no changes are needed. If you pass `request` as a keyword argument to this method, you will need to update the argument name to `cache_object` in your code or turn it into a positional argument.
+
+Passing a `request` keyword argument will continue to work for now and raise a deprecation warning, but support for this will be removed in a future release.

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -4,6 +4,7 @@ import functools
 import logging
 import posixpath
 import uuid
+import warnings
 
 from django.conf import settings
 from django.contrib.auth.models import Group, Permission
@@ -63,6 +64,7 @@ from wagtail.signals import (
     pre_validate_delete,
 )
 from wagtail.url_routing import RouteResult
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
 from wagtail.utils.timestamps import ensure_utc
 
 from .audit_log import BaseLogEntry, BaseLogEntryManager, LogEntryQuerySet
@@ -1317,13 +1319,19 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         """
         return (not self.is_leaf()) or self.depth == 2
 
-    def _get_site_root_paths(self, request=None):
+    def _get_site_root_paths(self, cache_object=None, **kwargs):
         """
         Return ``Site.get_site_root_paths()``, using the cached copy on the
-        request object if available.
+        cache_object if available.
         """
-        # if we have a request, use that to cache site_root_paths; otherwise, use self
-        cache_object = request if request else self
+        if "request" in kwargs:
+            warnings.warn(
+                "The `request` kwarg in `Page._get_site_root_paths()` is now `cache_object`.",
+                category=RemovedInWagtail90Warning,
+            )
+            cache_object = cache_object or kwargs["request"]
+        # if we have a cache_object, use that to cache site_root_paths; otherwise, use self
+        cache_object = cache_object if cache_object else self
         try:
             return cache_object._wagtail_cached_site_root_paths
         except AttributeError:

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -73,6 +73,7 @@ from wagtail.test.testapp.models import (
 )
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.url_routing import RouteResult
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
 
 def get_ct(model):
@@ -362,6 +363,19 @@ class TestSiteRouting(TestCase):
         request.META["HTTP_HOST"] = "disallowed:80"
         with self.assertNumQueries(1):
             self.assertEqual(Site.find_for_request(request), self.default_site)
+
+    def test_get_site_root_paths_deprecation(self):
+        with self.assertWarnsMessage(
+            RemovedInWagtail90Warning,
+            "The `request` kwarg in `Page._get_site_root_paths()` "
+            "is now `cache_object`.",
+        ):
+            self.assertEqual(
+                self.events_site.root_page._get_site_root_paths(
+                    request=get_dummy_request()
+                ),
+                Site.get_site_root_paths(),
+            )
 
 
 class TestRouting(TestCase):


### PR DESCRIPTION
Fixes #13827.

The page’s _get_site_root_paths method took a parameter named request. However, the method could also be called with a Page instance as a fallback cache container itself, effectively passing a parameter named self. For that reason, the variable request could not reliably be expected to be a HttpRequest instance.

# AI Usage
None