### PR TITLE
Fix image renditions sections

### DIFF
--- a/docs/advanced_topics/images/renditions.md
+++ b/docs/advanced_topics/images/renditions.md
@@ -64,12 +64,6 @@ Wagtail will cache image rendition lookups, which can improve the performance of
 
 By default, Wagtail will try to use the cache called "renditions". If no such cache exists, it will fall back to using the default cache.
 
-(prefetching_image_renditions)=
-
-## Prefetching image renditions
-
-When using a queryset to render a list of images or objects with images, you can prefetch the renditions needed with a single additional query. For long lists of items, or where multiple renditions are used for each item, this can provide a significant boost to performance.
-
 (regenerate_image_renditions)=
 
 ## Regenerating existing renditions
@@ -81,6 +75,12 @@ You can also directly use the image management command from the console to regen
 ```
 
 You can read more about this command from [](wagtail_update_image_renditions)
+
+(prefetching_image_renditions)=
+
+## Prefetching image renditions
+
+When using a queryset to render a list of images or objects with images, you can prefetch the renditions needed with a single additional query. For long lists of items, or where multiple renditions are used for each item, this can provide a significant boost to performance.
 
 ### Image QuerySets
 


### PR DESCRIPTION
https://docs.wagtail.org/en/stable/advanced_topics/images/renditions.html#regenerating-existing-renditions

The current structure is not logical, querysets doc should be part of prefetching

<img width="344" height="253" alt="image" src="https://github.com/user-attachments/assets/d6e4a310-b06d-4125-97cb-4f11f2b3ecb9" />