### PR TITLE
Configure Ruff to format Python code blocks in Markdown docs`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+      - 'stable/**'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint-server:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[testing]' --config-settings editable_mode=strict
+      - name: Check Python formatting in docs
+        run: |
+          grep -rL '```{' docs/ --include="*.md" | xargs ruff format --preview --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
+        args: [--preview]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0

--- a/docs/advanced_topics/accessibility_considerations.md
+++ b/docs/advanced_topics/accessibility_considerations.md
@@ -153,21 +153,22 @@ class CustomAccessibilityItem(AccessibilityItem):
                 "id": "p-as-heading",
                 "options": {
                     "margins": [
-                        { "weight": 150 },
+                        {"weight": 150},
                     ],
                     "passLength": 1,
-                    "failLength": 0.5
+                    "failLength": 0.5,
                 },
             },
         )
         return checks
 
 
-@hooks.register('construct_wagtail_userbar')
+@hooks.register("construct_wagtail_userbar")
 def replace_userbar_accessibility_item(request, items, page):
     items[:] = [
         CustomAccessibilityItem(in_editor=item.in_editor)
-        if isinstance(item, AccessibilityItem) else item
+        if isinstance(item, AccessibilityItem)
+        else item
         for item in items
     ]
 ```
@@ -293,11 +294,12 @@ class CustomAccessibilityItem(AccessibilityItem):
             return self.axe_run_only
 
 
-@hooks.register('construct_wagtail_userbar')
+@hooks.register("construct_wagtail_userbar")
 def replace_userbar_accessibility_item(request, items, page):
     items[:] = [
         CustomAccessibilityItem(in_editor=item.in_editor)
-        if isinstance(item, AccessibilityItem) else item
+        if isinstance(item, AccessibilityItem)
+        else item
         for item in items
     ]
 ```

--- a/docs/advanced_topics/add_to_django_project.md
+++ b/docs/advanced_topics/add_to_django_project.md
@@ -26,15 +26,14 @@ What follows is a settings reference which skips many boilerplate Django setting
 
 ```python
 MIDDLEWARE = [
-  'django.contrib.sessions.middleware.SessionMiddleware',
-  'django.middleware.common.CommonMiddleware',
-  'django.middleware.csrf.CsrfViewMiddleware',
-  'django.contrib.auth.middleware.AuthenticationMiddleware',
-  'django.contrib.messages.middleware.MessageMiddleware',
-  'django.middleware.clickjacking.XFrameOptionsMiddleware',
-  'django.middleware.security.SecurityMiddleware',
-
-  'wagtail.contrib.redirects.middleware.RedirectMiddleware',
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django.middleware.security.SecurityMiddleware",
+    "wagtail.contrib.redirects.middleware.RedirectMiddleware",
 ]
 ```
 
@@ -47,30 +46,26 @@ Wagtail depends on the default set of Django middleware modules, to cover basic 
 
 ```python
 INSTALLED_APPS = [
-
-  'myapp',  # your own app
-
-  'wagtail.contrib.forms',
-  'wagtail.contrib.redirects',
-  'wagtail.embeds',
-  'wagtail.sites',
-  'wagtail.users',
-  'wagtail.snippets',
-  'wagtail.documents',
-  'wagtail.images',
-  'wagtail.search',
-  'wagtail.admin',
-  'wagtail',
-
-  'taggit',
-  'modelcluster',
-
-  'django.contrib.admin',
-  'django.contrib.auth',
-  'django.contrib.contenttypes',
-  'django.contrib.sessions',
-  'django.contrib.messages',
-  'django.contrib.staticfiles',
+    "myapp",  # your own app
+    "wagtail.contrib.forms",
+    "wagtail.contrib.redirects",
+    "wagtail.embeds",
+    "wagtail.sites",
+    "wagtail.users",
+    "wagtail.snippets",
+    "wagtail.documents",
+    "wagtail.images",
+    "wagtail.search",
+    "wagtail.admin",
+    "wagtail",
+    "taggit",
+    "modelcluster",
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
 ]
 ```
 
@@ -130,17 +125,14 @@ from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 urlpatterns = [
-    path('django-admin/', admin.site.urls),
-
-    path('admin/', include(wagtailadmin_urls)),
-    path('documents/', include(wagtaildocs_urls)),
-
+    path("django-admin/", admin.site.urls),
+    path("admin/", include(wagtailadmin_urls)),
+    path("documents/", include(wagtaildocs_urls)),
     # Optional URL for including your own vanilla Django urls/views
-    re_path(r'', include('myapp.urls')),
-
+    re_path(r"", include("myapp.urls")),
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's serving mechanism
-    re_path(r'', include(wagtail_urls)),
+    re_path(r"", include(wagtail_urls)),
 ]
 ```
 
@@ -172,84 +164,80 @@ DEBUG = True
 # Application definition
 
 INSTALLED_APPS = [
-    'myapp',
-
-    'wagtail.contrib.forms',
-    'wagtail.contrib.redirects',
-    'wagtail.embeds',
-    'wagtail.sites',
-    'wagtail.users',
-    'wagtail.snippets',
-    'wagtail.documents',
-    'wagtail.images',
-    'wagtail.search',
-    'wagtail.admin',
-    'wagtail',
-
-    'taggit',
-    'modelcluster',
-
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
+    "myapp",
+    "wagtail.contrib.forms",
+    "wagtail.contrib.redirects",
+    "wagtail.embeds",
+    "wagtail.sites",
+    "wagtail.users",
+    "wagtail.snippets",
+    "wagtail.documents",
+    "wagtail.images",
+    "wagtail.search",
+    "wagtail.admin",
+    "wagtail",
+    "taggit",
+    "modelcluster",
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
 ]
 
 
 MIDDLEWARE = [
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.security.SecurityMiddleware',
-
-    'wagtail.contrib.redirects.middleware.RedirectMiddleware',
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django.middleware.security.SecurityMiddleware",
+    "wagtail.contrib.redirects.middleware.RedirectMiddleware",
 ]
 
-ROOT_URLCONF = 'myproject.urls'
+ROOT_URLCONF = "myproject.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            PROJECT_DIR / 'templates',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [
+            PROJECT_DIR / "templates",
         ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'myproject.wsgi.application'
+WSGI_APPLICATION = "myproject.wsgi.application"
 
 # Database
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'myprojectdb',
-        'USER': 'postgres',
-        'PASSWORD': '',
-        'HOST': '',  # Set to empty string for localhost.
-        'PORT': '',  # Set to empty string for default.
-        'CONN_MAX_AGE': 600,  # number of seconds database connections should persist for
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "myprojectdb",
+        "USER": "postgres",
+        "PASSWORD": "",
+        "HOST": "",  # Set to empty string for localhost.
+        "PORT": "",  # Set to empty string for default.
+        "CONN_MAX_AGE": 600,  # number of seconds database connections should persist for
     }
 }
 
 # Internationalization
 
-LANGUAGE_CODE = 'en-us'
-TIME_ZONE = 'UTC'
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True
@@ -258,19 +246,19 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 
 STATICFILES_FINDERS = [
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
 
 STATICFILES_DIRS = [
-    PROJECT_DIR / 'static',
+    PROJECT_DIR / "static",
 ]
 
-STATIC_ROOT = BASE_DIR / 'static'
-STATIC_URL = '/static/'
+STATIC_ROOT = BASE_DIR / "static"
+STATIC_URL = "/static/"
 
-MEDIA_ROOT = BASE_DIR / 'media'
-MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / "media"
+MEDIA_URL = "/media/"
 
 
 ADMINS = [
@@ -280,17 +268,17 @@ MANAGERS = ADMINS
 
 # Default to dummy email backend. Configure dev/production/local backend
 # as per https://docs.djangoproject.com/en/stable/topics/email/#email-backends
-EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
+EMAIL_BACKEND = "django.core.mail.backends.dummy.EmailBackend"
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 ALLOWED_HOSTS = []
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = 'change-me'
+SECRET_KEY = "change-me"
 
-EMAIL_SUBJECT_PREFIX = '[Wagtail] '
+EMAIL_SUBJECT_PREFIX = "[Wagtail] "
 
-INTERNAL_IPS = ('127.0.0.1', '10.0.2.2')
+INTERNAL_IPS = ("127.0.0.1", "10.0.2.2")
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
@@ -298,27 +286,23 @@ INTERNAL_IPS = ('127.0.0.1', '10.0.2.2')
 # See https://docs.djangoproject.com/en/stable/topics/logging for
 # more details on how to customize your logging configuration.
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse'
+    "version": 1,
+    "disable_existing_loggers": False,
+    "filters": {"require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}},
+    "handlers": {
+        "mail_admins": {
+            "level": "ERROR",
+            "filters": ["require_debug_false"],
+            "class": "django.utils.log.AdminEmailHandler",
         }
     },
-    'handlers': {
-        'mail_admins': {
-            'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
-        }
-    },
-    'loggers': {
-        'django.request': {
-            'handlers': ['mail_admins'],
-            'level': 'ERROR',
-            'propagate': True,
+    "loggers": {
+        "django.request": {
+            "handlers": ["mail_admins"],
+            "level": "ERROR",
+            "propagate": True,
         },
-    }
+    },
 }
 
 
@@ -326,15 +310,15 @@ LOGGING = {
 
 # This is the human-readable name of your Wagtail install
 # which welcomes users upon login to the Wagtail admin.
-WAGTAIL_SITE_NAME = 'My Project'
+WAGTAIL_SITE_NAME = "My Project"
 
 # Replace the search backend
-#WAGTAILSEARCH_BACKENDS = {
+# WAGTAILSEARCH_BACKENDS = {
 #  'default': {
 #    'BACKEND': 'wagtail.search.backends.elasticsearch8',
 #    'INDEX': 'myapp'
 #  }
-#}
+# }
 
 # Wagtail email notifications from address
 # WAGTAILADMIN_NOTIFICATION_FROM_EMAIL = 'wagtail@myhost.io'
@@ -346,7 +330,18 @@ WAGTAIL_SITE_NAME = 'My Project'
 # This can be omitted to allow all files, but note that this may present a security risk
 # if untrusted users are allowed to upload files -
 # see https://docs.wagtail.org/en/stable/advanced_topics/deploying.html#user-uploaded-files
-WAGTAILDOCS_EXTENSIONS = ['csv', 'docx', 'key', 'odt', 'pdf', 'pptx', 'rtf', 'txt', 'xlsx', 'zip']
+WAGTAILDOCS_EXTENSIONS = [
+    "csv",
+    "docx",
+    "key",
+    "odt",
+    "pdf",
+    "pptx",
+    "rtf",
+    "txt",
+    "xlsx",
+    "zip",
+]
 
 # Reverse the default case-sensitive handling of tags
 TAGGIT_CASE_INSENSITIVE = True
@@ -368,23 +363,28 @@ from wagtail.documents import urls as wagtaildocs_urls
 
 
 urlpatterns = [
-    path('django-admin/', admin.site.urls),
-
-    path('admin/', include(wagtailadmin_urls)),
-    path('documents/', include(wagtaildocs_urls)),
-
+    path("django-admin/", admin.site.urls),
+    path("admin/", include(wagtailadmin_urls)),
+    path("documents/", include(wagtaildocs_urls)),
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's serving mechanism
-    re_path(r'', include(wagtail_urls)),
+    re_path(r"", include(wagtail_urls)),
 ]
 
 
 if settings.DEBUG:
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
-    urlpatterns += staticfiles_urlpatterns() # tell gunicorn where static files are in dev mode
-    urlpatterns += static(settings.MEDIA_URL + 'images/', document_root=settings.MEDIA_ROOT / 'images')
+    urlpatterns += (
+        staticfiles_urlpatterns()
+    )  # tell gunicorn where static files are in dev mode
+    urlpatterns += static(
+        settings.MEDIA_URL + "images/", document_root=settings.MEDIA_ROOT / "images"
+    )
     urlpatterns += [
-        path('favicon.ico', RedirectView.as_view(url=settings.STATIC_URL + 'myapp/images/favicon.ico'))
+        path(
+            "favicon.ico",
+            RedirectView.as_view(url=settings.STATIC_URL + "myapp/images/favicon.ico"),
+        )
     ]
 ```

--- a/docs/advanced_topics/amp.md
+++ b/docs/advanced_topics/amp.md
@@ -33,9 +33,8 @@ the default URL from Wagtail, or it will try to find `/amp` as a page:
 
 urlpatterns += [
     # Add this line just before the default ``include(wagtail_urls)`` line
-    path('amp/', include(wagtail_urls)),
-
-    path('', include(wagtail_urls)),
+    path("amp/", include(wagtail_urls)),
+    path("", include(wagtail_urls)),
 ]
 ```
 
@@ -85,6 +84,7 @@ from asgiref.local import Local
 
 _amp_mode_active = Local()
 
+
 @contextmanager
 def activate_amp_mode():
     """
@@ -96,11 +96,12 @@ def activate_amp_mode():
     finally:
         del _amp_mode_active.value
 
+
 def amp_mode_active():
     """
     Returns True if AMP mode is currently active
     """
-    return hasattr(_amp_mode_active, 'value')
+    return hasattr(_amp_mode_active, "value")
 ```
 
 This module defines two functions:
@@ -120,6 +121,7 @@ from django.template.response import SimpleTemplateResponse
 from wagtail.views import serve as wagtail_serve
 
 from .amp_utils import activate_amp_mode
+
 
 def serve(request, path):
     with activate_amp_mode():
@@ -142,9 +144,7 @@ from wagtail.urls import serve_pattern
 
 from . import amp_views
 
-urlpatterns = [
-    re_path(serve_pattern, amp_views.serve, name='wagtail_amp_serve')
-]
+urlpatterns = [re_path(serve_pattern, amp_views.serve, name="wagtail_amp_serve")]
 ```
 
 Finally, we need to update the project's main `urls.py` to use this new URLs
@@ -157,9 +157,8 @@ from myapp import amp_urls as wagtail_amp_urls
 
 urlpatterns += [
     # Change this line to point at your amp_urls instead of Wagtail's urls
-    path('amp/', include(wagtail_amp_urls)),
-
-    re_path(r'', include(wagtail_urls)),
+    path("amp/", include(wagtail_amp_urls)),
+    re_path(r"", include(wagtail_urls)),
 ]
 ```
 
@@ -179,9 +178,10 @@ following:
 
 from .amp_utils import amp_mode_active
 
+
 def amp(request):
     return {
-        'amp_mode_active': amp_mode_active(),
+        "amp_mode_active": amp_mode_active(),
     }
 ```
 
@@ -231,13 +231,13 @@ import os.path
 
 ...
 
-class PageAMPTemplateMixin:
 
+class PageAMPTemplateMixin:
     @property
     def amp_template(self):
         # Get the default template name and insert `_amp` before the extension
         name, ext = os.path.splitext(self.template)
-        return name + '_amp' + ext
+        return name + "_amp" + ext
 
     def get_template(self, request):
         if amp_mode_active():
@@ -253,8 +253,8 @@ Now add this mixin to any page model, for example:
 
 from .amp_utils import PageAMPTemplateMixin
 
-class MyPageModel(PageAMPTemplateMixin, Page):
-    ...
+
+class MyPageModel(PageAMPTemplateMixin, Page): ...
 ```
 
 When AMP mode is active, the template at `app_label/mypagemodel_amp.html`
@@ -268,8 +268,9 @@ If you have a different naming convention, you can override the
 
 from .amp_utils import PageAMPTemplateMixin
 
+
 class MyPageModel(PageAMPTemplateMixin, Page):
-    amp_template = 'my_custom_amp_template.html'
+    amp_template = "my_custom_amp_template.html"
 ```
 
 ## Overriding the `{% image %}` tag to output `<amp-img>` tags
@@ -293,15 +294,16 @@ from wagtail.images.models import AbstractRendition
 
 ...
 
+
 class CustomRendition(AbstractRendition):
     def img_tag(self, extra_attributes):
         attrs = self.attrs_dict.copy()
         attrs.update(extra_attributes)
 
         if amp_mode_active():
-            return mark_safe('<amp-img{}>'.format(flatatt(attrs)))
+            return mark_safe("<amp-img{}>".format(flatatt(attrs)))
         else:
-            return mark_safe('<img{}>'.format(flatatt(attrs)))
+            return mark_safe("<img{}>".format(flatatt(attrs)))
 
     ...
 ```
@@ -316,6 +318,7 @@ from django.utils.safestring import mark_safe
 
 from wagtail.images.models import Rendition
 
