### PR TITLE
Avoid creating a new editing session when updating UI elements after an autosave

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Add support for Flourish oEmbeds (Garrett Coakley)
  * Add support for Heyzine oEmbeds (Baptiste Darthenay)
  * Allow specifying `creation_form_class` on `ChooserViewSet` as a dotted path string (Adithya00012)
+ * Avoid creating a new editing session when updating UI elements after an autosave (Sage Abdullah)
  * Fix: Handle nested inline models when displaying object usage information (Sage Abdullah, Kacper Walęga, Tian Jie Wong)
  * Fix: Avoid duplicate `get_object()` DB query in API detail view (Siddheshwar Kadam)
  * Fix: Ensure `ImageBlock` alt text populates on choosing a new image after unchecking decorative state (Pratham Jaiswal)

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -22,6 +22,7 @@ Wagtail 7.4 is designated a Long Term Support (LTS) release. Long Term Support r
  * Add support for Flourish oEmbeds (Garrett Coakley)
  * Add support for Heyzine oEmbeds (Baptiste Darthenay)
  * Allow specifying `creation_form_class` on `ChooserViewSet` as a dotted path string (Adithya00012)
+ * Avoid creating a new editing session when updating UI elements after an autosave (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -15,6 +15,7 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.action_menu import ActionMenuItem, PublishMenuItem
 from wagtail.admin.admin_url_finder import AdminURLFinder
+from wagtail.admin.models import EditingSession
 from wagtail.exceptions import PageClassNotFoundError
 from wagtail.models import (
     Comment,
@@ -26,6 +27,7 @@ from wagtail.models import (
     PageSubscription,
     Revision,
     Site,
+    get_default_page_content_type,
 )
 from wagtail.signals import page_published
 from wagtail.test.testapp.models import (
@@ -1067,6 +1069,43 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         self.assertEqual(
             editing_sessions.select_one("input[name='revision_created_at']")["value"],
             latest_revision.created_at.isoformat(),
+        )
+
+    def test_save_with_json_response_does_not_affect_sessions(self):
+        # an old session that would be cleaned up when loading the editor
+        old_session = EditingSession.objects.create(
+            user=self.user,
+            content_type=get_default_page_content_type(),
+            object_id=self.child_page.pk,
+            last_seen_at=timezone.now() - datetime.timedelta(hours=5),
+        )
+        # a recent session that would not be cleaned up when loading the editor
+        recent_session = EditingSession.objects.create(
+            user=self.user,
+            content_type=get_default_page_content_type(),
+            object_id=self.child_page.pk,
+            last_seen_at=timezone.now() - datetime.timedelta(seconds=5),
+        )
+        loaded_revision = self.child_page.get_latest_revision()
+        post_data = {
+            "title": "I've been edited!",
+            "content": "Some content",
+            "slug": "hello-world",
+            "loaded_revision_id": loaded_revision.pk,
+            "loaded_revision_created_at": loaded_revision.created_at.isoformat(),
+        }
+        response = self.client.post(
+            reverse("wagtailadmin_pages:edit", args=(self.child_page.pk,)),
+            post_data,
+            headers={"Accept": "application/json"},
+        )
+        self.assertEqual(response.status_code, 200)
+        # Saving with a JSON response does not fully load the editor, so it
+        # should not run a cleanup of old sessions, nor should it create a new
+        # session for the current request.
+        self.assertEqual(
+            list(EditingSession.objects.values_list("pk", flat=True).order_by("pk")),
+            [old_session.pk, recent_session.pk],
         )
 
     def test_page_edit_post_unpublished_page(self):

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -847,10 +847,15 @@ class CreateEditViewOptionalFeaturesMixin:
             settings, "WAGTAIL_WORKFLOW_CANCEL_ON_PUBLISH", True
         ) and bool(self.workflow_tasks)
         context["revisions_compare_url_name"] = self.revisions_compare_url_name
-        context["editing_sessions"] = self.get_editing_sessions()
         context["loaded_revision_created_at"] = self.latest_revision_created_at
-        if self.autosave_enabled:
-            context["autosave_indicator"] = AutosaveIndicator()
+
+        if not self.expects_json_response:
+            # These components do not need to be loaded when rendering partials
+            # for autosave. In particular, `get_editing_sessions` performs
+            # database writes that are not necessary when autosaving.
+            context["editing_sessions"] = self.get_editing_sessions()
+            if self.autosave_enabled:
+                context["autosave_indicator"] = AutosaveIndicator()
         return context
 
     def is_valid(self, form):

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -1109,13 +1109,22 @@ class EditView(
                 "media": media,
                 "autosave_enabled": self.autosave_enabled,
                 "autosave_interval": self.autosave_interval,
-                "autosave_indicator": AutosaveIndicator(),
-                "editing_sessions": self.get_editing_sessions(),
                 "loaded_revision_created_at": self.latest_revision_created_at,
                 "is_partial": self.expects_json_response or self.hydrate_create_view,
                 "hydrate_create_view": self.hydrate_create_view,
             }
         )
+
+        if not self.expects_json_response:
+            # These components do not need to be loaded when rendering partials
+            # for autosave. In particular, `get_editing_sessions` performs
+            # database writes that are not necessary when autosaving.
+            context.update(
+                {
+                    "editing_sessions": self.get_editing_sessions(),
+                    "autosave_indicator": AutosaveIndicator(),
+                }
+            )
 
         return context
 

--- a/wagtail/snippets/tests/test_edit_view.py
+++ b/wagtail/snippets/tests/test_edit_view.py
@@ -11,11 +11,13 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.timezone import now
 from freezegun import freeze_time
 from taggit.models import Tag
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
+from wagtail.admin.models import EditingSession
 from wagtail.models import Locale, ModelLogEntry, Revision
 from wagtail.signals import published
 from wagtail.snippets.action_menu import (
@@ -1238,6 +1240,35 @@ class TestEditRevisionSnippet(BaseTestSnippetEditView):
         latest_revision = self.test_snippet.get_latest_revision()
         self.assertEqual(latest_revision.id, user_revision.id)
         self.assertEqual(latest_revision.content["text"], "Initial revision")
+
+    def test_save_with_json_response_does_not_affect_sessions(self):
+        # an old session that would be cleaned up when loading the editor
+        content_type = ContentType.objects.get_for_model(self.test_snippet)
+        old_session = EditingSession.objects.create(
+            user=self.user,
+            content_type=content_type,
+            object_id=self.test_snippet.pk,
+            last_seen_at=timezone.now() - datetime.timedelta(hours=5),
+        )
+        # a recent session that would not be cleaned up when loading the editor
+        recent_session = EditingSession.objects.create(
+            user=self.user,
+            content_type=content_type,
+            object_id=self.test_snippet.pk,
+            last_seen_at=timezone.now() - datetime.timedelta(seconds=5),
+        )
+        response = self.post(
+            post_data={"text": "Autosaved"},
+            headers={"Accept": "application/json"},
+        )
+        self.assertEqual(response.status_code, 200)
+        # Saving with a JSON response does not fully load the editor, so it
+        # should not run a cleanup of old sessions, nor should it create a new
+        # session for the current request.
+        self.assertEqual(
+            list(EditingSession.objects.values_list("pk", flat=True).order_by("pk")),
+            [old_session.pk, recent_session.pk],
+        )
 
 
 class TestEditDraftStateSnippet(BaseTestSnippetEditView):


### PR DESCRIPTION


<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->


### Description

Normally, `get_context_data()` is only called for GET requests, or POST request with an invalid form (to re-render the form with errors). With autosave, we now render a partial template to update the UI, and we call `get_context_data()` as part of this process.

Inside `get_context_data()`, we have a call to `get_editing_sessions()`, which does a cleanup of old sessions, as well as creating a new one for the current session. This is irrelevant for autosave, and may reduce its performance unnecessarily.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Copilot for autocompletion only.