### PR TITLE
Add the image description field to search index

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -363,6 +363,8 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         index.SearchField("title", boost=10),
         index.AutocompleteField("title"),
         index.FilterField("title"),
+        index.SearchField("description"),
+        index.AutocompleteField("description"),
         index.RelatedFields(
             "tags",
             [


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #13864 

### Description

<!-- Please describe the problem you're fixing. -->
**Problem:** Image was unsearchable using the description field. It only search the images using the title field.
**Fix:** By adding the description field to the search index, it is possible to query from the description field of the images.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
This pull request includes code written with the assistance of AI and has been reviewed and verified by me.
I've run manual tests and I've also run unit tests.
