### PR TITLE
Combine site history querysets more efficiently (#14041)

### DIFF
--- a/wagtail/admin/views/reports/audit_logging.py
+++ b/wagtail/admin/views/reports/audit_logging.py
@@ -154,7 +154,9 @@ class LogEntriesView(ReportView):
             if queryset is None:
                 queryset = sub_queryset
             else:
-                queryset = queryset.union(sub_queryset)
+                # The log_model_index value makes duplicate rows impossible across the subqueries,
+                # so we pass all=True to union() to avoid unnecessary deduplication overhead.
+                queryset = queryset.union(sub_queryset, all=True)
 
         return queryset.order_by("-timestamp")
 


### PR DESCRIPTION
Fixes #14041 

### Description

The site history report (_/admin/reports/site-history/_) uses `union()` to combine querysets from multiple models (e.g. `PageLogEntry` and `ModelLogEntry`).

By default `union()` enforces distinctness, which requires significant processing overhead for sorting etc. when handling large numbers of records. This overhead's also unnecessary since duplicates aren't possible here, due to the distinct `log_model_index` value added as an annotation to each sub-queryset.

This PR changes the call to `union()` to pass it the `all=True` argument. This skips the unnecessary deduplication, eliminating that processing overhead.

### AI usage

This issue and fix were identified with the assistance of Claude AI & Claude Code.