+
 def img_tag(rendition, extra_attributes={}):
     """
     Replacement implementation for Rendition.img_tag
@@ -326,9 +329,10 @@ def img_tag(rendition, extra_attributes={}):
     attrs.update(extra_attributes)
 
     if amp_mode_active():
-        return mark_safe('<amp-img{}>'.format(flatatt(attrs)))
+        return mark_safe("<amp-img{}>".format(flatatt(attrs)))
     else:
-        return mark_safe('<img{}>'.format(flatatt(attrs)))
+        return mark_safe("<img{}>".format(flatatt(attrs)))
+
 
 Rendition.img_tag = img_tag
 ```

--- a/docs/advanced_topics/api/django-ninja.md
+++ b/docs/advanced_topics/api/django-ninja.md
@@ -122,6 +122,7 @@ class HomePageSchema(BasePageSchema, ModelSchema):
     class Config(BasePageSchema.Config):
         model = HomePage
 
+
 @api.get("/pages/{page_id}/", response=BlogPageSchema | HomePageSchema)
 def get_page(request: "HttpRequest", page_id: int):
     return get_object_or_404(Page, id=page_id).specific

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -55,9 +55,11 @@ from rest_framework.renderers import JSONRenderer
 
 # ...
 
+
 class CustomPagesAPIViewSet(PagesAPIViewSet):
     renderer_classes = [JSONRenderer]
     name = "pages"
+
 
 api_router.register_endpoint("pages", CustomPagesAPIViewSet)
 ```
@@ -68,6 +70,7 @@ Or changing the desired model to use for page results.
 from rest_framework.renderers import JSONRenderer
 
 # ...
+
 
 class PostPagesAPIViewSet(PagesAPIViewSet):
     model = models.BlogPage
@@ -87,6 +90,7 @@ class CustomFieldsAPIViewSet(PagesAPIViewSet):
     nested_default_fields = PagesAPIViewSet.nested_default_fields + ["seo_title"]
     name = "pages"
 
+
 api_router.register_endpoint("pages", CustomFieldsAPIViewSet)
 ```
 
@@ -105,15 +109,15 @@ from wagtail.images.api.v2.views import ImagesAPIViewSet
 from wagtail.documents.api.v2.views import DocumentsAPIViewSet
 
 # Create the router. "wagtailapi" is the URL namespace
-api_router = WagtailAPIRouter('wagtailapi')
+api_router = WagtailAPIRouter("wagtailapi")
 
 # Add the three endpoints using the "register_endpoint" method.
 # The first parameter is the name of the endpoint (such as pages, images). This
 # is used in the URL of the endpoint
 # The second parameter is the endpoint class that handles the requests
-api_router.register_endpoint('pages', PagesAPIViewSet)
-api_router.register_endpoint('images', ImagesAPIViewSet)
-api_router.register_endpoint('documents', DocumentsAPIViewSet)
+api_router.register_endpoint("pages", PagesAPIViewSet)
+api_router.register_endpoint("images", ImagesAPIViewSet)
+api_router.register_endpoint("documents", DocumentsAPIViewSet)
 ```
 
 Next, register the URLs so Django can route requests into the API:
@@ -191,10 +195,11 @@ If you have a FormBuilder page called `FormPage` this is an example of how you w
 ```python
 from wagtail.api import APIField
 
+
 class FormPage(AbstractEmailForm):
-    #...
+    # ...
     api_fields = [
-        APIField('form_fields'),
+        APIField("form_fields"),
     ]
 ```
 
@@ -207,13 +212,14 @@ JSON format. You can override the serializer for any field using the
 ```python
 from rest_framework.fields import DateField
 
+
 class BlogPage(Page):
     ...
 
     api_fields = [
         # Change the format of the published_date field to "Thursday 06 April 2017"
-        APIField('published_date', serializer=DateField(format='%A %d %B %Y')),
-        ...
+        APIField("published_date", serializer=DateField(format="%A %d %B %Y")),
+        ...,
     ]
 ```
 
@@ -223,16 +229,19 @@ to add API fields that have a different field name or no underlying field at all
 ```python
 from rest_framework.fields import DateField
 
+
 class BlogPage(Page):
     ...
 
     api_fields = [
         # Date in ISO8601 format (the default)
-        APIField('published_date'),
-
+        APIField("published_date"),
         # A separate published_date_display field with a different format
-        APIField('published_date_display', serializer=DateField(format='%A %d %B %Y', source='published_date')),
-        ...
+        APIField(
+            "published_date_display",
+            serializer=DateField(format="%A %d %B %Y", source="published_date"),
+        ),
+        ...,
     ]
 ```
 
@@ -265,7 +274,7 @@ class RichTextSerializer(CharField):
 We can then change our `api_fields` definition so `body` uses this new serializer:
 
 ```python
-APIField('body', serializer=RichTextSerializer()),
+(APIField("body", serializer=RichTextSerializer()),)
 ```
 
 (api_v2_images)=
@@ -283,16 +292,19 @@ For example:
 from wagtail.api import APIField
 from wagtail.images.api.fields import ImageRenditionField
 
+
 class BlogPage(Page):
     ...
 
     api_fields = [
         # Adds information about the source image (eg, title) into the API
-        APIField('feed_image'),
-
+        APIField("feed_image"),
         # Adds a URL to a rendered thumbnail of the image to the API
-        APIField('feed_image_thumbnail', serializer=ImageRenditionField('fill-100x100', source='feed_image')),
-        ...
+        APIField(
+            "feed_image_thumbnail",
+            serializer=ImageRenditionField("fill-100x100", source="feed_image"),
+        ),
+        ...,
     ]
 ```
 
@@ -337,16 +349,19 @@ Common examples include:
 
 ```python
 # Square crop and fill
-APIField('thumbnail', serializer=ImageRenditionField('fill-300x300', source='image'))
+APIField("thumbnail", serializer=ImageRenditionField("fill-300x300", source="image"))
 
 # Maintain aspect ratio with maximum dimensions
-APIField('preview', serializer=ImageRenditionField('max-800x600', source='image'))
+APIField("preview", serializer=ImageRenditionField("max-800x600", source="image"))
 
 # Exact dimensions without cropping
-APIField('banner', serializer=ImageRenditionField('width-1200', source='image'))
+APIField("banner", serializer=ImageRenditionField("width-1200", source="image"))
 
 # Chained operations (multiple filters combined)
-APIField('compressed_thumb', serializer=ImageRenditionField('fill-200x200|jpegquality-60', source='image'))
+APIField(
+    "compressed_thumb",
+    serializer=ImageRenditionField("fill-200x200|jpegquality-60", source="image"),
+)
 ```
 
 The generated rendition URLs will be included in the API response, allowing clients to directly access optimized versions of images without additional processing.
@@ -361,6 +376,7 @@ To protect the access to your API, you can implement an [authentication](https:/
 from rest_framework.permissions import IsAuthenticated
 
 # ...
+
 
 class CustomPagesAPIViewSet(PagesAPIViewSet):
     name = "pages"

--- a/docs/advanced_topics/boundblocks_and_values.md
+++ b/docs/advanced_topics/boundblocks_and_values.md
@@ -7,7 +7,7 @@ All StreamField block types accept a `template` parameter to determine how they 
 ```python
 class HeadingBlock(blocks.CharBlock):
     class Meta:
-        template = 'blocks/heading.html'
+        template = "blocks/heading.html"
 ```
 
 where `blocks/heading.html` consists of:
@@ -22,7 +22,7 @@ This gives us a block that behaves as an ordinary text field, but wraps its outp
 class BlogPage(Page):
     body = StreamField([
         # ...
-        ('heading', HeadingBlock()),
+        ("heading", HeadingBlock()),
         # ...
     ])
 ```
@@ -52,7 +52,7 @@ class EventBlock(blocks.StructBlock):
     # ...
 
     class Meta:
-        template = 'blocks/event.html'
+        template = "blocks/event.html"
 ```
 
 In `blocks/event.html`:
@@ -94,11 +94,14 @@ This limitation does not apply to StructBlock and StreamBlock values as children
 class EventBlock(blocks.StructBlock):
     heading = HeadingBlock()
     description = blocks.TextBlock()
-    guest_speaker = blocks.StructBlock([
-        ('first_name', blocks.CharBlock()),
-        ('surname', blocks.CharBlock()),
-        ('photo', ImageChooserBlock()),
-    ], template='blocks/speaker.html')
+    guest_speaker = blocks.StructBlock(
+        [
+            ("first_name", blocks.CharBlock()),
+            ("surname", blocks.CharBlock()),
+            ("photo", ImageChooserBlock()),
+        ],
+        template="blocks/speaker.html",
+    )
 ```
 
 then `{% include_block value.guest_speaker %}` within the EventBlock's template will pick up the template rendering from `blocks/speaker.html` as intended.

--- a/docs/advanced_topics/customization/custom_page_listings.md
+++ b/docs/advanced_topics/customization/custom_page_listings.md
@@ -24,6 +24,8 @@ class BlogPageListingViewSet(PageListingViewSet):
 
 
 blog_page_listing_viewset = BlogPageListingViewSet("blog_pages")
+
+
 @hooks.register("register_admin_viewset")
 def register_blog_page_listing_viewset():
     return blog_page_listing_viewset
@@ -37,6 +39,7 @@ from wagtail.admin.ui.tables import Column
 from wagtail.admin.viewsets.pages import PageListingViewSet
 
 from myapp.models import BlogPage
+
 
 class BlogPageListingViewSet(PageListingViewSet):
     # ...

--- a/docs/advanced_topics/documents/overview.md
+++ b/docs/advanced_topics/documents/overview.md
@@ -13,7 +13,7 @@ To use the `wagtail.documents` app, you need to include it in the `INSTALLED_APP
 
 INSTALLED_APPS = [
     # ...
-    'wagtail.documents',
+    "wagtail.documents",
     # ...
 ]
 ```
@@ -29,7 +29,7 @@ from wagtail.documents import urls as wagtaildocs_urls
 
 urlpatterns = [
     # ...
-    path('documents/', include(wagtaildocs_urls)),
+    path("documents/", include(wagtaildocs_urls)),
     # ...
 ]
 ```
@@ -60,9 +60,8 @@ class YourPage(Page):
 
     content_panels = Page.content_panels + [
         # ...
-        FieldPanel('document'),
+        FieldPanel("document"),
     ]
-
 ```
 
 This allows you to select a document file when creating or editing a page, and link to it in your page template.
@@ -93,11 +92,11 @@ You can either exclude or include these by passing the `features` to your `RichT
 # models.py
 from wagtail.fields import RichTextField
 
+
 class BlogPage(Page):
     # ...other fields
     document_footnotes = RichTextField(
-        blank=True,
-        features=["bold", "italic", "ol", "document-link"]
+        blank=True, features=["bold", "italic", "ol", "document-link"]
     )
 
     panels = [
@@ -122,9 +121,8 @@ from wagtail.documents.blocks import DocumentChooserBlock
 class BlogPage(Page):
     # ... other fields
 
-    documents = StreamField([
-            ('document', DocumentChooserBlock())
-        ],
+    documents = StreamField(
+        [("document", DocumentChooserBlock())],
         null=True,
         blank=True,
         use_json_field=True,
@@ -153,14 +151,15 @@ Here's an example:
 ```python
 from wagtail.documents import get_document_model
 
+
 class PageWithCollection(Page):
     collection = models.ForeignKey(
         "wagtailcore.Collection",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        verbose_name='Document Collection',
+        related_name="+",
+        verbose_name="Document Collection",
     )
 
     content_panels = Page.content_panels + [
@@ -170,9 +169,8 @@ class PageWithCollection(Page):
     def get_context(self, request):
         context = super().get_context(request)
         documents = get_document_model().objects.filter(collection=self.collection)
-        context['documents'] = documents
+        context["documents"] = documents
         return context
-
 ```
 
 Here’s an example template to access the document collection and render it:

--- a/docs/advanced_topics/documents/testing.md
+++ b/docs/advanced_topics/documents/testing.md
@@ -25,11 +25,13 @@ class CustomDocumentFormTest(TestCase):
             "tags": [],
         }
         file_data = {
-            "file": SimpleUploadedFile('simple.txt', b'hello world' * 1024 * 1024, content_type='text/plain'),
+            "file": SimpleUploadedFile(
+                "simple.txt", b"hello world" * 1024 * 1024, content_type="text/plain"
+            ),
         }
         form_cls = get_document_form(models.Document)
         form = form_cls(form_data, file_data)
         self.assertFormError(
-            form, 'file', ['The file size exceeds the configured limit (1MB).']
+            form, "file", ["The file size exceeds the configured limit (1MB)."]
         )
 ```

--- a/docs/advanced_topics/documents/title_generation_on_upload.md
+++ b/docs/advanced_topics/documents/title_generation_on_upload.md
@@ -43,9 +43,10 @@ from django.utils.html import format_html
 
 from wagtail import hooks
 
+
 @hooks.register("insert_global_admin_js")
 def get_global_admin_js():
-    script_url = static('js/title_with_extension.js')
+    script_url = static("js/title_with_extension.js")
     return format_html('<script src="{}"></script>', script_url)
 ```
 
@@ -73,9 +74,10 @@ from django.utils.html import format_html
 
 from wagtail import hooks
 
+
 @hooks.register("insert_editor_js")
 def get_editor_js():
-    script_url = static('js/remove_dashes_underscores.js')
+    script_url = static("js/remove_dashes_underscores.js")
     return format_html('<script src="{}"></script>', script_url)
 ```
 
@@ -102,9 +104,10 @@ from django.utils.html import format_html
 
 from wagtail import hooks
 
+
 @hooks.register("insert_global_admin_js")
 def insert_stop_prefill_js():
-    script_url = static('js/stop_title_prefill.js')
+    script_url = static("js/stop_title_prefill.js")
     return format_html('<script src="{}"></script>', script_url)
 ```
 

--- a/docs/advanced_topics/embeds.md
+++ b/docs/advanced_topics/embeds.md
@@ -35,6 +35,7 @@ For example:
 ```python
 from wagtail.embeds.blocks import EmbedBlock
 
+
 class MyStreamField(blocks.StreamBlock):
     ...
 
@@ -72,7 +73,7 @@ from wagtail.embeds.embeds import get_embed
 from wagtail.embeds.exceptions import EmbedException
 
 try:
-    embed = get_embed('https://www.youtube.com/watch?v=Ffu-2jEdLPw')
+    embed = get_embed("https://www.youtube.com/watch?v=Ffu-2jEdLPw")
 
     print(embed.html)
 except EmbedException:
@@ -94,11 +95,7 @@ successfully returns an embed:
 The default configuration is:
 
 ```python
-WAGTAILEMBEDS_FINDERS = [
-    {
-        'class': 'wagtail.embeds.finders.oembed'
-    }
-]
+WAGTAILEMBEDS_FINDERS = [{"class": "wagtail.embeds.finders.oembed"}]
 ```
 
 (oEmbed)=
@@ -131,16 +128,16 @@ from wagtail.embeds.oembed_providers import youtube, vimeo
 # - 'endpoint' is the URL of the oEmbed endpoint that Wagtail will call
 # - 'urls' specifies which patterns
 my_custom_provider = {
-    'endpoint': 'https://customvideosite.com/oembed',
-    'urls': [
-        '^http(?:s)?://(?:www\\.)?customvideosite\\.com/[^#?/]+/videos/.+$',
-    ]
+    "endpoint": "https://customvideosite.com/oembed",
+    "urls": [
+        "^http(?:s)?://(?:www\\.)?customvideosite\\.com/[^#?/]+/videos/.+$",
+    ],
 }
 
 WAGTAILEMBEDS_FINDERS = [
     {
-        'class': 'wagtail.embeds.finders.oembed',
-        'providers': [youtube, vimeo, my_custom_provider],
+        "class": "wagtail.embeds.finders.oembed",
+        "providers": [youtube, vimeo, my_custom_provider],
     }
 ]
 ```
@@ -161,15 +158,14 @@ WAGTAILEMBEDS_FINDERS = [
     # Fetches YouTube videos but puts ``?scheme=https`` in the GET parameters
     # when calling YouTube's oEmbed endpoint
     {
-        'class': 'wagtail.embeds.finders.oembed',
-        'providers': [youtube],
-        'options': {'scheme': 'https'}
+        "class": "wagtail.embeds.finders.oembed",
+        "providers": [youtube],
+        "options": {"scheme": "https"},
     },
-
     # Handles all other oEmbed providers the default way
     {
-        'class': 'wagtail.embeds.finders.oembed',
-    }
+        "class": "wagtail.embeds.finders.oembed",
+    },
 ]
 ```
 
@@ -210,20 +206,19 @@ the App ID and App Secret from your app:
 ```python
 WAGTAILEMBEDS_FINDERS = [
     {
-        'class': 'wagtail.embeds.finders.facebook',
-        'app_id': 'YOUR FACEBOOK APP_ID HERE',
-        'app_secret': 'YOUR FACEBOOK APP_SECRET HERE',
+        "class": "wagtail.embeds.finders.facebook",
+        "app_id": "YOUR FACEBOOK APP_ID HERE",
+        "app_secret": "YOUR FACEBOOK APP_SECRET HERE",
     },
     {
-        'class': 'wagtail.embeds.finders.instagram',
-        'app_id': 'YOUR INSTAGRAM APP_ID HERE',
-        'app_secret': 'YOUR INSTAGRAM APP_SECRET HERE',
+        "class": "wagtail.embeds.finders.instagram",
+        "app_id": "YOUR INSTAGRAM APP_ID HERE",
+        "app_secret": "YOUR INSTAGRAM APP_SECRET HERE",
     },
-
     # Handles all other oEmbed providers the default way
     {
-        'class': 'wagtail.embeds.finders.oembed',
-    }
+        "class": "wagtail.embeds.finders.oembed",
+    },
 ]
 ```
 
@@ -254,10 +249,7 @@ Now add an embed finder to your `WAGTAILEMBEDS_FINDERS` setting that uses the
 
 ```python
 WAGTAILEMBEDS_FINDERS = [
-    {
-        'class': 'wagtail.embeds.finders.embedly',
-        'key': 'YOUR EMBED.LY KEY HERE'
-    }
+    {"class": "wagtail.embeds.finders.embedly", "key": "YOUR EMBED.LY KEY HERE"}
 ]
 ```
 
@@ -297,14 +289,14 @@ class ExampleFinder(EmbedFinder):
         # Parse the response and return the embed information
 
         return {
-            'title': "Title of the content",
-            'author_name': "Author name",
-            'provider_name': "Provider name (such as YouTube, Vimeo, etc)",
-            'type': "Either 'photo', 'video', 'link' or 'rich'",
-            'thumbnail_url': "URL to thumbnail image",
-            'width': width_in_pixels,
-            'height': height_in_pixels,
-            'html': "<h2>The Embed HTML</h2>",
+            "title": "Title of the content",
+            "author_name": "Author name",
+            "provider_name": "Provider name (such as YouTube, Vimeo, etc)",
+            "type": "Either 'photo', 'video', 'link' or 'rich'",
+            "thumbnail_url": "URL to thumbnail image",
+            "width": width_in_pixels,
+            "height": height_in_pixels,
+            "html": "<h2>The Embed HTML</h2>",
         }
 ```
 
@@ -314,7 +306,7 @@ Once you've implemented all of those methods, you just need to add it to your
 ```python
 WAGTAILEMBEDS_FINDERS = [
     {
-        'class': 'path.to.your.finder.class.here',
+        "class": "path.to.your.finder.class.here",
         # Any other options will be passed as kwargs to the __init__ method
     }
 ]

--- a/docs/advanced_topics/formbuilder_routablepage_redirect.md
+++ b/docs/advanced_topics/formbuilder_routablepage_redirect.md
@@ -20,7 +20,6 @@ from wagtail.contrib.routable_page.models import RoutablePageMixin, path
 
 
 class FormPage(RoutablePageMixin, AbstractEmailForm):
-
     # fields, content_panels, …
 
     @path("")

--- a/docs/advanced_topics/i18n.md
+++ b/docs/advanced_topics/i18n.md
@@ -172,9 +172,9 @@ enable English, French, and Spanish:
 # my_project/settings.py
 
 WAGTAIL_CONTENT_LANGUAGES = LANGUAGES = [
-    ('en', "English"),
-    ('fr', "French"),
-    ('es', "Spanish"),
+    ("en", "English"),
+    ("fr", "French"),
+    ("es", "Spanish"),
 ]
 ```
 
@@ -194,16 +194,16 @@ for example) but use the same Wagtail content in multiple regions:
 # my_project/settings.py
 
 LANGUAGES = [
-    ('en-GB', "English (Great Britain)"),
-    ('en-US', "English (United States)"),
-    ('en-CA', "English (Canada)"),
-    ('fr-FR', "French (France)"),
-    ('fr-CA', "French (Canada)"),
+    ("en-GB", "English (Great Britain)"),
+    ("en-US", "English (United States)"),
+    ("en-CA", "English (Canada)"),
+    ("fr-FR", "French (France)"),
+    ("fr-CA", "French (Canada)"),
 ]
 
 WAGTAIL_CONTENT_LANGUAGES = [
-    ('en-GB', "English"),
-    ('fr-FR', "French"),
+    ("en-GB", "English"),
+    ("fr-FR", "French"),
 ]
 ```
 
@@ -230,7 +230,7 @@ To enable it, add `wagtail.locales` into `INSTALLED_APPS`:
 
 INSTALLED_APPS = [
     # ...
-    'wagtail.locales',
+    "wagtail.locales",
     # ...
 ]
 ```
@@ -260,16 +260,15 @@ from django.conf.urls.i18n import i18n_patterns
 # Note: if you are using the Wagtail API or sitemaps,
 # these should not be added to `i18n_patterns` either
 urlpatterns = [
-    path('django-admin/', admin.site.urls),
-
-    path('admin/', include(wagtailadmin_urls)),
-    path('documents/', include(wagtaildocs_urls)),
+    path("django-admin/", admin.site.urls),
+    path("admin/", include(wagtailadmin_urls)),
+    path("documents/", include(wagtaildocs_urls)),
 ]
 
 # Translatable URLs
 # These will be available under a language code prefix. For example /en/search/
 urlpatterns += i18n_patterns(
-    path('search/', search_views.search, name='search'),
+    path("search/", search_views.search, name="search"),
     path("", include(wagtail_urls)),
 )
 ```
@@ -285,10 +284,10 @@ For example, if you have your languages configured like this:
 
 # ...
 
-LANGUAGE_CODE = 'en'
+LANGUAGE_CODE = "en"
 WAGTAIL_CONTENT_LANGUAGES = LANGUAGES = [
-    ('en', "English"),
-    ('fr', "French"),
+    ("en", "English"),
+    ("fr", "French"),
 ]
 
 # ...
@@ -304,7 +303,7 @@ And your `urls.py` configured like this:
 # are not set as default in LANGUAGE_CODE.
 
 urlpatterns += i18n_patterns(
-    path('search/', search_views.search, name='search'),
+    path("search/", search_views.search, name="search"),
     path("", include(wagtail_urls)),
     prefix_default_language=False,
 )
@@ -331,7 +330,7 @@ Django's `LocaleMiddleware`:
 
 MIDDLEWARE = [
     # ...
-    'django.middleware.locale.LocaleMiddleware',
+    "django.middleware.locale.LocaleMiddleware",
     # ...
 ]
 ```
@@ -436,10 +435,10 @@ context processor to your `TEMPLATES` setting:
 TEMPLATES = [
     {
         # ...
-        'OPTIONS': {
-            'context_processors': [
+        "OPTIONS": {
+            "context_processors": [
                 # ...
-                'django.template.context_processors.i18n',
+                "django.template.context_processors.i18n",
             ],
         },
     },
@@ -570,7 +569,7 @@ class Advert(BootstrapTranslatableMixin, models.Model):
     # if the model has a Meta class, ensure it inherits from
     # BootstrapTranslatableMixin.Meta too
     class Meta(BootstrapTranslatableMixin.Meta):
-        verbose_name = 'adverts'
+        verbose_name = "adverts"
 ```
 
 Run `python manage.py makemigrations myapp` to generate the schema migration.
@@ -588,19 +587,19 @@ that migration and add a `BootstrapTranslatableModel` for each model to bootstra
 in that app:
 
 ```python
-
 from django.db import migrations
 from wagtail.models import BootstrapTranslatableModel
 
+
 class Migration(migrations.Migration):
     dependencies = [
-        ('myapp', '0002_bootstraptranslations'),
+        ("myapp", "0002_bootstraptranslations"),
     ]
 
     # Add one operation for each model to bootstrap here
     # Note: Only include models that are in the same app!
     operations = [
-        BootstrapTranslatableModel('myapp.Advert'),
+        BootstrapTranslatableModel("myapp.Advert"),
     ]
 ```
 
@@ -617,12 +616,13 @@ constraints:
 
 from wagtail.models import TranslatableMixin  # Change this line
 
+
 @register_snippet
 class Advert(TranslatableMixin, models.Model):  # Change this line
     name = models.CharField(max_length=255)
 
     class Meta(TranslatableMixin.Meta):  # Change this line, if present
-        verbose_name = 'adverts'
+        verbose_name = "adverts"
 ```
 
 ###### Step 4: Run `makemigrations` to generate schema migrations, then migrate!

--- a/docs/advanced_topics/icons.md
+++ b/docs/advanced_topics/icons.md
@@ -43,7 +43,7 @@ Add the icon with the `register_icons` hook.
 ```python
 @hooks.register("register_icons")
 def register_icons(icons):
-    return icons + ['app_name/toucan.svg']
+    return icons + ["app_name/toucan.svg"]
 ```
 
 The majority of Wagtail’s default icons are drawn on a 16x16 viewBox, sourced from the [FontAwesome v6 free icons set](https://fontawesome.com/v6/search?m=free).

--- a/docs/advanced_topics/images/image_file_formats.md
+++ b/docs/advanced_topics/images/image_file_formats.md
@@ -39,11 +39,11 @@ to an output type.
 For example:
 
 ```python
-    WAGTAILIMAGES_FORMAT_CONVERSIONS = {
-        'avif': 'avif',
-        'bmp': 'jpeg',
-        'webp': 'webp',
-    }
+WAGTAILIMAGES_FORMAT_CONVERSIONS = {
+    "avif": "avif",
+    "bmp": "jpeg",
+    "webp": "webp",
+}
 ```
 
 will convert `bmp` images to `jpeg` and disable the default `avif` and `webp`

--- a/docs/advanced_topics/images/image_serve_view.md
+++ b/docs/advanced_topics/images/image_serve_view.md
@@ -62,17 +62,21 @@ Here's an example of this being used in a view:
 def display_image(request, image_id):
     image = get_object_or_404(Image, id=image_id)
 
-    return render(request, 'display_image.html', {
-        'image_url': generate_image_url(image, 'fill-100x100')
-    })
+    return render(
+        request,
+        "display_image.html",
+        {"image_url": generate_image_url(image, "fill-100x100")},
+    )
 ```
 
 Image operations can be chained by joining them with a `|` character:
 
 ```python
-return render(request, 'display_image.html', {
-    'image_url': generate_image_url(image, 'fill-100x100|jpegquality-40')
-})
+return render(
+    request,
+    "display_image.html",
+    {"image_url": generate_image_url(image, "fill-100x100|jpegquality-40")},
+)
 ```
 
 In your templates:
@@ -149,6 +153,7 @@ setting:
 from wagtail.images.views.serve import SendFileView
 from project.sendfile_backends import MyCustomBackend
 
+
 class MySendFileView(SendFileView):
     backend = MyCustomBackend
 ```
@@ -159,6 +164,7 @@ is to be authenticated (Django >= 1.9):
 ```python
 from django.contrib.auth.mixins import LoginRequiredMixin
 from wagtail.images.views.serve import SendFileView
+
 
 class PrivateSendFileView(LoginRequiredMixin, SendFileView):
     raise_exception = True

--- a/docs/advanced_topics/images/title_generation_on_upload.md
+++ b/docs/advanced_topics/images/title_generation_on_upload.md
@@ -43,9 +43,10 @@ from django.utils.html import format_html
 
 from wagtail import hooks
 
+
 @hooks.register("insert_global_admin_js")
 def get_global_admin_js():
-    script_url = static('js/wagtail_admin.js')
+    script_url = static("js/wagtail_admin.js")
     return format_html('<script src="{}"></script>', script_url)
 ```
 
@@ -101,9 +102,10 @@ from django.utils.html import format_html
 
 from wagtail import hooks
 
+
 @hooks.register("insert_global_admin_js")
 def get_global_admin_js():
-    script_url = static('js/stop_prefill.js')
+    script_url = static("js/stop_prefill.js")
     return format_html('<script src="{}"></script>', script_url)
 ```
 

--- a/docs/advanced_topics/performance.md
+++ b/docs/advanced_topics/performance.md
@@ -12,14 +12,14 @@ We recommend [Redis](https://redis.io/) as a fast, persistent cache. Install Red
 
 ```python
 CACHES = {
-    'default': {
-        'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': 'redis://127.0.0.1:6379/dbname',
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://127.0.0.1:6379/dbname",
         # for django-redis < 3.8.0, use:
         # 'LOCATION': '127.0.0.1:6379',
-        'OPTIONS': {
-            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-        }
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
     }
 }
 ```
@@ -30,15 +30,13 @@ To use a different cache backend for [caching image renditions](caching_image_re
 
 ```python
 CACHES = {
-    'default': {...},
-    'renditions': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': '127.0.0.1:11211',
-        'TIMEOUT': 600,
-        'OPTIONS': {
-            'MAX_ENTRIES': 1000
-        }
-    }
+    "default": {...},
+    "renditions": {
+        "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+        "LOCATION": "127.0.0.1:11211",
+        "TIMEOUT": 600,
+        "OPTIONS": {"MAX_ENTRIES": 1000},
+    },
 }
 ```
 

--- a/docs/advanced_topics/privacy.md
+++ b/docs/advanced_topics/privacy.md
@@ -24,7 +24,7 @@ Any existing shared password usage will remain active but will not be viewable b
 from wagtail.models import Page
 
 for page in Page.objects.private():
-   page.get_view_restrictions().filter(restriction_type='password').delete()
+    page.get_view_restrictions().filter(restriction_type="password").delete()
 ```
 
 (private_collections)=
@@ -45,7 +45,7 @@ Any existing shared password usage will remain active but will not be viewable w
 from wagtail.models import Collection
 
 for collection in Collection.objects.all():
-    collection.get_view_restrictions().filter(restriction_type='password').delete()
+    collection.get_view_restrictions().filter(restriction_type="password").delete()
 ```
 
 (login_page)=
@@ -59,7 +59,7 @@ However, the default "login" and "password required" forms are only bare-bones H
 The basic login page can be customized by setting `WAGTAIL_FRONTEND_LOGIN_TEMPLATE` to the path of a template you wish to use:
 
 ```python
-WAGTAIL_FRONTEND_LOGIN_TEMPLATE = 'myapp/login.html'
+WAGTAIL_FRONTEND_LOGIN_TEMPLATE = "myapp/login.html"
 ```
 
 Wagtail uses Django's standard `django.contrib.auth.views.LoginView` view here, and so the context variables available on the template are as detailed in [Django's login view documentation](django.contrib.auth.views.LoginView).
@@ -67,7 +67,7 @@ Wagtail uses Django's standard `django.contrib.auth.views.LoginView` view here, 
 If the stock Django login view is not suitable - for example, you wish to use an external authentication system, or you are integrating Wagtail into an existing Django site that already has a working login view - you can specify the URL of the login view via the `WAGTAIL_FRONTEND_LOGIN_URL` setting:
 
 ```python
-WAGTAIL_FRONTEND_LOGIN_URL = '/accounts/login/'
+WAGTAIL_FRONTEND_LOGIN_URL = "/accounts/login/"
 ```
 
 To integrate Wagtail into a Django site with an existing login mechanism, setting `WAGTAIL_FRONTEND_LOGIN_URL = LOGIN_URL` will usually be sufficient.
@@ -87,23 +87,28 @@ The method must return a dictionary with at least a `type` key. The value must b
 
 ```python
 class BlogPage(Page):
-    #...
+    # ...
     def get_default_privacy_setting(self, request):
         # set default to group
         from django.contrib.auth.models import Group
         from wagtail.models import BaseViewRestriction
+
         moderators = Group.objects.filter(name="Moderators").first()
         editors = Group.objects.filter(name="Editors").first()
-        return {"type": BaseViewRestriction.GROUPS, "groups": [moderators,editors]}
+        return {"type": BaseViewRestriction.GROUPS, "groups": [moderators, editors]}
+
 
 class SecretPage(Page):
-    #...
+    # ...
     def get_default_privacy_setting(self, request):
         # set default to auto-generated password
         from django.utils.crypto import get_random_string
         from wagtail.models import BaseViewRestriction
 
-        return {"type": BaseViewRestriction.PASSWORD, "password": django.utils.crypto.get_random_string(length=32)}
+        return {
+            "type": BaseViewRestriction.PASSWORD,
+            "password": django.utils.crypto.get_random_string(length=32),
+        }
 ```
 
 ## Setting up a global "password required" page
@@ -111,7 +116,7 @@ class SecretPage(Page):
 By setting `WAGTAIL_PASSWORD_REQUIRED_TEMPLATE` in your Django settings file, you can specify the path of a template which will be used for all "password required" forms on the site (except for page types that specifically override it - see below):
 
 ```python
-WAGTAIL_PASSWORD_REQUIRED_TEMPLATE = 'myapp/password_required.html'
+WAGTAIL_PASSWORD_REQUIRED_TEMPLATE = "myapp/password_required.html"
 ```
 
 This template will receive the same set of context variables that the blocked page would pass to its own template via `get_context()` - including `page` to refer to the page object itself - plus the following additional variables (which override any of the page's own context variables of the same name):
@@ -163,5 +168,5 @@ The attribute `password_required_template` can be defined on a page model to use
 class VideoPage(Page):
     ...
 
-    password_required_template = 'video/password_required.html'
+    password_required_template = "video/password_required.html"
 ```

--- a/docs/advanced_topics/reference_index.md
+++ b/docs/advanced_topics/reference_index.md
@@ -28,6 +28,7 @@ from django.apps import AppConfig
 
 class SprocketAppConfig(AppConfig):
     ...
+
     def ready(self):
         from wagtail.models.reference_index import ReferenceIndex
 

--- a/docs/advanced_topics/streamfield_migrations.md
+++ b/docs/advanced_topics/streamfield_migrations.md
@@ -22,8 +22,7 @@ def convert_to_streamfield(apps, schema_editor):
     BlogPage = apps.get_model("demo", "BlogPage")
     for page in BlogPage.objects.all():
         page.body = json.dumps(
-            [{"type": "rich_text", "value": page.body}],
-            cls=DjangoJSONEncoder
+            [{"type": "rich_text", "value": page.body}], cls=DjangoJSONEncoder
         )
         page.save()
 
@@ -34,14 +33,12 @@ def convert_to_richtext(apps, schema_editor):
         if page.body:
             stream = json.loads(page.body)
             page.body = "".join([
-                child["value"] for child in stream
-                if child["type"] == "rich_text"
+                child["value"] for child in stream if child["type"] == "rich_text"
             ])
             page.save()
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         # leave the dependency line from the generated migration intact!
         ("demo", "0001_initial"),
@@ -52,7 +49,6 @@ class Migration(migrations.Migration):
             convert_to_streamfield,
             convert_to_richtext,
         ),
-
         # leave the generated AlterField intact!
         migrations.AlterField(
             model_name="BlogPage",
@@ -101,11 +97,8 @@ def pagerevision_to_streamfield(revision_data):
             json.loads(body)
         except ValueError:
             revision_data["body"] = json.dumps(
-                [{
-                    "value": body,
-                    "type": "rich_text"
-                }],
-                cls=DjangoJSONEncoder)
+                [{"value": body, "type": "rich_text"}], cls=DjangoJSONEncoder
+            )
             changed = True
         else:
             # It's already valid JSON. Leave it.
@@ -123,8 +116,7 @@ def page_to_richtext(page):
             pass
         else:
             page.body = "".join([
-                child["value"] for child in body_data
-                if child["type"] == "rich_text"
+                child["value"] for child in body_data if child["type"] == "rich_text"
             ])
             changed = True
 
@@ -142,8 +134,7 @@ def pagerevision_to_richtext(revision_data):
             pass
         else:
             raw_text = "".join([
-                child["value"] for child in body_data
-                if child["type"] == "rich_text"
+                child["value"] for child in body_data if child["type"] == "rich_text"
             ])
             revision_data["body"] = raw_text
             changed = True
@@ -156,7 +147,6 @@ def convert(apps, schema_editor, page_converter, pagerevision_converter):
     Revision = apps.get_model("wagtailcore", "Revision")
 
     for page in BlogPage.objects.all():
-
         page, changed = page_converter(page)
         if changed:
             page.save()
@@ -172,7 +162,9 @@ def convert(apps, schema_editor, page_converter, pagerevision_converter):
 
 
 def convert_to_streamfield(apps, schema_editor):
-    return convert(apps, schema_editor, page_to_streamfield, pagerevision_to_streamfield)
+    return convert(
+        apps, schema_editor, page_to_streamfield, pagerevision_to_streamfield
+    )
 
 
 def convert_to_richtext(apps, schema_editor):
@@ -180,7 +172,6 @@ def convert_to_richtext(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         # leave the dependency line from the generated migration intact!
         ("demo", "0001_initial"),
@@ -192,7 +183,6 @@ class Migration(migrations.Migration):
             convert_to_streamfield,
             convert_to_richtext,
         ),
-
         # leave the generated AlterField intact!
         migrations.AlterField(
             model_name="BlogPage",
@@ -240,9 +230,7 @@ Suppose we have a `BlogPage` model in an app named `blog`, defined as follows:
 ```python
 class BlogPage(Page):
     content = StreamField([
-        ("stream1", blocks.StreamBlock([
-            ("field1", blocks.CharBlock())
-        ])),
+        ("stream1", blocks.StreamBlock([("field1", blocks.CharBlock())])),
     ])
 ```
 
@@ -251,9 +239,7 @@ After running the initial migrations and populating the database with some recor
 ```python
 class BlogPage(Page):
     content = StreamField([
-        ("stream1", blocks.StreamBlock([
-            ("block1", blocks.CharBlock())
-        ])),
+        ("stream1", blocks.StreamBlock([("block1", blocks.CharBlock())])),
     ])
 ```
 
@@ -274,20 +260,15 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [...]
 
-    operations = [
-    ]
+    operations = []
 ```
 
 We need to make sure that either this migration or one of the migrations it depends on has the Wagtail core migrations as a dependency, since the utilities need the migrations for the `Revision` models to be able to run.
 
 ```python
-    dependencies = [
-        ('wagtailcore', '0069_log_entry_jsonfield'),
-        ...
-    ]
+dependencies = [("wagtailcore", "0069_log_entry_jsonfield"), ...]
 ```
 
 (if the project started off with Wagtail 4, '0076_modellogentry_revision' would also be fine)
@@ -301,8 +282,8 @@ from django.db import migrations
 
 from wagtail.blocks.migrations.migrate_operation import MigrateStreamData
 
-class Migration(migrations.Migration):
 
+class Migration(migrations.Migration):
     dependencies = [...]
 
     operations = [
@@ -310,7 +291,7 @@ class Migration(migrations.Migration):
             app_name="blog",
             model_name="BlogPage",
             field_name="content",
-            operations_and_block_paths=[...]
+            operations_and_block_paths=[...],
         ),
     ]
 ```
@@ -331,11 +312,9 @@ from django.db import migrations
 from wagtail.blocks.migrations.migrate_operation import MigrateStreamData
 from wagtail.blocks.migrations.operations import RenameStreamChildrenOperation
 
-class Migration(migrations.Migration):
 
-    dependencies = [
-        ...
-    ]
+class Migration(migrations.Migration):
+    dependencies = [...]
 
     operations = [
         MigrateStreamData(
@@ -343,11 +322,13 @@ class Migration(migrations.Migration):
             model_name="BlogPage",
             field_name="content",
             operations_and_block_paths=[
-                (RenameStreamChildrenOperation(old_name="field1", new_name="block1"), "stream1"),
-            ]
+                (
+                    RenameStreamChildrenOperation(old_name="field1", new_name="block1"),
+                    "stream1",
+                ),
+            ],
         ),
     ]
-
 ```
 
 (using_streamfield_migration_block_paths)=
@@ -357,11 +338,7 @@ class Migration(migrations.Migration):
 The `MigrateStreamData` class takes a list of operations and corresponding block paths as a parameter `operations_and_block_paths`. Each operation in the list will be applied to all blocks that match the corresponding block path.
 
 ```python
-operations_and_block_paths=[
-    (operation1, block_path1),
-    (operation2, block_path2),
-    ...
-]
+operations_and_block_paths = [(operation1, block_path1), (operation2, block_path2), ...]
 ```
 
 #### Block path
@@ -380,13 +357,16 @@ class MyDeepNestedBlock(StreamBlock):
     foo = CharBlock()
     date = DateBlock()
 
+
 class MyNestedBlock(StreamBlock):
     char1 = CharBlock()
     deepnested1 = MyDeepNestedBlock()
 
+
 class MyStreamBlock(StreamBlock):
     field1 = CharBlock()
     nested1 = MyNestedBlock()
+
 
 class MyPage(Page):
     content = StreamField(MyStreamBlock)
@@ -431,6 +411,7 @@ When the path contains a ListBlock child, 'item' must be added to the block path
 class MyStructBlock(StructBlock):
     char1 = CharBlock()
     char2 = CharBlock()
+
 
 class MyStreamBlock(StreamBlock):
     list1 = ListBlock(MyStructBlock())
@@ -521,6 +502,7 @@ For example, if we want to truncate the string in a `CharBlock` to a given lengt
 ```python
 from wagtail.blocks.migrations.operations import BaseBlockOperation
 
+
 class MyBlockOperation(BaseBlockOperation):
     def __init__(self, length):
         super().__init__()
@@ -529,14 +511,12 @@ class MyBlockOperation(BaseBlockOperation):
 
     def apply(self, block_value):
         # block value is the string value of the CharBlock
-        new_block_value = block_value[:self.length]
+        new_block_value = block_value[: self.length]
         return new_block_value
-
 
     @property
     def operation_name_fragment(self):
         return "truncate_{}".format(self.length)
-
 ```
 
 #### block_value
@@ -549,9 +529,9 @@ The value passed to `apply` when the matched block is a StreamBlock would look l
 
 ```python
 [
-    { "type": "...", "value": "...", "id": "..." },
-    { "type": "...", "value": "...", "id": "..." },
-    ...
+    {"type": "...", "value": "...", "id": "..."},
+    {"type": "...", "value": "...", "id": "..."},
+    ...,
 ]
 ```
 
@@ -569,9 +549,9 @@ The value passed to `apply` when the matched block is a ListBlock would look lik
 
 ```python
 [
-    { "type": "item", "value": "...", "id": "..." },
-    { "type": "item", "value": "...", "id": "..." },
-    ...
+    {"type": "item", "value": "...", "id": "..."},
+    {"type": "item", "value": "...", "id": "..."},
+    ...,
 ]
 ```
 
@@ -588,20 +568,16 @@ Prior to Wagtail version 2.16, `ListBlock` children were saved as just a normal 
 Old format
 
 ```python
-[
-    value1,
-    value2,
-    ...
-]
+[value1, value2, ...]
 ```
 
 New format
 
 ```python
 [
-    { "type": "item", "id": "...", "value": value1 },
-    { "type": "item", "id": "...", "value": value2 },
-    ...
+    {"type": "item", "id": "...", "value": value1},
+    {"type": "item", "id": "...", "value": value2},
+    ...,
 ]
 ```
 

--- a/docs/advanced_topics/streamfield_validation.md
+++ b/docs/advanced_topics/streamfield_validation.md
@@ -17,6 +17,7 @@ The following example is a StructBlock that:
 from django.core.exceptions import ValidationError
 from wagtail.blocks import StructBlock, PageChooserBlock, URLBlock
 
+
 class LinkBlock(StructBlock):
     page = PageChooserBlock(required=False)
     url = URLBlock(required=False)
@@ -24,7 +25,7 @@ class LinkBlock(StructBlock):
 
     def clean(self, value):
         result = super().clean(value)
-        if not self.is_deferred_validation and not (result['page'] or result['url']):
+        if not self.is_deferred_validation and not (result["page"] or result["url"]):
             raise ValidationError("Either page or URL must be specified")
         return result
 ```
@@ -50,6 +51,7 @@ The following example demonstrates raising a validation error attached to the 'd
 from django.core.exceptions import ValidationError
 from wagtail.blocks import CharBlock, StructBlock, StructBlockValidationError, TextBlock
 
+
 class TopicBlock(StructBlock):
     keyword = CharBlock()
     description = TextBlock()
@@ -57,9 +59,13 @@ class TopicBlock(StructBlock):
     def clean(self, value):
         result = super().clean(value)
         if result["keyword"] not in result["description"]:
-            raise StructBlockValidationError(block_errors={
-                "description": ValidationError("Description must contain the keyword")
-            })
+            raise StructBlockValidationError(
+                block_errors={
+                    "description": ValidationError(
+                        "Description must contain the keyword"
+                    )
+                }
+            )
         return result
 ```
 
@@ -68,6 +74,7 @@ ListBlock and StreamBlock also have corresponding exception classes `wagtail.blo
 ```python
 from django.core.exceptions import ValidationError
 from wagtail.blocks import ListBlock, ListBlockValidationError
+
 
 class AscendingListBlock(ListBlock):
     # example usage:

--- a/docs/advanced_topics/tags.md
+++ b/docs/advanced_topics/tags.md
@@ -40,8 +40,10 @@ We can now make use of the many-to-many tag relationship in our views and templa
 ```python
 from django.shortcuts import render
 
+
 class BlogIndexPage(Page):
     ...
+
     def get_context(self, request):
         context = super().get_context(request)
 
@@ -49,11 +51,11 @@ class BlogIndexPage(Page):
         blog_entries = BlogPage.objects.child_of(self).live()
 
         # Filter by tag
-        tag = request.GET.get('tag')
+        tag = request.GET.get("tag")
         if tag:
             blog_entries = blog_entries.filter(tags__name=tag)
 
-        context['blog_entries'] = blog_entries
+        context["blog_entries"] = blog_entries
         return context
 ```
 
@@ -79,6 +81,7 @@ from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
 from taggit.models import TagBase, ItemBase
 
+
 class BlogTag(TagBase):
     class Meta:
         verbose_name = "blog tag"
@@ -90,14 +93,13 @@ class TaggedBlog(ItemBase):
         BlogTag, related_name="tagged_blogs", on_delete=models.CASCADE
     )
     content_object = ParentalKey(
-        to='demo.BlogPage',
-        on_delete=models.CASCADE,
-        related_name='tagged_items'
+        to="demo.BlogPage", on_delete=models.CASCADE, related_name="tagged_items"
     )
+
 
 class BlogPage(Page):
     ...
-    tags = ClusterTaggableManager(through='demo.TaggedBlog', blank=True)
+    tags = ClusterTaggableManager(through="demo.TaggedBlog", blank=True)
 ```
 
 Within the admin, the tag field will automatically recognize the custom tag model being used and will offer autocomplete suggestions taken from that tag model.
@@ -109,6 +111,7 @@ By default, tag fields work on a "free tagging" basis: editors can enter anythin
 ```python
 from taggit.models import TagBase
 from wagtail.snippets.models import register_snippet
+
 
 @register_snippet
 class BlogTag(TagBase):
@@ -145,6 +148,7 @@ class TagsSnippetViewSet(SnippetViewSet):
     menu_order = 200  # will put in 3rd place (000 being 1st, 100 2nd)
     list_display = ["name", "slug"]
     search_fields = ("name",)
+
 
 register_snippet(TagsSnippetViewSet)
 ```

--- a/docs/advanced_topics/testing.md
+++ b/docs/advanced_topics/testing.md
@@ -13,9 +13,9 @@ Wagtail comes with some utilities that simplify writing tests for your site.
 from wagtail.test.utils import WagtailPageTestCase
 from myapp.models import MyPage
 
+
 class MyPageTests(WagtailPageTestCase):
-    def test_can_create_a_page(self):
-        ...
+    def test_can_create_a_page(self): ...
 ```
 
 **assertPageIsRoutable(_page, route_path="/", msg=None_)**
@@ -30,6 +30,7 @@ This assertion is great for getting coverage on custom routing logic for page ty
 from wagtail.test.utils import WagtailPageTestCase
 from myapp.models import EventListPage
 
+
 class EventListPageRoutabilityTests(WagtailPageTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -43,7 +44,6 @@ class EventListPageRoutabilityTests(WagtailPageTestCase):
         # NOTE: Despite this page type raising a 404 when no events exist for
         # the specified year, routing should still be successful
         self.assertPageIsRoutable(self.page, "archive/year/1984/")
-
 ```
 
 **assertPageIsRenderable(_page, route_path="/", query_data=None, post_data=None, user=None, accept_404=False, accept_redirect=False, msg=None_)**
@@ -66,13 +66,17 @@ This assertion is great for getting coverage on custom rendering logic for page 
 def test_default_route_rendering(self):
     self.assertPageIsRenderable(self.page)
 
+
 def test_year_archive_route_with_zero_matches(self):
     # NOTE: Should raise a 404 when no events exist for the specified year
     self.assertPageIsRenderable(self.page, "archive/year/1984/", accept_404=True)
 
+
 def test_month_archive_route_with_zero_matches(self):
     # NOTE: Should redirect to year-specific view when no events exist for the specified month
-    self.assertPageIsRenderable(self.page, "archive/year/1984/07/", accept_redirect=True)
+    self.assertPageIsRenderable(
+        self.page, "archive/year/1984/07/", accept_redirect=True
+    )
 ```
 
 **assertPageIsEditable(_page, post_data=None, user=None, msg=None_)**
@@ -89,6 +93,7 @@ This assertion is great for getting coverage on custom fields, panel configurati
 def test_editability(self):
     self.assertPageIsEditable(self.page)
 
+
 def test_editability_on_post(self):
     self.assertPageIsEditable(
         self.page,
@@ -98,7 +103,7 @@ def test_editability_on_post(self):
             "show_featured": True,
             "show_expired": False,
             "action-publish": "",
-        }
+        },
     )
 ```
 
@@ -117,6 +122,7 @@ This assertion is great for getting coverage on custom preview modes, or getting
 ```python
 def test_general_previewability(self):
     self.assertPageIsPreviewable(self.page)
+
 
 def test_archive_previewability(self):
     self.assertPageIsPreviewable(self.page, mode="year-archive")
@@ -150,17 +156,22 @@ Assert that a child of the given Page type can be created under the parent, usin
 ```python
 from wagtail.test.utils.form_data import nested_form_data, streamfield
 
+
 def test_can_create_content_page(self):
     # Get the HomePage
     root_page = HomePage.objects.get(pk=2)
 
     # Assert that a ContentPage can be made here, with this POST data
-    self.assertCanCreate(root_page, ContentPage, nested_form_data({
-        'title': 'About us',
-        'body': streamfield([
-            ('text', 'Lorem ipsum dolor sit amet'),
-        ])
-    }))
+    self.assertCanCreate(
+        root_page,
+        ContentPage,
+        nested_form_data({
+            "title": "About us",
+            "body": streamfield([
+                ("text", "Lorem ipsum dolor sit amet"),
+            ]),
+        }),
+    )
 ```
 
 See [](form_data_test_helpers) for a set of functions useful for constructing POST data.
@@ -174,12 +185,10 @@ The list of allowed parent models may differ from those set in `Page.parent_page
 def test_content_page_parent_pages(self):
     # A ContentPage can only be created under a HomePage
     # or another ContentPage
-    self.assertAllowedParentPageTypes(
-        ContentPage, {HomePage, ContentPage})
+    self.assertAllowedParentPageTypes(ContentPage, {HomePage, ContentPage})
 
     # An EventPage can only be created under an EventIndex
-    self.assertAllowedParentPageTypes(
-        EventPage, {EventIndex})
+    self.assertAllowedParentPageTypes(EventPage, {EventIndex})
 ```
 
 **assertAllowedSubpageTypes(_parent_model, child_models, msg=None_)**
@@ -190,12 +199,10 @@ The list of allowed child models may differ from those set in `Page.subpage_type
 ```python
 def test_content_page_subpages(self):
     # A ContentPage can only have other ContentPage children
-    self.assertAllowedSubpageTypes(
-        ContentPage, {ContentPage})
+    self.assertAllowedSubpageTypes(ContentPage, {ContentPage})
 
     # A HomePage can have ContentPage and EventIndex children
-    self.assertAllowedSubpageTypes(
-        HomePage, {ContentPage, EventIndex})
+    self.assertAllowedSubpageTypes(HomePage, {ContentPage, EventIndex})
 ```
 
 (form_data_test_helpers)=
@@ -261,18 +268,17 @@ You will likely want to test the content of your page. If it includes a `StreamF
 ...
 from wagtail.rich_text import RichText
 
+
 class MyPageTest(WagtailPageTestCase):
     @classmethod
     def setUpTestData(cls):
         ...
         # Create page instance here
-        cls.page.body.extend(
-            [
-                ("heading", "Just a CharField Heading"),
-                ("paragraph", RichText("<p>First paragraph</p>")),
-                ("paragraph", RichText("<p>Second paragraph</p>")),
-            ]
-        )
+        cls.page.body.extend([
+            ("heading", "Just a CharField Heading"),
+            ("paragraph", RichText("<p>First paragraph</p>")),
+            ("paragraph", RichText("<p>Second paragraph</p>")),
+        ])
         cls.page.save()
 
     def test_page_content(self):

--- a/docs/contributing/documentation_guidelines.md
+++ b/docs/contributing/documentation_guidelines.md
@@ -480,8 +480,9 @@ With its [autodoc](inv:sphinx#ext-autodoc) feature, Sphinx supports writing docu
 Modules, classes, and functions can be documented with docstrings. Class and instance attributes can be documented with docstrings (with triple quotes `"""`) or doc comments (with hash-colon `#:`). Docstrings are preferred, as they have better integration with code editors. Docstrings in Python code must be written in reStructuredText syntax.
 
 ```py
-SLUG_REGEX = r'^[-a-zA-Z0-9_]+$'
+SLUG_REGEX = r"^[-a-zA-Z0-9_]+$"
 """Docstring for module-level variable ``SLUG_REGEX``."""
+
 
 class Foo:
     """Docstring for class ``Foo``."""

--- a/docs/contributing/python_guidelines.md
+++ b/docs/contributing/python_guidelines.md
@@ -40,6 +40,7 @@ If the code needs to use something that changed in a version of Django many time
 ```python
 import django
 
