### PR TITLE
Add support for latest Azure SDK for frontend cache invalidation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ Changelog
  * Maintenance: Add renovate configuration to automate Python dependencies management (Sage Abdullah)
  * Maintenance: Use Renovate to update GitHub Actions dependencies pins (Sage Abdullah)
  * Maintenance: Enable flake8-bandit security-focused linting rules (Storm Heg)
+ * Maintenance: Add support for latest Azure SDK for frontend cache invalidation (Sage Abdullah)
 
 
 7.4.2 (15.06.2026)

--- a/docs/reference/contrib/frontendcache.md
+++ b/docs/reference/contrib/frontendcache.md
@@ -143,9 +143,13 @@ The third-party dependencies of this backend are:
 
 | PyPI Package                                                           | Essential            | Reason                                                                                                                              |
 | ---------------------------------------------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| [`azure-mgmt-cdn`](https://pypi.org/project/azure-mgmt-cdn/)           | Yes (v10.0 or above) | Interacting with the CDN service.                                                                                                   |
+| [`azure-mgmt-cdn`](https://pypi.org/project/azure-mgmt-cdn/)           | Yes (v13.0 or above) | Interacting with the CDN service.                                                                                                   |
 | [`azure-identity`](https://pypi.org/project/azure-identity/)           | No                   | Obtaining credentials. It's optional if you want to specify your own credential using a `CREDENTIALS` setting (more details below). |
 | [`azure-mgmt-resource`](https://pypi.org/project/azure-mgmt-resource/) | No                   | For obtaining the subscription ID. Redundant if you want to explicitly specify a `SUBSCRIPTION_ID` setting (more details below).    |
+
+```{versionchanged} 7.4
+Support for versions of `azure-mgmt-cdn` below 13.0 is deprecated and will be dropped in a future release.
+```
 
 Add an item into the `WAGTAILFRONTENDCACHE` and set the `BACKEND` parameter to `wagtail.contrib.frontend_cache.backends.AzureCdnBackend`. This backend requires the following settings to be set:
 
@@ -193,9 +197,13 @@ The third-party dependencies of this backend are:
 
 | PyPI Package                                                             | Essential           | Reason                                                                                                                              |
 | ------------------------------------------------------------------------ | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| [`azure-mgmt-frontdoor`](https://pypi.org/project/azure-mgmt-frontdoor/) | Yes (v1.0 or above) | Interacting with the Front Door service.                                                                                            |
+| [`azure-mgmt-frontdoor`](https://pypi.org/project/azure-mgmt-frontdoor/) | Yes (v1.1 or above) | Interacting with the Front Door service.                                                                                            |
 | [`azure-identity`](https://pypi.org/project/azure-identity/)             | No                  | Obtaining credentials. It's optional if you want to specify your own credential using a `CREDENTIALS` setting (more details below). |
 | [`azure-mgmt-resource`](https://pypi.org/project/azure-mgmt-resource/)   | No                  | For obtaining the subscription ID. Redundant if you want to explicitly specify a `SUBSCRIPTION_ID` setting (more details below).    |
+
+```{versionchanged} 7.4
+Support for versions of `azure-mgmt-frontdoor` below 1.1 is deprecated and will be dropped in a future release.
+```
 
 Add an item into the `WAGTAILFRONTENDCACHE` and set the `BACKEND` parameter to `wagtail.contrib.frontend_cache.backends.AzureFrontDoorBackend`. This backend requires the following settings to be set:
 

--- a/docs/reference/contrib/frontendcache.md
+++ b/docs/reference/contrib/frontendcache.md
@@ -147,7 +147,7 @@ The third-party dependencies of this backend are:
 | [`azure-identity`](https://pypi.org/project/azure-identity/)           | No                   | Obtaining credentials. It's optional if you want to specify your own credential using a `CREDENTIALS` setting (more details below). |
 | [`azure-mgmt-resource`](https://pypi.org/project/azure-mgmt-resource/) | No                   | For obtaining the subscription ID. Redundant if you want to explicitly specify a `SUBSCRIPTION_ID` setting (more details below).    |
 
-```{versionchanged} 7.4
+```{versionchanged} 8.0
 Support for versions of `azure-mgmt-cdn` below 13.0 is deprecated and will be dropped in a future release.
 ```
 
@@ -201,7 +201,7 @@ The third-party dependencies of this backend are:
 | [`azure-identity`](https://pypi.org/project/azure-identity/)             | No                  | Obtaining credentials. It's optional if you want to specify your own credential using a `CREDENTIALS` setting (more details below). |
 | [`azure-mgmt-resource`](https://pypi.org/project/azure-mgmt-resource/)   | No                  | For obtaining the subscription ID. Redundant if you want to explicitly specify a `SUBSCRIPTION_ID` setting (more details below).    |
 
-```{versionchanged} 7.4
+```{versionchanged} 8.0
 Support for versions of `azure-mgmt-frontdoor` below 1.1 is deprecated and will be dropped in a future release.
 ```
 

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -216,6 +216,15 @@ StreamField blocks [template rendering](streamfield_template_rendering) with `in
 
 Django 4.2 is no longer supported as of this release; please upgrade to Django 5.2 or above before upgrading Wagtail.
 
+### Support for legacy versions of `azure-mgmt-cdn` and `azure-mgmt-frontdoor` packages will be dropped
+
+If you are using the front-end cache invalidator module (`wagtail.contrib.frontend_cache`) with Azure CDN or Azure Front Door, the following packages need to be updated:
+
+* For Azure CDN: upgrade `azure-mgmt-cdn` to version 13 or above
+* For Azure Front Door: upgrade `azure-mgmt-frontdoor` to version 1.1 or above
+
+Support for older versions will be dropped in a future release.
+
 ## Upgrade considerations - changes affecting Wagtail customizations
 
 ### Refactored content checker

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -216,15 +216,6 @@ StreamField blocks [template rendering](streamfield_template_rendering) with `in
 
 Django 4.2 is no longer supported as of this release; please upgrade to Django 5.2 or above before upgrading Wagtail.
 
-### Support for legacy versions of `azure-mgmt-cdn` and `azure-mgmt-frontdoor` packages will be dropped
-
-If you are using the front-end cache invalidator module (`wagtail.contrib.frontend_cache`) with Azure CDN or Azure Front Door, the following packages need to be updated:
-
-* For Azure CDN: upgrade `azure-mgmt-cdn` to version 13 or above
-* For Azure Front Door: upgrade `azure-mgmt-frontdoor` to version 1.1 or above
-
-Support for older versions will be dropped in a future release.
-
 ## Upgrade considerations - changes affecting Wagtail customizations
 
 ### Refactored content checker

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -59,6 +59,7 @@ Wagtail 8.0 introduces a new API transport layer at `/api/v3/`, built on [Django
  * Add renovate configuration to automate Python dependencies management (Sage Abdullah)
  * Use Renovate to update GitHub Actions dependencies pins (Sage Abdullah)
  * Enable flake8-bandit security-focused linting rules (Storm Heg)
+ * Add support for latest Azure SDK for frontend cache invalidation (Sage Abdullah)
 
 ## Upgrade considerations - removal of deprecated features from Wagtail 6.4 - 7.3
 
@@ -90,6 +91,15 @@ For additional details on these changes, see:
 ## Upgrade considerations - changes affecting all projects
 
 ## Upgrade considerations - deprecation of old functionality
+
+### Support for legacy versions of `azure-mgmt-cdn` and `azure-mgmt-frontdoor` packages will be dropped
+
+If you are using the front-end cache invalidator module (`wagtail.contrib.frontend_cache`) with Azure CDN or Azure Front Door, the following packages need to be updated:
+
+* For Azure CDN: upgrade `azure-mgmt-cdn` to version 13 or above
+* For Azure Front Door: upgrade `azure-mgmt-frontdoor` to version 1.1 or above
+
+Support for older versions will be dropped in a future release.
 
 ## Upgrade considerations - changes affecting Wagtail customizations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,8 @@ testing = [
   "Jinja2>=3.0,<3.2",
   "boto3>=1.28,<2",
   "freezegun>=0.3.8",
-  "azure-mgmt-cdn>=12.0,<13.0",
-  "azure-mgmt-frontdoor>=1.0,<1.1",
+  "azure-mgmt-cdn>=12.0,<14.0",
+  "azure-mgmt-frontdoor>=1.0,<1.3",
   "django-pattern-library>=0.7",
   "responses>=0.25,<1",
   # For coverage and PEP8 linting

--- a/uv.lock
+++ b/uv.lock
@@ -3192,8 +3192,8 @@ testing = [
 [package.metadata]
 requires-dist = [
     { name = "anyascii", specifier = ">=0.1.5" },
-    { name = "azure-mgmt-cdn", marker = "extra == 'testing'", specifier = ">=12.0,<13.0" },
-    { name = "azure-mgmt-frontdoor", marker = "extra == 'testing'", specifier = ">=1.0,<1.1" },
+    { name = "azure-mgmt-cdn", marker = "extra == 'testing'", specifier = ">=12.0,<14.0" },
+    { name = "azure-mgmt-frontdoor", marker = "extra == 'testing'", specifier = ">=1.0,<1.3" },
     { name = "beautifulsoup4", specifier = ">=4.13.3,<5" },
     { name = "boto3", marker = "extra == 'testing'", specifier = ">=1.28,<2" },
     { name = "coverage", marker = "extra == 'testing'", specifier = ">=3.7.0" },

--- a/wagtail/contrib/frontend_cache/backends/azure.py
+++ b/wagtail/contrib/frontend_cache/backends/azure.py
@@ -1,7 +1,10 @@
 import logging
+import warnings
 from urllib.parse import urlsplit, urlunsplit
 
 from django.core.exceptions import ImproperlyConfigured
+
+from wagtail.utils.deprecation import RemovedInWagtail80Warning
 
 from .base import BaseBackend
 
@@ -12,6 +15,10 @@ __all__ = ["AzureBaseBackend", "AzureFrontDoorBackend", "AzureCdnBackend"]
 
 
 class AzureBaseBackend(BaseBackend):
+    _package_name = ""
+    _required_version = ""
+    _installed_version = ""
+
     def __init__(self, params):
         super().__init__(params)
         self._credentials = params.pop("CREDENTIALS", None)
@@ -23,6 +30,22 @@ class AzureBaseBackend(BaseBackend):
                 "The setting 'WAGTAILFRONTENDCACHE' requires 'RESOURCE_GROUP_NAME' to be specified."
             ) from e
         self._custom_headers = params.pop("CUSTOM_HEADERS", None)
+        self._legacy_azure_library = self._is_legacy_azure_library(
+            required=self._required_version,
+            installed=self._installed_version,
+        )
+        if self._legacy_azure_library:
+            warnings.warn(
+                f"Support for {self._package_name} {self._installed_version} "
+                f"will be dropped in a future release. Please upgrade to "
+                f"{self._package_name} >= {self._required_version}.",
+                RemovedInWagtail80Warning,
+            )
+
+    def _is_legacy_azure_library(self, *, required, installed):
+        required_ver = [int(part) for part in required.split(".")]
+        version_ver = [int(part) for part in installed.split(".")]
+        return version_ver < required_ver
 
     def purge_batch(self, urls):
         self._purge_content([self._get_path(url) for url in urls])
@@ -104,23 +127,33 @@ class AzureBaseBackend(BaseBackend):
         }
 
     def _purge_content(self, paths):
-        from msrest.exceptions import HttpOperationError
+        if self._legacy_azure_library:
+            from msrest.exceptions import HttpOperationError as HttpError
+        else:
+            from azure.core.exceptions import HttpResponseError as HttpError
 
         client = self._get_client()
         try:
             self._make_purge_call(client, paths)
-        except HttpOperationError as exception:
+        except HttpError as exception:
             for path in paths:
                 logger.exception(
-                    "Couldn't purge '%s' from %s cache. HttpOperationError: %r",
+                    "Couldn't purge '%s' from %s cache. %s: %r",
                     path,
                     type(self).__name__,
+                    type(exception).__name__,
                     exception.response,
                 )
 
 
 class AzureFrontDoorBackend(AzureBaseBackend):
     def __init__(self, params):
+        from azure.mgmt.frontdoor import __version__
+
+        self._package_name = "azure-mgmt-frontdoor"
+        self._required_version = "1.1.0"
+        self._installed_version = __version__
+
         super().__init__(params)
         try:
             self._front_door_name = params.pop("FRONT_DOOR_NAME")
@@ -150,6 +183,12 @@ class AzureFrontDoorBackend(AzureBaseBackend):
 
 class AzureCdnBackend(AzureBaseBackend):
     def __init__(self, params):
+        from azure.mgmt.cdn import __version__
+
+        self._package_name = "azure-mgmt-cdn"
+        self._required_version = "13.0.0"
+        self._installed_version = __version__
+
         super().__init__(params)
         try:
             self._cdn_profile_name = params.pop("CDN_PROFILE_NAME")

--- a/wagtail/contrib/frontend_cache/backends/azure.py
+++ b/wagtail/contrib/frontend_cache/backends/azure.py
@@ -4,7 +4,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 from django.core.exceptions import ImproperlyConfigured
 
-from wagtail.utils.deprecation import RemovedInWagtail80Warning
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
 from .base import BaseBackend
 
@@ -39,7 +39,7 @@ class AzureBaseBackend(BaseBackend):
                 f"Support for {self._package_name} {self._installed_version} "
                 f"will be dropped in a future release. Please upgrade to "
                 f"{self._package_name} >= {self._required_version}.",
-                RemovedInWagtail80Warning,
+                RemovedInWagtail90Warning,
             )
 
     def _is_legacy_azure_library(self, *, required, installed):

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -19,6 +19,7 @@ from wagtail.contrib.frontend_cache.backends import (
 from wagtail.contrib.frontend_cache.utils import get_backends
 from wagtail.models import Page
 from wagtail.test.testapp.models import EventIndex, EventPage
+from wagtail.utils.deprecation import RemovedInWagtail80Warning
 
 from .utils import (
     PurgeBatch,
@@ -129,6 +130,34 @@ class TestBackendConfiguration(SimpleTestCase):
             backends["azure_cdn"]._cdn_endpoint_name, "wagtail-io-endpoint"
         )
 
+    @mock.patch("azure.mgmt.cdn.__version__", "12.0.0")
+    def test_azure_cdn_deprecation(self):
+        with self.assertWarnsMessage(
+            RemovedInWagtail80Warning,
+            "Support for azure-mgmt-cdn 12.0.0 will be dropped in a future release. "
+            "Please upgrade to azure-mgmt-cdn >= 13.0.0.",
+        ):
+            backends = get_backends(
+                backend_settings={
+                    "azure_cdn": {
+                        "BACKEND": "wagtail.contrib.frontend_cache.backends.AzureCdnBackend",
+                        "RESOURCE_GROUP_NAME": "test-resource-group",
+                        "CDN_PROFILE_NAME": "wagtail-org-profile",
+                        "CDN_ENDPOINT_NAME": "wagtail-org-endpoint",
+                    },
+                }
+            )
+
+        self.assertEqual(set(backends.keys()), {"azure_cdn"})
+        self.assertIsInstance(backends["azure_cdn"], AzureCdnBackend)
+        self.assertEqual(
+            backends["azure_cdn"]._resource_group_name, "test-resource-group"
+        )
+        self.assertEqual(backends["azure_cdn"]._cdn_profile_name, "wagtail-org-profile")
+        self.assertEqual(
+            backends["azure_cdn"]._cdn_endpoint_name, "wagtail-org-endpoint"
+        )
+
     def test_azure_front_door(self):
         backends = get_backends(
             backend_settings={
@@ -147,6 +176,32 @@ class TestBackendConfiguration(SimpleTestCase):
         )
         self.assertEqual(
             backends["azure_front_door"]._front_door_name, "wagtail-io-front-door"
+        )
+
+    @mock.patch("azure.mgmt.frontdoor.__version__", "1.0.0")
+    def test_azure_front_door_deprecation(self):
+        with self.assertWarnsMessage(
+            RemovedInWagtail80Warning,
+            "Support for azure-mgmt-frontdoor 1.0.0 will be dropped in a future release. "
+            "Please upgrade to azure-mgmt-frontdoor >= 1.1.0.",
+        ):
+            backends = get_backends(
+                backend_settings={
+                    "azure_front_door": {
+                        "BACKEND": "wagtail.contrib.frontend_cache.backends.AzureFrontDoorBackend",
+                        "RESOURCE_GROUP_NAME": "test-resource-group",
+                        "FRONT_DOOR_NAME": "wagtail-org-front-door",
+                    },
+                }
+            )
+
+        self.assertEqual(set(backends.keys()), {"azure_front_door"})
+        self.assertIsInstance(backends["azure_front_door"], AzureFrontDoorBackend)
+        self.assertEqual(
+            backends["azure_front_door"]._resource_group_name, "test-resource-group"
+        )
+        self.assertEqual(
+            backends["azure_front_door"]._front_door_name, "wagtail-org-front-door"
         )
 
     def test_azure_cdn_get_client(self):

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -19,7 +19,7 @@ from wagtail.contrib.frontend_cache.backends import (
 from wagtail.contrib.frontend_cache.utils import get_backends
 from wagtail.models import Page
 from wagtail.test.testapp.models import EventIndex, EventPage
-from wagtail.utils.deprecation import RemovedInWagtail80Warning
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
 from .utils import (
     PurgeBatch,
@@ -133,7 +133,7 @@ class TestBackendConfiguration(SimpleTestCase):
     @mock.patch("azure.mgmt.cdn.__version__", "12.0.0")
     def test_azure_cdn_deprecation(self):
         with self.assertWarnsMessage(
-            RemovedInWagtail80Warning,
+            RemovedInWagtail90Warning,
             "Support for azure-mgmt-cdn 12.0.0 will be dropped in a future release. "
             "Please upgrade to azure-mgmt-cdn >= 13.0.0.",
         ):
@@ -181,7 +181,7 @@ class TestBackendConfiguration(SimpleTestCase):
     @mock.patch("azure.mgmt.frontdoor.__version__", "1.0.0")
     def test_azure_front_door_deprecation(self):
         with self.assertWarnsMessage(
-            RemovedInWagtail80Warning,
+            RemovedInWagtail90Warning,
             "Support for azure-mgmt-frontdoor 1.0.0 will be dropped in a future release. "
             "Please upgrade to azure-mgmt-frontdoor >= 1.1.0.",
         ):


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->

Was working on #13952, but looks like this one is a bit more involved, so I decided to split it off based on #9824.

### Description

<!-- Please describe the problem you're fixing. -->

msrest is deprecated: https://github.com/Azure/msrest-for-python

> - The authentication part of this package has been moved to [azure-identity](https://pypi.org/project/azure-identity/)
> - The serialization part of this package is now vendored inside SDKs themselves
> - The other parts of this library are covered by [azure-core](https://pypi.org/project/azure-core/)

Upstream packages have dropped it in recent versions, see `CHANGELOG.md` and `setup.py` of these commits:

- azure-mgmt-frontdoor dropped it in v1.1 : https://github.com/Azure/azure-sdk-for-python/commit/c6a90bd3e84f94b5a89ec8ffcfb6e9711c49c512
- azure-mgmt-cdn dropped it in v13.0: https://github.com/Azure/azure-sdk-for-python/commit/ef4966935dc2fcbb0ee58fc7155b051b5b5d23ad

We only use `msrest` directly to catch the `HttpOperationError` exception. Looking at https://learn.microsoft.com/en-us/azure/developer/python/sdk/fundamentals/errors, it looks like we should be catching `azure.core.exceptions.HttpResponseError` instead. The two exceptions don't share a reasonably specific common ancestor for us to use, so we should probably keep the existing code during the deprecation period.

### Notes

I haven't actually tested this with a real Azure account myself. Just thought what's reasonable based on #9824 and the release notes in the Azure packages.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Copilot for autocomplete