### PR TITLE
Add soft_min_num and soft_max_num to StreamBlock

### DIFF
--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -8,6 +8,8 @@ import { hideTooltipOnEsc } from '../../../controllers/TooltipController';
 import {
   addErrorMessages,
   removeErrorMessages,
+  addWarningMessages,
+  removeWarningMessages,
 } from '../../../includes/streamFieldErrors';
 import { setAttrs } from '../../../utils/attrs';
 import { gettext } from '../../../utils/gettext';
@@ -323,6 +325,30 @@ export class StreamBlock extends BaseSequenceBlock {
     } else {
       this.setError({});
     }
+
+    const warningMessages = [];
+
+    const softMaxNum = this.blockDef.meta.softMaxNum;
+    if (typeof softMaxNum === 'number' && this.children.length > softMaxNum) {
+      const message = gettext(
+        'The recommended maximum number of items is %(soft_max_num)d',
+      ).replace('%(soft_max_num)d', `${softMaxNum}`);
+      warningMessages.push(message);
+    }
+
+    const softMinNum = this.blockDef.meta.softMinNum;
+    if (typeof softMinNum === 'number' && this.children.length < softMinNum) {
+      const message = gettext(
+        'The recommended minimum number of items is %(soft_min_num)d',
+      ).replace('%(soft_min_num)d', `${softMinNum}`);
+      warningMessages.push(message);
+    }
+
+    if (warningMessages.length) {
+      this.setWarning({ messages: warningMessages });
+    } else {
+      this.setWarning({});
+    }
   }
 
   _createChild(
@@ -436,6 +462,18 @@ export class StreamBlock extends BaseSequenceBlock {
           this.children[blockIndex].setError(error.blockErrors[blockIndex]);
         }
       }
+    }
+  }
+
+  setWarning(warning) {
+    if (!warning) return;
+
+    // Non block warnings (messages applying to the block as a whole)
+    const container = this.container[0];
+    removeWarningMessages(container);
+
+    if (warning.messages) {
+      addWarningMessages(container, warning.messages);
     }
   }
 }

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -1208,6 +1208,186 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.min_num set', ()
   });
 });
 