+
 def related_field(field):
     if DJANGO_VERSION >= (1, 9):
         return field.rel

--- a/docs/contributing/translations.md
+++ b/docs/contributing/translations.md
@@ -48,7 +48,10 @@ In both Python and templates, make sure to always use a named placeholder. In ad
 from django.utils.translation import gettext_lazy as _
 
 # Do this: printf style + named placeholders
-_("Page %(page_title)s with status %(status)s") % {"page_title": page.title, "status": page.status_string}
+_("Page %(page_title)s with status %(status)s") % {
+    "page_title": page.title,
+    "status": page.status_string,
+}
 
 # Do not use anonymous placeholders
 _("Page %s with status %s") % (page.title, page.status_string)
@@ -58,11 +61,20 @@ _("Page {} with status {}").format(page.title, page.status_string)
 _("Page {0} with status {1}").format(page.title, page.status_string)
 
 # Do not use new style
-_("Page {page_title} with status {status}").format(page_title=page.title, status=page.status_string)
+_("Page {page_title} with status {status}").format(
+    page_title=page.title, status=page.status_string
+)
 
 # Do not interpolate within the gettext call
-_("Page %(page_title)s with status %(status)s" % {"page_title": page.title, "status": page.status_string})
-_("Page {page_title} with status {status}".format(page_title=page.title, status=page.status_string))
+_(
+    "Page %(page_title)s with status %(status)s"
+    % {"page_title": page.title, "status": page.status_string}
+)
+_(
+    "Page {page_title} with status {status}".format(
+        page_title=page.title, status=page.status_string
+    )
+)
 
 # Do not use f-string
 _(f"Page {page.title} with status {page.status_string}")

--- a/docs/contributing/ui_guidelines.md
+++ b/docs/contributing/ui_guidelines.md
@@ -234,7 +234,7 @@ To install the styleguide module on your site, add it to the list of `INSTALLED_
 ```python
 INSTALLED_APPS = (
     # ...
-    'wagtail.contrib.styleguide',
+    "wagtail.contrib.styleguide",
     # ...
 )
 ```

--- a/docs/deployment/flyio.md
+++ b/docs/deployment/flyio.md
@@ -340,10 +340,7 @@ from .base import *
 DEBUG = False
 
 DATABASES = {
-    "default": dj_database_url.config(
-        conn_max_age=600,
-        conn_health_checks=True
-    )
+    "default": dj_database_url.config(conn_max_age=600, conn_health_checks=True)
 }
 
 SECRET_KEY = os.environ["SECRET_KEY"]
@@ -359,7 +356,9 @@ CSRF_TRUSTED_ORIGINS = os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS", "").split(",")
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 MIDDLEWARE.append("whitenoise.middleware.WhiteNoiseMiddleware")
-STORAGES["staticfiles"]["BACKEND"] = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STORAGES["staticfiles"]["BACKEND"] = (
+    "whitenoise.storage.CompressedManifestStaticFilesStorage"
+)
 
 if "AWS_STORAGE_BUCKET_NAME" in os.environ:
     AWS_STORAGE_BUCKET_NAME = os.getenv("AWS_STORAGE_BUCKET_NAME")
@@ -373,7 +372,7 @@ if "AWS_STORAGE_BUCKET_NAME" in os.environ:
     STORAGES["default"]["BACKEND"] = "storages.backends.s3boto3.S3Boto3Storage"
 
     AWS_S3_OBJECT_PARAMETERS = {
-        'CacheControl': 'max-age=86400',
+        "CacheControl": "max-age=86400",
     }
 
 LOGGING = {

--- a/docs/extending/adding_reports.md
+++ b/docs/extending/adding_reports.md
@@ -43,7 +43,6 @@ class CustomModelReport(ReportView):
 
     def get_queryset(self):
         return MySnippetModel.objects.all()
-
 ```
 
 ### Other attributes
@@ -156,6 +155,7 @@ We will register this view using the `unpublished_changes_report` name for the U
 # <project>/views.py
 from wagtail.admin.views.reports import PageReportView
 
+
 class UnpublishedChangesReportView(PageReportView):
     index_url_name = "unpublished_changes_report"
     index_results_url_name = "unpublished_changes_report_results"
@@ -211,16 +211,31 @@ from wagtail import hooks
 
 from .views import UnpublishedChangesReportView
 
-@hooks.register('register_reports_menu_item')
-def register_unpublished_changes_report_menu_item():
-    return AdminOnlyMenuItem("Pages with unpublished changes", reverse('unpublished_changes_report'), icon_name=UnpublishedChangesReportView.header_icon, order=700)
 
-@hooks.register('register_admin_urls')
+@hooks.register("register_reports_menu_item")
+def register_unpublished_changes_report_menu_item():
+    return AdminOnlyMenuItem(
+        "Pages with unpublished changes",
+        reverse("unpublished_changes_report"),
+        icon_name=UnpublishedChangesReportView.header_icon,
+        order=700,
+    )
+
+
+@hooks.register("register_admin_urls")
 def register_unpublished_changes_report_url():
     return [
-        path('reports/unpublished-changes/', UnpublishedChangesReportView.as_view(), name='unpublished_changes_report'),
+        path(
+            "reports/unpublished-changes/",
+            UnpublishedChangesReportView.as_view(),
+            name="unpublished_changes_report",
+        ),
         # Add a results-only view to add support for AJAX-based filtering
-        path('reports/unpublished-changes/results/', UnpublishedChangesReportView.as_view(results_only=True), name='unpublished_changes_report_results'),
+        path(
+            "reports/unpublished-changes/results/",
+            UnpublishedChangesReportView.as_view(results_only=True),
+            name="unpublished_changes_report_results",
+        ),
     ]
 ```
 
@@ -231,12 +246,11 @@ Here, we use the `AdminOnlyMenuItem` class to ensure our report icon is only sho
 Even with the menu item hidden, it would still be possible for any user to visit the report's URL directly, and so it is necessary to set up a permission restriction on the report view itself. This can be done by adding a `dispatch` method to the existing `UnpublishedChangesReportView` view:
 
 ```python
-
-    # add the below dispatch method to the existing UnpublishedChangesReportView view
-    def dispatch(self, request, *args, **kwargs):
-        if not self.request.user.is_superuser:
-            return permission_denied(request)
-        return super().dispatch(request, *args, **kwargs)
+# add the below dispatch method to the existing UnpublishedChangesReportView view
+def dispatch(self, request, *args, **kwargs):
+    if not self.request.user.is_superuser:
+        return permission_denied(request)
+    return super().dispatch(request, *args, **kwargs)
 ```
 
 ### The full code
@@ -248,15 +262,18 @@ from wagtail.admin.auth import permission_denied
 from wagtail.admin.views.reports import PageReportView
 from wagtail.models import Page
 
+
 class UnpublishedChangesReportView(PageReportView):
     index_url_name = "unpublished_changes_report"
     index_results_url_name = "unpublished_changes_report_results"
-    header_icon = 'doc-empty-inverse'
-    results_template_name = 'reports/unpublished_changes_report_results.html'
+    header_icon = "doc-empty-inverse"
+    results_template_name = "reports/unpublished_changes_report_results.html"
     page_title = "Pages with unpublished changes"
 
-    list_export = PageReportView.list_export + ['last_published_at']
-    export_headings = dict(last_published_at='Last Published', **PageReportView.export_headings)
+    list_export = PageReportView.list_export + ["last_published_at"]
+    export_headings = dict(
+        last_published_at="Last Published", **PageReportView.export_headings
+    )
 
     def get_queryset(self):
         return Page.objects.filter(has_unpublished_changes=True)
@@ -277,15 +294,30 @@ from wagtail import hooks
 
 from .views import UnpublishedChangesReportView
 
-@hooks.register('register_reports_menu_item')
-def register_unpublished_changes_report_menu_item():
-    return AdminOnlyMenuItem("Pages with unpublished changes", reverse('unpublished_changes_report'), icon_name=UnpublishedChangesReportView.header_icon, order=700)
 
-@hooks.register('register_admin_urls')
+@hooks.register("register_reports_menu_item")
+def register_unpublished_changes_report_menu_item():
+    return AdminOnlyMenuItem(
+        "Pages with unpublished changes",
+        reverse("unpublished_changes_report"),
+        icon_name=UnpublishedChangesReportView.header_icon,
+        order=700,
+    )
+
+
+@hooks.register("register_admin_urls")
 def register_unpublished_changes_report_url():
     return [
-        path('reports/unpublished-changes/', UnpublishedChangesReportView.as_view(), name='unpublished_changes_report'),
-        path('reports/unpublished-changes/results/', UnpublishedChangesReportView.as_view(results_only=True), name='unpublished_changes_report_results'),
+        path(
+            "reports/unpublished-changes/",
+            UnpublishedChangesReportView.as_view(),
+            name="unpublished_changes_report",
+        ),
+        path(
+            "reports/unpublished-changes/results/",
+            UnpublishedChangesReportView.as_view(results_only=True),
+            name="unpublished_changes_report_results",
+        ),
     ]
 ```
 

--- a/docs/extending/admin_views.md
+++ b/docs/extending/admin_views.md
@@ -39,10 +39,10 @@ from wagtail import hooks
 from .views import index
 
 
-@hooks.register('register_admin_urls')
+@hooks.register("register_admin_urls")
 def register_calendar_url():
     return [
-        path('calendar/', index, name='calendar'),
+        path("calendar/", index, name="calendar"),
     ]
 ```
 
@@ -65,14 +65,19 @@ import calendar
 from django.shortcuts import render
 from django.utils import timezone
 
+
 def index(request):
     current_year = timezone.now().year
     calendar_html = calendar.HTMLCalendar().formatyear(current_year)
 
-    return render(request, 'wagtailcalendar/index.html', {
-        'current_year': current_year,
-        'calendar_html': calendar_html,
-    })
+    return render(
+        request,
+        "wagtailcalendar/index.html",
+        {
+            "current_year": current_year,
+            "calendar_html": calendar_html,
+        },
+    )
 ```
 
 Now create a `templates/wagtailcalendar/` folder within the `wagtailcalendar` app, containing `index.html` and `calendar.css` as follows:
@@ -128,16 +133,16 @@ from wagtail import hooks
 from .views import index
 
 
-@hooks.register('register_admin_urls')
+@hooks.register("register_admin_urls")
 def register_calendar_url():
     return [
-        path('calendar/', index, name='calendar'),
+        path("calendar/", index, name="calendar"),
     ]
 
 
-@hooks.register('register_admin_menu_item')
+@hooks.register("register_admin_menu_item")
 def register_calendar_menu_item():
-    return MenuItem('Calendar', reverse('calendar'), icon_name='date')
+    return MenuItem("Calendar", reverse("calendar"), icon_name="date")
 ```
 
 A 'Calendar' item will now appear in the menu.

--- a/docs/extending/audit_log.md
+++ b/docs/extending/audit_log.md
@@ -33,23 +33,20 @@ When adding logging, you need to log the action or actions that happen to the ob
 ```
 
 ```python
+# mypackage/views.py
+from wagtail.log_actions import log
 
-    # mypackage/views.py
-    from wagtail.log_actions import log
 
-    def copy_for_translation(page):
-        # ...
-        page.copy(log_action='mypackage.copy_for_translation')
+def copy_for_translation(page):
+    # ...
+    page.copy(log_action="mypackage.copy_for_translation")
 
-    def my_method(request, page):
-        # ..
-        # Manually log an action
-        data = {
-            'make': {'it': 'so'}
-        }
-        log(
-            instance=page, action='mypackage.custom_action', data=data
-        )
+
+def my_method(request, page):
+    # ..
+    # Manually log an action
+    data = {"make": {"it": "so"}}
+    log(instance=page, action="mypackage.custom_action", data=data)
 ```
 
 ## Log actions provided by Wagtail
@@ -90,11 +87,11 @@ such as import scripts:
 ```python
 from wagtail.log_actions import LogContext
 
-with LogContext(user=User.objects.get(username='admin')):
+with LogContext(user=User.objects.get(username="admin")):
     # ...
-    log(page, 'wagtail.edit')
+    log(page, "wagtail.edit")
     # ...
-    log(page, 'wagtail.publish')
+    log(page, "wagtail.publish")
 ```
 
 All `log` calls within the block will then be attributed to the specified user, and assigned a common UUID. A log context is created automatically for views within the Wagtail admin.
@@ -116,7 +113,8 @@ model, and registering that model with the log registry's `register_model` metho
 from myapp.models import Sprocket, SprocketLogEntry
 # here SprocketLogEntry is a subclass of BaseLogEntry
 
-@hooks.register('register_log_actions')
+
+@hooks.register("register_log_actions")
 def sprocket_log_model(actions):
     actions.register_model(Sprocket, SprocketLogEntry)
 ```

--- a/docs/extending/custom_account_settings.md
+++ b/docs/extending/custom_account_settings.md
@@ -19,8 +19,8 @@ Here is an example of how to add a new form that operates on the user model:
 from django import forms
 from django.contrib.auth import get_user_model
 
-class CustomSettingsForm(forms.ModelForm):
 
+class CustomSettingsForm(forms.ModelForm):
     class Meta:
         model = get_user_model()
         fields = [...]
@@ -33,13 +33,14 @@ from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail import hooks
 from .forms import CustomSettingsForm
 
-@hooks.register('register_account_settings_panel')
+
+@hooks.register("register_account_settings_panel")
 class CustomSettingsPanel(BaseSettingsPanel):
-    name = 'custom'
+    name = "custom"
     title = "My custom settings"
     order = 500
     form_class = CustomSettingsForm
-    form_object = 'user'
+    form_object = "user"
 ```
 
 The attributes are as follows:
@@ -62,8 +63,8 @@ To add a panel that alters data on the user's `wagtail.users.models.UserProfile`
 from django import forms
 from wagtail.users.models import UserProfile
 
-class CustomProfileSettingsForm(forms.ModelForm):
 
+class CustomProfileSettingsForm(forms.ModelForm):
     class Meta:
         model = UserProfile
         fields = [...]
@@ -76,13 +77,14 @@ from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail import hooks
 from .forms import CustomProfileSettingsForm
 
-@hooks.register('register_account_settings_panel')
+
+@hooks.register("register_account_settings_panel")
 class CustomSettingsPanel(BaseSettingsPanel):
-    name = 'custom'
+    name = "custom"
     title = "My custom settings"
     order = 500
     form_class = CustomProfileSettingsForm
-    form_object = 'profile'
+    form_object = "profile"
 ```
 
 ## Creating new tabs
@@ -96,11 +98,12 @@ from wagtail.admin.views.account import BaseSettingsPanel, SettingsTab
 from wagtail import hooks
 from .forms import CustomSettingsForm
 
-custom_tab = SettingsTab('custom', "Custom settings", order=300)
+custom_tab = SettingsTab("custom", "Custom settings", order=300)
 
-@hooks.register('register_account_settings_panel')
+
+@hooks.register("register_account_settings_panel")
 class CustomSettingsPanel(BaseSettingsPanel):
-    name = 'custom'
+    name = "custom"
     title = "My custom settings"
     tab = custom_tab
     order = 100
@@ -124,13 +127,14 @@ from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail import hooks
 from .forms import CustomSettingsForm
 
-@hooks.register('register_account_settings_panel')
+
+@hooks.register("register_account_settings_panel")
 class CustomSettingsPanel(BaseSettingsPanel):
-    name = 'custom'
+    name = "custom"
     title = "My custom settings"
     order = 500
     form_class = CustomSettingsForm
-    template_name = 'myapp/admin/custom_settings.html'
+    template_name = "myapp/admin/custom_settings.html"
 ```
 
 ```html+django

--- a/docs/extending/custom_bulk_actions.md
+++ b/docs/extending/custom_bulk_actions.md
@@ -11,7 +11,7 @@ from wagtail.admin.views.bulk_action import BulkAction
 from wagtail import hooks
 
 
-@hooks.register('register_bulk_action')
+@hooks.register("register_bulk_action")
 class CustomDeleteBulkAction(BulkAction):
     display_name = _("Delete")
     aria_label = _("Delete selected objects")
@@ -23,7 +23,10 @@ class CustomDeleteBulkAction(BulkAction):
     def execute_action(cls, objects, **kwargs):
         for obj in objects:
             do_something(obj)
-        return num_parent_objects, num_child_objects  # return the count of updated objects
+        return (
+            num_parent_objects,
+            num_child_objects,
+        )  # return the count of updated objects
 ```
 
 The attributes are as follows:
@@ -102,7 +105,7 @@ The `execute_action` classmethod is the only method that must be overridden for 
 @classmethod
 def execute_action(cls, objects, **kwargs):
     # the kwargs here is the output of the get_execution_context method
-    user = kwargs.get('user', None)
+    user = kwargs.get("user", None)
     num_parent_objects, num_child_objects = 0, 0
     # you could run the action per object or run them in bulk using django's bulk update and delete methods
     for obj in objects:
@@ -117,7 +120,7 @@ The `get_execution_context` method can be overridden to provide context to the `
 
 ```python
 def get_execution_context(self):
-    return { 'user': self.request.user }
+    return {"user": self.request.user}
 ```
 
 The `get_context_data` method can be overridden to pass additional context to the confirmation template.
@@ -125,7 +128,7 @@ The `get_context_data` method can be overridden to pass additional context to th
 ```python
 def get_context_data(self, **kwargs):
     context = super().get_context_data(**kwargs)
-    context['new_key'] = some_value
+    context["new_key"] = some_value
     return context
 ```
 
@@ -133,14 +136,18 @@ The `check_perm` method can be overridden to check if an object has some permiss
 
 ```python
 def check_perm(self, obj):
-    return obj.has_perm('some_perm')  # returns True or False
+    return obj.has_perm("some_perm")  # returns True or False
 ```
 
 The success message shown on the admin can be customized by overriding the `get_success_message` method.
 
 ```python
 def get_success_message(self, num_parent_objects, num_child_objects):
-    return _("{} objects, including {} child objects have been updated".format(num_parent_objects, num_child_objects))
+    return _(
+        "{} objects, including {} child objects have been updated".format(
+            num_parent_objects, num_child_objects
+        )
+    )
 ```
 
 ## Adding bulk actions to the page explorer
@@ -154,9 +161,8 @@ from wagtail.admin.views.pages.bulk_actions.page_bulk_action import PageBulkActi
 from wagtail import hooks
 
 
-@hooks.register('register_bulk_action')
-class CustomPageBulkAction(PageBulkAction):
-    ...
+@hooks.register("register_bulk_action")
+class CustomPageBulkAction(PageBulkAction): ...
 ```
 
 ## Adding bulk actions to the Images listing
@@ -170,9 +176,8 @@ from wagtail.images.views.bulk_actions.image_bulk_action import ImageBulkAction
 from wagtail import hooks
 
 
-@hooks.register('register_bulk_action')
-class CustomImageBulkAction(ImageBulkAction):
-    ...
+@hooks.register("register_bulk_action")
+class CustomImageBulkAction(ImageBulkAction): ...
 ```
 
 ## Adding bulk actions to the documents listing
@@ -186,9 +191,8 @@ from wagtail.documents.views.bulk_actions.document_bulk_action import DocumentBu
 from wagtail import hooks
 
 
-@hooks.register('register_bulk_action')
-class CustomDocumentBulkAction(DocumentBulkAction):
-    ...
+@hooks.register("register_bulk_action")
+class CustomDocumentBulkAction(DocumentBulkAction): ...
 ```
 
 ## Adding bulk actions to the user listing
@@ -202,9 +206,8 @@ from wagtail.users.views.bulk_actions.user_bulk_action import UserBulkAction
 from wagtail import hooks
 
 
-@hooks.register('register_bulk_action')
-class CustomUserBulkAction(UserBulkAction):
-    ...
+@hooks.register("register_bulk_action")
+class CustomUserBulkAction(UserBulkAction): ...
 ```
 
 (wagtailsnippets_custom_bulk_actions)=
@@ -233,7 +236,7 @@ from wagtail.snippets.bulk_actions.snippet_bulk_action import SnippetBulkAction
 from wagtail import hooks
 
 
-@hooks.register('register_bulk_action')
+@hooks.register("register_bulk_action")
 class CustomSnippetBulkAction(SnippetBulkAction):
     models = [SnippetA, SnippetB]
     # ...

--- a/docs/extending/custom_tasks.md
+++ b/docs/extending/custom_tasks.md
@@ -42,9 +42,11 @@ from wagtail.models import Task
 
 
 class UserApprovalTask(Task):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=False)
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=False
+    )
 
-    admin_form_fields = Task.admin_form_fields + ['user']
+    admin_form_fields = Task.admin_form_fields + ["user"]
 ```
 
 Any fields that shouldn't be edited after task creation - for example, anything that would fundamentally change the meaning of the task in any history logs - can be added to `admin_form_readonly_on_edit_fields`. For example:
@@ -58,13 +60,17 @@ from wagtail.models import Task
 
 
 class UserApprovalTask(Task):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=False)
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=False
+    )
 
-    admin_form_fields = Task.admin_form_fields + ['user']
+    admin_form_fields = Task.admin_form_fields + ["user"]
 
     # prevent editing of `user` after the task is created
     # by default, this attribute contains the 'name' field to prevent tasks from being renamed
-    admin_form_readonly_on_edit_fields = Task.admin_form_readonly_on_edit_fields + ['user']
+    admin_form_readonly_on_edit_fields = Task.admin_form_readonly_on_edit_fields + [
+        "user"
+    ]
 ```
 
 Wagtail will choose a default form widget to use based on the field type. But you can override the form widget using the `admin_form_widgets` attribute:
@@ -80,12 +86,14 @@ from .widgets import CustomUserChooserWidget
 
 
 class UserApprovalTask(Task):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=False)
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=False
+    )
 
-    admin_form_fields = Task.admin_form_fields + ['user']
+    admin_form_fields = Task.admin_form_fields + ["user"]
 
     admin_form_widgets = {
-        'user': CustomUserChooserWidget,
+        "user": CustomUserChooserWidget,
     }
 ```
 
@@ -120,9 +128,11 @@ class UserApprovalTaskState(TaskState):
 
 
 class UserApprovalTask(Task):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=False)
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=False
+    )
 
-    admin_form_fields = Task.admin_form_fields + ['user']
+    admin_form_fields = Task.admin_form_fields + ["user"]
 
     task_state_class = UserApprovalTaskState
 ```
@@ -184,9 +194,9 @@ For example:
 def get_actions(self, obj, user):
     if user == self.user:
         return [
-            ('approve', "Approve", False),
-            ('reject', "Reject", False),
-            ('cancel', "Cancel", False),
+            ("approve", "Approve", False),
+            ("reject", "Reject", False),
+            ("cancel", "Cancel", False),
         ]
     else:
         return []
@@ -208,7 +218,7 @@ For example, let's say we wanted to add an additional option: canceling the enti
 
 ```python
 def on_action(self, task_state, user, action_name):
-    if action_name == 'cancel':
+    if action_name == "cancel":
         return task_state.workflow_state.cancel(user=user)
     else:
         return super().on_action(task_state, user, workflow_state)
@@ -224,7 +234,9 @@ For example:
 def get_task_states_user_can_moderate(self, user, **kwargs):
     if user == self.user:
         # get all task states linked to the (base class of) current task
-        return TaskState.objects.filter(status=TaskState.STATUS_IN_PROGRESS, task=self.task_ptr)
+        return TaskState.objects.filter(
+            status=TaskState.STATUS_IN_PROGRESS, task=self.task_ptr
+        )
     else:
         return TaskState.objects.none()
 ```
@@ -266,15 +278,21 @@ class BaseUserApprovalTaskStateEmailNotifier(EmailNotificationMixin, Notifier):
         super().__init__((UserApprovalTaskState, TaskState))
 
     def can_handle(self, instance, **kwargs):
-        if super().can_handle(instance, **kwargs) and isinstance(instance.task.specific, UserApprovalTask):
+        if super().can_handle(instance, **kwargs) and isinstance(
+            instance.task.specific, UserApprovalTask
+        ):
             # Don't send notifications if a Task has been canceled and then resumed - when object was updated to a new revision
-            return not TaskState.objects.filter(workflow_state=instance.workflow_state, task=instance.task, status=TaskState.STATUS_CANCELLED).exists()
+            return not TaskState.objects.filter(
+                workflow_state=instance.workflow_state,
+                task=instance.task,
+                status=TaskState.STATUS_CANCELLED,
+            ).exists()
         return False
 
     def get_context(self, task_state, **kwargs):
         context = super().get_context(task_state, **kwargs)
-        context['object'] = task_state.workflow_state.content_object
-        context['task'] = task_state.task.specific
+        context["object"] = task_state.workflow_state.content_object
+        context["task"] = task_state.task.specific
         return context
 
     def get_recipient_users(self, task_state, **kwargs):
@@ -287,10 +305,12 @@ class BaseUserApprovalTaskStateEmailNotifier(EmailNotificationMixin, Notifier):
         return recipients
 
 
-class UserApprovalTaskStateSubmissionEmailNotifier(BaseUserApprovalTaskStateEmailNotifier):
+class UserApprovalTaskStateSubmissionEmailNotifier(
+    BaseUserApprovalTaskStateEmailNotifier
+):
     """A notifier to send updates for UserApprovalTask submission events"""
 
-    notification = 'submitted'
+    notification = "submitted"
 ```
 
 Similarly, you could define notifier subclasses for approval and rejection notifications.
