### PR TITLE
Ensure translation aliases have slug synced with original

### DIFF
--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -1140,6 +1140,11 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                 target=alias_updated, exclude=exclude_fields
             )
 
+            # A translation of the page will have the same translation key
+            # An alias of a translation (which is also an alias) will have a
+            # different translation key
+            alias_is_translation = alias.translation_key == self.translation_key
+
             # Process child objects
             # This has two jobs:
             #  - If the alias is in a different locale, this updates the
@@ -1148,7 +1153,6 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             #    changes the translation_key field of all child objects
             #    so they do not clash
             if child_object_map:
-                alias_is_translation = alias.translation_key == self.translation_key
 
                 def process_child_object(child_object):
                     if isinstance(child_object, TranslatableMixin):
@@ -1173,9 +1177,11 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                 specific_self, alias_updated, exclude_fields=exclude_fields
             )
 
-            # Don't change the aliases slug
+            # Don't change the aliases slug if it is not a translation
             # Aliases can have their own slugs so they can be siblings of the original
-            alias_updated.slug = alias.slug
+            # Translations should have their slug updated to match the original
+            if not alias_is_translation:
+                alias_updated.slug = alias.slug
             alias_updated.set_url_path(alias_updated.get_parent())
 
             # Aliases don't have revisions, so update fields that would normally be updated by save_revision

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -48,6 +48,7 @@ from wagtail.compat import HTTPMethod
 from wagtail.coreutils import (
     WAGTAIL_APPEND_SLASH,
     camelcase_to_underscore,
+    find_available_slug,
     get_supported_content_language_variant,
     resolve_model_string,
     safe_md5,
@@ -1182,6 +1183,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             # Translations should have their slug updated to match the original
             if not alias_is_translation:
                 alias_updated.slug = alias.slug
+            elif alias.slug != self.slug:
+                alias_updated.slug = find_available_slug(alias_updated.get_parent(), self.slug)
             alias_updated.set_url_path(alias_updated.get_parent())
 
             # Aliases don't have revisions, so update fields that would normally be updated by save_revision

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -1184,7 +1184,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             if not alias_is_translation:
                 alias_updated.slug = alias.slug
             elif alias.slug != self.slug:
-                alias_updated.slug = find_available_slug(alias_updated.get_parent(), self.slug)
+                alias_updated.slug = find_available_slug(
+                    alias_updated.get_parent(), self.slug
+                )
             alias_updated.set_url_path(alias_updated.get_parent())
 
             # Aliases don't have revisions, so update fields that would normally be updated by save_revision

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -3167,6 +3167,7 @@ class TestUpdateAliases(TestCase):
         self.assertEqual(event_page.slug, "merry-christmas")
         self.assertEqual(alias_of_translation_alias.slug, "merry-christmas")
 
+
 class TestCopyForTranslation(TestCase):
     fixtures = ["test.json"]
 

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -3087,6 +3087,62 @@ class TestUpdateAliases(TestCase):
             ).exists()
         )
 
+    def test_update_aliases_does_not_update_slug(self):
+        event_page = EventPage.objects.get(url_path="/home/events/christmas/")
+        alias = event_page.create_alias(update_slug="christmas-alias")
+
+        event_page.slug = "xmas"
+        event_page.save()
+
+        event_page.update_aliases()
+
+        alias.refresh_from_db()
+        self.assertEqual(alias.slug, "christmas-alias")
+
+    def test_update_aliases_updates_slug_for_translation(self):
+        event_page = EventPage.objects.get(url_path="/home/events/christmas/")
+        fr_locale = Locale.objects.create(language_code="fr")
+
+        # Create a parent for the translation alias in the French locale
+        fr_events_parent = (
+            event_page.get_parent()
+            .get_parent()
+            .add_child(
+                instance=Page(title="Events FR", slug="events-fr", locale=fr_locale)
+            )
+        )
+
+        # Create a translation alias: same translation_key, different locale
+        translation_alias = event_page.create_alias(
+            parent=fr_events_parent,
+            update_locale=fr_locale,
+            reset_translation_key=False,
+        )
+        self.assertEqual(translation_alias.slug, "christmas")
+
+        # Create a sibling alias of the translation alias
+        alias_of_translation_alias = translation_alias.create_alias(
+            parent=fr_events_parent,
+            update_locale=fr_locale,
+            update_slug="merry-christmas",
+        )
+
+        self.assertEqual(alias_of_translation_alias.slug, "merry-christmas")
+
+        event_page.slug = "xmas"
+        event_page.save()
+
+        event_page.update_aliases()
+
+        translation_alias.refresh_from_db()
+        alias_of_translation_alias.refresh_from_db()
+
+        # The translation alias should have its slug updated
+        self.assertEqual(translation_alias.slug, "xmas")
+
+        # The alias of the translation alias should NOT have its slug updated, since it has a custom slug
+        self.assertEqual(alias_of_translation_alias.slug, "merry-christmas")
+
 
 class TestCopyForTranslation(TestCase):
     fixtures = ["test.json"]

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -3102,27 +3102,17 @@ class TestUpdateAliases(TestCase):
     def test_update_aliases_updates_slug_for_translation(self):
         event_page = EventPage.objects.get(url_path="/home/events/christmas/")
         fr_locale = Locale.objects.create(language_code="fr")
