### PR TITLE
Fix: handling of Orderable Meta conflicts

### DIFF
--- a/wagtail/models/orderable.py
+++ b/wagtail/models/orderable.py
@@ -1,3 +1,4 @@
+from django.core import checks
 from django.db import models
 
 
@@ -8,6 +9,50 @@ class Orderable(models.Model):
     class Meta:
         abstract = True
         ordering = ["sort_order"]
+
+    @classmethod
+    def check(cls, **kwargs):
+        errors = super().check(**kwargs)
+
+        meta_attr = cls._meta.original_attrs
+        ordering = cls._meta.ordering or []
+        ordering_defined = "ordering" in meta_attr
+
+        # Scenario - 1
+        # Developer added a class Meta for an unrelated reason (e.g. verbose_name),
+        # now needs to add Orderable.Meta
+        if not ordering_defined and "sort_order" not in ordering:
+            errors.append(
+                checks.Warning(
+                    "{0}.{1} inherits from Orderable, but its Meta does not inherit "
+                    "Orderable.Meta, so ordering is lost.".format(
+                        cls._meta.app_label, cls.__name__
+                    ),
+                    hint="Add Orderable.Meta as parent class to {}.Meta".format(
+                        cls.__name__
+                    ),
+                    obj=cls,
+                    id="wagtailcore.W002",
+                )
+            )
+            return errors
+
+        # Scenario - 2
+        # Developer added a class Meta (with or without the Orderable.Meta) with the
+        # intention of overriding ordering, now needs to add 'sort_order' back
+        if "sort_order" not in ordering:
+            errors.append(
+                checks.Warning(
+                    "{0}.{1} inherits from Orderable, but "
+                    "{1}.Meta.ordering does not include 'sort_order'".format(
+                        cls._meta.app_label, cls.__name__
+                    ),
+                    hint="Add 'sort_order' to {}.Meta.ordering.".format(cls.__name__),
+                    obj=cls,
+                    id="wagtailcore.W003",
+                )
+            )
+        return errors
 
 
 def set_max_order(instance, sort_order_field):

--- a/wagtail/tests/test_orderable.py
+++ b/wagtail/tests/test_orderable.py
@@ -1,0 +1,41 @@
+from django.apps import apps
+from django.core import checks
+from django.test import TestCase
+
+from wagtail.models import Orderable
+
+
+class TestOrderable(TestCase):
+    def tearDown(self):
+        for model in ("orderablewithoutinheritance", "orderablewithoutsortorder"):
+            try:
+                del apps.all_models["wagtailcore"][model]
+            except KeyError:
+                pass
+        apps.clear_cache()
+
+    def test_raises_warning_if_meta_does_not_inherit_from_orderable(self):
+        # class Meta should be inherited from Orderable
+        class OrderableWithoutInheritance(Orderable):
+            class Meta:
+                app_label = "wagtailcore"
+                verbose_name = "Orderable Without Inheritance"
+
+        errors = OrderableWithoutInheritance.check()
+
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], checks.Warning)
+        self.assertEqual(errors[0].id, "wagtailcore.W002")
+
+    def test_raises_warning_if_sort_order_not_in_meta_ordering(self):
+        # for ordering the 'sort_order' should be defined
+        class OrderableWithoutSortOrder(Orderable):
+            class Meta(Orderable.Meta):
+                app_label = "wagtailcore"
+                ordering = []
+
+        errors = OrderableWithoutSortOrder.check()
+
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], checks.Warning)
+        self.assertEqual(errors[0].id, "wagtailcore.W003")


### PR DESCRIPTION
Fixes: #13316 

### Changes Made
- `wagtail/models/orderable.py`: added two checks for scenario -1, 2
- `wagtail/models/i18n.py`: added one check for scenario - 3
- `wagtail/tests/test_orderable.py`: added two test cases for scenario - 1, 2
- `wagtail/tests/test_translatablemixin.py`: added one test cases for scenario - 3

### Why?
As, mentioned in previous PR attempt https://github.com/wagtail/wagtail/pull/6273#issuecomment-694357884, following are the cases needed to be handled with check warnings:

1. the developer added a class `Meta` for an unrelated reason (e.g. `verbose_name`), and now needs to add `Orderable.Meta` to fix it
2. the developer added a class `Meta` (with or without the `Orderable.Meta`) with the express intention of overriding ordering, and now needs to be told to add `'sort_order'` back
3. the developer is extending both `TranslatableMixin` and `Orderable`, and is quite possibly unaware of the need for a class `Meta` at all, and now needs to be told to add one.

Also, as mentioned in https://github.com/wagtail/wagtail/issues/13316#issuecomment-3903743128 that, why i think a slight modification was required in current approach. 

### Test Cases
I have included test cases for all three scenarios in PR.

If there is something that i am missing, please let me know. 
Thanks!