### PR TITLE
Fix forgotten password link not respecting WAGTAILUSERS_PASSWORD_RESET_ENABLED

### DIFF
--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -68,7 +68,11 @@ def email_management_enabled():
 
 def password_reset_enabled():
     return getattr(
-        settings, "WAGTAIL_PASSWORD_RESET_ENABLED", password_management_enabled()
+        settings,
+        "WAGTAILUSERS_PASSWORD_RESET_ENABLED",
+        getattr(
+            settings, "WAGTAIL_PASSWORD_RESET_ENABLED", password_management_enabled()
+        ),
     )
 
 


### PR DESCRIPTION
## Description
Fixes #14026

The `password_reset_enabled()` function only checked `WAGTAIL_PASSWORD_RESET_ENABLED` but not `WAGTAILUSERS_PASSWORD_RESET_ENABLED`. This caused the Forgotten password link to still appear even when `WAGTAILUSERS_PASSWORD_RESET_ENABLED = False`.

## Changes
Updated `password_reset_enabled()` to check `WAGTAILUSERS_PASSWORD_RESET_ENABLED` first, falling back to `WAGTAIL_PASSWORD_RESET_ENABLED`, then `password_management_enabled()`.

## Tests
All 8 existing password reset tests pass.

## AI usage
I used Claude (claude.ai) to help navigate the codebase. The fix was identified and verified by reading the source code directly. All changes were confirmed by running the existing test suite.