### PR TITLE
Docs: wagtail start clarification

### DIFF
--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -95,7 +95,7 @@ Because the folder `mysite` was already created by `venv`, run `wagtail start` w
 wagtail start mysite mysite
 ```
 
-* The first `mysite` is the **project name**, used for configuration and internal references.
+* The first `mysite` is the **project name**, used for template selections.
 * The second `mysite` is the **destination directory**, where the project files will be created.
 
 Alternatively, to create the project in the current directory, you can run:


### PR DESCRIPTION

The usage of the `wagtail start` command was unclear when providing two arguments.
```sh
wagtail start mysite mysite
```
Specifically, it was not clear which parameter refers to the project name and which refers to the destination directory. This can be confusing for users when the target folder already exists, since the documentation earlier instructs creating it while setting up the virtual environment.

This PR adds a clarification explaining:
- the first argument is the project name
- the second argument is the destination directory

It also includes an additional example using `.` to demonstrate creating a project in the current directory.
