### PR TITLE
Docs: clarify form accessibility ticket references

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@ Changelog
  * Docs: Correct references to macOS and POSIX shell in tutorial (Ankit Kumar)
  * Docs: Add PowerShell setup instructions to tutorial and correct method versus property terminology (Mustansir Dabhiya)
  * Docs: Fix ordering of image rendition documentation (Seb Corbin)
+ * Docs: Remove references to now-addressed Django accessibility issues (Nirmal Kumar)
  * Maintenance: Removed support for Django 4.2
  * Maintenance: Fix LocaleController test failures caused by differing timezone representations between Node versions (Saptami, Matt Westcott)
  * Maintenance: Fix frontend coverage upload to Codecov (Sage Abdullah)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -959,6 +959,7 @@
 * K Adithya
 * Devarshi Mani Tripathi
 * Om Harsh
+* Nirmal Kumar
 
 ## Translators
 

--- a/docs/advanced_topics/accessibility_considerations.md
+++ b/docs/advanced_topics/accessibility_considerations.md
@@ -101,7 +101,7 @@ h6:empty {
 
 The [Form builder](form_builder) uses Django’s forms API. Here are considerations specific to forms in templates:
 
--   Avoid rendering helpers such as `as_table`, `as_ul`, `as_p`, which can make forms harder to navigate for screen reader users or cause HTML validation issues (for Django < 5.0, see Django ticket [#32339](https://code.djangoproject.com/ticket/32339)).
+-   Avoid rendering helpers such as `as_table`, `as_ul`, `as_p`, which can make forms harder to navigate for screen reader users or cause HTML validation issues.
 -   Make sure to visually distinguish required and optional fields.
 -   Take the time to group related fields together in `fieldset`, with an appropriate `legend`, in particular for radios and checkboxes.
 -   If relevant, use the appropriate `autocomplete` and `autocapitalize` attributes.

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -65,6 +65,7 @@ This feature was developed by Sage Abdullah.
  * Correct references to macOS and POSIX shell in tutorial (Ankit Kumar)
  * Add PowerShell setup instructions to tutorial and correct method versus property terminology (Mustansir Dabhiya)
  * Fix ordering of image rendition documentation (Seb Corbin)
+ * Remove references to now-addressed Django accessibility issues (Nirmal Kumar)
 
 ### Maintenance
 


### PR DESCRIPTION
This updates the forms accessibility guidance in the docs to reflect Django ticket status and avoid outdated references.
Changes:

Clarify that the as_table/as_ul/as_p warning references Django ticket #32339 for Django versions below 5.0.
Keep fieldset guidance as a best practice without tying it directly to closed ticket #32338.
Keep the existing #32340 reference unchanged.
Refs #12009