### PR TITLE
Autosave UX improvements

### DIFF
--- a/client/scss/components/_autosave.scss
+++ b/client/scss/components/_autosave.scss
@@ -4,7 +4,10 @@
 }
 
 .w-autosave-indicator__state {
-  display: none;
+  // Minimize layout shift by reserving space for the indicator when it's hidden.
+  height: 0;
+  visibility: hidden;
+  display: flex;
   align-items: center;
   gap: theme('spacing.2');
   white-space: nowrap;
@@ -23,7 +26,8 @@
 [data-w-autosave-state-value='saving'] .w-autosave-indicator__state--saving,
 [data-w-autosave-state-value='saved'] .w-autosave-indicator__state--saved,
 [data-w-autosave-state-value='paused'] .w-autosave-indicator__state--paused {
-  display: flex;
+  height: auto;
+  visibility: visible;
 }
 
 .w-autosave-indicator__state--paused {

--- a/client/scss/components/_editing-sessions.scss
+++ b/client/scss/components/_editing-sessions.scss
@@ -10,6 +10,11 @@
   @apply w-mx-px w-w-7 w-h-7 w-border-2 w-border-surface-field hover:w-border-positive-100;
 }
 
+.w-editing-sessions__avatar--idle img {
+  opacity: 0.5;
+  filter: grayscale(1);
+}
+
 .w-editing-sessions__decorated-avatar {
   @apply w-relative w-rounded-full;
 
@@ -51,7 +56,7 @@
 
 .w-editing-sessions__session--saved {
   .w-editing-sessions__avatar {
-    @apply w-border-text-error;
+    @apply w-border-text-error w-opacity-100;
   }
 
   .icon {
@@ -61,7 +66,7 @@
 
 .w-editing-sessions__session--editing {
   .w-editing-sessions__avatar {
-    @apply w-border-warning-100;
+    @apply w-border-warning-100 w-opacity-100;
   }
 
   .icon {

--- a/client/scss/components/_editing-sessions.scss
+++ b/client/scss/components/_editing-sessions.scss
@@ -3,7 +3,7 @@
 }
 
 .w-editing-sessions__list {
-  @apply w-flex w-p-0 w-m-0;
+  @apply w-flex w-items-center w-p-0 w-m-0;
 }
 
 .w-editing-sessions__avatar {

--- a/client/src/controllers/AutosaveController.test.js
+++ b/client/src/controllers/AutosaveController.test.js
@@ -708,6 +708,25 @@ describe('AutosaveController', () => {
       // No new call, retries should be cleared after success
       expect(fetch).toHaveBeenCalledTimes(4);
 
+      fetch.mockReset();
+      errorListener.mockReset();
+      input.value = 'Max retries';
+      unsavedEvent = await dispatchUnsaved(form);
+      await expectSaveAttempt(1);
+      await jest.advanceTimersByTimeAsync(2000);
+      await expectSaveAttempt(2);
+      await jest.advanceTimersByTimeAsync(4000);
+      await expectSaveAttempt(3);
+      await jest.advanceTimersByTimeAsync(8000);
+      await expectSaveAttempt(4);
+      await jest.advanceTimersByTimeAsync(16000);
+      await expectSaveAttempt(5);
+      await jest.advanceTimersByTimeAsync(32000);
+      await expectSaveAttempt(6);
+      await jest.advanceTimersByTimeAsync(64500);
+      // 1 initial attempt, 5 retries max
+      expect(fetch).toHaveBeenCalledTimes(6);
+
       form.removeEventListener('w-autosave:error', errorListener);
     });
   });

--- a/client/src/controllers/AutosaveController.test.js
+++ b/client/src/controllers/AutosaveController.test.js
@@ -452,36 +452,47 @@ describe('AutosaveController', () => {
 
       fetch.mockResponseBadRequest(JSON.stringify(serverResponse));
 
-      const deactivatedEvent = new Promise((resolve) => {
-        form.addEventListener(
-          'w-autosave:deactivated',
-          (event) => resolve(event),
-          {
-            once: true,
-          },
-        );
-      });
       const errorEvent = new Promise((resolve) => {
         form.addEventListener('w-autosave:error', (event) => resolve(event), {
           once: true,
         });
+      });
+      const finishError = Promise.withResolvers();
+      const deactivatedHandler = jest.fn();
+      const deactivatedEvent = new Promise((resolve) => {
+        form.addEventListener(
+          'w-autosave:deactivated',
+          async (event) => {
+            // Ensure deactivated event is dispatched after error event
+            await finishError.promise;
+            deactivatedHandler();
+            resolve(event);
+          },
+          {
+            once: true,
+          },
+        );
       });
 
       const unsavedEvent1 = await dispatchUnsaved(form);
       await jest.advanceTimersByTimeAsync(500);
       expect(fetch).toHaveBeenCalledTimes(1);
 
-      const { detail: deactivatedEventDetail } = await deactivatedEvent;
-      expect(deactivatedEventDetail.response).toEqual(serverResponse);
-      expect(deactivatedEventDetail.error).toBeInstanceOf(Error);
-      expect(deactivatedEventDetail.error.message).toBe('Invalid revision');
-      expect(deactivatedEventDetail.trigger).toBe(unsavedEvent1);
-
       const { detail: errorEventDetail } = await errorEvent;
       expect(errorEventDetail.response).toEqual(serverResponse);
       expect(errorEventDetail.error).toBeInstanceOf(Error);
       expect(errorEventDetail.error.message).toBe('Invalid revision');
       expect(errorEventDetail.trigger).toBe(unsavedEvent1);
+      expect(deactivatedHandler).not.toHaveBeenCalled();
+
+      finishError.resolve();
+
+      const { detail: deactivatedEventDetail } = await deactivatedEvent;
+      expect(deactivatedEventDetail.response).toEqual(serverResponse);
+      expect(deactivatedEventDetail.error).toBeInstanceOf(Error);
+      expect(deactivatedEventDetail.error.message).toBe('Invalid revision');
+      expect(deactivatedEventDetail.trigger).toBe(unsavedEvent1);
+      expect(deactivatedHandler).toHaveBeenCalledTimes(1);
 
       // Should have deactivated autosave
       expect(form.getAttribute('data-w-autosave-active-value')).toBe('false');

--- a/client/src/controllers/AutosaveController.test.js
+++ b/client/src/controllers/AutosaveController.test.js
@@ -51,6 +51,7 @@ describe('AutosaveController', () => {
     document.body.innerHTML = '';
     fetch.mockReset();
     window.history.replaceState.mockRestore();
+    jest.clearAllTimers();
   });
 
   describe('basic behavior', () => {
@@ -577,6 +578,114 @@ describe('AutosaveController', () => {
       expect(response).toBeNull();
       expect(error).toEqual({ status: 500, statusText: 'Internal Error' });
       expect(trigger).toBe(unsavedEvent);
+    });
+
+    it('retries with exponential backoff on network errors', async () => {
+      const form = await setup();
+      const networkError = new TypeError('Failed to fetch');
+
+      const errorListener = jest.fn();
+      form.addEventListener('w-autosave:error', errorListener);
+
+      let unsavedEvent = await dispatchUnsaved(form);
+
+      const expectSaveAttempt = async (n) => {
+        // Fetch not fired until the 500ms debounce
+        expect(fetch).toHaveBeenCalledTimes(n - 1);
+        fetch.mockImplementationOnce(() => Promise.reject(networkError));
+        await jest.advanceTimersByTimeAsync(500);
+        expect(fetch).toHaveBeenCalledTimes(n);
+        expect(errorListener).toHaveBeenCalledTimes(n);
+        const errorEventDetail = errorListener.mock.calls[n - 1][0].detail;
+        const { response, error, trigger } = errorEventDetail;
+        expect(response).toBeNull();
+        expect(error).toEqual(networkError);
+        expect(trigger).toBe(unsavedEvent);
+      };
+
+      await expectSaveAttempt(1);
+      await jest.advanceTimersByTimeAsync(2000);
+      await expectSaveAttempt(2);
+      await jest.advanceTimersByTimeAsync(4000);
+      await expectSaveAttempt(3);
+
+      // Simulate the user making another change in between retries
+      // (but before the 'unsaved' event is dispatched)
+      const input = form.querySelector('input[name="title"]');
+      input.value = 'Updated title';
+
+      await jest.advanceTimersByTimeAsync(8000);
+      await expectSaveAttempt(4);
+      // The retry should use the latest data in the payload
+      expect(fetch.mock.calls[3][1].body.get('title')).toBe('Updated title');
+
+      const saveHandler = jest.fn();
+      form.addEventListener('w-autosave:save', saveHandler, { once: true });
+      fetch.mockResponseSuccessJSON(JSON.stringify({ success: true }));
+
+      await jest.advanceTimersByTimeAsync(16000);
+      expect(fetch).toHaveBeenCalledTimes(4);
+      await jest.advanceTimersByTimeAsync(500);
+      expect(fetch).toHaveBeenCalledTimes(5);
+      expect(saveHandler).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(32500);
+      // No new call, retries should be cleared after success
+      expect(fetch).toHaveBeenCalledTimes(5);
+
+      fetch.mockReset();
+      errorListener.mockReset();
+      input.value = 'Another update';
+      unsavedEvent = await dispatchUnsaved(form);
+      // Should trigger a new save immediately,
+      // and any errors should trigger a new retry sequence
+      await expectSaveAttempt(1);
+      await jest.advanceTimersByTimeAsync(2000);
+      await expectSaveAttempt(2);
+      await jest.advanceTimersByTimeAsync(4000);
+      await expectSaveAttempt(3);
+
+      // If another save attempt is made in between retries, and it also fails,
+      // keep the existing retry schedule and don't start a new one
+      input.value = 'Yet another update';
+      unsavedEvent = await dispatchUnsaved(form);
+      await expectSaveAttempt(4);
+      await jest.advanceTimersByTimeAsync(7000);
+      expect(fetch).toHaveBeenCalledTimes(4);
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(fetch).toHaveBeenCalledTimes(5);
+
+      // If the error is a server error instead of a network error, do not retry
+      fetch.mockResponseFailure();
+      await jest.advanceTimersByTimeAsync(16000);
+      expect(fetch).toHaveBeenCalledTimes(5);
+      await jest.advanceTimersByTimeAsync(500);
+      expect(fetch).toHaveBeenCalledTimes(6);
+      await jest.advanceTimersByTimeAsync(32500);
+      expect(fetch).toHaveBeenCalledTimes(6);
+
+      fetch.mockReset();
+      errorListener.mockReset();
+      // Trigger a new save attempt to ensure retries are cleared after a server error
+      input.value = 'Try again';
+      unsavedEvent = await dispatchUnsaved(form);
+      await expectSaveAttempt(1);
+      await jest.advanceTimersByTimeAsync(2000);
+      await expectSaveAttempt(2);
+      await jest.advanceTimersByTimeAsync(4000);
+      await expectSaveAttempt(3);
+
+      // Simulate another trigger (not from retry) in between retries and it's successful
+      fetch.mockResponseSuccessJSON(JSON.stringify({ success: true }));
+      input.value = 'Now it succeeds';
+      unsavedEvent = await dispatchUnsaved(form);
+      await jest.advanceTimersByTimeAsync(500);
+      expect(fetch).toHaveBeenCalledTimes(4);
+      await jest.advanceTimersByTimeAsync(8500);
+      // No new call, retries should be cleared after success
+      expect(fetch).toHaveBeenCalledTimes(4);
+
+      form.removeEventListener('w-autosave:error', errorListener);
     });
   });
 

--- a/client/src/controllers/AutosaveController.test.js
+++ b/client/src/controllers/AutosaveController.test.js
@@ -309,6 +309,29 @@ describe('AutosaveController', () => {
     });
 
     describe('error handling for hydration requests', () => {
+      it('gracefully ignores hydration if partials target is unavailable', async () => {
+        partialsTarget.remove();
+        fetch.mockResponseSuccessText('A bottle of water');
+
+        jest
+          .spyOn(window, 'requestAnimationFrame')
+          .mockImplementationOnce((callback) => callback());
+        const successListener = jest.fn();
+        form.addEventListener('w-autosave:success', successListener, {
+          once: true,
+        });
+
+        const unsavedEvent = await dispatchUnsaved(form);
+        await jest.advanceTimersByTimeAsync(500);
+
+        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(fetch.mock.calls[1][0]).toBe(
+          '/edit/123/?_w_hydrate_create_view=1',
+        );
+        expect(document.body.innerHTML).not.toContain('A bottle of water');
+        expect(successListener).toHaveBeenCalledTimes(1);
+      });
+
       it('dispatches an error event when the fetch fails', async () => {
         expect(partialsTarget.innerHTML).toBe('');
 

--- a/client/src/controllers/AutosaveController.ts
+++ b/client/src/controllers/AutosaveController.ts
@@ -153,6 +153,9 @@ export class AutosaveController extends Controller<
    */
   declare stateValue: AutosaveState;
 
+  retryTimeout: ReturnType<typeof setTimeout> | null = null;
+  retryTimes = 0;
+
   initialize(): void {
     this.submit = this.submit.bind(this);
   }
@@ -244,6 +247,8 @@ export class AutosaveController extends Controller<
         this.partialsTarget.innerHTML = response.html;
       }
 
+      this.clearRetries();
+
       // Ensure any UI updates have finished before dispatching the success event
       requestAnimationFrame(() =>
         this.dispatch('success', {
@@ -266,6 +271,20 @@ export class AutosaveController extends Controller<
         // Fetch failed, no response at all
         type = ClientErrorCode.NETWORK_ERROR;
         text = gettext('A network error occurred.');
+
+        // Another save attempt may happen in between retries. If it also fails,
+        // keep the current retry timeout and don't set a new one.
+        if (!this.retryTimeout) {
+          this.retryTimes += 1;
+          this.retryTimeout = setTimeout(
+            () => {
+              this.save(event);
+              this.retryTimeout = null;
+            },
+            // Exponential backoff
+            1000 * 2 ** this.retryTimes,
+          );
+        }
       } else if (
         // Non-JSON response
         !response ||
@@ -282,6 +301,10 @@ export class AutosaveController extends Controller<
       } else {
         type = response.error_code as ServerErrorCode;
         text = response.error_message;
+      }
+
+      if (type !== ClientErrorCode.NETWORK_ERROR) {
+        this.clearRetries();
       }
 
       this.dispatch('error', {
@@ -355,6 +378,15 @@ export class AutosaveController extends Controller<
           { cause: error },
         );
       });
+  }
+
+  /** Resets retry state so future retries start with the initial delay. */
+  clearRetries() {
+    if (this.retryTimeout) {
+      clearTimeout(this.retryTimeout);
+    }
+    this.retryTimeout = null;
+    this.retryTimes = 0;
   }
 
   /** Applies the new debounce interval to the submit function. */

--- a/client/src/controllers/AutosaveController.ts
+++ b/client/src/controllers/AutosaveController.ts
@@ -130,6 +130,8 @@ export class AutosaveController extends Controller<
     state: { type: String, default: 'idle' as AutosaveState },
   };
 
+  static maxRetries = 5;
+
   declare readonly hasPartialsTarget: boolean;
   /** The target element for partial HTML updates. */
   declare readonly partialsTarget: HTMLDivElement;
@@ -274,7 +276,10 @@ export class AutosaveController extends Controller<
 
         // Another save attempt may happen in between retries. If it also fails,
         // keep the current retry timeout and don't set a new one.
-        if (!this.retryTimeout) {
+        if (
+          !this.retryTimeout &&
+          this.retryTimes < AutosaveController.maxRetries
+        ) {
           this.retryTimes += 1;
           this.retryTimeout = setTimeout(
             () => {

--- a/client/src/controllers/AutosaveController.ts
+++ b/client/src/controllers/AutosaveController.ts
@@ -115,8 +115,8 @@ export type AutosaveEvent =
  * @fires `w-autosave:save` - before saving, cancelable.
  * @fires `w-autosave:hydrate` - to hydrate a create view into an edit view.
  * @fires `w-autosave:success` - on successful save and any UI updates.
- * @fires `w-autosave:deactivated` - when autosave is deactivated due to an unrecoverable error.
  * @fires `w-autosave:error` - on save error, e.g. due to validation errors.
+ * @fires `w-autosave:deactivated` - when autosave is deactivated due to an unrecoverable error.
  *
  */
 export class AutosaveController extends Controller<
@@ -284,6 +284,17 @@ export class AutosaveController extends Controller<
         text = response.error_message;
       }
 
+      this.dispatch('error', {
+        cancelable: false,
+        detail: {
+          response,
+          error,
+          trigger: event,
+          text, // Used for showing the unsaved changes message
+          type,
+        },
+      });
+
       // There's no reliable way to recover from an invalid revision or a
       // hydration error, so deactivate and inform listeners (e.g. to
       // immediately trigger a notification)
@@ -301,17 +312,6 @@ export class AutosaveController extends Controller<
           },
         });
       }
-
-      this.dispatch('error', {
-        cancelable: false,
-        detail: {
-          response,
-          error,
-          trigger: event,
-          text, // Used for showing the unsaved changes message
-          type,
-        },
-      });
     }
   };
 

--- a/client/src/controllers/SessionController.test.js
+++ b/client/src/controllers/SessionController.test.js
@@ -123,6 +123,52 @@ describe('SessionController', () => {
       expect(handlePing).toHaveBeenCalledTimes(0);
       handlePing.mockClear();
     });
+
+    it('should allow pausing and resuming the ping', async () => {
+      expect(handlePing).not.toHaveBeenCalled();
+      document.body.innerHTML = /* html */ `
+        <div
+          data-controller="w-session"
+          data-action="w-autosave:save@document->w-session#pause w-autosave:success@document->w-session#resume visibilitychange@document->w-session#ping"
+          data-w-session-active-value="false"
+          >
+          Inactive by default
+        </div>
+      `;
+      await Promise.resolve();
+
+      // If activeValue is false, it should not dispatch the event immediately
+      expect(handlePing).not.toHaveBeenCalled();
+
+      // Should not dispatch the event after the set interval either
+      jest.advanceTimersByTime(10000);
+      expect(handlePing).not.toHaveBeenCalled();
+
+      document.dispatchEvent(new CustomEvent('w-autosave:success'));
+      await Promise.resolve();
+      // Ping is not done immediately after resume
+      expect(handlePing).not.toHaveBeenCalled();
+
+      // Should dispatch the event after the set interval
+      jest.advanceTimersByTime(10000);
+      expect(handlePing).toHaveBeenCalledTimes(1);
+      // Should continue dispatching the ping event via actions
+      document.dispatchEvent(new Event('visibilitychange'));
+      expect(handlePing).toHaveBeenCalledTimes(2);
+
+      document.dispatchEvent(new CustomEvent('w-autosave:save'));
+      await Promise.resolve();
+
+      // Should not dispatch the event after pausing
+      expect(handlePing).toHaveBeenCalledTimes(2);
+      jest.advanceTimersByTime(10000);
+      expect(handlePing).toHaveBeenCalledTimes(2);
+
+      // Should not dispatch the event even when triggering the ping action
+      document.dispatchEvent(new Event('visibilitychange'));
+      await Promise.resolve();
+      expect(handlePing).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('dispatching the visibility state of the document', () => {

--- a/client/src/controllers/SessionController.test.js
+++ b/client/src/controllers/SessionController.test.js
@@ -498,21 +498,13 @@ describe('SessionController', () => {
     });
   });
 
-  describe('storing unsaved changes state to a checkbox input and update reload buttons accordingly', () => {
-    let reloadButton;
-
+  describe('storing unsaved changes state to a checkbox input', () => {
     beforeEach(() => {
       document.body.innerHTML = /* html */ `
         <form data-controller="w-session" data-action="w-unsaved:add@document->w-session#setUnsavedChanges w-unsaved:clear@document->w-session#setUnsavedChanges">
           <input type="checkbox" name="is_editing" data-w-session-target="unsavedChanges" value="1" />
         </form>
       `;
-
-      reloadButton = document.createElement('button');
-      reloadButton.type = 'button';
-      reloadButton.setAttribute('data-w-session-target', 'reload');
-      reloadButton.setAttribute('data-dialog-id', 'w-unsaved-changes-dialog');
-      reloadButton.innerHTML = 'Refresh';
     });
 
     it('should set the checkbox state to be checked when there is a w-unsaved:add event', async () => {
@@ -520,28 +512,12 @@ describe('SessionController', () => {
       const checkbox = document.querySelector('input');
       expect(checkbox.checked).toBe(false);
 
-      // when connected, the reload button should be set up to reload the page
-      form.appendChild(reloadButton);
-      await Promise.resolve();
-      expect(reloadButton.getAttribute('data-a11y-dialog-show')).toBeNull();
-      expect(reloadButton.getAttribute('data-action')).toEqual(
-        'w-action#reload',
-      );
-
       document.dispatchEvent(new CustomEvent('w-unsaved:add'));
       await Promise.resolve();
       expect(checkbox.checked).toBe(true);
 
       // should be included in the form
       expect(new FormData(form).get('is_editing')).toBe('1');
-
-      // should make the reload button show the unsaved changes dialog instead
-      // of reloading, by setting the data-a11y-dialog-show attribute and
-      // removing the data-action attribute
-      expect(reloadButton.getAttribute('data-a11y-dialog-show')).toEqual(
-        'w-unsaved-changes-dialog',
-      );
-      expect(reloadButton.getAttribute('data-action')).toBeNull();
     });
 
     it('should set the checkbox state to be unchecked when there is a w-unsaved:clear event', async () => {
@@ -550,29 +526,12 @@ describe('SessionController', () => {
       checkbox.checked = true;
       expect(checkbox.checked).toBe(true);
 
-      // when connected, the reload button should be set up to show the unsaved
-      // changes dialog
-      form.appendChild(reloadButton);
-      await Promise.resolve();
-      expect(reloadButton.getAttribute('data-a11y-dialog-show')).toEqual(
-        'w-unsaved-changes-dialog',
-      );
-      expect(reloadButton.getAttribute('data-action')).toBeNull();
-
       document.dispatchEvent(new CustomEvent('w-unsaved:clear'));
       await Promise.resolve();
       expect(checkbox.checked).toBe(false);
 
       // should not be included in the form
       expect(new FormData(form).get('is_editing')).toBeNull();
-
-      // should make the reload button reload the page instead of showing the
-      // unsaved changes dialog, by setting the data-action attribute and
-      // removing the data-a11y-dialog-show attribute
-      expect(reloadButton.getAttribute('data-a11y-dialog-show')).toBeNull();
-      expect(reloadButton.getAttribute('data-action')).toEqual(
-        'w-action#reload',
-      );
     });
 
     it('should work fine if there is no unsavedChanges target', async () => {
@@ -587,21 +546,6 @@ describe('SessionController', () => {
       document.dispatchEvent(new CustomEvent('w-unsaved:clear'));
       await Promise.resolve();
       expect(form.innerHTML.trim()).toEqual('');
-    });
-
-    it('should work fine if there is no reload target', async () => {
-      const form = document.querySelector('form');
-      const checkbox = document.querySelector('input');
-
-      // the reloadButton is never appended to the form
-
-      document.dispatchEvent(new CustomEvent('w-unsaved:add'));
-      await Promise.resolve();
-      expect(form.innerHTML.trim()).toEqual(checkbox.outerHTML.trim());
-
-      document.dispatchEvent(new CustomEvent('w-unsaved:clear'));
-      await Promise.resolve();
-      expect(form.innerHTML.trim()).toEqual(checkbox.outerHTML.trim());
     });
   });
 

--- a/client/src/controllers/SessionController.test.js
+++ b/client/src/controllers/SessionController.test.js
@@ -253,7 +253,7 @@ describe('SessionController', () => {
           <button type="button" data-workflow-action-name="approve">Approve</button>
 
           <div
-            id="w-overwrite-changes-dialog"
+            id="w-save-confirmation-dialog"
             aria-hidden="true"
             data-controller="w-dialog"
             data-action="w-dialog:hide->w-dialog#hide w-dialog:show->w-dialog#show"
@@ -272,7 +272,7 @@ describe('SessionController', () => {
         <div
           data-controller="w-session"
           data-w-session-intercept-value="true"
-          data-w-session-w-dialog-outlet="[data-edit-form] [data-controller='w-dialog']#w-overwrite-changes-dialog"
+          data-w-session-w-dialog-outlet="[data-edit-form] [data-controller='w-dialog']#w-save-confirmation-dialog"
         >
         </div>
       `;
@@ -284,7 +284,7 @@ describe('SessionController', () => {
       workflowActionButton.addEventListener('click', handleWorkflowAction, {
         capture: true,
       });
-      const dialog = document.getElementById('w-overwrite-changes-dialog');
+      const dialog = document.getElementById('w-save-confirmation-dialog');
       dialog.addEventListener('w-dialog:shown', handleDialogShow);
       dialog.addEventListener('w-dialog:hidden', handleDialogHidden);
       dialog.addEventListener('w-dialog:confirmed', handleDialogConfirmed);
@@ -303,7 +303,7 @@ describe('SessionController', () => {
 
     it('should not prevent the submit event if the intercept value is unset', async () => {
       const submitButton = form.querySelector('button[type="submit"]');
-      const dialog = document.querySelector('#w-overwrite-changes-dialog');
+      const dialog = document.querySelector('#w-save-confirmation-dialog');
       const element = document.querySelector('[data-controller="w-session"]');
       element.removeAttribute('data-w-session-intercept-value');
       await Promise.resolve();
@@ -318,7 +318,7 @@ describe('SessionController', () => {
 
     it('should not prevent the submit event if the intercept value is set to false', async () => {
       const submitButton = form.querySelector('button[type="submit"]');
-      const dialog = document.querySelector('#w-overwrite-changes-dialog');
+      const dialog = document.querySelector('#w-save-confirmation-dialog');
       const element = document.querySelector('[data-controller="w-session"]');
       element.setAttribute('data-w-session-intercept-value', 'false');
       await Promise.resolve();
@@ -332,7 +332,7 @@ describe('SessionController', () => {
     });
 
     it('should show the dialog and prevent the submit event', async () => {
-      const dialog = document.querySelector('#w-overwrite-changes-dialog');
+      const dialog = document.querySelector('#w-save-confirmation-dialog');
       const submitButton = form.querySelector('button[type="submit"]');
       expect(dialog.getAttribute('aria-hidden')).toEqual('true');
       expect(handleDialogShow).not.toHaveBeenCalled();
@@ -346,7 +346,7 @@ describe('SessionController', () => {
     });
 
     it('should continue the action after confirming the dialog', async () => {
-      const dialog = document.querySelector('#w-overwrite-changes-dialog');
+      const dialog = document.querySelector('#w-save-confirmation-dialog');
       const confirmButton = document.getElementById('confirm');
       expect(handleDialogShow).not.toHaveBeenCalled();
 
@@ -367,7 +367,7 @@ describe('SessionController', () => {
     });
 
     it('should allow the action to be cancelled', async () => {
-      const dialog = document.querySelector('#w-overwrite-changes-dialog');
+      const dialog = document.querySelector('#w-save-confirmation-dialog');
       const cancelButton = document.getElementById('cancel');
       expect(handleDialogShow).not.toHaveBeenCalled();
 
@@ -387,7 +387,7 @@ describe('SessionController', () => {
     });
 
     it('should show the dialog again if clicking the action again after the dialog is hidden', async () => {
-      const dialog = document.querySelector('#w-overwrite-changes-dialog');
+      const dialog = document.querySelector('#w-save-confirmation-dialog');
       const confirmButton = document.getElementById('confirm');
       const cancelButton = document.getElementById('cancel');
       expect(handleDialogShow).not.toHaveBeenCalled();
@@ -434,7 +434,7 @@ describe('SessionController', () => {
     });
 
     it('should use the action button label as the dialog confirm target label if it has one', async () => {
-      const dialog = document.querySelector('#w-overwrite-changes-dialog');
+      const dialog = document.querySelector('#w-save-confirmation-dialog');
       const submitButton = form.querySelector('button[type="submit"]');
       const confirmButton = document.getElementById('confirm');
       // Mark the confirm button as DialogController's confirm target
@@ -497,7 +497,7 @@ describe('SessionController', () => {
 
       // Reconnect the DialogController so the submit button in the
       // schedule publishing dialog works
-      const dialog = document.querySelector('#w-overwrite-changes-dialog');
+      const dialog = document.querySelector('#w-save-confirmation-dialog');
       dialog.removeAttribute('data-controller');
       await Promise.resolve();
       dialog.setAttribute('data-controller', 'w-dialog');

--- a/client/src/controllers/SessionController.test.js
+++ b/client/src/controllers/SessionController.test.js
@@ -271,7 +271,7 @@ describe('SessionController', () => {
 
         <div
           data-controller="w-session"
-          data-w-session-intercept-value="true"
+          data-w-session-intercept-value="conflict"
           data-w-session-w-dialog-outlet="[data-edit-form] [data-controller='w-dialog']#w-save-confirmation-dialog"
         >
         </div>
@@ -316,11 +316,11 @@ describe('SessionController', () => {
       expect(handleDialogShow).not.toHaveBeenCalled();
     });
 
-    it('should not prevent the submit event if the intercept value is set to false', async () => {
+    it('should not prevent the submit event if the intercept value is set to empty string', async () => {
       const submitButton = form.querySelector('button[type="submit"]');
       const dialog = document.querySelector('#w-save-confirmation-dialog');
       const element = document.querySelector('[data-controller="w-session"]');
-      element.setAttribute('data-w-session-intercept-value', 'false');
+      element.setAttribute('data-w-session-intercept-value', '');
       await Promise.resolve();
 
       submitButton.click();
@@ -615,6 +615,8 @@ describe('SessionController', () => {
           data-action="
             w-session:ping->w-swap#submit
             w-swap:json->w-session#updateSessionData
+            w-swap:error->w-session#setNetworkIntercept
+            w-swap:success->w-session#setNetworkIntercept
             w-autosave:success@document->w-session#updateSessionData
           "
         >
@@ -689,7 +691,7 @@ describe('SessionController', () => {
         expect(element.dataset.wActionUrlValue).toEqual(
           'http://localhost/sessions/release/999/',
         );
-        expect(element.dataset.wSessionInterceptValue).toEqual('true');
+        expect(element.dataset.wSessionInterceptValue).toEqual('conflict');
 
         await Promise.resolve();
         await Promise.resolve();
@@ -751,6 +753,175 @@ describe('SessionController', () => {
         await Promise.resolve();
         expect(document.getElementById('w-editing-sessions').innerHTML).toEqual(
           '<ul><li>Session 1</li></ul>',
+        );
+      });
+
+      it('should set the intercept value when there is a network error', async () => {
+        fetch.mockImplementationOnce(() =>
+          Promise.reject(new TypeError('Failed to fetch')),
+        );
+        jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+        await setup();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'http://localhost/sessions/1/',
+          expect.any(Object),
+        );
+        expect(element.getAttribute('data-w-session-intercept-value')).toEqual(
+          'network',
+        );
+      });
+
+      it('should clear the network intercept value when a request is successful', async () => {
+        fetch.mockResponseSuccessJSON(
+          JSON.stringify({
+            html: '',
+            ping_url: 'http://localhost/sessions/2/',
+            release_url: 'http://localhost/sessions/2/release/',
+            other_sessions: [],
+          }),
+        );
+        await setup();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'http://localhost/sessions/1/',
+          expect.any(Object),
+        );
+
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(element.dataset.wSwapSrcValue).toEqual(
+          'http://localhost/sessions/2/',
+        );
+        expect(element.dataset.wActionUrlValue).toEqual(
+          'http://localhost/sessions/2/release/',
+        );
+        element.setAttribute('data-w-session-intercept-value', 'network');
+        await Promise.resolve();
+        expect(element.getAttribute('data-w-session-intercept-value')).toEqual(
+          'network',
+        );
+
+        // Simulate ping after 10s
+        fetch.mockResponseSuccessJSON(
+          JSON.stringify({
+            html: '<ul><li>Session 7</li></ul>',
+            ping_url: 'http://localhost/sessions/999/',
+            release_url: 'http://localhost/sessions/release/999/',
+            other_sessions: [{ session_id: 7 }],
+          }),
+        );
+        jest.advanceTimersByTime(10000);
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'http://localhost/sessions/2/',
+          expect.any(Object),
+        );
+
+        // Simulate request finishing
+        await Promise.resolve();
+
+        // Simulate JSON parsing
+        await Promise.resolve();
+
+        // Simulate HTML updating and deferred write to the DOM
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(element.dataset.wSwapSrcValue).toEqual(
+          'http://localhost/sessions/999/',
+        );
+        expect(element.dataset.wActionUrlValue).toEqual(
+          'http://localhost/sessions/release/999/',
+        );
+        expect(element.getAttribute('data-w-session-intercept-value')).toEqual(
+          '',
+        );
+      });
+
+      it('should let non-network intercept types to take priority', async () => {
+        fetch.mockResponseSuccessJSON(
+          JSON.stringify({
+            html: '',
+            ping_url: 'http://localhost/sessions/2/',
+            release_url: 'http://localhost/sessions/2/release/',
+            other_sessions: [],
+          }),
+        );
+        await setup();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'http://localhost/sessions/1/',
+          expect.any(Object),
+        );
+
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(element.dataset.wSwapSrcValue).toEqual(
+          'http://localhost/sessions/2/',
+        );
+        expect(element.dataset.wActionUrlValue).toEqual(
+          'http://localhost/sessions/2/release/',
+        );
+        element.setAttribute('data-w-session-intercept-value', 'network');
+        await Promise.resolve();
+        expect(element.getAttribute('data-w-session-intercept-value')).toEqual(
+          'network',
+        );
+
+        // Simulate ping after 10s
+        fetch.mockResponseSuccessJSON(
+          JSON.stringify({
+            html: '<ul><li>Session 7</li></ul>',
+            ping_url: 'http://localhost/sessions/999/',
+            release_url: 'http://localhost/sessions/release/999/',
+            other_sessions: [{ session_id: 7, revision_id: 456 }],
+          }),
+        );
+        jest.advanceTimersByTime(10000);
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'http://localhost/sessions/2/',
+          expect.any(Object),
+        );
+
+        // Simulate request finishing
+        await Promise.resolve();
+
+        // Simulate JSON parsing
+        await Promise.resolve();
+
+        // Simulate HTML updating and deferred write to the DOM
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(element.dataset.wSwapSrcValue).toEqual(
+          'http://localhost/sessions/999/',
+        );
+        expect(element.dataset.wActionUrlValue).toEqual(
+          'http://localhost/sessions/release/999/',
+        );
+        expect(element.getAttribute('data-w-session-intercept-value')).toEqual(
+          'conflict',
+        );
+
+        // Simulate a network error on the next ping
+        fetch.mockImplementationOnce(() =>
+          Promise.reject(new TypeError('Failed to fetch')),
+        );
+        jest.advanceTimersByTime(10000);
+        jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+        await Promise.resolve();
+        await Promise.resolve();
+        // Should not override the existing conflict intercept with a network intercept
+        expect(element.getAttribute('data-w-session-intercept-value')).toEqual(
+          'conflict',
         );
       });
     });

--- a/client/src/controllers/SessionController.ts
+++ b/client/src/controllers/SessionController.ts
@@ -19,6 +19,12 @@ export interface PingResponse {
   html: string;
 }
 
+export enum ConfirmationInterceptType {
+  CONFLICT = 'conflict',
+  NETWORK = 'network',
+  NONE = '',
+}
+
 /**
  * Manage an editing session by indicating the presence of the user and handling
  * cases when there are multiple users editing the same content.
@@ -56,7 +62,7 @@ export class SessionController extends Controller<HTMLElement> {
   static values = {
     active: { type: Boolean, default: true },
     interval: { type: Number, default: 1000 * 10 }, // 10 seconds
-    intercept: { type: Boolean, default: false },
+    intercept: { type: String, default: '' },
   };
 
   static outlets = ['w-dialog'];
@@ -80,7 +86,7 @@ export class SessionController extends Controller<HTMLElement> {
   /** The interval duration for the ping event */
   declare intervalValue: number;
   /** Whether to intercept the original event and show a confirmation dialog */
-  declare interceptValue: boolean;
+  declare interceptValue: ConfirmationInterceptType;
 
   /** The interval ID for the periodic pinging */
   declare interval: number | null;
@@ -163,6 +169,29 @@ export class SessionController extends Controller<HTMLElement> {
   }
 
   /**
+   * Set the intercept value to 'network' (or remove it if already set) based on
+   * network-related events.
+   * @param event A network-related event containing a `TypeError` as `detail.error`
+   * when the network is offline, otherwise the network is assumed to be back online.
+   */
+  setNetworkIntercept(event: CustomEvent<{ error?: Error | TypeError }>) {
+    // Let other intercept types (e.g. conflict) take precedence
+    if (
+      this.interceptValue &&
+      this.interceptValue !== ConfirmationInterceptType.NETWORK
+    )
+      return;
+
+    this.interceptValue =
+      // Assume TypeError to be a network error from fetch()
+      'error' in event.detail && event.detail.error instanceof TypeError
+        ? ConfirmationInterceptType.NETWORK
+        : // If there's no error, or it's not a TypeError,
+          // assume the network is back and clear the intercept
+          ConfirmationInterceptType.NONE;
+  }
+
+  /**
    * Dispatch the visibility state of the document. When used as an event
    * listener for the `visibilitychange` event, it will dispatch two separate
    * events: `identifier:visible` and `identifier:hidden`, which makes it easier
@@ -215,9 +244,10 @@ export class SessionController extends Controller<HTMLElement> {
    * Proceed with the original action after the user confirms the dialog.
    */
   confirmAction(): void {
-    this.interceptValue = false;
+    const originalInterceptValue = this.interceptValue;
+    this.interceptValue = ConfirmationInterceptType.NONE;
     this.lastActionButton?.click();
-    this.interceptValue = true;
+    this.interceptValue = originalInterceptValue;
   }
 
   wDialogOutletConnected(): void {
@@ -316,12 +346,14 @@ export class SessionController extends Controller<HTMLElement> {
       this.revisionCreatedAtTarget.value = data.revision_created_at!;
     }
 
-    // Set the interceptValue to true if any of the other sessions have a
+    // Set the interceptValue to 'conflict' if any of the other sessions have a
     // revision ID (assumed to be newer than the one we have loaded)
     if (!('other_sessions' in data && data.other_sessions)) return;
     this.interceptValue = data.other_sessions.some(
       (session) => session.revision_id,
-    );
+    )
+      ? ConfirmationInterceptType.CONFLICT
+      : this.interceptValue;
   }
 
   disconnect(): void {

--- a/client/src/controllers/SessionController.ts
+++ b/client/src/controllers/SessionController.ts
@@ -46,7 +46,7 @@ export interface PingResponse {
  *   data-w-swap-json-path-value="html"
  *   data-w-action-continue-value="true"
  *   data-w-action-url-value="/path/to/release/session/"
- *   data-w-session-w-dialog-outlet="[data-edit-form] [data-controller='w-dialog']#w-overwrite-changes-dialog"
+ *   data-w-session-w-dialog-outlet="[data-edit-form] [data-controller='w-dialog']#w-save-confirmation-dialog"
  *   data-action="visibilitychange@document->w-session#dispatchVisibilityState w-session:visible->w-session#ping w-session:visible->w-session#addInterval w-session:hidden->w-session#clearInterval w-session:hidden->w-action#sendBeacon"
  * >
  * </form>

--- a/client/src/controllers/SessionController.ts
+++ b/client/src/controllers/SessionController.ts
@@ -54,6 +54,7 @@ export interface PingResponse {
  */
 export class SessionController extends Controller<HTMLElement> {
   static values = {
+    active: { type: Boolean, default: true },
     interval: { type: Number, default: 1000 * 10 }, // 10 seconds
     intercept: { type: Boolean, default: false },
   };
@@ -74,6 +75,8 @@ export class SessionController extends Controller<HTMLElement> {
   declare readonly unsavedChangesTarget: HTMLInputElement;
   /** The confirmation dialog for overwriting changes made by another user */
   declare readonly wDialogOutlet: DialogController;
+  /** Whether the session is currently active */
+  declare activeValue: boolean;
   /** The interval duration for the ping event */
   declare intervalValue: number;
   /** Whether to intercept the original event and show a confirmation dialog */
@@ -114,6 +117,7 @@ export class SessionController extends Controller<HTMLElement> {
    * alive or indicate presence.
    */
   ping(): void {
+    if (!this.activeValue) return;
     this.dispatch('ping');
   }
 
@@ -138,6 +142,24 @@ export class SessionController extends Controller<HTMLElement> {
       window.clearInterval(this.interval);
       this.interval = null;
     }
+  }
+
+  /**
+   * Clear the interval and prevent any pings from being dispatched
+   * until the session is resumed.
+   */
+  pause(): void {
+    this.clearInterval();
+    this.activeValue = false;
+  }
+
+  /**
+   * Set the interval and allow pings to be dispatched again
+   * after the session has been paused.
+   */
+  resume(): void {
+    this.activeValue = true;
+    this.addInterval();
   }
 
   /**

--- a/client/src/controllers/SessionController.ts
+++ b/client/src/controllers/SessionController.ts
@@ -72,7 +72,7 @@ export class SessionController extends Controller<HTMLElement> {
   declare readonly hasUnsavedChangesTarget: boolean;
   declare readonly hasWDialogOutlet: boolean;
   /** Reload buttons in the sessions' popups */
-  declare readonly reloadTargets: HTMLButtonElement[];
+  declare readonly reloadTargets: HTMLAnchorElement[];
   /** The hidden input to store the current revision created at datetime. */
   declare readonly revisionCreatedAtTarget: HTMLInputElement;
   /** The hidden input to store the current revision ID */
@@ -260,17 +260,17 @@ export class SessionController extends Controller<HTMLElement> {
    * show the "unsaved changes" dialog based on the unsaved changes state.
    * @param button The reload button to update
    */
-  reloadTargetConnected(button: HTMLButtonElement): void {
+  reloadTargetConnected(button: HTMLAnchorElement): void {
     if (
       this.hasUnsavedChangesTarget &&
       this.unsavedChangesTarget.checked &&
       button.dataset.dialogId
     ) {
-      button.removeAttribute('data-action');
+      button.setAttribute('data-action', 'w-action#noop:prevent');
       button.setAttribute('data-a11y-dialog-show', button.dataset.dialogId);
     } else {
       button.removeAttribute('data-a11y-dialog-show');
-      button.setAttribute('data-action', 'w-action#reload');
+      button.setAttribute('data-action', 'w-action#reload:prevent');
     }
   }
 

--- a/client/src/controllers/SessionController.ts
+++ b/client/src/controllers/SessionController.ts
@@ -60,19 +60,12 @@ export class SessionController extends Controller<HTMLElement> {
 
   static outlets = ['w-dialog'];
 
-  static targets = [
-    'reload',
-    'revisionCreatedAt',
-    'revisionId',
-    'unsavedChanges',
-  ];
+  static targets = ['revisionCreatedAt', 'revisionId', 'unsavedChanges'];
 
   declare readonly hasRevisionCreatedAtTarget: boolean;
   declare readonly hasRevisionIdTarget: boolean;
   declare readonly hasUnsavedChangesTarget: boolean;
   declare readonly hasWDialogOutlet: boolean;
-  /** Reload buttons in the sessions' popups */
-  declare readonly reloadTargets: HTMLAnchorElement[];
   /** The hidden input to store the current revision created at datetime. */
   declare readonly revisionCreatedAtTarget: HTMLInputElement;
   /** The hidden input to store the current revision ID */
@@ -252,26 +245,6 @@ export class SessionController extends Controller<HTMLElement> {
     if (!this.hasUnsavedChangesTarget) return;
     const type = event.type.split(':')[1];
     this.unsavedChangesTarget.checked = type !== 'clear';
-    this.reloadTargets.forEach((button) => this.reloadTargetConnected(button));
-  }
-
-  /**
-   * Conditionally set whether the reload button should immediately reload or
-   * show the "unsaved changes" dialog based on the unsaved changes state.
-   * @param button The reload button to update
-   */
-  reloadTargetConnected(button: HTMLAnchorElement): void {
-    if (
-      this.hasUnsavedChangesTarget &&
-      this.unsavedChangesTarget.checked &&
-      button.dataset.dialogId
-    ) {
-      button.setAttribute('data-action', 'w-action#noop:prevent');
-      button.setAttribute('data-a11y-dialog-show', button.dataset.dialogId);
-    } else {
-      button.removeAttribute('data-a11y-dialog-show');
-      button.setAttribute('data-action', 'w-action#reload:prevent');
-    }
   }
 
   get swapController() {

--- a/wagtail/admin/models.py
+++ b/wagtail/admin/models.py
@@ -77,12 +77,12 @@ def popular_tags_for_model(model, count=10):
 class EditingSessionQuerySet(models.QuerySet):
     def stale(self):
         return self.filter(
-            last_seen_at__lt=timezone.now() - timezone.timedelta(hours=1)
+            last_seen_at__lt=timezone.now() - EditingSession.STALE_TIMEOUT
         )
 
     def available(self):
         return self.filter(
-            last_seen_at__gte=timezone.now() - timezone.timedelta(minutes=25)
+            last_seen_at__gte=timezone.now() - EditingSession.AVAILABLE_TIMEOUT
         )
 
 
@@ -106,6 +106,10 @@ class EditingSession(models.Model):
     is_editing = models.BooleanField(default=False)
     objects = EditingSessionManager()
 
+    IDLE_TIMEOUT = timezone.timedelta(minutes=10)
+    AVAILABLE_TIMEOUT = timezone.timedelta(minutes=25)
+    STALE_TIMEOUT = timezone.timedelta(hours=1)
+
     @classmethod
     def cleanup(cls):
         """Delete all editing sessions that have not pinged in the last hour."""
@@ -117,7 +121,7 @@ class EditingSession(models.Model):
         Whether this session is idle. A session is considered idle when the user
         has not pinged in the last 10 minutes.
         """
-        return self.last_seen_at < timezone.now() - timezone.timedelta(minutes=10)
+        return self.last_seen_at < timezone.now() - self.IDLE_TIMEOUT
 
     @property
     def is_available(self):
@@ -125,7 +129,7 @@ class EditingSession(models.Model):
         Whether this session is available. A session is considered available when
         the user has pinged in the last 25 minutes.
         """
-        return self.last_seen_at >= timezone.now() - timezone.timedelta(minutes=25)
+        return self.last_seen_at >= timezone.now() - self.AVAILABLE_TIMEOUT
 
     class Meta:
         indexes = [

--- a/wagtail/admin/models.py
+++ b/wagtail/admin/models.py
@@ -74,6 +74,21 @@ def popular_tags_for_model(model, count=10):
     )
 
 
+class EditingSessionQuerySet(models.QuerySet):
+    def stale(self):
+        return self.filter(
+            last_seen_at__lt=timezone.now() - timezone.timedelta(hours=1)
+        )
+
+    def available(self):
+        return self.filter(
+            last_seen_at__gte=timezone.now() - timezone.timedelta(minutes=25)
+        )
+
+
+EditingSessionManager = models.Manager.from_queryset(EditingSessionQuerySet)
+
+
 class EditingSession(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -89,12 +104,28 @@ class EditingSession(models.Model):
     )
     last_seen_at = models.DateTimeField()
     is_editing = models.BooleanField(default=False)
+    objects = EditingSessionManager()
 
-    @staticmethod
-    def cleanup():
-        EditingSession.objects.filter(
-            last_seen_at__lt=timezone.now() - timezone.timedelta(hours=1)
-        ).delete()
+    @classmethod
+    def cleanup(cls):
+        """Delete all editing sessions that have not pinged in the last hour."""
+        cls.objects.stale().delete()
+
+    @property
+    def is_idle(self):
+        """
+        Whether this session is idle. A session is considered idle when the user
+        has not pinged in the last 10 minutes.
+        """
+        return self.last_seen_at < timezone.now() - timezone.timedelta(minutes=10)
+
+    @property
+    def is_available(self):
+        """
+        Whether this session is available. A session is considered available when
+        the user has pinged in the last 25 minutes.
+        """
+        return self.last_seen_at >= timezone.now() - timezone.timedelta(minutes=25)
 
     class Meta:
         indexes = [

--- a/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/list.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/list.html
@@ -32,15 +32,9 @@
                             {% icon name="warning" %}
                             {{ saved_new_version_message }}
                         </div>
-
-                        {% comment %}
-                            Use a custom button element instead of the dialog_toggle.html so we can add arbitrary
-                            data attributes to the button element. This is useful for allowing the SessionController
-                            to conditionally show the dialog, i.e. only when the user has unsaved changes.
-                        {% endcomment %}
-                        <a href="" data-w-session-target="reload" class="button button-small button-secondary chooser__choose-button" data-dialog-id="w-unsaved-changes-dialog">
-                            {% icon name="rotate" %}
-                            {% trans "Refresh" %}
+                        <a href="" target="_blank" class="button button-small button-secondary chooser__choose-button">
+                            {% icon name="link-external" %}
+                            {% trans "View latest version" %}
                         </a>
                     </div>
                 {% enddropdown %}
@@ -120,13 +114,18 @@
     <template data-controller="w-teleport" data-w-teleport-target-value="#subtitle-w-overwrite-changes-dialog" data-w-teleport-mode-value="textContent">
         {% if current_session.user == sessions.0.user %}
             {% blocktranslate trimmed asvar overwrite_message %}
-                Proceeding will overwrite the changes you made in that window. Refreshing the page will show you the new changes, but you will lose any of your unsaved changes in the current window.
+                Proceeding will overwrite the changes you made in that window.
             {% endblocktranslate %}
         {% else %}
             {% blocktranslate trimmed with user_name=sessions.0.user|user_display_name|default:_("System") asvar overwrite_message %}
-                Proceeding will overwrite the changes made by {{ user_name }}. Refreshing the page will show you the new changes, but you will lose any of your unsaved changes.
+                Proceeding will overwrite the changes made by {{ user_name }}.
             {% endblocktranslate %}
         {% endif %}
-        {{ overwrite_message }}
+        <span>{{ overwrite_message|capfirst }}</span>
+        <span>
+            {% blocktranslate trimmed %}
+                Alternatively, you can view the latest version in a new tab.
+            {% endblocktranslate %}
+        </span>
     </template>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/list.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/list.html
@@ -38,10 +38,10 @@
                             data attributes to the button element. This is useful for allowing the SessionController
                             to conditionally show the dialog, i.e. only when the user has unsaved changes.
                         {% endcomment %}
-                        <button type="button" data-w-session-target="reload" class="button button-small button-secondary chooser__choose-button" data-dialog-id="w-unsaved-changes-dialog">
+                        <a href="" data-w-session-target="reload" class="button button-small button-secondary chooser__choose-button" data-dialog-id="w-unsaved-changes-dialog">
                             {% icon name="rotate" %}
                             {% trans "Refresh" %}
-                        </button>
+                        </a>
                     </div>
                 {% enddropdown %}
             {% elif session.is_editing %}

--- a/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/list.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/list.html
@@ -105,7 +105,7 @@
 </ol>
 
 {% if sessions.0.revision_id %}
-    <template data-controller="w-teleport" data-w-teleport-target-value="#title-text-w-overwrite-changes-dialog" data-w-teleport-mode-value="textContent">
+    <template data-controller="w-teleport" data-w-teleport-target-value="#title-text-w-save-confirmation-dialog" data-w-teleport-mode-value="textContent">
         {% if current_session.user == sessions.0.user %}
             {% blocktranslate trimmed asvar someone_has_saved_message %}
                 You saved a new version in another window
@@ -118,7 +118,7 @@
         {{ someone_has_saved_message }}
     </template>
 
-    <template data-controller="w-teleport" data-w-teleport-target-value="#subtitle-w-overwrite-changes-dialog" data-w-teleport-mode-value="textContent">
+    <template data-controller="w-teleport" data-w-teleport-target-value="#subtitle-w-save-confirmation-dialog" data-w-teleport-mode-value="textContent">
         {% if current_session.user == sessions.0.user %}
             {% blocktranslate trimmed asvar overwrite_message %}
                 Proceeding will overwrite the changes you made in that window.

--- a/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/list.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/list.html
@@ -3,8 +3,9 @@
 <ol class="w-editing-sessions__list">
     {% for session in sessions|slice:":4" %}
         <li>
+            {% fragment as avatar_classname %}w-editing-sessions__avatar{% if session.is_idle %} w-editing-sessions__avatar--idle{% endif %}{% endfragment %}
             {% fragment as avatar %}
-                {% avatar user=session.user classname="w-editing-sessions__avatar" %}
+                {% avatar user=session.user classname=avatar_classname %}
             {% endfragment %}
 
             {% if session.revision_id %}
@@ -63,7 +64,13 @@
                     <div class="w-editing-sessions__popup" data-w-tooltip-target="content" hidden>
                         <span class="w-editing-sessions__name">{{ session.user|user_display_name|default:_("System") }}</span>
                         <span class="w-sr-only">-</span>
-                        <span>{% trans "Currently viewing" %}</span>
+                        <span>
+                            {% if session.is_idle %}
+                                {% trans 'Currently idle' %}
+                            {% else %}
+                                {% trans 'Currently viewing' %}
+                            {% endif %}
+                        </span>
                     </div>
                 </button>
             {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
@@ -30,7 +30,7 @@
                  w-session:visible->w-session#ping
                  w-session:visible->w-session#addInterval
                  w-session:hidden->w-session#clearInterval
-                 w-session:hidden->w-action#sendBeacon
+                 pagehide@window->w-action#sendBeacon
                  w-unsaved:add@document->w-session#setUnsavedChanges
                  w-unsaved:clear@document->w-session#setUnsavedChanges
                  w-swap:json->w-session#updateSessionData

--- a/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
@@ -1,11 +1,18 @@
 {% load i18n l10n wagtailadmin_tags %}
 
 {% comment %}
-    The "-" strings are only placeholders so that the appropriate elements are rendered.
-    The messages will be provided via the sessions list component and teleported into the corresponding elements.
-    The dialog won't ever be shown without the actual messages under normal circumstances.
+    The confirmation dialog is initially rendered with a message for a network error.
+    If there is a conflict due to a new version being saved in another window,
+    the message is updated to reflect that instead, using the w-teleport controller.
 {% endcomment %}
-{% dialog id="w-save-confirmation-dialog" dialog_root_selector='[data-edit-form]' icon_name="warning" icon_classname="w-text-text-error" title="-" subtitle="-" %}
+{% blocktranslate trimmed asvar dialog_title %}
+    A network error occurred
+{% endblocktranslate %}
+{% blocktranslate trimmed asvar dialog_subtitle %}
+    Troubleshoot your connection to the site before proceeding.
+    Open the editor in a separate tab to view the last saved version.
+{% endblocktranslate %}
+{% dialog id="w-save-confirmation-dialog" dialog_root_selector='[data-edit-form]' icon_name="warning" icon_classname="w-text-text-error" title=dialog_title subtitle=dialog_subtitle %}
     <div class="w-editing-sessions-dialog-buttons">
         <button class="button" type="button" data-w-dialog-target="confirm" data-action="w-dialog#confirm">{% trans "Continue" %}</button>
         <a href="" target="_blank" class="button button-secondary" data-controller="w-action">{% trans "View latest version" %}</a>
@@ -34,10 +41,14 @@
                  w-unsaved:add@document->w-session#setUnsavedChanges
                  w-unsaved:clear@document->w-session#setUnsavedChanges
                  w-swap:json->w-session#updateSessionData
+                 w-swap:success->w-session#setNetworkIntercept
+                 w-swap:error->w-session#setNetworkIntercept
                  w-autosave:save@document->w-session#pause
                  w-autosave:success@document->w-session#updateSessionData
                  w-autosave:success@document->w-session#resume
+                 w-autosave:success@document->w-session#setNetworkIntercept
                  w-autosave:error@document->w-session#resume
+                 w-autosave:error@document->w-session#setNetworkIntercept
                  w-autosave:deactivated@document->w-session#ping
                 "
 >

--- a/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
@@ -5,7 +5,7 @@
     The messages will be provided via the sessions list component and teleported into the corresponding elements.
     The dialog won't ever be shown without the actual messages under normal circumstances.
 {% endcomment %}
-{% dialog id="w-overwrite-changes-dialog" dialog_root_selector='[data-edit-form]' icon_name="warning" icon_classname="w-text-text-error" title="-" subtitle="-" %}
+{% dialog id="w-save-confirmation-dialog" dialog_root_selector='[data-edit-form]' icon_name="warning" icon_classname="w-text-text-error" title="-" subtitle="-" %}
     <div class="w-editing-sessions-dialog-buttons">
         <button class="button" type="button" data-w-dialog-target="confirm" data-action="w-dialog#confirm">{% trans "Continue" %}</button>
         <a href="" target="_blank" class="button button-secondary" data-controller="w-action">{% trans "View latest version" %}</a>
@@ -23,7 +23,7 @@
     data-w-action-continue-value="true"
     data-w-action-url-value="{{ release_url }}"
     data-w-session-interval-value="{{ ping_interval|unlocalize }}"
-    data-w-session-w-dialog-outlet="[data-edit-form] [data-controller='w-dialog']#w-overwrite-changes-dialog"
+    data-w-session-w-dialog-outlet="[data-edit-form] [data-controller='w-dialog']#w-save-confirmation-dialog"
     data-action="
                  w-session:ping->w-swap#submit
                  visibilitychange@document->w-session#dispatchVisibilityState

--- a/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
@@ -34,7 +34,10 @@
                  w-unsaved:add@document->w-session#setUnsavedChanges
                  w-unsaved:clear@document->w-session#setUnsavedChanges
                  w-swap:json->w-session#updateSessionData
+                 w-autosave:save@document->w-session#pause
                  w-autosave:success@document->w-session#updateSessionData
+                 w-autosave:success@document->w-session#resume
+                 w-autosave:error@document->w-session#resume
                  w-autosave:deactivated@document->w-session#ping
                 "
 >

--- a/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
@@ -1,12 +1,5 @@
 {% load i18n l10n wagtailadmin_tags %}
 
-{% dialog id="w-unsaved-changes-dialog" icon_name="warning" icon_classname="w-text-text-error" title=_("Refreshing the page means you will lose any unsaved changes") %}
-    <div class="w-editing-sessions-dialog-buttons">
-        <a href="" class="button" data-controller="w-action" data-action="w-action#forceReload:prevent">{% trans "Refresh page" %}</a>
-        <button class="button button-secondary" type="button" data-action="w-dialog#hide">{% trans "Cancel" %}</button>
-    </div>
-{% enddialog %}
-
 {% comment %}
     The "-" strings are only placeholders so that the appropriate elements are rendered.
     The messages will be provided via the sessions list component and teleported into the corresponding elements.
@@ -15,7 +8,7 @@
 {% dialog id="w-overwrite-changes-dialog" dialog_root_selector='[data-edit-form]' icon_name="warning" icon_classname="w-text-text-error" title="-" subtitle="-" %}
     <div class="w-editing-sessions-dialog-buttons">
         <button class="button" type="button" data-w-dialog-target="confirm" data-action="w-dialog#confirm">{% trans "Continue" %}</button>
-        <a href="" class="button button-secondary" data-controller="w-action" data-action="w-action#forceReload:prevent">{% trans "Refresh the page" %}</a>
+        <a href="" target="_blank" class="button button-secondary" data-controller="w-action">{% trans "View latest version" %}</a>
     </div>
 {% enddialog %}
 

--- a/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
@@ -2,7 +2,7 @@
 
 {% dialog id="w-unsaved-changes-dialog" icon_name="warning" icon_classname="w-text-text-error" title=_("Refreshing the page means you will lose any unsaved changes") %}
     <div class="w-editing-sessions-dialog-buttons">
-        <button class="button" type="button" data-controller="w-action" data-action="w-action#forceReload">{% trans "Refresh page" %}</button>
+        <a href="" class="button" data-controller="w-action" data-action="w-action#forceReload:prevent">{% trans "Refresh page" %}</a>
         <button class="button button-secondary" type="button" data-action="w-dialog#hide">{% trans "Cancel" %}</button>
     </div>
 {% enddialog %}
@@ -15,7 +15,7 @@
 {% dialog id="w-overwrite-changes-dialog" dialog_root_selector='[data-edit-form]' icon_name="warning" icon_classname="w-text-text-error" title="-" subtitle="-" %}
     <div class="w-editing-sessions-dialog-buttons">
         <button class="button" type="button" data-w-dialog-target="confirm" data-action="w-dialog#confirm">{% trans "Continue" %}</button>
-        <button class="button button-secondary" type="button" data-controller="w-action" data-action="w-action#forceReload">{% trans "Refresh the page" %}</button>
+        <a href="" class="button button-secondary" data-controller="w-action" data-action="w-action#forceReload:prevent">{% trans "Refresh the page" %}</a>
     </div>
 {% enddialog %}
 

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -15,6 +15,7 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.action_menu import ActionMenuItem, PublishMenuItem
 from wagtail.admin.admin_url_finder import AdminURLFinder
+from wagtail.admin.models import EditingSession
 from wagtail.exceptions import PageClassNotFoundError
 from wagtail.models import (
     Comment,
@@ -26,6 +27,7 @@ from wagtail.models import (
     PageSubscription,
     Revision,
     Site,
+    get_default_page_content_type,
 )
 from wagtail.signals import page_published
 from wagtail.test.testapp.models import (
@@ -1067,6 +1069,43 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         self.assertEqual(
             editing_sessions.select_one("input[name='revision_created_at']")["value"],
             latest_revision.created_at.isoformat(),
+        )
+
+    def test_save_with_json_response_does_not_affect_sessions(self):
+        # an old session that would be cleaned up when loading the editor
+        old_session = EditingSession.objects.create(
+            user=self.user,
+            content_type=get_default_page_content_type(),
+            object_id=self.child_page.pk,
+            last_seen_at=timezone.now() - datetime.timedelta(hours=5),
+        )
+        # a recent session that would not be cleaned up when loading the editor
+        recent_session = EditingSession.objects.create(
+            user=self.user,
+            content_type=get_default_page_content_type(),
+            object_id=self.child_page.pk,
+            last_seen_at=timezone.now() - datetime.timedelta(seconds=5),
+        )
+        loaded_revision = self.child_page.get_latest_revision()
+        post_data = {
+            "title": "I've been edited!",
+            "content": "Some content",
+            "slug": "hello-world",
+            "loaded_revision_id": loaded_revision.pk,
+            "loaded_revision_created_at": loaded_revision.created_at.isoformat(),
+        }
+        response = self.client.post(
+            reverse("wagtailadmin_pages:edit", args=(self.child_page.pk,)),
+            post_data,
+            headers={"Accept": "application/json"},
+        )
+        self.assertEqual(response.status_code, 200)
+        # Saving with a JSON response does not fully load the editor, so it
+        # should not run a cleanup of old sessions, nor should it create a new
+        # session for the current request.
+        self.assertEqual(
+            list(EditingSession.objects.values_list("pk", flat=True).order_by("pk")),
+            [old_session.pk, recent_session.pk],
         )
 
     def test_page_edit_post_unpublished_page(self):

--- a/wagtail/admin/tests/test_editing_sessions.py
+++ b/wagtail/admin/tests/test_editing_sessions.py
@@ -26,6 +26,9 @@ if settings.USE_TZ:
     TIMESTAMP_PAST = timezone.make_aware(
         datetime.datetime(2020, 1, 1, 10, 30, 0), timezone=datetime.timezone.utc
     )
+    TIMESTAMP_IDLE = timezone.make_aware(
+        datetime.datetime(2020, 1, 1, 11, 45, 0), timezone=datetime.timezone.utc
+    )
     TIMESTAMP_1 = timezone.make_aware(
         datetime.datetime(2020, 1, 1, 11, 59, 51), timezone=datetime.timezone.utc
     )
@@ -44,6 +47,7 @@ if settings.USE_TZ:
 else:
     TIMESTAMP_ANCIENT = datetime.datetime(2019, 1, 1, 10, 30, 0)
     TIMESTAMP_PAST = datetime.datetime(2020, 1, 1, 10, 30, 0)
+    TIMESTAMP_IDLE = datetime.datetime(2020, 1, 1, 11, 45, 0)
     TIMESTAMP_1 = datetime.datetime(2020, 1, 1, 11, 59, 51)
     TIMESTAMP_2 = datetime.datetime(2020, 1, 1, 11, 59, 52)
     TIMESTAMP_3 = datetime.datetime(2020, 1, 1, 11, 59, 53)
@@ -154,6 +158,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -192,6 +197,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -207,6 +213,57 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.session.refresh_from_db()
         self.assertEqual(self.session.last_seen_at, TIMESTAMP_NOW)
         self.assertTrue(self.session.is_editing)
+
+    @freeze_time(TIMESTAMP_NOW)
+    def test_ping_with_other_idle_session(self):
+        idle_session = EditingSession.objects.create(
+            user=self.third_user,
+            content_type=ContentType.objects.get_for_model(Page),
+            object_id=self.page.id,
+            last_seen_at=TIMESTAMP_IDLE,
+        )
+        response = self.client.post(
+            reverse(
+                "wagtailadmin_editing_sessions:ping",
+                args=("wagtailcore", "page", self.page.id, self.session.id),
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertEqual(response_json["session_id"], self.session.id)
+        self.assertEqual(
+            response_json["other_sessions"],
+            [
+                # Should show the idle session with is_idle set to True
+                {
+                    "session_id": self.other_session.id,
+                    "user": "Vic Otheruser",
+                    "last_seen_at": TIMESTAMP_2.isoformat(),
+                    "is_editing": False,
+                    "is_idle": False,
+                    "revision_id": None,
+                },
+                {
+                    "session_id": idle_session.id,
+                    "user": "Gordon Thirduser",
+                    "last_seen_at": TIMESTAMP_IDLE.isoformat(),
+                    "is_editing": False,
+                    "is_idle": True,
+                    "revision_id": None,
+                },
+            ],
+        )
+
+        soup = self.get_soup(response_json["html"])
+        rendered_sessions = soup.select("ol.w-editing-sessions__list li")
+        self.assertEqual(len(rendered_sessions), 2)
+        session_text = rendered_sessions[1].text
+        self.assertIn("Gordon Thirduser", session_text)
+        self.assertIn("Currently idle", session_text)
+
+        self.session.refresh_from_db()
+        self.assertEqual(self.session.last_seen_at, TIMESTAMP_NOW)
+        self.assertFalse(self.session.is_editing)
 
     @freeze_time(TIMESTAMP_NOW)
     def test_ping_with_revision(self):
@@ -230,6 +287,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -270,6 +328,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_3.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": new_revision.id,
                 },
             ],
@@ -327,6 +386,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_3.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": new_revision.id,
                 },
             ],
@@ -394,6 +454,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -444,6 +505,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_3.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": loaded_revision.id,
                 },
             ],
@@ -500,6 +562,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_3.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": loaded_revision.id,
                 },
             ],
@@ -571,6 +634,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Gordon Thirduser",
                     "last_seen_at": TIMESTAMP_4.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": latest_revision.id,
                 },
                 {
@@ -582,6 +646,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     # it's not the latest one.
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -649,6 +714,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "",
                     "last_seen_at": TIMESTAMP_3.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": latest_revision.id,
                 },
                 {
@@ -656,6 +722,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -749,6 +816,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Gordon Thirduser",
                     "last_seen_at": TIMESTAMP_3.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": new_revision.id,
                 },
                 # Then any sessions that are currently editing
@@ -757,6 +825,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Chell Fifthuser",
                     "last_seen_at": TIMESTAMP_4.isoformat(),
                     "is_editing": True,
+                    "is_idle": False,
                     "revision_id": None,
                 },
                 # Then any other sessions, sorted ascending by session_id
@@ -765,6 +834,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
                 {
@@ -772,6 +842,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Alyx Fourthuser",
                     "last_seen_at": TIMESTAMP_1.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -806,6 +877,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -861,6 +933,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -896,6 +969,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Bob Testuser",
                     "last_seen_at": TIMESTAMP_NOW.isoformat(),
                     "is_editing": True,
+                    "is_idle": False,
                     "revision_id": None,
                 },
                 {
@@ -903,6 +977,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -962,6 +1037,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -998,6 +1074,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -1040,6 +1117,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Bob Testuser",
                     "last_seen_at": TIMESTAMP_NOW.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": new_revision.id,
                 },
                 {
@@ -1047,6 +1125,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -1075,6 +1154,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Bob Testuser",
                     "last_seen_at": TIMESTAMP_NOW.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": new_revision.id,
                 },
                 {
@@ -1082,6 +1162,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -1114,6 +1195,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Bob Testuser",
                     "last_seen_at": TIMESTAMP_4.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": new_revision.id,
                 },
                 {
@@ -1121,6 +1203,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_2.isoformat(),
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -1283,6 +1366,7 @@ class TestPingView(WagtailTestUtils, TestCase):
                     "user": "Vic Otheruser",
                     "last_seen_at": TIMESTAMP_3.isoformat(),
                     "is_editing": True,
+                    "is_idle": False,
                     "revision_id": None,
                 },
             ],
@@ -1424,6 +1508,13 @@ class TestCleanup(WagtailTestUtils, TestCase):
             object_id=self.page.id,
             last_seen_at=TIMESTAMP_1,
         )
+        self.idle_session = EditingSession.objects.create(
+            user=self.user,
+            content_type=page_content_type,
+            object_id=self.page.id,
+            last_seen_at=TIMESTAMP_IDLE,
+            is_editing=True,
+        )
         self.old_session = EditingSession.objects.create(
             user=self.user,
             content_type=page_content_type,
@@ -1435,6 +1526,7 @@ class TestCleanup(WagtailTestUtils, TestCase):
     def test_cleanup(self):
         EditingSession.cleanup()
         self.assertTrue(EditingSession.objects.filter(id=self.session.id).exists())
+        self.assertTrue(EditingSession.objects.filter(id=self.idle_session.id).exists())
         self.assertFalse(EditingSession.objects.filter(id=self.old_session.id).exists())
 
 

--- a/wagtail/admin/tests/test_editing_sessions.py
+++ b/wagtail/admin/tests/test_editing_sessions.py
@@ -296,8 +296,8 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertIsNotNone(dialog_subtitle)
         self.assertIn(
             "Proceeding will overwrite the changes made by Vic Otheruser. "
-            "Refreshing the page will show you the new changes, but you will lose any of your unsaved changes.",
-            dialog_subtitle.string,
+            "Alternatively, you can view the latest version in a new tab.",
+            dialog_subtitle.get_text(strip=True, separator=" "),
         )
 
         self.session.refresh_from_db()
@@ -356,8 +356,8 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertIsNotNone(dialog_subtitle)
         self.assertIn(
             "Proceeding will overwrite the changes made by Vic Otheruser. "
-            "Refreshing the page will show you the new changes, but you will lose any of your unsaved changes.",
-            dialog_subtitle.string,
+            "Alternatively, you can view the latest version in a new tab.",
+            dialog_subtitle.get_text(strip=True, separator=" "),
         )
 
         self.session.refresh_from_db()
@@ -466,8 +466,8 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertIsNotNone(dialog_subtitle)
         self.assertIn(
             "Proceeding will overwrite the changes made by Vic Otheruser. "
-            "Refreshing the page will show you the new changes, but you will lose any of your unsaved changes.",
-            dialog_subtitle.string,
+            "Alternatively, you can view the latest version in a new tab.",
+            dialog_subtitle.get_text(strip=True, separator=" "),
         )
 
         self.session.refresh_from_db()
@@ -525,8 +525,8 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertIsNotNone(dialog_subtitle)
         self.assertIn(
             "Proceeding will overwrite the changes made by Vic Otheruser. "
-            "Refreshing the page will show you the new changes, but you will lose any of your unsaved changes.",
-            dialog_subtitle.string,
+            "Alternatively, you can view the latest version in a new tab.",
+            dialog_subtitle.get_text(strip=True, separator=" "),
         )
 
         self.session.refresh_from_db()
@@ -611,8 +611,8 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertIsNotNone(dialog_subtitle)
         self.assertIn(
             "Proceeding will overwrite the changes made by Gordon Thirduser. "
-            "Refreshing the page will show you the new changes, but you will lose any of your unsaved changes.",
-            dialog_subtitle.string,
+            "Alternatively, you can view the latest version in a new tab.",
+            dialog_subtitle.get_text(strip=True, separator=" "),
         )
         other_session_text = rendered_sessions[1].text
         self.assertIn("Vic Otheruser", other_session_text)
@@ -685,8 +685,8 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertIsNotNone(dialog_subtitle)
         self.assertIn(
             "Proceeding will overwrite the changes made by System. "
-            "Refreshing the page will show you the new changes, but you will lose any of your unsaved changes.",
-            dialog_subtitle.string,
+            "Alternatively, you can view the latest version in a new tab.",
+            dialog_subtitle.get_text(strip=True, separator=" "),
         )
         other_session_text = rendered_sessions[1].text
         self.assertIn("Vic Otheruser", other_session_text)
@@ -1147,9 +1147,8 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertIsNotNone(dialog_subtitle)
         self.assertIn(
             "Proceeding will overwrite the changes you made in that window. "
-            "Refreshing the page will show you the new changes, but you will "
-            "lose any of your unsaved changes in the current window.",
-            dialog_subtitle.text.strip(),
+            "Alternatively, you can view the latest version in a new tab.",
+            dialog_subtitle.get_text(strip=True, separator=" "),
         )
 
     @freeze_time(TIMESTAMP_NOW)

--- a/wagtail/admin/tests/test_editing_sessions.py
+++ b/wagtail/admin/tests/test_editing_sessions.py
@@ -342,14 +342,14 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertNotIn("Currently viewing", session_text)
         dialog_title = soup.select_one(
             "template"
-            '[data-w-teleport-target-value="#title-text-w-overwrite-changes-dialog"]'
+            '[data-w-teleport-target-value="#title-text-w-save-confirmation-dialog"]'
             '[data-w-teleport-mode-value="textContent"]'
         )
         self.assertIsNotNone(dialog_title)
         self.assertIn("Vic Otheruser saved a new version", dialog_title.string)
         dialog_subtitle = soup.select_one(
             "template"
-            '[data-w-teleport-target-value="#subtitle-w-overwrite-changes-dialog"]'
+            '[data-w-teleport-target-value="#subtitle-w-save-confirmation-dialog"]'
             '[data-w-teleport-mode-value="textContent"]'
         )
         self.assertIsNotNone(dialog_subtitle)
@@ -400,7 +400,7 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertNotIn("Currently viewing", session_text)
         dialog_title = soup.select_one(
             "template"
-            '[data-w-teleport-target-value="#title-text-w-overwrite-changes-dialog"]'
+            '[data-w-teleport-target-value="#title-text-w-save-confirmation-dialog"]'
             '[data-w-teleport-mode-value="textContent"]'
         )
         self.assertIsNotNone(dialog_title)
@@ -410,7 +410,7 @@ class TestPingView(WagtailTestUtils, TestCase):
         )
         dialog_subtitle = soup.select_one(
             "template"
-            '[data-w-teleport-target-value="#subtitle-w-overwrite-changes-dialog"]'
+            '[data-w-teleport-target-value="#subtitle-w-save-confirmation-dialog"]'
             '[data-w-teleport-mode-value="textContent"]'
         )
         self.assertIsNotNone(dialog_subtitle)
@@ -518,12 +518,12 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertIn("Vic Otheruser saved a new version", session_text)
         self.assertNotIn("Currently viewing", session_text)
         dialog_title = soup.select_one(
-            'template[data-w-teleport-target-value="#title-text-w-overwrite-changes-dialog"]'
+            'template[data-w-teleport-target-value="#title-text-w-save-confirmation-dialog"]'
         )
         self.assertIsNotNone(dialog_title)
         self.assertIn("Vic Otheruser saved a new version", dialog_title.string)
         dialog_subtitle = soup.select_one(
-            'template[data-w-teleport-target-value="#subtitle-w-overwrite-changes-dialog"]'
+            'template[data-w-teleport-target-value="#subtitle-w-save-confirmation-dialog"]'
         )
         self.assertIsNotNone(dialog_subtitle)
         self.assertIn(
@@ -575,7 +575,7 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertIn("Vic Otheruser saved a new version", session_text)
         self.assertNotIn("Currently viewing", session_text)
         dialog_title = soup.select_one(
-            'template[data-w-teleport-target-value="#title-text-w-overwrite-changes-dialog"]'
+            'template[data-w-teleport-target-value="#title-text-w-save-confirmation-dialog"]'
         )
         self.assertIsNotNone(dialog_title)
         self.assertIn(
@@ -583,7 +583,7 @@ class TestPingView(WagtailTestUtils, TestCase):
             dialog_title.string,
         )
         dialog_subtitle = soup.select_one(
-            'template[data-w-teleport-target-value="#subtitle-w-overwrite-changes-dialog"]'
+            'template[data-w-teleport-target-value="#subtitle-w-save-confirmation-dialog"]'
         )
         self.assertIsNotNone(dialog_subtitle)
         self.assertIn(
@@ -660,7 +660,7 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertNotIn("Currently viewing", session_text)
         dialog_title = soup.select_one(
             "template"
-            '[data-w-teleport-target-value="#title-text-w-overwrite-changes-dialog"]'
+            '[data-w-teleport-target-value="#title-text-w-save-confirmation-dialog"]'
             '[data-w-teleport-mode-value="textContent"]'
         )
         self.assertIsNotNone(dialog_title)
@@ -670,7 +670,7 @@ class TestPingView(WagtailTestUtils, TestCase):
         )
         dialog_subtitle = soup.select_one(
             "template"
-            '[data-w-teleport-target-value="#subtitle-w-overwrite-changes-dialog"]'
+            '[data-w-teleport-target-value="#subtitle-w-save-confirmation-dialog"]'
             '[data-w-teleport-mode-value="textContent"]'
         )
         self.assertIsNotNone(dialog_subtitle)
@@ -736,7 +736,7 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertNotIn("Currently viewing", session_text)
         dialog_title = soup.select_one(
             "template"
-            '[data-w-teleport-target-value="#title-text-w-overwrite-changes-dialog"]'
+            '[data-w-teleport-target-value="#title-text-w-save-confirmation-dialog"]'
             '[data-w-teleport-mode-value="textContent"]'
         )
         self.assertIsNotNone(dialog_title)
@@ -746,7 +746,7 @@ class TestPingView(WagtailTestUtils, TestCase):
         )
         dialog_subtitle = soup.select_one(
             "template"
-            '[data-w-teleport-target-value="#subtitle-w-overwrite-changes-dialog"]'
+            '[data-w-teleport-target-value="#subtitle-w-save-confirmation-dialog"]'
             '[data-w-teleport-mode-value="textContent"]'
         )
         self.assertIsNotNone(dialog_subtitle)
@@ -991,13 +991,13 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertNotIn("Currently viewing", session_text)
         dialog_title = soup.select_one(
             "template"
-            '[data-w-teleport-target-value="#title-text-w-overwrite-changes-dialog"]'
+            '[data-w-teleport-target-value="#title-text-w-save-confirmation-dialog"]'
             '[data-w-teleport-mode-value="textContent"]'
         )
         self.assertIsNone(dialog_title)
         dialog_subtitle = soup.select_one(
             "template"
-            '[data-w-teleport-target-value="#subtitle-w-overwrite-changes-dialog"]'
+            '[data-w-teleport-target-value="#subtitle-w-save-confirmation-dialog"]'
             '[data-w-teleport-mode-value="textContent"]'
         )
         self.assertIsNone(dialog_subtitle)
@@ -1218,14 +1218,14 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertIn("You saved a new version in another window", session_text)
         self.assertNotIn("Currently viewing", session_text)
         dialog_title = soup.select_one(
-            'template[data-w-teleport-target-value="#title-text-w-overwrite-changes-dialog"]'
+            'template[data-w-teleport-target-value="#title-text-w-save-confirmation-dialog"]'
         )
         self.assertIsNotNone(dialog_title)
         self.assertIn(
             "You saved a new version in another window", dialog_title.text.strip()
         )
         dialog_subtitle = soup.select_one(
-            'template[data-w-teleport-target-value="#subtitle-w-overwrite-changes-dialog"]'
+            'template[data-w-teleport-target-value="#subtitle-w-save-confirmation-dialog"]'
         )
         self.assertIsNotNone(dialog_subtitle)
         self.assertIn(

--- a/wagtail/admin/views/editing_sessions.py
+++ b/wagtail/admin/views/editing_sessions.py
@@ -76,10 +76,10 @@ def ping(request, app_label, model_name, object_id, session_id):
         session.save()
 
     other_sessions = (
-        EditingSession.objects.filter(
+        EditingSession.objects.available()
+        .filter(
             content_type=content_type,
             object_id=unquoted_object_id,
-            last_seen_at__gte=timezone.now() - timezone.timedelta(minutes=1),
         )
         .exclude(id=session.id)
         .select_related("user", "user__wagtail_userprofile")
@@ -99,6 +99,7 @@ def ping(request, app_label, model_name, object_id, session_id):
                 "user": other_session.user,
                 "last_seen_at": other_session.last_seen_at,
                 "is_editing": other_session.is_editing,
+                "is_idle": other_session.is_idle,
                 "revision_id": None,
             }
         else:
@@ -140,6 +141,7 @@ def ping(request, app_label, model_name, object_id, session_id):
                     "user": newest_revision.user,
                     "last_seen_at": newest_revision.created_at,
                     "is_editing": False,
+                    "is_idle": False,
                     "revision_id": newest_revision.id,
                 }
             else:
@@ -198,6 +200,7 @@ def ping(request, app_label, model_name, object_id, session_id):
                     "user": get_user_display_name(other_session["user"]),
                     "last_seen_at": other_session["last_seen_at"].isoformat(),
                     "is_editing": other_session["is_editing"],
+                    "is_idle": other_session["is_idle"],
                     "revision_id": other_session["revision_id"],
                 }
                 for other_session in other_sessions

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -847,10 +847,15 @@ class CreateEditViewOptionalFeaturesMixin:
             settings, "WAGTAIL_WORKFLOW_CANCEL_ON_PUBLISH", True
         ) and bool(self.workflow_tasks)
         context["revisions_compare_url_name"] = self.revisions_compare_url_name
-        context["editing_sessions"] = self.get_editing_sessions()
         context["loaded_revision_created_at"] = self.latest_revision_created_at
-        if self.autosave_enabled:
-            context["autosave_indicator"] = AutosaveIndicator()
+
+        if not self.expects_json_response:
+            # These components do not need to be loaded when rendering partials
+            # for autosave. In particular, `get_editing_sessions` performs
+            # database writes that are not necessary when autosaving.
+            context["editing_sessions"] = self.get_editing_sessions()
+            if self.autosave_enabled:
+                context["autosave_indicator"] = AutosaveIndicator()
         return context
 
     def is_valid(self, form):

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -1109,13 +1109,22 @@ class EditView(
                 "media": media,
                 "autosave_enabled": self.autosave_enabled,
                 "autosave_interval": self.autosave_interval,
-                "autosave_indicator": AutosaveIndicator(),
-                "editing_sessions": self.get_editing_sessions(),
                 "loaded_revision_created_at": self.latest_revision_created_at,
                 "is_partial": self.expects_json_response or self.hydrate_create_view,
                 "hydrate_create_view": self.hydrate_create_view,
             }
         )
+
+        if not self.expects_json_response:
+            # These components do not need to be loaded when rendering partials
+            # for autosave. In particular, `get_editing_sessions` performs
+            # database writes that are not necessary when autosaving.
+            context.update(
+                {
+                    "editing_sessions": self.get_editing_sessions(),
+                    "autosave_indicator": AutosaveIndicator(),
+                }
+            )
 
         return context
 

--- a/wagtail/snippets/tests/test_edit_view.py
+++ b/wagtail/snippets/tests/test_edit_view.py
@@ -11,11 +11,13 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.timezone import now
 from freezegun import freeze_time
 from taggit.models import Tag
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
+from wagtail.admin.models import EditingSession
 from wagtail.models import Locale, ModelLogEntry, Revision
 from wagtail.signals import published
 from wagtail.snippets.action_menu import (
@@ -1238,6 +1240,35 @@ class TestEditRevisionSnippet(BaseTestSnippetEditView):
         latest_revision = self.test_snippet.get_latest_revision()
         self.assertEqual(latest_revision.id, user_revision.id)
         self.assertEqual(latest_revision.content["text"], "Initial revision")
+
+    def test_save_with_json_response_does_not_affect_sessions(self):
+        # an old session that would be cleaned up when loading the editor
+        content_type = ContentType.objects.get_for_model(self.test_snippet)
+        old_session = EditingSession.objects.create(
+            user=self.user,
+            content_type=content_type,
+            object_id=self.test_snippet.pk,
+            last_seen_at=timezone.now() - datetime.timedelta(hours=5),
+        )
+        # a recent session that would not be cleaned up when loading the editor
+        recent_session = EditingSession.objects.create(
+            user=self.user,
+            content_type=content_type,
+            object_id=self.test_snippet.pk,
+            last_seen_at=timezone.now() - datetime.timedelta(seconds=5),
+        )
+        response = self.post(
+            post_data={"text": "Autosaved"},
+            headers={"Accept": "application/json"},
+        )
+        self.assertEqual(response.status_code, 200)
+        # Saving with a JSON response does not fully load the editor, so it
+        # should not run a cleanup of old sessions, nor should it create a new
+        # session for the current request.
+        self.assertEqual(
+            list(EditingSession.objects.values_list("pk", flat=True).order_by("pk")),
+            [old_session.pk, recent_session.pk],
+        )
 
 
 class TestEditDraftStateSnippet(BaseTestSnippetEditView):


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Progress for #13863, fixes #12207, builds on #13974 and #13917. Includes an assortment of UI/UX tweaks for autosave and concurrent editing notifications.

### Description

<!-- Please describe the problem you're fixing. -->
Testing tips:

- You may want to temporarily change the timeout values e.g. `EditingSession.IDLE_TIMEOUT` in `wagtail.admin.models`.
- Switching to a different tab and then switching back to an editor tab will immediately trigger a "ping", useful if you don't want to wait for the interval.
- For testing "conflict with own session", you can add a `time.sleep(10)` just before the autosave success response is returned here: https://github.com/wagtail/wagtail/blob/be8d778e484afc17c6ca20e4a240ed2313e394e5/wagtail/admin/views/pages/edit.py#L665-L677 and then switch between tabs while autosave is "stuck" at saving.

Things to test:

1. After loading an editor tab and switching to a different tab, and waiting for `IDLE_TIMEOUT`, the session should be shown as "idle" (with faded avatar) when viewed by a different user. Example: <img width="358" height="289" alt="image" src="https://github.com/user-attachments/assets/21cba141-4cd7-4c65-8cc5-c6af2f342397" />
2. If you have unsaved changes (unlikely with autosave, but possible if you have validation errors) or have made a new revision, your session is still rendered normally (full-color and opacity).
3. If you leave an editor tab for longer than `AVAILABLE_TIMEOUT`, your session won't be shown to other users (but won't be cleaned up until `STALE_TIMEOUT`).
4. Upon closing the tab, your session should immediately be removed from other users (and the database).
5. Autosave indicator icon and text should not shift back and forth between states (Saving, Saved, Paused)
6. SessionController should not trigger a ping while an autosave is in progress, to prevent "conflict" with your own session.
7. If an autosave fails due to a network error, next time you try to click "Save draft" or any other footer actions, you should get a popup reminding you to check your internet connection.
8. After an exponential backoff, autosave failures due to network errors should be retried. Backoff is cleared when the network error is resolved (either with a successful autosave, or an error response from the server).



### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

Copilot for autocompletion only.