### PR TITLE
Use POST instead of DELETE in Cloudflare Frontend Cache Backend

### DIFF
--- a/wagtail/contrib/frontend_cache/backends/cloudflare.py
+++ b/wagtail/contrib/frontend_cache/backends/cloudflare.py
@@ -64,7 +64,7 @@ class CloudflareBackend(BaseBackend):
 
             data = {"files": urls}
 
-            response = requests.delete(
+            response = requests.post(
                 purge_url,
                 json=data,
                 headers=headers,

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -820,8 +820,8 @@ class TestPurgeBatchClass(TestCase):
             },
         )
 
-    @mock.patch("wagtail.contrib.frontend_cache.backends.cloudflare.requests.delete")
-    def test_http_error_on_cloudflare_purge_batch(self, requests_delete_mock):
+    @mock.patch("wagtail.contrib.frontend_cache.backends.cloudflare.requests.post")
+    def test_http_error_on_cloudflare_purge_batch(self, requests_post_mock):
         backend_settings = {
             "cloudflare": {
                 "BACKEND": "wagtail.contrib.frontend_cache.backends.CloudflareBackend",
@@ -838,7 +838,7 @@ class TestPurgeBatchClass(TestCase):
         http_error = requests.exceptions.HTTPError(
             response=MockResponse(status_code=500)
         )
-        requests_delete_mock.side_effect = http_error
+        requests_post_mock.side_effect = http_error
 
         batch = PurgeBatch()
         batch.add_url("http://localhost/events/")


### PR DESCRIPTION
Cloudflare's documentation for this endpoint now only lists `POST` as a valid request method (ref. https://developers.cloudflare.com/api/resources/cache/).

While `DELETE` appears to still work, in testing, I found that Cloudflare's audit logging tool does not record cache purge requests made using `DELETE` requests, but does using `POST` requests.

### AI usage

AI was not used for this PR
