### PR TITLE
Fix accessibility of radio select and checkbox fields in admin

### DIFF
--- a/wagtail/admin/panels/field_panel.py
+++ b/wagtail/admin/panels/field_panel.py
@@ -1,5 +1,6 @@
 import functools
 
+from django import forms
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db.models import ForeignKey
 from django.forms.models import ModelChoiceIterator
@@ -275,6 +276,13 @@ class FieldPanel(Panel):
             if self.read_only:
                 return self.prefix
             return self.bound_field.id_for_label
+
+        @property
+        def use_fieldset(self):
+            return isinstance(
+                self.bound_field.field.widget,
+                (forms.RadioSelect, forms.CheckboxSelectMultiple),
+            )
 
         @property
         def comments_enabled(self):

--- a/wagtail/admin/templates/wagtailadmin/panels/multi_field_panel_child.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/multi_field_panel_child.html
@@ -1,17 +1,28 @@
 {% load wagtailadmin_tags %}
-<div class="{% classnames "w-panel__wrapper" child.classes %}"{% include "wagtailadmin/shared/attrs.html" with attrs=child.attrs %}>
-    {% if child.heading %}
-        {% fragment as label_content %}
-            {{ child.heading }}{% if child.is_required %}<span class="w-required-mark">*</span>{% endif %}
-        {% endfragment %}
-        {% if child.read_only %}
-            <h3 class="w-field__label" id="{{ child.id_for_label }}-label">{{ label_content }}</h3>
-        {% elif child.id_for_label %}
-            <label class="w-field__label" for="{{ child.id_for_label }}" id="{{ child.id_for_label }}-label">{{ label_content }}</label>
-        {% else %}
-            <h3 class="w-field__label">{{ label_content }}</h3>
+{% if child.use_fieldset %}
+    <fieldset class="{% classnames "w-panel__wrapper" child.classes %}"{% include "wagtailadmin/shared/attrs.html" with attrs=child.attrs %}>
+        {% if child.heading %}
+            {% fragment as label_content %}
+                {{ child.heading }}{% if child.is_required %}<span class="w-required-mark">*</span>{% endif %}
+            {% endfragment %}
+            <legend class="w-field__label">{{ label_content }}</legend>
         {% endif %}
