### PR TITLE
Update MacOS reference to 'macOS' and specify shell

### DIFF
--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -49,7 +49,7 @@ mysite\env\Scripts\activate.bat
 mysite\env\Scripts\activate
 ```
 
-**On GNU/Linux or MacOS** (bash):
+**On GNU/Linux or macOS** (POSIX shell):
 
 Create the virtual environment using:
 


### PR DESCRIPTION
- I use Debian, where `bash` is the default shell. In contrast, macOS uses `zsh` as its shell. The reference to `bash` earlier was misleading; it was a minor mistake. 
- Additionally, there was incorrect branding regarding Apple. Apple refers to its operating system as macOS. This is consistently used throughout their official site, which can be found at https://developer.apple.com/macos/.
- POSIX shell can be ignored if it becomes too technical for common people to understand, as opposed to bash or zsh.


