### PR TITLE
Fix _get_page_cached_urls when WAGTAIL_APPEND_SLASH=False

### DIFF
--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -28,6 +28,7 @@ Wagtail 7.4 is designated a Long Term Support (LTS) release. Long Term Support r
  * Set `verbose_name_plural` for Query model in search promotions app (Saptami)
  * Truncate overly long task names in workflow admin view (Gaurav Takhi)
  * Hide "Add child page" button when no child pages can be created as per `max_count` or `max_count_per_parent` (Lasse Schmieding)
+ * Fix URL concatenation in `_get_page_cached_urls` when `WAGTAIL_APPEND_SLASH` is `False` (Aditya Sharma)
 
 ### Documentation
 

--- a/wagtail/contrib/frontend_cache/utils.py
+++ b/wagtail/contrib/frontend_cache/utils.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urljoin
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -111,7 +112,7 @@ def _get_page_cached_urls(page, cache_object=None):
         return []
 
     return [
-        page_url + path.lstrip("/")
+        urljoin(page_url.rstrip("/") + "/", path.lstrip("/"))
         for path in page.specific_deferred.get_cached_paths()
     ]
 


### PR DESCRIPTION
Ensure slash-safe joining when constructing cached URLs. Adds regression test covering base URLs without trailing slash.

Fixes #13920

---

### Description

When `WAGTAIL_APPEND_SLASH = False`, `_get_page_cached_urls()` may generate incorrect URLs if the base page URL does not end with a trailing slash.

If a page URL is:

```
http://localhost/test-events
```

and `get_cached_paths()` returns:

```
["/", "/archive"]
```

the previous implementation produced:

```
http://localhost/test-eventsarchive
```

because the base URL and path were concatenated directly.

This change ensures that URLs are joined safely so that the expected results are:

```
http://localhost/test-events/
http://localhost/test-events/archive
```

A regression test has been added to cover this case.

---

### AI usage

Minor assistance used for wording the PR description.
All debugging, implementation and testing were done manually.