### PR TITLE
Fix `WorkflowState.user_can_cancel` logic

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@ Changelog
  * Fix: Fix translation sync logic for django-treebeard 5.0.2 (Matt Westcott)
  * Fix: Correctly HTML-escape page title in approval/rejection notification emails (Matt Westcott)
  * Fix: Correctly HTML-escape URL in photo type oembeds (Thibaud Colas)
+ * Fix: Ensure user with appropriate permissions can cancel a workflow task (Dan Braghis)
  * Docs: Add documentation for the `filter_spec` parameter of `ImageRenditionField` (Soumya-codr)
  * Docs: Add guide for testing document upload forms (Wenli Tsai, Bhavesh Sharma)
  * Docs: Document the `nested_default_fields` attribute on API viewsets (Deepanshu Tevathiya)

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -70,6 +70,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Fix translation sync logic for django-treebeard 5.0.2 (Matt Westcott)
  * Correctly HTML-escape page title in approval/rejection notification emails (Matt Westcott)
  * Correctly HTML-escape URL in photo type oembeds (Thibaud Colas)
+ * Ensure user with appropriate permissions can cancel a workflow task (Dan Braghis)
 
 ### Documentation
 

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -2014,11 +2014,12 @@ class TestSubmitPageToWorkflow(BasePageWorkflowTests):
         )
 
         # After submit, as a moderator, should only see save, approve, and reject buttons
+        # as well as cancel workflow
         self.login(self.moderator)
         response = self.client.get(edit_url)
         self.assertContains(response, "Save draft")
+        self.assertContains(response, "Cancel workflow")
         self.assertNotContains(response, "Submit to test_workflow")
-        self.assertNotContains(response, "Cancel workflow")
         self.assertNotContains(response, "Restart workflow")
         self.assertContains(response, "Approve")
         self.assertContains(response, "Request changes")
@@ -2366,11 +2367,12 @@ class TestSubmitSnippetToWorkflowNotLockable(TestSubmitSnippetToWorkflow):
         )
 
         # After submit, as a moderator, should only see save, approve, and reject buttons
+        # as well as cancel workflow
         self.login(self.moderator)
         response = self.client.get(edit_url)
         self.assertContains(response, "Save draft")
+        self.assertContains(response, "Cancel workflow")
         self.assertNotContains(response, "Submit to test_workflow")
-        self.assertNotContains(response, "Cancel workflow")
         self.assertNotContains(response, "Restart workflow")
         self.assertContains(response, "Approve")
         self.assertContains(response, "Request changes")