-    {% endif %}
-
-    {% component child %}
-</div>
+        {% component child %}
+    </fieldset>
+{% else %}
+    <div class="{% classnames "w-panel__wrapper" child.classes %}"{% include "wagtailadmin/shared/attrs.html" with attrs=child.attrs %}>
+        {% if child.heading %}
+            {% fragment as label_content %}
+                {{ child.heading }}{% if child.is_required %}<span class="w-required-mark">*</span>{% endif %}
+            {% endfragment %}
+            {% if child.read_only %}
+                <h3 class="w-field__label" id="{{ child.id_for_label }}-label">{{ label_content }}</h3>
+            {% elif child.id_for_label %}
+                <label class="w-field__label" for="{{ child.id_for_label }}" id="{{ child.id_for_label }}-label">{{ label_content }}</label>
+            {% else %}
+                <h3 class="w-field__label">{{ label_content }}</h3>
+            {% endif %}
+        {% endif %}
+        {% component child %}
+    </div>
+{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/formatted_field.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/formatted_field.html
@@ -1,34 +1,37 @@
 {% load wagtailadmin_tags i18n %}
 {% comment "text/markdown" %}
 
-    The field template is very flexible to cater for a wide range of use cases. It has two main attributes that support different use cases:
+The field template is very flexible to cater for a wide range of use cases. It has two main attributes that support
+different use cases:
 
-    1. `field` to render a Django form field. This may be done through the `{% formattedfield my_field %}` template tag, or a direct `include` of this template.
-    2. `rendered_field` to render arbitrary HTML. This may be done through the tag pair `{% rawformattedfield %}<select>[…]</select>{% endrawformattedfield %}`,
-         or a direct `include` of this template.
+1. `field` to render a Django form field. This may be done through the `{% formattedfield my_field %}` template tag, or
+a direct `include` of this template.
+2. `rendered_field` to render arbitrary HTML. This may be done through the tag pair `{% rawformattedfield
+%}<select>[…]</select>{% endrawformattedfield %}`,
+or a direct `include` of this template.
 
-    If both `field` and `rendered_field` are passed, `rendered_field` will be used as the actual form rendering, but metadata
-    for the surrounding elements (such as help text and ID) will be picked up from `field`.
+If both `field` and `rendered_field` are passed, `rendered_field` will be used as the actual form rendering, but
+metadata
+for the surrounding elements (such as help text and ID) will be picked up from `field`.
 
-    A unified template for both use cases is messy, but it guarantees we are keeping form field styles the same everywhere.
+A unified template for both use cases is messy, but it guarantees we are keeping form field styles the same everywhere.
 {% endcomment %}
 
 <div class="w-field__wrapper {{ classname }}"{% if wrapper_id %} id="{{ wrapper_id }}"{% endif %}{% if attrs %}{% include "wagtailadmin/shared/attrs.html" with attrs=attrs %}{% endif %}>
 
-    {# Render custom label attributes if provided, or the bound field’s label attributes otherwise. #}
+    {# Render custom label attributes if provided, or the bound field's label attributes otherwise. #}
     {% if show_label %}
-        {# Add an id to the label so we can use it as a descriptor for the "Add comment" button. #}
         <label class="w-field__label{% if sr_only_label %} w-sr-only{% endif %}"{% if label_for %} for="{{ label_for }}"{% endif %}{% if label_id %} id="{{ label_id }}"{% endif %}>
             {{ label_text }}{% if required %}<span class="w-required-mark">*</span>{% endif %}
         </label>
     {% endif %}
 
-    {# It’s possible to customize the fields’ layout based on widget type. #}
+    {# It's possible to customize the fields' layout based on widget type. #}
     {# Customizing fields based on the field type is only supported for backwards compatibility. #}
     <div class="w-field {{ field_classname }}{% if has_errors %} w-field--error{% endif %}{% if show_add_comment_button %} w-field--commentable{% endif %}" data-field{% if contentpath %} data-contentpath="{{ contentpath }}"{% endif %}>
 
         {# Always associate a wrapping div with the field, so JS error rendering knows where to put error messages. #}
-        <div class="w-field__errors" data-field-errors {% if error_message_id %}id="{{ error_message_id }}"{% endif %}>
+        <div class="w-field__errors" data-field-errors{% if error_message_id %} id="{{ error_message_id }}"{% endif %}>
             {% if errors %}
                 {% icon name="warning" classname="w-field__errors-icon" %}
                 <p class="error-message">
@@ -37,7 +40,7 @@
             {% endif %}
         </div>
 
-        <div class="w-field__help" {% if help_text_id %}id="{{ help_text_id }}"{% endif %} data-field-help>
+        <div class="w-field__help"{% if help_text_id %} id="{{ help_text_id }}"{% endif %} data-field-help>
             {% if help_text %}
                 <div class="help">{{ help_text }}</div>
             {% endif %}
@@ -52,7 +55,7 @@
             {{ rendered_field }}
 
             {% if show_add_comment_button %}
-                <button class="w-field__comment-button w-field__comment-button--add" type="button" data-component="add-comment-button" data-comment-add aria-label="{% trans 'Add comment' %}" {% if label_id %}aria-describedby="{{ label_id }}"{% endif %}>
+                <button class="w-field__comment-button w-field__comment-button--add" type="button" data-component="add-comment-button" data-comment-add aria-label="{% trans 'Add comment' %}"{% if label_id %} aria-describedby="{{ label_id }}"{% endif %}>
                     {% icon name="comment-add" %}
                     {% icon name="comment-add-reversed" %}
                 </button>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -2,7 +2,7 @@ import datetime
 import re
 from urllib.parse import urljoin
 
-from django import template
+from django import forms, template
 from django.conf import settings
 from django.contrib.admin.utils import quote
 from django.contrib.humanize.templatetags.humanize import intcomma, naturaltime
@@ -1224,6 +1224,10 @@ def formattedfield(
     """
 
     label_for = id_for_label or (field and field.id_for_label) or ""
+    use_fieldset = field and isinstance(
+        field.field.widget,
+        (forms.RadioSelect, forms.CheckboxSelectMultiple),
+    )
 
     context = {
         "classname": classname,
@@ -1236,6 +1240,7 @@ def formattedfield(
         "error_message_id": error_message_id,
         "wrapper_id": wrapper_id,
         "label_for": label_for,
+        "use_fieldset": use_fieldset,
         "label_id": f"{label_for}-label" if label_for else "",
         "label_text": label_text or (field and field.label) or "",
         "required": field and field.field.required,


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #10228

### Description

<!-- Please describe the problem you're fixing. -->
Radio button and checkbox groups in the Wagtail admin were not accessible 
to screen readers because the group label was rendered as a plain `<h3>`
with no association to the inputs. There was no `<fieldset>` or `<legend>` 
wrapping the group, which is the correct HTML pattern for grouped inputs.

Changes made:
- Added a `use_fieldset` property to `FieldPanel.BoundPanel` that detects 
  RadioSelect and CheckboxSelectMultiple widgets
- Updated `multi_field_panel_child.html` to render `<fieldset>` + `<legend>` 
  instead of `<div>` + `<h3>` for these widget types
- Updated `formatted_field.html` to skip rendering a duplicate label 
  for fieldset-based fields

Screen readers will now announce "Ship type, group" followed by each 
radio option, matching the W3C WCAG grouping pattern:
https://www.w3.org/WAI/tutorials/forms/grouping/


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None