### PR TITLE
Add w-block- CSS class prefix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -88,6 +88,7 @@ Changelog
  * Maintenance: Upgrade BeautifulSoup dependency to >=4.13.3 (Matt Westcott)
  * Maintenance: Make sphinx_llms.txt extension optional when building docs (Sage Abdullah)
  * Maintenance: Refactor handling of invalid form submissions in choosers (Sage Abdullah)
+ * Maintenance: Switch StreamField block rendering to use `w-block-` prefixes for block type class names (Kalash Kumari Thakur)
 
 
 7.3.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -140,6 +140,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Upgrade BeautifulSoup dependency to >=4.13.3 (Matt Westcott)
  * Make sphinx_llms.txt extension optional when building docs (Sage Abdullah)
  * Refactor handling of invalid form submissions in choosers (Sage Abdullah)
+ * Switch StreamField block rendering to use `w-block-` prefixes for block type class names (Kalash Kumari Thakur)
 
 
 ## Upgrade considerations - changes affecting all projects

--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -63,7 +63,7 @@ StreamField provides an HTML representation for the stream content as a whole, a
 {% include_block page.body %}
 ```
 
-In the default rendering, each block of the stream is wrapped in a `<div class="block-my_block_name">` element (where `my_block_name` is the block name given in the StreamField definition). If you wish to provide your own HTML markup, you can instead iterate over the field's value, and invoke `{% include_block %}` on each block in turn:
+In the default rendering, each block of the stream is wrapped in a `<div class="w-block-my_block_name">` element (where `my_block_name` is the block name given in the StreamField definition). For backwards compatibility, the unprefixed class `block-my_block_name` is also added. If you wish to provide your own HTML markup, you can instead iterate over the field's value, and invoke `{% include_block %}` on each block in turn:
 
 ```html+django
 {% load wagtailcore_tags %}
@@ -89,7 +89,7 @@ For more control over the rendering of specific block types, each block object p
         {% if block.block_type == 'heading' %}
             <h1>{{ block.value }}</h1>
         {% else %}
-            <section class="block-{{ block.block_type }}">
+            <section class="w-block-{{ block.block_type }}">
                 {% include_block block %}
             </section>
         {% endif %}

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -392,7 +392,7 @@ class BaseStreamBlock(Block):
     def render_basic(self, value, context=None):
         return format_html_join(
             "\n",
-            '<div class="block-{1}">{0}</div>',
+            '<div class="w-block-{1} block-{1}">{0}</div>',
             [(child.render(context=context), child.block_type) for child in value],
         )
 

--- a/wagtail/templates/wagtailcore/shared/block_preview.html
+++ b/wagtail/templates/wagtailcore/shared/block_preview.html
@@ -22,9 +22,10 @@
                         StreamBlock renders each child block in a `div` wrapper
                         like the following. Since we are rendering the block
                         directly (without a StreamBlock), add the div wrapper
-                        here in case the styles rely on the `block-` CSS class.
+                        here in case the styles rely on the `w-block-` or
+                        `block-` CSS classes.
                     {% endcomment %}
-                    <div class="block-{{ block_def.name }}">
+                    <div class="w-block-{{ block_def.name }} block-{{ block_def.name }}">
                         {% include_block bound_block %}
                     </div>
                 {% endblock %}

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -4305,11 +4305,15 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
             ]
         )
 
-        self.assertIn('<div class="block-heading">My title</div>', html)
+        self.assertIn('<div class="w-block-heading block-heading">My title</div>', html)
         self.assertIn(
-            '<div class="block-paragraph">My <i>first</i> paragraph</div>', html
+            '<div class="w-block-paragraph block-paragraph">My <i>first</i> paragraph</div>',
+            html,
         )
-        self.assertIn('<div class="block-paragraph">My second paragraph</div>', html)
+        self.assertIn(
+            '<div class="w-block-paragraph block-paragraph">My second paragraph</div>',
+            html,
+        )
 
     def test_render_unknown_type(self):
         # This can happen if a developer removes a type from their StreamBlock
@@ -4327,7 +4331,10 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         )
         self.assertNotIn("foo", html)
         self.assertNotIn("Hello", html)
