### PR TITLE
Fix workflow label using parent workflow fallback

### DIFF
--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -131,6 +131,11 @@ class SubmitForModerationMenuItem(ActionMenuItem):
             }
         elif page:
             workflow = page.get_workflow()
+            # fallback to parent workflow during page creation
+            if not workflow:
+                parent = page.get_parent()
+                if parent and hasattr(parent, "specific"):
+                    workflow = parent.specific.get_workflow()
             if workflow:
                 context["label"] = _("Submit to %(workflow_name)s") % {
                     "workflow_name": workflow.name


### PR DESCRIPTION
Fixes #14019

### Description

Fix inconsistent "Submit for moderation" button label during page creation.

Previously, the workflow name was not displayed until page reload because
`page.get_workflow()` returns `None` during initial page creation. As a result,
the button label remained generic ("Submit for moderation") even after autosave
switched the view to edit mode, and only updated after a full reload.

This change introduces a fallback to the parent page's workflow when the page
workflow is not yet available. Since new pages inherit workflows from their
parent, this ensures the correct label ("Submit to %(workflow_name)s") is shown
consistently across create, autosave, and reload states.

### AI usage

Assisted by AI for understanding the issue and structuring the solution. The
implementation and testing were completed manually.