### PR TITLE
Fix formatting in Jinja2 image() example

### DIFF
--- a/docs/reference/jinja2.md
+++ b/docs/reference/jinja2.md
@@ -79,7 +79,7 @@ Resize an image, and render an `<img>` tag:
 Or resize an image and retrieve the resized image object (rendition) for more bespoke use:
 
 ```html+jinja
-{% set background=image(page.background_image, "max-1024x1024") %}
+{% set background = image(page.background_image, "max-1024x1024") %}
 <div class="wrapper" style="background-image: url({{ background.url }});"></div>
 ```
 


### PR DESCRIPTION
Fixes #13715

### Description

This PR improves the formatting of the Jinja2 `image()` example in the documentation.

Specifically, it adds spacing around the assignment operator in the `{% set %}` statement to improve readability and maintain consistency with standard Jinja2 formatting conventions.

Before:
{% set background=image(page.background_image, "max-1024x1024") %}

After:
{% set background = image(page.background_image, "max-1024x1024") %}

### AI usage

Used ChatGPT for drafting the PR description.