### PR TITLE
docs: add documentation for published and unpublished signals

### DIFF
--- a/docs/reference/signals.md
+++ b/docs/reference/signals.md
@@ -70,6 +70,15 @@ This signal is emitted from a `Page` when the page is unpublished.
 -   `instance` - The specific `Page` instance.
 -   `kwargs` - Any other arguments passed to `page_unpublished.send()`
 
+## `published`
+
+This signal is triggered when a page is published using the `PublishRevisionAction`.
+
+
+## `unpublished`
+
+This signal is triggered when a page is unpublished using the `UnpublishAction`.
+
 ## `pre_page_move` and `post_page_move`
 
 These signals are emitted from a `Page` immediately before and after it is moved.


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #13826 

### Description

This PR adds documentation for the generic published and unpublished signals, which were missing from the signals reference page.



### AI usage

none
