### PR TITLE
Fix StreamBlock group ordering to follow declaration order

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Changelog
  * Optimize combining of querysets in site history report (Alex Bridge)
  * Add more informative error for `format-*` operations on SVG images (Ankit Kumar)
  * Store preview data in new `FormState` model to improve compatibility with cookie-based sessions (Sage Abdullah)
+ * Change StreamBlock options so groups are shown in declaration order of their blocks (Darshan Kerkar)
  * Fix: Handle nested inline models when displaying object usage information (Sage Abdullah, Kacper Walęga, Tian Jie Wong)
  * Fix: Avoid duplicate `get_object()` DB query in API detail view (Siddheshwar Kadam)
  * Fix: Ensure `ImageBlock` alt text populates on choosing a new image after unchecking decorative state (Pratham Jaiswal)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -960,6 +960,7 @@
 * Devarshi Mani Tripathi
 * Om Harsh
 * Nirmal Kumar
+* Darshan Kerkar
 
 ## Translators
 

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -48,6 +48,7 @@ This feature was developed by Sage Abdullah. We would like to thank Personalkoll
  * Add `WAGTAILDOCS_MAX_UPLOAD_SIZE` setting for specifying maximum document file size (Om Harsh)
  * Optimize combining of querysets in site history report (Alex Bridge)
  * Add more informative error for `format-*` operations on SVG images (Ankit Kumar)
+ * Change StreamBlock options so groups are shown in declaration order of their blocks (Darshan Kerkar)
 
 ### Bug fixes
 

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -99,7 +99,7 @@ class BaseStreamBlock(Block):
     def empty_value(self, raw_text=None):
         return StreamValue(self, [], raw_text=raw_text)
 
-    def sorted_child_blocks(self):
+    def ordered_child_blocks(self):
         """Child blocks in declaration order."""
         return self.child_blocks.values()
 
@@ -111,7 +111,7 @@ class BaseStreamBlock(Block):
         """
         grouped_blocks = OrderedDict()
 
-        for child_block in self.sorted_child_blocks():
+        for child_block in self.ordered_child_blocks():
             group_name = child_block.meta.group
             grouped_blocks.setdefault(group_name, []).append(child_block)
 

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -4907,28 +4907,13 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         self.assertEqual(blockdefs_dict.keys(), {"", "group1", "group2"})
 
     def test_adapt_preserves_group_order_by_declaration_order(self):
-        class ContentBlock(blocks.CharBlock):
-            class Meta:
-                group = "content"
-
-        class MediaBlock(blocks.CharBlock):
-            class Meta:
-                group = "media"
-
-        class CardsBlock(blocks.CharBlock):
-            class Meta:
-                group = "cards"
-
-        class NoGroupBlock(blocks.CharBlock):
-            pass
-
         block = blocks.StreamBlock(
             [
-                ("content_1", ContentBlock()),
-                ("media_1", MediaBlock()),
-                ("content_2", ContentBlock()),
-                ("cards_1", CardsBlock()),
-                ("no_group", NoGroupBlock()),
+                ("content_1", blocks.CharBlock(group="content")),
+                ("media_1", blocks.CharBlock(group="media")),
+                ("content_2", blocks.CharBlock(group="content")),
+                ("cards_1", blocks.CharBlock(group="cards")),
+                ("no_group", blocks.CharBlock()),
             ]
         )
 


### PR DESCRIPTION
Fixes #14051

cc @joeyjurjens @thibaudcolas

## Summary

StreamBlock/StreamField groups were previously ordered alphabetically by group name.
This PR updates ordering to follow block declaration order, which gives editors more intentional control over how groups appear.
This keeps the existing `Meta.group` API unchanged.

## Changes

- Preserve declaration order when building grouped chooser options
- Keep existing `Meta.group` API (no new BlockGroup-style API introduced)
- Add tests for:
  - group order
  - block order within each group

## Compatibility note

If projects prefer alphabetical order, they can still get it by declaring grouped blocks in alphabetical order in the StreamBlock definition.

## Verification

- Ran:
  - `python runtests.py -- wagtail.tests.test_blocks.TestStreamBlock`
- Result:
  - All tests passed locally

## Screenshots

### Before
Groups were ordered alphabetically.
<img width="1913" height="908" alt="Screenshot 2026-03-24 005755" src="https://github.com/user-attachments/assets/58a1b10b-67ed-4de4-87ce-27ed4067691d" />


### After
Groups follow declaration order from StreamBlock definition.
<img width="1920" height="972" alt="Screenshot (538)" src="https://github.com/user-attachments/assets/3fb35935-725d-42d6-b4af-3414aed6485f" />


## AI usage

I used Claude for understanding the repo structure and the actual issue which is happening in the app.