--- a/wagtail/models/workflows.py
+++ b/wagtail/models/workflows.py
@@ -251,7 +251,7 @@ class WorkflowState(models.Model):
                 and "approve"
                 in [
                     action[0]
-                    for action in self.current_task_state.task.get_actions(
+                    for action in self.current_task_state.task.specific.get_actions(
                         self.content_object, user
                     )
                 ]

--- a/wagtail/tests/test_workflow.py
+++ b/wagtail/tests/test_workflow.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest import mock
+from unittest import mock, skip
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -157,8 +157,12 @@ class TestPageWorkflows(WagtailTestUtils, TestCase):
         WorkflowTask.objects.create(workflow=workflow, task=task_2, sort_order=2)
         return workflow, task_1, task_2
 
-    def start_workflow(self):
-        workflow, task_1, task_2 = self.create_workflow_and_tasks()
+    def start_workflow(self, workflow=None):
+        if workflow is None:
+            workflow, task_1, task_2 = self.create_workflow_and_tasks()
+        else:
+            task_1 = workflow.workflow_tasks.first().task
+            task_2 = None
         self.object.save_revision()
         user = get_user_model().objects.first()
         workflow_state = workflow.start(self.object, user)
@@ -486,6 +490,54 @@ class TestPageWorkflows(WagtailTestUtils, TestCase):
         self.object.delete()
         self.assertIs(WorkflowState.objects.filter(**query).exists(), False)
 
+    def test_user_can_cancel(self):
+        data = self.start_workflow(workflow=Workflow.objects.first())
+        workflow_state = data["workflow_state"]
+        obj = data["object"]
+        owner = self.create_user("owner")
+        obj.owner = owner
+        obj.save()
+        # Refresh the workflow state to ensure user_can_cancel() uses the
+        # specific task even on a freshly fetched workflow state instance
+        workflow_state.refresh_from_db()
+
+        # user is submitter
+        self.assertTrue(workflow_state.user_can_cancel(data["user"]))
+
+        # user is owner
+        # only applicable when the workflow state content object has that attribute
+        if hasattr(workflow_state.content_object, "owner"):
+            self.assertTrue(workflow_state.user_can_cancel(owner))
+
+        # user can approve
+        moderators = Group.objects.get(name="Moderators")
+        moderator = self.create_user("moderator")
+        moderator.groups.add(moderators)
+        superuser = self.create_superuser("root")
+        self.assertTrue(workflow_state.user_can_cancel(moderator))
+        self.assertTrue(workflow_state.user_can_cancel(superuser))
+
+    def test_user_can_cancel_random_user(self):
+        data = self.start_workflow(workflow=Workflow.objects.first())
+        workflow_state = data["workflow_state"]
+        workflow_state.refresh_from_db()
+
+        # a random user who is neither the page creator, the workflow submitter,
+        # nor can approve
+        self.assertFalse(workflow_state.user_can_cancel(self.create_user("random")))
+
+    def test_user_can_cancel_locked(self):
+        data = self.start_workflow(workflow=Workflow.objects.first())
+        workflow_state = data["workflow_state"]
+        workflow_state.refresh_from_db()
+        submitter = data["user"]
+        obj = data["object"]
+        obj.locked = True
+        obj.locked_by = self.create_superuser("root")
+        obj.save()
+        workflow_state.content_object.refresh_from_db()
+        self.assertFalse(workflow_state.user_can_cancel(submitter))
+
 
 class TestSnippetWorkflows(TestPageWorkflows):
     fixtures = None
@@ -516,6 +568,10 @@ class TestSnippetWorkflowsNotLockable(TestSnippetWorkflows):
         self.assertEqual(workflow_state.workflow, workflow)
         self.assertEqual(workflow_state.content_object, self.object)
         self.assertEqual(workflow_state.status, "in_progress")
+
+    @skip("Model is not lockable")
+    def test_user_can_cancel_locked(self):
+        super().test_user_can_cancel_locked()
 
     # The ModeratedModel does not explicitly define a `GenericRelation` to
     # `WorkflowState`, but the `WorkflowState` should still be deleted when the


### PR DESCRIPTION
Fixes #11795

### Description

The logic for when a user can cancel a workflow is contained by `WorkflowState.user_can_cancel()`

https://github.com/wagtail/wagtail/blob/3f261d831003017d26dece999433d32749290656/wagtail/models/workflows.py#L237-L259

and is:

- if the object (page, snippet) is lockable, and it is locked, then the workflow cannot be cancelled
- otherwise, it can be cancelled if the current user
  - is the user that initiated the workflow OR
  - is the page owner OR
  - has the permission to approve

However, in practice only the "initiator" and "page owner" parts work because `self.current_task_state.task.get_actions()` always returns an empty list because `.task` is the base `Task` class, rather than the specific task models used in the workflow

#### To test

- using bakerydemo, create a page and submit for moderation as one user
- login with the moderator user, or a superuser, go to edit the page.
- before: cannot cancel the workflow
- after: should be able to cancel the workflow

> [!Note]
> This bug was there since 2.10.x 🙈 ([ref](https://github.com/wagtail/wagtail/blob/stable/2.10.x/wagtail/core/models.py#L3257))

### AI usage

This PR has been lovingly crafted without the aid of any AI/LLMs
