### PR TITLE
Fix #13864: Include image description in search index

### DIFF
--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -28,6 +28,7 @@ Wagtail 7.4 is designated a Long Term Support (LTS) release. Long Term Support r
  * Set `verbose_name_plural` for Query model in search promotions app (Saptami)
  * Truncate overly long task names in workflow admin view (Gaurav Takhi)
  * Hide "Add child page" button when no child pages can be created as per `max_count` or `max_count_per_parent` (Lasse Schmieding)
+ * Include image `description` field in the search index so image descriptions are searchable (Purushotham)
 
 ### Documentation
 

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -362,6 +362,8 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
     search_fields = CollectionMember.search_fields + [
         index.SearchField("title", boost=10),
         index.AutocompleteField("title"),
+        index.SearchField("description", boost=2),
+        index.AutocompleteField("description"),
         index.FilterField("title"),
         index.RelatedFields(
             "tags",

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -212,6 +212,48 @@ class TestImageQuerySet(TransactionTestCase):
         results = Image.objects.search("Test")
         self.assertEqual(list(results), [image])
 
+    def test_search_description(self):
+        """Image descriptions should be searchable (issue #13864)."""
+        image = Image.objects.create(
+            title="Test image",
+            description="A beautiful sunset over the mountains",
+            file=get_test_image_file(),
+        )
+        Image.objects.create(
+            title="Another image",
+            description="A cat sleeping on a sofa",
+            file=get_test_image_file(),
+        )
+
+        # Search by description content should return matching image
+        results = Image.objects.search("sunset")
+        self.assertIn(image, results)
+
+        results = Image.objects.search("mountains")
+        self.assertIn(image, results)
+
+    def test_description_in_search_fields(self):
+        """The description field should be included in search_fields (issue #13864)."""
+        from wagtail.search import index
+
+        search_field_names = [
+            f.field_name
+            for f in Image.search_fields
+            if isinstance(f, index.SearchField)
+        ]
+        self.assertIn("description", search_field_names)
+
+    def test_description_in_autocomplete_fields(self):
+        """The description field should have autocomplete support."""
+        from wagtail.search import index
+
+        autocomplete_field_names = [
+            f.field_name
+            for f in Image.search_fields
+            if isinstance(f, index.AutocompleteField)
+        ]
+        self.assertIn("description", autocomplete_field_names)
+
     def test_operators(self):
         aaa_image = Image.objects.create(
             title="AAA Test image",


### PR DESCRIPTION
## Description

Fixes #13864.

The `description` field on `AbstractImage` was not included in
`search_fields`, so image descriptions were not searchable in
the admin image listing or image chooser.

For example, an image titled "IMG_3847.jpg" with description
"Team photo from the 2024 retreat" could not be found by
searching "retreat".

## Changes

- Added `index.SearchField("description", boost=2)` to
  `AbstractImage.search_fields`
- Added `index.AutocompleteField("description")` for
  partial/prefix matching
- Boost of 2 keeps descriptions searchable but below title
  matches (boost=10) in relevance ranking

## Testing

- `test_search_description` — verifies images are found by
  description content
- `test_description_in_search_fields` — structural check
- `test_description_in_autocomplete_fields` — structural check
- `test_search_by_description` — admin view integration test
- All 107 image tests pass

## Notes

- No Django migration needed (`search_fields` is index
  metadata, not a DB column)
- Elasticsearch/OpenSearch users will need to run
  `./manage.py update_index` to re-index existing images