### PR TITLE
Docs: add request.in_preview_panel documention

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ Changelog
  * Fix: Prevent stale content types from breaking audit log message formatting (Thibaud Colas)
  * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
  * Docs: Fix panel classname and deprecated usage of `format_html` in `construct_homepage_panels` example (Andreas Nüßlein)
+ * Docs: Add docs for `request.in_preview_panel` to explain its use (Raghad Dahi)
  * Maintenance: Rename `request` argument to `cache_object` in `Page._get_site_root_paths()` for correctness (Kailesh)
  * Maintenance: Fix blank choice tests for Django 6.1 (Sage Abdullah)
  * Maintenance: Ignore `EMAIL_BACKEND` setting deprecation on Django 6.1 when running project template tests (Sage Abdullah)

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -55,6 +55,7 @@ For more details, refer to the [](permissions_reference) reference documentation
  * Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
  * Fix panel classname and deprecated usage of `format_html` in `construct_homepage_panels` example (Andreas Nüßlein)
  * Update django-ninja code examples to use new Meta class implemented in django-ninja V1 (Jack Whitworth)
+ * Document [`request.in_preview_panel`](custom_rendering_in_preview_panel) to explain its use (Raghad Dahi)
 
 ### Maintenance
 

--- a/docs/topics/writing_templates.md
+++ b/docs/topics/writing_templates.md
@@ -323,7 +323,7 @@ The user bar is also available as a [template component](template_components), w
 
 ## Varying output between preview and live
 
-Sometimes you may wish to vary the template output depending on whether the page is being previewed or viewed live. For example, if you have visitor-tracking code such as Google Analytics in place on your site, it's a good idea to leave this out when previewing, so that editor activity doesn't appear in your analytics reports. Wagtail provides a `request.is_preview` variable to distinguish between preview and live:
+Sometimes you may wish to vary the template output depending on whether the page is being previewed or viewed live. For example, if you have visitor-tracking code such as Google Analytics in place on your site, it's a good idea to leave this out when previewing, so that editor activity doesn't appear in your analytics reports. Wagtail provides the `request.is_preview` (also available as `is_preview`) variable to distinguish between preview and live:
 
 ```html+django
 {% if not request.is_preview %}
@@ -336,6 +336,22 @@ Sometimes you may wish to vary the template output depending on whether the page
 
 If the page is being previewed, `request.preview_mode` can be used to determine the specific preview mode being used,
 if the page supports [multiple preview modes](wagtail.models.Page.preview_modes).
+
+### Opening links within the live preview panel
+
+The live preview panel utilizes an iframe to display the preview in the editor page, which requires the page in the iframe to have the `X-Frame-Options` header set to `SAMEORIGIN` (or unset). If you click a link within the preview panel, 
+you may notice that the iframe stops working. This is because the link is loaded within the iframe and the linked page may have the `X-Frame-Options` header set to `DENY`. 
+To work around this problem, Wagtail provides the `request.in_preview_panel` (also available as `in_preview_panel`) variable. Add the following `<base>` tag within your `<head>` element in your `base.html` template, before any `<link>` elements:
+
+```html+django
+{% if request.in_preview_panel %}
+    <base target="_blank">
+{% endif %}
+```
+
+This will make all links in the live preview panel open in a new tab.
+
+New Wagtail projects created through the `wagtail start` command already include this change in the base template.
 
 (template_fragment_caching)=
 

--- a/docs/topics/writing_templates.md
+++ b/docs/topics/writing_templates.md
@@ -323,7 +323,7 @@ The user bar is also available as a [template component](template_components), w
 
 ## Varying output between preview and live
 
-Sometimes you may wish to vary the template output depending on whether the page is being previewed or viewed live. For example, if you have visitor-tracking code such as Google Analytics in place on your site, it's a good idea to leave this out when previewing, so that editor activity doesn't appear in your analytics reports. Wagtail provides the `request.is_preview` (also available as `is_preview`) variable to distinguish between preview and live:
+Sometimes you may wish to vary the template output depending on whether the page is being previewed or viewed live. For example, if you have visitor-tracking code such as Google Analytics in place on your site, it's a good idea to leave this out when previewing, so that editor activity doesn't appear in your analytics reports. Wagtail provides the `request.is_preview` variable, whose `is_preview` attribute is used to distinguish between preview and live:
 
 ```html+django
 {% if not request.is_preview %}
