### PR TITLE
Fix #13864: Add image description field to search index

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -363,6 +363,8 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         index.SearchField("title", boost=10),
         index.AutocompleteField("title"),
         index.FilterField("title"),
+        index.SearchField("description"),
+        index.AutocompleteField("description"),
         index.RelatedFields(
             "tags",
             [

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -2327,6 +2327,22 @@ class TestImageChooserViewSearch(WagtailTestUtils, TransactionTestCase):
         self.assertEqual(len(response.context["results"]), 1)
         self.assertEqual(response.context["results"][0], image)
 
+    def test_search_by_description(self):
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+            description="orange flowers in a garden",
+        )
+        Image.objects.create(
+            title="Another image",
+            file=get_test_image_file(),
+            description="blue sky over mountains",
+        )
+
+        response = self.get({"q": "orange flowers"})
+        self.assertEqual(len(response.context["results"]), 1)
+        self.assertEqual(response.context["results"][0], image)
+
 
 class TestImageChooserChosenView(WagtailTestUtils, TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #13864

When the built-in `description` field for images was introduced in Wagtail 6.3 to manage alt text, it wasn't added to `AbstractImage.search_fields` in [`wagtail/images/models.py`](https://github.com/wagtail/wagtail/blob/main/wagtail/images/models.py#L365-L368). As a result, searching for images by their description text in the Chooser returned no results. 

This PR fixes the issue by explicitly adding the `description` field to `search_fields` on the `AbstractImage` model using `index.SearchField` and `index.AutocompleteField`. 

It mirrors the existing pattern used by the `title` field, but without `boost=10` so that title matches continue to rank higher than generic description matches.

* Added a new test `test_search_by_description` in [`wagtail/images/tests/test_admin_views.py`](https://github.com/wagtail/wagtail/blob/main/wagtail/images/tests/test_admin_views.py#L2331-L2345) covering this exact scenario.