### PR TITLE
Use correct npm prefix when installing playwright browsers on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
               npm --prefix ./client/tests/integration ci
           fi
           if [[ ! -e "~/.cache/ms-playwright" ]]; then
-              npx playwright install
+              npm --prefix ./client/tests/integration exec playwright install
           fi
       - save_cache:
           key: *ui_tests-npm-cache


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes failing UI tests CI.

### Description

<!-- Please describe the problem you're fixing. -->

Looking at the logs, it looks like NPM tries to install the latest version of playwright when running `npx` because it could not find the cached playwright package. Seems to be because we're running `npm`/`npx` from the repo root instead of `client/tests/integration`. For the `npm ci`, we already handled this by specifying `--prefix`. However, `npx` does not support it, so we use `npm exec` instead (which is what `npx` is shorthand for anyway). Ref: https://stackoverflow.com/questions/60739550/how-to-specify-pathlike-npm-prefix-in-npx


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

None