@@ -341,7 +341,7 @@ if the page supports [multiple preview modes](wagtail.models.Page.preview_modes)
 
 The live preview panel utilizes an iframe to display the preview in the editor page, which requires the page in the iframe to have the `X-Frame-Options` header set to `SAMEORIGIN` (or unset). If you click a link within the preview panel, 
 you may notice that the iframe stops working. This is because the link is loaded within the iframe and the linked page may have the `X-Frame-Options` header set to `DENY`. 
-To work around this problem, Wagtail provides the `request.in_preview_panel` (also available as `in_preview_panel`) variable. Add the following `<base>` tag within your `<head>` element in your `base.html` template, before any `<link>` elements:
+To work around this problem, Wagtail provides a `request.in_preview_panel` variable, whose `in_preview_panel` attribute indicates that the page is being rendered inside the preview panel. Add the following `<base>` tag within your `<head>` element in your `base.html` template, before any `<link>` elements:
 
 ```html+django
 {% if request.in_preview_panel %}

--- a/docs/topics/writing_templates.md
+++ b/docs/topics/writing_templates.md
@@ -323,7 +323,7 @@ The user bar is also available as a [template component](template_components), w
 
 ## Varying output between preview and live
 
-Sometimes you may wish to vary the template output depending on whether the page is being previewed or viewed live. For example, if you have visitor-tracking code such as Google Analytics in place on your site, it's a good idea to leave this out when previewing, so that editor activity doesn't appear in your analytics reports. Wagtail provides the `request.is_preview` variable, whose `is_preview` attribute is used to distinguish between preview and live:
+Sometimes you may wish to vary the template output depending on whether the page is being previewed or viewed live. For example, if you have visitor-tracking code such as Google Analytics in place on your site, it's a good idea to leave this out when previewing, so that editor activity doesn't appear in your analytics reports. Wagtail provides the `request.is_preview` variable. The `is_preview` flag is used to distinguish between preview and live content:
 
 ```html+django
 {% if not request.is_preview %}
@@ -337,11 +337,9 @@ Sometimes you may wish to vary the template output depending on whether the page
 If the page is being previewed, `request.preview_mode` can be used to determine the specific preview mode being used,
 if the page supports [multiple preview modes](wagtail.models.AbstractPage.preview_modes).
 
-### Opening links within the live preview panel
+### Customizing rendering in the preview panel
 
-The live preview panel utilizes an iframe to display the preview in the editor page, which requires the page in the iframe to have the `X-Frame-Options` header set to `SAMEORIGIN` (or unset). If you click a link within the preview panel, 
-you may notice that the iframe stops working. This is because the link is loaded within the iframe and the linked page may have the `X-Frame-Options` header set to `DENY`. 
-To work around this problem, Wagtail provides a `request.in_preview_panel` variable, whose `in_preview_panel` attribute indicates that the page is being rendered inside the preview panel. Add the following `<base>` tag within your `<head>` element in your `base.html` template, before any `<link>` elements:
+Wagtail provides a `request.in_preview_panel` variable to customize rendering specifically within the preview panel. The `in_preview_panel` attribute indicates that the page is being rendered inside the panel. The live preview panel uses an iframe to display the preview in the editor page. It is help for editors to configure the rendered page so links open outside of the iframe. To achieve this, add a `<base>` tag within your `<head>` element:
 
 ```html+django
 {% if request.in_preview_panel %}
@@ -349,9 +347,7 @@ To work around this problem, Wagtail provides a `request.in_preview_panel` varia
 {% endif %}
 ```
 
-This will make all links in the live preview panel open in a new tab.
-
-New Wagtail projects created through the `wagtail start` command already include this change in the base template.
+This will make all links in the live preview panel open in a new tab. New Wagtail projects created through the `wagtail start` command already include this change in the base template.
 
 (template_fragment_caching)=
 

--- a/docs/topics/writing_templates.md
+++ b/docs/topics/writing_templates.md
@@ -323,7 +323,7 @@ The user bar is also available as a [template component](template_components), w
 
 ## Varying output between preview and live
 
