### PR TITLE
feat: enable sortable columns in chooser view

### DIFF
--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -190,12 +190,14 @@ class BrowseView(View):
                 label=_("Updated"),
                 width="12%",
                 accessor="latest_revision_created_at",
+                sort_key="latest_revision_created_at",
             ),
             Column(
                 "type",
                 label=_("Type"),
                 width="12%",
                 accessor="page_type_display_name",
+                sort_key="page_type_display_name",
             ),
             PageStatusColumn("status", label=_("Status"), width="12%"),
             PageNavigateToChildrenColumn("children", label="", width="10%"),
@@ -212,6 +214,9 @@ class BrowseView(View):
     def get_object_list(self):
         # Get children of parent page (without streamfields)
         pages = self.parent_page.get_children().defer_streamfields().specific()
+        ordering = self.request.GET.get("ordering")
+        if ordering:
+            pages = pages.order_by(ordering)
         if self.i18n_enabled:
             pages = pages.select_related("locale")
         return pages


### PR DESCRIPTION
## Problem
Currently, chooser views in Wagtail define `sort_key` for columns, but sorting is not actually applied because the queryset is not ordered based on request parameters.

## Solution
- Added support for dynamic ordering using `request.GET['ordering'].`
- Applied ordering in the `get_object_list()` method
- Enabled sorting for columns like "Updated" and "Type."

## Changes
- Added `sort_key` to relevant columns
- Updated `get_object_list()` to apply ordering

## Result
Columns with `sort_key` can now be sorted dynamically.

## Notes
This implementation keeps behavior backward-compatible and only applies ordering when explicitly requested.