### PR TITLE
Document how `list_export` in reports accepts a dotted path for nested attribute resolution

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -66,6 +66,7 @@ Changelog
  * Docs: Add documentation for generic `published` and `unpublished` signals (Kunal Hemnani)
  * Docs: Improve organization of signals reference docs (Sage Abdullah)
  * Docs: Add documentation for overriding the default user avatar image (Aviral Sapra)
+ * Docs: Document how `list_export` in reports accepts a dotted path for nested attribute resolution (mikko2577)
  * Maintenance: Removed support for Django 4.2
  * Maintenance: Fix LocaleController test failures caused by differing timezone representations between Node versions (Saptami, Matt Westcott)
  * Maintenance: Fix frontend coverage upload to Codecov (Sage Abdullah)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -967,6 +967,7 @@
 * Aviral Sapra
 * Raghad Dahi
 * Divyansh Mishra
+* mikko2577
 
 ## Translators
 

--- a/docs/extending/adding_reports.md
+++ b/docs/extending/adding_reports.md
@@ -115,6 +115,18 @@ and specific type of any pages. For our example, we might want to know when the 
 
 ``list_export = PageReportView.list_export + ['last_published_at']``
 
+The ``list_export`` attribute also supports dotted paths to access nested attributes.
+
+For example:
+
+.. code-block:: python
+
+    list_export = ['author.name']
+
+This will export the ``name`` attribute of the related ``author`` object.
+
+This works using Django’s standard attribute resolution, similar to how variables are resolved in templates.
+
 .. attribute:: export_headings
 
 (dictionary)

--- a/docs/extending/adding_reports.md
+++ b/docs/extending/adding_reports.md
@@ -115,17 +115,11 @@ and specific type of any pages. For our example, we might want to know when the 
 
 ``list_export = PageReportView.list_export + ['last_published_at']``
 
-The ``list_export`` attribute also supports dotted paths to access nested attributes.
-
-For example:
+The ``list_export`` attribute also supports dotted paths to access nested attributes. For example, this will export the ``name`` attribute of the related ``author`` object:
 
 .. code-block:: python
 
     list_export = ['author.name']
-
-This will export the ``name`` attribute of the related ``author`` object.
-
-This works using Django’s standard attribute resolution, similar to how variables are resolved in templates.
 
 .. attribute:: export_headings
 

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -127,6 +127,7 @@ This release includes a number of improvements around the User Experience in the
  * Add documentation for generic `published` and `unpublished` signals (Kunal Hemnani)
  * Improve organization of signals reference docs (Sage Abdullah)
  * Add documentation for overriding the default user avatar image (Aviral Sapra)
+ * Document how `list_export` in [reports](adding_reports) accepts a dotted path for nested attribute resolution (mikko2577)
 
 ### Maintenance
 


### PR DESCRIPTION
Adds documentation explaining that list_export supports dotted paths for nested attribute access, with a simple example.