### PR TITLE
Fix slug change via update_fields not creating redirect (#9833)

### DIFF
--- a/wagtail/contrib/redirects/tests/test_signal_handlers.py
+++ b/wagtail/contrib/redirects/tests/test_signal_handlers.py
@@ -209,6 +209,29 @@ class TestAutocreateRedirects(WagtailTestUtils, TestCase):
             },
         )
 
+    def test_redirect_created_when_slug_changed_via_update_fields(self):
+        """
+        Regression test for #9833: changing a page slug via
+        save(update_fields=["slug"]) must still create a redirect.
+        Previously, url_path was not included in update_fields, so the
+        page_slug_changed signal saw no URL change and no redirect was created.
+        """
+        test_subject = self.event_index
+        old_url = test_subject.url
+
+        test_subject.slug += "-extra"
+        with self.captureOnCommitCallbacks(execute=True):
+            test_subject.save(update_fields=["slug"], clean=False)
+
+        # A redirect from the old URL should have been created
+        self.assertTrue(
+            Redirect.objects.filter(redirect_page=test_subject).exists(),
+            "Expected a redirect when slug changed via update_fields=['slug']",
+        )
+        redirect = Redirect.objects.get(redirect_page=test_subject)
+        self.assertEqual(redirect.old_path, Redirect.normalise_path(old_url))
+        self.assertTrue(redirect.automatically_created)
+
     def test_no_redirects_created_when_pages_are_moved_to_a_different_site(self):
         with self.captureOnCommitCallbacks(execute=True):
             # Add a new home page

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -767,6 +767,12 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                     old_url_path = old_record.url_path
                     new_url_path = self.url_path
 
+        if (
+            slug_changed
+            and "update_fields" in kwargs
+            and kwargs["update_fields"] is not None
+        ):
+            kwargs["update_fields"] = list(kwargs["update_fields"]) + ["url_path"]
         result = super().save(**kwargs)
 
         if slug_changed:


### PR DESCRIPTION
Fixes #9833 

When Page.save() is called with update_fields=['slug'], the url_path field was updated in memory by set_url_path() but never persisted to the database. This meant the page_slug_changed signal saw identical old and new url_path values and created no redirect.

### Fix: 
When slug_changed is True and update_fields is specified, append 'url_path' to update_fields before calling super().save().

Regression test added to test_signal_handlers.py.