### PR TITLE
Stop advertising GPG key for security email

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ Wagtail is sponsored by [Torchbox](https://torchbox.com/). If you need help impl
 
 We take the security of Wagtail, and related packages we maintain, seriously. If you have found a security issue with any of our projects please email us at [security@wagtail.org](mailto:security@wagtail.org) so we can work together to find and patch the issue. We appreciate responsible disclosure with any security related issues, so please contact us first before creating a GitHub issue.
 
-If you want to send an encrypted email (optional), the public key ID for security@wagtail.org is 0xbed227b4daf93ff9, and this public key is available from most commonly-used keyservers.
-
 ### 🕒 Release schedule
 
 Feature releases of Wagtail are released every three months. Selected releases are designated as Long Term Support (LTS) releases, and will receive maintenance updates for an extended period to address any security and data-loss related issues. For dates of past and upcoming releases and support periods, see [Release Schedule](https://github.com/wagtail/wagtail/wiki/Release-schedule).

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -15,8 +15,6 @@ Mail sent to that address reaches a subset of the core team, who can forward sec
 
 Once you've submitted an issue via email, you should receive an acknowledgment from a member of the security team within 48 hours, and depending on the action to be taken, you may receive further followup emails.
 
-If you want to send an encrypted email (optional), the public key ID for <security@wagtail.org> is `0xbed227b4daf93ff9`, and this public key is available from most commonly-used keyservers.
-
 This information can also be found in our [security.txt](https://wagtail.org/.well-known/security.txt).
 
 Django security issues should be reported directly to the Django Project, following [Django's security policies](inv:django#internals/security) (upon which Wagtail's own policies are based).


### PR DESCRIPTION
### Description

The security team have decided that the drawbacks of advertising and maintaining a GPG key for security reports is not worth the effort. Since the current one has expired, we will not be renewing it and instead opting for a GPG-less existence.

### AI usage

None