### PR TITLE
docs: improve clarity of linting and formatting reference links

### DIFF
--- a/docs/contributing/ui_guidelines.md
+++ b/docs/contributing/ui_guidelines.md
@@ -61,7 +61,7 @@ The audit also states which parts of Wagtail have and haven’t been tested, how
 
 ## HTML guidelines
 
-We use [djhtml](https://github.com/rtts/djhtml) for formatting and [Curlylint](https://www.curlylint.org/) for linting. See [](linting_and_formatting).
+We use [djhtml](https://github.com/rtts/djhtml) for formatting and [Curlylint](https://www.curlylint.org/) for linting.See the linting and formatting guidelines.
 
 -   Write [valid](https://validator.w3.org/nu/), [semantic](https://html5doctor.com/element-index/) HTML.
 -   Follow [ARIA authoring practices](https://w3c.github.io/aria-practices/), in particular, [No ARIA is better than Bad ARIA](https://w3c.github.io/aria-practices/#no_aria_better_bad_aria).


### PR DESCRIPTION
Clarified unclear reference to linting and formatting guidelines by replacing empty link text with descriptive wording.