### PR TITLE
Wrap page type name and description in container to ensure alignment

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ Changelog
  * Fix: Correctly HTML-escape URL in photo type oembeds (Thibaud Colas)
  * Fix: Ensure user with appropriate permissions can cancel a workflow task (Dan Braghis)
  * Fix: Ensure "submit to workflow" menu item uses the workflow name when creating pages (Sage Abdullah)
+ * Fix: Better align page descriptions in add subpage views (Tibor Leupold)
  * Docs: Add documentation for the `filter_spec` parameter of `ImageRenditionField` (Soumya-codr)
  * Docs: Add guide for testing document upload forms (Wenli Tsai, Bhavesh Sharma)
  * Docs: Document the `nested_default_fields` attribute on API viewsets (Deepanshu Tevathiya)

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -77,6 +77,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Correctly HTML-escape URL in photo type oembeds (Thibaud Colas)
  * Ensure user with appropriate permissions can cancel a workflow task (Dan Braghis)
  * Ensure "submit to workflow" menu item uses the workflow name when creating pages (Sage Abdullah)
+ * Better align page descriptions in add subpage views (Tibor Leupold)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
@@ -20,12 +20,16 @@
                     <li>
                         <div class="row row-flush">
                             <div class="col8">
-                                <a href="{% url 'wagtailadmin_pages:add' app_label model_name parent_page.id %}{% if next %}?next={{ next }}{% endif %}">
-                                    {% icon name="plus-inverse" classname="default w-mr-1 w-align-middle" %}
-                                    {{ verbose_name }}
-                                    {% if page_description %}
-                                        <div><span class="w-sr-only">.</span><small>{{ page_description }}</small></div>
-                                    {% endif %}
+                                <a class="w-flex" href="{% url 'wagtailadmin_pages:add' app_label model_name parent_page.id %}{% if next %}?next={{ next }}{% endif %}">
+                                    {% icon name="plus-inverse" classname="default w-shrink-0" %}
+
+                                    <div class="w-ml-2">
+                                        {{ verbose_name }}
+
+                                        {% if page_description %}
+                                            <div class="w-inline-block"><span class="w-sr-only">.</span><small>{{ page_description }}</small></div>
+                                        {% endif %}
+                                    </div>
                                 </a>
                             </div>
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #14035

### Description

<!-- Please describe the problem you're fixing. -->
When a page has a description, then the page description and the page name did not align horizontally, because the page name is preceeded by an icon. 

This PR wraps the title and description in one `div` to ensure they share the same inline starting edge. 

The page type name and the icon still align vertically. 


**Before**

<img width="300" alt="Wagtail's 'add subpage screen' before the fix showing unaligned page name and description." src="https://github.com/user-attachments/assets/8d11113d-a4da-4830-ad9d-a7e19766b628" />


**After**

<img width="300" alt="Wagtail's 'add subpage screen' after the fix showing aligned page name and description." src="https://github.com/user-attachments/assets/e4c6ff76-03a4-4ebd-92bb-7ad5b85eea32" />


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None. 