### PR TITLE
Bump minimum Django version to 5.2.8 (CVE-2025-64459)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
   "Topic :: Internet :: WWW/HTTP :: Site Management",
 ]
 dependencies = [
-  "Django>=5.2",
+  "Django>=5.2.8",
   "django-modelcluster>=6.4.1,<7.0",
   "django-permissionedforms>=0.1,<1.0",
   "django-taggit>=5.0,<7",


### PR DESCRIPTION
Django versions below 5.2.8 are affected by CVE-2025-64459 (CVSS 9.1), a SQL injection vulnerability in the ORM. When a developer passes user-controlled dictionary keys directly to `filter(**kwargs)`, attackers can inject `_connector=OR` or `_negated=True` to manipulate the WHERE clause.

The fix was released in Django 4.2.26, 5.1.14, and 5.2.8.

This PR bumps the minimum required Django version from `>=5.2` to `>=5.2.8` to ensure downstream projects installing wagtail are protected against this vulnerability.

Reference: https://www.djangoproject.com/weblog/2025/may/07/security-releases/