### PR TITLE
Fix #6465 - Add update_redirects management command to convert redire…

### DIFF
--- a/wagtail/contrib/redirects/management/commands/update_redirects.py
+++ b/wagtail/contrib/redirects/management/commands/update_redirects.py
@@ -1,0 +1,63 @@
+from urllib.parse import urlparse
+
+from django.core.management.base import BaseCommand
+
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.models import Page
+from wagtail.models.sites import get_site_for_hostname
+
+
+class Command(BaseCommand):
+    help = "Converts target URLs to Wagtail pages, if they exist"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Run only in test mode, will not update redirects",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options.pop("dry_run", False)
+
+        converted = 0
+        skipped = 0
+        total = 0
+
+        for redirect in Redirect.objects.exclude(redirect_link=""):
+            total += 1
+            url = urlparse(redirect.redirect_link)
+            hostname = url.hostname
+            port = url.port or 80
+            path = url.path
+            site = get_site_for_hostname(hostname, port)
+            if not path.endswith("/"):
+                path = path + "/"
+
+            if site:
+                root_path = site.root_page.url_path
+                full_path = root_path + path.lstrip("/")
+                page = Page.objects.filter(url_path=full_path).live().first()
+                if page:
+                    if dry_run:
+                        converted += 1
+                        self.stdout.write(f"Would convert redirect {redirect.id}")
+                        continue
+                    redirect.redirect_page = page
+                    redirect.redirect_link = ""
+                    redirect.save()
+                    converted += 1
+                    self.stdout.write(f"Converted redirect {redirect.id}")
+                else:
+                    skipped += 1
+                    self.stdout.write(
+                        f"Skipping redirect {redirect.id} - no matching page found"
+                    )
+            else:
+                skipped += 1
+                self.stdout.write(
+                    f"Skipping redirect {redirect.id} - no matching page found"
+                )
+        self.stdout.write(f"Total: {total}")
+        self.stdout.write(f"Converted: {converted}")
+        self.stdout.write(f"Skipped: {skipped}")

--- a/wagtail/contrib/redirects/tests/test_update_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_update_redirects.py
@@ -1,0 +1,70 @@
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from wagtail.contrib.redirects.models import Redirect
+
+
+class TestUpdateCommand(TestCase):
+    fixtures = ["test.json"]
+
+    def test_redirect_gets_converted(self):
+        Redirect.objects.create(
+            old_path="/old-events/", redirect_link="http://localhost/events/"
+        )
+
+        out = StringIO()
+        call_command("update_redirects", stdout=out)
+
+        redirect = Redirect.objects.first()
+        self.assertIsNotNone(redirect.redirect_page)
+
+    def test_redirect_not_converted_when_page_not_found(self):
+        Redirect.objects.create(
+            old_path="/old-events/", redirect_link="http://localhost/non-existing-page/"
+        )
+
+        out = StringIO()
+        call_command("update_redirects", stdout=out)
+
+        redirect = Redirect.objects.first()
+        self.assertIsNone(redirect.redirect_page)
+        self.assertNotEqual(redirect.redirect_link, "")
+
+    def test_external_url_gets_skipped(self):
+        Redirect.objects.create(
+            old_path="/old-events/", redirect_link="https://google.com/some-page/"
+        )
+
+        out = StringIO()
+        call_command("update_redirects", stdout=out)
+
+        redirect = Redirect.objects.first()
+        self.assertIsNone(redirect.redirect_page)
+        self.assertNotEqual(redirect.redirect_link, "")
+
+    def test_nothing_gets_saved_on_dry_run(self):
+        Redirect.objects.create(
+            old_path="/old-events/", redirect_link="http://localhost/events/"
+        )
+
+        out = StringIO()
+        call_command("update_redirects", dry_run=True, stdout=out)
+
+        redirect = Redirect.objects.first()
+        self.assertIsNone(redirect.redirect_page)
+        self.assertNotEqual(redirect.redirect_link, "")
+        self.assertIn("Would convert redirect", out.getvalue())
+
+    def test_redirect_converts_without_trailing_slash(self):
+        Redirect.objects.create(
+            old_path="/old-events/", redirect_link="http://localhost/events"
+        )
+
+        out = StringIO()
+        call_command("update_redirects", stdout=out)
+
+        redirect = Redirect.objects.first()
+        self.assertIsNotNone(redirect.redirect_page)
+        self.assertEqual(redirect.redirect_link, "")


### PR DESCRIPTION

<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #6465

### Description

This PR adds the implementation of a management command to convert 
redirect URLs to Wagtail pages on bulk import.
- Supports `--dry-run` to test without saving

### Testing
- Added unit tests to test update_redirects command.

- All unit tests passed.

- Tested the command in bakery demo websites and it worked.

### Docs 

- [ ]  I will update the docs after finishing the implementation of command arguments.

### AI usage
Used [claude.ai](http://claude.ai/) to understand `import_redirects.py` code, and in writing `test_update_redirects.py`

All code is tested and verified by me.
