### PR TITLE
Fix DocumentChooserBlock validation error display

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/generic/chooser/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/chooser/chooser.html
@@ -62,7 +62,7 @@
         </section>
 
         {% if creation_form %}
-            {% include view.creation_form_template_name %}
+            {% include view.creation_form_template_name with hidden=True %}
         {% endif %}
     </div>
 </div>

--- a/wagtail/admin/templates/wagtailadmin/generic/chooser/creation_form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/chooser/creation_form.html
@@ -3,7 +3,7 @@
     id="tab-{{ view.creation_tab_id }}"
     class="w-tabs__panel"
     role="tabpanel"
-    hidden
+    {% if hidden %} hidden {% endif %}
     aria-labelledby="tab-label-{{ view.creation_tab_id }}"
     data-w-tabs-target="panel"
     data-action="w-focus:focus->w-tabs#selectInside"

--- a/wagtail/admin/tests/test_chooser.py
+++ b/wagtail/admin/tests/test_chooser.py
@@ -1,0 +1,54 @@
+import json
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from wagtail.test.utils import WagtailTestUtils
+
+
+class TestChooserUploadHidden(WagtailTestUtils, TestCase):
+    """Test upload tab visibility for generic chooser"""
+
+    def setUp(self):
+        self.login()
+
+    @override_settings(WAGTAILDOCS_EXTENSIONS=["pdf"])
+    def test_upload_tab_visible_on_validation_error(self):
+        """Test upload tab visibility on validation error"""
+
+        # Upload file with invalid extension
+        test_file = SimpleUploadedFile("test.txt", b"Test File")
+        response = self.client.post(
+            reverse("wagtaildocs_chooser:create"), {"title": "Test", "file": test_file}
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        response_json = json.loads(response.content.decode("utf-8"))
+
+        self.assertEqual(response_json["step"], "reshow_creation_form")
+
+        html = response_json.get("htmlFragment")
+        self.assertIsNotNone(html)
+
+        soup = self.get_soup(html)
+        upload_tab = soup.find(id="tab-upload")
+
+        self.assertIsNotNone(upload_tab)
+        self.assertNotIn("hidden", upload_tab.attrs)
+
+    def test_upload_tab_hidden_on_initial_load(self):
+        """Test upload tab hidden on initial load"""
+        response = self.client.get(reverse("wagtaildocs_chooser:choose"))
+
+        response_json = json.loads(response.content.decode("utf-8"))
+
+        html = response_json.get("html", "")
+        self.assertIsNotNone(html)
+
+        soup = self.get_soup(html)
+        upload_tab = soup.find(id="tab-upload")
+
+        self.assertIsNotNone(upload_tab)
+        self.assertIn("hidden", upload_tab.attrs)


### PR DESCRIPTION
Fixes #13915

### Description
Following are the changes that were made:
- `wagtail/admin/templates/wagtailadmin/generic/chooser/creation_form.html`: Conditionally disabling `hidden` to fix issue, where on validation error `form` vanishes from the view(mentioned in issue #13915).

- `wagtail/admin/tests/test_chooser.py`: Added `test_cases` for the fix.

### Sources
- Test cases follow existing `test_cases` structure  at `wagtail/admin/tests`.
- https://www.crummy.com/software/BeautifulSoup/bs4/css-selector-update-doc/


### AI usage
- To learn basic `BeautifulSoup` syntax.

I've verified and tested the changes solves the issue. Please let me know,  if there is still some edge cases that i am missing.