### PR TITLE
Clarify StreamField template usage and add example in AGENTS instruct…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ The main developer documentation for Wagtail lives in the `docs/contributing` di
 
 ## Pull request guidelines
 
-- Describe the "why" of the changes, why the proposed solution is the right one.
+- Describe the "why" of the changes — why these changes are necessary and why the proposed solution is the right one.
 - Highlight areas of the proposed changes that require careful review.
 - Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution.
 
@@ -18,4 +18,13 @@ The main developer documentation for Wagtail lives in the `docs/contributing` di
 
 ### StreamField and StreamBlock template access
 
-- Wagtail's StreamBlock and StreamField use the same template syntax, but they differ from standard Django field access. When you use StreamField and other custom block types in Wagtail templates, you usually need to use the value property in your data variables. 
+- Wagtail's StreamBlock and StreamField use a template syntax that differs from standard Django field access. When working with StreamField or custom block types in templates, you should access block data via the `value` property.
+
+Example:
+```
+{% for block in page.body %}
+  {{ block.value }}
+{% endfor %}
+```
+Failing to use `block.value` may result in unexpected output or missing data in templates.
+Use `block.value` (or `self.value` inside a block template) rather than treating the field like a plain Django model field.


### PR DESCRIPTION
Related to documentation improvements
### Description

This PR improves the AGENTS instructions by clarifying how StreamField and StreamBlock data should be accessed in Wagtail templates.

The previous wording could be slightly unclear for contributors unfamiliar with Wagtail’s template behavior. This update refines the explanation and adds a concrete example demonstrating the correct usage of `block.value`.

This helps prevent common mistakes such as attempting to access block data like standard Django model fields, which can result in missing or incorrect output in templates.

### AI usage
This pull request includes code written with the assistance of AI.  
The code has not yet been fully reviewed and may require further validation.