### PR TITLE
#13944 Bump modelsearch to 1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "anyascii>=0.1.5",
   "telepath>=0.3.1,<1",
   "laces>=0.1,<0.2",
-  "django-tasks>=0.11,<0.12",
+  "django-tasks>=0.9,<0.12",
   "modelsearch>=1.2,<1.3",
 ]
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #13944 

### Description

`modelsearch 1.1` limits `django-tasks` to 0.9 version which is broken https://github.com/RealOrangeOne/django-tasks/issues/223
Bumping `modelsearch` to 1.2 so we can use `django-tasks` 0.11


### AI usage

None
