### PR TITLE
Add support for Flourish oEmbeds

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
  * Add `is_deferred_validation` flag to support skipping custom validation when saving drafts (Daniel Kirkham)
  * Update project template Dockerfile to build dependencies in a separate stage (Brylie Oxley, Akshat Gupta)
  * Add `include_root` parameter to admin pages API endpoint (Divyansh Mishra)
+ * Add support for Flourish oEmbeds (Garrett Coakley)
  * Fix: Handle nested inline models when displaying object usage information (Sage Abdullah, Kacper Walęga, Tian Jie Wong)
  * Fix: Avoid duplicate `get_object()` DB query in API detail view (Siddheshwar Kadam)
  * Fix: Ensure `ImageBlock` alt text populates on choosing a new image after unchecking decorative state (Pratham Jaiswal)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -951,6 +951,7 @@
 * Divyansh Mishra
 * Gaurav Takhi
 * Ashutosh
+* Garrett Coakley
 
 ## Translators
 

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -19,6 +19,7 @@ Wagtail 7.4 is designated a Long Term Support (LTS) release. Long Term Support r
  * Add `is_deferred_validation` flag to support skipping custom validation when saving drafts (Daniel Kirkham)
  * Update project template Dockerfile to build dependencies in a separate stage (Brylie Oxley, Akshat Gupta)
  * Add `include_root` parameter to admin pages API endpoint (Divyansh Mishra)
+ * Add support for Flourish oEmbeds (Garrett Coakley)
 
 ### Bug fixes
 

--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -172,6 +172,14 @@ flickr = {
     ],
 }
 
+flourish = {
+    "endpoint": "https://app.flourish.studio/api/v1/oembed",
+    "urls": [
+        r"^https?://public\.flourish\.studio/visualisation/.+$",
+        r"^https?://public\.flourish\.studio/story/.+$",
+    ],
+}
+
 funny_or_die = {
     "endpoint": "https://www.funnyordie.com/oembed.{format}",
     "urls": [
@@ -659,6 +667,7 @@ all_providers = [
     five_hundred_px,
     five_min,
     flickr,
+    flourish,
     funny_or_die,
     geograph_gg,
     geograph_uk,


### PR DESCRIPTION
### Description

Adds oEmbed support for the [Flourish](https://flourish.studio/) data visualisation tool as per their [developer documentation](https://developers.flourish.studio/embedding/oembed-integration/).


### AI usage

None.
