### PR TITLE
Fix 500 error on bulk delete/move with ancestor-descendant pages

### DIFF
--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_delete.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_delete.py
@@ -599,3 +599,26 @@ class TestBulkDelete(WagtailTestUtils, TestCase):
                 self.assertFalse(
                     SimplePage.objects.filter(id=grandchild_page.id).exists()
                 )
+
+    def test_bulk_delete_with_ancestor_descendant_selection(self):
+        parent = SimplePage(title="Parent page", slug="parent-page", content="parent")
+        self.root_page.add_child(instance=parent)
+        child = SimplePage(title="Child page", slug="child-page", content="child")
+        parent.add_child(instance=child)
+
+        url = (
+            reverse(
+                "wagtail_bulk_action",
+                args=("wagtailcore", "page", "delete"),
+            )
+            + "?"
+        )
+        query_params = {
+            "next": self.explore_url,
+            "id": [parent.pk, child.pk],
+        }
+        url += urlencode(query_params, doseq=True)
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(SimplePage.objects.filter(id=parent.id).exists())
+        self.assertFalse(SimplePage.objects.filter(id=child.id).exists())

--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_move.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_move.py
@@ -350,3 +350,23 @@ class TestBulkMove(WagtailTestUtils, TestCase):
             ),
             html,
         )
+
+    def test_bulk_move_with_ancestor_descendant_selection(self):
+        parent = SimplePage(title="Parent page", slug="parent-page", content="parent")
+        self.section_c.add_child(instance=parent)
+        child = SimplePage(title="Child page", slug="child-page", content="child")
+        parent.add_child(instance=child)
+
+        url = (
+            reverse(
+                "wagtail_bulk_action",
+                args=("wagtailcore", "page", "move"),
+            )
+            + f"?id={parent.id}&id={child.id}"
+        )
+        response = self.client.post(url, {"chooser": self.section_b.id})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            Page.objects.get(id=parent.id).get_parent().id, self.section_b.id
+        )
+        self.assertEqual(Page.objects.get(id=child.id).get_parent().id, parent.id)

--- a/wagtail/admin/views/pages/bulk_actions/delete.py
+++ b/wagtail/admin/views/pages/bulk_actions/delete.py
@@ -52,7 +52,13 @@ class DeleteBulkAction(ReferenceIndexMixin, PageBulkAction):
     @classmethod
     def execute_action(cls, objects, user=None, **kwargs):
         num_parent_objects, num_child_objects = 0, 0
-        for page in objects:
+        object_ids = {page.pk for page in objects}
+        pages_to_delete = [
+            page
+            for page in objects
+            if not page.get_ancestors().filter(pk__in=object_ids).exists()
+        ]
+        for page in pages_to_delete:
             num_parent_objects += 1
             num_child_objects += page.get_descendant_count()
             page.delete(user=user)

--- a/wagtail/admin/views/pages/bulk_actions/move.py
+++ b/wagtail/admin/views/pages/bulk_actions/move.py
@@ -152,7 +152,13 @@ class MoveBulkAction(PageBulkAction):
         num_parent_objects = 0
         if destination is None:
             return
-        for page in objects:
+        object_ids = {page.pk for page in objects}
+        pages_to_move = [
+            page
+            for page in objects
+            if not page.get_ancestors().filter(pk__in=object_ids).exists()
+        ]
+        for page in pages_to_move:
             page.move(destination, pos="last-child", user=user)
             num_parent_objects += 1
         return num_parent_objects, 0


### PR DESCRIPTION


<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #7949

### Description

<!-- Please describe the problem you're fixing. -->
When performing a bulk delete or bulk move operation on pages where one 
page is a descendant of another selected page, a 500 error occurs.

For bulk delete: deleting the parent cascades to the child, then the 
loop tries to delete the already-deleted child, causing:
`SimplePage.DoesNotExist: SimplePage matching query does not exist.`

For bulk move: moving the parent changes the tree structure, then the 
loop tries to move the already-moved child, causing:
`Page.DoesNotExist: Page matching query does not exist.`

**Fix:** In `execute_action` for both delete and move, filter out pages 
that are already descendants of other selected pages before performing 
the operation. Descendants will be handled automatically with their 
ancestor.

Tests added to verify both the delete and move scenarios.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None
