### PR TITLE
Fix: Bitwarden last login filter overlay issue

### DIFF
--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -70,9 +70,7 @@ class UserFilterSet(WagtailFilterSet):
     )
     last_login = django_filters.DateFromToRangeFilter(
         label=gettext_lazy("Last login"),
-        widget=DateRangePickerWidget(
-            attrs={"data-bwignore": "true"}
-        ),
+        widget=DateRangePickerWidget(attrs={"data-bwignore": "true"}),
     )
 
     def __init__(


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #13762 

### Description
On the Users listing, "Last login" filter fields are impossible to use with the Bitwarden browser extension, which displays its password matches over the date picker UI.

All testcases passed locally and the issue was tested in with bakerydemo website and also with the test link provided below using firefox browser.

Test yourself in [Wagtail 6.1 static demo - users listing](https://static-wagtail-v6-1.netlify.app/admin/users/)

### Steps to reproduce

1.    Install and configure the Bitwarden browser extension
2.    Go to any site’s /admin/users/
3.    Attempt to filter by "Last login"

<!-- Please describe the problem you're fixing. -->

### Method
I just applied the "attrs={"data-bwignore": "true"}" in the users view to ignore this overlay issue rather than modifying at template level which mixes presentation layer with behaviour and makes it harder to maintain.
It is stated in the docs of [Bitwarden 2021-06-29 release notes](https://bitwarden.com/help/releasenotes/#2021-06-29).

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None
I just used the sentences again from the issue page here, thanks to thibaud for his clear explanation.
