### PR TITLE
Fix oEmbed when some response fields are null

### DIFF
--- a/wagtail/embeds/finders/oembed.py
+++ b/wagtail/embeds/finders/oembed.py
@@ -77,9 +77,9 @@ class OEmbedFinder(EmbedFinder):
 
         # Return embed as a dict
         result = {
-            "title": oembed.get("title", ""),
-            "author_name": oembed.get("author_name", ""),
-            "provider_name": oembed.get("provider_name", ""),
+            "title": oembed.get("title", "") or "",
+            "author_name": oembed.get("author_name", "") or "",
+            "provider_name": oembed.get("provider_name", "") or "",
             "type": oembed["type"],
             "thumbnail_url": oembed.get("thumbnail_url"),
             "width": oembed.get("width"),

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -699,6 +699,42 @@ class TestOembed(TestCase):
         with self.assertRaises(EmbedNotFoundException):
             OEmbedFinder().find_embed("https://www.youtube.com/watch/")
 
+    @responses.activate
+    def test_oembed_field_value_null(self):
+        responses.get(
+            url="https://www.youtube.com/oembed",
+            match=[
+                matchers.query_param_matcher(
+                    {"url": "https://www.youtube.com/watch/", "format": "json"}
+                ),
+            ],
+            json={  # valid JSON but some fields are null
+                "type": "something",
+                "url": "http://www.example.com",
+                "title": None,
+                "author_name": None,
+                "provider_name": None,
+                "thumbnail_url": "test_thumbail_url",
+                "width": "test_width",
+                "height": "test_height",
+                "html": "test_html",
+            },
+        )
+        result = OEmbedFinder().find_embed("https://www.youtube.com/watch/")
+        self.assertEqual(
+            result,
+            {
+                "type": "something",
+                "title": "",
+                "author_name": "",
+                "provider_name": "",
+                "thumbnail_url": "test_thumbail_url",
+                "width": "test_width",
+                "height": "test_height",
+                "html": "test_html",
+            },
+        )
+
 
 class TestInstagramOEmbed(TestCase):
     def setUp(self):


### PR DESCRIPTION
### Description

I found an OEmbed endpoint that returns `null` on the title.

With the current code, the value `null`, then `None` in Python, is passed to the database:

```python
oembed.get("title", "")
```

With the following code, a nullish value like `None` would be casted as an empty string.
 
```python
oembed.get("title", "") or ""
```

Example endpoint:

[https://heyzine.com/api1/oembed](https://heyzine.com/api1/oembed?url=https://heyzine.com/flip-book/656e10b5e8.html)

### Details

#### IntegrityError at /admin/pages/1/edit/

null value in column "title" of relation "wagtailembeds_embed" violates not-null constraint
DETAIL:  Failing row contains (9, https://heyzine.com/flip-book/656e10b5e8.html, null, rich, <iframe allowfullscreen="allowfullscreen" allow="clipboard-write..., null, , Heyzine, https://cdnc.heyzine.com/files/uploaded/656e10b5e8d7719626a15de6..., 1920, 2725, 2026-03-10 18:23:10.879874+00, 02fae3f1bd6d1f1936e0bacb315097e1, null).

<details>
<summary>Traceback</summary>

```python-traceback


Internal Server Error: /admin/pages/1/edit/
Traceback (most recent call last):
  File "~/django/db/models/query.py", line 987, in get_or_create
    return self.get(**kwargs), False
           ~~~~~~~~^^^^^^^^^^
  File "~/django/db/models/query.py", line 639, in get
    raise self.model.DoesNotExist(
        "%s matching query does not exist." % self.model._meta.object_name
    )
wagtail.embeds.models.Embed.DoesNotExist: Embed matching query does not exist.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "~/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "~/psycopg/cursor.py", line 117, in execute
    raise ex.with_traceback(None)
psycopg.errors.NotNullViolation: null value in column "title" of relation "wagtailembeds_embed" violates not-null constraint
DETAIL:  Failing row contains (9, https://heyzine.com/flip-book/656e10b5e8.html, null, rich, <iframe allowfullscreen="allowfullscreen" allow="clipboard-write..., null, , Heyzine, https://cdnc.heyzine.com/files/uploaded/656e10b5e8d7719626a15de6..., 1920, 2725, 2026-03-10 18:23:10.879874+00, 02fae3f1bd6d1f1936e0bacb315097e1, null).

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "~/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "~/django/core/handlers/base.py", line 198, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "~/django/views/decorators/cache.py", line 80, in _view_wrapper
    response = view_func(request, *args, **kwargs)
  File "~/wagtail/admin/urls/__init__.py", line 178, in wrapper
    return view_func(request, *args, **kwargs)
  File "~/wagtail/admin/auth.py", line 137, in decorated_view
    return get_localized_response(view_func, request, *args, **kwargs)
  File "~/wagtail/admin/localization.py", line 136, in get_localized_response
    response = view_func(request, *args, **kwargs)
  File "~/django/views/generic/base.py", line 106, in view
    return self.dispatch(request, *args, **kwargs)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/wagtail/admin/views/pages/edit.py", line 428, in dispatch
    return super().dispatch(request, page_id, **kwargs)
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/django/views/generic/base.py", line 145, in dispatch
    return handler(request, *args, **kwargs)
  File "~/wagtail/admin/views/pages/edit.py", line 558, in post
    if self.form.is_valid() and not self.locked_for_user:
       ~~~~~~~~~~~~~~~~~~^^
  File "~/wagtail/admin/forms/pages.py", line 206, in is_valid
    return super().is_valid()
           ~~~~~~~~~~~~~~~~^^
  File "~/modelcluster/forms.py", line 345, in is_valid
    form_is_valid = super().is_valid()
  File "~/django/forms/forms.py", line 206, in is_valid
    return self.is_bound and not self.errors
                                 ^^^^^^^^^^^
  File "~/django/forms/forms.py", line 201, in errors
    self.full_clean()
    ~~~~~~~~~~~~~~~^^
  File "~/django/forms/forms.py", line 337, in full_clean
    self._clean_fields()
    ~~~~~~~~~~~~~~~~~~^^
  File "~/django/forms/forms.py", line 345, in _clean_fields
    self.cleaned_data[name] = field._clean_bound_field(bf)
                              ~~~~~~~~~~~~~~~~~~~~~~~~^^^^
  File "~/django/forms/fields.py", line 272, in _clean_bound_field
    return self.clean(value)
           ~~~~~~~~~~^^^^^^^
  File "~/wagtail/blocks/base.py", line 769, in clean
    return self.block.clean(
           ~~~~~~~~~~~~~~~~^
        value, ignore_required_constraints=not self.required
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "~/wagtail/blocks/stream_block.py", line 171, in clean
    (child.block.name, child.block.clean(child.value), child.id)
                       ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "~/wagtail/embeds/blocks.py", line 85, in clean
    if isinstance(value, EmbedValue) and not value.html:
                                             ^^^^^^^^^^
  File "~/django/utils/functional.py", line 47, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
                                         ~~~~~~~~~^^^^^^^^^^
  File "~/wagtail/embeds/blocks.py", line 25, in html
    return embed_to_frontend_html(self.url, self.max_width, self.max_height)
  File "~/wagtail/embeds/format.py", line 9, in embed_to_frontend_html
    embed = embeds.get_embed(url, max_width, max_height)
  File "~/wagtail/embeds/embeds.py", line 57, in get_embed
    embed, created = Embed.objects.update_or_create(
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        hash=embed_hash, defaults=dict(url=url, max_width=max_width, **embed_dict)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "~/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "~/django/db/models/query.py", line 1029, in update_or_create
    obj, created = self.select_for_update().get_or_create(
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        create_defaults, **kwargs
        ^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "~/django/db/models/query.py", line 994, in get_or_create
    return self.create(**params), True
           ~~~~~~~~~~~^^^^^^^^^^
  File "~/django/db/models/query.py", line 669, in create
    obj.save(force_insert=True, using=self.db)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/django/db/models/base.py", line 874, in save
    self.save_base(
    ~~~~~~~~~~~~~~^
        using=using,
        ^^^^^^^^^^^^
    ...<2 lines>...
        update_fields=update_fields,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "~/django/db/models/base.py", line 966, in save_base
    updated = self._save_table(
        raw,
    ...<4 lines>...
        update_fields,
    )
  File "~/django/db/models/base.py", line 1169, in _save_table
    results = self._do_insert(
        cls._base_manager, using, insert_fields, returning_fields, raw
    )
  File "~/django/db/models/base.py", line 1220, in _do_insert
    return manager._insert(
           ~~~~~~~~~~~~~~~^
        [self],
        ^^^^^^^
    ...<3 lines>...
        raw=raw,
        ^^^^^^^^
    )
    ^
  File "~/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "~/django/db/models/query.py", line 1918, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "~/django/db/models/sql/compiler.py", line 1925, in execute_sql
    cursor.execute(sql, params)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "~/django/db/backends/utils.py", line 122, in execute
    return super().execute(sql, params)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "~/django/db/backends/utils.py", line 79, in execute
    return self._execute_with_wrappers(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        sql, params, many=False, executor=self._execute
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "~/django/db/backends/utils.py", line 92, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "~/django/db/backends/utils.py", line 100, in _execute
    with self.db.wrap_database_errors:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/django/db/utils.py", line 94, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "~/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "~/psycopg/cursor.py", line 117, in execute
    raise ex.with_traceback(None)
django.db.utils.IntegrityError: null value in column "title" of relation "wagtailembeds_embed" violates not-null constraint
DETAIL:  Failing row contains (9, https://heyzine.com/flip-book/656e10b5e8.html, null, rich, <iframe allowfullscreen="allowfullscreen" allow="clipboard-write..., null, , Heyzine, https://cdnc.heyzine.com/files/uploaded/656e10b5e8d7719626a15de6..., 1920, 2725, 2026-03-10 18:23:10.879874+00, 02fae3f1bd6d1f1936e0bacb315097e1, null).
```

</details>

### AI usage

no
