### PR TITLE
Introduce PageViewSet to allow custom explorer views per page type

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Changelog
  * Preserve "Collapse all" button state when switching between editor tabs (Raghad Dahi)
  * Upgrade modelsearch to 1.3 (Matt Westcott)
  * Implement checker error highlights within the preview panel (Thibaud Colas)
+ * Add support for customizing page explorer views per page type using `PageViewSet` (Sage Abdullah)
  * Fix: Handle nested inline models when displaying object usage information (Sage Abdullah, Kacper Walęga, Tian Jie Wong)
  * Fix: Avoid duplicate `get_object()` DB query in API detail view (Siddheshwar Kadam)
  * Fix: Ensure `ImageBlock` alt text populates on choosing a new image after unchecking decorative state (Pratham Jaiswal)

--- a/docs/advanced_topics/customization/custom_page_listings.md
+++ b/docs/advanced_topics/customization/custom_page_listings.md
@@ -1,6 +1,96 @@
 (custom_page_listings)=
 
-# Custom page listings
+# Customizing page listings
+
+(custom_page_explorer_listings)=
+
+## Customizing the page explorer
+
+```{versionadded} 7.4
+The ability to customize the page explorer listing was added.
+```
+
+The page explorer is the default listing of pages in the Wagtail admin, where editors can navigate through the structure of the page tree. The pages in the tree can be of different types, thus only a limited set of fields common to all pages are available for display, filtering, and ordering. Wagtail provides a default set of columns and filters for the page explorer, but you may want to customize them to cater to your editors' needs.
+
+To customize the default page explorer listing, create a subclass of {class}`~wagtail.admin.viewsets.pages.PageViewSet` and register it using the [`register_admin_viewset`](register_admin_viewset) hook. For example, to add a column for the `slug` field on all page listings, you could add the following definitions to a `wagtail_hooks.py` file within the app:
+
+```python
+# myapp/wagtail_hooks.py
+from wagtail import hooks
+from wagtail.admin.ui.tables import Column
+from wagtail.admin.viewsets.pages import PageViewSet
+from wagtail.models import Page
+
+
+class CustomPageViewSet(PageViewSet):
+    columns = PageViewSet.columns.copy()
+    # Last column before the "Explore child pages" button column
+    columns.insert(-1, Column("slug", label="Slug", sort_key="slug"))
+
+
+custom_page_viewset = CustomPageViewSet()
+@hooks.register("register_admin_viewset")
+def register_custom_page_viewset():
+    return custom_page_viewset
+```
+
+The filtering options for the listing can be customized by overriding the `filterset_class` attribute on the viewset. For example, you could add a filter for the `slug` field as follows:
+
+```python
+from wagtail import hooks
+from wagtail.admin.viewsets.pages import PageViewSet
+from wagtail.models import Page
+
+
+class CustomPageFilterSet(PageViewSet.filterset_class):
+    class Meta:
+        model = Page
+        fields = ["slug"]
+
+
+class CustomPageViewSet(PageViewSet):
+    # ...
+    filterset_class = CustomPageFilterSet
+```
+
+For some page types, you may have enforced that only a single page type can be created under a given parent page. For example, your site may implement a `BlogIndexPage` model with its {attr}`~wagtail.models.Page.subpage_types` set to only allow `BlogPage` instances under it. With the listing limited to `BlogPage` instances, you can display, filter, and order on additional fields specific to `BlogPage` when viewing the children of a `BlogIndexPage`.
+
+To customize the page explorer listing for a given parent page, set the `model` and `parent_models` attributes on a custom `PageViewSet` subclass. The following is an example of a custom viewset that adds a column and a filter for the `blog_category` field on the listing of `BlogPage` instances under a `BlogIndexPage`:
+
+```python
+# myapp/wagtail_hooks.py
+from wagtail import hooks
+from wagtail.admin.ui.tables import Column
+from wagtail.admin.viewsets.pages import PageViewSet
+
+from myapp.models import BlogIndexPage, BlogPage
+
+
+class BlogPageFilterSet(PageViewSet.filterset_class):
+    class Meta:
+        model = BlogPage
+        fields = ["blog_category"]
+
+
+class BlogPageViewSet(PageViewSet):
+    model = BlogPage
+    parent_models = [BlogIndexPage]
+    columns = PageViewSet.columns.copy()
+    columns.insert(-1, Column("blog_category", label="Category", sort_key="blog_category"))
+    filterset_class = BlogPageFilterSet
+
+
+blog_page_viewset = BlogPageViewSet()
+@hooks.register("register_admin_viewset")
+def register_blog_page_viewset():
+    return blog_page_viewset
+```
+
+Various other options are available for customizing the page explorer listing, such as the `list_per_page` attribute to control how many items are shown per page, and the `ordering` attribute to control the default ordering of items in the listing. See the documentation for {class}`~wagtail.admin.viewsets.pages.PageViewSet` for more details.
+
+(custom_flat_page_listings)=
+
+## Custom flat page listings
 
 Normally, editors navigate through the Wagtail admin interface by following the structure of the page tree. However, this can make it slow to locate a specific page for editing, especially on large sites where pages are organised into a deep hierarchy.
 

--- a/docs/extending/template_components.md
+++ b/docs/extending/template_components.md
@@ -101,6 +101,8 @@ class WelcomePanel(Component):
         }
 ```
 
+(using_template_components_in_templates)=
+
 ## Using components on your own templates
 
 The `wagtailadmin_tags` tag library provides a `{% component %}` tag for including components on a template. This takes care of passing context variables from the calling template to the component (which would not be the case for a basic `{{ ... }}` variable tag). For example, given the view:

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -233,12 +233,50 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
 
 ## PageListingViewSet
 
+```{versionadded} 7.4
+Support for `list_display`, `list_filter`, `list_per_page`, `list_export`, `export_headings` and `export_filename` was added to `PageListingViewSet`.
+```
+
 ```{eval-rst}
 .. autoclass:: wagtail.admin.viewsets.pages.PageListingViewSet
 
    .. autoattribute:: model
    .. autoattribute:: index_view_class
    .. autoattribute:: choose_parent_view_class
+   .. autoattribute:: list_display
    .. autoattribute:: columns
+
+      A list of ``wagtail.admin.ui.tables.Column`` instances for the columns in the listing.
+      This takes priority over :attr:`list_display` if both are defined.
+   .. autoattribute:: list_filter
    .. autoattribute:: filterset_class
+   .. autoattribute:: list_per_page
+   .. autoattribute:: list_export
+   .. autoattribute:: export_headings
+   .. autoattribute:: export_filename
+```
+
+## PageViewSet
+
+```{versionadded} 7.4
+The `PageViewSet` class was added.
+```
+
+```{eval-rst}
+.. autoclass:: wagtail.admin.viewsets.pages.PageViewSet
+
+   .. autoattribute:: model
+   .. autoattribute:: parent_models
+   .. autoattribute:: index_view_class
+   .. autoattribute:: list_display
+   .. autoattribute:: columns
+
+      A list of ``wagtail.admin.ui.tables.Column`` instances for the columns in the listing.
+      This takes priority over :attr:`list_display` if both are defined.
+   .. autoattribute:: list_filter
+   .. autoattribute:: filterset_class
+   .. autoattribute:: list_per_page
+   .. autoattribute:: list_export
+   .. autoattribute:: export_headings
+   .. autoattribute:: export_filename
 ```

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -14,6 +14,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
 .. autoclass:: wagtail.admin.viewsets.base.ViewSet
 
    .. autoattribute:: UNDEFINED
+      :no-value:
    .. autoattribute:: name
    .. autoattribute:: url_prefix
    .. autoattribute:: url_namespace
@@ -90,7 +91,6 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: pk_path_converter
    .. autoattribute:: ordering
    .. autoattribute:: sort_order_field
-      :annotation: = UNDEFINED
    .. autoattribute:: list_per_page
    .. autoattribute:: list_display
    

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -93,6 +93,13 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
       :annotation: = UNDEFINED
    .. autoattribute:: list_per_page
    .. autoattribute:: list_display
+   
+        This list will be passed to the ``list_display`` attribute of the index
+        view. If left unset, the ``list_display`` attribute of the index view
+        will be used instead, which by default is defined as
+        ``["__str__", wagtail.admin.ui.tables.LocaleColumn(), wagtail.admin.ui.tables.UpdatedAtColumn()]``.
+    
+        Note that the ``LocaleColumn`` is only included if the model is translatable.
    .. autoattribute:: list_export
    .. autoattribute:: list_filter
    .. autoattribute:: filterset_class

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -245,9 +245,6 @@ Support for `list_display`, `list_filter`, `list_per_page`, `list_export`, `expo
    .. autoattribute:: choose_parent_view_class
    .. autoattribute:: list_display
    .. autoattribute:: columns
-
-      A list of ``wagtail.admin.ui.tables.Column`` instances for the columns in the listing.
-      This takes priority over :attr:`list_display` if both are defined.
    .. autoattribute:: list_filter
    .. autoattribute:: filterset_class
    .. autoattribute:: list_per_page
@@ -270,9 +267,6 @@ The `PageViewSet` class was added.
    .. autoattribute:: index_view_class
    .. autoattribute:: list_display
    .. autoattribute:: columns
-
-      A list of ``wagtail.admin.ui.tables.Column`` instances for the columns in the listing.
-      This takes priority over :attr:`list_display` if both are defined.
    .. autoattribute:: list_filter
    .. autoattribute:: filterset_class
    .. autoattribute:: list_per_page

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -42,7 +42,7 @@ This feature was developed by Ben Enright and Thibaud Colas.
 
 ### Custom per-page-type listings
 
-A new viewset class `PageListingViewSet` has been introduced, allowing developers to create custom page listings for specific page types similar to those previously provided by the Modeladmin package - see [](custom_page_listings). This feature was developed by Matt Westcott.
+A new viewset class `PageListingViewSet` has been introduced, allowing developers to create custom page listings for specific page types similar to those previously provided by the Modeladmin package - see [](custom_flat_page_listings). This feature was developed by Matt Westcott.
 
 ### Keyboard shortcuts overview
 

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -151,3 +151,9 @@ Django 4.2 is no longer supported as of this release; please upgrade to Django 5
 The userbar `AccessibilityItem` has been renamed to {class}`~wagtail.admin.userbar.ContentCheckerItem`, to better signify its use for all types of content checks. The public API is identical aside from the renaming. Internals have also been renamed to use more appropriate terminology.
 
 ## Upgrade considerations - changes to undocumented internals
+
+### Deprecation of the `{% page_header_buttons %}` template tag
+
+The undocumented `{% page_header_buttons %}` template tag and its corresponding `wagtailadmin/pages/listing/_page_header_buttons.html` template have been deprecated and will be removed in a future release. If you made use of them in your templates, consider using the documented [`register_page_header_buttons`](register_page_header_buttons) hook, or overriding `header_more_buttons` and/or `header_buttons` in your custom page view instead. Alternatively, use the `wagtail.admin.ui.menus.pages.get_page_header_buttons` function to get the buttons, and render them as [template components](using_template_components_in_templates) inside a [dropdown menu](ui_components) instead.
+
+Using the `{% page_header_buttons %}` template tag and its template will continue to work for now, but will raise a deprecation warning.

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -33,6 +33,12 @@ The preview feature has been improved to be more compatible with projects that u
 
 This feature was developed by Sage Abdullah. We would like to thank Personalkollen for their sponsorship of this feature.
 