-Sometimes you may wish to vary the template output depending on whether the page is being previewed or viewed live. For example, if you have visitor-tracking code such as Google Analytics in place on your site, it's a good idea to leave this out when previewing, so that editor activity doesn't appear in your analytics reports. Wagtail provides the `request.is_preview` (also available as `is_preview`) variable to distinguish between preview and live:
+Sometimes you may wish to vary the template output depending on whether the page is being previewed or viewed live. For example, if you have visitor-tracking code such as Google Analytics in place on your site, it's a good idea to leave this out when previewing, so that editor activity doesn't appear in your analytics reports. Wagtail provides the `request.is_preview` variable, whose `is_preview` attribute is used to distinguish between preview and live:
 
 ```html+django
 {% if not request.is_preview %}
@@ -341,7 +341,7 @@ if the page supports [multiple preview modes](wagtail.models.AbstractPage.previe
 
 The live preview panel utilizes an iframe to display the preview in the editor page, which requires the page in the iframe to have the `X-Frame-Options` header set to `SAMEORIGIN` (or unset). If you click a link within the preview panel, 
 you may notice that the iframe stops working. This is because the link is loaded within the iframe and the linked page may have the `X-Frame-Options` header set to `DENY`. 
-To work around this problem, Wagtail provides the `request.in_preview_panel` (also available as `in_preview_panel`) variable. Add the following `<base>` tag within your `<head>` element in your `base.html` template, before any `<link>` elements:
+To work around this problem, Wagtail provides a `request.in_preview_panel` variable, whose `in_preview_panel` attribute indicates that the page is being rendered inside the preview panel. Add the following `<base>` tag within your `<head>` element in your `base.html` template, before any `<link>` elements:
 
 ```html+django
 {% if request.in_preview_panel %}

--- a/docs/topics/writing_templates.md
+++ b/docs/topics/writing_templates.md
@@ -323,7 +323,7 @@ The user bar is also available as a [template component](template_components), w
 
 ## Varying output between preview and live
 
-Sometimes you may wish to vary the template output depending on whether the page is being previewed or viewed live. For example, if you have visitor-tracking code such as Google Analytics in place on your site, it's a good idea to leave this out when previewing, so that editor activity doesn't appear in your analytics reports. Wagtail provides a `request.is_preview` variable to distinguish between preview and live:
+Sometimes you may wish to vary the template output depending on whether the page is being previewed or viewed live. For example, if you have visitor-tracking code such as Google Analytics in place on your site, it's a good idea to leave this out when previewing, so that editor activity doesn't appear in your analytics reports. Wagtail provides the `request.is_preview` (also available as `is_preview`) variable to distinguish between preview and live:
 
 ```html+django
 {% if not request.is_preview %}
@@ -336,6 +336,22 @@ Sometimes you may wish to vary the template output depending on whether the page
 
 If the page is being previewed, `request.preview_mode` can be used to determine the specific preview mode being used,
 if the page supports [multiple preview modes](wagtail.models.AbstractPage.preview_modes).
+
+### Opening links within the live preview panel
+
+The live preview panel utilizes an iframe to display the preview in the editor page, which requires the page in the iframe to have the `X-Frame-Options` header set to `SAMEORIGIN` (or unset). If you click a link within the preview panel, 
+you may notice that the iframe stops working. This is because the link is loaded within the iframe and the linked page may have the `X-Frame-Options` header set to `DENY`. 
+To work around this problem, Wagtail provides the `request.in_preview_panel` (also available as `in_preview_panel`) variable. Add the following `<base>` tag within your `<head>` element in your `base.html` template, before any `<link>` elements:
+
+```html+django
+{% if request.in_preview_panel %}
+    <base target="_blank">
+{% endif %}
+```
+
+This will make all links in the live preview panel open in a new tab.
+
+New Wagtail projects created through the `wagtail start` command already include this change in the base template.
 
 (template_fragment_caching)=
 

--- a/docs/topics/writing_templates.md
+++ b/docs/topics/writing_templates.md
@@ -337,6 +337,8 @@ Sometimes you may wish to vary the template output depending on whether the page
 If the page is being previewed, `request.preview_mode` can be used to determine the specific preview mode being used,
 if the page supports [multiple preview modes](wagtail.models.AbstractPage.preview_modes).
 
+(custom_rendering_in_preview_panel)=
+
 ### Customizing rendering in the preview panel
 
 Wagtail provides a `request.in_preview_panel` variable to customize rendering specifically within the preview panel. The `in_preview_panel` attribute indicates that the page is being rendered inside the panel. The live preview panel uses an iframe to display the preview in the editor page. It is help for editors to configure the rendered page so links open outside of the iframe. To achieve this, add a `<base>` tag within your `<head>` element:


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #14007


### Description
This PR:

-  Adds the documentation of request.in_preview_panel that was located in the v4.0.0 release notes.

- Adds request.in_preview_panel / in_preview_panel (with and without prefix) to improve the odds of people finding the docs.

- Adds request.is_preview / is_preview (with and without prefix) to improve the odds of people finding the docs.


### AI usage

None.