### PR TITLE
Remove image/heic from file input accept attribute for Safari/Mac

### DIFF
--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -2068,6 +2068,29 @@ class TestImageChooserView(WagtailTestUtils, TestCase):
             "image/*, image/heic, image/avif",
         )
 
+    @override_settings(
+        WAGTAILIMAGES_EXTENSIONS=["gif", "jpg", "jpeg", "png", "webp", "avif", "heic"]
+    )
+    def test_upload_field_omits_heic_on_safari_mac(self):
+        # Safari on macOS has a bug where listing 'image/heic' in the accept attribute
+        # prevents HEIC files from appearing in the file picker.
+        safari_mac_ua = (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/605.1.15 (KHTML, like Gecko) "
+            "Version/16.0 Safari/605.1.15"
+        )
+        response = self.client.get(
+            reverse("wagtailimages_chooser:choose"),
+            HTTP_USER_AGENT=safari_mac_ua,
+        )
+        self.assertEqual(response.status_code, 200)
+        response_json = json.loads(response.content.decode())
+        soup = self.get_soup(response_json["html"])
+        self.assertEqual(
+            soup.select_one('input[type="file"]').get("accept"),
+            "image/*, image/avif",
+        )
+
     @override_settings(WAGTAILIMAGES_EXTENSIONS=["gif", "jpg", "jpeg", "png", "webp"])
     def test_upload_field_without_avif(self):
         response = self.get()
@@ -2944,6 +2967,28 @@ class TestMultipleImageUploader(AdminTemplateTestUtils, WagtailTestUtils, TestCa
         self.assertEqual(
             soup.select_one("input[type='file'][multiple]").get("accept"),
             "image/*, image/heic, image/avif",
+        )
+
+    @override_settings(
+        WAGTAILIMAGES_EXTENSIONS=["gif", "jpg", "jpeg", "png", "webp", "avif", "heic"]
+    )
+    def test_multiple_upload_field_omits_heic_on_safari_mac(self):
+        # Safari on macOS has a bug where listing 'image/heic' in the accept attribute
+        # prevents HEIC files from appearing in the file picker.
+        safari_mac_ua = (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/605.1.15 (KHTML, like Gecko) "
+            "Version/16.0 Safari/605.1.15"
+        )
+        response = self.client.get(
+            reverse("wagtailimages:add_multiple"),
+            HTTP_USER_AGENT=safari_mac_ua,
+        )
+        self.assertEqual(response.status_code, 200)
+        soup = self.get_soup(response.content)
+        self.assertEqual(
+            soup.select_one("input[type='file'][multiple]").get("accept"),
+            "image/*, image/avif",
         )
 
     @override_settings(WAGTAILIMAGES_EXTENSIONS=["gif", "jpg", "jpeg", "png", "webp"])

--- a/wagtail/images/utils.py
+++ b/wagtail/images/utils.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import hmac
+import re
 
 from django.conf import settings
 from django.utils.crypto import constant_time_compare
@@ -150,10 +151,24 @@ def get_allowed_image_extensions():
     )
 
 
-def get_accept_attributes():
+def is_safari_mac(request):
+    """
+    Returns True if the request appears to come from Safari/MacOS
+    """
+    if request is None:
+        return False
+    user_agent = request.headers.get("User-Agent", "")
+    return bool(
+        re.search(r"Macintosh", user_agent)
+        and re.search(r"Safari", user_agent)
+        and not re.search(r"Chrome|Chromium", user_agent)
+    )
+
+
+def get_accept_attributes(request=None):
     allowed_image_extensions = get_allowed_image_extensions()
     accept_attrs = "image/*"
-    if "heic" in allowed_image_extensions:
+    if "heic" in allowed_image_extensions and not is_safari_mac(request):
         accept_attrs += ", image/heic"
     if "avif" in allowed_image_extensions:
         accept_attrs += ", image/avif"

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -33,7 +33,7 @@ from wagtail.images import get_image_model
 from wagtail.images.formats import get_image_format
 from wagtail.images.forms import ImageInsertionForm, get_image_form
 from wagtail.images.permissions import permission_policy
-from wagtail.images.utils import find_image_duplicates
+from wagtail.images.utils import find_image_duplicates, get_accept_attributes
 from wagtail.models import ReferenceIndex
 
 permission_checker = PermissionPolicyChecker(permission_policy)
@@ -76,6 +76,15 @@ class ImageCreationFormMixin(CreationFormMixin):
             kwargs["instance"] = self.model(uploaded_by_user=self.request.user)
 
         return kwargs
+
+    def get_creation_form(self):
+        # Update file input accept attribute (for AVIF and HEIC files)
+        form = super().get_creation_form()
+        if form is not None:
+            form.fields["file"].widget.attrs["accept"] = get_accept_attributes(
+                self.request
+            )
+        return form
 
 
 class BaseImageChooseView(BaseChooseView):

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -107,7 +107,7 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
                 "max_filesize": self.form.fields["file"].max_upload_size,
                 "max_title_length": self.form.fields["title"].max_length,
                 "allowed_extensions": get_allowed_image_extensions(),
-                "accept_attributes": get_accept_attributes(),
+                "accept_attributes": get_accept_attributes(self.request),
                 "error_max_file_size": self.form.fields["file"].error_messages[
                     "file_too_large_unknown_size"
                 ],


### PR DESCRIPTION
Fixes #13971
Fixes #13972

### Description

Adding `heic` to `WAGTAIL_EXTENSIONS` can cause crashes and other unexpected behaviors in Safari/Mac. This is because `wagtail.images.utils.get_accept_attributes()` adds `image/heic` to the `accept` attribute of file inputs in the Wagtail admin, which triggers a bug in Safari. See https://github.com/wagtail/wagtail/issues/13971#issuecomment-3988301803 for a few more details.

### AI usage

Claude (Opus 4.6) initially pinpointed `get_accept_attributes()` and suggested this was related to the MacOS Photos library. I’m not certain about its hypothesis about the Photos library. Claude couldn’t provide any source documentation & I didn’t find anything in bugs.webkit.org. But this is probably an Apple system bug, not a Webkit bug, and I’m not an Apple developer.