-
-        # Create a parent for the translation alias in the French locale
-        fr_events_parent = (
-            event_page.get_parent()
-            .get_parent()
-            .add_child(
-                instance=Page(title="Events FR", slug="events-fr", locale=fr_locale)
-            )
-        )
-
         # Create a translation alias: same translation_key, different locale
-        translation_alias = event_page.create_alias(
-            parent=fr_events_parent,
-            update_locale=fr_locale,
-            reset_translation_key=False,
+        translation_alias = event_page.copy_for_translation(
+            locale=fr_locale,
+            alias=True,
+            copy_parents=True,
         )
         self.assertEqual(translation_alias.slug, "christmas")
 
         # Create a sibling alias of the translation alias
         alias_of_translation_alias = translation_alias.create_alias(
-            parent=fr_events_parent,
+            parent=translation_alias.get_parent(),
             update_locale=fr_locale,
             update_slug="merry-christmas",
         )
@@ -3143,6 +3133,39 @@ class TestUpdateAliases(TestCase):
         # The alias of the translation alias should NOT have its slug updated, since it has a custom slug
         self.assertEqual(alias_of_translation_alias.slug, "merry-christmas")
 
+    def test_update_aliases_uses_different_slug_if_preexisting(self):
+        event_page = EventPage.objects.get(url_path="/home/events/christmas/")
+        fr_locale = Locale.objects.create(language_code="fr")
+        # Create a translation alias: same translation_key, different locale
+        translation_alias = event_page.copy_for_translation(
+            locale=fr_locale,
+            alias=True,
+            copy_parents=True,
+        )
+
+        # Create a sibling alias of the translation alias
+        alias_of_translation_alias = translation_alias.create_alias(
+            parent=translation_alias.get_parent(),
+            update_locale=fr_locale,
+            update_slug="merry-christmas",
+        )
+
+        # Change the original page's slug to be the same as the sibling alias
+        # of the translation alias so that there is a potential clash
+        event_page.slug = "merry-christmas"
+        event_page.save()
+
+        event_page.update_aliases()
+
+        translation_alias.refresh_from_db()
+        alias_of_translation_alias.refresh_from_db()
+
+        # The translation alias should have its slug updated to "merry-christmas-1" since "merry-christmas" is taken by the sibling alias
+        self.assertEqual(translation_alias.slug, "merry-christmas-1")
+
+        # The original page and the sibling alias should keep their slugs
+        self.assertEqual(event_page.slug, "merry-christmas")
+        self.assertEqual(alias_of_translation_alias.slug, "merry-christmas")
 
 class TestCopyForTranslation(TestCase):
     fixtures = ["test.json"]


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #7168, which is also referenced in #14102.

### Description

Previously, the `update_aliases()` method would always ensure that the slug of the alias remains unchanged (for context, this method is called by `_after_publish()`).

This meant that if a translation in the form of a page alias existed, and you modified the slug of the original page, the alias would retain the original slug. However, currently it is impossible to modify an alias' slug.

As described in the issues linked above (#7168, #14102) the expectation is that the translations are kept "in sync", meaning that all content is kept the same, including the slug.

This change adds a condition checking if the alias is a translation (i.e. its translation key matches the key assigned to the original page). If it is a translation, the slug remains updated; if not, the slug is reverted to the previous value (original behaviour).

Note that it is possible to create an alias of an alias - specifically, you can create an alias of a translation, which is an alias. In this case, such alias will keep its slug. This change will only affect translation aliases created manually (by clicking on "Translate"), or automatically when `WAGTAILSIMPLETRANSLATION_SYNC_PAGE_TREE` is set to true.


### AI usage

AI was used for code reviewing purposes. AI was instructed to review changes and provide feedback.
