### PR TITLE
Docs: use hyphens for list markers in releases/7.2.1.md

### DIFF
--- a/docs/releases/7.2.1.md
+++ b/docs/releases/7.2.1.md
@@ -21,7 +21,7 @@ depth: 1
 
 ### Maintenance
 
-* Remove use of `_WAGTAILSEARCH_FORCE_AUTO_UPDATE` in search tests (Matt Westcott)
+- Remove use of `_WAGTAILSEARCH_FORCE_AUTO_UPDATE` in search tests (Matt Westcott)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
Fixes #13310

### Description
Changed list marker from `*` to `-` in docs/releases/7.2.1.md 
under the Maintenance section for consistency.

This is part of the documentation formatting consistency 
improvements to consistently use hyphens for unordered 
lists across all documentation files.

### Changes
- docs/releases/7.2.1.md: Changed `*` to `-` for list marker 
  under Maintenance section

### AI assistance
Used Claude AI for guidance on finding the issue and 
understanding the codebase structure.