### PR TITLE
Fix URL concatenation in frontend_cache when WAGTAIL_APPEND_SLASH is …

### DIFF
--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -28,6 +28,7 @@ Wagtail 7.4 is designated a Long Term Support (LTS) release. Long Term Support r
  * Set `verbose_name_plural` for Query model in search promotions app (Saptami)
  * Truncate overly long task names in workflow admin view (Gaurav Takhi)
  * Hide "Add child page" button when no child pages can be created as per `max_count` or `max_count_per_parent` (Lasse Schmieding)
+ * Fix URL concatenation in `_get_page_cached_urls` when `WAGTAIL_APPEND_SLASH` is False (Praveen Kumar)
 
 ### Documentation
 

--- a/wagtail/contrib/frontend_cache/utils.py
+++ b/wagtail/contrib/frontend_cache/utils.py
@@ -111,7 +111,7 @@ def _get_page_cached_urls(page, cache_object=None):
         return []
 
     return [
-        page_url + path.lstrip("/")
+        (page_url.rstrip("/") + "/" + path.lstrip("/")) if path != "/" else page_url
         for path in page.specific_deferred.get_cached_paths()
     ]
 


### PR DESCRIPTION
Fixes #13920 
Picked this up to confirm and fix — reproduced on a fresh project.

When `WAGTAIL_APPEND_SLASH = False`, the page URL has no trailing slash. So appending a path from [get_cached_paths()](cci:1://file:///Users/praveenkumar/Desktop/wagtail/wagtail/wagtail/test/testapp/models.py:601:4-602:54) like `/archive` directly gives you `https://example.com/the-pagearchive` instead of `https://example.com/the-page/archive`.

The issue is in [_get_page_cached_urls](cci:1://file:///Users/praveenkumar/Desktop/wagtail/wagtail/wagtail/contrib/frontend_cache/utils.py:107:0-115:5) in [utils.py](cci:7://file:///Users/praveenkumar/Desktop/wagtail/wagtail/wagtail/coreutils.py:0:0-0:0) — it was stripping the leading slash from the cached path but not ensuring the base URL ended with one before joining.

Fix: strip any trailing slash from the base URL, strip any leading slash from the path, and join them with exactly one `/`. The root path `/` is treated as a special case and returns the base URL as-is, so it doesn't add an unwanted extra slash when WAGTAIL_APPEND_SLASH is True.

Changes:
- [wagtail/contrib/frontend_cache/utils.py](cci:7://file:///Users/praveenkumar/Desktop/wagtail/wagtail/wagtail/contrib/frontend_cache/utils.py:0:0-0:0) — the fix
- [wagtail/contrib/frontend_cache/tests.py](cci:7://file:///Users/praveenkumar/Desktop/wagtail/wagtail/wagtail/contrib/frontend_cache/tests.py:0:0-0:0) — added [TestGetPageCachedUrls](cci:2://file:///Users/praveenkumar/Desktop/wagtail/wagtail/wagtail/contrib/frontend_cache/tests.py:855:0-877:66) to cover this case with `WAGTAIL_APPEND_SLASH = False`
- [docs/releases/7.4.md](cci:7://file:///Users/praveenkumar/Desktop/wagtail/wagtail/docs/releases/7.4.md:0:0-0:0) — changelog entry under Bug Fixes

Ran the full frontend_cache test suite (44 tests), all green.


