### PR TITLE
Update format_html call in extending client docs

### DIFF
--- a/docs/extending/extending_client_side.md
+++ b/docs/extending/extending_client_side.md
@@ -114,7 +114,7 @@ from wagtail import hooks
 @hooks.register('insert_global_admin_js')
 def global_admin_js():
     return format_html(
-        f'<script src="{static("js/example.js")}"></script>',
+        '<script src="{}"></script>', static('js/example.js')
     )
 ```
 


### PR DESCRIPTION
### Description

In the simple controller example in the [extending client-side behaviour docs](https://docs.wagtail.org/en/v7.3.1/extending/extending_client_side.html#a-simple-controller-example) there is a call to `format_html` with no args or kwargs.
I think this was deprecated in Django 5.0 and removed in Django 6.0. https://code.djangoproject.com/ticket/34609

### AI usage

None
