### PR TITLE
Remove unnecessary sidebar collapsing in InlinePanel E2E tests

### DIFF
--- a/client/tests/integration/editor.test.js
+++ b/client/tests/integration/editor.test.js
@@ -19,8 +19,6 @@ describe('Editor', () => {
   });
 
   it('axe InlinePanel', async () => {
-    const toggle = await page.$('.sidebar__collapse-toggle');
-    toggle.click();
     const trigger = await page.$('#id_carousel_items-ADD');
     trigger.click();
     await expect(page).toPassAxeTests({


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes the ui-tests job on CircleCI that's failing after #13918.

### Description

<!-- Please describe the problem you're fixing. -->
[This commit in the PR](https://github.com/wagtail/wagtail/pull/13918/changes/6820bf1bdfd9c3bc3257bbda8c303487ce607fcb) removed the global Axe exclude for the sidebar.

It seems our sidebar menu doesn't pass Axe tests when it's collapsed. The offending element is the user account popup (where it shows your username). It looks like Axe doesn't count the `aria-describedby` added by Tippy as the button's label. Maybe we should add an `aria-label`?

I'm not sure why the InlinePanel test had to collapse the side panel. Maybe it was done to allow for more space in the editor given the small window size of the E2E tests? When running in non-headless mode, I didn't see anything that significantly changed in the inline panel interface when the sidebar is collapsed/expanded.

In any case, the sidebar state shouldn't affect the results of inline panel tests. We should ignore the sidebar here either by adding it to Axe's ignore selector or by not collapsing it in the first place. Then, we fix the sidebar issue and test the toggle separately.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None