### PR TITLE
Implement SEO meta description check in content checker

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Change StreamBlock options so groups are shown in declaration order of their blocks (Darshan Kerkar)
  * Add `WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS` setting to disable permission filtering on page searches (Matt Westcott)
  * Use choice label when displaying choice fields in `SnippetViewSet`/`ModelViewSet`'s `list_display` (Srishti Jaiswal)
+ * Add new content check `empty-meta-description` to validate meta description tags are not empty (Thibaud Colas)
  * Fix: Handle nested inline models when displaying object usage information (Sage Abdullah, Kacper Walęga, Tian Jie Wong)
  * Fix: Avoid duplicate `get_object()` DB query in API detail view (Siddheshwar Kadam)
  * Fix: Ensure `ImageBlock` alt text populates on choosing a new image after unchecking decorative state (Pratham Jaiswal)

--- a/client/src/includes/contentChecker.test.ts
+++ b/client/src/includes/contentChecker.test.ts
@@ -2,6 +2,7 @@ import axe, { AxeResults, Spec } from 'axe-core';
 import {
   WagtailAxeConfiguration,
   addCustomChecks,
+  checkEmptyMetaDescription,
   checkImageAltText,
   getCheckerReport,
   registerCustomCheck,
@@ -133,6 +134,27 @@ describe('checkImageAltText edge cases', () => {
   test('should not flag images with no alt attribute', () => {
     const image = document.createElement('img');
     expect(checkImageAltText(image, options)).toBe(true);
+  });
+});
+
+describe.each`
+  content        | result
+  ${'A summary'} | ${true}
+  ${'  x  '}     | ${true}
+  ${''}          | ${false}
+  ${'   '}       | ${false}
+  ${null}        | ${true}
+`('checkEmptyMetaDescription', ({ content, result }) => {
+  const expectation = result ? 'passes' : 'fails';
+  test(`content ${JSON.stringify(content)} ${expectation}`, () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('name', 'description');
+    if (content !== null) {
+      meta.setAttribute('content', content);
+    }
+    document.body.innerHTML = '';
+    document.body.appendChild(meta);
+    expect(checkEmptyMetaDescription()).toBe(result);
   });
 });
 