-        self.assertIn('<div class="block-paragraph">My first paragraph</div>', html)
+        self.assertIn(
+            '<div class="w-block-paragraph block-paragraph">My first paragraph</div>',
+            html,
+        )
 
     def test_render_calls_block_render_on_children(self):
         """
@@ -4345,12 +4352,16 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         )
         value = block.to_python([{"type": "heading", "value": "Hello"}])
         html = block.render(value)
-        self.assertIn('<div class="block-heading"><h1>Hello</h1></div>', html)
+        self.assertIn(
+            '<div class="w-block-heading block-heading"><h1>Hello</h1></div>', html
+        )
 
         # calling render_as_block() on value (a StreamValue instance)
         # should be equivalent to block.render(value)
         html = value.render_as_block()
-        self.assertIn('<div class="block-heading"><h1>Hello</h1></div>', html)
+        self.assertIn(
+            '<div class="w-block-heading block-heading"><h1>Hello</h1></div>', html
+        )
 
     def test_render_passes_context_to_children(self):
         block = blocks.StreamBlock(
@@ -4370,7 +4381,8 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
             },
         )
         self.assertIn(
-            '<div class="block-heading"><h1 lang="fr">Bonjour</h1></div>', html
+            '<div class="w-block-heading block-heading"><h1 lang="fr">Bonjour</h1></div>',
+            html,
         )
 
         # calling render_as_block(context=foo) on value (a StreamValue instance)
@@ -4381,7 +4393,8 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
             }
         )
         self.assertIn(
-            '<div class="block-heading"><h1 lang="fr">Bonjour</h1></div>', html
+            '<div class="w-block-heading block-heading"><h1 lang="fr">Bonjour</h1></div>',
+            html,
         )
 
     def test_render_on_stream_child_uses_child_template(self):

--- a/wagtail/tests/test_streamfield.py
+++ b/wagtail/tests/test_streamfield.py
@@ -369,10 +369,10 @@ class TestStreamFieldRenderingBase(TestCase):
         img_tag = self.image.get_rendition("original").img_tag()
         self.expected = "".join(
             [
-                '<div class="block-rich_text"><p>Rich text</p></div>',
-                '<div class="block-rich_text"><p>Привет, Микола</p></div>',
-                f'<div class="block-image">{img_tag}</div>',
-                '<div class="block-text">Hello, World!</div>',
+                '<div class="w-block-rich_text block-rich_text"><p>Rich text</p></div>',
+                '<div class="w-block-rich_text block-rich_text"><p>Привет, Микола</p></div>',
+                f'<div class="w-block-image block-image">{img_tag}</div>',
+                '<div class="w-block-text block-text">Hello, World!</div>',
             ]
         )
 


### PR DESCRIPTION
**Fixes:** #14114

---

## Summary

Adds the `w-` prefix to StreamField block CSS classes to properly namespace Wagtail-generated classes and prevent collisions with project-specific CSS.

---

## Changes Made

### 1. `wagtail/blocks/stream_block.py`

* Updated `render_basic()` method
* Now renders **both**:

  * `w-block-{type}` (new standard)
  * `block-{type}` (backwards compatibility)

---

### 2. `wagtail/templates/wagtailcore/shared/block_preview.html`

* Updated template output to include both CSS classes.

---

### 3. Documentation (`docs/topics/streamfield.md`)

* Updated documentation to recommend using the new `w-block-` class.
* Added note explaining backwards compatibility.

---

### 4. Tests Updated

Updated expectations to reflect the new class naming:

* `wagtail/tests/test_streamfield.py`
* `wagtail/tests/test_blocks.py`

---

## Example Output

**Before**

```html
<div class="block-heading">Hello World</div>
```

**After**

```html
<div class="w-block-heading block-heading">Hello World</div>
```

---

## Approach

This change follows Wagtail’s standard **two-release migration policy**:

* **Release 1:**
  Add `w-block-` class while keeping `block-` class for backwards compatibility 

* **Release 2 (future):**
  Remove legacy `block-` class as a planned breaking change.

---

## Rationale

This aligns StreamField blocks with Wagtail’s existing namespacing convention, already used across the admin UI:

* `w-tabs`
* `w-flex`
* `w-block`

Namespacing avoids CSS conflicts in user projects while maintaining a smooth migration path.