### PR TITLE
UI: Add Locale column to Page Explorer

### DIFF
--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -23,7 +23,7 @@ from wagtail.admin.ui.components import MediaContainer
 from wagtail.admin.ui.side_panels import (
     PageStatusSidePanel,
 )
-from wagtail.admin.ui.tables import DateColumn
+from wagtail.admin.ui.tables import DateColumn, LocaleColumn
 from wagtail.admin.ui.tables.pages import (
     BulkActionsColumn,
     NavigateToChildrenColumn,
@@ -140,6 +140,7 @@ class PageListingMixin:
             sort_key="title",
             classname="title",
         ),
+        LocaleColumn(),
         ParentPageColumn("parent", label=_("Parent")),
         DateColumn(
             "latest_revision_created_at",


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->

Currently, editors working on multilingual Wagtail sites have to click into a page to see which language it belongs to. This PR adds a 'Locale' column to the Page Explorer listing, providing immediate visual feedback at the top level. It utilizes the existing 
LocaleColumn
 logic to ensure UI consistency.



AI usage: gemini