+### Customizable page explorer
+
+The page explorer can now be customized for each page type using the {class}`~wagtail.admin.viewsets.pages.PageViewSet`. This allows you to add custom columns, filters, and more based on the parent page. For more details, refer to [](custom_page_explorer_listings).
+
+This feature was developed by Sage Abdullah.
+
 ### Search enhancements
 
 The [Django Modelsearch](https://django-modelsearch.readthedocs.io/) library has been upgraded to version 1.3, bringing enhancements including support for fuzzy search on PostgreSQL, searching and filtering across related fields to any level of nesting, and ranking of results on SQLite.

--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -64,7 +64,7 @@
 
         {% block footer %}
             <footer class="footer w-grid md:w-grid-flow-col">
-                <nav class="actions actions--primary footer__container" aria-label="{% trans 'Actions' %}">
+                <nav class="actions actions--primary footer__container" aria-label="{% trans 'Actions (footer)' %}">
                     {% block actions %}
                         {% fragment as main_action %}
                             {% block main_action %}

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -8,7 +8,7 @@
     {% get_comments_enabled as comments_enabled %}
     {% page_permissions page as page_perms %}
 
-    {% include 'wagtailadmin/shared/headers/page_edit_header.html' with title=header_title %}
+    {% include 'wagtailadmin/shared/headers/page_edit_header.html' with title=header_title buttons=header_buttons %}
 
     {% block form %}
 

--- a/wagtail/admin/templates/wagtailadmin/pages/edit_partials.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit_partials.html
@@ -5,15 +5,5 @@
     {% page_breadcrumbs page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' %}
 {% endblock %}
 
-{% block header_buttons %}
-    {% if hydrate_create_view %}
-        {% fragment as actions %}
-            {% page_header_buttons page user=request.user view_name="edit" %}
-        {% endfragment %}
-
-        {% include "wagtailadmin/shared/headers/_actions.html" with actions=actions %}
-    {% endif %}
-{% endblock %}
-
 {# For pages, the title "heading" is the editable title field. #}
 {% block form_title_heading %}{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/explorable_index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/explorable_index.html
@@ -4,7 +4,7 @@
 
 {% block header %}
     {% page_permissions parent_page as parent_page_perms %}
-    {% include 'wagtailadmin/pages/page_listing_header.html' with title=header_title search_url=index_results_url page_perms=parent_page_perms %}
+    {% include 'wagtailadmin/pages/page_listing_header.html' with title=header_title search_url=index_results_url page_perms=parent_page_perms buttons=header_buttons %}
 {% endblock %}
 
 {% block extra_js %}

--- a/wagtail/admin/templates/wagtailadmin/pages/explorable_index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/explorable_index_results.html
@@ -1,15 +1,6 @@
 {% extends "wagtailadmin/pages/index_results.html" %}
 {% load wagtailadmin_tags i18n %}
 
-{% block filter_partials %}
-    {% comment %}
-        The explorable index view does not follow the generic mechanism for rendering the header buttons.
-        It also does not have any header buttons that need re-rendering, so don't render the fragment
-        to avoid overwriting the existing buttons with a blank fragment.
-    {% endcomment %}
-    {% include "wagtailadmin/shared/listing/filter_partials.html" with render_buttons_fragment=False %}
-{% endblock %}
-
 {% block before_results %}
     {% if not is_searching and not is_filtering %}
         {% comment %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
@@ -5,7 +5,7 @@
     {% if result_scope == "whole_tree" %}
         {% if items_count %}
             {% blocktranslate trimmed with start_index=start_index|intcomma end_index=end_index|intcomma items_count=items_count|intcomma %}
-                {{ start_index }}-{{ end_index }} of {{ items_count }} across entire site.
+                {{ start_index }}-{{ end_index }} of {{ items_count }} {{ verbose_name_plural }} across entire site.
             {% endblocktranslate %}
         {% else %}
             {% blocktranslate trimmed %}
@@ -18,7 +18,7 @@
     {% elif result_scope == "parent" %}
         {% if items_count %}
             {% blocktranslate trimmed with title=parent_page.get_admin_display_title start_index=start_index|intcomma end_index=end_index|intcomma items_count=items_count|intcomma %}
-                {{ start_index }}-{{ end_index }} of {{ items_count }} in '<span class="w-title-ellipsis">{{ title }}</span>'.
+                {{ start_index }}-{{ end_index }} of {{ items_count }} {{ verbose_name_plural }} in '<span class="w-title-ellipsis">{{ title }}</span>'.
             {% endblocktranslate %}
         {% else %}
             {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}
@@ -30,7 +30,7 @@
         </a>
     {% else %}
         {% blocktranslate trimmed with start_index=start_index|intcomma end_index=end_index|intcomma items_count=items_count|intcomma %}
-            {{ start_index }}-{{ end_index }} of {{ items_count }}
+            {{ start_index }}-{{ end_index }} of {{ items_count }} {{ verbose_name_plural }}
         {% endblocktranslate %}
     {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_column_header.html
@@ -5,7 +5,7 @@
     {% if result_scope == "whole_tree" %}
         {% if items_count %}
             {% blocktranslate trimmed with start_index=start_index|intcomma end_index=end_index|intcomma items_count=items_count|intcomma %}
-                {{ start_index }}-{{ end_index }} of {{ items_count }} {{ verbose_name_plural }} across entire site.
+                {{ start_index }}-{{ end_index }} of {{ items_count }} {{ model_name }} across entire site.
             {% endblocktranslate %}
         {% else %}
             {% blocktranslate trimmed %}
@@ -18,7 +18,7 @@
     {% elif result_scope == "parent" %}
         {% if items_count %}
             {% blocktranslate trimmed with title=parent_page.get_admin_display_title start_index=start_index|intcomma end_index=end_index|intcomma items_count=items_count|intcomma %}
-                {{ start_index }}-{{ end_index }} of {{ items_count }} {{ verbose_name_plural }} in '<span class="w-title-ellipsis">{{ title }}</span>'.
+                {{ start_index }}-{{ end_index }} of {{ items_count }} {{ model_name }} in '<span class="w-title-ellipsis">{{ title }}</span>'.
             {% endblocktranslate %}
         {% else %}
             {% blocktranslate trimmed with title=parent_page.get_admin_display_title %}
@@ -30,7 +30,7 @@
         </a>
     {% else %}
         {% blocktranslate trimmed with start_index=start_index|intcomma end_index=end_index|intcomma items_count=items_count|intcomma %}
-            {{ start_index }}-{{ end_index }} of {{ items_count }} {{ verbose_name_plural }}
+            {{ start_index }}-{{ end_index }} of {{ items_count }} {{ model_name }}
         {% endblocktranslate %}
     {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
@@ -3,7 +3,7 @@
 
 {% block breadcrumbs %}
     {# breadcrumbs #}
-    {% page_breadcrumbs parent_page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' %}
+    {% page_breadcrumbs parent_page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' icon_name=header_icon %}
 {% endblock %}
 
 {% block actions %}

--- a/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
@@ -6,17 +6,6 @@
     {% page_breadcrumbs parent_page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' icon_name=header_icon %}
 {% endblock %}
 
-{% block actions %}
-    {% page_permissions parent_page as parent_page_perms %}
-    {% if parent_page_perms.can_add_subpage %}
-        {% trans 'Add child page' as add_child_page_str %}
-        {# Keep this in sync with the styles of HeaderButton. #}
-        <a href="{% url "wagtailadmin_pages:add_subpage" parent_page.id %}" class="w-header-button button" data-controller="w-tooltip" data-w-tooltip-content-value="{{ add_child_page_str }}" aria-label="{{ add_child_page_str }}">{% icon name="plus" %}</a>
-    {% endif %}
-
-    {# Page actions dropdown #}
-    {% page_header_buttons parent_page user=request.user view_name="index" %}
-{% endblock %}
 {% block toggles %}
     {{ block.super }}
     {% include "wagtailadmin/shared/page_status_tag_new.html" with page=parent_page %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/_actions.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/_actions.html
@@ -1,5 +1,5 @@
 {# Actions divider #}
 <div class="w-w-px w-h-[30px] w-ml-auto sm:w-ml-0 w-bg-border-furniture"></div>
-<div id="w-slim-header-buttons" class="w-flex w-items-center w-ml-2.5 w-gap-1">
+<nav aria-label="Actions" id="w-slim-header-buttons" class="w-flex w-items-center w-ml-2.5 w-gap-1">
     {{ actions }}
-</div>
+</nav>

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
@@ -5,11 +5,6 @@
     {% page_breadcrumbs page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' %}
 {% endblock %}
 
-{% block actions %}
-    {# Page actions dropdown #}
-    {% page_header_buttons page user=request.user view_name="edit" %}
-{% endblock %}
-
 {% block toggles %}
     {{ block.super }}
     {% include "wagtailadmin/shared/page_status_tag_new.html" with page=page_for_status %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+import warnings
 from urllib.parse import urljoin, urlsplit
 
 from django import template
@@ -58,6 +59,7 @@ from wagtail.models import (
     PageViewRestriction,
 )
 from wagtail.users.utils import get_gravatar_url
+from wagtail.utils.deprecation import RemovedInWagtail80Warning
 
 register = template.Library()
 
@@ -478,6 +480,11 @@ def page_listing_buttons(context, page, user, next_url=None):
     "wagtailadmin/pages/listing/_page_header_buttons.html", takes_context=True
 )
 def page_header_buttons(context, page, user, view_name):
+    warnings.warn(
+        "`{% page_header_buttons %}` tag is deprecated. "
+        "Use the `register_page_header_buttons` hook instead.",
+        category=RemovedInWagtail80Warning,
+    )
     next_url = context["request"].path
     buttons = get_page_header_buttons(page, user, next_url, view_name)
     buttons.sort()

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -35,6 +35,7 @@ from wagtail.admin.staticfiles import versioned_static as versioned_static_func
 from wagtail.admin.telepath import JSContext
 from wagtail.admin.ui import sidebar
 from wagtail.admin.ui.menus import MenuItem
+from wagtail.admin.ui.menus.pages import get_page_header_buttons
 from wagtail.admin.utils import (
     get_admin_base_url,
     get_keyboard_key_labels_from_request,
@@ -478,26 +479,7 @@ def page_listing_buttons(context, page, user, next_url=None):
 )
 def page_header_buttons(context, page, user, view_name):
     next_url = context["request"].path
-    button_hooks = hooks.get_hooks("register_page_header_buttons")
-
-    hook_buttons = []
-    for hook in button_hooks:
-        hook_buttons.extend(
-            hook(page=page, user=user, next_url=next_url, view_name=view_name)
-        )
-
-    buttons = []
-    for button in hook_buttons:
-        # Allow hooks to return either Button or MenuItem instances
-        if isinstance(button, MenuItem):
-            if button.is_shown(user):
-                buttons.append(Button.from_menu_item(button))
-        elif button.show:
-            buttons.append(button)
-
-    if more_buttons := context.get("header_more_buttons"):
-        buttons.extend(more_buttons)
-
+    buttons = get_page_header_buttons(page, user, next_url, view_name)
     buttons.sort()
     attrs = {
         # Hide the dropdown when the breadcrumbs are opened or closed, which

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -495,6 +495,9 @@ def page_header_buttons(context, page, user, view_name):
         elif button.show:
             buttons.append(button)
 
+    if more_buttons := context.get("header_more_buttons"):
+        buttons.extend(more_buttons)
+
     buttons.sort()
     attrs = {
         # Hide the dropdown when the breadcrumbs are opened or closed, which

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -667,7 +667,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         )
         self.assertIsNotNone(breadcrumbs)
         # Should not include header buttons as they're already rendered
-        self.assertIsNone(breadcrumbs.select_one("#w-slim-header-buttons"))
+        self.assertIsNone(breadcrumbs.select_one("nav#w-slim-header-buttons"))
 
         # History link should not be included as it's already present on the page
         history_link = soup.find(
@@ -993,7 +993,7 @@ class TestPageEdit(WagtailTestUtils, TestCase):
         )
         self.assertIsNotNone(breadcrumbs)
         # Should include header buttons as they were not rendered in the create view
-        self.assertIsNotNone(breadcrumbs.select_one("#w-slim-header-buttons"))
+        self.assertIsNotNone(breadcrumbs.select_one("nav#w-slim-header-buttons"))
 
         # Should render the history link button as it wasn't rendered in the create view
         history_link = soup.find(

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -129,13 +129,38 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         )
         self.assertContains(response, f'href="{expected_new_page_copy_url}"')
 
+        # There should be a fragment to update the header buttons and it should
+        # retain the existing buttons. This is not very useful for the default
+        # view, but can be used by custom views to ensure export buttons have
+        # their URLs updated with the current filters applied.
         soup = self.get_soup(response.content)
         header_buttons = soup.select_one(
             'template[data-controller="w-teleport"]'
             '[data-w-teleport-target-value="#w-slim-header-buttons"]'
             '[data-w-teleport-mode-value="innerHTML"]'
         )
-        self.assertIsNone(header_buttons)
+        self.assertIsNotNone(header_buttons)
+        add_button = header_buttons.select_one(":is(template > a)")
+        self.assertIsNotNone(add_button)
+        self.assertEqual(
+            add_button.get("href"),
+            reverse("wagtailadmin_pages:add_subpage", args=(self.root_page.id,)),
+        )
+        self.assertEqual(add_button.get("aria-label"), "Add child page")
+        buttons = header_buttons.select('[data-w-dropdown-target="content"] a')
+        self.assertEqual(len(buttons), 7)
+        self.assertEqual(
+            [button.text.strip() for button in buttons],
+            [
+                "Edit",
+                "Move",
+                "Copy",
+                "Delete",
+                "Unpublish",
+                "History",
+                "Sort menu order",
+            ],
+        )
 
         self.assertContains(response, "1-3 of 3")
 
@@ -865,7 +890,28 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
             '[data-w-teleport-target-value="#w-slim-header-buttons"]'
             '[data-w-teleport-mode-value="innerHTML"]'
         )
-        self.assertIsNone(header_buttons)
+        self.assertIsNotNone(header_buttons)
+        add_button = header_buttons.select_one(":is(template > a)")
+        self.assertIsNotNone(add_button)
+        self.assertEqual(
+            add_button.get("href"),
+            reverse("wagtailadmin_pages:add_subpage", args=(self.root_page.id,)),
+        )
+        self.assertEqual(add_button.get("aria-label"), "Add child page")
+        buttons = header_buttons.select('[data-w-dropdown-target="content"] a')
+        self.assertEqual(len(buttons), 7)
+        self.assertEqual(
+            [button.text.strip() for button in buttons],
+            [
+                "Edit",
+                "Move",
+                "Copy",
+                "Delete",
+                "Unpublish",
+                "History",
+                "Sort menu order",
+            ],
+        )
 
     def test_filter_by_owner(self):
         barry = self.create_user(

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -682,7 +682,7 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         )
         self.assertEqual(
             title_th.get_text(strip=True, separator=" | "),
-            "Title | 1-1 of 1 pages in ' | Welcome to your new Wagtail site! | '.",
+            "Title | 1-1 of 1 page in ' | Welcome to your new Wagtail site! | '.",
         )
 
     def test_search_results(self):
@@ -736,7 +736,7 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         )
         self.assertEqual(
             title_th.get_text(strip=True, separator=" | "),
-            "Title | 1-1 of 1 pages across entire site.",
+            "Title | 1-1 of 1 page across entire site.",
         )
 
     def test_search_whole_tree_filter_by_permissions(self):

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -661,16 +661,29 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailadmin/pages/explorable_index.html")
 
     def test_search(self):
-        response = self.client.get(
-            reverse("wagtailadmin_explore", args=(self.root_page.id,)),
-            {"q": "old"},
-        )
+        url = reverse("wagtailadmin_explore", args=(self.root_page.id,))
+        response = self.client.get(url, {"q": "old"})
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/pages/explorable_index.html")
 
         page_ids = [page.id for page in response.context["pages"]]
         self.assertEqual(page_ids, [self.old_page.id])
-        self.assertContains(response, "Search the whole site")
+        soup = self.get_soup(response.content)
+        title_th = soup.select_one("main table th.title")
+        self.assertIsNotNone(title_th)
+        search_whole_tree_url = f"{url}?q=old&search_all=1"
+        search_whole_tree_link = title_th.select_one(
+            f'a[href="{search_whole_tree_url}"]'
+        )
+        self.assertIsNotNone(search_whole_tree_link)
+        self.assertHTMLEqual(
+            search_whole_tree_link.extract().decode_contents(),
+            "Search the whole site",
+        )
+        self.assertEqual(
+            title_th.get_text(strip=True, separator=" | "),
+            "Title | 1-1 of 1 pages in ' | Welcome to your new Wagtail site! | '.",
+        )
 
     def test_search_results(self):
         response = self.client.get(
@@ -706,16 +719,24 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertEqual(page_ids, [])
 
     def test_search_whole_tree(self):
-        response = self.client.get(
-            reverse("wagtailadmin_explore", args=(self.new_page.id,)),
-            {"q": "old", "search_all": "1"},
-        )
+        url = reverse("wagtailadmin_explore", args=(self.new_page.id,))
+        response = self.client.get(url, {"q": "old", "search_all": "1"})
         self.assertEqual(response.status_code, 200)
         page_ids = [page.id for page in response.context["pages"]]
         self.assertEqual(page_ids, [self.old_page.id])
-        self.assertContains(
-            response,
+        soup = self.get_soup(response.content)
+        title_th = soup.select_one("main table th.title")
+        self.assertIsNotNone(title_th)
+        search_in_parent_url = f"{url}?q=old"
+        search_parent_link = title_th.select_one(f'a[href="{search_in_parent_url}"]')
+        self.assertIsNotNone(search_parent_link)
+        self.assertHTMLEqual(
+            search_parent_link.extract().decode_contents(),
             "Search in '<span class=\"w-title-ellipsis\">New page (simple page)</span>'",
+        )
+        self.assertEqual(
+            title_th.get_text(strip=True, separator=" | "),
+            "Title | 1-1 of 1 pages across entire site.",
         )
 
     def test_search_whole_tree_filter_by_permissions(self):

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -1549,7 +1549,7 @@ class TestInWorkflowStatus(WagtailTestUtils, TestCase):
         # Warm up cache
         self.client.get(self.url)
 
-        with self.assertNumQueries(41):
+        with self.assertNumQueries(42):
             response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -1549,7 +1549,7 @@ class TestInWorkflowStatus(WagtailTestUtils, TestCase):
         # Warm up cache
         self.client.get(self.url)
 
-        with self.assertNumQueries(44):
+        with self.assertNumQueries(41):
             response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -1,0 +1,104 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from wagtail.test.testapp.models import EventIndex
+from wagtail.test.utils import WagtailTestUtils
+from wagtail.test.utils.template_tests import AdminTemplateTestUtils
+
+
+class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
+    fixtures = ["test.json"]
+    base_breadcrumb_items = [
+        {"url": reverse("wagtailadmin_explore_root"), "label": "Root"}
+    ]
+
+    def setUp(self):
+        self.user = self.login()
+
+    def test_get(self):
+        event_index_page = EventIndex.objects.first()
+        parent = event_index_page.get_parent()
+        url = reverse("wagtailadmin_explore", args=[event_index_page.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
+        self.assertBreadcrumbsItemsRendered(
+            [
+                {
+                    "url": reverse("wagtailadmin_explore", args=[parent.pk]),
+                    "label": str(parent),
+                },
+                {"url": url, "label": "Events"},
+            ],
+            response.content,
+        )
+
+        soup = self.get_soup(response.content)
+
+        table = soup.select_one("main table")
+        for dropdown in table.select("[data-controller='w-dropdown']"):
+            dropdown.extract()
+        trs = table.select("tbody tr")
+        tds = [
+            [td.get_text(strip=True, separator=" | ") for td in tr.select("td")]
+            for tr in trs
+        ]
+        self.assertEqual(
+            tds,
+            [
+                [
+                    "",
+                    "Christmas",
+                    "",
+                    "Event page",
+                    "Current page status: | live",
+                    "public",
+                    "",
+                ],
+                [
+                    "",
+                    "Tentative Unpublished Event",
+                    "",
+                    "Event page",
+                    "Current page status: | draft",
+                    "public",
+                    "",
+                ],
+                [
+                    "",
+                    "Someone Else's Event",
+                    "",
+                    "Event page",
+                    "Current page status: | draft",
+                    "private",
+                    "",
+                ],
+                [
+                    "",
+                    "Ameristralia Day",
+                    "",
+                    "Event page",
+                    "Current page status: | live",
+                    "public",
+                    "",
+                ],
+                [
+                    "",
+                    "Saint Patrick (single event)",
+                    "",
+                    "Single event page",
+                    "Current page status: | live",
+                    "private",
+                    "",
+                ],
+                [
+                    "",
+                    "Businessy events",
+                    "",
+                    "Business index",
+                    "Current page status: | draft",
+                    "",
+                    "",
+                ],
+            ],
+        )

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -300,7 +300,7 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(
                     response["Content-Disposition"],
-                    'attachment; filename="spreadsheet-export.csv"',
+                    'attachment; filename="tests_eventpage.csv"',
                 )
                 data_lines = response.getvalue().decode().strip().split("\r\n")
                 self.assertEqual(data_lines, results)
@@ -338,7 +338,7 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(
                     response["Content-Disposition"],
-                    'attachment; filename="spreadsheet-export.xlsx"',
+                    'attachment; filename="tests_eventpage.xlsx"',
                 )
                 workbook_data = response.getvalue()
                 worksheet = load_workbook(filename=BytesIO(workbook_data)).active

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -1,21 +1,101 @@
+from unittest import mock
+
 from django.test import SimpleTestCase, TestCase
+from django.test.utils import isolate_apps
 from django.urls import reverse
 
 from wagtail.admin.viewsets.pages import PageViewSet
-from wagtail.test.testapp.models import EventIndex, SimpleChildPage, SimpleParentPage
+from wagtail.models import Page
+from wagtail.test.testapp.models import (
+    BusinessChild,
+    BusinessSubIndex,
+    EventIndex,
+    SimpleChildPage,
+    SimplePage,
+    SimpleParentPage,
+)
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 
 
 class TestPageViewSet(SimpleTestCase):
-    def test_default_parent_model(self):
-        self.assertEqual(PageViewSet().parent_model, None)
+    def test_default_parent_models(self):
+        self.assertEqual(PageViewSet(model=SimplePage).parent_models, [])
 
-    def test_default_parent_model_with_type_restrictions(self):
+    def test_default_parent_models_with_type_restrictions(self):
+        # Simple one-to-one mapping
         self.assertEqual(
-            PageViewSet(model=SimpleChildPage).parent_model,
-            SimpleParentPage,
+            PageViewSet(model=SimpleChildPage).parent_models,
+            [SimpleParentPage],
         )
+
+        # BusinessChild can exist under BusinessIndex and BusinessSubIndex.
+        # BusinessIndex can contain BusinessChild or BusinessSubIndex, and
+        # the latter is not a subclass of the former.
+        # BusinessSubIndex can only contain BusinessChild.
+        # Associating the viewset with BusinessIndex would prevent
+        # BusinessSubIndex from being shown when listing the children of
+        # BusinessIndex (as we would only query BusinessChild pages).
+        # Therefore, we only associate the viewset with BusinessSubIndex.
+        self.assertEqual(
+            PageViewSet(model=BusinessChild).parent_models,
+            [BusinessSubIndex],
+        )
+
+    @isolate_apps("wagtail.test.testapp", "wagtail", kwarg_name="apps")
+    def test_multiple_default_parent_models(self, apps):
+        # We are not under the testapp directory, so explicitly define app_label
+        class TestsMeta:
+            app_label = "tests"
+
+        class BaseChild(Page):
+            parent_page_types = ["tests.BaseParent", "tests.BaseAndSpecificParent"]
+            Meta = TestsMeta
+
+        class SpecificChild(BaseChild):
+            parent_page_types = ["tests.SpecificParent", "tests.BaseAndSpecificParent"]
+            Meta = TestsMeta
+
+        class BaseParent(Page):
+            subpage_types = [BaseChild]
+            Meta = TestsMeta
+
+        class BaseAndSpecificParent(Page):
+            subpage_types = [BaseChild, SpecificChild]
+            Meta = TestsMeta
+
+        class SpecificParent(Page):
+            subpage_types = [SpecificChild]
+            Meta = TestsMeta
+
+        # Patch the registry used for resolving model strings with the isolated version
+        with mock.patch("wagtail.coreutils.apps", apps):
+            self.assertEqual(
+                PageViewSet(model=BaseChild).parent_models,
+                [
+                    # BaseParent can only have BaseChild children, so it is included.
+                    BaseParent,
+                    # BaseAndSpecificParent can have both BaseChild and SpecificChild
+                    # children. SpecificChild pages are also BaseChild pages and thus
+                    # can be queried as BaseChild, so it is okay to use this viewset
+                    # for BaseAndSpecificParent.
+                    BaseAndSpecificParent,
+                    # SpecificParent does not allow BaseChild children.
+                ],
+            )
+            self.assertEqual(
+                PageViewSet(model=SpecificChild).parent_models,
+                [
+                    # SpecificChild can exist under SpecificParent and
+                    # SpecificParent only allows SpecificChild to exist under it.
+                    SpecificParent
+                    # Even though SpecificChild can exist under BaseAndSpecificParent,
+                    # and BaseAndSpecificParent allows SpecificChild to exist under it,
+                    # associating BaseAndSpecificParent here would prevent BaseChild
+                    # pages (that are not SpecificChild) from being displayed, so
+                    # we do not include it by default.
+                ],
+            )
 
 
 class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -158,7 +158,7 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
                     "",
                     "Event page",
                     "Current page status: | live",
-                    "public",
+                    "Public",
                     "",
                 ],
                 [
@@ -167,7 +167,7 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
                     "",
                     "Single event page",
                     "Current page status: | live",
-                    "private",
+                    "Private",
                     "",
                 ],
                 [
@@ -176,7 +176,7 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
                     "",
                     "Event page",
                     "Current page status: | live",
-                    "public",
+                    "Public",
                     "",
                 ],
                 [
@@ -185,7 +185,7 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
                     "",
                     "Event page",
                     "Current page status: | draft",
-                    "private",
+                    "Private",
                     "",
                 ],
                 [
@@ -194,7 +194,7 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
                     "",
                     "Event page",
                     "Current page status: | draft",
-                    "public",
+                    "Public",
                     "",
                 ],
             ],

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -251,3 +251,30 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
                 "2015-07-04",
             ],
         )
+
+    def test_list_per_page(self):
+        pages = [
+            EventPage(
+                title=f"Event {i}",
+                date_from=f"2015-01-{i}",
+                audience="public",
+                location="Somewhere",
+                cost=f"£{i}",
+            )
+            for i in range(1, 21)
+        ]
+        for page in pages:
+            self.event_index_page.add_child(instance=page)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["object_list"]), 10)
+        soup = self.get_soup(response.content)
+        pagination = (
+            soup.select_one("nav.pagination")
+            .get_text(strip=True, separator="|")
+            .split("|")
+        )
+        self.assertEqual(
+            pagination,
+            ["Page 1 of 3", "Previous", "1", "2", "3", "Next", "25 event pages"],
+        )

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -220,6 +220,22 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
             [page.audience for page in pages],
             ["private", "private"],
         )
+        soup = self.get_soup(response.content)
+        title_th = soup.select_one("main table th.title")
+        self.assertIsNotNone(title_th)
+        search_whole_tree_url = f"{self.url}?audience=private&search_all=1"
+        search_whole_tree_link = title_th.select_one(
+            f'a[href="{search_whole_tree_url}"]'
+        )
+        self.assertIsNotNone(search_whole_tree_link)
+        self.assertHTMLEqual(
+            search_whole_tree_link.extract().decode_contents(),
+            "Search the whole site",
+        )
+        self.assertEqual(
+            title_th.get_text(strip=True, separator=" | "),
+            "Title | 1-2 of 2 event pages in ' | Events | '.",
+        )
 
     def test_filter_results(self):
         response = self.client.get(self.results_url, {"audience": "private"})
@@ -261,6 +277,65 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
                 "Download XLSX",
                 "Download CSV",
             ],
+        )
+
+    def test_search_filter(self):
+        response = self.client.get(self.url, {"q": "event", "audience": "private"})
+        self.assertEqual(response.status_code, 200)
+        pages = response.context["object_list"]
+        self.assertEqual({page.title for page in pages}, {"Someone Else's Event"})
+        self.assertEqual([page.audience for page in pages], ["private"])
+        soup = self.get_soup(response.content)
+        title_th = soup.select_one("main table th.title")
+        self.assertIsNotNone(title_th)
+        search_whole_tree_url = f"{self.url}?q=event&audience=private&search_all=1"
+        search_whole_tree_link = title_th.select_one(
+            f'a[href="{search_whole_tree_url}"]'
+        )
+        self.assertIsNotNone(search_whole_tree_link)
+        self.assertHTMLEqual(
+            search_whole_tree_link.extract().decode_contents(),
+            "Search the whole site",
+        )
+        self.assertEqual(
+            title_th.get_text(strip=True, separator=" | "),
+            "Title | 1-1 of 1 event pages in ' | Events | '.",
+        )
+
+    def test_search_filter_whole_tree(self):
+        root_page = Page.objects.get(pk=2)
+        new_page = EventPage(
+            title="Nice private event",
+            date_from="2026-04-01",
+            location="somewhere else on the site",
+            cost="nada",
+            audience="private",
+        )
+        root_page.add_child(instance=new_page)
+        response = self.client.get(
+            self.url,
+            {"q": "event", "audience": "private", "search_all": "1"},
+        )
+        self.assertEqual(response.status_code, 200)
+        pages = response.context["object_list"]
+        self.assertEqual(
+            {page.title for page in pages},
+            {"Nice private event", "Someone Else's Event"},
+        )
+        self.assertEqual([page.audience for page in pages], ["private", "private"])
+        soup = self.get_soup(response.content)
+        title_th = soup.select_one("main table th.title")
+        self.assertIsNotNone(title_th)
+        search_in_parent_url = f"{self.url}?q=event&audience=private"
+        search_parent_link = title_th.select_one(f'a[href="{search_in_parent_url}"]')
+        self.assertIsNotNone(search_parent_link)
+        self.assertHTMLEqual(
+            search_parent_link.extract().decode_contents(),
+            "Search in '<span class=\"w-title-ellipsis\">Events</span>'",
+        )
+        self.assertEqual(
+            title_th.get_text(strip=True, separator=" | "),
+            "Title | 1-2 of 2 event pages across entire site.",
         )
 
     def test_default_order_by_date_from(self):

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -292,7 +292,7 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
         self.assertEqual(response.status_code, 200)
         soup = self.get_soup(response.content)
         dropdown = soup.select_one(
-            "#w-slim-header-buttons [data-controller='w-dropdown']"
+            "nav#w-slim-header-buttons [data-controller='w-dropdown']"
         )
         self.assertIsNotNone(dropdown)
         expected = [

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -1,9 +1,21 @@
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.urls import reverse
 
-from wagtail.test.testapp.models import EventIndex
+from wagtail.admin.viewsets.pages import PageViewSet
+from wagtail.test.testapp.models import EventIndex, SimpleChildPage, SimpleParentPage
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
+
+
+class TestPageViewSet(SimpleTestCase):
+    def test_default_parent_model(self):
+        self.assertEqual(PageViewSet().parent_model, None)
+
+    def test_default_parent_model_with_type_restrictions(self):
+        self.assertEqual(
+            PageViewSet(model=SimpleChildPage).parent_model,
+            SimpleParentPage,
+        )
 
 
 class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -15,20 +15,27 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
     def setUp(self):
         self.user = self.login()
 
+    @classmethod
+    def setUpTestData(cls):
+        cls.event_index_page = EventIndex.objects.first()
+        cls.parent = cls.event_index_page.get_parent()
+        cls.url = reverse("wagtailadmin_explore", args=[cls.event_index_page.id])
+        cls.results_url = reverse(
+            "wagtailadmin_explore_results",
+            args=[cls.event_index_page.id],
+        )
+
     def test_get(self):
-        event_index_page = EventIndex.objects.first()
-        parent = event_index_page.get_parent()
-        url = reverse("wagtailadmin_explore", args=[event_index_page.id])
-        response = self.client.get(url)
+        response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
         self.assertBreadcrumbsItemsRendered(
             [
                 {
-                    "url": reverse("wagtailadmin_explore", args=[parent.pk]),
-                    "label": str(parent),
+                    "url": reverse("wagtailadmin_explore", args=[self.parent.pk]),
+                    "label": str(self.parent),
                 },
-                {"url": url, "label": "Events"},
+                {"url": self.url, "label": "Events"},
             ],
             response.content,
         )
@@ -97,14 +104,33 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
                     "private",
                     "",
                 ],
-                [
-                    "",
-                    "Businessy events",
-                    "",
-                    "Business index",
-                    "Current page status: | draft",
-                    "",
-                    "",
-                ],
             ],
+        )
+
+    def test_order_by_audience(self):
+        response = self.client.get(self.url, {"ordering": "audience"})
+        self.assertEqual(response.status_code, 200)
+        pages = response.context["object_list"]
+        self.assertEqual(
+            [page.audience for page in pages],
+            ["private", "private", "public", "public", "public"],
+        )
+
+    def test_filter(self):
+        response = self.client.get(self.url, {"audience": "private"})
+        self.assertEqual(response.status_code, 200)
+        pages = response.context["object_list"]
+        self.assertEqual(
+            [page.audience for page in pages],
+            ["private", "private"],
+        )
+
+    def test_filter_results(self):
+        response = self.client.get(self.results_url, {"audience": "private"})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index_results.html")
+        pages = response.context["object_list"]
+        self.assertEqual(
+            [page.audience for page in pages],
+            ["private", "private"],
         )

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -230,6 +230,38 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
             [page.audience for page in pages],
             ["private", "private"],
         )
+        soup = self.get_soup(response.content)
+        header_buttons_fragment = soup.select_one(
+            'template[data-controller="w-teleport"]'
+            '[data-w-teleport-target-value="#w-slim-header-buttons"]'
+            '[data-w-teleport-mode-value="innerHTML"]'
+        )
+        self.assertIsNotNone(header_buttons_fragment)
+        buttons = header_buttons_fragment.select('[data-w-dropdown-target="content"] a')
+        # Check that download links preserve the current filters, and buttons
+        # from the register_page_header_buttons hook are also shown
+        self.assertLess(
+            {
+                f"{self.results_url}?audience=private&export=xlsx",
+                f"{self.results_url}?audience=private&export=csv",
+            },
+            {btn["href"] for btn in buttons},
+        )
+        self.assertEqual(len(buttons), 9)
+        self.assertEqual(
+            [button.text.strip() for button in buttons],
+            [
+                "Edit",
+                "Move",
+                "Copy",
+                "Delete",
+                "Unpublish",
+                "History",
+                "Sort menu order",
+                "Download XLSX",
+                "Download CSV",
+            ],
+        )
 
     def test_default_order_by_date_from(self):
         new_page = EventPage(

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -299,7 +299,7 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
         )
         self.assertEqual(
             title_th.get_text(strip=True, separator=" | "),
-            "Title | 1-1 of 1 event pages in ' | Events | '.",
+            "Title | 1-1 of 1 event page in ' | Events | '.",
         )
 
     def test_search_filter_whole_tree(self):

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -1,8 +1,11 @@
+import datetime
+from io import BytesIO
 from unittest import mock
 
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import isolate_apps
 from django.urls import reverse
+from openpyxl import load_workbook
 
 from wagtail.admin.viewsets.pages import PageViewSet
 from wagtail.models import Page
@@ -251,6 +254,96 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
                 "2015-07-04",
             ],
         )
+
+    def test_render_export_buttons(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        soup = self.get_soup(response.content)
+        dropdown = soup.select_one(
+            "#w-slim-header-buttons [data-controller='w-dropdown']"
+        )
+        self.assertIsNotNone(dropdown)
+        expected = [
+            (f"{self.url}?export=csv", "Download CSV"),
+            (f"{self.url}?export=xlsx", "Download XLSX"),
+        ]
+        for url, label in expected:
+            button = dropdown.select_one(f'a[href="{url}"]')
+            self.assertIsNotNone(button)
+            self.assertEqual(button.get_text(strip=True), label)
+
+    def test_csv_export(self):
+        cases = [
+            [
+                {"export": "csv", "ordering": "title"},
+                [
+                    "Pk,Title,Audience,Start date",
+                    "9,Ameristralia Day,public,2015-04-22",
+                    "4,Christmas,public,2014-12-25",
+                    "13,Saint Patrick,private,2014-12-25",
+                    "6,Someone Else's Event,private,2015-07-04",
+                    "5,Tentative Unpublished Event,public,2015-07-04",
+                ],
+            ],
+            [
+                {"export": "csv", "audience": "private", "ordering": "title"},
+                [
+                    "Pk,Title,Audience,Start date",
+                    "13,Saint Patrick,private,2014-12-25",
+                    "6,Someone Else's Event,private,2015-07-04",
+                ],
+            ],
+        ]
+        for params, results in cases:
+            with self.subTest(params=params):
+                response = self.client.get(self.url, params)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    response["Content-Disposition"],
+                    'attachment; filename="spreadsheet-export.csv"',
+                )
+                data_lines = response.getvalue().decode().strip().split("\r\n")
+                self.assertEqual(data_lines, results)
+
+    def test_xlsx_export(self):
+        cases = [
+            [
+                {"export": "xlsx", "ordering": "title"},
+                [
+                    ["Pk", "Title", "Audience", "Start date"],
+                    [9, "Ameristralia Day", "public", datetime.date(2015, 4, 22)],
+                    [4, "Christmas", "public", datetime.date(2014, 12, 25)],
+                    [13, "Saint Patrick", "private", datetime.date(2014, 12, 25)],
+                    [6, "Someone Else's Event", "private", datetime.date(2015, 7, 4)],
+                    [
+                        5,
+                        "Tentative Unpublished Event",
+                        "public",
+                        datetime.date(2015, 7, 4),
+                    ],
+                ],
+            ],
+            [
+                {"export": "xlsx", "audience": "private", "ordering": "title"},
+                [
+                    ["Pk", "Title", "Audience", "Start date"],
+                    [13, "Saint Patrick", "private", datetime.date(2014, 12, 25)],
+                    [6, "Someone Else's Event", "private", datetime.date(2015, 7, 4)],
+                ],
+            ],
+        ]
+        for params, results in cases:
+            with self.subTest(params=params):
+                response = self.client.get(self.url, params)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    response["Content-Disposition"],
+                    'attachment; filename="spreadsheet-export.xlsx"',
+                )
+                workbook_data = response.getvalue()
+                worksheet = load_workbook(filename=BytesIO(workbook_data)).active
+                data_cells = [[cell.value for cell in row] for row in worksheet.rows]
+                self.assertEqual(data_cells, results)
 
     def test_list_per_page(self):
         pages = [

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -10,6 +10,7 @@ from wagtail.test.testapp.models import (
     BusinessChild,
     BusinessSubIndex,
     EventIndex,
+    EventPage,
     SimpleChildPage,
     SimplePage,
     SimpleParentPage,
@@ -162,19 +163,10 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
                 ],
                 [
                     "",
-                    "Tentative Unpublished Event",
+                    "Saint Patrick (single event)",
                     "",
-                    "Event page",
-                    "Current page status: | draft",
-                    "public",
-                    "",
-                ],
-                [
-                    "",
-                    "Someone Else's Event",
-                    "",
-                    "Event page",
-                    "Current page status: | draft",
+                    "Single event page",
+                    "Current page status: | live",
                     "private",
                     "",
                 ],
@@ -189,11 +181,20 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
                 ],
                 [
                     "",
-                    "Saint Patrick (single event)",
+                    "Someone Else's Event",
                     "",
-                    "Single event page",
-                    "Current page status: | live",
+                    "Event page",
+                    "Current page status: | draft",
                     "private",
+                    "",
+                ],
+                [
+                    "",
+                    "Tentative Unpublished Event",
+                    "",
+                    "Event page",
+                    "Current page status: | draft",
+                    "public",
                     "",
                 ],
             ],
@@ -225,4 +226,28 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
         self.assertEqual(
             [page.audience for page in pages],
             ["private", "private"],
+        )
+
+    def test_default_order_by_date_from(self):
+        new_page = EventPage(
+            title="New Years 2025",
+            date_from="2015-01-01",
+            audience="public",
+            location="Somewhere",
+            cost="free",
+        )
+        self.event_index_page.add_child(instance=new_page)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        pages = response.context["object_list"]
+        self.assertEqual(
+            [str(page.date_from) for page in pages],
+            [
+                "2014-12-25",
+                "2014-12-25",
+                "2015-01-01",
+                "2015-04-22",
+                "2015-07-04",
+                "2015-07-04",
+            ],
         )

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -35,6 +35,12 @@ class TestCustomExplorableIndexView(AdminTemplateTestUtils, WagtailTestUtils, Te
 
         soup = self.get_soup(response.content)
 
+        breadcrumbs_icon = soup.select_one(".w-breadcrumbs__icon")
+        self.assertIsNotNone(breadcrumbs_icon)
+        use = breadcrumbs_icon.select_one("use")
+        self.assertIsNotNone(use)
+        self.assertEqual(use["href"], "#icon-calendar")
+
         table = soup.select_one("main table")
         for dropdown in table.select("[data-controller='w-dropdown']"):
             dropdown.extract()

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -290,8 +290,9 @@ class TestPageHeaderButtonsHooks(TestButtonsHooks):
             )
 
         self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/shared/headers/_actions.html")
         self.assertTemplateUsed(
-            response, "wagtailadmin/pages/listing/_page_header_buttons.html"
+            response, "wagtailadmin/shared/button_with_dropdown.html"
         )
 
         self.assertContains(response, "Another useless header button")

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -27,6 +27,7 @@ from wagtail.models import Locale, Page
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 from wagtail.users.models import UserProfile
+from wagtail.utils.deprecation import RemovedInWagtail80Warning
 
 
 class TestAvatarUrlInterceptTemplateTag(WagtailTestUtils, TestCase):
@@ -1035,6 +1036,37 @@ class PageBreadcrumbsTagTest(AdminTemplateTestUtils, WagtailTestUtils, TestCase)
         self.assertEqual(len(invalid_icons), 0)
         icon = soup.select_one("ol li:last-child svg use[href='#icon-site']")
         self.assertIsNotNone(icon)
+
+
+class PageHeaderButtonsTest(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
+    fixtures = ["test.json"]
+
+    def setUp(self):
+        self.request = get_dummy_request()
+        self.user = self.login()
+        self.request.user = self.user
+
+    def test_page_header_buttons_deprecation(self):
+        cases = [("index", 6), ("edit", 7)]
+        for view_name, button_count in cases:
+            with self.subTest(view_name=view_name):
+                template = f"""
+                    {{% load wagtailadmin_tags %}}
+                    {{% page_header_buttons page user=request.user view_name="{view_name}" %}}
+                """
+                page = Page.objects.get(id=15)
+                with self.assertWarnsMessage(
+                    RemovedInWagtail80Warning,
+                    "`{% page_header_buttons %}` tag is deprecated. "
+                    "Use the `register_page_header_buttons` hook instead.",
+                ):
+                    rendered = Template(template).render(
+                        Context({"page": page, "request": self.request})
+                    )
+
+                soup = self.get_soup(rendered)
+                buttons = soup.select("[data-controller='w-dropdown'] a")
+                self.assertEqual(len(buttons), button_count)
 
 
 class ThemeColorSchemeTest(AdminTemplateTestUtils, WagtailTestUtils, TestCase):

--- a/wagtail/admin/ui/menus/pages.py
+++ b/wagtail/admin/ui/menus/pages.py
@@ -2,7 +2,9 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.http import urlencode
 
+from wagtail import hooks
 from wagtail.admin.ui.menus import MenuItem
+from wagtail.admin.widgets.button import Button
 
 
 class PageMenuItem(MenuItem):
@@ -41,3 +43,23 @@ class PageMenuItem(MenuItem):
             if self.next_url:
                 url += "?" + urlencode({"next": self.next_url})
             return url
+
+
+def get_page_header_buttons(page, user, next_url, view_name):
+    button_hooks = hooks.get_hooks("register_page_header_buttons")
+
+    hook_buttons = []
+    for hook in button_hooks:
+        hook_buttons.extend(
+            hook(page=page, user=user, next_url=next_url, view_name=view_name)
+        )
+
+    buttons = []
+    for button in hook_buttons:
+        # Allow hooks to return either Button or MenuItem instances
+        if isinstance(button, MenuItem):
+            if button.is_shown(user):
+                buttons.append(Button.from_menu_item(button))
+        elif button.show:
+            buttons.append(button)
+    return buttons

--- a/wagtail/admin/ui/tables/pages.py
+++ b/wagtail/admin/ui/tables/pages.py
@@ -15,7 +15,6 @@ class PageTitleColumn(BaseColumn):
         parent_page = parent_context.get("parent_page")
 
         context["items_count"] = parent_context.get("items_count")
-        context["verbose_name_plural"] = parent_context.get("verbose_name_plural")
         context["page_obj"] = parent_context.get("page_obj")
         context["parent_page"] = parent_page
 
@@ -39,6 +38,11 @@ class PageTitleColumn(BaseColumn):
         if context["page_obj"]:
             context["start_index"] = context["page_obj"].start_index()
             context["end_index"] = context["page_obj"].end_index()
+
+        if context["items_count"] == 1:
+            context["model_name"] = parent_context.get("verbose_name")
+        else:
+            context["model_name"] = parent_context.get("verbose_name_plural")
 
         return context
 
@@ -176,5 +180,6 @@ class PageTable(OrderableTableMixin, Table):
         context["actions_next_url"] = (
             self.actions_next_url or parent_context.get("request").path
         )
+        context["verbose_name"] = parent_context.get("verbose_name")
         context["verbose_name_plural"] = parent_context.get("verbose_name_plural")
         return context

--- a/wagtail/admin/ui/tables/pages.py
+++ b/wagtail/admin/ui/tables/pages.py
@@ -15,6 +15,7 @@ class PageTitleColumn(BaseColumn):
         parent_page = parent_context.get("parent_page")
 
         context["items_count"] = parent_context.get("items_count")
+        context["verbose_name_plural"] = parent_context.get("verbose_name_plural")
         context["page_obj"] = parent_context.get("page_obj")
         context["parent_page"] = parent_page
 
@@ -175,4 +176,5 @@ class PageTable(OrderableTableMixin, Table):
         context["actions_next_url"] = (
             self.actions_next_url or parent_context.get("request").path
         )
+        context["verbose_name_plural"] = parent_context.get("verbose_name_plural")
         return context

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -36,12 +36,15 @@ urlpatterns = [
     ),
     path(
         "pages/<int:parent_page_id>/",
-        page_viewset_registry.as_view("index", page_id_kwarg="parent_page_id"),
+        page_viewset_registry.as_view("index", parent_page_id_kwarg="parent_page_id"),
         name="wagtailadmin_explore",
     ),
     path(
         "pages/<int:parent_page_id>/results/",
-        page_viewset_registry.as_view("index_results", page_id_kwarg="parent_page_id"),
+        page_viewset_registry.as_view(
+            "index_results",
+            parent_page_id_kwarg="parent_page_id",
+        ),
         name="wagtailadmin_explore_results",
     ),
     # bulk actions

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -20,7 +20,7 @@ from wagtail.admin.views import account, chooser, dismissibles, home, tags
 from wagtail.admin.views.bulk_action import index as bulk_actions
 from wagtail.admin.views.generic.preview import StreamFieldBlockPreview
 from wagtail.admin.views.i18n import localized_js_catalog
-from wagtail.admin.views.pages import listing
+from wagtail.admin.viewsets.pages import base_page_viewset, page_viewset_registry
 from wagtail.utils.urlpatterns import decorate_urlpatterns
 
 urlpatterns = [
@@ -31,17 +31,17 @@ urlpatterns = [
     # TODO: Move into wagtailadmin_pages namespace
     path(
         "pages/",
-        listing.ExplorableIndexView.as_view(),
+        base_page_viewset.index_view,
         name="wagtailadmin_explore_root",
     ),
     path(
         "pages/<int:parent_page_id>/",
-        listing.ExplorableIndexView.as_view(),
+        page_viewset_registry.as_view("index", page_id_kwarg="parent_page_id"),
         name="wagtailadmin_explore",
     ),
     path(
         "pages/<int:parent_page_id>/results/",
-        listing.ExplorableIndexView.as_view(results_only=True),
+        page_viewset_registry.as_view("index_results", page_id_kwarg="parent_page_id"),
         name="wagtailadmin_explore_results",
     ),
     # bulk actions

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -76,11 +76,11 @@ class WagtailAdminTemplateMixin(TemplateResponseMixin, ContextMixin):
     def get_header_buttons(self):
         buttons = sorted(self.header_buttons)
 
-        more_buttons = self.get_header_more_buttons()
-        if more_buttons:
+        self.produced_header_more_buttons = self.get_header_more_buttons()
+        if self.produced_header_more_buttons:
             buttons.append(
                 ButtonWithDropdown(
-                    buttons=more_buttons,
+                    buttons=self.produced_header_more_buttons,
                     icon_name="dots-horizontal",
                     attrs={
                         "aria-label": _("Actions"),
@@ -111,6 +111,9 @@ class WagtailAdminTemplateMixin(TemplateResponseMixin, ContextMixin):
         # Breadcrumbs are enabled by default.
         context["breadcrumbs_items"] = self.get_breadcrumbs_items()
         context["header_buttons"] = self.get_header_buttons()
+        # Expose the "more" buttons list separately in the context for
+        # subclasses that want to make use of it.
+        context["header_more_buttons"] = self.produced_header_more_buttons
         return context
 
     def get_template_names(self):

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -207,6 +207,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
     search_backend_name = "default"
     default_ordering = None
     filterset_class = None
+    verbose_name = None
     verbose_name_plural = None
     paginator_class = WagtailPaginator
 
@@ -466,6 +467,7 @@ class BaseListingView(WagtailAdminTemplateMixin, BaseListView):
 
         context["index_url"] = self.index_url
         context["index_results_url"] = self.index_results_url
+        context["verbose_name"] = self.verbose_name
         context["verbose_name_plural"] = self.verbose_name_plural
         context["no_results_message"] = self.no_results_message
         context["ordering"] = self.ordering

--- a/wagtail/admin/views/generic/base.py
+++ b/wagtail/admin/views/generic/base.py
@@ -76,11 +76,11 @@ class WagtailAdminTemplateMixin(TemplateResponseMixin, ContextMixin):
     def get_header_buttons(self):
         buttons = sorted(self.header_buttons)
 
-        self.produced_header_more_buttons = self.get_header_more_buttons()
-        if self.produced_header_more_buttons:
+        more_buttons = self.get_header_more_buttons()
+        if more_buttons:
             buttons.append(
                 ButtonWithDropdown(
-                    buttons=self.produced_header_more_buttons,
+                    buttons=more_buttons,
                     icon_name="dots-horizontal",
                     attrs={
                         "aria-label": _("Actions"),
@@ -111,9 +111,6 @@ class WagtailAdminTemplateMixin(TemplateResponseMixin, ContextMixin):
         # Breadcrumbs are enabled by default.
         context["breadcrumbs_items"] = self.get_breadcrumbs_items()
         context["header_buttons"] = self.get_header_buttons()
-        # Expose the "more" buttons list separately in the context for
-        # subclasses that want to make use of it.
-        context["header_more_buttons"] = self.produced_header_more_buttons
         return context
 
     def get_template_names(self):

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -444,6 +444,12 @@ class IndexView(
         return _("Add")
 
     @cached_property
+    def verbose_name(self):
+        if self.model:
+            return self.model._meta.verbose_name
+        return None
+
+    @cached_property
     def verbose_name_plural(self):
         if self.model:
             return self.model._meta.verbose_name_plural

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -88,6 +88,7 @@ class IndexView(
     list_filter = None
     show_other_searches = False
     sort_order_field = None
+    base_filterset_class = WagtailFilterSet
 
     @cached_property
     def is_searchable(self):
@@ -115,7 +116,7 @@ class IndexView(
 
         return type(
             f"{self.model.__name__}FilterSet",
-            (WagtailFilterSet,),
+            (self.base_filterset_class,),
             {"Meta": Meta},
         )
 

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -32,6 +32,7 @@ from wagtail.admin.ui.fields import display_class_registry
 from wagtail.admin.ui.menus import MenuItem
 from wagtail.admin.ui.side_panels import StatusSidePanel
 from wagtail.admin.ui.tables import (
+    BaseColumn,
     ButtonsColumnMixin,
     Column,
     LocaleColumn,
@@ -292,7 +293,7 @@ class IndexView(
         # If not explicitly overridden, derive from list_display
         columns = []
         for i, field in enumerate(self.list_display):
-            if isinstance(field, Column):
+            if isinstance(field, BaseColumn):
                 column = field
             elif i == 0:
                 column = self._get_title_column(field)

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -342,13 +342,7 @@ class IndexView(
     def header_buttons(self):
         buttons = []
         if self.add_url:
-            buttons.append(
-                HeaderButton(
-                    self.add_item_label,
-                    url=self.add_url,
-                    icon_name="plus",
-                )
-            )
+            buttons.append(self.add_button)
         return buttons
 
     @cached_property
@@ -357,6 +351,14 @@ class IndexView(
         if self.reorder_button:
             buttons.append(self.reorder_button)
         return buttons
+
+    @cached_property
+    def add_button(self):
+        return HeaderButton(
+            self.add_item_label,
+            url=self.add_url,
+            icon_name="plus",
+        )
 
     @cached_property
     def reorder_button(self):

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -354,15 +354,18 @@ class IndexView(
     @cached_property
     def header_more_buttons(self):
         buttons = super().header_more_buttons
-        if self.get_reorder_url():
-            buttons.append(
-                Button(
-                    _("Sort item order"),
-                    url=self.index_url + f"?ordering={self.sort_order_field}",
-                    icon_name="list-ul",
-                )
-            )
+        if self.reorder_button:
+            buttons.append(self.reorder_button)
         return buttons
+
+    @cached_property
+    def reorder_button(self):
+        if self.get_reorder_url():
+            return Button(
+                _("Sort item order"),
+                url=self.index_url + f"?ordering={self.sort_order_field}",
+                icon_name="list-ul",
+            )
 
     def get_list_more_buttons(self, instance):
         buttons = []

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -24,6 +24,7 @@ from wagtail.admin.telepath import JSContext
 from wagtail.admin.ui.autosave import AutosaveIndicator
 from wagtail.admin.ui.components import MediaContainer
 from wagtail.admin.ui.editing_sessions import EditingSessionsModule
+from wagtail.admin.ui.menus.pages import get_page_header_buttons
 from wagtail.admin.ui.side_panels import (
     ChecksSidePanel,
     CommentsSidePanel,
@@ -1057,6 +1058,18 @@ class EditView(
             lock=self.lock,
             locked_for_user=self.locked_for_user,
         )
+
+    @cached_property
+    def header_more_buttons(self):
+        next_url = self.request.path
+        buttons = get_page_header_buttons(
+            page=self.page,
+            user=self.request.user,
+            next_url=next_url,
+            view_name="edit",
+        )
+        buttons.extend(super().header_more_buttons)
+        return buttons
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -128,7 +128,6 @@ class PageListingMixin:
     context_object_name = "pages"
     table_class = PageTable
     filterset_class = GenericPageFilterSet
-    default_ordering = "-latest_revision_created_at"
     model = Page
     is_searchable = True
 
@@ -281,6 +280,7 @@ class IndexView(PageListingMixin, generic.IndexView):
     paginate_by = 50
     table_classname = "listing full-width"
     filterset_class = PageFilterSet
+    default_ordering = "-latest_revision_created_at"
 
     @classproperty
     def columns(cls):
@@ -316,6 +316,7 @@ class ExplorableIndexView(IndexView):
     # This is not a real field on the model, but it allows reuse of ordering
     # logic from generic IndexView
     sort_order_field = "ord"
+    default_ordering = None
 
     @classproperty
     def columns(cls):
@@ -416,7 +417,9 @@ class ExplorableIndexView(IndexView):
             # default to ordering by relevance
             default_ordering = None
         else:
-            default_ordering = self.parent_page.get_admin_default_ordering()
+            default_ordering = (
+                self.default_ordering or self.parent_page.get_admin_default_ordering()
+            )
 
         ordering = self.request.GET.get("ordering", default_ordering)
         if ordering not in self.get_valid_orderings():

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -369,9 +369,9 @@ class ExplorableIndexView(IndexView):
             if self.is_searching_whole_tree:
                 pages = Page.objects.all()
             else:
-                pages = self.parent_page.get_descendants()
+                pages = self.model._default_manager.descendant_of(self.parent_page)
         else:
-            pages = self.parent_page.get_children()
+            pages = self.model._default_manager.child_of(self.parent_page)
 
         if (not self.is_searching) or getattr(
             settings, "WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS", True

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -20,6 +20,7 @@ from wagtail.admin.filters import (
     WagtailFilterSet,
 )
 from wagtail.admin.ui.components import MediaContainer
+from wagtail.admin.ui.menus.pages import get_page_header_buttons
 from wagtail.admin.ui.side_panels import (
     PageStatusSidePanel,
 )
@@ -34,6 +35,7 @@ from wagtail.admin.ui.tables.pages import (
     ParentPageColumn,
 )
 from wagtail.admin.views import generic
+from wagtail.admin.widgets.button import HeaderButton
 from wagtail.models import Page, PageLogEntry, Site, get_page_content_types
 from wagtail.permissions import page_permission_policy
 
@@ -320,6 +322,8 @@ class ExplorableIndexView(IndexView):
     index_url_name = "wagtailadmin_explore"
     index_results_url_name = "wagtailadmin_explore_results"
     page_title = _("Exploring")
+    add_item_label = _("Add child page")
+    add_url_name = "wagtailadmin_pages:add_subpage"
     # This is not a real field on the model, but it allows reuse of ordering
     # logic from generic IndexView
     sort_order_field = "ord"
@@ -355,6 +359,7 @@ class ExplorableIndexView(IndexView):
 
         self.parent_page = self.parent_page.specific
         self.scheduled_page = self.parent_page.get_scheduled_revision_as_object()
+        self.permissions = self.parent_page.permissions_for_user(self.request.user)
 
         if self.i18n_enabled and not self.parent_page.is_root():
             self.locale = self.parent_page.locale
@@ -374,6 +379,30 @@ class ExplorableIndexView(IndexView):
     @cached_property
     def show_locale_labels(self):
         return self.i18n_enabled and self.parent_page.is_root()
+
+    @cached_property
+    def add_button(self):
+        if self.add_url:
+            return HeaderButton(
+                self.add_item_label,
+                url=self.add_url,
+                icon_name="plus",
+                icon_only=True,  # Only so much space in the header
+            )
+
+    @cached_property
+    def header_more_buttons(self):
+        next_url = self.request.path
+        # Get header buttons from hooks
+        buttons = get_page_header_buttons(
+            page=self.parent_page,
+            user=self.request.user,
+            next_url=next_url,
+            view_name="index",
+        )
+        # Include any buttons from the superclass, e.g. export buttons
+        buttons.extend(super().header_more_buttons)
+        return buttons
 
     def get_base_queryset(self):
         if self.is_searching or self.is_filtering:
@@ -409,9 +438,12 @@ class ExplorableIndexView(IndexView):
     def get_index_results_url(self):
         return reverse(self.index_results_url_name, args=[self.parent_page.id])
 
+    def get_add_url(self):
+        if self.permissions.can_add_subpage():
+            return reverse(self.add_url_name, args=[self.parent_page.id])
+
     def get_history_url(self):
-        permissions = self.parent_page.permissions_for_user(self.request.user)
-        if permissions.can_view_revisions():
+        if self.permissions.can_view_revisions():
             return reverse("wagtailadmin_pages:history", args=[self.parent_page.id])
 
     def get_reorder_url(self):

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -323,6 +323,8 @@ class ExplorableIndexView(IndexView):
     # This is not a real field on the model, but it allows reuse of ordering
     # logic from generic IndexView
     sort_order_field = "ord"
+    # Reordering button is added via a register_page_header_buttons hook
+    reorder_button = None
     default_ordering = None
     base_filterset_class = GenericPageFilterSet
 

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -127,7 +127,6 @@ class PageListingMixin:
     template_name = "wagtailadmin/pages/listing.html"
     context_object_name = "pages"
     table_class = PageTable
-    filterset_class = GenericPageFilterSet
     model = Page
     is_searchable = True
 
@@ -279,12 +278,18 @@ class IndexView(PageListingMixin, generic.IndexView):
     results_template_name = "wagtailadmin/pages/index_results.html"
     paginate_by = 50
     table_classname = "listing full-width"
-    filterset_class = PageFilterSet
+    base_filterset_class = PageFilterSet
     default_ordering = "-latest_revision_created_at"
 
     @classproperty
     def columns(cls):
         return [col for col in PageListingMixin.columns if col.name != "type"]
+
+    @cached_property
+    def filterset_class(self):
+        if self.list_filter:
+            return super().filterset_class
+        return self.base_filterset_class
 
     def get_base_queryset(self):
         pages = self.model.objects.filter(depth__gt=1)
@@ -312,11 +317,11 @@ class ExplorableIndexView(IndexView):
     index_url_name = "wagtailadmin_explore"
     index_results_url_name = "wagtailadmin_explore_results"
     page_title = _("Exploring")
-    filterset_class = GenericPageFilterSet
     # This is not a real field on the model, but it allows reuse of ordering
     # logic from generic IndexView
     sort_order_field = "ord"
     default_ordering = None
+    base_filterset_class = GenericPageFilterSet
 
     @classproperty
     def columns(cls):

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -130,7 +130,7 @@ class PageListingMixin:
     model = Page
     is_searchable = True
 
-    columns = [
+    base_columns = [
         BulkActionsColumn("bulk_actions"),
         PageTitleColumn(
             "title",
@@ -280,10 +280,13 @@ class IndexView(PageListingMixin, generic.IndexView):
     table_classname = "listing full-width"
     base_filterset_class = PageFilterSet
     default_ordering = "-latest_revision_created_at"
+    base_columns = [col for col in PageListingMixin.base_columns if col.name != "type"]
 
-    @classproperty
-    def columns(cls):
-        return [col for col in PageListingMixin.columns if col.name != "type"]
+    @cached_property
+    def columns(self):
+        if self.list_display:
+            return super().columns
+        return self.base_columns
 
     @cached_property
     def filterset_class(self):
@@ -324,8 +327,8 @@ class ExplorableIndexView(IndexView):
     base_filterset_class = GenericPageFilterSet
 
     @classproperty
-    def columns(cls):
-        columns = [col for col in PageListingMixin.columns if col.name != "parent"]
+    def base_columns(cls):
+        columns = [col for col in PageListingMixin.base_columns if col.name != "parent"]
         columns.append(NavigateToChildrenColumn("navigate", width="10%"))
         return columns
 

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -407,7 +407,7 @@ class ExplorableIndexView(IndexView):
     def get_base_queryset(self):
         if self.is_searching or self.is_filtering:
             if self.is_searching_whole_tree:
-                pages = Page.objects.all()
+                pages = self.model._default_manager.all()
             else:
                 pages = self.model._default_manager.descendant_of(self.parent_page)
         else:

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -71,7 +71,7 @@ class SearchView(PageListingMixin, PermissionCheckedMixin, BaseListingView):
 
     @classproperty
     def columns(cls):
-        columns = PageListingMixin.columns.copy()
+        columns = PageListingMixin.base_columns.copy()
         columns.append(NavigateToChildrenColumn("navigate", width="10%"))
         return columns
 

--- a/wagtail/admin/views/pages/usage.py
+++ b/wagtail/admin/views/pages/usage.py
@@ -40,7 +40,7 @@ class ContentTypeUseView(PageListingMixin, PermissionCheckedMixin, BaseListingVi
 
     @classproperty
     def columns(cls):
-        return [col for col in PageListingMixin.columns if col.name != "type"]
+        return [col for col in PageListingMixin.base_columns if col.name != "type"]
 
     def get(self, request, *, content_type_app_name, content_type_model_name):
         try:

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -36,7 +36,7 @@ from wagtail.admin.ui.tables import BaseColumn, Column, TitleColumn
 from wagtail.admin.views.generic import CreateView, DeleteView, EditView, IndexView
 from wagtail.admin.views.generic.base import BaseListingView
 from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
-from wagtail.admin.views.pages.listing import PageListingMixin
+from wagtail.admin.views.pages.listing import GenericPageFilterSet, PageListingMixin
 from wagtail.coreutils import resolve_model_string
 from wagtail.models import (
     Page,
@@ -427,6 +427,7 @@ class WorkflowUsageView(PageListingMixin, PermissionCheckedMixin, BaseListingVie
     paginate_by = 20
     header_icon = "tasks"
     page_title = _("Usage")
+    filterset_class = GenericPageFilterSet
 
     def dispatch(self, request, *args, **kwargs):
         self.object = self.get_object()

--- a/wagtail/admin/viewsets/base.py
+++ b/wagtail/admin/viewsets/base.py
@@ -19,7 +19,7 @@ class ViewSet(WagtailMenuRegisterable):
 
     #: A special value that, when passed in a kwargs dict to construct a view, indicates that
     #: the attribute should not be written and should instead be left as the view's initial value.
-    UNDEFINED = object()
+    UNDEFINED = type("UNDEFINED", (object,), {"__repr__": lambda self: "UNDEFINED"})()
 
     #: A name for this viewset, used as the default URL prefix and namespace.
     name = None

--- a/wagtail/admin/viewsets/listing.py
+++ b/wagtail/admin/viewsets/listing.py
@@ -1,0 +1,80 @@
+from wagtail.admin.viewsets.base import ViewSet
+
+
+class ListingViewSetMixin:
+    #: The number of items to display per page in the index view.
+    list_per_page = ViewSet.UNDEFINED
+
+    #: The default ordering to use for the index view.
+    #: Can be a string or a list/tuple in the same format as Django's
+    #: :attr:`~django.db.models.Options.ordering`.
+    ordering = ViewSet.UNDEFINED
+
+    list_display = ViewSet.UNDEFINED
+    """
+    A list or tuple, where each item is either:
+
+    - The name of a field on the model;
+    - The name of a callable or property on the model that accepts a single
+      parameter for the model instance; or
+    - An instance of the ``wagtail.admin.ui.tables.Column`` class.
+
+    If the name refers to a database field, the ability to sort the listing
+    by the database column will be offered and the field's verbose name
+    will be used as the column header.
+
+    If the name refers to a callable or property, an ``admin_order_field``
+    attribute can be defined on it to point to the database column for
+    sorting. A ``short_description`` attribute can also be defined on the
+    callable or property to be used as the column header.
+    """
+
+    list_filter = ViewSet.UNDEFINED
+    """
+    A list or tuple, where each item is the name of model fields of type
+    ``BooleanField``, ``CharField``, ``DateField``, ``DateTimeField``,
+    ``IntegerField`` or ``ForeignKey``.
+    Alternatively, it can also be a dictionary that maps a field name to a
+    list of lookup expressions.
+    This will be passed as django-filter's ``FilterSet.Meta.fields``
+    attribute. See
+    `its documentation <https://django-filter.readthedocs.io/en/stable/guide/usage.html#generating-filters-with-meta-fields>`_
+    for more details.
+    If ``filterset_class`` is set, this attribute will be ignored.
+    """
+
+    filterset_class = ViewSet.UNDEFINED
+    """
+    A subclass of ``wagtail.admin.filters.WagtailFilterSet``, which is a
+    subclass of `django_filters.FilterSet <https://django-filter.readthedocs.io/en/stable/ref/filterset.html>`_.
+    This will be passed to the ``filterset_class`` attribute of the index view.
+    """
+
+    list_export = ViewSet.UNDEFINED
+    """
+    A list or tuple, where each item is the name of a field, an attribute,
+    or a single-argument callable on the model to be exported.
+    """
+
+    export_headings = ViewSet.UNDEFINED
+    """
+    A dictionary of export column heading overrides in the format
+    ``{field_name: heading}``.
+    """
+
+    export_filename = ViewSet.UNDEFINED
+    """The base file name for the exported listing, without extensions."""
+
+    def get_index_view_kwargs(self, **kwargs):
+        view_kwargs = {
+            "paginate_by": self.list_per_page,
+            "default_ordering": self.ordering,
+            "list_display": self.list_display,
+            "list_filter": self.list_filter,
+            "list_export": self.list_export,
+            "export_headings": self.export_headings,
+            "export_filename": self.export_filename,
+            "filterset_class": self.filterset_class,
+            **kwargs,
+        }
+        return view_kwargs

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -71,8 +71,6 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
     #: The number of items to display per page in the index view. Defaults to 20.
     list_per_page = 20
 
-    ordering = None
-
     #: Whether to enable the inspect view. Defaults to ``False``.
     inspect_view_enabled = False
 
@@ -434,10 +432,6 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
         )
 
     @cached_property
-    def list_filter(self):
-        return self.index_view_class.list_filter
-
-    @cached_property
     def search_fields(self):
         """
         The fields to use for the search in the index view.
@@ -452,15 +446,7 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
         The name of the Wagtail search backend to use for the search in the index view.
         If set to a falsy value, the search will fall back to use Django's QuerySet API.
         """
-        return self.index_view_class.search_backend_name
-
-    @cached_property
-    def list_export(self):
-        return self.index_view_class.list_export
-
-    @cached_property
-    def export_headings(self):
-        return self.index_view_class.export_headings
+        return self.UNDEFINED
 
     @cached_property
     def export_filename(self):

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -17,13 +17,14 @@ from wagtail.admin.admin_url_finder import (
 from wagtail.admin.panels.group import ObjectList
 from wagtail.admin.views import generic
 from wagtail.admin.views.generic import history, usage
+from wagtail.admin.viewsets.listing import ListingViewSetMixin
 from wagtail.models import ReferenceIndex
 from wagtail.permissions import ModelPermissionPolicy
 
 from .base import ViewSet, ViewSetGroup
 
 
-class ModelViewSet(ViewSet):
+class ModelViewSet(ListingViewSetMixin, ViewSet):
     """
     A viewset to allow listing, creating, editing and deleting model instances.
 
@@ -70,9 +71,6 @@ class ModelViewSet(ViewSet):
     #: The number of items to display per page in the index view. Defaults to 20.
     list_per_page = 20
 
-    #: The default ordering to use for the index view.
-    #: Can be a string or a list/tuple in the same format as Django's
-    #: :attr:`~django.db.models.Options.ordering`.
     ordering = None
 
     #: Whether to enable the inspect view. Defaults to ``False``.
@@ -181,22 +179,15 @@ class ModelViewSet(ViewSet):
         return view_kwargs
 
     def get_index_view_kwargs(self, **kwargs):
-        view_kwargs = {
-            "template_name": self.index_template_name,
-            "results_template_name": self.index_results_template_name,
-            "list_display": self.list_display,
-            "list_filter": self.list_filter,
-            "list_export": self.list_export,
-            "export_headings": self.export_headings,
-            "export_filename": self.export_filename,
-            "filterset_class": self.filterset_class,
-            "search_fields": self.search_fields,
-            "search_backend_name": self.search_backend_name,
-            "paginate_by": self.list_per_page,
-            **kwargs,
-        }
-        if self.ordering:
-            view_kwargs["default_ordering"] = self.ordering
+        view_kwargs = super().get_index_view_kwargs(
+            **{
+                "template_name": self.index_template_name,
+                "results_template_name": self.index_results_template_name,
+                "search_fields": self.search_fields,
+                "search_backend_name": self.search_backend_name,
+                **kwargs,
+            }
+        )
         if self.reorder_view_enabled:
             view_kwargs["sort_order_field"] = self.sort_order_field
             view_kwargs["reorder_url_name"] = self.get_url_name("reorder")
@@ -443,57 +434,8 @@ class ModelViewSet(ViewSet):
         )
 
     @cached_property
-    def list_display(self):
-        """
-        A list or tuple, where each item is either:
-
-        - The name of a field on the model;
-        - The name of a callable or property on the model that accepts a single
-          parameter for the model instance; or
-        - An instance of the ``wagtail.admin.ui.tables.Column`` class.
-
-        If the name refers to a database field, the ability to sort the listing
-        by the database column will be offered and the field's verbose name
-        will be used as the column header.
-
-        If the name refers to a callable or property, an ``admin_order_field``
-        attribute can be defined on it to point to the database column for
-        sorting. A ``short_description`` attribute can also be defined on the
-        callable or property to be used as the column header.
-
-        This list will be passed to the ``list_display`` attribute of the index
-        view. If left unset, the ``list_display`` attribute of the index view
-        will be used instead, which by default is defined as
-        ``["__str__", wagtail.admin.ui.tables.LocaleColumn(), wagtail.admin.ui.tables.UpdatedAtColumn()]``.
-
-        Note that the ``LocaleColumn`` is only included if the model is translatable.
-        """
-        return self.UNDEFINED
-
-    @cached_property
     def list_filter(self):
-        """
-        A list or tuple, where each item is the name of model fields of type
-        ``BooleanField``, ``CharField``, ``DateField``, ``DateTimeField``,
-        ``IntegerField`` or ``ForeignKey``.
-        Alternatively, it can also be a dictionary that maps a field name to a
-        list of lookup expressions.
-        This will be passed as django-filter's ``FilterSet.Meta.fields``
-        attribute. See
-        `its documentation <https://django-filter.readthedocs.io/en/stable/guide/usage.html#generating-filters-with-meta-fields>`_
-        for more details.
-        If ``filterset_class`` is set, this attribute will be ignored.
-        """
         return self.index_view_class.list_filter
-
-    @cached_property
-    def filterset_class(self):
-        """
-        A subclass of ``wagtail.admin.filters.WagtailFilterSet``, which is a
-        subclass of `django_filters.FilterSet <https://django-filter.readthedocs.io/en/stable/ref/filterset.html>`_.
-        This will be passed to the ``filterset_class`` attribute of the index view.
-        """
-        return self.UNDEFINED
 
     @cached_property
     def search_fields(self):
@@ -514,18 +456,10 @@ class ModelViewSet(ViewSet):
 
     @cached_property
     def list_export(self):
-        """
-        A list or tuple, where each item is the name of a field, an attribute,
-        or a single-argument callable on the model to be exported.
-        """
         return self.index_view_class.list_export
 
     @cached_property
     def export_headings(self):
-        """
-        A dictionary of export column heading overrides in the format
-        ``{field_name: heading}``.
-        """
         return self.index_view_class.export_headings
 
     @cached_property

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -59,6 +59,15 @@ class PageListingViewSet(ListingViewSetMixin, ViewSet):
         # that logic.
         return cls.UNDEFINED
 
+    @cached_property
+    def export_filename(self):
+        """
+        The base file name for the exported listing, without extensions.
+        If unset, the model's :attr:`~django.db.models.Options.db_table` will be
+        used instead.
+        """
+        return self.model._meta.db_table
+
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(
             **{

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -99,28 +99,34 @@ class PageViewSet(PageListingViewSet):
         return self.views[name]
 
     @cached_property
-    def parent_model(self):
+    def parent_models(self):
         """
-        The parent page model to associate in the main page explorer, so this
+        The parent page models to associate in the main page explorer, so this
         viewset's listing view will be used when exploring the parent page
-        model's children. This allows displaying, filtering, and ordering on
+        models' children. This allows displaying, filtering, and ordering on
         fields of a specific child page model in the explorer.
 
-        By default, if :attr:`Page.parent_page_types` is defined with a single
-        model, and that model also defines :attr:`Page.subpage_types` with only
-        this viewset's model, then that parent model will be used.
+        By default, if the main :attr:`model`
+        :attr:`~wagtail.models.Page.parent_page_types` is defined, this will be
+        every model in the list that also defines
+        :attr:`~wagtail.models.Page.subpage_types` with only this viewset's
+        model (or its subclasses). In other words, this will apply to this
+        viewset model's parents that only allow this viewset model (or its
+        subclasses) as children.
 
         Otherwise, the viewset's listing view customizations will not have any
         effect.
         """
         if self.model is Page:
-            return Page
-        allowed_models = self.model.allowed_parent_page_models()
-        if len(allowed_models) == 1:
-            parent_model = allowed_models[0]
-            if parent_model.allowed_subpage_models() == [self.model]:
-                return parent_model
-        return None
+            return [Page]
+        return [
+            model
+            for model in self.model.allowed_parent_page_models()
+            if all(
+                issubclass(child_model, self.model)
+                for child_model in model.allowed_subpage_models()
+            )
+        ]
 
     def get_url_name(self, view_name):
         """
@@ -140,7 +146,9 @@ class PageViewSet(PageListingViewSet):
     def on_register(self):
         """Register the viewset to the global page viewset registry."""
         super().on_register()
-        page_viewset_registry.register(self.model, self, parent_model=self.parent_model)
+        page_viewset_registry.register(
+            self.model, self, parent_models=self.parent_models
+        )
 
 
 class PageViewSetRegistry(ObjectTypeRegistry):
@@ -182,9 +190,9 @@ class PageViewSetRegistry(ObjectTypeRegistry):
         model = self.get_page_model_by_content_type_id(content_type_id)
         return self.get_by_parent_model(model)
 
-    def register(self, cls, value=None, exact_class=False, parent_model=None):
+    def register(self, cls, value=None, exact_class=False, parent_models=()):
         super().register(cls, value, exact_class)
-        if parent_model:
+        for parent_model in parent_models:
             self.values_by_parent_model[parent_model] = value
 
     def as_view(self, view_name, parent_page_id_kwarg):

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -6,13 +6,14 @@ from django.utils.functional import cached_property
 
 from wagtail.admin.views.pages.choose_parent import ChooseParentView
 from wagtail.admin.views.pages.listing import ExplorableIndexView, IndexView
+from wagtail.admin.viewsets.listing import ListingViewSetMixin
 from wagtail.models import Page
 from wagtail.utils.registry import ObjectTypeRegistry
 
 from .base import ViewSet
 
 
-class PageListingViewSet(ViewSet):
+class PageListingViewSet(ListingViewSetMixin, ViewSet):
     """
     A viewset to present a flat listing of all pages of a specific type.
     All attributes and methods from :class:`~wagtail.admin.viewsets.base.ViewSet`
@@ -45,12 +46,13 @@ class PageListingViewSet(ViewSet):
         )
 
     def get_index_view_kwargs(self, **kwargs):
-        return {
-            "index_results_url_name": self.get_url_name("index_results"),
-            "columns": self.columns,
-            "filterset_class": self.filterset_class,
-            **kwargs,
-        }
+        return super().get_index_view_kwargs(
+            **{
+                "index_results_url_name": self.get_url_name("index_results"),
+                "columns": self.columns,
+                **kwargs,
+            }
+        )
 
     def get_choose_parent_view_kwargs(self, **kwargs):
         return kwargs

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -2,10 +2,15 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404
 from django.urls import path
-from django.utils.functional import cached_property
+from django.utils.functional import cached_property, classproperty
 
 from wagtail.admin.views.pages.choose_parent import ChooseParentView
-from wagtail.admin.views.pages.listing import ExplorableIndexView, IndexView
+from wagtail.admin.views.pages.listing import (
+    ExplorableIndexView,
+    GenericPageFilterSet,
+    IndexView,
+    PageFilterSet,
+)
 from wagtail.admin.viewsets.listing import ListingViewSetMixin
 from wagtail.models import Page
 from wagtail.utils.registry import ObjectTypeRegistry
@@ -29,10 +34,22 @@ class PageListingViewSet(ListingViewSetMixin, ViewSet):
     model = Page
     #: A list of ``wagtail.admin.ui.tables.Column`` instances for the columns in the listing.
     columns = IndexView.columns
-    #: A subclass of ``wagtail.admin.filters.WagtailFilterSet``, which is a
-    #: subclass of `django_filters.FilterSet <https://django-filter.readthedocs.io/en/stable/ref/filterset.html>`_.
-    #: This will be passed to the ``filterset_class`` attribute of the index view.
-    filterset_class = IndexView.filterset_class
+
+    @classproperty
+    def filterset_class(cls):
+        # For backwards compatibility, use a classproperty so existing code that
+        # directly subclasses the viewset's filterset_class attribute will
+        # continue to work, while allowing new code to use list_filter to
+        # automatically generate a filterset class if desired.
+        if not cls.list_filter or cls.list_filter is cls.UNDEFINED:
+            if cls.model is Page:
+                # Add filter by content type
+                return GenericPageFilterSet
+            return PageFilterSet
+        # The filterset class generation is done in IndexView with a
+        # cached_property, so we need to use UNDEFINED here to avoid overwriting
+        # that logic.
+        return cls.UNDEFINED
 
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(
@@ -86,7 +103,6 @@ class PageListingViewSet(ListingViewSetMixin, ViewSet):
 class PageViewSet(PageListingViewSet):
     index_view_class = ExplorableIndexView
     columns = PageListingViewSet.UNDEFINED
-    filterset_class = PageListingViewSet.UNDEFINED
     menu_url = None
     """Unused. There is no specific URL to link to for the menu item."""
 

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -32,8 +32,16 @@ class PageListingViewSet(ListingViewSetMixin, ViewSet):
     choose_parent_view_class = ChooseParentView
     #: Required; the page model class that this viewset will work with.
     model = Page
-    #: A list of ``wagtail.admin.ui.tables.Column`` instances for the columns in the listing.
-    columns = IndexView.columns
+
+    @classproperty
+    def columns(cls):
+        # For backwards compatibility, use a classproperty so existing code that
+        # directly extends the viewset's columns attribute will continue to
+        # work, while allowing new code to set columns to automatically generate
+        # the columns for the listing with list_display.
+        if cls.list_display is cls.UNDEFINED:
+            return cls.index_view_class.base_columns
+        return cls.UNDEFINED
 
     @classproperty
     def filterset_class(cls):
@@ -102,7 +110,6 @@ class PageListingViewSet(ListingViewSetMixin, ViewSet):
 
 class PageViewSet(PageListingViewSet):
     index_view_class = ExplorableIndexView
-    columns = PageListingViewSet.UNDEFINED
     menu_url = None
     """Unused. There is no specific URL to link to for the menu item."""
 

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -112,6 +112,11 @@ class PageViewSet(PageListingViewSet):
         """
         return []
 
+    def on_register(self):
+        """Register the viewset to the global page viewset registry."""
+        super().on_register()
+        page_viewset_registry.register(self.model, self)
+
 
 class PageViewSetRegistry(ObjectTypeRegistry):
     def get_content_type_id_by_page_id(self, page_id):
@@ -157,6 +162,5 @@ class PageViewSetRegistry(ObjectTypeRegistry):
 page_viewset_registry = PageViewSetRegistry()
 
 # Provide a fallback default viewset for any page types that don't have a custom
-# viewset registered
+# viewset, to be registered via the register_admin_viewset hook.
 base_page_viewset = PageViewSet()
-page_viewset_registry.register(Page, base_page_viewset)

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -98,6 +98,12 @@ class PageViewSet(PageListingViewSet):
     def get_view_by_name(self, name):
         return self.views[name]
 
+    @cached_property
+    def parent_model(self):
+        if self.model is Page:
+            return Page
+        return None
+
     def get_url_name(self, view_name):
         """
         Unused. URL names are shared across all page types and are defined
@@ -116,10 +122,14 @@ class PageViewSet(PageListingViewSet):
     def on_register(self):
         """Register the viewset to the global page viewset registry."""
         super().on_register()
-        page_viewset_registry.register(self.model, self)
+        page_viewset_registry.register(self.model, self, parent_model=self.parent_model)
 
 
 class PageViewSetRegistry(ObjectTypeRegistry):
+    def __init__(self):
+        super().__init__()
+        self.values_by_parent_model = {}
+
     def get_content_type_id_by_page_id(self, page_id):
         return (
             Page.objects.filter(pk=page_id)
@@ -131,6 +141,13 @@ class PageViewSetRegistry(ObjectTypeRegistry):
         # A stale content type's model_class() returns None, fall back to base Page.
         return ContentType.objects.get_for_id(content_type_id).model_class() or Page
 
+    def get_by_parent_model(self, cls):
+        for ancestor in cls.mro():
+            try:
+                return self.values_by_parent_model[ancestor]
+            except KeyError:
+                pass
+
     def get_by_page_id(self, page_id):
         """Get a viewset by the page ID whose model is registered."""
         # Only fetch the content type ID to optimise the query, as the full page
@@ -139,7 +156,20 @@ class PageViewSetRegistry(ObjectTypeRegistry):
         model = self.get_page_model_by_content_type_id(content_type_id)
         return self.get_by_type(model)
 
-    def as_view(self, view_name, page_id_kwarg):
+    def get_by_parent_page_id(self, parent_page_id):
+        """Get a viewset by the parent page ID whose model is registered."""
+        # Only fetch the content type ID to optimise the query, as the full page
+        # instance will be fetched later by the view itself.
+        content_type_id = self.get_content_type_id_by_page_id(parent_page_id)
+        model = self.get_page_model_by_content_type_id(content_type_id)
+        return self.get_by_parent_model(model)
+
+    def register(self, cls, value=None, exact_class=False, parent_model=None):
+        super().register(cls, value, exact_class)
+        if parent_model:
+            self.values_by_parent_model[parent_model] = value
+
+    def as_view(self, view_name, parent_page_id_kwarg):
         """
         Create a view function that routes to the appropriate view based on the
         model of the page being accessed.
@@ -150,7 +180,7 @@ class PageViewSetRegistry(ObjectTypeRegistry):
 
         def view_router(request, *args, **kwargs):
             try:
-                viewset = self.get_by_page_id(kwargs.get(page_id_kwarg))
+                viewset = self.get_by_parent_page_id(kwargs.get(parent_page_id_kwarg))
             except ObjectDoesNotExist as e:
                 # Page or ContentType not found
                 raise Http404 from e

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -23,7 +23,7 @@ class PageListingViewSet(ListingViewSetMixin, ViewSet):
     A viewset to present a flat listing of all pages of a specific type.
     All attributes and methods from :class:`~wagtail.admin.viewsets.base.ViewSet`
     are available.
-    For more information on how to use this class, see :ref:`custom_page_listings`.
+    For more information on how to use this class, see :ref:`custom_flat_page_listings`.
     """
 
     #: The view class to use for the index view; must be a subclass of ``wagtail.admin.views.pages.listing.IndexView``.
@@ -35,6 +35,10 @@ class PageListingViewSet(ListingViewSetMixin, ViewSet):
 
     @classproperty
     def columns(cls):
+        """
+        A list of ``wagtail.admin.ui.tables.Column`` instances for the columns in the listing.
+        This takes priority over :attr:`list_display` if both are defined.
+        """
         # For backwards compatibility, use a classproperty so existing code that
         # directly extends the viewset's columns attribute will continue to
         # work, while allowing new code to set columns to automatically generate
@@ -118,7 +122,16 @@ class PageListingViewSet(ListingViewSetMixin, ViewSet):
 
 
 class PageViewSet(PageListingViewSet):
+    """
+    A viewset to define the views for pages of a specific type.
+    For more information on how to use this class, see :ref:`custom_page_explorer_listings`.
+    """
+
     index_view_class = ExplorableIndexView
+    """
+    The view class to use for the index view; must be a subclass of
+    ``wagtail.admin.views.pages.listing.ExplorableIndexView``.
+    """
     menu_url = None
     """Unused. There is no specific URL to link to for the menu item."""
 

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -2,6 +2,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404
 from django.urls import path
+from django.utils.functional import cached_property
 
 from wagtail.admin.views.pages.choose_parent import ChooseParentView
 from wagtail.admin.views.pages.listing import ExplorableIndexView, IndexView
@@ -54,19 +55,19 @@ class PageListingViewSet(ViewSet):
     def get_choose_parent_view_kwargs(self, **kwargs):
         return kwargs
 
-    @property
+    @cached_property
     def index_view(self):
         return self.construct_view(
             self.index_view_class, **self.get_index_view_kwargs()
         )
 
-    @property
+    @cached_property
     def index_results_view(self):
         return self.construct_view(
             self.index_view_class, **self.get_index_view_kwargs(), results_only=True
         )
 
-    @property
+    @cached_property
     def choose_parent_view(self):
         return self.construct_view(
             self.choose_parent_view_class, **self.get_choose_parent_view_kwargs()
@@ -87,7 +88,7 @@ class PageViewSet(PageListingViewSet):
     menu_url = None
     """Unused. There is no specific URL to link to for the menu item."""
 
-    @property
+    @cached_property
     def views(self):
         return {
             "index": self.index_view,

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -100,8 +100,26 @@ class PageViewSet(PageListingViewSet):
 
     @cached_property
     def parent_model(self):
+        """
+        The parent page model to associate in the main page explorer, so this
+        viewset's listing view will be used when exploring the parent page
+        model's children. This allows displaying, filtering, and ordering on
+        fields of a specific child page model in the explorer.
+
+        By default, if :attr:`Page.parent_page_types` is defined with a single
+        model, and that model also defines :attr:`Page.subpage_types` with only
+        this viewset's model, then that parent model will be used.
+
+        Otherwise, the viewset's listing view customizations will not have any
+        effect.
+        """
         if self.model is Page:
             return Page
+        allowed_models = self.model.allowed_parent_page_models()
+        if len(allowed_models) == 1:
+            parent_model = allowed_models[0]
+            if parent_model.allowed_subpage_models() == [self.model]:
+                return parent_model
         return None
 
     def get_url_name(self, view_name):

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -33,12 +33,14 @@ class PageListingViewSet(ListingViewSetMixin, ViewSet):
     #: Required; the page model class that this viewset will work with.
     model = Page
 
-    @classproperty
+    columns = classproperty()
+    """
+    A list of ``wagtail.admin.ui.tables.Column`` instances for the columns in the listing.
+    This takes priority over :attr:`list_display` if both are defined.
+    """
+
+    @columns.getter
     def columns(cls):
-        """
-        A list of ``wagtail.admin.ui.tables.Column`` instances for the columns in the listing.
-        This takes priority over :attr:`list_display` if both are defined.
-        """
         # For backwards compatibility, use a classproperty so existing code that
         # directly extends the viewset's columns attribute will continue to
         # work, while allowing new code to set columns to automatically generate

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -1,8 +1,12 @@
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import Http404
 from django.urls import path
 
 from wagtail.admin.views.pages.choose_parent import ChooseParentView
-from wagtail.admin.views.pages.listing import IndexView
+from wagtail.admin.views.pages.listing import ExplorableIndexView, IndexView
 from wagtail.models import Page
+from wagtail.utils.registry import ObjectTypeRegistry
 
 from .base import ViewSet
 
@@ -74,3 +78,85 @@ class PageListingViewSet(ViewSet):
             path("results/", self.index_results_view, name="index_results"),
             path("choose_parent/", self.choose_parent_view, name="choose_parent"),
         ]
+
+
+class PageViewSet(PageListingViewSet):
+    index_view_class = ExplorableIndexView
+    columns = PageListingViewSet.UNDEFINED
+    filterset_class = PageListingViewSet.UNDEFINED
+    menu_url = None
+    """Unused. There is no specific URL to link to for the menu item."""
+
+    @property
+    def views(self):
+        return {
+            "index": self.index_view,
+            "index_results": self.index_results_view,
+        }
+
+    def get_view_by_name(self, name):
+        return self.views[name]
+
+    def get_url_name(self, view_name):
+        """
+        Unused. URL names are shared across all page types and are defined
+        in the view classes directly.
+        """
+        return self.UNDEFINED
+
+    def get_urlpatterns(self):
+        """
+        Unused. URL patterns are shared across all page types and defined in
+        the main URL configuration. A thin view wrapper is used to route to the
+        appropriate viewset based on the model of the page being accessed.
+        """
+        return []
+
+
+class PageViewSetRegistry(ObjectTypeRegistry):
+    def get_content_type_id_by_page_id(self, page_id):
+        return (
+            Page.objects.filter(pk=page_id)
+            .values_list("content_type_id", flat=True)
+            .get()
+        )
+
+    def get_page_model_by_content_type_id(self, content_type_id):
+        # A stale content type's model_class() returns None, fall back to base Page.
+        return ContentType.objects.get_for_id(content_type_id).model_class() or Page
+
+    def get_by_page_id(self, page_id):
+        """Get a viewset by the page ID whose model is registered."""
+        # Only fetch the content type ID to optimise the query, as the full page
+        # instance will be fetched later by the view itself.
+        content_type_id = self.get_content_type_id_by_page_id(page_id)
+        model = self.get_page_model_by_content_type_id(content_type_id)
+        return self.get_by_type(model)
+
+    def as_view(self, view_name, page_id_kwarg):
+        """
+        Create a view function that routes to the appropriate view based on the
+        model of the page being accessed.
+
+        This allows the use of custom views for specific page types, while still
+        using the same URL pattern for all page types.
+        """
+
+        def view_router(request, *args, **kwargs):
+            try:
+                viewset = self.get_by_page_id(kwargs.get(page_id_kwarg))
+            except ObjectDoesNotExist as e:
+                # Page or ContentType not found
+                raise Http404 from e
+            view = viewset.get_view_by_name(view_name)
+            return view(request, *args, **kwargs)
+
+        return view_router
+
+
+page_viewset_registry = PageViewSetRegistry()
+
+# Provide a fallback default viewset for any page types that don't have a custom
+# viewset registered
+base_page_viewset = PageViewSet()
+page_viewset_registry.register(Page, base_page_viewset)

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -52,6 +52,7 @@ from wagtail.admin.views.pages.bulk_actions import (
     UnpublishBulkAction,
 )
 from wagtail.admin.viewsets import viewsets
+from wagtail.admin.viewsets.pages import base_page_viewset
 from wagtail.admin.widgets import ButtonWithDropdownFromHook
 from wagtail.models import Collection, Page, Task, Workflow
 from wagtail.permissions import (
@@ -66,6 +67,11 @@ from wagtail.templatetags.wagtailcore_tags import (
 )
 from wagtail.utils.version import get_main_version
 from wagtail.whitelist import allow_without_attributes, attribute_rule, check_url
+
+
+@hooks.register("register_admin_viewset", order=-1)
+def register_base_page_viewset():
+    return base_page_viewset
 
 
 class ExplorerMenuItem(MenuItem):

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -91,7 +91,9 @@ class FormPagesListView(PageListingMixin, PermissionCheckedMixin, BaseListingVie
     @classproperty
     def columns(self):
         columns = [
-            col for col in PageListingMixin.columns if col.name not in {"title", "type"}
+            col
+            for col in PageListingMixin.base_columns
+            if col.name not in {"title", "type"}
         ]
         columns.insert(
             1,

--- a/wagtail/contrib/simple_translation/tests/test_views.py
+++ b/wagtail/contrib/simple_translation/tests/test_views.py
@@ -545,7 +545,7 @@ class TestPageListing(WagtailTestUtils, TestCase):
     def test_translate_button_displayed(self):
         url = reverse("wagtailadmin_explore", args=(self.en_homepage.pk,))
         response = self.client.get(url)
-        with self.assertNumQueries(41):
+        with self.assertNumQueries(42):
             response = self.client.get(url)
 
         soup = self.get_soup(response.content)

--- a/wagtail/snippets/tests/test_edit_view.py
+++ b/wagtail/snippets/tests/test_edit_view.py
@@ -221,7 +221,7 @@ class TestSnippetEditView(BaseTestSnippetEditView):
         )
         self.assertIsNotNone(breadcrumbs)
         # Should include header buttons as they were not rendered in the create view
-        self.assertIsNotNone(breadcrumbs.select_one("#w-slim-header-buttons"))
+        self.assertIsNotNone(breadcrumbs.select_one("nav#w-slim-header-buttons"))
 
         # Should render the history link button as it wasn't rendered in the create view
         history_link = soup.find(
@@ -848,7 +848,7 @@ class TestEditRevisionSnippet(BaseTestSnippetEditView):
         )
         self.assertIsNotNone(breadcrumbs)
         # Should include header buttons as they were not rendered in the create view
-        self.assertIsNotNone(breadcrumbs.select_one("#w-slim-header-buttons"))
+        self.assertIsNotNone(breadcrumbs.select_one("nav#w-slim-header-buttons"))
 
         # Should render the history link button as it wasn't rendered in the create view
         history_link = soup.find(
@@ -1411,7 +1411,7 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         )
         self.assertIsNotNone(breadcrumbs)
         # Should include header buttons as they were not rendered in the create view
-        self.assertIsNotNone(breadcrumbs.select_one("#w-slim-header-buttons"))
+        self.assertIsNotNone(breadcrumbs.select_one("nav#w-slim-header-buttons"))
 
         # Should render the history link button as it wasn't rendered in the create view
         history_link = soup.find(

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -439,6 +439,7 @@ class EventPage(Page):
         index.SearchField("location"),
         index.SearchField("body"),
         index.FilterField("url_path"),
+        index.FilterField("audience"),
     ]
 
     password_required_template = "tests/event_page_password_required.html"

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -356,6 +356,7 @@ event_page_listing_viewset = EventPageListingViewSet("event_pages")
 
 class EventIndexPageViewSet(PageViewSet):
     model = EventIndex
+    icon = "calendar"
     columns = PageViewSet.index_view_class.columns.copy()
     columns.insert(-1, Column("audience", label="Audience", sort_key="audience"))
     filterset_class = EventPageFilterSet

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -361,6 +361,7 @@ class EventPageViewSet(PageViewSet):
     columns = PageViewSet.index_view_class.columns.copy()
     columns.insert(-1, Column("audience", label="Audience", sort_key="audience"))
     filterset_class = EventPageFilterSet
+    ordering = ("date_from", "title")
 
 
 event_page_viewset = EventPageViewSet()

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -358,8 +358,8 @@ class EventPageViewSet(PageViewSet):
     model = EventPage
     parent_models = [EventIndex]
     icon = "calendar"
-    columns = PageViewSet.index_view_class.columns.copy()
-    columns.insert(-1, Column("audience", label="Audience", sort_key="audience"))
+    list_display = PageViewSet.columns.copy()
+    list_display.insert(-1, "audience")
     list_filter = ["audience"]
     list_per_page = 10
     ordering = ("date_from", "title")

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -361,6 +361,7 @@ class EventPageViewSet(PageViewSet):
     columns = PageViewSet.index_view_class.columns.copy()
     columns.insert(-1, Column("audience", label="Audience", sort_key="audience"))
     filterset_class = EventPageFilterSet
+    list_per_page = 10
     ordering = ("date_from", "title")
 
 

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -360,7 +360,7 @@ class EventPageViewSet(PageViewSet):
     icon = "calendar"
     columns = PageViewSet.index_view_class.columns.copy()
     columns.insert(-1, Column("audience", label="Audience", sort_key="audience"))
-    filterset_class = EventPageFilterSet
+    list_filter = ["audience"]
     list_per_page = 10
     ordering = ("date_from", "title")
 

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -336,7 +336,7 @@ class EventPageFilterSet(PageListingViewSet.filterset_class):
 
 
 class EventPageIndexView(PageListingViewSet.index_view_class):
-    list_export = ["pk", "title", "audience", "event_date"]
+    list_export = ["pk", "title", "audience", "date_from"]
 
 
 class EventPageListingViewSet(PageListingViewSet):
@@ -361,6 +361,7 @@ class EventPageViewSet(PageViewSet):
     list_display = PageViewSet.columns.copy()
     list_display.insert(-1, "audience")
     list_filter = ["audience"]
+    list_export = ["pk", "title", "audience", "date_from"]
     list_per_page = 10
     ordering = ("date_from", "title")
 

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -24,10 +24,11 @@ from wagtail.admin.views.generic import (
 from wagtail.admin.viewsets.base import ViewSet, ViewSetGroup
 from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.admin.viewsets.model import ModelViewSet, ModelViewSetGroup
-from wagtail.admin.viewsets.pages import PageListingViewSet
+from wagtail.admin.viewsets.pages import PageListingViewSet, PageViewSet
 from wagtail.contrib.forms.views import SubmissionsListView
 from wagtail.test.testapp.models import (
     Advert,
+    EventIndex,
     EventPage,
     FeatureCompleteToy,
     JSONBlockCountsStreamModel,
@@ -351,6 +352,16 @@ class EventPageListingViewSet(PageListingViewSet):
 
 
 event_page_listing_viewset = EventPageListingViewSet("event_pages")
+
+
+class EventIndexPageViewSet(PageViewSet):
+    model = EventIndex
+    columns = PageViewSet.index_view_class.columns.copy()
+    columns.insert(-1, Column("audience", label="Audience", sort_key="audience"))
+    filterset_class = EventPageFilterSet
+
+
+event_index_page_viewset = EventIndexPageViewSet()
 
 
 class PlayView(View):

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -354,15 +354,16 @@ class EventPageListingViewSet(PageListingViewSet):
 event_page_listing_viewset = EventPageListingViewSet("event_pages")
 
 
-class EventIndexPageViewSet(PageViewSet):
-    model = EventIndex
+class EventPageViewSet(PageViewSet):
+    model = EventPage
+    parent_model = EventIndex
     icon = "calendar"
     columns = PageViewSet.index_view_class.columns.copy()
     columns.insert(-1, Column("audience", label="Audience", sort_key="audience"))
     filterset_class = EventPageFilterSet
 
 
-event_index_page_viewset = EventIndexPageViewSet()
+event_page_viewset = EventPageViewSet()
 
 
 class PlayView(View):

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -356,7 +356,7 @@ event_page_listing_viewset = EventPageListingViewSet("event_pages")
 
 class EventPageViewSet(PageViewSet):
     model = EventPage
-    parent_model = EventIndex
+    parent_models = [EventIndex]
     icon = "calendar"
     columns = PageViewSet.index_view_class.columns.copy()
     columns.insert(-1, Column("audience", label="Audience", sort_key="audience"))

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -23,6 +23,7 @@ from wagtail.admin.ui.components import Component
 from wagtail.admin.ui.tables import BooleanColumn, UpdatedAtColumn
 from wagtail.admin.utils import set_query_params
 from wagtail.admin.views.account import BaseSettingsPanel
+from wagtail.admin.viewsets.pages import page_viewset_registry
 from wagtail.admin.widgets import Button
 from wagtail.permission_policies.base import ModelPermissionPolicy
 from wagtail.snippets.bulk_actions.snippet_bulk_action import SnippetBulkAction
@@ -31,6 +32,7 @@ from wagtail.snippets.views.chooser import SnippetChooserViewSet
 from wagtail.snippets.views.snippets import SnippetViewSet, SnippetViewSetGroup
 from wagtail.test.testapp.models import (
     DraftStateModel,
+    EventIndex,
     FullFeaturedSnippet,
     ModeratedModel,
     RevisableChildModel,
@@ -45,6 +47,7 @@ from wagtail.test.testapp.views import (
     ToyViewSetGroup,
     advert_chooser_viewset,
     animated_advert_chooser_viewset,
+    event_index_page_viewset,
     event_page_listing_viewset,
     opera_viewset,
 )
@@ -460,3 +463,6 @@ def register_avatar_intercept_url(user, size):
 @hooks.register("register_admin_viewset")
 def register_advert_chooser_viewset():
     return advert_chooser_viewset
+
+
+page_viewset_registry.register(EventIndex, event_index_page_viewset)

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -45,8 +45,8 @@ from wagtail.test.testapp.views import (
     ToyViewSetGroup,
     advert_chooser_viewset,
     animated_advert_chooser_viewset,
-    event_index_page_viewset,
     event_page_listing_viewset,
+    event_page_viewset,
     opera_viewset,
 )
 
@@ -447,8 +447,8 @@ def register_event_page_listing_viewset():
 
 
 @hooks.register("register_admin_viewset")
-def register_event_index_page_viewset():
-    return event_index_page_viewset
+def register_event_page_viewset():
+    return event_page_viewset
 
 
 @hooks.register("register_admin_viewset")

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -23,7 +23,6 @@ from wagtail.admin.ui.components import Component
 from wagtail.admin.ui.tables import BooleanColumn, UpdatedAtColumn
 from wagtail.admin.utils import set_query_params
 from wagtail.admin.views.account import BaseSettingsPanel
-from wagtail.admin.viewsets.pages import page_viewset_registry
 from wagtail.admin.widgets import Button
 from wagtail.permission_policies.base import ModelPermissionPolicy
 from wagtail.snippets.bulk_actions.snippet_bulk_action import SnippetBulkAction
@@ -32,7 +31,6 @@ from wagtail.snippets.views.chooser import SnippetChooserViewSet
 from wagtail.snippets.views.snippets import SnippetViewSet, SnippetViewSetGroup
 from wagtail.test.testapp.models import (
     DraftStateModel,
-    EventIndex,
     FullFeaturedSnippet,
     ModeratedModel,
     RevisableChildModel,
@@ -449,6 +447,11 @@ def register_event_page_listing_viewset():
 
 
 @hooks.register("register_admin_viewset")
+def register_event_index_page_viewset():
+    return event_index_page_viewset
+
+
+@hooks.register("register_admin_viewset")
 def register_opera_viewset():
     return opera_viewset
 
@@ -463,6 +466,3 @@ def register_avatar_intercept_url(user, size):
 @hooks.register("register_admin_viewset")
 def register_advert_chooser_viewset():
     return advert_chooser_viewset
-
-
-page_viewset_registry.register(EventIndex, event_index_page_viewset)


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #11931, ~~fixes~~ lays foundation for #12463, and fixes #882

### Description

<!-- Please describe the problem you're fixing. -->

My bakerydemo patch:

```patch
From 559d3a0bb7a00117cd4af749be6f95bd40ced258 Mon Sep 17 00:00:00 2001
From: Sage Abdullah <sage.abdullah@torchbox.com>
Date: Mon, 30 Mar 2026 14:36:02 +0700
Subject: [PATCH] Add customized page listings

---
 bakerydemo/blog/models.py        |  1 +
 bakerydemo/blog/views.py         | 39 ++++++++++++++++++++++++++++++++
 bakerydemo/blog/wagtail_hooks.py |  8 +++++++
 3 files changed, 48 insertions(+)
 create mode 100644 bakerydemo/blog/views.py
 create mode 100644 bakerydemo/blog/wagtail_hooks.py

diff --git a/bakerydemo/blog/models.py b/bakerydemo/blog/models.py
index b3a4ae1..17db8ba 100644
--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -93,6 +93,7 @@ class BlogPage(Page):
 
     search_fields = Page.search_fields + [
         index.SearchField("body"),
+        index.FilterField("date_published"),
     ]
 
     api_fields = [
diff --git a/bakerydemo/blog/views.py b/bakerydemo/blog/views.py
new file mode 100644
index 0000000..6987996
--- /dev/null
+++ b/bakerydemo/blog/views.py
@@ -0,0 +1,39 @@
+from django_filters.filters import DateFromToRangeFilter
+from wagtail.admin.filters import DateRangePickerWidget
+from wagtail.admin.ui.tables import Column, DateColumn
+from wagtail.admin.viewsets.pages import PageViewSet
+
+from bakerydemo.blog.models import BlogPage
+
+
+class BlogPageFilterSet(PageViewSet.filterset_class):
+    date_published = DateFromToRangeFilter(
+        label="Date published",
+        widget=DateRangePickerWidget,
+    )
+
+
+class BlogPageViewSet(PageViewSet):
+    model = BlogPage
+    icon = "comment"
+    columns = PageViewSet.columns.copy()
+    columns.insert(
+        -1,
+        DateColumn(
+            "date_published",
+            label="Date published",
+            sort_key="date_published",
+        ),
+    )
+    filterset_class = BlogPageFilterSet
+    list_export = ["title", "latest_revision_created_at", "live", "date_published"]
+    ordering = "-date_published"
+
+
+class CustomPageViewSet(PageViewSet):
+    list_display = PageViewSet.columns.copy()
+    list_display.insert(-1, Column("slug", label="Slug", sort_key="slug"))
+    list_filter = ["slug"]
+    list_export = ["title", "slug", "latest_revision_created_at", "live"]
+    ordering = "slug"
+    export_filename = "pages"
diff --git a/bakerydemo/blog/wagtail_hooks.py b/bakerydemo/blog/wagtail_hooks.py
new file mode 100644
index 0000000..3cd7ec6
--- /dev/null
+++ b/bakerydemo/blog/wagtail_hooks.py
@@ -0,0 +1,8 @@
+from wagtail import hooks
+
+from bakerydemo.blog.views import BlogPageViewSet, CustomPageViewSet
+
+
+@hooks.register("register_admin_viewset")
+def register_page_viewsets():
+    return [BlogPageViewSet(), CustomPageViewSet()]
-- 
2.50.1 (Apple Git-155)


```

Copy, then do `cat | git am`, then Cmd+V and Ctrl+D.

To test:

- The page explorer for most pages now include the "slug" column and is ordered on that by default, as well as a filter for it.
- There should be a "Download XLSX" and "Download CSV" anywhere on the page listing
  - Upon search/filtering, the links for these buttons should reflect the search and filter. Any other buttons in the Actions dropdown should remain existing.
- Create a new blog index page somewhere on the tree, as well as some blog pages under it.
- When browsing the "Blog" blog index page:
  - The breadcrumbs now has an icon.
  - There is a "Date published" column (and is ordered on that by default).
  - There is a filter for Date published.
  - Upon search and filtering, you can click on the "Search the whole site" and retain the column and filters.
    - This will give you BlogPages across the whole site.
    - The column header of the page title should say "1-x of x **blog pages**" to indicate that the results are limited to blog pages.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

Copilot for autocomplete.