@@ -306,8 +326,12 @@ from .mail import UserApprovalTaskStateSubmissionEmailNotifier
 
 task_submission_email_notifier = UserApprovalTaskStateSubmissionEmailNotifier()
 
+
 def register_signal_handlers():
-    task_submitted.connect(user_approval_task_submission_email_notifier, dispatch_uid='user_approval_task_submitted_email_notification')
+    task_submitted.connect(
+        user_approval_task_submission_email_notifier,
+        dispatch_uid="user_approval_task_submitted_email_notification",
+    )
 ```
 
 `register_signal_handlers()` should then be run on loading the app: for example, by adding it to the `ready()` method in your `AppConfig`.
@@ -318,11 +342,12 @@ from django.apps import AppConfig
 
 
 class MyAppConfig(AppConfig):
-    name = 'myappname'
-    label = 'myapplabel'
-    verbose_name = 'My verbose app name'
+    name = "myappname"
+    label = "myapplabel"
+    verbose_name = "My verbose app name"
 
     def ready(self):
         from .signal_handlers import register_signal_handlers
+
         register_signal_handlers()
 ```

--- a/docs/extending/customizing_group_views.md
+++ b/docs/extending/customizing_group_views.md
@@ -18,11 +18,16 @@ from django.db import models
 
 
 class ADGroup(models.Model):
-    guid = models.CharField(verbose_name="GUID", max_length=64, db_index=True, unique=True)
+    guid = models.CharField(
+        verbose_name="GUID", max_length=64, db_index=True, unique=True
+    )
     name = models.CharField(verbose_name="Group", max_length=255)
     domain = models.CharField(verbose_name="Domain", max_length=255, db_index=True)
     description = models.TextField(verbose_name="Description", blank=True, null=True)
-    roles = models.ManyToManyField(Group, verbose_name="Role", related_name="adgroups", blank=True)
+    roles = models.ManyToManyField(
+        Group, verbose_name="Role", related_name="adgroups", blank=True
+    )
+
 
 class Meta:
     verbose_name = "AD group"

--- a/docs/extending/editor_api.md
+++ b/docs/extending/editor_api.md
@@ -156,6 +156,7 @@ def editor_js():
         ((static(filename),) for filename in js_files),
     )
 