+describe('telepath: wagtail.blocks.StreamBlock with softMaxNum set', () => {
+  // Define a test block
+  const blockDef = new StreamBlockDefinition(
+    '',
+    [
+      [
+        '',
+        [
+          new FieldBlockDefinition(
+            'test_block_a',
+            new DummyWidgetDefinition('Block A widget'),
+            {
+              label: 'Test Block <A>',
+              required: true,
+              icon: 'placeholder',
+              classname: 'w-field w-field--char_field w-field--text_input',
+            },
+          ),
+        ],
+      ],
+    ],
+    {
+      test_block_a: 'Block A options',
+    },
+    {
+      label: '',
+      required: true,
+      icon: 'placeholder',
+      classname: null,
+      helpText: 'use <strong>plenty</strong> of these',
+      helpIcon: '<svg></svg>',
+      maxNum: null,
+      minNum: null,
+      blockCounts: {},
+      softMaxNum: 2,
+      softMinNum: null,
+    },
+  );
+
+  const assertShowingWarningMessage = () => {
+    expect(
+      document.querySelector('p.help-block.help-warning').innerHTML,
+    ).toBe('The recommended maximum number of items is 2');
+  };
+
+  const assertNotShowingWarningMessage = () => {
+    expect(document.querySelector('p.help-block.help-warning')).toBe(null);
+  };
+
+  test('test no warning message when at soft limit', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    blockDef.render($('#placeholder'), 'the-prefix', [
+      { id: '1', type: 'test_block_a', value: 'First value' },
+      { id: '2', type: 'test_block_a', value: 'Second value' },
+    ]);
+    assertNotShowingWarningMessage();
+  });
+
+  test('test warning message shown when above soft limit', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    blockDef.render($('#placeholder'), 'the-prefix', [
+      { id: '1', type: 'test_block_a', value: 'First value' },
+      { id: '2', type: 'test_block_a', value: 'Second value' },
+      { id: '3', type: 'test_block_a', value: 'Third value' },
+    ]);
+    assertShowingWarningMessage();
+  });
+
+  test('inserting block above softMaxNum shows warning message', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      { id: '1', type: 'test_block_a', value: 'First value' },
+      { id: '2', type: 'test_block_a', value: 'Second value' },
+    ]);
+    assertNotShowingWarningMessage();
+    boundBlock.insert({ id: '3', type: 'test_block_a', value: 'Third value' }, 2);
+    assertShowingWarningMessage();
+  });
+
+  test('deleting block to get back to softMaxNum removes warning message', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      { id: '1', type: 'test_block_a', value: 'First value' },
+      { id: '2', type: 'test_block_a', value: 'Second value' },
+      { id: '3', type: 'test_block_a', value: 'Third value' },
+    ]);
+    assertShowingWarningMessage();
+    boundBlock.deleteBlock(2);
+    assertNotShowingWarningMessage();
+  });
+});
+
+describe('telepath: wagtail.blocks.StreamBlock with softMinNum set', () => {
+  // Define a test block
+  const blockDef = new StreamBlockDefinition(
+    '',
+    [
+      [
+        '',
+        [
+          new FieldBlockDefinition(
+            'test_block_a',
+            new DummyWidgetDefinition('Block A widget'),
+            {
+              label: 'Test Block <A>',
+              required: true,
+              icon: 'placeholder',
+              classname: 'w-field w-field--char_field w-field--text_input',
+            },
+          ),
+        ],
+      ],
+    ],
+    {
+      test_block_a: 'Block A options',
+    },
+    {
+      label: '',
+      required: true,
+      icon: 'placeholder',
+      classname: null,
+      helpText: 'use <strong>plenty</strong> of these',
+      helpIcon: '<svg></svg>',
+      maxNum: null,
+      minNum: null,
+      blockCounts: {},
+      softMaxNum: null,
+      softMinNum: 2,
+    },
+  );
+
+  const assertShowingWarningMessage = () => {
+    expect(
+      document.querySelector('p.help-block.help-warning').innerHTML,
+    ).toBe('The recommended minimum number of items is 2');
+  };
+
+  const assertNotShowingWarningMessage = () => {
+    expect(document.querySelector('p.help-block.help-warning')).toBe(null);
+  };
+
+  test('test warning message shown when below soft limit', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    blockDef.render($('#placeholder'), 'the-prefix', [
+      { id: '1', type: 'test_block_a', value: 'First value' },
+    ]);
+    assertShowingWarningMessage();
+  });
+
+  test('test no warning message when at soft limit', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    blockDef.render($('#placeholder'), 'the-prefix', [
+      { id: '1', type: 'test_block_a', value: 'First value' },
+      { id: '2', type: 'test_block_a', value: 'Second value' },
+    ]);
+    assertNotShowingWarningMessage();
+  });
+
+  test('inserting block to reach softMinNum removes warning message', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      { id: '1', type: 'test_block_a', value: 'First value' },
+    ]);
+    assertShowingWarningMessage();
+    boundBlock.insert({ id: '2', type: 'test_block_a', value: 'Second value' }, 1);
+    assertNotShowingWarningMessage();
+  });
+
+  test('deleting block below softMinNum shows warning message', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      { id: '1', type: 'test_block_a', value: 'First value' },
+      { id: '2', type: 'test_block_a', value: 'Second value' },
+    ]);
+    assertNotShowingWarningMessage();
+    boundBlock.deleteBlock(1);
+    assertShowingWarningMessage();
+  });
+});
+
 describe('telepath: wagtail.blocks.StreamBlock with unique block type', () => {
   let boundBlock;
 

--- a/client/src/includes/streamFieldErrors.js
+++ b/client/src/includes/streamFieldErrors.js
@@ -16,4 +16,25 @@ const addErrorMessages = (container, messages) => {
   });
 };
 
-export { addErrorMessages, removeErrorMessages };
+const removeWarningMessages = (container) => {
+  container
+    .querySelectorAll(':scope > .help-block.help-warning')
+    .forEach((element) => element.remove());
+};
+
+const addWarningMessages = (container, messages) => {
+  messages.forEach((message) => {
+    const warningElement = document.createElement('p');
+    warningElement.classList.add('help-block');
+    warningElement.classList.add('help-warning');
+    warningElement.innerHTML = h(message);
+    container.insertBefore(warningElement, container.childNodes[0]);
+  });
+};
+
+export {
+  addErrorMessages,
+  removeErrorMessages,
+  addWarningMessages,
+  removeWarningMessages,
+};

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -478,6 +478,8 @@ class BaseStreamBlock(Block):
         max_num = None
         block_counts = {}
         collapsed = False
