### PR TITLE
Improve error message for format-* operations on SVG images

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1098,6 +1098,12 @@ class Filter:
                     original_format, original_format
                 )
 
+            # Prevent raster-only format conversions for SVG images
+            if original_format == "svg" and output_format != "svg":
+                raise InvalidFilterSpecError(
+                    "format-* operations are not supported for SVG images. Use 'preserve-svg'."
+                )
+
             if output_format == "jpeg":
                 # Allow changing of JPEG compression quality
                 if "jpeg-quality" in env:

--- a/wagtail/images/tests/test_jinja2_svg.py
+++ b/wagtail/images/tests/test_jinja2_svg.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from wagtail.images.exceptions import InvalidFilterSpecError
 from wagtail.images.models import Image
 from wagtail.images.tests.utils import (
     get_test_image_file,
@@ -50,8 +51,8 @@ class TestJinja2SVGSupport(WagtailTestUtils, TestCase):
         )
 
     def test_image_with_svg_without_preserve(self):
-        """Test that without preserve-svg, SVGs get all operations (which would fail in production)."""
-        with self.assertRaises(AttributeError):
+        """Test that without preserve-svg, applying unsupported operations to SVG raises an error."""
+        with self.assertRaises(InvalidFilterSpecError):
             self.render(
                 '{{ image(img, "width-200|format-webp") }}', {"img": self.svg_image}
             )


### PR DESCRIPTION
## Related discussion

This PR is related to the earlier discussion in #13982.

That discussion clarified that `format-*` operations are intentionally unsupported for SVG images unless `preserve-svg` is explicitly used.

This change does not alter that behaviour. It only improves the error message so developers receive a clearer and more actionable explanation when such a conversion is attempted.

<img width="1339" height="1015" alt="image" src="https://github.com/user-attachments/assets/31374dd5-8660-4eb3-8374-83e3fcdb3b16" />

## Summary

Applying a `format-*` filter to an SVG image currently results in a confusing `AttributeError` when the image pipeline reaches raster-only logic (e.g. `has_alpha()`). This change raises a clearer `InvalidFilterSpecError` earlier when format conversion is requested for SVG.

**Example:**
```django
{% image page.hero_image width-200|format-webp %}
```

**Now raises:**
```
InvalidFilterSpecError: format-* operations are not supported for SVG images. Use 'preserve-svg'.
```

This preserves existing behavior (format conversion for SVG is unsupported) but surfaces a clearer error message.

---

## Why this check is safe

The guard only triggers when:
```python
original_format == "svg" and output_format != "svg"
```

**Examples that trigger the error:** `format-webp`, `format-jpeg`, `format-png`, `format-avif`

### Normal SVG operations are unaffected
```django
{% image page.hero_image width-200 %}
```

Resolves to `output_format = "svg"` → no error raised.

- SVG resizing works 
- SVG passthrough works 
- Only raster conversions error 



---

## Manual verification
<img width="1490" height="1018" alt="image" src="https://github.com/user-attachments/assets/29fd00f2-c08e-4d0f-bb6e-c3795bd9b6c1" />

Tested in a fresh Wagtail project (`pip install -e .`):
```django
{% image page.hero_image format-webp width-200 %}
```


