### PR TITLE
Sync autosave field_updates when server mutates form fields

### DIFF
--- a/wagtail/admin/forms/models.py
+++ b/wagtail/admin/forms/models.py
@@ -2,7 +2,11 @@ import copy
 
 from django import VERSION as DJANGO_VERSION
 from django import forms
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import (
+    FieldDoesNotExist,
+    ImproperlyConfigured,
+    ValidationError,
+)
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext as _
@@ -16,6 +20,7 @@ from taggit.managers import TaggableManager
 
 from wagtail.admin import widgets
 from wagtail.admin.forms.tags import TagField
+from wagtail.fields import RichTextField, StreamField
 from wagtail.models import Page
 from wagtail.utils.registry import ModelFieldRegistry
 
@@ -187,6 +192,56 @@ class WagtailAdminModelForm(
 
         self.is_deferred_validation = False
 
+    def _get_server_mutated_field_updates(self):
+        """
+        Return (name, value) pairs for form fields where the saved instance differs from
+        the POST data (e.g. model ``save()`` side effects or ``post_save`` signals).
+        The autosave client applies these so the next submission does not overwrite
+        server-authoritative values with stale input (e.g. title in the header vs the
+        title field).
+        """
+        if not self.is_bound or not getattr(self.instance, "pk", None):
+            return []
+
+        if self.prefix:
+            return []
+
+        updates = []
+        for field_name, field in self.fields.items():
+            data_key = self.add_prefix(field_name)
+            if data_key not in self.data:
+                continue
+            try:
+                model_field = self.instance._meta.get_field(field_name)
+            except FieldDoesNotExist:
+                continue
+            if not model_field.concrete:
+                continue
+            if model_field.primary_key:
+                continue
+            if isinstance(model_field, (models.ManyToManyField, models.FileField)):
+                continue
+            
+            if isinstance(model_field, (RichTextField, StreamField)):
+                continue
+
+            raw_submitted = self.data.get(data_key)
+            instance_value = getattr(self.instance, field_name)
+
+            try:
+                submitted_python = field.to_python(raw_submitted)
+            except ValidationError:
+                continue
+
+            if submitted_python != instance_value:
+                prepared = field.prepare_value(instance_value)
+                if prepared is None:
+                    prepared = ""
+                # JSON keys must match HTML input names (include form prefix when used).
+                updates.append((data_key, prepared))
+
+        return updates
+
     def get_field_updates_for_resave(self):
         """
         Following a successful save (as a background HTTP request), returns a list of
@@ -220,8 +275,7 @@ class WagtailAdminModelForm(
                         # instance has a PK but the form data doesn't include it - it must have
                         # been created during the save we just performed
                         updates.append((id_field_name, str(form.instance.pk)))
-
-        return updates
+        return self._get_server_mutated_field_updates() + updates
 
     class Meta:
         formfield_callback = formfield_for_dbfield

--- a/wagtail/admin/forms/models.py
+++ b/wagtail/admin/forms/models.py
@@ -221,7 +221,9 @@ class WagtailAdminModelForm(
                 continue
             if isinstance(model_field, (models.ManyToManyField, models.FileField)):
                 continue
-            
+
+            if isinstance(model_field, models.BooleanField):
+                continue
             if isinstance(model_field, (RichTextField, StreamField)):
                 continue
 

--- a/wagtail/admin/tests/test_forms.py
+++ b/wagtail/admin/tests/test_forms.py
@@ -226,6 +226,30 @@ class TestGetFieldUpdatesForResave(TestCase):
             ],
         )
 
+    def test_get_field_updates_for_resave_includes_server_mutated_simple_fields(self):
+        """
+        When the saved instance differs from POST (e.g. post_save signal), field_updates
+        must include those fields so autosave can sync the form inputs.
+        """
+
+        class AdvertForm(WagtailAdminModelForm):
+            class Meta:
+                model = Advert
+                fields = ["url", "text"]
+
+        advert = Advert.objects.create(url="https://example.com/", text="hello")
+        form = AdvertForm(
+            {"url": "https://example.com/", "text": "hello"},
+            instance=advert,
+        )
+        self.assertTrue(form.is_valid())
+        form.save()
+        form.instance.url = "https://changed.example.com/"
+        self.assertEqual(
+            dict(form.get_field_updates_for_resave()),
+            {"url": "https://changed.example.com/"},
+        )
+
     def test_get_field_updates_for_resave_on_update(self):
         snippet = MultiSectionRichTextSnippet()
         section_1 = snippet.sections.create(body="<p>Initial body 1</p>")


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->

Fixes: #14087 

### Description

**What went wrong**
After autosave, the page title in the header could update (because the server saved a new title), but the title **field in the form** could still show the old text. The next save then sent that old text again and undid the server’s change. This happens when something on the server changes the title after save (for example a `post_save` signal).

**Why**
Autosave responses already send a `field_updates` map so the browser can fix form fields after save. Until now, that map only covered **formsets** (inline rows, new IDs, etc.). It did **not** include normal fields like `title` when the saved value no longer matched what was posted.

**What we changed**
We now add those “plain” fields to `field_updates` when the saved copy of the page/snippet doesn’t match the POST data. The admin JavaScript already applies `field_updates` to inputs, so the title box stays in step with the server.

We only do this for the **main** form (not each inline form row), and we skip a few field types where comparing saved vs posted values is misleading (for example rich text and stream fields, where the saved HTML often changes slightly even when the user didn’t “change” the meaning).

A small test in `test_forms.py` was added to lock this in.

### AI usage

AI assistance was taken to refine the PR description to make sure the the PR was descriptive enough to understand the solution. 