+        soft_min_num = None
+        soft_max_num = None
 
     MUTABLE_META_ATTRIBUTES = [
         "required",
@@ -485,6 +487,8 @@ class BaseStreamBlock(Block):
         "max_num",
         "block_counts",
         "collapsed",
+        "soft_min_num",
+        "soft_max_num",
     ]
 
 
@@ -845,6 +849,8 @@ class StreamBlockAdapter(Adapter):
             "minNum": block.meta.min_num,
             "blockCounts": block.meta.block_counts,
             "collapsed": block.meta.collapsed,
+            "softMinNum": block.meta.soft_min_num,
+            "softMaxNum": block.meta.soft_max_num,
         }
         help_text = getattr(block.meta, "help_text", None)
         if help_text:

--- a/wagtail/fields.py
+++ b/wagtail/fields.py
@@ -123,7 +123,7 @@ class StreamField(models.Field):
 
         # extract kwargs that are to be passed on to the block, not handled by super
         self.block_opts = {}
-        for arg in ["min_num", "max_num", "block_counts", "collapsed"]:
+        for arg in ["min_num", "max_num", "block_counts", "collapsed", "soft_min_num", "soft_max_num"]:
             if arg in kwargs:
                 self.block_opts[arg] = kwargs.pop(arg)
 

--- a/wagtail/tests/test_streamfield.py
+++ b/wagtail/tests/test_streamfield.py
@@ -766,6 +766,29 @@ class TestStreamFieldCountValidation(TestCase):
         self.assertIsNone(field.stream_block.meta.max_num)
         self.assertIsNone(field.stream_block.meta.block_counts)
 
+    def test_streamfield_soft_count_argument_precedence(self):
+        class TestStreamBlock(blocks.StreamBlock):
+            heading = blocks.CharBlock()
+
+            class Meta:
+                soft_min_num = 2
+                soft_max_num = 5
+
+        # args being picked up from the class definition
+        field = StreamField(TestStreamBlock)
+        self.assertEqual(field.stream_block.meta.soft_min_num, 2)
+        self.assertEqual(field.stream_block.meta.soft_max_num, 5)
+
+        # args being overridden by StreamField
+        field = StreamField(TestStreamBlock, soft_min_num=3, soft_max_num=6)
+        self.assertEqual(field.stream_block.meta.soft_min_num, 3)
+        self.assertEqual(field.stream_block.meta.soft_max_num, 6)
+
+        # passing None from StreamField should cancel soft limits set at the block level
+        field = StreamField(TestStreamBlock, soft_min_num=None, soft_max_num=None)
+        self.assertIsNone(field.stream_block.meta.soft_min_num)
+        self.assertIsNone(field.stream_block.meta.soft_max_num)
+
 
 class TestJSONStreamField(TestCase):
     @classmethod


### PR DESCRIPTION
Fixes #13962

## Description

This PR adds `soft_min_num` and `soft_max_num` to `StreamBlock`. It nudges editors toward a sensible range of blocks without hard blocking them. These soft limits show a yellow warning when editors go over or under, but they can still save.

* Added `soft_min_num` and `soft_max_num` to `StreamBlock.Meta` and `MUTABLE_META_ATTRIBUTES`
* Extended `StreamField` to accept them as kwargs, same way `min_num`/`max_num` works
* Added `addWarningMessages`/`removeWarningMessages` helpers in `streamFieldErrors.js`
* Wired up the real-time warning logic in `blockCountChanged()` so the warning shows and clears as blocks are added/removed
* Added a `setWarning()` method on `StreamBlock` to keep warning state separate from error state

## Testing

* Added JS unit tests for both `softMaxNum` and `softMinNum`, all 41 StreamBlock tests pass
* Added Python tests to verify the config flows correctly from `StreamField` down to `StreamBlock.meta`
* Tested in Wagtail Bakery demo, yellow warning shows up when you go over/under the soft limits and the page still saves fine

## AI usage

Used Claude to explore the codebase and understand how `min_num`/`max_num` was implemented

All code tested and verified by me.