### PR TITLE
Fix incorrect plural name for Query model in search_promotions

### DIFF
--- a/wagtail/contrib/search_promotions/models.py
+++ b/wagtail/contrib/search_promotions/models.py
@@ -67,6 +67,10 @@ class Query(models.Model):
             .order_by("-_hits")
         )
 
+    class Meta:
+        verbose_name = _("query")
+        verbose_name_plural = _("queries")
+
 
 class QueryDailyHits(models.Model):
     query = models.ForeignKey(


### PR DESCRIPTION
Description:

Corrects the grammar error in the word "Query", which has "s" as its plural form but was incorrectly written as "Querys" in the admin

Added verbose_name_plural = _("queries") to the Query model’s Meta class.

Used gettext_lazy for translation support.

Fixes #13893

# AI USAGE

None