### PR TITLE
Fix #13906: Expose Widget and BoundWidget base classes via window.wagtail.widgets

### DIFF
--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -2,6 +2,7 @@ import * as StimulusModule from '@hotwired/stimulus';
 import Telepath from 'telepath-unpack';
 
 import { Icon, Portal } from '../..';
+import { Widget, BoundWidget } from '../../components/Widget';
 import { ExpandingFormset } from '../../components/ExpandingFormset';
 import { InlinePanel } from '../../components/InlinePanel';
 import { MultipleChooserPanel } from '../../components/MultipleChooserPanel';
@@ -33,6 +34,9 @@ wagtail.app = initStimulus({ definitions: coreControllerDefinitions });
 
 /** Expose components as globals for third-party reuse. */
 wagtail.components = { Icon, Portal };
+
+/** Expose vanilla JavaScript widget classes for third-party reuse. */
+wagtail.widgets = { Widget, BoundWidget };
 
 /** Expose a global for undocumented third-party usage. */
 window.wagtailConfig = WAGTAIL_CONFIG;

--- a/client/src/entrypoints/admin/core.test.js
+++ b/client/src/entrypoints/admin/core.test.js
@@ -18,6 +18,13 @@ describe('core', () => {
     expect(Object.keys(window.wagtail.components)).toEqual(['Icon', 'Portal']);
   });
 
+  it('exposes widget classes for reuse', () => {
+    expect(Object.keys(window.wagtail.widgets)).toEqual([
+      'Widget',
+      'BoundWidget',
+    ]);
+  });
+
   it('exposes the Stimulus module for reuse', () => {
     expect(Object.keys(window.StimulusModule)).toEqual(
       expect.arrayContaining(['Application', 'Controller']),


### PR DESCRIPTION
Fixes #13906

This PR exposes the `Widget` and `BoundWidget` JavaScript classes on the window.wagtail object to make it easier for developers to extend these base classes when writing custom blocks and widgets for the Wagtail admin interface. 

Previously, developers had to rely on undocumented internals (like accessing the Telepath constructor registry via `window.telepath.constructors['wagtail.widgets.Widget']`). 

To address this, the base classes are now exposed under a new, stable namespace: `window.wagtail.widgets`. 
* Example usage: `class MyCustomWidget extends window.wagtail.widgets.Widget { ... }`

The existing window.wagtail.components namespace is specifically used for exposing React components (like `Icon` and `Portal`). Exposing vanilla JavaScript classes alongside React components in the same object would blur the architectural boundaries. Using a dedicated `widgets` namespace keeps the API surface clean, predictable, and maintainable.
