### PR TITLE
Make operation_name_fragment optional for block migrations

### DIFF
--- a/docs/advanced_topics/streamfield_migrations.md
+++ b/docs/advanced_topics/streamfield_migrations.md
@@ -506,14 +506,14 @@ Block ids are not preserved here since the new blocks are structurally different
 
 #### Basic usage
 
-While this package comes with a set of operations for common use cases, there may be many instances where you need to define your own operation for mapping data. Making a custom operation is fairly straightforward. All you need to do is extend the `BaseBlockOperation` class and define the required methods,
+While this package comes with a set of operations for common use cases, there may be many instances where you need to define your own operation for mapping data. Making a custom operation is fairly straightforward. All you need to do is extend the `BaseBlockOperation` class and define the required method,
 
 -   `apply`  
     This applies the actual changes to the existing block value and returns the new block value.
--   `operation_name_fragment`  
-    (`@property`) Returns a name to be used for generating migration names.
+-   `operation_name_fragment` (optional)  
+    (`@property`) Returns a name to be used for generating migration names. If omitted, a default will be generated from the operation class name (`MyBlockOperation` -> `my_block_operation`).
 
-(**NOTE:** `BaseBlockOperation` inherits from `abc.ABC`, so all of the required methods
+(**NOTE:** `BaseBlockOperation` inherits from `abc.ABC`, so the required methods
 mentioned above have to be defined on any class inheriting from it.)
 
 For example, if we want to truncate the string in a `CharBlock` to a given length,

--- a/wagtail/blocks/migrations/operations.py
+++ b/wagtail/blocks/migrations/operations.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC, abstractmethod
 from wagtail.blocks.migrations.utils import formatted_list_child_generator
 from django.utils.deconstruct import deconstructible
@@ -12,9 +13,8 @@ class BaseBlockOperation(ABC):
         pass
 
     @property
-    @abstractmethod
     def operation_name_fragment(self):
-        pass
+        return re.sub(r"(?<!^)(?=[A-Z])", "_", self.__class__.__name__).lower()
 
 
 @deconstructible

--- a/wagtail/tests/streamfield_migrations/test_migration_names.py
+++ b/wagtail/tests/streamfield_migrations/test_migration_names.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from wagtail.blocks.migrations.operations import (
+    BaseBlockOperation,
     RemoveStreamChildrenOperation,
     RenameStreamChildrenOperation,
 )
@@ -57,3 +58,33 @@ class MigrationNameTest(TestCase, MigrationTestMixin):
 
         suggested_name = migration.suggest_name()
         self.assertEqual(suggested_name, "rename_char1_to_renamed1_remove_char1")
+
+    def test_custom_operation_uses_default_fragment(self):
+        class SimpleCustomOperation(BaseBlockOperation):
+            def apply(self, block_value):
+                return block_value
+
+        operations_and_block_paths = [(SimpleCustomOperation(), "")]
+        migration = self.init_migration(
+            operations_and_block_paths=operations_and_block_paths
+        )
+
+        suggested_name = migration.suggest_name()
+        self.assertEqual(suggested_name, "simple_custom_operation")
+
+    def test_custom_operation_can_override_fragment(self):
+        class CustomNamedOperation(BaseBlockOperation):
+            def apply(self, block_value):
+                return block_value
+
+            @property
+            def operation_name_fragment(self):
+                return "custom_name"
+
+        operations_and_block_paths = [(CustomNamedOperation(), "")]
+        migration = self.init_migration(
+            operations_and_block_paths=operations_and_block_paths
+        )
+
+        suggested_name = migration.suggest_name()
+        self.assertEqual(suggested_name, "custom_name")


### PR DESCRIPTION
Fixes #...

### Description

This PR makes custom StreamField migration operations easier to write by making `operation_name_fragment` optional on `BaseBlockOperation`.

Previously, custom operations had to implement both `apply` and `operation_name_fragment`, even when no custom migration naming was needed. This added boilerplate for simple transforms.
Now, `BaseBlockOperation` provides a default fragment derived from the class name (for example, `MyBlockOperation` -> `my_block_operation`), while still allowing explicit overrides.

Changes included:
- default `operation_name_fragment` implementation in `wagtail/blocks/migrations/operations.py`
- tests for default behavior and override behavior
- docs update in `docs/advanced_topics/streamfield_migrations.md`

Please review carefully:
- migration name generation behavior for custom operations
- backwards compatibility for built-in operations with explicit fragments

### AI usage

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.