+
 # Replace the default `FieldPanel` for `search_description`
 # with a custom one that uses the `summarize` controller.
 Page.promote_panels[0].args[0][-1] = FieldPanel(

--- a/docs/extending/extending_client_side.md
+++ b/docs/extending/extending_client_side.md
@@ -111,7 +111,8 @@ from django.utils.html import format_html
 
 from wagtail import hooks
 
-@hooks.register('insert_global_admin_js')
+
+@hooks.register("insert_global_admin_js")
 def global_admin_js():
     return format_html(
         f'<script src="{static("js/example.js")}"></script>',
@@ -198,12 +199,16 @@ from django.templatetags.static import static
 from wagtail import hooks
 
 
-@hooks.register('insert_editor_js')
+@hooks.register("insert_editor_js")
 def editor_js():
     # add more controller code as needed
-    js_files = ['js/word-count-controller.js',]
-    return format_html_join('\n', '<script src="{0}"></script>',
-        ((static(filename),) for filename in js_files)
+    js_files = [
+        "js/word-count-controller.js",
+    ]
+    return format_html_join(
+        "\n",
+        '<script src="{0}"></script>',
+        ((static(filename),) for filename in js_files),
     )
 ```
 
@@ -229,21 +234,22 @@ from django.forms import Media, TextInput
 
 from django.utils.translation import gettext as _
 
+
 class ColorWidget(TextInput):
     """
     See https://coloris.js.org/
     """
 
-    def __init__(self, attrs=None, swatches=[], theme='large'):
+    def __init__(self, attrs=None, swatches=[], theme="large"):
         self.swatches = swatches
         self.theme = theme
-        super().__init__(attrs=attrs);
+        super().__init__(attrs=attrs)
 
     def build_attrs(self, *args, **kwargs):
         attrs = super().build_attrs(*args, **kwargs)
-        attrs['data-controller'] = 'color'
-        attrs['data-color-theme-value'] = self.theme
-        attrs['data-color-swatches-value'] = json.dumps(swatches)
+        attrs["data-controller"] = "color"
+        attrs["data-color-theme-value"] = self.theme
+        attrs["data-color-swatches-value"] = json.dumps(swatches)
         return attrs
 
     @property
@@ -255,7 +261,11 @@ class ColorWidget(TextInput):
                 # load controller JS
                 "js/color-controller.js",
             ],
-            css={"all": ["https://cdn.jsdelivr.net/gh/mdbassit/Coloris@latest/dist/coloris.min.css"]},
+            css={
+                "all": [
+                    "https://cdn.jsdelivr.net/gh/mdbassit/Coloris@latest/dist/coloris.min.css"
+                ]
+            },
         )
 ```
 
@@ -295,8 +305,8 @@ from .widgets import ColorWidget
 
 class ColorBlock(FieldBlock):
     def __init__(self, *args, **kwargs):
-        swatches = kwargs.pop('swatches', [])
-        theme = kwargs.pop('theme', 'large')
+        swatches = kwargs.pop("swatches", [])
+        theme = kwargs.pop("theme", "large")
         self.field = forms.CharField(widget=ColorWidget(swatches=swatches, theme=theme))
         super().__init__(*args, **kwargs)
 ```
@@ -314,12 +324,16 @@ from .widgets import ColorWidget
 
 BREAD_COLOR_PALETTE = ["#CFAC89", "#C68C5F", "#C47647", "#98644F", "#42332E"]
 
+
 class BreadPage(Page):
-    body = StreamField([
-        # ...
-        ('color', ColorBlock(swatches=BREAD_COLOR_PALETTE)),
-        # ...
-    ], use_json_field=True)
+    body = StreamField(
+        [
+            # ...
+            ("color", ColorBlock(swatches=BREAD_COLOR_PALETTE)),
+            # ...
+        ],
+        use_json_field=True,
+    )
     color = models.CharField(blank=True, max_length=50)
 
     # ... other fields

--- a/docs/extending/extending_draftail.md
+++ b/docs/extending/extending_draftail.md
@@ -16,46 +16,49 @@ All of these extensions are created with a similar baseline, which we can demons
 
 ```python
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
-from wagtail.admin.rich_text.converters.html_to_contentstate import InlineStyleElementHandler
+from wagtail.admin.rich_text.converters.html_to_contentstate import (
+    InlineStyleElementHandler,
+)
 from wagtail import hooks
 
+
 # 1. Use the register_rich_text_features hook.
-@hooks.register('register_rich_text_features')
+@hooks.register("register_rich_text_features")
 def register_mark_feature(features):
     """
     Registering the `mark` feature, which uses the `MARK` Draft.js inline style type,
     and is stored as HTML with a `<mark>` tag.
     """
-    feature_name = 'mark'
-    type_ = 'MARK'
-    tag = 'mark'
+    feature_name = "mark"
+    type_ = "MARK"
+    tag = "mark"
 
     # 2. Configure how Draftail handles the feature in its toolbar.
     control = {
-        'type': type_,
-        'label': '☆',
-        'description': 'Mark',
+        "type": type_,
+        "label": "☆",
+        "description": "Mark",
         # This isn’t even required – Draftail has predefined styles for MARK.
         # 'style': {'textDecoration': 'line-through'},
     }
 
     # 3. Call register_editor_plugin to register the configuration for Draftail.
     features.register_editor_plugin(
-        'draftail', feature_name, draftail_features.InlineStyleFeature(control)
+        "draftail", feature_name, draftail_features.InlineStyleFeature(control)
     )
 
     # 4.configure the content transform from the DB to the editor and back.
     db_conversion = {
-        'from_database_format': {tag: InlineStyleElementHandler(type_)},
-        'to_database_format': {'style_map': {type_: tag}},
+        "from_database_format": {tag: InlineStyleElementHandler(type_)},
+        "to_database_format": {"style_map": {type_: tag}},
     }
 
     # 5. Call register_converter_rule to register the content transformation conversion.
-    features.register_converter_rule('contentstate', feature_name, db_conversion)
+    features.register_converter_rule("contentstate", feature_name, db_conversion)
 
     # 6. (optional) Add the feature to the default features list to make it available
     # on rich text fields that do not specify an explicit 'features' list
-    features.default_features.append('mark')
+    features.default_features.append("mark")
 ```
 
 These steps will always be the same for all Draftail plugins. The important parts are to:
@@ -85,31 +88,44 @@ import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
 from wagtail import hooks
 
-@hooks.register('register_rich_text_features')
+
+@hooks.register("register_rich_text_features")
 def register_help_text_feature(features):
     """
     Registering the `help-text` feature, which uses the `help-text` Draft.js block type,
     and is stored as HTML with a `<div class="help-text">` tag.
     """
-    feature_name = 'help-text'
-    type_ = 'help-text'
+    feature_name = "help-text"
+    type_ = "help-text"
 
     control = {
-        'type': type_,
-        'label': '?',
-        'description': 'Help text',
+        "type": type_,
+        "label": "?",
+        "description": "Help text",
         # Optionally, we can tell Draftail what element to use when displaying those blocks in the editor.
-        'element': 'div',
+        "element": "div",
     }
 
     features.register_editor_plugin(
-        'draftail', feature_name, draftail_features.BlockFeature(control, css={'all': ['help-text.css']})
+        "draftail",
+        feature_name,
+        draftail_features.BlockFeature(control, css={"all": ["help-text.css"]}),
     )
 
-    features.register_converter_rule('contentstate', feature_name, {
-        'from_database_format': {'div[class=help-text]': BlockElementHandler(type_)},
-        'to_database_format': {'block_map': {type_: {'element': 'div', 'props': {'class': 'help-text'}}}},
-    })
+    features.register_converter_rule(
+        "contentstate",
+        feature_name,
+        {
+            "from_database_format": {
+                "div[class=help-text]": BlockElementHandler(type_)
+            },
+            "to_database_format": {
+                "block_map": {
+                    type_: {"element": "div", "props": {"class": "help-text"}}
+                }
+            },
+        },
+    )
 ```
 
 Here are the main differences:
@@ -167,35 +183,43 @@ Those tokens are then saved in the rich text on publish. When the news article i
 In order to achieve this, we start with registering the rich text feature like for inline styles and blocks:
 
 ```python
-@hooks.register('register_rich_text_features')
+@hooks.register("register_rich_text_features")
 def register_stock_feature(features):
-    features.default_features.append('stock')
+    features.default_features.append("stock")
     """
     Registering the `stock` feature, which uses the `STOCK` Draft.js entity type,
     and is stored as HTML with a `<span data-stock>` tag.
     """
-    feature_name = 'stock'
-    type_ = 'STOCK'
+    feature_name = "stock"
+    type_ = "STOCK"
 
     control = {
-        'type': type_,
-        'label': '$',
-        'description': 'Stock',
+        "type": type_,
+        "label": "$",
+        "description": "Stock",
     }
 
     features.register_editor_plugin(
-        'draftail', feature_name, draftail_features.EntityFeature(
-            control,
-            js=['stock.js'],
-            css={'all': ['stock.css']}
-        )
+        "draftail",
+        feature_name,
+        draftail_features.EntityFeature(
+            control, js=["stock.js"], css={"all": ["stock.css"]}
+        ),
     )
 
-    features.register_converter_rule('contentstate', feature_name, {
-        # Note here that the conversion is more complicated than for blocks and inline styles.
-        'from_database_format': {'span[data-stock]': StockEntityElementHandler(type_)},
-        'to_database_format': {'entity_decorators': {type_: stock_entity_decorator}},
-    })
+    features.register_converter_rule(
+        "contentstate",
+        feature_name,
+        {
+            # Note here that the conversion is more complicated than for blocks and inline styles.
+            "from_database_format": {
+                "span[data-stock]": StockEntityElementHandler(type_)
+            },
+            "to_database_format": {
+                "entity_decorators": {type_: stock_entity_decorator}
+            },
+        },
+    )
 ```
 
 The `js` and `css` keyword arguments on `EntityFeature` can be used to specify additional JS and CSS files to load when this feature is active. Both are optional. Their values are added to a `Media` object, more documentation on these objects is available in the [Django Form Assets documentation](inv:django#topics/forms/media).
@@ -204,16 +228,23 @@ Since entities hold data, the conversion to/from database format is more complic
 
 ```python
 from draftjs_exporter.dom import DOM
-from wagtail.admin.rich_text.converters.html_to_contentstate import InlineEntityElementHandler
+from wagtail.admin.rich_text.converters.html_to_contentstate import (
+    InlineEntityElementHandler,
+)
+
 
 def stock_entity_decorator(props):
     """
     Draft.js ContentState to database HTML.
     Converts the STOCK entities into a span tag.
     """
-    return DOM.create_element('span', {
-        'data-stock': props['stock'],
-    }, props['children'])
+    return DOM.create_element(
+        "span",
+        {
+            "data-stock": props["stock"],
+        },
+        props["children"],
+    )
 
 
 class StockEntityElementHandler(InlineEntityElementHandler):
@@ -221,13 +252,14 @@ class StockEntityElementHandler(InlineEntityElementHandler):
     Database HTML to Draft.js ContentState.
     Converts the span tag into a STOCK entity, with the right data.
     """
-    mutability = 'IMMUTABLE'
+
+    mutability = "IMMUTABLE"
 
     def get_attribute_data(self, attrs):
         """
         Take the `stock` value from the `data-stock` HTML attribute.
         """
-        return { 'stock': attrs['data-stock'] }
+        return {"stock": attrs["data-stock"]}
 ```
 
 Note how they both do similar conversions, but use different APIs. `to_database_format` is built with the [Draft.js exporter](https://github.com/springload/draftjs_exporter) components API, whereas `from_database_format` uses a Wagtail API.
@@ -360,18 +392,19 @@ from wagtail.admin.rich_text.editors.draftail.features import ControlFeature
 from wagtail import hooks
 
 
-@hooks.register('register_rich_text_features')
+@hooks.register("register_rich_text_features")
 def register_sentences_counter(features):
-    feature_name = 'sentences'
+    feature_name = "sentences"
     features.default_features.append(feature_name)
 
     features.register_editor_plugin(
-        'draftail',
+        "draftail",
         feature_name,
-        ControlFeature({
-            'type': feature_name,
-        },
-        js=['draftail_sentences.js'],
+        ControlFeature(
+            {
+                "type": feature_name,
+            },
+            js=["draftail_sentences.js"],
         ),
     )
 ```
@@ -406,10 +439,10 @@ For example:
 
 ```python
 WAGTAILADMIN_RICH_TEXT_EDITORS = {
-    'default': {
-        'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea',
-        'OPTIONS': {
-            'features': ['bold', 'italic', 'link', 'sentences'],  # Add 'sentences' here
+    "default": {
+        "WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea",
+        "OPTIONS": {
+            "features": ["bold", "italic", "link", "sentences"],  # Add 'sentences' here
         },
     },
 }
@@ -431,18 +464,19 @@ from wagtail.admin.rich_text.editors.draftail.features import DecoratorFeature
 from wagtail import hooks
 
 
-@hooks.register('register_rich_text_features')
+@hooks.register("register_rich_text_features")
 def register_punctuation_highlighter(features):
-    feature_name = 'punctuation'
+    feature_name = "punctuation"
     features.default_features.append(feature_name)
 
     features.register_editor_plugin(
-        'draftail',
+        "draftail",
         feature_name,
-        DecoratorFeature({
-            'type': feature_name,
-        },
-            js=['draftail_punctuation.js'],
+        DecoratorFeature(
+            {
+                "type": feature_name,
+            },
+            js=["draftail_punctuation.js"],
         ),
     )
 ```
@@ -487,18 +521,19 @@ Draftail supports plugins following the [Draft.js Plugins](https://www.draft-js-
 A common scenario where this API can help is to add bespoke copy-paste processing. Here is a simple example, automatically converting URL anchor hash references to links. First, let’s register the extension in Python:
 
 ```python
-@hooks.register('register_rich_text_features')
+@hooks.register("register_rich_text_features")
 def register_anchorify(features):
-    feature_name = 'anchorify'
+    feature_name = "anchorify"
     features.default_features.append(feature_name)
 
     features.register_editor_plugin(
-        'draftail',
+        "draftail",
         feature_name,
-        PluginFeature({
-            'type': feature_name,
-        },
-            js=['draftail_anchorify.js'],
+        PluginFeature(
+            {
+                "type": feature_name,
+            },
+            js=["draftail_anchorify.js"],
         ),
     )
 ```

--- a/docs/extending/forms.md
+++ b/docs/extending/forms.md
@@ -44,14 +44,17 @@ from django.db.models import ForeignKey
 
 
 class WagtailVideosAppConfig(AppConfig):
-    name = 'wagtail.videos'
-    label = 'wagtailvideos'
+    name = "wagtail.videos"
+    label = "wagtailvideos"
 
     def ready(self):
         from wagtail.admin.forms.models import register_form_field_override
         from .models import Video
         from .widgets import VideoChooser
-        register_form_field_override(ForeignKey, to=Video, override={'widget': VideoChooser})
+
+        register_form_field_override(
+            ForeignKey, to=Video, override={"widget": VideoChooser}
+        )
 ```
 
 Wagtail's edit views for pages and snippets use `WagtailAdminModelForm` as standard, so this change will take effect across the Wagtail admin; a foreign key to `Video` on a page model will automatically use the `VideoChooser` widget, with no need to specify this explicitly.

--- a/docs/extending/generic_views.md
+++ b/docs/extending/generic_views.md
@@ -17,6 +17,7 @@ The {class}`~wagtail.admin.viewsets.model.ModelViewSet` class provides the views
 ```python
 from django.db import models
 
+
 class Person(models.Model):
     first_name = models.CharField(max_length=255)
     last_name = models.CharField(max_length=255)
@@ -152,8 +153,8 @@ from django.db import migrations, models
 
 
 def populate_sort_order(apps, schema_editor):
-    Employee = apps.get_model('myapp', 'Employee')
-    for i, employee in enumerate(Employee.objects.order_by('id')):
+    Employee = apps.get_model("myapp", "Employee")
+    for i, employee in enumerate(Employee.objects.order_by("id")):
         employee.sort_order = i
         employee.save()
 
@@ -299,39 +300,48 @@ The chooser widget now needs to be configured to pass these URL parameters when 
 
 ```python
 class BlogPage(Page):
-    country = models.ForeignKey(Country, null=True, blank=True, on_delete=models.SET_NULL)
+    country = models.ForeignKey(
+        Country, null=True, blank=True, on_delete=models.SET_NULL
+    )
     author = models.ForeignKey(Person, null=True, blank=True, on_delete=models.SET_NULL)
 
     content_panels = Page.content_panels + [
-        FieldPanel('country'),
-        FieldPanel('author', widget=PersonChooserWidget(linked_fields={
-            # pass the country selected in the id_country input to the person chooser
-            # as a URL parameter `country`
-            'country': '#id_country',
-        })),
+        FieldPanel("country"),
+        FieldPanel(
+            "author",
+            widget=PersonChooserWidget(
+                linked_fields={
+                    # pass the country selected in the id_country input to the person chooser
+                    # as a URL parameter `country`
+                    "country": "#id_country",
+                }
+            ),
+        ),
     ]
 ```
 
 A number of other lookup mechanisms are available:
 
 ```python
-PersonChooserWidget(linked_fields={
-    'country': {'selector': '#id_country'}  # equivalent to 'country': '#id_country'
-})
+PersonChooserWidget(
+    linked_fields={
+        "country": {"selector": "#id_country"}  # equivalent to 'country': '#id_country'
+    }
+)
 
 # Look up by ID
-PersonChooserWidget(linked_fields={
-    'country': {'id': 'id_country'}
-})
+PersonChooserWidget(linked_fields={"country": {"id": "id_country"}})
 
 # Regexp match, for use in StreamFields and InlinePanels where IDs are dynamic:
 # 1) Match the ID of the current widget's form element (the PersonChooserWidget)
 #      against the regexp '^id_blog_person_relationship-\d+-'
 # 2) Append 'country' to the matched substring
 # 3) Retrieve the input field with that ID
-PersonChooserWidget(linked_fields={
-    'country': {'match': r'^id_blog_person_relationship-\d+-', 'append': 'country'},
-})
+PersonChooserWidget(
+    linked_fields={
+        "country": {"match": r"^id_blog_person_relationship-\d+-", "append": "country"},
+    }
+)
 ```
 
 (chooser_viewsets_non_model_data)=
@@ -359,15 +369,19 @@ class Pokemon(APIModel):
     @classmethod
     def from_query_data(cls, data):
         return cls(
-            id=int(re.match(r'https://pokeapi.co/api/v2/pokemon/(\d+)/', data['url']).group(1)),
-            name=data['name'],
+            id=int(
+                re.match(
+                    r"https://pokeapi.co/api/v2/pokemon/(\d+)/", data["url"]
+                ).group(1)
+            ),
+            name=data["name"],
         )
 
     @classmethod
     def from_individual_data(cls, data):
         return cls(
-            id=data['id'],
-            name=data['name'],
+            id=data["id"],
+            name=data["name"],
         )
 
     def __str__(self):

--- a/docs/extending/rich_text_internals.md
+++ b/docs/extending/rich_text_internals.md
@@ -149,8 +149,9 @@ Below is an example custom rewrite handler that implements some of these methods
 from django.contrib.auth import get_user_model
 from wagtail.rich_text import LinkHandler
 
+
 class UserLinkHandler(LinkHandler):
-    identifier = 'user'
+    identifier = "user"
 
     @staticmethod
     def get_model():
@@ -159,7 +160,7 @@ class UserLinkHandler(LinkHandler):
     @classmethod
     def get_instance(cls, attrs):
         model = cls.get_model()
-        return model.objects.get(username=attrs['username'])
+        return model.objects.get(username=attrs["username"])
 
     @classmethod
     def expand_db_attributes(cls, attrs):
@@ -183,7 +184,8 @@ This method allows you to register a custom handler deriving from ``wagtail.rich
 from wagtail import hooks
 from my_app.handlers import MyCustomLinkHandler
 
-@hooks.register('register_rich_text_features')
+
+@hooks.register("register_rich_text_features")
 def register_link_handler(features):
     features.register_link_type(MyCustomLinkHandler)
 ```
@@ -195,15 +197,17 @@ from django.utils.html import escape
 from wagtail import hooks
 from wagtail.rich_text import LinkHandler
 
+
 class NoFollowExternalLinkHandler(LinkHandler):
-    identifier = 'external'
+    identifier = "external"
 
     @classmethod
     def expand_db_attributes(cls, attrs):
         href = attrs["href"]
         return '<a href="%s" rel="nofollow">' % escape(href)
 
-@hooks.register('register_rich_text_features')
+
+@hooks.register("register_rich_text_features")
 def register_external_link(features):
     features.register_link_type(NoFollowExternalLinkHandler)
 ```
@@ -222,7 +226,8 @@ This method allows you to register a custom handler deriving from ``wagtail.rich
 from wagtail import hooks
 from my_app.handlers import MyCustomEmbedHandler
 
-@hooks.register('register_rich_text_features')
+
+@hooks.register("register_rich_text_features")
 def register_embed_handler(features):
     features.register_embed_type(MyCustomEmbedHandler)
 ```
@@ -242,9 +247,9 @@ For example, a third-party Wagtail extension might introduce `table` as a new ri
 The `default_features` attribute of the feature registry is a list of feature identifiers to be used whenever an explicit feature list has not been given in `RichTextField` / `RichTextBlock` or `WAGTAILADMIN_RICH_TEXT_EDITORS`. This list can be modified within the `register_rich_text_features` hook to make new features enabled by default, and retrieved by calling `get_default_features()`.
 
 ```python
-@hooks.register('register_rich_text_features')
+@hooks.register("register_rich_text_features")
 def make_h1_default(features):
-    features.default_features.append('h1')
+    features.default_features.append("h1")
 ```
 
 Outside of the `register_rich_text_features` hook - for example, inside a widget class - the feature registry can be imported as the object `wagtail.rich_text.features`. A possible starting point for a rich text editor with feature support would be:
@@ -253,13 +258,14 @@ Outside of the `register_rich_text_features` hook - for example, inside a widget
 from django.forms import widgets
 from wagtail.rich_text import features
 
+
 class CustomRichTextArea(widgets.TextArea):
     accepts_features = True
 
     def __init__(self, *args, **kwargs):
-        self.options = kwargs.pop('options', None)
+        self.options = kwargs.pop("options", None)
 
-        self.features = kwargs.pop('features', None)
+        self.features = kwargs.pop("features", None)
         if self.features is None:
             self.features = features.get_default_features()
 

--- a/docs/extending/template_components.md
+++ b/docs/extending/template_components.md
@@ -41,8 +41,9 @@ The preferred way to create a component is to define a subclass of `wagtail.admi
 ```python
 from wagtail.admin.ui.components import Component
 
+
 class WelcomePanel(Component):
-    template_name = 'my_app/panels/welcome.html'
+    template_name = "my_app/panels/welcome.html"
 
 
 my_welcome_panel = WelcomePanel()
@@ -60,6 +61,7 @@ For simple cases that don't require a template, the `render_html` method can be 
 from django.utils.html import format_html
 from wagtail.admin.components import Component
 
+
 class WelcomePanel(Component):
     def render_html(self, parent_context):
         return format_html("<h1>{}</h1>", "Welcome to my app!")
@@ -72,12 +74,13 @@ The `get_context_data` method can be overridden to pass context variables to the
 ```python
 from wagtail.admin.ui.components import Component
 
+
 class WelcomePanel(Component):
-    template_name = 'my_app/panels/welcome.html'
+    template_name = "my_app/panels/welcome.html"
 
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)
-        context['username'] = parent_context['request'].user.username
+        context["username"] = parent_context["request"].user.username
         return context
 ```
 
@@ -93,12 +96,10 @@ Like Django form widgets, components can specify associated JavaScript and CSS r
 
 ```python
 class WelcomePanel(Component):
-    template_name = 'my_app/panels/welcome.html'
+    template_name = "my_app/panels/welcome.html"
 
     class Media:
-        css = {
-            'all': ('my_app/css/welcome-panel.css',)
-        }
+        css = {"all": ("my_app/css/welcome-panel.css",)}
 ```
 
 ## Using components on your own templates
@@ -108,14 +109,19 @@ The `wagtailadmin_tags` tag library provides a `{% component %}` tag for includi
 ```python
 from django.shortcuts import render
 
+
 def welcome_page(request):
     panels = [
         WelcomePanel(),
     ]
 
-    render(request, 'my_app/welcome.html', {
-        'panels': panels,
-    })
+    render(
+        request,
+        "my_app/welcome.html",
+        {
+            "panels": panels,
+        },
+    )
 ```
 
 the `my_app/welcome.html` template could render the panels as follows:
@@ -153,6 +159,7 @@ Note that it is your template's responsibility to output any media declarations 
 from django.forms import Media
 from django.shortcuts import render
 
+
 def welcome_page(request):
     panels = [
         WelcomePanel(),
@@ -162,10 +169,14 @@ def welcome_page(request):
     for panel in panels:
         media += panel.media
 
-    render(request, 'my_app/welcome.html', {
-        'panels': panels,
-        'media': media,
-    })
+    render(
+        request,
+        "my_app/welcome.html",
+        {
+            "panels": panels,
+            "media": media,
+        },
+    )
 ```
 
 `my_app/welcome.html`:

--- a/docs/getting_started/integrating_into_django.md
+++ b/docs/getting_started/integrating_into_django.md
@@ -19,26 +19,26 @@ or add the package to your existing requirements file. This will also install th
 In your settings.py file, add the following apps to `INSTALLED_APPS`:
 
 ```python
-'wagtail.contrib.forms',
-'wagtail.contrib.redirects',
-'wagtail.embeds',
-'wagtail.sites',
-'wagtail.users',
-'wagtail.snippets',
-'wagtail.documents',
-'wagtail.images',
-'wagtail.search',
-'wagtail.admin',
-'wagtail',
+("wagtail.contrib.forms",)
+("wagtail.contrib.redirects",)
+("wagtail.embeds",)
+("wagtail.sites",)
+("wagtail.users",)
+("wagtail.snippets",)
+("wagtail.documents",)
+("wagtail.images",)
+("wagtail.search",)
+("wagtail.admin",)
+("wagtail",)
 
-'modelcluster',
-'taggit',
+("modelcluster",)
+("taggit",)
 ```
 
 Add the following entry to `MIDDLEWARE`:
 
 ```python
-'wagtail.contrib.redirects.middleware.RedirectMiddleware',
+("wagtail.contrib.redirects.middleware.RedirectMiddleware",)
 ```
 
 Add a `STATIC_ROOT` setting, if your project doesn't have one already:
@@ -51,7 +51,7 @@ Add `MEDIA_ROOT` and `MEDIA_URL` settings, if your project doesn't have these al
 
 ```python
 MEDIA_ROOT = BASE_DIR / "media"
-MEDIA_URL = '/media/'
+MEDIA_URL = "/media/"
 ```
 
 Set the `DATA_UPLOAD_MAX_NUMBER_FIELDS` setting to 10000 or higher. This specifies the maximum number of fields allowed in a form submission, and it is recommended to increase this from Django's default of 1000, as particularly complex page models can exceed this limit within Wagtail's page editor:
@@ -63,13 +63,13 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = 10_000
 Add a `WAGTAIL_SITE_NAME` - this will be displayed on the main dashboard of the Wagtail admin backend:
 
 ```python
-WAGTAIL_SITE_NAME = 'My Example Site'
+WAGTAIL_SITE_NAME = "My Example Site"
 ```
 
 Add a `WAGTAILADMIN_BASE_URL` - this is the base URL used by the Wagtail admin site. It is typically used for generating URLs to include in notification emails:
 
 ```python
-WAGTAILADMIN_BASE_URL = 'https://example.com'
+WAGTAILADMIN_BASE_URL = "https://example.com"
 ```
 
 If this setting is not present, Wagtail will fall back to `request.site.root_url` or to the hostname of the request. Although this setting is not strictly required, it is highly recommended because leaving it out may produce unusable URLs in notification emails.
@@ -77,7 +77,18 @@ If this setting is not present, Wagtail will fall back to `request.site.root_url
 Add a `WAGTAILDOCS_EXTENSIONS` setting to specify the file types that Wagtail will allow to be uploaded as documents. This can be omitted to allow all file types, but this may present a security risk if untrusted users are allowed to upload documents - see [](user_uploaded_files).
 
 ```python
-WAGTAILDOCS_EXTENSIONS = ['csv', 'docx', 'key', 'odt', 'pdf', 'pptx', 'rtf', 'txt', 'xlsx', 'zip']
+WAGTAILDOCS_EXTENSIONS = [
+    "csv",
+    "docx",
+    "key",
+    "odt",
+    "pdf",
+    "pptx",
+    "rtf",
+    "txt",
+    "xlsx",
+    "zip",
+]
 ```
 
 Various other settings are available to configure Wagtail's behavior - see [Settings](/reference/settings).
@@ -116,9 +127,12 @@ Finally, you need to set up your project to serve user-uploaded files from `MEDI
 from django.conf import settings
 from django.conf.urls.static import static
 
-urlpatterns = [
-    # ... the rest of your URLconf goes here ...
-] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+urlpatterns = (
+    [
+        # ... the rest of your URLconf goes here ...
+    ]
+    + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+)
 ```
 
 Note that this only works in development mode (`DEBUG = True`); in production, you have to configure your web server to serve files from `MEDIA_ROOT`. For further details, see the Django documentation: [Serving files uploaded by a user during development](<inv:django#howto/static-files/index:serving files uploaded by a user during development>) and [Deploying static files](inv:django#howto/static-files/deployment).

--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -271,7 +271,7 @@ Add the new `blog` app to `INSTALLED_APPS` in `mysite/settings/base.py`.
 
 ```python
 INSTALLED_APPS = [
-    "blog", # <- Our new blog app.
+    "blog",  # <- Our new blog app.
     "home",
     "search",
     "wagtail.contrib.forms",
@@ -279,7 +279,7 @@ INSTALLED_APPS = [
     "wagtail.embeds",
     "wagtail.sites",
     "wagtail.users",
-    #... other packages
+    # ... other packages
 ]
 ```
 
@@ -365,6 +365,7 @@ from wagtail.models import Page
 from wagtail.fields import RichTextField
 
 # Keep the BlogIndexPage model code as is, and add the BlogPage model:
+
 
 class BlogPage(Page):
     date = models.DateField("Post date")
@@ -511,12 +512,13 @@ Modify your `BlogIndexPage` model:
 ```python
 class BlogIndexPage(Page):
     intro = RichTextField(blank=True)
+
     # add the get_context method:
     def get_context(self, request):
         # Update context to include only published posts, ordered by reverse-chron
         context = super().get_context(request)
-        blogpages = self.get_children().live().order_by('-first_published_at')
-        context['blogpages'] = blogpages
+        blogpages = self.get_children().live().order_by("-first_published_at")
+        context["blogpages"] = blogpages
         return context
 
     # ...
@@ -551,23 +553,27 @@ from wagtail.fields import RichTextField
 
 # ... Keep the definition of BlogIndexPage, update the content_panels of BlogPage, and add a new BlogPageGalleryImage model:
 
+
 class BlogPage(Page):
     date = models.DateField("Post date")
     intro = models.CharField(max_length=250)
     body = RichTextField(blank=True)
 
     content_panels = Page.content_panels + [
-        "date", "intro", "body",
-
+        "date",
+        "intro",
+        "body",
         # Add this
-         "gallery_images",
-        ]
+        "gallery_images",
+    ]
 
 
 class BlogPageGalleryImage(Orderable):
-    page = ParentalKey(BlogPage, on_delete=models.CASCADE, related_name='gallery_images')
+    page = ParentalKey(
+        BlogPage, on_delete=models.CASCADE, related_name="gallery_images"
+    )
     image = models.ForeignKey(
-        'wagtailimages.Image', on_delete=models.CASCADE, related_name='+'
+        "wagtailimages.Image", on_delete=models.CASCADE, related_name="+"
     )
     caption = models.CharField(blank=True, max_length=250)
 
@@ -628,6 +634,7 @@ class BlogPage(Page):
     date = models.DateField("Post date")
     intro = models.CharField(max_length=250)
     body = RichTextField(blank=True)
+
     # Add the main_image method:
     def main_image(self):
         gallery_item = self.gallery_images.first()
@@ -675,13 +682,17 @@ To create Authors and give each author an author image as well as a name, add th
 # Add this to the top of the file
 from wagtail.snippets.models import register_snippet
 
+
 # ... Keep BlogIndexPage, BlogPage, BlogPageGalleryImage models, and then add the Author model:
 @register_snippet
 class Author(models.Model):
     name = models.CharField(max_length=255)
     author_image = models.ForeignKey(
-        'wagtailimages.Image', null=True, blank=True,
-        on_delete=models.SET_NULL, related_name='+'
+        "wagtailimages.Image",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="+",
     )
 
     panels = ["name", "author_image"]
@@ -690,7 +701,7 @@ class Author(models.Model):
         return self.name
 
     class Meta:
-        verbose_name_plural = 'Authors'
+        verbose_name_plural = "Authors"
 ```
 
 ```{note}
@@ -711,18 +722,21 @@ from wagtail.fields import RichTextField
 from wagtail.admin.panels import MultiFieldPanel
 from wagtail.snippets.models import register_snippet
 
+
 class BlogPage(Page):
     date = models.DateField("Post date")
     intro = models.CharField(max_length=250)
     body = RichTextField(blank=True)
 
     # Add this:
-    authors = ParentalManyToManyField('blog.Author', blank=True)
+    authors = ParentalManyToManyField("blog.Author", blank=True)
 
     # ... Keep the main_image method. Modify your content_panels:
     content_panels = Page.content_panels + [
         MultiFieldPanel(["date", "authors"], heading="Blog information"),
-        "intro", "body", "gallery_images"
+        "intro",
+        "body",
+        "gallery_images",
     ]
 ```
 
@@ -745,20 +759,26 @@ from wagtail.fields import RichTextField
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 from wagtail.snippets.models import register_snippet
 
+
 class BlogPage(Page):
     date = models.DateField("Post date")
     intro = models.CharField(max_length=250)
     body = RichTextField(blank=True)
 
-    authors = ParentalManyToManyField('blog.Author', blank=True)
+    authors = ParentalManyToManyField("blog.Author", blank=True)
 
     content_panels = Page.content_panels + [
-        MultiFieldPanel([
-            "date",
-            # Change this:
-            FieldPanel("authors", widget=forms.CheckboxSelectMultiple),
-        ], heading="Blog information"),
-        "intro", "body", "gallery_images"
+        MultiFieldPanel(
+            [
+                "date",
+                # Change this:
+                FieldPanel("authors", widget=forms.CheckboxSelectMultiple),
+            ],
+            heading="Blog information",
+        ),
+        "intro",
+        "body",
+        "gallery_images",
     ]
 ```
 
@@ -836,32 +856,35 @@ from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 # ... Keep the definition of BlogIndexPage model and add a new BlogPageTag model
 class BlogPageTag(TaggedItemBase):
     content_object = ParentalKey(
-        'BlogPage',
-        related_name='tagged_items',
-        on_delete=models.CASCADE
+        "BlogPage", related_name="tagged_items", on_delete=models.CASCADE
     )
+
 
 # Modify the BlogPage model:
 class BlogPage(Page):
     date = models.DateField("Post date")
     intro = models.CharField(max_length=250)
     body = RichTextField(blank=True)
-    authors = ParentalManyToManyField('blog.Author', blank=True)
+    authors = ParentalManyToManyField("blog.Author", blank=True)
 
     # Add this:
     tags = ClusterTaggableManager(through=BlogPageTag, blank=True)
 
     # ... Keep the main_image method. Then modify the content_panels:
     content_panels = Page.content_panels + [
-        MultiFieldPanel([
-            "date",
-            FieldPanel("authors", widget=forms.CheckboxSelectMultiple),
-
-            # Add this:
-            "tags",
-        ], heading="Blog information"),
-            "intro", "body", "gallery_images"
-        ]
+        MultiFieldPanel(
+            [
+                "date",
+                FieldPanel("authors", widget=forms.CheckboxSelectMultiple),
+                # Add this:
+                "tags",
+            ],
+            heading="Blog information",
+        ),
+        "intro",
+        "body",
+        "gallery_images",
+    ]
 ```
 
 Run `python manage.py makemigrations` and `python manage.py migrate`.
@@ -902,16 +925,15 @@ Return to `blog/models.py` and add a new `BlogTagIndexPage` model:
 
 ```python
 class BlogTagIndexPage(Page):
-
     def get_context(self, request):
 
         # Filter by tag
-        tag = request.GET.get('tag')
+        tag = request.GET.get("tag")
         blogpages = BlogPage.objects.filter(tags__name=tag)
 
         # Update template context
         context = super().get_context(request)
-        context['blogpages'] = blogpages
+        context["blogpages"] = blogpages
         return context
 ```
 

--- a/docs/reference/contrib/settings.md
+++ b/docs/reference/contrib/settings.md
@@ -12,7 +12,7 @@ Add `wagtail.contrib.settings` to your `INSTALLED_APPS`:
 
 ```python
 INSTALLED_APPS += [
-    'wagtail.contrib.settings',
+    "wagtail.contrib.settings",
 ]
 ```
 
@@ -36,9 +36,11 @@ from wagtail.contrib.settings.models import (
     register_setting,
 )
 
+
 @register_setting
 class GenericSocialMediaSettings(BaseGenericSetting):
     facebook = models.URLField()
+
 
 @register_setting
 class SiteSpecificSocialMediaSettings(BaseSiteSetting):
@@ -58,29 +60,30 @@ Add a `panels` setting to your model defining all the edit handlers required:
 @register_setting
 class GenericImportantPages(BaseGenericSetting):
     donate_page = models.ForeignKey(
-        'wagtailcore.Page', null=True, on_delete=models.SET_NULL, related_name='+'
+        "wagtailcore.Page", null=True, on_delete=models.SET_NULL, related_name="+"
     )
     sign_up_page = models.ForeignKey(
-        'wagtailcore.Page', null=True, on_delete=models.SET_NULL, related_name='+'
+        "wagtailcore.Page", null=True, on_delete=models.SET_NULL, related_name="+"
     )
 
     panels = [
-        FieldPanel('donate_page'),
-        FieldPanel('sign_up_page'),
+        FieldPanel("donate_page"),
+        FieldPanel("sign_up_page"),
     ]
+
 
 @register_setting
 class SiteSpecificImportantPages(BaseSiteSetting):
     donate_page = models.ForeignKey(
-        'wagtailcore.Page', null=True, on_delete=models.SET_NULL, related_name='+'
+        "wagtailcore.Page", null=True, on_delete=models.SET_NULL, related_name="+"
     )
     sign_up_page = models.ForeignKey(
-        'wagtailcore.Page', null=True, on_delete=models.SET_NULL, related_name='+'
+        "wagtailcore.Page", null=True, on_delete=models.SET_NULL, related_name="+"
     )
 
     panels = [
-        FieldPanel('donate_page'),
-        FieldPanel('sign_up_page'),
+        FieldPanel("donate_page"),
+        FieldPanel("sign_up_page"),
     ]
 ```
 
@@ -89,19 +92,20 @@ You can also customize the edit handlers [like you would do for `Page` model](cu
 ```python
 from wagtail.admin.panels import TabbedInterface, ObjectList
 
+
 @register_setting
 class MySettings(BaseGenericSetting):
     # ...
     first_tab_panels = [
-        FieldPanel('field_1'),
+        FieldPanel("field_1"),
     ]
     second_tab_panels = [
-        FieldPanel('field_2'),
+        FieldPanel("field_2"),
     ]
 
     edit_handler = TabbedInterface([
-        ObjectList(first_tab_panels, heading='First tab'),
-        ObjectList(second_tab_panels, heading='Second tab'),
+        ObjectList(first_tab_panels, heading="First tab"),
+        ObjectList(second_tab_panels, heading="Second tab"),
     ])
 ```
 
@@ -118,15 +122,18 @@ You can add an icon to the menu by passing an `icon` argument to the
 `register_setting` decorator:
 
 ```python
-@register_setting(icon='placeholder')
+@register_setting(icon="placeholder")
 class GenericSocialMediaSettings(BaseGenericSetting):
     ...
+
     class Meta:
         verbose_name = "Social media settings for all sites"
 
-@register_setting(icon='placeholder')
+
+@register_setting(icon="placeholder")
 class SiteSpecificSocialMediaSettings(BaseSiteSetting):
     ...
+
     class Meta:
         verbose_name = "Site-specific social media settings"
 ```
@@ -173,7 +180,9 @@ retrieve settings for, you can use
 
 ```python
 def view(request):
-    social_media_settings = SiteSpecificSocialMediaSettings.for_site(site=user.origin_site)
+    social_media_settings = SiteSpecificSocialMediaSettings.for_site(
+        site=user.origin_site
+    )
     ...
 ```
 
@@ -316,20 +325,19 @@ following shows how `select_related` can be set to improve efficiency:
 ```python
 @register_setting
 class GenericImportantPages(BaseGenericSetting):
-
     # Fetch these pages when looking up GenericImportantPages for or a site
     select_related = ["donate_page", "sign_up_page"]
 
     donate_page = models.ForeignKey(
-        'wagtailcore.Page', null=True, on_delete=models.SET_NULL, related_name='+'
+        "wagtailcore.Page", null=True, on_delete=models.SET_NULL, related_name="+"
     )
     sign_up_page = models.ForeignKey(
-        'wagtailcore.Page', null=True, on_delete=models.SET_NULL, related_name='+'
+        "wagtailcore.Page", null=True, on_delete=models.SET_NULL, related_name="+"
     )
 
     panels = [
-        FieldPanel('donate_page'),
-        FieldPanel('sign_up_page'),
+        FieldPanel("donate_page"),
+        FieldPanel("sign_up_page"),
     ]
 ```
 
@@ -429,7 +437,8 @@ class SiteSpecificSocialMediaSettings(PreviewableMixin, BaseSiteSetting):
         # Add a Page instance to the context for the preview
         context = super().get_preview_context(request, mode_name)
         context["page"] = (
-            self._models_for_preview[mode_name]
+            self
+            ._models_for_preview[mode_name]
             .objects.descendant_of(self.site.root_page, inclusive=True)
             .first()
         )

--- a/docs/reference/contrib/table_block.md
+++ b/docs/reference/contrib/table_block.md
@@ -58,30 +58,30 @@ When defining a TableBlock, Wagtail provides the ability to pass an optional `ta
 
 ```python
 default_table_options = {
-    'minSpareRows': 0,
-    'startRows': 3,
-    'startCols': 3,
-    'colHeaders': False,
-    'rowHeaders': False,
-    'contextMenu': [
-        'row_above',
-        'row_below',
-        '---------',
-        'col_left',
-        'col_right',
-        '---------',
-        'remove_row',
-        'remove_col',
-        '---------',
-        'undo',
-        'redo'
+    "minSpareRows": 0,
+    "startRows": 3,
+    "startCols": 3,
+    "colHeaders": False,
+    "rowHeaders": False,
+    "contextMenu": [
+        "row_above",
+        "row_below",
+        "---------",
+        "col_left",
+        "col_right",
+        "---------",
+        "remove_row",
+        "remove_col",
+        "---------",
+        "undo",
+        "redo",
     ],
-    'editor': 'text',
-    'stretchH': 'all',
-    'height': 108,
-    'language': language,
-    'renderer': 'text',
-    'autoColumnSize': False,
+    "editor": "text",
+    "stretchH": "all",
+    "height": 108,
+    "language": language,
+    "renderer": "text",
+    "autoColumnSize": False,
 }
 ```
 
@@ -113,19 +113,20 @@ To change the default table options just pass a new table_options dictionary whe
 
 ```python
 new_table_options = {
-    'minSpareRows': 0,
-    'startRows': 6,
-    'startCols': 4,
-    'colHeaders': False,
-    'rowHeaders': False,
-    'contextMenu': True,
-    'editor': 'text',
-    'stretchH': 'all',
-    'height': 216,
-    'language': 'en',
-    'renderer': 'text',
-    'autoColumnSize': False,
+    "minSpareRows": 0,
+    "startRows": 6,
+    "startCols": 4,
+    "colHeaders": False,
+    "rowHeaders": False,
+    "contextMenu": True,
+    "editor": "text",
+    "stretchH": "all",
+    "height": 216,
+    "language": "en",
+    "renderer": "text",
+    "autoColumnSize": False,
 }
+
 
 class DemoStreamBlock(StreamBlock):
     ...
@@ -142,25 +143,26 @@ HTML classes set by handsontable will be kept on the rendered block. You'll then
 
 ```python
 new_table_options = {
-    'contextMenu': [
-        'row_above',
-        'row_below',
-        '---------',
-        'col_left',
-        'col_right',
-        '---------',
-        'remove_row',
-        'remove_col',
-        '---------',
-        'undo',
-        'redo',
-        '---------',
-        'copy',
-        'cut',
-        '---------',
-        'alignment',
+    "contextMenu": [
+        "row_above",
+        "row_below",
+        "---------",
+        "col_left",
+        "col_right",
+        "---------",
+        "remove_row",
+        "remove_col",
+        "---------",
+        "undo",
+        "redo",
+        "---------",
+        "copy",
+        "cut",
+        "---------",
+        "alignment",
     ],
 }
+
 
 class DemoStreamBlock(StreamBlock):
     ...

--- a/docs/reference/contrib/typed_table_block.md
+++ b/docs/reference/contrib/typed_table_block.md
@@ -22,14 +22,15 @@ from wagtail.contrib.typed_table_block.blocks import TypedTableBlock
 from wagtail import blocks
 from wagtail.images.blocks import ImageChooserBlock
 
+
 class DemoStreamBlock(blocks.StreamBlock):
     title = blocks.CharBlock()
     paragraph = blocks.RichTextBlock()
     table = TypedTableBlock([
-        ('text', blocks.CharBlock()),
-        ('numeric', blocks.FloatBlock()),
-        ('rich_text', blocks.RichTextBlock()),
-        ('image', ImageChooserBlock())
+        ("text", blocks.CharBlock()),
+        ("numeric", blocks.FloatBlock()),
+        ("rich_text", blocks.RichTextBlock()),
+        ("image", ImageChooserBlock()),
     ])
 ```
 
@@ -37,18 +38,23 @@ To keep the UI as simple as possible for authors, it's generally recommended to 
 
 ```python
 table = TypedTableBlock([
-    ('text', blocks.CharBlock()),
-    ('numeric', blocks.FloatBlock()),
-    ('rich_text', blocks.RichTextBlock()),
-    ('image', ImageChooserBlock()),
-    ('country', ChoiceBlock(choices=[
-        ('be', 'Belgium'),
-        ('fr', 'France'),
-        ('de', 'Germany'),
-        ('nl', 'Netherlands'),
-        ('pl', 'Poland'),
-        ('uk', 'United Kingdom'),
-    ])),
+    ("text", blocks.CharBlock()),
+    ("numeric", blocks.FloatBlock()),
+    ("rich_text", blocks.RichTextBlock()),
+    ("image", ImageChooserBlock()),
+    (
+        "country",
+        ChoiceBlock(
+            choices=[
+                ("be", "Belgium"),
+                ("fr", "France"),
+                ("de", "Germany"),
+                ("nl", "Netherlands"),
+                ("pl", "Poland"),
+                ("uk", "United Kingdom"),
+            ]
+        ),
+    ),
 ])
 ```
 
@@ -81,7 +87,10 @@ As with other blocks, validation logic on `TypedTableBlock` can be customized by
 ```python
 from django.core.exceptions import ValidationError
 from wagtail.blocks import IntegerBlock
-from wagtail.contrib.typed_table_block.blocks import TypedTableBlock, TypedTableBlockValidationError
+from wagtail.contrib.typed_table_block.blocks import (
+    TypedTableBlock,
+    TypedTableBlockValidationError,
+)
 
 
 class LuckyTableBlock(TypedTableBlock):
@@ -93,9 +102,11 @@ class LuckyTableBlock(TypedTableBlock):
         print(result.row_data)
         for row_num, row in enumerate(result.row_data):
             row_errors = {}
-            for col_num, cell in enumerate(row['values']):
+            for col_num, cell in enumerate(row["values"]):
                 if cell == 13:
-                    row_errors[col_num] = ValidationError("Table cannot contain the number 13")
+                    row_errors[col_num] = ValidationError(
+                        "Table cannot contain the number 13"
+                    )
             if row_errors:
                 errors[row_num] = row_errors
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -22,7 +22,7 @@ def my_hook_function(arg1, arg2...):
 Alternatively, `hooks.register` can be called as an ordinary function, passing in the name of the hook and a handler function defined elsewhere:
 
 ```python
-hooks.register('name_of_hook', my_hook_function)
+hooks.register("name_of_hook", my_hook_function)
 ```
 
 If you need your hooks to run in a particular order, you can pass the `order` parameter. If order is not specified then the hooks proceed in the order given by `INSTALLED_APPS`. Wagtail uses hooks internally, too, so you need to be aware of order when overriding built-in Wagtail functionality (such as removing default summary items):
@@ -55,9 +55,9 @@ manager. Here's an example of how to register a hook function for just a single 
 def my_hook_function():
     pass
 
-class MyHookTest(TestCase):
 
-    @hooks.register_temporarily('name_of_hook', my_hook_function)
+class MyHookTest(TestCase):
+    @hooks.register_temporarily("name_of_hook", my_hook_function)
     def test_my_hook_function(self):
         # Test with the hook registered here
         pass
@@ -117,13 +117,14 @@ Specify a custom user avatar to be displayed in the Wagtail admin. The callable 
 ```python
 from datetime import datetime
 
-@hooks.register('get_avatar_url')
+
+@hooks.register("get_avatar_url")
 def get_profile_avatar(user, size):
     today = datetime.now()
     is_christmas_day = today.month == 12 and today.day == 25
 
     if is_christmas_day:
-        return '/static/images/santa.png'
+        return "/static/images/santa.png"
 
     return None
 ```
@@ -144,6 +145,7 @@ from django.utils.html import format_html
 from wagtail.admin.ui.components import Component
 from wagtail import hooks
 
+
 class WelcomePanel(Component):
     order = 50
 
@@ -156,7 +158,8 @@ class WelcomePanel(Component):
             """
         )
 
-@hooks.register('construct_homepage_panels')
+
+@hooks.register("construct_homepage_panels")
 def add_another_welcome_panel(request, panels):
     panels.append(WelcomePanel())
 ```
@@ -190,10 +193,11 @@ Called just before the Wagtail admin menu is output, to allow the list of menu i
 ```python
 from wagtail import hooks
 
-@hooks.register('construct_main_menu')
+
+@hooks.register("construct_main_menu")
 def hide_explorer_menu_item_from_frank(request, menu_items):
-  if request.user.username == 'frank':
-    menu_items[:] = [item for item in menu_items if item.name != 'explorer']
+    if request.user.username == "frank":
+        menu_items[:] = [item for item in menu_items if item.name != "explorer"]
 ```
 
 (describe_collection_contents)=
@@ -216,9 +220,10 @@ This hook can be added to a subclass of `BaseSettingsPanel`. For example:
 from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail import hooks
 
-@hooks.register('register_account_settings_panel')
+
+@hooks.register("register_account_settings_panel")
 class CustomSettingsPanel(BaseSettingsPanel):
-    name = 'custom'
+    name = "custom"
     title = "My custom settings"
     order = 500
     form_class = CustomSettingsForm
@@ -230,13 +235,15 @@ Alternatively, it can also be added to a function. For example, this function is
 from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail import hooks
 
+
 class CustomSettingsPanel(BaseSettingsPanel):
-    name = 'custom'
+    name = "custom"
     title = "My custom settings"
     order = 500
     form_class = CustomSettingsForm
 
-@hooks.register('register_account_settings_panel')
+
+@hooks.register("register_account_settings_panel")
 def register_custom_settings_panel(request, user, profile):
     return CustomSettingsPanel(request, user, profile)
 ```
@@ -255,12 +262,13 @@ The callable for this hook should return a dict with the keys
 from django.urls import reverse
 from wagtail import hooks
 
-@hooks.register('register_account_menu_item')
+
+@hooks.register("register_account_menu_item")
 def register_account_delete_account(request):
     return {
-        'url': reverse('delete-account'),
-        'label': 'Delete account',
-        'help_text': 'This permanently deletes your account.'
+        "url": reverse("delete-account"),
+        "label": "Delete account",
+        "help_text": "This permanently deletes your account.",
     }
 ```
 
@@ -285,9 +293,10 @@ from django.urls import reverse
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 
-@hooks.register('register_admin_menu_item')
+
+@hooks.register("register_admin_menu_item")
 def register_frank_menu_item():
-  return MenuItem('Frank', reverse('frank'), icon_name='folder-inverse', order=10000)
+    return MenuItem("Frank", reverse("frank"), icon_name="folder-inverse", order=10000)
 ```
 
 (register_admin_urls)=
@@ -302,16 +311,18 @@ from django.urls import path
 
 from wagtail import hooks
 
-def admin_view(request):
-  return HttpResponse(
-    "I have approximate knowledge of many things!",
-    content_type="text/plain")
 
-@hooks.register('register_admin_urls')
+def admin_view(request):
+    return HttpResponse(
+        "I have approximate knowledge of many things!", content_type="text/plain"
+    )
+
+
+@hooks.register("register_admin_urls")
 def urlconf_time():
-  return [
-    path('how_did_you_almost_know_my_name/', admin_view, name='frank'),
-  ]
+    return [
+        path("how_did_you_almost_know_my_name/", admin_view, name="frank"),
+    ]
 ```
 
 (register_admin_viewset)=
@@ -323,6 +334,7 @@ Register a {class}`~wagtail.admin.viewsets.base.ViewSet` or {class}`~wagtail.adm
 ```python
 from .views import CalendarViewSet
 
+
 @hooks.register("register_admin_viewset")
 def register_viewset():
     return CalendarViewSet()
@@ -332,6 +344,7 @@ Alternatively, it can also return a list of `ViewSet` or `ViewSetGroup` instance
 
 ```python
 from .views import AgendaViewSetGroup, VenueViewSet
+
 
 @hooks.register("register_admin_viewset")
 def register_viewsets():
@@ -405,9 +418,12 @@ from django.urls import reverse
 from wagtail import hooks
 from wagtail.admin.search import SearchArea
 
-@hooks.register('register_admin_search_area')
+
+@hooks.register("register_admin_search_area")
 def register_frank_search_area():
-    return SearchArea('Frank', reverse('frank'), icon_name='folder-inverse', order=10000)
+    return SearchArea(
+        "Frank", reverse("frank"), icon_name="folder-inverse", order=10000
+    )
 ```
 
 (register_permissions)=
@@ -417,18 +433,24 @@ def register_frank_search_area():
 Return a QuerySet of `Permission` objects to be shown in the Groups administration area.
 
 ```python
-  from django.contrib.auth.models import Permission
-  from wagtail import hooks
+from django.contrib.auth.models import Permission
+from wagtail import hooks
 
 
-  @hooks.register('register_permissions')
-  def register_permissions():
-      app = 'blog'
-      model = 'extramodelset'
+@hooks.register("register_permissions")
+def register_permissions():
+    app = "blog"
+    model = "extramodelset"
 
-      return Permission.objects.filter(content_type__app_label=app, codename__in=[
-          f"view_{model}", f"add_{model}", f"change_{model}", f"delete_{model}"
-      ])
+    return Permission.objects.filter(
+        content_type__app_label=app,
+        codename__in=[
+            f"view_{model}",
+            f"add_{model}",
+            f"change_{model}",
+            f"delete_{model}",
+        ],
+    )
 ```
 
 (register_user_listing_buttons)=
@@ -446,6 +468,7 @@ This example will add a button inside the "More" dropdown and a top-level button
 
 ```python
 from wagtail.admin import widgets as wagtailadmin_widgets
+
 
 @hooks.register("register_user_listing_buttons")
 def user_listing_external_profile(user, request_user):
@@ -485,7 +508,7 @@ For example, to prevent non-superusers from accessing form submissions:
 from wagtail import hooks
 
 
-@hooks.register('filter_form_submissions_for_user')
+@hooks.register("filter_form_submissions_for_user")
 def construct_forms_for_user(user, queryset):
     if not user.is_superuser:
         queryset = queryset.none()
@@ -516,9 +539,12 @@ from django.templatetags.static import static
 
 from wagtail import hooks
 
-@hooks.register('insert_global_admin_css')
+
+@hooks.register("insert_global_admin_css")
 def global_admin_css():
-    return format_html('<link rel="stylesheet" href="{}">', static('my/wagtail/theme.css'))
+    return format_html(
+        '<link rel="stylesheet" href="{}">', static("my/wagtail/theme.css")
+    )
 ```
 
 (insert_editor_js)=
@@ -536,16 +562,17 @@ from django.utils.html import format_html, format_html_join
 
 from wagtail import hooks
 
+
 @hooks.register("insert_editor_js")
 def editor_js():
     js_files = [
-        'js/fireworks.js', # See https://fireworks.js.org for CDN import URLs
-        'js/init-fireworks.js',
+        "js/fireworks.js",  # See https://fireworks.js.org for CDN import URLs
+        "js/init-fireworks.js",
     ]
     return format_html_join(
-        '\n',
+        "\n",
         '<script src="{}"></script>',
-        ((static(filename),) for filename in js_files)
+        ((static(filename),) for filename in js_files),
     )
 ```
 
@@ -583,11 +610,12 @@ from django.utils.html import format_html
 
 from wagtail import hooks
 
-@hooks.register('insert_global_admin_js')
+
+@hooks.register("insert_global_admin_js")
 def global_admin_js():
     return format_html(
         '<script src="{}"></script>',
-        "https://cdnjs.cloudflare.com/ajax/libs/three.js/r74/three.js"
+        "https://cdnjs.cloudflare.com/ajax/libs/three.js/r74/three.js",
     )
 ```
 
@@ -602,12 +630,11 @@ This example will add a simple button to the secondary dropdown menu:
 ```python
 from wagtail.admin import widgets as wagtailadmin_widgets
 
-@hooks.register('register_page_header_buttons')
+
+@hooks.register("register_page_header_buttons")
 def page_header_buttons(page, user, view_name, next_url=None):
     yield wagtailadmin_widgets.Button(
-        'A dropdown button',
-        '/goes/to/a/url/',
-        priority=60
+        "A dropdown button", "/goes/to/a/url/", priority=60
     )
 ```
 
@@ -635,7 +662,8 @@ from django.http import HttpResponse
 
 from wagtail import hooks
 
-@hooks.register('after_create_page')
+
+@hooks.register("after_create_page")
 def do_after_page_create(request, page):
     return HttpResponse("Congrats on making content!", content_type="text/plain")
 ```
@@ -643,14 +671,14 @@ def do_after_page_create(request, page):
 If you set attributes on a `Page` object, you should also call `save_revision()`, since the edit and index view pick up their data from the revisions table rather than the actual saved page record.
 
 ```python
-  @hooks.register('after_create_page')
-  def set_attribute_after_page_create(request, page):
-      page.title = 'Persistent Title'
-      new_revision = page.save_revision()
-      if page.live:
-          # page has been created and published at the same time,
-          # so ensure that the updated title is on the published version too
-          new_revision.publish()
+@hooks.register("after_create_page")
+def set_attribute_after_page_create(request, page):
+    page.title = "Persistent Title"
+    new_revision = page.save_revision()
+    if page.live:
+        # page has been created and published at the same time,
+        # so ensure that the updated title is on the published version too
+        new_revision.publish()
 ```
 
 (before_create_page)=
@@ -671,7 +699,8 @@ from wagtail import hooks
 from .models import AwesomePage
 from .admin_views import edit_awesome_page
 
-@hooks.register('before_create_page')
+
+@hooks.register("before_create_page")
 def before_create_page(request, parent_page, page_class):
     # Use a custom create view for the AwesomePage model
     if page_class == AwesomePage:
@@ -704,13 +733,13 @@ from wagtail import hooks
 from .models import AwesomePage
 
 
-@hooks.register('before_delete_page')
+@hooks.register("before_delete_page")
 def before_delete_page(request, page):
     """Block awesome page deletion and show a message."""
 
-    if request.method == 'POST' and page.specific_class in [AwesomePage]:
+    if request.method == "POST" and page.specific_class in [AwesomePage]:
         messages.warning(request, "Awesome pages cannot be deleted, only unpublished")
-        return redirect('wagtailadmin_pages:delete', page.pk)
+        return redirect("wagtailadmin_pages:delete", page.pk)
 ```
 
 This hook runs only when deleting a page through the deletion view at `/admin/pages/<id>/delete/`. It will not run when deleting pages through other routes, such as bulk actions (see [](before_bulk_action) for implementing such hooks for bulk actions). If you wish to perform some action on any page deletion, regardless of how the deletion was performed, it may be more appropriate to use Django's [pre_delete](https://docs.djangoproject.com/en/stable/ref/signals/#pre-delete) signal.
@@ -859,15 +888,16 @@ The `get_url`, `is_shown`, `get_context_data`, and `render_html` methods all acc
 from wagtail import hooks
 from wagtail.admin.action_menu import ActionMenuItem
 
+
 class GuacamoleMenuItem(ActionMenuItem):
-    name = 'action-guacamole'
+    name = "action-guacamole"
     label = "Guacamole"
 
     def get_url(self, context):
         return "https://www.youtube.com/watch?v=dNJdJIwCF_Y"
 
 
-@hooks.register('register_page_action_menu_item')
+@hooks.register("register_page_action_menu_item")
 def register_guacamole_menu_item():
     return GuacamoleMenuItem(order=10)
 ```
@@ -879,18 +909,18 @@ def register_guacamole_menu_item():
 Modify the final list of action menu items on the page creation and edit views. The callable passed to this hook receives a list of `ActionMenuItem` objects, a request object and a context dictionary as per `register_page_action_menu_item`, and should modify the list of menu items in-place.
 
 ```python
-@hooks.register('construct_page_action_menu')
+@hooks.register("construct_page_action_menu")
 def remove_submit_to_moderator_option(menu_items, request, context):
-    menu_items[:] = [item for item in menu_items if item.name != 'action-submit']
+    menu_items[:] = [item for item in menu_items if item.name != "action-submit"]
 ```
 
 The `construct_page_action_menu` hook is called after the menu items have been sorted by their order attributes, so setting a menu item's order will have no effect at this point. Instead, items can be reordered by changing their position in the list, with the first item being selected as the default action. For example, to change the default action to Publish:
 
 ```python
-@hooks.register('construct_page_action_menu')
+@hooks.register("construct_page_action_menu")
 def make_publish_default_action(menu_items, request, context):
-    for (index, item) in enumerate(menu_items):
-        if item.name == 'action-publish':
+    for index, item in enumerate(menu_items):
+        if item.name == "action-publish":
             # move to top of list
             menu_items.pop(index)
             menu_items.insert(0, item)
@@ -907,12 +937,16 @@ Add or remove items from the Wagtail [user bar](wagtailuserbar_tag). Actions for
 from wagtail import hooks
 from wagtail.admin.ui.components import Component
 
+
 class UserbarPuppyLinkItem(Component):
     def render_html(self, parent_context):
-        return '<li><a href="https://unsplash.com/s/photos/puppies" ' \
+        return (
+            '<li><a href="https://unsplash.com/s/photos/puppies" '
             + 'target="_parent" role="menuitem" class="action">Puppies!</a></li>'
+        )
 
-@hooks.register('construct_wagtail_userbar')
+
+@hooks.register("construct_wagtail_userbar")
 def add_puppy_link_item(request, items, page):
     items.append(UserbarPuppyLinkItem())
 ```
@@ -934,7 +968,8 @@ from django.http import HttpResponse
 
 from wagtail import hooks
 
-@hooks.register('after_create_user')
+
+@hooks.register("after_create_user")
 def do_after_create_user(request, user):
     return HttpResponse("Congrats on creating a new user!", content_type="text/plain")
 ```
@@ -959,7 +994,8 @@ from wagtail import hooks
 from .models import AwesomePage
 from .admin_views import edit_awesome_page
 
-@hooks.register('before_create_user')
+
+@hooks.register("before_create_user")
 def do_before_create_user(request):
     return HttpResponse("A user creation form", content_type="text/plain")
 ```
@@ -1003,7 +1039,8 @@ Called when rendering the page chooser view, to allow the page listing QuerySet 
 ```python
 from wagtail import hooks
 
-@hooks.register('construct_page_chooser_queryset')
+
+@hooks.register("construct_page_chooser_queryset")
 def show_my_pages_only(pages, request):
     # Only show own pages
     pages = pages.filter(owner=request.user)
@@ -1020,7 +1057,8 @@ Called when rendering the document chooser view, to allow the document listing Q
 ```python
 from wagtail import hooks
 
-@hooks.register('construct_document_chooser_queryset')
+
+@hooks.register("construct_document_chooser_queryset")
 def show_my_uploaded_documents_only(documents, request):
     # Only show uploaded documents
     documents = documents.filter(uploaded_by_user=request.user)
@@ -1037,7 +1075,8 @@ Called when rendering the image chooser view, to allow the image listing QuerySe
 ```python
 from wagtail import hooks
 
-@hooks.register('construct_image_chooser_queryset')
+
+@hooks.register("construct_image_chooser_queryset")
 def show_my_uploaded_images_only(images, request):
     # Only show uploaded images
     images = images.filter(uploaded_by_user=request.user)
@@ -1056,10 +1095,11 @@ Called when rendering the page explorer view, to allow the page listing QuerySet
 ```python
 from wagtail import hooks
 
-@hooks.register('construct_explorer_page_queryset')
+
+@hooks.register("construct_explorer_page_queryset")
 def show_my_profile_only(parent_page, pages, request):
     # If we're in the 'user-profiles' section, only show the user's own profile
-    if parent_page.slug == 'user-profiles':
+    if parent_page.slug == "user-profiles":
         pages = pages.filter(owner=request.user)
 
     return pages
@@ -1076,12 +1116,11 @@ This example will add a simple button to the listing:
 ```python
 from wagtail.admin import widgets as wagtailadmin_widgets
 
-@hooks.register('register_page_listing_buttons')
+
+@hooks.register("register_page_listing_buttons")
 def page_listing_buttons(page, user, next_url=None):
     yield wagtailadmin_widgets.ListingButton(
-        'A page listing button',
-        '/goes/to/a/url/',
-        priority=10
+        "A page listing button", "/goes/to/a/url/", priority=10
     )
 ```
 
@@ -1108,12 +1147,11 @@ This example will add a simple button to the dropdown menu:
 ```python
 from wagtail.admin import widgets as wagtailadmin_widgets
 
-@hooks.register('register_page_listing_more_buttons')
+
+@hooks.register("register_page_listing_more_buttons")
 def page_listing_more_buttons(page, user, next_url=None):
     yield wagtailadmin_widgets.Button(
-        'A dropdown button',
-        '/goes/to/a/url/',
-        priority=60
+        "A dropdown button", "/goes/to/a/url/", priority=60
     )
 ```
 
@@ -1137,26 +1175,36 @@ This example shows how Wagtail's default admin dropdown is implemented. You can 
 ```python
 from wagtail.admin import widgets as wagtailadmin_widgets
 
-@hooks.register('register_page_listing_buttons')
+
+@hooks.register("register_page_listing_buttons")
 def page_custom_listing_buttons(page, user, next_url=None):
     yield wagtailadmin_widgets.ButtonWithDropdownFromHook(
-        'More actions',
-        hook_name='my_button_dropdown_hook',
+        "More actions",
+        hook_name="my_button_dropdown_hook",
         page=page,
         user=user,
         next_url=next_url,
-        priority=50
+        priority=50,
     )
 
-@hooks.register('my_button_dropdown_hook')
+
+@hooks.register("my_button_dropdown_hook")
 def page_custom_listing_more_buttons(page, user, next_url=None):
     page_perms = page.permissions_for_user(user)
     if page_perms.can_move():
-        yield wagtailadmin_widgets.Button('Move', reverse('wagtailadmin_pages:move', args=[page.id]), priority=10)
+        yield wagtailadmin_widgets.Button(
+            "Move", reverse("wagtailadmin_pages:move", args=[page.id]), priority=10
+        )
     if page_perms.can_delete():
-        yield wagtailadmin_widgets.Button('Delete', reverse('wagtailadmin_pages:delete', args=[page.id]), priority=30)
+        yield wagtailadmin_widgets.Button(
+            "Delete", reverse("wagtailadmin_pages:delete", args=[page.id]), priority=30
+        )
     if page_perms.can_unpublish():
-        yield wagtailadmin_widgets.Button('Unpublish', reverse('wagtailadmin_pages:unpublish', args=[page.id]), priority=40)
+        yield wagtailadmin_widgets.Button(
+            "Unpublish",
+            reverse("wagtailadmin_pages:unpublish", args=[page.id]),
+            priority=40,
+        )
 ```
 
 The template for the dropdown button can be customized by overriding `wagtailadmin/pages/listing/_button_with_dropdown.html`. Make sure to leave the dropdown UI component itself as-is.
@@ -1168,10 +1216,10 @@ The template for the dropdown button can be customized by overriding `wagtailadm
 Modify the final list of page listing buttons in the page explorer. The callable passed to this hook receives a list of `ListingButton` objects, a page, a user object, and a context dictionary, and should modify the list of listing items in-place.
 
 ```python
-@hooks.register('construct_page_listing_buttons')
+@hooks.register("construct_page_listing_buttons")
 def remove_page_listing_button_item(buttons, page, user, context=None):
     if page.is_root:
-        buttons.pop() # removes the last 'more' dropdown button on the root page listing buttons
+        buttons.pop()  # removes the last 'more' dropdown button on the root page listing buttons
 ```
 
 ## Page serving
@@ -1187,9 +1235,10 @@ from django.http import HttpResponse
 
 from wagtail import hooks
 
-@hooks.register('before_serve_page')
+
+@hooks.register("before_serve_page")
 def block_googlebot(page, request, serve_args, serve_kwargs):
-    if request.META.get('HTTP_USER_AGENT') == 'GoogleBot':
+    if request.META.get("HTTP_USER_AGENT") == "GoogleBot":
         return HttpResponse("<h1>bad googlebot no cookie</h1>")
 ```
 
@@ -1206,12 +1255,14 @@ For example, to add custom cache headers to the response:
 ```python
 from wagtail import hooks
 
-@hooks.register('on_serve_page')
+
+@hooks.register("on_serve_page")
 def add_custom_headers(next_serve_page):
     def wrapper(page, request, args, kwargs):
         response = next_serve_page(page, request, args, kwargs)
-        response['Custom-Header'] = 'value'
+        response["Custom-Header"] = "value"
         return response
+
     return wrapper
 ```
 
@@ -1252,9 +1303,13 @@ from django.http import HttpResponse
 
 from wagtail import hooks
 
-@hooks.register('after_edit_snippet')
+
+@hooks.register("after_edit_snippet")
 def after_snippet_update(request, instance):
-    return HttpResponse(f"Congrats on editing a snippet with id {instance.pk}", content_type="text/plain")
+    return HttpResponse(
+        f"Congrats on editing a snippet with id {instance.pk}",
+        content_type="text/plain",
+    )
 ```
 
 (before_edit_snippet)=
@@ -1268,10 +1323,13 @@ from django.http import HttpResponse
 
 from wagtail import hooks
 
-@hooks.register('before_edit_snippet')
+
+@hooks.register("before_edit_snippet")
 def block_snippet_edit(request, instance):
     if isinstance(instance, RestrictedSnippet) and instance.prevent_edit:
-        return HttpResponse("Sorry, you can't edit this snippet", content_type="text/plain")
+        return HttpResponse(
+            "Sorry, you can't edit this snippet", content_type="text/plain"
+        )
 ```
 
 (after_create_snippet)=
@@ -1297,11 +1355,14 @@ from django.http import HttpResponse
 
 from wagtail import hooks
 
-@hooks.register('after_delete_snippet')
+
+@hooks.register("after_delete_snippet")
 def after_snippet_delete(request, instances):
     # "instances" is a list
     total = len(instances)
-    return HttpResponse(f"{total} snippets have been deleted", content_type="text/plain")
+    return HttpResponse(
+        f"{total} snippets have been deleted", content_type="text/plain"
+    )
 ```
 
 (before_delete_snippet)=
@@ -1315,17 +1376,20 @@ from django.http import HttpResponse
 
 from wagtail import hooks
 
-@hooks.register('before_delete_snippet')
+
+@hooks.register("before_delete_snippet")
 def before_snippet_delete(request, instances):
     # "instances" is a list
     total = len(instances)
 
-    if request.method == 'POST':
+    if request.method == "POST":
         for instance in instances:
             # Override the deletion behavior
             instance.delete()
 
-        return HttpResponse(f"{total} snippets have been deleted", content_type="text/plain")
+        return HttpResponse(
+            f"{total} snippets have been deleted", content_type="text/plain"
+        )
 ```
 
 (register_snippet_action_menu_item)=
@@ -1356,15 +1420,16 @@ The `get_url`, `is_shown`, `get_context_data`, and `render_html` methods all acc
 from wagtail import hooks
 from wagtail.snippets.action_menu import ActionMenuItem
 
+
 class GuacamoleMenuItem(ActionMenuItem):
-    name = 'action-guacamole'
+    name = "action-guacamole"
     label = "Guacamole"
 
     def get_url(self, context):
         return "https://www.youtube.com/watch?v=dNJdJIwCF_Y"
 
 
-@hooks.register('register_snippet_action_menu_item')
+@hooks.register("register_snippet_action_menu_item")
 def register_guacamole_menu_item(model):
     return GuacamoleMenuItem(order=10)
 ```
@@ -1377,18 +1442,18 @@ Modify the final list of action menu items on the snippet creation and edit view
 The callable passed to this hook receives a list of `ActionMenuItem` objects, a request object, and a context dictionary as per `register_snippet_action_menu_item`, and should modify the list of menu items in-place.
 
 ```python
-@hooks.register('construct_snippet_action_menu')
+@hooks.register("construct_snippet_action_menu")
 def remove_delete_option(menu_items, request, context):
-    menu_items[:] = [item for item in menu_items if item.name != 'delete']
+    menu_items[:] = [item for item in menu_items if item.name != "delete"]
 ```
 
 The `construct_snippet_action_menu` hook is called after the menu items have been sorted by their order attributes, so setting a menu item's order will have no effect at this point. Instead, items can be reordered by changing their position in the list, with the first item being selected as the default action. For example, to change the default action to Delete:
 
 ```python
-@hooks.register('construct_snippet_action_menu')
+@hooks.register("construct_snippet_action_menu")
 def make_delete_default_action(menu_items, request, context):
-    for (index, item) in enumerate(menu_items):
-        if item.name == 'delete':
+    for index, item in enumerate(menu_items):
+        if item.name == "delete":
             # move to top of list
             menu_items.pop(index)
             menu_items.insert(0, item)
@@ -1406,17 +1471,16 @@ This example will add a button inside the "More" dropdown and a top-level button
 ```python
 from wagtail.admin import widgets as wagtailadmin_widgets
 
-@hooks.register('register_snippet_listing_buttons')
+
+@hooks.register("register_snippet_listing_buttons")
 def snippet_listing_buttons(snippet, user, next_url=None):
     yield wagtailadmin_widgets.Button(
         'A snippet listing button inside the "More" dropdown',
-        '/goes/to/a/url/',
-        priority=90
+        "/goes/to/a/url/",
+        priority=90,
     )
     yield wagtailadmin_widgets.ListingButton(
-        'A top-level snippet listing button',
-        '/goes/to/a/url/',
-        priority=10
+        "A top-level snippet listing button", "/goes/to/a/url/", priority=10
     )
 ```
 
@@ -1439,7 +1503,7 @@ The `wagtail.snippets.widgets.SnippetListingButton` class is deprecated in favor
 Modify the final list of snippet listing buttons in the "More" dropdown menu. The callable passed to this hook receives a list of `Button` objects, the snippet object and a user, and should modify the list of menu items in-place.
 
 ```python
-@hooks.register('construct_snippet_listing_buttons')
+@hooks.register("construct_snippet_listing_buttons")
 def remove_snippet_listing_button_item(buttons, snippet, user):
     buttons.pop()  # Removes the 'delete' button
 ```
@@ -1459,9 +1523,13 @@ from django.http import HttpResponse
 
 from wagtail import hooks
 
-@hooks.register('after_edit_setting')
+
+@hooks.register("after_edit_setting")
 def after_setting_update(request, instance):
-    return HttpResponse(f"Congrats on editing a setting with id {instance.pk}", content_type="text/plain")
+    return HttpResponse(
+        f"Congrats on editing a setting with id {instance.pk}",
+        content_type="text/plain",
+    )
 ```
 
 (before_edit_setting)=
@@ -1475,10 +1543,13 @@ from django.http import HttpResponse
 
 from wagtail import hooks
 
-@hooks.register('before_edit_setting')
+
+@hooks.register("before_edit_setting")
 def block_setting_edit(request, instance):
     if isinstance(instance, RestrictedSetting) and instance.prevent_edit:
-        return HttpResponse("Sorry, you can't edit this setting", content_type="text/plain")
+        return HttpResponse(
+            "Sorry, you can't edit this setting", content_type="text/plain"
+        )
 ```
 
 ## Bulk actions
@@ -1506,12 +1577,14 @@ class CustomBulkAction(BulkAction):
     template_name = "/path/to/template"
     models = [...]  # list of models the action should execute upon
 
-
     @classmethod
     def execute_action(cls, objects, **kwargs):
         for object in objects:
             do_something(object)
-        return num_parent_objects, num_child_objects  # return the count of updated objects
+        return (
+            num_parent_objects,
+            num_child_objects,
+        )  # return the count of updated objects
 ```
 
 (before_bulk_action)=
@@ -1525,10 +1598,13 @@ This hook can be used to return an HTTP response. For example:
 ```python
 from wagtail import hooks
 
+
 @hooks.register("before_bulk_action")
 def hook_func(request, action_type, objects, action_class_instance):
-  if action_type == 'delete':
-    return HttpResponse(f"{len(objects)} objects would be deleted", content_type="text/plain")
+    if action_type == "delete":
+        return HttpResponse(
+            f"{len(objects)} objects would be deleted", content_type="text/plain"
+        )
 ```
 
 (after_bulk_action)=
@@ -1542,10 +1618,13 @@ This hook can be used to return an HTTP response. For example:
 ```python
 from wagtail import hooks
 
+
 @hooks.register("after_bulk_action")
 def hook_func(request, action_type, objects, action_class_instance):
-  if action_type == 'delete':
-    return HttpResponse(f"{len(objects)} objects have been deleted", content_type="text/plain")
+    if action_type == "delete":
+        return HttpResponse(
+            f"{len(objects)} objects have been deleted", content_type="text/plain"
+        )
 ```
 
 ## Audit log
@@ -1563,9 +1642,10 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 
-@hooks.register('register_log_actions')
+
+@hooks.register("register_log_actions")
 def additional_log_actions(actions):
-    actions.register_action('wagtail_package.echo', _('Echo'), _('Sent an echo'))
+    actions.register_action("wagtail_package.echo", _("Echo"), _("Sent an echo"))
 ```
 
 Alternatively, for a log message that varies according to the log entry's data, create a subclass of `wagtail.log_actions.LogFormatter` that overrides the `format_message` method, and use `register_action` as a decorator on that class:
@@ -1576,15 +1656,16 @@ from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.log_actions import LogFormatter
 
-@hooks.register('register_log_actions')
+
+@hooks.register("register_log_actions")
 def additional_log_actions(actions):
-    @actions.register_action('wagtail_package.greet_audience')
+    @actions.register_action("wagtail_package.greet_audience")
     class GreetingActionFormatter(LogFormatter):
-        label = _('Greet audience')
+        label = _("Greet audience")
 
         def format_message(self, log_entry):
-            return _('Hello %(audience)s') % {
-                'audience': log_entry.data['audience'],
+            return _("Hello %(audience)s") % {
+                "audience": log_entry.data["audience"],
             }
 ```
 

--- a/docs/reference/jinja2.md
+++ b/docs/reference/jinja2.md
@@ -15,16 +15,16 @@ TEMPLATES = [
         # ... the rest of the existing Django template configuration ...
     },
     {
-        'BACKEND': 'django.template.backends.jinja2.Jinja2',
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'extensions': [
-                'wagtail.jinja2tags.core',
-                'wagtail.admin.jinja2tags.userbar',
-                'wagtail.images.jinja2tags.images',
+        "BACKEND": "django.template.backends.jinja2.Jinja2",
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "extensions": [
+                "wagtail.jinja2tags.core",
+                "wagtail.admin.jinja2tags.userbar",
+                "wagtail.images.jinja2tags.images",
             ],
         },
-    }
+    },
 ]
 ```
 

--- a/docs/reference/panels.md
+++ b/docs/reference/panels.md
@@ -174,12 +174,12 @@ class CustomInlinePanel(InlinePanel):
 
 
 class BlogPage(Page):
-        # .. fields
+    # .. fields
 
-        content_panels = Page.content_panels + [
-               CustomInlinePanel("blog_person_relationship"),
-              # ... other panels
-        ]
+    content_panels = Page.content_panels + [
+        CustomInlinePanel("blog_person_relationship"),
+        # ... other panels
+    ]
 ```
 
 Using JavaScript is as follows.
@@ -382,17 +382,17 @@ The `title` class can be used to make the input stand out with a bigger font siz
 The `collapsed` class will load the editor page with the panel collapsed under its heading.
 
 ```python
-    content_panels = [
-        MultiFieldPanel(
-            [
-                FieldPanel('cover'),
-                FieldPanel('book_file'),
-                FieldPanel('publisher'),
-            ],
-            heading="Collection of Book Fields",
-            classname="collapsed",
-        ),
-    ]
+content_panels = [
+    MultiFieldPanel(
+        [
+            FieldPanel("cover"),
+            FieldPanel("book_file"),
+            FieldPanel("publisher"),
+        ],
+        heading="Collection of Book Fields",
+        classname="collapsed",
+    ),
+]
 ```
 
 ### Help text
@@ -407,8 +407,9 @@ For example, to customize placeholders for a `Book` snippet model:
 
 ```python
 # models.py
-from django import forms            # the default Django widgets live here
-from wagtail.admin import widgets   # to use Wagtail's special datetime widget
+from django import forms  # the default Django widgets live here
+from wagtail.admin import widgets  # to use Wagtail's special datetime widget
+
 
 class Book(models.Model):
     title = models.CharField(max_length=256)
@@ -416,22 +417,17 @@ class Book(models.Model):
     price = models.DecimalField(max_digits=5, decimal_places=2)
 
     # You can create them separately
-    title_widget = forms.TextInput(
-        attrs = {
-            'placeholder': 'Enter Full Title'
-        }
-    )
+    title_widget = forms.TextInput(attrs={"placeholder": "Enter Full Title"})
     # using the correct widget for your field type and desired effect
-    date_widget = widgets.AdminDateInput(
-        attrs = {
-            'placeholder': 'dd-mm-yyyy'
-        }
-    )
+    date_widget = widgets.AdminDateInput(attrs={"placeholder": "dd-mm-yyyy"})
 
     panels = [
-        TitleFieldPanel('title', widget=title_widget), # then add them as a variable
-        FieldPanel('release_date', widget=date_widget),
-        FieldPanel('price', widget=forms.NumberInput(attrs={'placeholder': 'Retail price on release'})) # or directly inline
+        TitleFieldPanel("title", widget=title_widget),  # then add them as a variable
+        FieldPanel("release_date", widget=date_widget),
+        FieldPanel(
+            "price",
+            widget=forms.NumberInput(attrs={"placeholder": "Retail price on release"}),
+        ),  # or directly inline
     ]
 ```
 
@@ -453,19 +449,19 @@ See [](permissions_overview) for details about working with permissions in Wagta
 In this example, 'notes' will be visible to all editors, 'cost' and 'details' will only be visible to those with the `submit` permission, 'budget approval' will be visible to super users only. Note that super users will have access to all fields.
 
 ```python
-    content_panels = [
-        FieldPanel("notes"),
-        MultiFieldPanel(
-            [
-                FieldPanel("cost"),
-                FieldPanel("details"),
-            ],
-            heading="Budget details",
-            classname="collapsed",
-            permission="submit"
-        ),
-        FieldPanel("budget_approval", permission="superuser"),
-    ]
+content_panels = [
+    FieldPanel("notes"),
+    MultiFieldPanel(
+        [
+            FieldPanel("cost"),
+            FieldPanel("details"),
+        ],
+        heading="Budget details",
+        classname="collapsed",
+        permission="submit",
+    ),
+    FieldPanel("budget_approval", permission="superuser"),
+]
 ```
 
 (panels_attrs)=
@@ -477,18 +473,18 @@ Use the `attrs` parameter to add custom attributes to the HTML element of the pa
 For example, you can use the `attrs` parameter to integrate your Stimulus controller into the panel:
 
 ```python
-    content_panels = [
-        MultiFieldPanel(
-            [
-                FieldPanel('cover'),
-                FieldPanel('book_file'),
-                FieldPanel('publisher', attrs={'data-my-controller-target': 'myTarget'}),
-            ],
-            heading="Collection of Book Fields",
-            classname="collapsed",
-            attrs={'data-controller': 'my-controller'},
-        ),
-    ]
+content_panels = [
+    MultiFieldPanel(
+        [
+            FieldPanel("cover"),
+            FieldPanel("book_file"),
+            FieldPanel("publisher", attrs={"data-my-controller-target": "myTarget"}),
+        ],
+        heading="Collection of Book Fields",
+        classname="collapsed",
+        attrs={"data-controller": "my-controller"},
+    ),
+]
 ```
 
 (panels_api)=

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -7,7 +7,7 @@ Wagtail makes use of the following settings, in addition to [Django's core setti
 ### `WAGTAIL_SITE_NAME`
 
 ```python
-WAGTAIL_SITE_NAME = 'Stark Industries Skunkworks'
+WAGTAIL_SITE_NAME = "Stark Industries Skunkworks"
 ```
 
 This is the human-readable name of your Wagtail install which welcomes users upon login to the Wagtail admin.
@@ -17,7 +17,7 @@ This is the human-readable name of your Wagtail install which welcomes users upo
 ### `WAGTAILADMIN_BASE_URL`
 
 ```python
-WAGTAILADMIN_BASE_URL = 'https://example.com'
+WAGTAILADMIN_BASE_URL = "https://example.com"
 ```
 
 This is the base URL used by the Wagtail admin site. It is used for generating absolute URLs to the admin, such as in notification emails and the user bar. This setting must not include the admin path (`/admin`) or a trailing slash.
@@ -51,10 +51,7 @@ If you use the ``False`` setting, keep in mind that serving your pages both with
 
 ```python
 WAGTAILSEARCH_BACKENDS = {
-    'default': {
-        'BACKEND': 'wagtail.search.backends.elasticsearch8',
-        'INDEX': 'myapp'
-    }
+    "default": {"BACKEND": "wagtail.search.backends.elasticsearch8", "INDEX": "myapp"}
 }
 ```
 
@@ -98,8 +95,8 @@ For example:
 
 ```python
 WAGTAIL_CONTENT_LANGUAGES = [
-    ('en', _("English")),
-    ('fr', _("French")),
+    ("en", _("English")),
+    ("fr", _("French")),
 ]
 ```
 
@@ -111,10 +108,10 @@ This setting follows the same structure as Django's `LANGUAGES` setting, so they
 
 ```python
 LANGUAGES = WAGTAIL_CONTENT_LANGUAGES = [
-    ('en-gb', _("English (United Kingdom)")),
-    ('en-us', _("English (United States)")),
-    ('es-es', _("Spanish (Spain)")),
-    ('es-mx', _("Spanish (Mexico)")),
+    ("en-gb", _("English (United Kingdom)")),
+    ("en-us", _("English (United States)")),
+    ("es-es", _("Spanish (Spain)")),
+    ("es-mx", _("Spanish (Mexico)")),
 ]
 ```
 
@@ -122,16 +119,16 @@ However having them separate allows you to configure many different regions on y
 
 ```python
 LANGUAGES = [
-    ('en', _("English (United Kingdom)")),
-    ('en-us', _("English (United States)")),
-    ('es', _("Spanish (Spain)")),
-    ('es-mx', _("Spanish (Mexico)")),
+    ("en", _("English (United Kingdom)")),
+    ("en-us", _("English (United States)")),
+    ("es", _("Spanish (Spain)")),
+    ("es-mx", _("Spanish (Mexico)")),
 ]
 
 
 WAGTAIL_CONTENT_LANGUAGES = [
-    ('en', _("English")),
-    ('es', _("Spanish")),
+    ("en", _("English")),
+    ("es", _("Spanish")),
 ]
 ```
 
@@ -176,15 +173,13 @@ This setting lets you change the number of items shown at 'Your most recent edit
 
 ```python
 WAGTAILADMIN_RICH_TEXT_EDITORS = {
-    'default': {
-        'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea',
-        'OPTIONS': {
-            'features': ['h2', 'bold', 'italic', 'link', 'document-link']
-        }
+    "default": {
+        "WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea",
+        "OPTIONS": {"features": ["h2", "bold", "italic", "link", "document-link"]},
     },
-    'secondary': {
-        'WIDGET': 'some.external.RichTextEditor',
-    }
+    "secondary": {
+        "WIDGET": "some.external.RichTextEditor",
+    },
 }
 ```
 
@@ -200,7 +195,7 @@ If a `'default'` editor is not specified, rich text fields that do not specify a
 ### `WAGTAILADMIN_EXTERNAL_LINK_CONVERSION`
 
 ```python
-WAGTAILADMIN_EXTERNAL_LINK_CONVERSION = 'exact'
+WAGTAILADMIN_EXTERNAL_LINK_CONVERSION = "exact"
 ```
 
 Customize Wagtail's behavior when an internal page url is entered in the external link chooser. Possible values for this setting are `'all'`, `'exact'`, `'confirm'`, or `''`. The default, `'all'`, means that Wagtail will automatically convert submitted urls that exactly match page urls to the corresponding internal links. If the url is an inexact match - for example, the submitted url has query parameters - then Wagtail will confirm the conversion with the user. `'exact'` means that any inexact matches will be left as external urls, and the confirmation step will be skipped. `'confirm'` means that every link conversion will be confirmed with the user, even if the match is exact. `''` means that Wagtail will not attempt to convert any urls entered to internal page links.
@@ -212,9 +207,9 @@ If the url is relative, Wagtail will not convert the link if there are more than
 ### `WAGTAIL_DATE_FORMAT`, `WAGTAIL_DATETIME_FORMAT`, `WAGTAIL_TIME_FORMAT`
 
 ```python
-WAGTAIL_DATE_FORMAT = '%d.%m.%Y.'
-WAGTAIL_DATETIME_FORMAT = '%d.%m.%Y. %H:%M'
-WAGTAIL_TIME_FORMAT = '%H:%M'
+WAGTAIL_DATE_FORMAT = "%d.%m.%Y."
+WAGTAIL_DATETIME_FORMAT = "%d.%m.%Y. %H:%M"
+WAGTAIL_TIME_FORMAT = "%H:%M"
 ```
 
 Specifies the date, time, and datetime format to be used in input fields in the Wagtail admin. The format is specified in [Python datetime module syntax](inv:python#format-codes) and must be one of the recognized formats listed in the [`DATE_INPUT_FORMATS`](inv:django#DATE_INPUT_FORMATS), [`TIME_INPUT_FORMATS`](inv:django#TIME_INPUT_FORMATS), or [`DATETIME_INPUT_FORMATS`](inv:django#DATETIME_INPUT_FORMATS) setting respectively.
@@ -224,8 +219,8 @@ For example, to use US Imperial style date and time format (AM/PM times) in the 
 ```python
 # settings.py
 WAGTAIL_TIME_FORMAT = "%I:%M %p"  # 03:00 PM
-WAGTAIL_DATE_FORMAT = '%m/%d/%Y'  # 01/31/2004
-WAGTAIL_DATETIME_FORMAT = '%m/%d/%Y %I:%M %p'  # 01/31/2004 03:00 PM
+WAGTAIL_DATE_FORMAT = "%m/%d/%Y"  # 01/31/2004
+WAGTAIL_DATETIME_FORMAT = "%m/%d/%Y %I:%M %p"  # 01/31/2004 03:00 PM
 
 # Django uses formatting based on the system locale.
 # Therefore we must specify a locale and then override the date
@@ -349,7 +344,7 @@ This setting enables an additional confirmation step when deleting a page with a
 ### `WAGTAILIMAGES_IMAGE_MODEL`
 
 ```python
-WAGTAILIMAGES_IMAGE_MODEL = 'myapp.MyImage'
+WAGTAILIMAGES_IMAGE_MODEL = "myapp.MyImage"
 ```
 
 This setting lets you provide your own image model for use in Wagtail, which should extend the built-in `AbstractImage` class.
@@ -357,7 +352,7 @@ This setting lets you provide your own image model for use in Wagtail, which sho
 ### `WAGTAILIMAGES_IMAGE_FORM_BASE`
 
 ```python
-WAGTAILIMAGES_IMAGE_FORM_BASE = 'myapp.forms.MyImageBaseForm'
+WAGTAILIMAGES_IMAGE_FORM_BASE = "myapp.forms.MyImageBaseForm"
 ```
 
 This setting lets you provide your own image base form for use in Wagtail, which should extend the built-in `BaseImageForm` class.
@@ -419,9 +414,9 @@ Specifies the number of images shown per page in the image chooser modal.
 
 ```python
 # Recommended
-WAGTAILIMAGES_RENDITION_STORAGE = 'my_custom_storage'
+WAGTAILIMAGES_RENDITION_STORAGE = "my_custom_storage"
 # Or
-WAGTAILIMAGES_RENDITION_STORAGE = 'myapp.backends.MyCustomStorage'
+WAGTAILIMAGES_RENDITION_STORAGE = "myapp.backends.MyCustomStorage"
 WAGTAILIMAGES_RENDITION_STORAGE = MyCustomStorage()
 ```
 
@@ -432,7 +427,7 @@ Custom storage classes should subclass `django.core.files.storage.Storage`. See 
 ### `WAGTAILIMAGES_EXTENSIONS`
 
 ```python
-WAGTAILIMAGES_EXTENSIONS = ['avif', 'svg']
+WAGTAILIMAGES_EXTENSIONS = ["avif", "svg"]
 ```
 
 A list of allowed image extensions that will be validated during image uploading.
@@ -485,7 +480,7 @@ See [](customizing_output_formats).
 ### `WAGTAILDOCS_DOCUMENT_MODEL`
 
 ```python
-WAGTAILDOCS_DOCUMENT_MODEL = 'myapp.MyDocument'
+WAGTAILDOCS_DOCUMENT_MODEL = "myapp.MyDocument"
 ```
 
 This setting lets you provide your own document model for use in Wagtail, which should extend the built-in `AbstractDocument` class.
@@ -495,7 +490,7 @@ This setting lets you provide your own document model for use in Wagtail, which 
 ### `WAGTAILDOCS_DOCUMENT_FORM_BASE`
 
 ```python
-WAGTAILDOCS_DOCUMENT_FORM_BASE = 'myapp.forms.MyDocumentBaseForm'
+WAGTAILDOCS_DOCUMENT_FORM_BASE = "myapp.forms.MyDocumentBaseForm"
 ```
 
 This setting lets you provide your own Document base form for use in Wagtail, which should extend the built-in `BaseDocumentForm` class.
@@ -506,7 +501,7 @@ You can use it to specify or override the widgets to use in the admin form.
 ### `WAGTAILDOCS_SERVE_METHOD`
 
 ```python
-WAGTAILDOCS_SERVE_METHOD = 'redirect'
+WAGTAILDOCS_SERVE_METHOD = "redirect"
 ```
 
 Determines how document downloads will be linked to and served. Normally, requests for documents are sent through a Django view, to perform privacy checks (see [Collection Privacy settings](https://guide.wagtail.org/en-latest/how-to-guides/manage-collections/#privacy-settings)) and potentially other housekeeping tasks such as hit counting. To fully protect against users bypassing this check, it needs to happen in the same request where the document is served; however, this incurs a performance hit as the document then needs to be served by the Django server. In particular, this cancels out much of the benefit of hosting documents on external storage, such as S3 or a CDN.
@@ -529,8 +524,8 @@ Allowing direct access to document URLs within `MEDIA_ROOT` may present a securi
 
 ```python
 WAGTAILDOCS_CONTENT_TYPES = {
-    'pdf': 'application/pdf',
-    'txt': 'text/plain',
+    "pdf": "application/pdf",
+    "txt": "text/plain",
 }
 ```
 
@@ -541,7 +536,7 @@ Specifies the MIME content type that will be returned for the given file extensi
 ### `WAGTAILDOCS_INLINE_CONTENT_TYPES`
 
 ```python
-WAGTAILDOCS_INLINE_CONTENT_TYPES = ['application/pdf', 'text/plain']
+WAGTAILDOCS_INLINE_CONTENT_TYPES = ["application/pdf", "text/plain"]
 ```
 
 A list of MIME content types that will be shown inline in the browser (by serving the HTTP header `Content-Disposition: inline`) rather than served as a download, when using the `serve_view` method. Defaults to `application/pdf`.
@@ -565,7 +560,7 @@ Unless absolutely necessary, it's strongly recommended not to change this settin
 ### `WAGTAILDOCS_EXTENSIONS`
 
 ```python
-WAGTAILDOCS_EXTENSIONS = ['pdf', 'docx']
+WAGTAILDOCS_EXTENSIONS = ["pdf", "docx"]
 ```
 
 A list of allowed document extensions that will be validated during document uploading.
@@ -631,7 +626,7 @@ This specifies whether users are allowed to change their email (enabled by defau
 ### `WAGTAILADMIN_USER_PASSWORD_RESET_FORM`
 
 ```python
-WAGTAILADMIN_USER_PASSWORD_RESET_FORM = 'users.forms.PasswordResetForm'
+WAGTAILADMIN_USER_PASSWORD_RESET_FORM = "users.forms.PasswordResetForm"
 ```
 
 Allows the default `PasswordResetForm` to be extended with extra fields.
@@ -639,7 +634,7 @@ Allows the default `PasswordResetForm` to be extended with extra fields.
 ### `WAGTAILADMIN_USER_LOGIN_FORM`
 
 ```python
-WAGTAILADMIN_USER_LOGIN_FORM = 'users.forms.LoginForm'
+WAGTAILADMIN_USER_LOGIN_FORM = "users.forms.LoginForm"
 ```
 
 Allows the default `LoginForm` to be extended with extra fields.
@@ -649,7 +644,7 @@ Allows the default `LoginForm` to be extended with extra fields.
 ### `WAGTAILADMIN_LOGIN_URL`
 
 ```python
-WAGTAILADMIN_LOGIN_URL = 'https://example.com/login/'
+WAGTAILADMIN_LOGIN_URL = "https://example.com/login/"
 ```
 
 This specifies the URL to redirect when a user attempts to access a Wagtail admin page without being logged in. If omitted, Wagtail will fall back to using the standard login view (typically `/admin/login/`).
@@ -661,7 +656,7 @@ This specifies the URL to redirect when a user attempts to access a Wagtail admi
 ### `WAGTAIL_GRAVATAR_PROVIDER_URL`
 
 ```python
-WAGTAIL_GRAVATAR_PROVIDER_URL = '//www.gravatar.com/avatar'
+WAGTAIL_GRAVATAR_PROVIDER_URL = "//www.gravatar.com/avatar"
 ```
 
 If a user has not uploaded a profile picture, Wagtail will look for an avatar linked to their email address on gravatar.com. This setting allows you to specify an alternative provider such as like robohash.org, or can be set to `None` to disable the use of remote avatars completely.
@@ -682,7 +677,7 @@ It is possible to override this list via the `WAGTAIL_USER_TIME_ZONES` setting.
 If there is zero or one-time zone permitted, the account settings form will be hidden.
 
 ```python
-WAGTAIL_USER_TIME_ZONES = ['America/Chicago', 'Australia/Sydney', 'Europe/Rome']
+WAGTAIL_USER_TIME_ZONES = ["America/Chicago", "Australia/Sydney", "Europe/Rome"]
 ```
 
 (wagtailadmin_permitted_languages)=
@@ -692,14 +687,13 @@ WAGTAIL_USER_TIME_ZONES = ['America/Chicago', 'Australia/Sydney', 'Europe/Rome']
 Users can choose between several languages for the admin interface in the account settings. The list of languages is by default all the available languages in Wagtail with at least 90% coverage. To change it, set `WAGTAILADMIN_PERMITTED_LANGUAGES`:
 
 ```python
-WAGTAILADMIN_PERMITTED_LANGUAGES = [('en', 'English'),
-                                    ('pt', 'Portuguese')]
+WAGTAILADMIN_PERMITTED_LANGUAGES = [("en", "English"), ("pt", "Portuguese")]
 ```
 
 Since the syntax is the same as Django `LANGUAGES`, you can do this so users can only choose between front office languages:
 
 ```python
-LANGUAGES = WAGTAILADMIN_PERMITTED_LANGUAGES = [('en', 'English'), ('pt', 'Portuguese')]
+LANGUAGES = WAGTAILADMIN_PERMITTED_LANGUAGES = [("en", "English"), ("pt", "Portuguese")]
 ```
 
 ## Email notifications
@@ -707,7 +701,7 @@ LANGUAGES = WAGTAILADMIN_PERMITTED_LANGUAGES = [('en', 'English'), ('pt', 'Portu
 ### `WAGTAILADMIN_NOTIFICATION_FROM_EMAIL`
 
 ```python
-WAGTAILADMIN_NOTIFICATION_FROM_EMAIL = 'wagtail@myhost.io'
+WAGTAILADMIN_NOTIFICATION_FROM_EMAIL = "wagtail@myhost.io"
 ```
 
 Wagtail sends email notifications when content is submitted for moderation, and when the content is accepted or rejected. This setting lets you pick which email address these automatic notifications will come from. If omitted, Wagtail will fall back to using Django's `DEFAULT_FROM_EMAIL` setting.
@@ -759,7 +753,7 @@ For new releases, Wagtail may show a notification banner on the dashboard that h
 ### `WAGTAIL_PASSWORD_REQUIRED_TEMPLATE`
 
 ```python
-WAGTAIL_PASSWORD_REQUIRED_TEMPLATE = 'myapp/password_required.html'
+WAGTAIL_PASSWORD_REQUIRED_TEMPLATE = "myapp/password_required.html"
 ```
 
 This is the path to the Django template which will be used to display the "password required" form when a user accesses a private page. For more details, see the [](private_pages) documentation.
@@ -767,7 +761,7 @@ This is the path to the Django template which will be used to display the "passw
 ### `WAGTAILDOCS_PASSWORD_REQUIRED_TEMPLATE`
 
 ```python
-WAGTAILDOCS_PASSWORD_REQUIRED_TEMPLATE = 'myapp/document_password_required.html'
+WAGTAILDOCS_PASSWORD_REQUIRED_TEMPLATE = "myapp/document_password_required.html"
 ```
 
 As above, but for password restrictions on documents. For more details, see the [](private_pages) documentation.
@@ -777,7 +771,7 @@ As above, but for password restrictions on documents. For more details, see the 
 The basic login page can be customized with a custom template.
 
 ```python
-WAGTAIL_FRONTEND_LOGIN_TEMPLATE = 'myapp/login.html'
+WAGTAIL_FRONTEND_LOGIN_TEMPLATE = "myapp/login.html"
 ```
 
 ### `WAGTAIL_FRONTEND_LOGIN_URL`
@@ -785,7 +779,7 @@ WAGTAIL_FRONTEND_LOGIN_TEMPLATE = 'myapp/login.html'
 Or the login page can be a redirect to an external or internal URL.
 
 ```python
-WAGTAIL_FRONTEND_LOGIN_URL = '/accounts/login/'
+WAGTAIL_FRONTEND_LOGIN_URL = "/accounts/login/"
 ```
 
 For more details, see the [](login_page) documentation.
@@ -861,7 +855,7 @@ For full documentation on API configuration, including these settings, see [](ap
 ### `WAGTAILAPI_BASE_URL`
 
 ```python
-WAGTAILAPI_BASE_URL = 'https://api.example.com/'
+WAGTAILAPI_BASE_URL = "https://api.example.com/"
 ```
 
 Required when using frontend cache invalidation, used to generate absolute URLs to document files and invalidating the cache.
@@ -897,12 +891,12 @@ For full documentation on frontend cache invalidation, including these settings,
 ### `WAGTAILFRONTENDCACHE`
 
 ```python
-  WAGTAILFRONTENDCACHE = {
-      'varnish': {
-          'BACKEND': 'wagtail.contrib.frontend_cache.backends.HTTPBackend',
-          'LOCATION': 'http://localhost:8000',
-      },
-  }
+WAGTAILFRONTENDCACHE = {
+    "varnish": {
+        "BACKEND": "wagtail.contrib.frontend_cache.backends.HTTPBackend",
+        "LOCATION": "http://localhost:8000",
+    },
+}
 ```
 
 See the documentation linked above for the full options available.
@@ -924,13 +918,13 @@ Default is an empty list, there must be a list of languages to also purge the ur
 ### `WAGTAIL_REDIRECTS_FILE_STORAGE`
 
 ```python
-WAGTAIL_REDIRECTS_FILE_STORAGE = 'tmp_file'
+WAGTAIL_REDIRECTS_FILE_STORAGE = "tmp_file"
 ```
 
 By default the redirect importer keeps track of the uploaded file as a temp file, but on certain environments (load balanced/cloud environments), you cannot keep a shared file between environments. For those cases, you can use the built-in cache to store the file instead.
 
 ```python
-WAGTAIL_REDIRECTS_FILE_STORAGE = 'cache'
+WAGTAIL_REDIRECTS_FILE_STORAGE = "cache"
 ```
 
 ## Form builder
@@ -970,7 +964,7 @@ Moderation workflows can be used in two modes. The first is to require that all 
 ### `WAGTAIL_FINISH_WORKFLOW_ACTION`
 
 ```python
-WAGTAIL_FINISH_WORKFLOW_ACTION = 'wagtail.workflows.publish_workflow_state'
+WAGTAIL_FINISH_WORKFLOW_ACTION = "wagtail.workflows.publish_workflow_state"
 ```
 
 This sets the function to be called when a workflow completes successfully - by default, `wagtail.workflows.publish_workflow_state`,which publishes the page. The function must accept a `WorkflowState` object as its only positional argument.

--- a/docs/reference/signals.md
+++ b/docs/reference/signals.md
@@ -24,16 +24,19 @@ import requests
 
 # Let everyone know when a new page is published
 def send_to_slack(sender, **kwargs):
-    instance = kwargs['instance']
-    url = 'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
+    instance = kwargs["instance"]
+    url = (
+        "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    )
     values = {
-        "text" : "%s was published by %s " % (instance.title, instance.owner.username),
+        "text": "%s was published by %s " % (instance.title, instance.owner.username),
         "channel": "#publish-notifications",
         "username": "the squid of content",
-        "icon_emoji": ":octopus:"
+        "icon_emoji": ":octopus:",
     }
 
     response = requests.post(url, values)
+
 
 # Register a receiver
 page_published.connect(send_to_slack)
@@ -49,10 +52,12 @@ wish to do something when a new blog post is published:
 from wagtail.signals import page_published
 from mysite.models import BlogPostPage
 
+
 # Do something clever for each model type
 def receiver(sender, **kwargs):
     # Do something with blog posts
     pass
+
 
 # Register listeners for each page model class
 page_published.connect(receiver, sender=BlogPostPage)
@@ -98,16 +103,18 @@ The best way to distinguish between a 'move' and 'reorder' is to compare the `ur
 from wagtail.signals import pre_page_move
 from wagtail.contrib.frontend_cache.utils import purge_page_from_cache
 
+
 # Clear a page's old URLs from the cache when it moves to a different section
 def clear_page_url_from_cache_on_move(sender, **kwargs):
 
-    if kwargs['url_path_before'] == kwargs['url_path_after']:
+    if kwargs["url_path_before"] == kwargs["url_path_after"]:
         # No URLs are changing :) nothing to do here!
         return
 
     # The page is moving to a new section (possibly even a new site)
     # so clear old URL(s) from the cache
-    purge_page_from_cache(kwargs['instance'])
+    purge_page_from_cache(kwargs["instance"])
+
 
 # Register a receiver
 pre_page_move.connect(clear_old_page_urls_from_cache)
@@ -224,9 +231,11 @@ Here's an example of how to use this signal to pre-populate a new page's title u
 ```python
 from wagtail.signals import init_new_page
 
+
 def prepopulate_page(sender, page, parent, **kwargs):
     if parent:
         page.title = f"{parent.title}: New Page Title"
+
 
 init_new_page.connect(prepopulate_page)
 ```

--- a/docs/reference/streamfield/data_migrations.md
+++ b/docs/reference/streamfield/data_migrations.md
@@ -49,7 +49,7 @@ MigrateStreamData(
     operations_and_block_paths=[
         (RenameStreamChildrenOperation(old_name="field1", new_name="block1"), ""),
     ],
-    revisions_from=datetime.datetime(2022, 7, 25)
+    revisions_from=datetime.datetime(2022, 7, 25),
 )
 ```
 
@@ -223,8 +223,8 @@ Our altered stream data would look like this:
 ```python
 [
     ...,
-    { "type": "struct1", "value": { "char1": "Value1" } },
-    { "type": "struct1", "value": { "char1": "Value2" } },
+    {"type": "struct1", "value": {"char1": "Value1"}},
+    {"type": "struct1", "value": {"char1": "Value2"}},
     ...,
 ]
 ```

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -101,13 +101,13 @@ Python 3.6 is no longer supported as of this release; please upgrade to Python 3
 The data type returned as the value of a ListBlock is now a custom class, `ListValue`, rather than a Python `list` object. This change allows it to provide a `bound_blocks` property that exposes the list items as [`BoundBlock` objects](../advanced_topics/boundblocks_and_values) rather than plain values. `ListValue` objects are mutable sequences that behave similarly to lists, and so all code that iterates over them, accesses individual elements, or manipulates them should continue to work. However, code that specifically expects a `list` object (e.g. using `isinstance` or testing for equality against a list) may need to be updated. For example, a unit test that tests the value of a `ListBlock` as follows:
 
 ```python
-    self.assertEqual(page.body[0].value, ['hello', 'goodbye'])
+self.assertEqual(page.body[0].value, ["hello", "goodbye"])
 ```
 
 should be rewritten as:
 
 ```python
-    self.assertEqual(list(page.body[0].value), ['hello', 'goodbye'])
+self.assertEqual(list(page.body[0].value), ["hello", "goodbye"])
 ```
 
 ### Change to `set` method on tag fields

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -47,7 +47,6 @@ With every Wagtail Page you are able to add a helpful description text, similar 
 
 ```python
 class LandingPage(Page):
-
     page_description = "Use this page for converting users"
 ```
 
@@ -243,12 +242,12 @@ If you have models that are subclasses of `BaseLogEntry` in your project, be car
 ```python
 operations = [
     migrations.RemoveField(
-        model_name='mycustomlogentry',
-        name='data_json',
+        model_name="mycustomlogentry",
+        name="data_json",
     ),
     migrations.AddField(
-        model_name='mycustomlogentry',
-        name='data',
+        model_name="mycustomlogentry",
+        name="data",
         field=models.JSONField(blank=True, default=dict),
     ),
 ]
@@ -281,8 +280,9 @@ Example change
 def process_form_submission(self, form):
     self.get_submission_class().objects.create(
         # form_data=json.dumps(form.cleaned_data, cls=DjangoJSONEncoder),
-        form_data=form.cleaned_data, # new
-        page=self, user=form.user
+        form_data=form.cleaned_data,  # new
+        page=self,
+        user=form.user,
     )
 ```
 

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -435,6 +435,7 @@ The `wagtail.contrib.settings.models.BaseSetting` model has been replaced by two
 ```python
 from wagtail.contrib.settings.models import BaseSetting, register_setting
 
+
 @register_setting
 class SiteSpecificSocialMediaSettings(BaseSetting):
     facebook = models.URLField()
@@ -444,6 +445,7 @@ should become
 
 ```python
 from wagtail.contrib.settings.models import BaseSiteSetting, register_setting
+
 
 @register_setting
 class SiteSpecificSocialMediaSettings(BaseSiteSetting):

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -269,7 +269,7 @@ Like other userbar items, the new accessibility checker is configurable with the
 from wagtail.admin.userbar import AccessibilityItem
 
 
-@hooks.register('construct_wagtail_userbar')
+@hooks.register("construct_wagtail_userbar")
 def remove_userbar_accessibility_checks(request, items):
     items[:] = [item for item in items if not isinstance(item, AccessibilityItem)]
 ```

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -319,6 +319,7 @@ If using a custom edit handler or set of panels for page models, the correct wid
 from wagtail.admin.widgets.slug import SlugInput
 # ... other imports
 
+
 class MyPage(Page):
     promote_panels = [
         FieldPanel("slug", widget=SlugInput),

--- a/docs/releases/5.1.2.md
+++ b/docs/releases/5.1.2.md
@@ -34,10 +34,11 @@ As of Wagtail 5.1.2, the fallback behavior has been restored. Nevertheless, it i
 from wagtail.search import index
 # ... other imports
 
+
 @register_snippet
 class MySnippet(index.Indexed, models.Model):
-     search_fields = [
-         index.SearchField("name"),
-         index.AutocompleteField("name"),
-     ]
+    search_fields = [
+        index.SearchField("name"),
+        index.AutocompleteField("name"),
+    ]
 ```

--- a/docs/releases/5.1.md
+++ b/docs/releases/5.1.md
@@ -194,12 +194,13 @@ As of Wagtail 5.1.2, the fallback behavior has been restored. Nevertheless, it i
 from wagtail.search import index
 # ... other imports
 
+
 @register_snippet
 class MySnippet(index.Indexed, models.Model):
-     search_fields = [
-         index.SearchField("name"),
-         index.AutocompleteField("name"),
-     ]
+    search_fields = [
+        index.SearchField("name"),
+        index.AutocompleteField("name"),
+    ]
 ```
 
 ### `GroupPagePermission` now uses Django's `Permission` model
@@ -254,7 +255,9 @@ from wagtail.models import GroupPagePermission
 permission = GroupPagePermission(
     group=group,
     page=page,
-    permission=Permission.objects.get(content_type__app_label="wagtailcore", codename="change_page"),
+    permission=Permission.objects.get(
+        content_type__app_label="wagtailcore", codename="change_page"
+    ),
 )
 permission.save()
 ```

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -287,15 +287,16 @@ from django.urls import reverse
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 
-@hooks.register('register_admin_menu_item')
+
+@hooks.register("register_admin_menu_item")
 def register_frank_menu_item():
-  return MenuItem(
-    'Frank',
-    reverse('frank'),
-    icon_name='folder-inverse',
-    order=10000,
-    classname="highlight-menu" # not classnames=...
-  )
+    return MenuItem(
+        "Frank",
+        reverse("frank"),
+        icon_name="folder-inverse",
+        order=10000,
+        classname="highlight-menu",  # not classnames=...
+    )
 ```
 
 ### Edit and delete URLs in `ModelViewSet` changed to allow non-integer primary keys
@@ -547,16 +548,19 @@ from wagtail.images.formats import Format, register_image_format
 
 
 class CustomImageFormat(Format):
-
     def image_to_html(self, image, alt_text, extra_attributes=None):
         # contrived example - pull out the class and render on outside element
-        classname = self.classname # not self.classnames
-        self.classname = "" # not self.classnames
+        classname = self.classname  # not self.classnames
+        self.classname = ""  # not self.classnames
         inner_html = super().image_to_html(image, alt_text, extra_attributes)
-        return format_html("<custom-image class='{}'>{}</custom-image>", classname, inner_html)
+        return format_html(
+            "<custom-image class='{}'>{}</custom-image>", classname, inner_html
+        )
 
 
-custom_format = CustomImageFormat('custom_example', 'Custom example', 'example-image object-fit', 'width-750')
+custom_format = CustomImageFormat(
+    "custom_example", "Custom example", "example-image object-fit", "width-750"
+)
 
 register_image_format(custom_format)
 ```
@@ -587,10 +591,9 @@ The `get_template` method on StreamField blocks now accepts a `value` argument i
 
 ```python
 # Old
-def get_template(self, context=None):
-    ...
+def get_template(self, context=None): ...
+
 
 # New
-def get_template(self, value=None, context=None):
-    ...
+def get_template(self, value=None, context=None): ...
 ```

--- a/docs/releases/6.0.md
+++ b/docs/releases/6.0.md
@@ -302,12 +302,13 @@ This can be disabled by setting `copy_view_enabled = False`, for example.
 ```python
 class PersonViewSet(SnippetViewSet):
     model = Person
-    #...
+    # ...
     copy_view_enabled = False
+
 
 class PersonViewSet(ModelViewSet):
     model = Person
-    #...
+    # ...
     copy_view_enabled = False
 ```
 
@@ -333,6 +334,7 @@ Previously, the widget had to be explicitly added.
 from wagtail.admin.widgets.slug import SlugInput
 # ... other imports
 
+
 class MyPage(Page):
     promote_panels = [
         FieldPanel("slug", widget=SlugInput),
@@ -344,6 +346,7 @@ Keeping the widget as above is fine, but will no longer be required. The JavaScr
 
 ```python
 # ... imports
+
 
 class MyPage(Page):
     promote_panels = [
@@ -358,9 +361,10 @@ If you do not want this for some reason, you will now need to declare a differen
 from django.forms.widgets import TextInput
 # ... other imports
 
+
 class MyPage(Page):
     promote_panels = [
-        FieldPanel("slug", widget=TextInput), # use a plain text field
+        FieldPanel("slug", widget=TextInput),  # use a plain text field
         # ... other panels
     ]
 ```
@@ -453,11 +457,11 @@ from django.forms import Media, widgets
 class CustomRichTextArea(widgets.Textarea):
     def build_attrs(self, *args, **kwargs):
         attrs = super().build_attrs(*args, **kwargs)
-        attrs['data-controller'] = 'custom-editor'
+        attrs["data-controller"] = "custom-editor"
 
     @property
     def media(self):
-        return Media(js=["vendor/custom-editor.js","js/custom-editor-controller.js"])
+        return Media(js=["vendor/custom-editor.js", "js/custom-editor-controller.js"])
 ```
 
 ```javascript

--- a/docs/releases/6.1.md
+++ b/docs/releases/6.1.md
@@ -212,13 +212,13 @@ The undocumented `user_listing_buttons` template tag has been deprecated and wil
 The undocumented `wagtailusers_groups:users` URL pattern has been deprecated and will be removed in a future release. If you are using `reverse` with this URL pattern name, you should update your code to use the `wagtailusers_users:index` URL pattern name and the group ID as the `group` query parameter. For example:
 
 ```python
-reverse('wagtailusers_groups:users', args=[group.id])
+reverse("wagtailusers_groups:users", args=[group.id])
 ```
 
 should be updated to:
 
 ```python
-reverse('wagtailusers_users:index') + f'?group={group.id}'
+reverse("wagtailusers_users:index") + f"?group={group.id}"
 ```
 
 The corresponding `wagtailusers_groups:users_results` URL pattern has been removed as part of this change.
@@ -250,6 +250,7 @@ It's recommended that usage of this global is removed in any customizations or t
 ```python
 # .../wagtail_hooks.py
 
+
 @hooks.register("insert_editor_js")
 def editor_js():
     return format_html(
@@ -271,6 +272,7 @@ Remove the `insert_editor_js` hook usage and instead pass the data needed via th
 
 from django.urls import reverse_lazy
 
+
 @hooks.register("register_rich_text_features")
 def register_my_custom_feature(features):
     # features.register_link_type...
@@ -291,7 +293,6 @@ def register_my_custom_feature(features):
             js=["..."],
         ),
     )
-
 ```
 
 #### Overriding existing `chooserUrls` values
@@ -306,9 +307,12 @@ from django.urls import reverse_lazy
 
 from wagtail import hooks
 
+
 @hooks.register("register_rich_text_features")
 def override_embed_feature_url(features):
-    features.plugins_by_editor["draftail"]["embed"].data["chooserUrls"]["embedsChooser"] = reverse_lazy("my_embeds:chooser")
+    features.plugins_by_editor["draftail"]["embed"].data["chooserUrls"][
+        "embedsChooser"
+    ] = reverse_lazy("my_embeds:chooser")
 ```
 
 ### Deprecation of `window.initBlockWidget` to initialize a StreamField block
@@ -366,6 +370,7 @@ If this was required for slug field behavior, it's recommended that the `SlugInp
 ```python
 from wagtail.admin.widgets.slug import SlugInput
 # ... other imports
+
 
 class MyPage(Page):
     promote_panels = [

--- a/docs/releases/6.2.md
+++ b/docs/releases/6.2.md
@@ -125,11 +125,11 @@ Previous versions allowed passing a dict for `DISTRIBUTION_ID` within the `WAGTA
 
 ```python
 WAGTAILFRONTENDCACHE = {
-    'cloudfront': {
-        'BACKEND': 'wagtail.contrib.frontend_cache.backends.CloudfrontBackend',
-        'DISTRIBUTION_ID': {
-            'www.wagtail.org': 'your-distribution-id',
-            'www.madewithwagtail.org': 'other-distribution-id',
+    "cloudfront": {
+        "BACKEND": "wagtail.contrib.frontend_cache.backends.CloudfrontBackend",
+        "DISTRIBUTION_ID": {
+            "www.wagtail.org": "your-distribution-id",
+            "www.madewithwagtail.org": "other-distribution-id",
         },
     },
 }
@@ -139,15 +139,15 @@ should now be rewritten as:
 
 ```python
 WAGTAILFRONTENDCACHE = {
-    'mainsite': {
-        'BACKEND': 'wagtail.contrib.frontend_cache.backends.CloudfrontBackend',
-        'DISTRIBUTION_ID': 'your-distribution-id',
-        'HOSTNAMES': ['www.wagtail.org'],
+    "mainsite": {
+        "BACKEND": "wagtail.contrib.frontend_cache.backends.CloudfrontBackend",
+        "DISTRIBUTION_ID": "your-distribution-id",
+        "HOSTNAMES": ["www.wagtail.org"],
     },
-    'madewithwagtail': {
-        'BACKEND': 'wagtail.contrib.frontend_cache.backends.CloudfrontBackend',
-        'DISTRIBUTION_ID': 'other-distribution-id',
-        'HOSTNAMES': ['www.madewithwagtail.org'],
+    "madewithwagtail": {
+        "BACKEND": "wagtail.contrib.frontend_cache.backends.CloudfrontBackend",
+        "DISTRIBUTION_ID": "other-distribution-id",
+        "HOSTNAMES": ["www.madewithwagtail.org"],
     },
 }
 ```
@@ -176,6 +176,7 @@ Alternatively, if you wish to register the "view" permission without enabling th
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 
+
 class FooViewSet(SnippetViewSet):
     def get_permissions_to_register(self):
         content_type = ContentType.objects.get_for_model(self.model)
@@ -194,19 +195,25 @@ Given the following custom user model:
 
 ```py
 class User(AbstractUser):
-    country = models.CharField(verbose_name='country', max_length=255)
-    status = models.ForeignKey(MembershipStatus, on_delete=models.SET_NULL, null=True, default=1)
+    country = models.CharField(verbose_name="country", max_length=255)
+    status = models.ForeignKey(
+        MembershipStatus, on_delete=models.SET_NULL, null=True, default=1
+    )
 ```
 
 The following custom forms:
 
 ```py
 class CustomUserEditForm(UserEditForm):
-    status = forms.ModelChoiceField(queryset=MembershipStatus.objects, required=True, label=_("Status"))
+    status = forms.ModelChoiceField(
+        queryset=MembershipStatus.objects, required=True, label=_("Status")
+    )
 
 
 class CustomUserCreationForm(UserCreationForm):
-    status = forms.ModelChoiceField(queryset=MembershipStatus.objects, required=True, label=_("Status"))
+    status = forms.ModelChoiceField(
+        queryset=MembershipStatus.objects, required=True, label=_("Status")
+    )
 ```
 
 And the following settings:
@@ -223,7 +230,9 @@ Change the custom forms to the following:
 
 ```py
 class CustomUserEditForm(UserEditForm):
-    status = forms.ModelChoiceField(queryset=MembershipStatus.objects, required=True, label=_("Status"))
+    status = forms.ModelChoiceField(
+        queryset=MembershipStatus.objects, required=True, label=_("Status")
+    )
 
     # Use ModelForm's automatic form fields generation for the model's `country` field,
     # but use an explicit custom form field for `status`.
@@ -231,8 +240,11 @@ class CustomUserEditForm(UserEditForm):
     class Meta(UserEditForm.Meta):
         fields = UserEditForm.Meta.fields | {"country", "status"}
 
+
 class CustomUserCreationForm(UserCreationForm):
-    status = forms.ModelChoiceField(queryset=MembershipStatus.objects, required=True, label=_("Status"))
+    status = forms.ModelChoiceField(
+        queryset=MembershipStatus.objects, required=True, label=_("Status")
+    )
 
     # Use ModelForm's automatic form fields generation for the model's `country` field,
     # but use an explicit custom form field for `status`.

--- a/docs/releases/6.4.md
+++ b/docs/releases/6.4.md
@@ -56,7 +56,7 @@ Plain strings can now be used in panel definitions as a substitute for `FieldPan
 class MyPage(Page):
     body = RichTextField()
     content_panels = [
-        'body',
+        "body",
     ]
 ```
 
@@ -275,7 +275,7 @@ In previous releases, implementations of the [`construct_wagtail_userbar`](const
 **Old**
 
 ```python
-@hooks.register('construct_wagtail_userbar')
+@hooks.register("construct_wagtail_userbar")
 def construct_wagtail_userbar(request, items):
     pass
 ```
@@ -283,7 +283,7 @@ def construct_wagtail_userbar(request, items):
 **New**
 
 ```python
-@hooks.register('construct_wagtail_userbar')
+@hooks.register("construct_wagtail_userbar")
 def construct_wagtail_userbar(request, items, page):
     pass
 ```

--- a/docs/releases/7.0.md
+++ b/docs/releases/7.0.md
@@ -200,9 +200,7 @@ To strictly enforce requiredness on a field, including when saving as draft, you
 or
 
 ```python
-    content_panels = Page.content_panels + [
-        FieldPanel("subtitle", required_on_save=True)
-    ]
+content_panels = Page.content_panels + [FieldPanel("subtitle", required_on_save=True)]
 ```
 
 This option is enabled as standard for the `title` field of page models. It is also recommended to use this option for any fields that are used in the `__str__` representation of snippet models, so that these models always have a meaningful representation within listing views.

--- a/docs/topics/pages.md
+++ b/docs/topics/pages.md
@@ -27,56 +27,52 @@ from wagtail.search import index
 
 
 class BlogPage(Page):
-
     # Database fields
 
     body = RichTextField()
     date = models.DateField("Post date")
     feed_image = models.ForeignKey(
-        'wagtailimages.Image',
+        "wagtailimages.Image",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+'
+        related_name="+",
     )
-
 
     # Search index configuration
 
     search_fields = Page.search_fields + [
-        index.SearchField('body'),
-        index.FilterField('date'),
+        index.SearchField("body"),
+        index.FilterField("date"),
     ]
-
 
     # Editor panels configuration
 
     content_panels = Page.content_panels + [
-        FieldPanel('date'),
-        FieldPanel('body'),
-        InlinePanel('related_links'),
+        FieldPanel("date"),
+        FieldPanel("body"),
+        InlinePanel("related_links"),
     ]
 
     promote_panels = [
         MultiFieldPanel(Page.promote_panels, "Common page configuration"),
-        FieldPanel('feed_image'),
+        FieldPanel("feed_image"),
     ]
-
 
     # Parent page / subpage type rules
 
-    parent_page_types = ['blog.BlogIndex']
+    parent_page_types = ["blog.BlogIndex"]
     subpage_types = []
 
 
 class BlogPageRelatedLink(Orderable):
-    page = ParentalKey(BlogPage, on_delete=models.CASCADE, related_name='related_links')
+    page = ParentalKey(BlogPage, on_delete=models.CASCADE, related_name="related_links")
     name = models.CharField(max_length=255)
     url = models.URLField()
 
     panels = [
-        FieldPanel('name'),
-        FieldPanel('url'),
+        FieldPanel("name"),
+        FieldPanel("url"),
     ]
 ```
 
@@ -167,7 +163,6 @@ With every Wagtail Page you are able to add a helpful description text, similar 
 
 ```python
 class LandingPage(Page):
-
     page_description = "Use this page for converting users"
 ```
 
@@ -245,7 +240,7 @@ class BlogIndexPage(Page):
         context = super().get_context(request, *args, **kwargs)
 
         # Add extra variables and return the updated context
-        context['blog_entries'] = BlogPage.objects.child_of(self).live()
+        context["blog_entries"] = BlogPage.objects.child_of(self).live()
         return context
 ```
 
@@ -267,7 +262,7 @@ Set the `template` attribute on the class to use a different template file:
 class BlogPage(Page):
     ...
 
-    template = 'other_template.html'
+    template = "other_template.html"
 ```
 
 #### Dynamically choosing the template
@@ -282,9 +277,9 @@ class BlogPage(Page):
 
     def get_template(self, request, *args, **kwargs):
         if self.use_other_template:
-            return 'blog/other_blog_page.html'
+            return "blog/other_blog_page.html"
 
-        return 'blog/blog_page.html'
+        return "blog/blog_page.html"
 ```
 
 In this example, pages that have the `use_other_template` boolean field set will use the `blog/other_blog_page.html` template. All other pages will use the default `blog/blog_page.html`.
@@ -297,8 +292,8 @@ If you want to add AJAX functionality to a page, such as a paginated listing tha
 class BlogPage(Page):
     ...
 
-    ajax_template = 'other_template_fragment.html'
-    template = 'other_template.html'
+    ajax_template = "other_template_fragment.html"
+    template = "other_template.html"
 ```
 
 ### More control over page rendering
@@ -318,12 +313,11 @@ class BlogPage(Page):
 
     def serve(self, request):
         return JsonResponse({
-            'title': self.title,
-            'body': self.body,
-            'date': self.date,
-
+            "title": self.title,
+            "body": self.body,
+            "date": self.date,
             # Resizes the image to 300px width and gets a URL to it
-            'feed_image': self.feed_image.get_rendition('width-300').url,
+            "feed_image": self.feed_image.get_rendition("width-300").url,
         })
 ```
 
@@ -355,13 +349,13 @@ from wagtail.models import Orderable
 
 
 class BlogPageRelatedLink(Orderable):
-    page = ParentalKey(BlogPage, on_delete=models.CASCADE, related_name='related_links')
+    page = ParentalKey(BlogPage, on_delete=models.CASCADE, related_name="related_links")
     name = models.CharField(max_length=255)
     url = models.URLField()
 
     panels = [
-        FieldPanel('name'),
-        FieldPanel('url'),
+        FieldPanel("name"),
+        FieldPanel("url"),
     ]
 ```
 
@@ -387,36 +381,40 @@ from django.db import models
 from modelcluster.fields import ParentalKey
 from wagtail.models import Orderable
 
+
 # The abstract model for related links, complete with panels
 class RelatedLink(models.Model):
     name = models.CharField(max_length=255)
     url = models.URLField()
 
     panels = [
-        FieldPanel('name'),
-        FieldPanel('url'),
+        FieldPanel("name"),
+        FieldPanel("url"),
     ]
 
     class Meta:
         abstract = True
 
+
 # The real model which extends the abstract model with a ParentalKey relation back to the page model.
 # This can be repeated for each page type where the relation is to be added
 # (for example, NewsPageRelatedLink, PublicationPageRelatedLink and so on).
-class BlogPageRelatedLink(Orderable,RelatedLink):
-    page = ParentalKey(BlogPage, on_delete=models.CASCADE, related_name='related_links')
+class BlogPageRelatedLink(Orderable, RelatedLink):
+    page = ParentalKey(BlogPage, on_delete=models.CASCADE, related_name="related_links")
 ```
 
 Alternatively, if RelatedLink is going to appear on a significant number of the page types defined in your project, it may be more appropriate to set up a single `RelatedLink` model pointing to the base `wagtailcore.Page` model:
 
 ```python
 class RelatedLink(Orderable):
-    page = ParentalKey("wagtailcore.Page", on_delete=models.CASCADE, related_name='related_links')
+    page = ParentalKey(
+        "wagtailcore.Page", on_delete=models.CASCADE, related_name="related_links"
+    )
     name = models.CharField(max_length=255)
     url = models.URLField()
     panels = [
-        FieldPanel('name'),
-        FieldPanel('url'),
+        FieldPanel("name"),
+        FieldPanel("url"),
     ]
 ```
 
@@ -486,13 +484,13 @@ class NewsItemPage(Page):
     ...
 
     class Meta:
-        ordering = ('-publication_date', )  # will not work
+        ordering = ("-publication_date",)  # will not work
 ```
 
 This is because `Page` enforces ordering QuerySets by path. Instead, you must apply the ordering explicitly when constructing a QuerySet:
 
 ```python
-news_items = NewsItemPage.objects.live().order_by('-publication_date')
+news_items = NewsItemPage.objects.live().order_by("-publication_date")
 ```
 
 (custom_page_managers)=
@@ -505,8 +503,10 @@ You can add a custom `Manager` to your `Page` class. Any custom Managers should 
 from django.db import models
 from wagtail.models import Page, PageManager
 
+
 class EventPageManager(PageManager):
-    """ Custom manager for Event pages """
+    """Custom manager for Event pages"""
+
 
 class EventPage(Page):
     start_date = models.DateField()
@@ -521,12 +521,15 @@ from django.db import models
 from django.utils import timezone
 from wagtail.models import Page, PageManager, PageQuerySet
 
+
 class EventPageQuerySet(PageQuerySet):
     def future(self):
         today = timezone.localtime(timezone.now()).date()
         return self.filter(start_date__gte=today)
 
+
 EventPageManager = PageManager.from_queryset(EventPageQuerySet)
+
 
 class EventPage(Page):
     start_date = models.DateField()

--- a/docs/topics/search/backends.md
+++ b/docs/topics/search/backends.md
@@ -8,8 +8,8 @@ You can configure which backend to use with the `WAGTAILSEARCH_BACKENDS` setting
 
 ```python
 WAGTAILSEARCH_BACKENDS = {
-    'default': {
-        'BACKEND': 'wagtail.search.backends.database',
+    "default": {
+        "BACKEND": "wagtail.search.backends.database",
     }
 }
 ```
@@ -24,9 +24,9 @@ The `AUTO_UPDATE` setting allows you to disable this on a per-index basis:
 
 ```python
 WAGTAILSEARCH_BACKENDS = {
-    'default': {
-        'BACKEND': ...,
-        'AUTO_UPDATE': False,
+    "default": {
+        "BACKEND": ...,
+        "AUTO_UPDATE": False,
     }
 }
 ```
@@ -84,13 +84,13 @@ The backend is configured in settings:
 
 ```python
 WAGTAILSEARCH_BACKENDS = {
-    'default': {
-        'BACKEND': 'wagtail.search.backends.elasticsearch9',
-        'URLS': ['https://localhost:9200'],
-        'INDEX_PREFIX': '',
-        'TIMEOUT': 5,
-        'OPTIONS': {},
-        'INDEX_SETTINGS': {},
+    "default": {
+        "BACKEND": "wagtail.search.backends.elasticsearch9",
+        "URLS": ["https://localhost:9200"],
+        "INDEX_PREFIX": "",
+        "TIMEOUT": 5,
+        "OPTIONS": {},
+        "INDEX_SETTINGS": {},
     }
 }
 ```
@@ -207,13 +207,13 @@ The backend is configured in settings:
 
 ```python
 WAGTAILSEARCH_BACKENDS = {
-    'default': {
-        'BACKEND': 'wagtail.search.backends.opensearch3',
-        'URLS': ['https://localhost:9200'],
-        'INDEX_PREFIX': 'wagtail_',
-        'TIMEOUT': 5,
-        'OPTIONS': {},
-        'INDEX_SETTINGS': {},
+    "default": {
+        "BACKEND": "wagtail.search.backends.opensearch3",
+        "URLS": ["https://localhost:9200"],
+        "INDEX_PREFIX": "wagtail_",
+        "TIMEOUT": 5,
+        "OPTIONS": {},
+        "INDEX_SETTINGS": {},
     }
 }
 ```
@@ -247,19 +247,21 @@ from elasticsearch import RequestsHttpConnection
 from requests_aws4auth import AWS4Auth
 
 WAGTAILSEARCH_BACKENDS = {
-    'default': {
-        'BACKEND': 'wagtail.search.backends.opensearch3',
-        'INDEX_PREFIX': 'wagtail_',
-        'TIMEOUT': 5,
-        'HOSTS': [{
-            'host': 'YOURCLUSTER.REGION.es.amazonaws.com',
-            'port': 443,
-            'use_ssl': True,
-            'verify_certs': True,
-            'http_auth': AWS4Auth('ACCESS_KEY', 'SECRET_KEY', 'REGION', 'es'),
-        }],
-        'OPTIONS': {
-            'connection_class': RequestsHttpConnection,
+    "default": {
+        "BACKEND": "wagtail.search.backends.opensearch3",
+        "INDEX_PREFIX": "wagtail_",
+        "TIMEOUT": 5,
+        "HOSTS": [
+            {
+                "host": "YOURCLUSTER.REGION.es.amazonaws.com",
+                "port": 443,
+                "use_ssl": True,
+                "verify_certs": True,
+                "http_auth": AWS4Auth("ACCESS_KEY", "SECRET_KEY", "REGION", "es"),
+            }
+        ],
+        "OPTIONS": {
+            "connection_class": RequestsHttpConnection,
         },
     }
 }

--- a/docs/topics/snippets/registering.md
+++ b/docs/topics/snippets/registering.md
@@ -16,6 +16,7 @@ from wagtail.snippets.models import register_snippet
 
 # ...
 
+
 @register_snippet
 class Advert(models.Model):
     url = models.URLField(null=True, blank=True)
@@ -64,6 +65,7 @@ class AdvertViewSet(SnippetViewSet):
         FieldPanel("url"),
         FieldPanel("text"),
     ]
+
 
 # Instead of using @register_snippet as a decorator on the model class,
 # register the snippet using register_snippet as a function and pass in

--- a/docs/topics/snippets/rendering.md
+++ b/docs/topics/snippets/rendering.md
@@ -18,12 +18,13 @@ register = template.Library()
 
 # ...
 
+
 # Advert snippets
-@register.inclusion_tag('demo/tags/adverts.html', takes_context=True)
+@register.inclusion_tag("demo/tags/adverts.html", takes_context=True)
 def adverts(context):
     return {
-        'adverts': Advert.objects.all(),
-        'request': context['request'],
+        "adverts": Advert.objects.all(),
+        "request": context["request"],
     }
 ```
 
@@ -62,20 +63,20 @@ Then, in your own page templates, you can include your snippet template tag with
 In the above example, the list of adverts is a fixed list that is displayed via the custom template tag independent of any other content on the page. This might be what you want for a common panel in a sidebar, but, in another scenario, you might wish to display just one specific instance of a snippet on a particular page. This can be accomplished by defining a foreign key to the snippet model within your page model and adding a {class}`~wagtail.admin.panels.FieldPanel` to the page's `content_panels` list. For example, if you wanted to display a specific advert on a `BookPage` instance:
 
 ```python
-  # ...
-  class BookPage(Page):
-      advert = models.ForeignKey(
-          'demo.Advert',
-          null=True,
-          blank=True,
-          on_delete=models.SET_NULL,
-          related_name='+'
-      )
+# ...
+class BookPage(Page):
+    advert = models.ForeignKey(
+        "demo.Advert",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="+",
+    )
 
-      content_panels = Page.content_panels + [
-          FieldPanel('advert'),
-          # ...
-      ]
+    content_panels = Page.content_panels + [
+        FieldPanel("advert"),
+        # ...
+    ]
 ```
 
 The snippet could then be accessed within your template as `page.advert`.
@@ -91,16 +92,21 @@ from modelcluster.fields import ParentalKey
 
 # ...
 
+
 class BookPageAdvertPlacement(Orderable, models.Model):
-    page = ParentalKey('demo.BookPage', on_delete=models.CASCADE, related_name='advert_placements')
-    advert = models.ForeignKey('demo.Advert', on_delete=models.CASCADE, related_name='+')
+    page = ParentalKey(
+        "demo.BookPage", on_delete=models.CASCADE, related_name="advert_placements"
+    )
+    advert = models.ForeignKey(
+        "demo.Advert", on_delete=models.CASCADE, related_name="+"
+    )
 
     class Meta(Orderable.Meta):
         verbose_name = "advert placement"
         verbose_name_plural = "advert placements"
 
     panels = [
-        FieldPanel('advert'),
+        FieldPanel("advert"),
     ]
 
     def __str__(self):
@@ -111,7 +117,7 @@ class BookPage(Page):
     # ...
 
     content_panels = Page.content_panels + [
-        InlinePanel('advert_placements'),
+        InlinePanel("advert_placements"),
         # ...
     ]
 ```

--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -21,19 +21,20 @@ from wagtail import blocks
 from wagtail.admin.panels import FieldPanel
 from wagtail.images.blocks import ImageBlock
 
+
 class BlogPage(Page):
     author = models.CharField(max_length=255)
     date = models.DateField("Post date")
     body = StreamField([
-        ('heading', blocks.CharBlock(form_classname="title")),
-        ('paragraph', blocks.RichTextBlock()),
-        ('image', ImageBlock()),
+        ("heading", blocks.CharBlock(form_classname="title")),
+        ("paragraph", blocks.RichTextBlock()),
+        ("image", ImageBlock()),
     ])
 
     content_panels = Page.content_panels + [
-        FieldPanel('author'),
-        FieldPanel('date'),
-        FieldPanel('body'),
+        FieldPanel("author"),
+        FieldPanel("date"),
+        FieldPanel("body"),
     ]
 ```
 
@@ -161,10 +162,10 @@ class PersonBlock(blocks.StructBlock):
 
 ```python
 body = StreamField([
-    ('person', PersonBlock()),
-    ('heading', blocks.CharBlock(form_classname="title")),
-    ('paragraph', blocks.RichTextBlock()),
-    ('image', ImageBlock()),
+    ("person", PersonBlock()),
+    ("heading", blocks.CharBlock(form_classname="title")),
+    ("paragraph", blocks.RichTextBlock()),
+    ("image", ImageBlock()),
 ])
 ```
 
@@ -315,7 +316,7 @@ class CarouselBlock(blocks.StreamBlock):
     video = EmbedBlock()
 
     class Meta:
-        icon = 'image'
+        icon = "image"
 ```
 
 A StreamBlock subclass defined in this way can also be passed to a `StreamField` definition, instead of passing a list of block types. This allows setting up a common set of block types to be used on multiple page types:
@@ -358,11 +359,15 @@ When reading back the content of a StreamField, the value of a StreamBlock is a 
 By default, a StreamField can contain an unlimited number of blocks. The `min_num` and `max_num` options on `StreamField` or `StreamBlock` allow you to set a minimum or a maximum number of blocks:
 
 ```python
-body = StreamField([
-    ('heading', blocks.CharBlock(form_classname="title")),
-    ('paragraph', blocks.RichTextBlock()),
-    ('image', ImageBlock()),
-], min_num=2, max_num=5)
+body = StreamField(
+    [
+        ("heading", blocks.CharBlock(form_classname="title")),
+        ("paragraph", blocks.RichTextBlock()),
+        ("image", ImageBlock()),
+    ],
+    min_num=2,
+    max_num=5,
+)
 ```
 
 Or equivalently:
@@ -381,13 +386,16 @@ class CommonContentBlock(blocks.StreamBlock):
 The `block_counts` option can be used to set a minimum or maximum count for specific block types. This accepts a dict, mapping block names to a dict containing either or both `min_num` and `max_num`. For example, to permit between 1 and 3 'heading' blocks:
 
 ```python
-body = StreamField([
-    ('heading', blocks.CharBlock(form_classname="title")),
-    ('paragraph', blocks.RichTextBlock()),
-    ('image', ImageBlock()),
-], block_counts={
-    'heading': {'min_num': 1, 'max_num': 3},
-})
+body = StreamField(
+    [
+        ("heading", blocks.CharBlock(form_classname="title")),
+        ("paragraph", blocks.RichTextBlock()),
+        ("image", ImageBlock()),
+    ],
+    block_counts={
+        "heading": {"min_num": 1, "max_num": 3},
+    },
+)
 ```
 
 Or equivalently:
@@ -400,7 +408,7 @@ class CommonContentBlock(blocks.StreamBlock):
 
     class Meta:
         block_counts = {
-            'heading': {'min_num': 1, 'max_num': 3},
+            "heading": {"min_num": 1, "max_num": 3},
         }
 ```
 
@@ -411,16 +419,19 @@ class CommonContentBlock(blocks.StreamBlock):
 By default, each block is rendered using simple, minimal HTML markup, or no markup at all. For example, a CharBlock value is rendered as plain text, while a ListBlock outputs its child blocks in a `<ul>` wrapper. To override this with your own custom HTML rendering, you can pass a `template` argument to the block, giving the filename of a template file to be rendered. This is particularly useful for custom block types derived from StructBlock:
 
 ```python
-('person', blocks.StructBlock(
-    [
-        ('first_name', blocks.CharBlock()),
-        ('surname', blocks.CharBlock()),
-        ('photo', ImageBlock(required=False)),
-        ('biography', blocks.RichTextBlock()),
-    ],
-    template='myapp/blocks/person.html',
-    icon='user'
-))
+(
+    "person",
+    blocks.StructBlock(
+        [
+            ("first_name", blocks.CharBlock()),
+            ("surname", blocks.CharBlock()),
+            ("photo", ImageBlock(required=False)),
+            ("biography", blocks.RichTextBlock()),
+        ],
+        template="myapp/blocks/person.html",
+        icon="user",
+    ),
+)
 ```
 
 Or, when defined as a subclass of StructBlock:
@@ -433,8 +444,8 @@ class PersonBlock(blocks.StructBlock):
     biography = blocks.RichTextBlock()
 
     class Meta:
-        template = 'myapp/blocks/person.html'
-        icon = 'user'
+        template = "myapp/blocks/person.html"
+        icon = "user"
 ```
 
 Within the template, the block value is accessible as the variable `value`:
@@ -530,17 +541,18 @@ As well as passing variables from the parent template, block subclasses can pass
 ```python
 import datetime
 
+
 class EventBlock(blocks.StructBlock):
     title = blocks.CharBlock()
     date = blocks.DateBlock()
 
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
-        context['is_happening_today'] = (value['date'] == datetime.date.today())
+        context["is_happening_today"] = value["date"] == datetime.date.today()
         return context
 
     class Meta:
-        template = 'myapp/blocks/event.html'
+        template = "myapp/blocks/event.html"
 ```
 
 In this example, the variable `is_happening_today` will be made available within the block template. The `parent_context` keyword argument is available when the block is rendered through an `{% include_block %}` tag, and is a dict of variables passed from the calling template.
@@ -551,6 +563,7 @@ Similarly, a `get_template` method can be defined to dynamically select a templa
 
 ```python
 import datetime
+
 
 class EventBlock(blocks.StructBlock):
     title = blocks.CharBlock()
@@ -690,13 +703,13 @@ A StreamField's value behaves as a list, and blocks can be inserted, overwritten
 
 ```python
 # Replace the first block with a new block of type 'heading'
-my_page.body[0] = ('heading', "My story")
+my_page.body[0] = ("heading", "My story")
 
 # Delete the last block
 del my_page.body[-1]
 
 # Append a rich text block to the stream
-my_page.body.append(('paragraph', "<p>And they all lived happily ever after.</p>"))
+my_page.body.append(("paragraph", "<p>And they all lived happily ever after.</p>"))
 
 # Save the updated data back to the database
 my_page.save()
@@ -705,24 +718,24 @@ my_page.save()
 If a block extending a StructBlock is to be used inside of the StreamField's value, the value of this block can be provided as a Python dict (similar to what is accepted by the block's `.to_python` method).
 
 ```python
-
 from wagtail import blocks
 
+
 class UrlWithTextBlock(blocks.StructBlock):
-   url = blocks.URLBlock()
-   text = blocks.TextBlock()
+    url = blocks.URLBlock()
+    text = blocks.TextBlock()
+
 
 # using this block inside the content
 
 data = {
-    'url': 'https://github.com/wagtail/',
-    'text': 'A very interesting and useful repo'
+    "url": "https://github.com/wagtail/",
+    "text": "A very interesting and useful repo",
 }
 
 # append the new block to the stream as a tuple with the defined index for this block type
-my_page.body.append(('url', data))
+my_page.body.append(("url", data))
 my_page.save()
-
 ```
 
 (streamfield_retrieving_blocks_by_name)=
@@ -732,7 +745,7 @@ my_page.save()
 StreamField values provide a `blocks_by_name` method for retrieving all blocks of a given name:
 
 ```python
-my_page.body.blocks_by_name('heading')  # returns a list of 'heading' blocks
+my_page.body.blocks_by_name("heading")  # returns a list of 'heading' blocks
 ```
 
 Calling `blocks_by_name` with no arguments returns a `dict`-like object, mapping block names to the list of blocks of that name. This is particularly useful in template code, where passing arguments isn't possible:
@@ -766,9 +779,9 @@ Like any other field, content in a StreamField can be made searchable by adding 
 
 ```python
 body = StreamField([
-    ('normal_text', blocks.RichTextBlock()),
-    ('pull_quote', blocks.RichTextBlock(search_index=False)),
-    ('footnotes', blocks.ListBlock(blocks.CharBlock(), search_index=False)),
+    ("normal_text", blocks.RichTextBlock()),
+    ("pull_quote", blocks.RichTextBlock(search_index=False)),
+    ("footnotes", blocks.ListBlock(blocks.CharBlock(), search_index=False)),
 ])
 ```
 

--- a/docs/tutorial/add_search.md
+++ b/docs/tutorial/add_search.md
@@ -94,12 +94,13 @@ You can now run searches and view results. However, the search currently only re
 # Add to the existing imports:
 from wagtail.search import index
 
+
 class BlogPage(Page):
     # Keep the existing parent_page_types, fields, methods and content_panels definitions, and add:
 
     search_fields = Page.search_fields + [
-        index.SearchField('intro'),
-        index.SearchField('body'),
+        index.SearchField("intro"),
+        index.SearchField("body"),
     ]
 ```
 

--- a/docs/tutorial/create_contact_page.md
+++ b/docs/tutorial/create_contact_page.md
@@ -43,7 +43,7 @@ from wagtail.snippets.models import register_snippet
 
 # ... keep the definition of NavigationSettings and FooterText. Add FormField and FormPage:
 class FormField(AbstractFormField):
-    page = ParentalKey('FormPage', on_delete=models.CASCADE, related_name='form_fields')
+    page = ParentalKey("FormPage", on_delete=models.CASCADE, related_name="form_fields")
 
 
 class FormPage(AbstractEmailForm):
@@ -52,16 +52,19 @@ class FormPage(AbstractEmailForm):
 
     content_panels = AbstractEmailForm.content_panels + [
         FormSubmissionsPanel(),
-        FieldPanel('intro'),
-        InlinePanel('form_fields'),
-        FieldPanel('thank_you_text'),
-        MultiFieldPanel([
-            FieldRowPanel([
-                FieldPanel('from_address'),
-                FieldPanel('to_address'),
-            ]),
-            FieldPanel('subject'),
-        ], "Email"),
+        FieldPanel("intro"),
+        InlinePanel("form_fields"),
+        FieldPanel("thank_you_text"),
+        MultiFieldPanel(
+            [
+                FieldRowPanel([
+                    FieldPanel("from_address"),
+                    FieldPanel("to_address"),
+                ]),
+                FieldPanel("subject"),
+            ],
+            "Email",
+        ),
     ]
 ```
 

--- a/docs/tutorial/create_footer_for_all_pages.md
+++ b/docs/tutorial/create_footer_for_all_pages.md
@@ -27,6 +27,7 @@ from wagtail.contrib.settings.models import (
     register_setting,
 )
 
+
 @register_setting
 class NavigationSettings(BaseGenericSetting):
     linkedin_url = models.URLField(verbose_name="LinkedIn URL", blank=True)
@@ -75,7 +76,6 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-
                 # Add this to register the _settings_ context processor:
                 "wagtail.contrib.settings.context_processors.settings",
             ],
@@ -154,7 +154,6 @@ from django.db import models
 from wagtail.admin.panels import (
     FieldPanel,
     MultiFieldPanel,
-
     # import PublishingPanel:
     PublishingPanel,
 )
@@ -178,6 +177,7 @@ from wagtail.contrib.settings.models import (
 # import register_snippet:
 from wagtail.snippets.models import register_snippet
 
+
 # ...keep the definition of the NavigationSettings model and add the FooterText model:
 @register_snippet
 class FooterText(
@@ -187,7 +187,6 @@ class FooterText(
     TranslatableMixin,
     models.Model,
 ):
-
     body = RichTextField()
 
     panels = [

--- a/docs/tutorial/create_portfolio_page.md
+++ b/docs/tutorial/create_portfolio_page.md
@@ -89,6 +89,7 @@ class CaptionedImageBlock(StructBlock):
     image = ImageBlock(required=True)
     caption = CharBlock(required=False)
     attribution = CharBlock(required=False)
+
     class Meta:
         icon = "image"
         template = "base/blocks/captioned_image_block.html"
@@ -111,6 +112,7 @@ class HeadingBlock(StructBlock):
         blank=True,
         required=False,
     )
+
     class Meta:
         icon = "title"
         template = "base/blocks/heading_block.html"
@@ -178,6 +180,7 @@ Now create a `portfolio/blocks.py` file and import the block you intend to use a
 
 ```python
 from base.blocks import BaseStreamBlock
+
 
 class PortfolioStreamBlock(BaseStreamBlock):
     pass
@@ -250,6 +253,7 @@ from wagtail.images.blocks import ImageBlock
 
 from base.blocks import BaseStreamBlock
 
+
 # add CardBlock:
 class CardBlock(StructBlock):
     heading = CharBlock()
@@ -260,6 +264,7 @@ class CardBlock(StructBlock):
         icon = "form"
         template = "portfolio/blocks/card_block.html"
 
+
 # add FeaturedPostsBlock:
 class FeaturedPostsBlock(StructBlock):
     heading = CharBlock()
@@ -269,6 +274,7 @@ class FeaturedPostsBlock(StructBlock):
     class Meta:
         icon = "folder-open-inverse"
         template = "portfolio/blocks/featured_posts_block.html"
+
 
 class PortfolioStreamBlock(BaseStreamBlock):
     # delete the pass statement

--- a/docs/tutorial/customize_homepage.md
+++ b/docs/tutorial/customize_homepage.md
@@ -35,8 +35,7 @@ class HomePage(Page):
         help_text="Homepage image",
     )
     hero_text = models.CharField(
-        blank=True,
-        max_length=255, help_text="Write an introduction for the site"
+        blank=True, max_length=255, help_text="Write an introduction for the site"
     )
     hero_cta = models.CharField(
         blank=True,
@@ -67,7 +66,7 @@ class HomePage(Page):
             ],
             heading="Hero section",
         ),
-        FieldPanel('body'),
+        FieldPanel("body"),
     ]
 ```
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,6 +7,11 @@ exclude = [
 ]
 line-length = 88
 target-version = "py310" # minimum target version
+preview = true
+extend-include = ["docs/**/*.md"]
+
+[format]
+docstring-code-format = true
 
 [lint]
 # D100: Missing docstring in public module


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #14101 

### Description

<!-- Please describe the problem you're fixing. -->
Now that Ruff supports Python formatting within Markdown files (via preview 
mode), this sets up formatting enforcement for Python code blocks in the docs, 
replacing the previous `blacken-docs` approach from #12892.

This is structured as three commits for easier review:

1. **Configure Ruff** — enable `preview = true` and `extend-include = ["docs/**/*.md"]` 
   in `ruff.toml`, and pass `--preview` to `ruff-format` in `.pre-commit-config.yaml`
2. **Auto-reformat** — bulk reformat of all affected `docs/**/*.md` files using 
   `ruff format --preview`
3. **CI enforcement** — new `lint.yml` workflow running `ruff format --check` 
   and `ruff check` on every push and pull request


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None