--- a/client/src/includes/contentChecker.ts
+++ b/client/src/includes/contentChecker.ts
@@ -96,12 +96,22 @@ export const checkImageAltText = (
 };
 
 /**
+ * Checks whether a meta description tag is present but empty.
+ */
+export const checkEmptyMetaDescription = () => {
+  const elt = document.querySelector<HTMLMetaElement>(
+    'meta[name="description"][content]',
+  );
+  return !elt || elt.content.trim().length > 0;
+};
+
+/**
  * Defines custom Axe rules, mapping each check to its corresponding JavaScript function.
  * This object holds the custom checks that will be added to the Axe configuration.
  */
 export const customChecks = {
   'check-image-alt-text': checkImageAltText,
-  // Add other custom checks here
+  'check-empty-meta-description': checkEmptyMetaDescription,
 };
 
 /**

--- a/docs/advanced_topics/accessibility_considerations.md
+++ b/docs/advanced_topics/accessibility_considerations.md
@@ -124,7 +124,7 @@ Wagtail includes an content checker built into the [user bar](wagtailuserbar_tag
 
 The checker is based on the [Axe](https://github.com/dequelabs/axe-core) testing engine and scans the loaded page for errors.
 
-By default, the checker includes the following rules to find common accessibility issues in authored content:
+By default, the checker includes the following rules to find common issues in authored content:
 
 -   `button-name`: `<button>` elements must always have a text label.
 -   `empty-heading`: This rule checks for headings with no text content. Empty headings are confusing to screen readers users and should be avoided.
@@ -135,6 +135,7 @@ By default, the checker includes the following rules to find common accessibilit
 -   `link-name`: `<a>` link elements must always have a text label.
 -   `p-as-heading`: This rule checks for paragraphs that are styled as headings. Paragraphs should not be styled as headings, as they don’t help users who rely on headings to navigate content.
 -   `alt-text-quality`: A custom rule ensures that image alt texts don't contain anti-patterns like file extensions and underscores.
+-   `empty-meta-description`: An SEO-focused rule to make sure meta description tags always contain content when present.
 
 To customize how the checker is run (such as what rules to test), you can define a custom subclass of {class}`~wagtail.admin.userbar.ContentCheckerItem` and override the attributes to your liking. Then, swap the instance of the default `ContentCheckerItem` with an instance of your custom class via the [`construct_wagtail_userbar`](construct_wagtail_userbar) hook.
 

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -55,6 +55,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Change StreamBlock options so groups are shown in declaration order of their blocks (Darshan Kerkar)
  * Add [](wagtailadmin_page_search_filter_by_permissions) setting to disable permission filtering on page searches (Matt Westcott)
  * Use choice label when displaying choice fields in `SnippetViewSet`/`ModelViewSet`'s `list_display` (Srishti Jaiswal)
+ * Add new content check `empty-meta-description` to validate meta description tags are not empty (Thibaud Colas)
 
 ### Bug fixes
 

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -303,6 +303,10 @@ class TestContentCheckerConfig(WagtailTestUtils, TestCase):
             config["messages"]["empty-heading"]["help_text"],
             "Use meaningful text for screen reader users",
         )
+        self.assertEqual(
+            config["messages"]["empty-meta-description"]["error_name"],
+            "Meta description is empty",
+        )
 
     def test_custom_message(self):
         class CustomMessageContentCheckerItem(ContentCheckerItem):
@@ -492,6 +496,14 @@ class TestContentCheckerConfig(WagtailTestUtils, TestCase):
                             "selector": "img[alt]",
                             "tags": ["best-practice"],
                             "any": ["check-image-alt-text"],
+                            "enabled": True,
+                        },
+                        {
+                            "id": "empty-meta-description",
+                            "impact": "moderate",
+                            "selector": "h1",
+                            "tags": ["seo"],
+                            "any": ["check-empty-meta-description"],
                             "enabled": True,
                         },
                         {

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -64,6 +64,7 @@ class ContentCheckerItem(BaseItem):
         "link-name",
         "p-as-heading",
         "alt-text-quality",
+        "empty-meta-description",
     ]
 
     #: A dictionary that maps axe-core rule IDs to a dictionary of rule options,
@@ -74,6 +75,7 @@ class ContentCheckerItem(BaseItem):
 
     #: A list to add custom Axe rules or override their properties,
     #: alongside with ``axe_custom_checks``. Includes Wagtail’s custom rules.
+    # Always set `enabled`. If omitted, defaults to True and overrides configs in `axe_run_only`.
     #: For more details, see `Axe documentation <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure>`_.
     axe_custom_rules = [
         {
@@ -82,7 +84,16 @@ class ContentCheckerItem(BaseItem):
             "selector": "img[alt]",
             "tags": ["best-practice"],
             "any": ["check-image-alt-text"],
-            # If omitted, defaults to True and overrides configs in `axe_run_only`.
+            "enabled": True,
+        },
+        {
+            "id": "empty-meta-description",
+            "impact": "moderate",
+            # Axe does not support directly targeting invisible elements.
+            # h1 will help users understand it’s a page-level problem.
+            "selector": "h1",
+            "tags": ["seo"],
+            "any": ["check-empty-meta-description"],
             "enabled": True,
         },
     ]
@@ -94,6 +105,9 @@ class ContentCheckerItem(BaseItem):
         {
             "id": "check-image-alt-text",
             "options": {"pattern": "\\.(avif|gif|jpg|jpeg|png|svg|webp)$|_"},
+        },
+        {
+            "id": "check-empty-meta-description",
         },
     ]
 
@@ -136,6 +150,10 @@ class ContentCheckerItem(BaseItem):
         "alt-text-quality": {
             "error_name": _("Image alt text has inappropriate pattern"),
             "help_text": _("Use meaningful text"),
+        },
+        "empty-meta-description": {
+            "error_name": _("Meta description is empty"),
+            "help_text": _("Add a concise description for search engines"),
         },
     }
 


### PR DESCRIPTION
Fixes #12252. This is one relatively small addition on top of #14123, implementing the new SEO-focused check

### Description

I chose to make this a smaller change than suggested initially - no option to dismiss the issues found, no cue in the UI that some checks are "SEO" and others are "accessibility". From the [2024 Lighthouse scores we collected](https://docs.google.com/spreadsheets/d/1y7hXQciMHctMpWtse7rsxU2z-ZAG4VTm3D2tyWbLsg8/edit?gid=1843994435#gid=1843994435), this is a very common issue, and should be something that’s almost always fixable on the spot.

The default element targeting in Axe doesn’t support checks running on hidden elements, regardless of whether they are within the `include` selector configuration. So the check is set to assess `h1` elements. Bit funky but I thought this would be clear enough for CMS users.

To test this, there are a lot of pages without meta description in the bakerydemo, for example Southern Cornbread: http://localhost:8000/admin/pages/82/edit/

### AI usage

Cursor-generated first draft with all boilerplate, manually tweaked and reviewed.