### PR TITLE
Allow custom page listings to be used as content type usage view

### DIFF
--- a/docs/advanced_topics/customization/custom_page_listings.md
+++ b/docs/advanced_topics/customization/custom_page_listings.md
@@ -2,9 +2,9 @@
 
 # Customizing page listings
 
-(custom_page_explorer_listings)=
+(custom_default_page_listings)=
 
-## Customizing the page explorer
+## Customizing the default page listings
 
 ```{versionadded} 7.4
 The ability to customize the page explorer listing was added.
@@ -87,15 +87,17 @@ def register_blog_page_viewset():
     return blog_page_viewset
 ```
 
-Various other options are available for customizing the page explorer listing, such as the `list_per_page` attribute to control how many items are shown per page, and the `ordering` attribute to control the default ordering of items in the listing. See the documentation for {class}`~wagtail.admin.viewsets.pages.PageViewSet` for more details.
+Normally, editors navigate through the Wagtail admin interface by following the structure of the page tree. However, this can make it slow to locate a specific page for editing, especially on large sites where pages are organised into a deep hierarchy.
+
+By default, Wagtail also provides a flat listing for each page type that can be accessed from the page types usage report. If you have registered a custom `PageViewSet` to customize the page explorer listing for a specific page type (as described in the above section), then all customizations you have made will also be applied to the flat listing for that page type.
+
+Various other options are available for customizing the page listings, such as the `list_per_page` attribute to control how many items are shown per page, and the `ordering` attribute to control the default ordering of items in the listing. See the documentation for {class}`~wagtail.admin.viewsets.pages.PageViewSet` for more details.
 
 (custom_flat_page_listings)=
 
-## Custom flat page listings
+## Creating custom flat page listings
 
-Normally, editors navigate through the Wagtail admin interface by following the structure of the page tree. However, this can make it slow to locate a specific page for editing, especially on large sites where pages are organised into a deep hierarchy.
-
-Custom page listings are a way to present a flat list of all pages of a given type, accessed from a menu item in the Wagtail admin menu, with the ability for editors to search and filter this list to find the pages they are interested in. To define a custom page listing, create a subclass of {class}`~wagtail.admin.viewsets.pages.PageListingViewSet` and register it using the [`register_admin_viewset`](register_admin_viewset) hook.
+In addition to the default page explorer and flat per-page-type listings, you can also create your own custom flat listings of all pages of a given type. This custom listing can be accessed from a menu item in the Wagtail admin menu, with the ability for editors to search and filter this list to find the pages they are interested in. To define a custom page listing, create a subclass of {class}`~wagtail.admin.viewsets.pages.PageListingViewSet` and register it using the [`register_admin_viewset`](register_admin_viewset) hook.
 
 For example, if your site implemented the page type `BlogPage`, you could provide a "Blog pages" listing in the Wagtail admin by adding the following definitions to a `wagtail_hooks.py` file within the app:
 

--- a/docs/advanced_topics/customization/custom_page_listings.md
+++ b/docs/advanced_topics/customization/custom_page_listings.md
@@ -23,9 +23,9 @@ from wagtail.models import Page
 
 
 class CustomPageViewSet(PageViewSet):
-    columns = PageViewSet.columns.copy()
-    # Last column before the "Explore child pages" button column
-    columns.insert(-1, Column("slug", label="Slug", sort_key="slug"))
+    columns = PageViewSet.columns.copy() + [
+        Column("slug", label="Slug", sort_key="slug"),
+    ]
 
 
 custom_page_viewset = CustomPageViewSet()
@@ -75,8 +75,9 @@ class BlogPageFilterSet(PageViewSet.filterset_class):
 class BlogPageViewSet(PageViewSet):
     model = BlogPage
     parent_models = [BlogIndexPage]
-    columns = PageViewSet.columns.copy()
-    columns.insert(-1, Column("blog_category", label="Category", sort_key="blog_category"))
+    columns = PageViewSet.columns.copy() + [
+        Column("blog_category", label="Category", sort_key="blog_category"),
+    ]
     filterset_class = BlogPageFilterSet
 
 

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -265,6 +265,7 @@ The `PageViewSet` class was added.
    .. autoattribute:: model
    .. autoattribute:: parent_models
    .. autoattribute:: index_view_class
+   .. autoattribute:: choose_parent_view_class
    .. autoattribute:: list_display
    .. autoattribute:: columns
    .. autoattribute:: list_filter

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -35,7 +35,7 @@ This feature was developed by Sage Abdullah. We would like to thank Personalkoll
 
 ### Customizable page explorer
 
-The page explorer can now be customized for each page type using the {class}`~wagtail.admin.viewsets.pages.PageViewSet`. This allows you to add custom columns, filters, and more based on the parent page. For more details, refer to [](custom_page_explorer_listings).
+The page explorer can now be customized for each page type using the {class}`~wagtail.admin.viewsets.pages.PageViewSet`. This allows you to add custom columns, filters, and more based on the parent page. The same customizations can also be applied to the flat per-page-type listings. For more details, refer to [](custom_page_listings).
 
 This feature was developed by Sage Abdullah.
 

--- a/wagtail/admin/tests/pages/test_content_type_use_view.py
+++ b/wagtail/admin/tests/pages/test_content_type_use_view.py
@@ -1,8 +1,12 @@
+import datetime
+from io import BytesIO
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.http import urlencode
+from openpyxl import load_workbook
 
 from wagtail.models import GroupPagePermission, Page
 from wagtail.test.testapp.models import EventPage
@@ -14,12 +18,13 @@ class TestContentTypeUse(WagtailTestUtils, TestCase):
 
     def setUp(self):
         self.user = self.login()
+        self.url = reverse("wagtailadmin_pages:type_use", args=("tests", "eventpage"))
+        self.results_url = reverse(
+            "wagtailadmin_pages:type_use_results", args=("tests", "eventpage")
+        )
         self.christmas_page = EventPage.objects.get(title="Christmas")
 
     def test_with_no_permission(self):
-        request_url = reverse(
-            "wagtailadmin_pages:type_use", args=("tests", "eventpage")
-        )
         group = Group.objects.create(name="test group")
         self.user.is_superuser = False
         self.user.save()
@@ -31,14 +36,11 @@ class TestContentTypeUse(WagtailTestUtils, TestCase):
         )
         # No GroupPagePermission created
 
-        response = self.client.get(request_url)
+        response = self.client.get(self.url)
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse("wagtailadmin_home"))
 
     def test_with_minimal_permissions(self):
-        request_url = reverse(
-            "wagtailadmin_pages:type_use", args=("tests", "eventpage")
-        )
         group = Group.objects.create(name="test group")
         self.user.is_superuser = False
         self.user.save()
@@ -54,51 +56,106 @@ class TestContentTypeUse(WagtailTestUtils, TestCase):
             permission_type="change",
         )
 
-        response = self.client.get(request_url)
+        response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
     def test_content_type_use(self):
-        # Get use of event page
-        request_url = reverse(
-            "wagtailadmin_pages:type_use", args=("tests", "eventpage")
-        )
-        response = self.client.get(request_url)
+        response = self.client.get(self.url)
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailadmin/generic/listing.html")
-        self.assertTemplateUsed(response, "wagtailadmin/generic/listing_results.html")
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index_results.html")
         self.assertContains(response, "Christmas")
 
         # Links to 'delete' etc should include a 'next' URL parameter pointing back here
         delete_url = (
             reverse("wagtailadmin_pages:delete", args=(self.christmas_page.id,))
             + "?"
-            + urlencode({"next": request_url})
+            + urlencode({"next": self.url})
         )
         self.assertContains(response, delete_url)
         self.assertContains(response, "data-bulk-action-select-all-checkbox")
 
         with self.assertNumQueries(33):
-            self.client.get(request_url)
+            self.client.get(self.url)
+
+        soup = self.get_soup(response.content)
+        table = soup.select_one("main table")
+        for dropdown in table.select("[data-controller='w-dropdown']"):
+            dropdown.extract()
+        trs = table.select("tbody tr")
+        tds = [
+            [td.get_text(strip=True, separator=" | ") for td in tr.select("td")]
+            for tr in trs
+        ]
+        self.assertEqual(
+            tds,
+            [
+                [
+                    "",
+                    "Christmas",
+                    "Events",
+                    "",
+                    "Current page status: | live",
+                    "Public",
+                ],
+                [
+                    "",
+                    "Saint Patrick (single event)",
+                    "Events",
+                    "",
+                    "Current page status: | live",
+                    "Private",
+                ],
+                [
+                    "",
+                    "Ameristralia Day",
+                    "Events",
+                    "",
+                    "Current page status: | live",
+                    "Public",
+                ],
+                [
+                    "",
+                    "Someone Else's Event",
+                    "Events",
+                    "",
+                    "Current page status: | draft",
+                    "Private",
+                ],
+                [
+                    "",
+                    "Steal underpants",
+                    "Secret plans (simple page)",
+                    "",
+                    "Current page status: | live",
+                    "Private",
+                ],
+                [
+                    "",
+                    "Tentative Unpublished Event",
+                    "Events",
+                    "",
+                    "Current page status: | draft",
+                    "Public",
+                ],
+            ],
+        )
 
     def test_content_type_use_results(self):
         # Get the results view of event page use, with search and filter
         ameristralia_page = EventPage.objects.get(title="Ameristralia Day")
         user = get_user_model().objects.get(email="eventmoderator@example.com")
-        request_url = reverse(
-            "wagtailadmin_pages:type_use_results",
-            args=("tests", "eventpage"),
-        )
         response = self.client.get(
-            request_url,
+            self.results_url,
             data={"q": "Ameristralia", "owner": user.pk},
         )
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateNotUsed(response, "wagtailadmin/generic/listing.html")
-        self.assertTemplateUsed(response, "wagtailadmin/generic/listing_results.html")
+        self.assertTemplateNotUsed(response, "wagtailadmin/pages/index.html")
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index_results.html")
         self.assertContains(response, "Ameristralia Day")
 
         # Links to 'delete' etc should include a 'next' URL parameter pointing back
@@ -170,4 +227,232 @@ class TestContentTypeUse(WagtailTestUtils, TestCase):
         page_ids = [result.pk for result in response.context["pages"]]
         self.assertCountEqual(
             page_ids, [EventPage.objects.get(title="Christmas").pk, independence_day.pk]
+        )
+
+    def test_non_page_type(self):
+        cases = [
+            ("tests", "advert"),  # Not a page model
+            ("tests", "modeldoesnotexist"),  # Non-existent model
+        ]
+        for app_label, model_name in cases:
+            with self.subTest(app_label=app_label, model_name=model_name):
+                request_url = reverse(
+                    "wagtailadmin_pages:type_use",
+                    args=(app_label, model_name),
+                )
+                response = self.client.get(request_url)
+                self.assertEqual(response.status_code, 404)
+
+    def test_order_by_audience(self):
+        response = self.client.get(self.url, {"ordering": "audience"})
+        self.assertEqual(response.status_code, 200)
+        pages = response.context["object_list"]
+        self.assertEqual(
+            [page.audience for page in pages],
+            ["private", "private", "private", "public", "public", "public"],
+        )
+
+    def test_filter(self):
+        response = self.client.get(self.url, {"audience": "private"})
+        self.assertEqual(response.status_code, 200)
+        pages = response.context["object_list"]
+        self.assertEqual(
+            [page.audience for page in pages],
+            ["private", "private", "private"],
+        )
+        soup = self.get_soup(response.content)
+        title_th = soup.select_one("main table th.title")
+        self.assertIsNotNone(title_th)
+        # Not the explorable view, so no link to search the whole tree as it's
+        # already querying the whole tree
+        search_whole_tree_url = f"{self.url}?audience=private&search_all=1"
+        search_whole_tree_link = title_th.select_one(
+            f'a[href="{search_whole_tree_url}"]'
+        )
+        self.assertIsNone(search_whole_tree_link)
+
+    def test_filter_results(self):
+        response = self.client.get(self.results_url, {"audience": "private"})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index_results.html")
+        pages = response.context["object_list"]
+        self.assertEqual(
+            [page.audience for page in pages],
+            ["private", "private", "private"],
+        )
+        soup = self.get_soup(response.content)
+        header_buttons_fragment = soup.select_one(
+            'template[data-controller="w-teleport"]'
+            '[data-w-teleport-target-value="#w-slim-header-buttons"]'
+            '[data-w-teleport-mode-value="innerHTML"]'
+        )
+        self.assertIsNotNone(header_buttons_fragment)
+        buttons = header_buttons_fragment.select('[data-w-dropdown-target="content"] a')
+        # Check that download links preserve the current filters, and buttons
+        # from the register_page_header_buttons hook are not shown as this is not
+        # the explorable index view so there's no parent page to associate with
+        self.assertEqual(
+            {
+                f"{self.results_url}?audience=private&export=xlsx",
+                f"{self.results_url}?audience=private&export=csv",
+            },
+            {btn["href"] for btn in buttons},
+        )
+        self.assertEqual(len(buttons), 2)
+        self.assertEqual(
+            [button.text.strip() for button in buttons],
+            ["Download XLSX", "Download CSV"],
+        )
+
+    def test_search_filter(self):
+        response = self.client.get(self.url, {"q": "event", "audience": "private"})
+        self.assertEqual(response.status_code, 200)
+        pages = response.context["object_list"]
+        self.assertEqual({page.title for page in pages}, {"Someone Else's Event"})
+        self.assertEqual([page.audience for page in pages], ["private"])
+        soup = self.get_soup(response.content)
+        title_th = soup.select_one("main table th.title")
+        self.assertIsNotNone(title_th)
+        search_whole_tree_url = f"{self.url}?q=event&audience=private&search_all=1"
+        search_whole_tree_link = title_th.select_one(
+            f'a[href="{search_whole_tree_url}"]'
+        )
+        self.assertIsNone(search_whole_tree_link)
+
+    def test_default_order_by_date_from(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        pages = response.context["object_list"]
+        self.assertEqual(
+            [str(page.date_from) for page in pages],
+            [
+                "2014-12-25",
+                "2014-12-25",
+                "2015-04-22",
+                "2015-07-04",
+                "2015-07-04",
+                "2015-07-04",
+            ],
+        )
+
+    def test_render_export_buttons(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        soup = self.get_soup(response.content)
+        dropdown = soup.select_one(
+            "#w-slim-header-buttons [data-controller='w-dropdown']"
+        )
+        self.assertIsNotNone(dropdown)
+        expected = [
+            (f"{self.url}?export=csv", "Download CSV"),
+            (f"{self.url}?export=xlsx", "Download XLSX"),
+        ]
+        for url, label in expected:
+            button = dropdown.select_one(f'a[href="{url}"]')
+            self.assertIsNotNone(button)
+            self.assertEqual(button.get_text(strip=True), label)
+
+    def test_csv_export(self):
+        cases = [
+            [
+                {"export": "csv", "ordering": "title"},
+                [
+                    "Pk,Title,Audience,Start date",
+                    "9,Ameristralia Day,public,2015-04-22",
+                    "4,Christmas,public,2014-12-25",
+                    "13,Saint Patrick,private,2014-12-25",
+                    "6,Someone Else's Event,private,2015-07-04",
+                    "12,Steal underpants,private,2015-07-04",
+                    "5,Tentative Unpublished Event,public,2015-07-04",
+                ],
+            ],
+            [
+                {"export": "csv", "audience": "private", "ordering": "title"},
+                [
+                    "Pk,Title,Audience,Start date",
+                    "13,Saint Patrick,private,2014-12-25",
+                    "6,Someone Else's Event,private,2015-07-04",
+                    "12,Steal underpants,private,2015-07-04",
+                ],
+            ],
+        ]
+        for params, results in cases:
+            with self.subTest(params=params):
+                response = self.client.get(self.url, params)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    response["Content-Disposition"],
+                    'attachment; filename="tests_eventpage.csv"',
+                )
+                data_lines = response.getvalue().decode().strip().split("\r\n")
+                self.assertEqual(data_lines, results)
+
+    def test_xlsx_export(self):
+        cases = [
+            [
+                {"export": "xlsx", "ordering": "title"},
+                [
+                    ["Pk", "Title", "Audience", "Start date"],
+                    [9, "Ameristralia Day", "public", datetime.date(2015, 4, 22)],
+                    [4, "Christmas", "public", datetime.date(2014, 12, 25)],
+                    [13, "Saint Patrick", "private", datetime.date(2014, 12, 25)],
+                    [6, "Someone Else's Event", "private", datetime.date(2015, 7, 4)],
+                    [12, "Steal underpants", "private", datetime.date(2015, 7, 4)],
+                    [
+                        5,
+                        "Tentative Unpublished Event",
+                        "public",
+                        datetime.date(2015, 7, 4),
+                    ],
+                ],
+            ],
+            [
+                {"export": "xlsx", "audience": "private", "ordering": "title"},
+                [
+                    ["Pk", "Title", "Audience", "Start date"],
+                    [13, "Saint Patrick", "private", datetime.date(2014, 12, 25)],
+                    [6, "Someone Else's Event", "private", datetime.date(2015, 7, 4)],
+                    [12, "Steal underpants", "private", datetime.date(2015, 7, 4)],
+                ],
+            ],
+        ]
+        for params, results in cases:
+            with self.subTest(params=params):
+                response = self.client.get(self.url, params)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    response["Content-Disposition"],
+                    'attachment; filename="tests_eventpage.xlsx"',
+                )
+                workbook_data = response.getvalue()
+                worksheet = load_workbook(filename=BytesIO(workbook_data)).active
+                data_cells = [[cell.value for cell in row] for row in worksheet.rows]
+                self.assertEqual(data_cells, results)
+
+    def test_list_per_page(self):
+        pages = [
+            EventPage(
+                title=f"Event {i}",
+                date_from=f"2015-01-{i}",
+                audience="public",
+                location="Somewhere",
+                cost=f"£{i}",
+            )
+            for i in range(1, 21)
+        ]
+        root_page = Page.objects.get(pk=2)
+        for page in pages:
+            root_page.add_child(instance=page)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["object_list"]), 10)
+        soup = self.get_soup(response.content)
+        pagination = (
+            soup.select_one("nav.pagination")
+            .get_text(strip=True, separator="|")
+            .split("|")
+        )
+        self.assertEqual(
+            pagination,
+            ["Page 1 of 3", "Previous", "1", "2", "3", "Next", "26 event pages"],
         )

--- a/wagtail/admin/tests/pages/test_content_type_use_view.py
+++ b/wagtail/admin/tests/pages/test_content_type_use_view.py
@@ -143,6 +143,16 @@ class TestContentTypeUse(WagtailTestUtils, TestCase):
             ],
         )
 
+        # Should show an add button pointing to the generic choose parent view
+        header_buttons = soup.select_one("#w-slim-header-buttons")
+        self.assertIsNotNone(header_buttons)
+        choose_parent_url = reverse(
+            "wagtailadmin_pages:choose_parent", args=("tests", "eventpage")
+        )
+        add_button = header_buttons.select_one(f'a[href="{choose_parent_url}"]')
+        self.assertIsNotNone(add_button)
+        self.assertEqual(add_button.get_text(strip=True), "Add event page")
+
     def test_content_type_use_results(self):
         # Get the results view of event page use, with search and filter
         ameristralia_page = EventPage.objects.get(title="Ameristralia Day")

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -1616,7 +1616,7 @@ class TestInWorkflowStatus(WagtailTestUtils, TestCase):
         # Warm up cache
         self.client.get(self.url)
 
-        with self.assertNumQueries(42):
+        with self.assertNumQueries(43):
             response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)

--- a/wagtail/admin/tests/pages/test_parent_page_chooser_view.py
+++ b/wagtail/admin/tests/pages/test_parent_page_chooser_view.py
@@ -17,16 +17,17 @@ class TestParentPageChooserView(AdminTemplateTestUtils, WagtailTestUtils, TestCa
         super().setUp()
         self.user = self.login()
         self.view_url = reverse("event_pages:choose_parent")
+        self.previous_breadcrumbs_items = [
+            {"url": reverse("event_pages:index"), "label": "Event pages"},
+        ]
 
     def test_get_page_parent_chooser(self):
         response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtailadmin/pages/choose_parent.html")
         self.assertBreadcrumbsItemsRendered(
-            [
-                {"url": reverse("event_pages:index"), "label": "Event pages"},
-                {"url": "", "label": "Choose parent", "sublabel": "Event page"},
-            ],
+            self.previous_breadcrumbs_items
+            + [{"url": "", "label": "Choose parent", "sublabel": "Event page"}],
             response.content,
         )
 
@@ -161,3 +162,21 @@ class TestParentPageChooserView(AdminTemplateTestUtils, WagtailTestUtils, TestCa
                 args=("tests", "eventpage", parent_page.pk),
             ),
         )
+
+
+class TestGenericParentPageChooserView(TestParentPageChooserView):
+    def setUp(self):
+        super().setUp()
+        self.view_url = reverse(
+            "wagtailadmin_pages:choose_parent",
+            args=["tests", "eventpage"],
+        )
+        self.previous_breadcrumbs_items = [
+            {
+                "url": reverse(
+                    "wagtailadmin_pages:type_use",
+                    args=("tests", "eventpage"),
+                ),
+                "label": "Event pages",
+            }
+        ]

--- a/wagtail/admin/urls/pages.py
+++ b/wagtail/admin/urls/pages.py
@@ -18,6 +18,7 @@ from wagtail.admin.views.pages import (
     usage,
     workflow,
 )
+from wagtail.admin.viewsets.pages import page_viewset_registry
 
 app_name = "wagtailadmin_pages"
 urlpatterns = [
@@ -33,12 +34,20 @@ urlpatterns = [
     ),
     path(
         "usage/<slug:content_type_app_name>/<slug:content_type_model_name>/",
-        usage.ContentTypeUseView.as_view(),
+        page_viewset_registry.as_view(
+            "content_type_use",
+            app_label_kwarg="content_type_app_name",
+            model_name_kwarg="content_type_model_name",
+        ),
         name="type_use",
     ),
     path(
         "usage/<slug:content_type_app_name>/<slug:content_type_model_name>/results/",
-        usage.ContentTypeUseView.as_view(results_only=True),
+        page_viewset_registry.as_view(
+            "content_type_use_results",
+            app_label_kwarg="content_type_app_name",
+            model_name_kwarg="content_type_model_name",
+        ),
         name="type_use_results",
     ),
     path("<int:page_id>/usage/", usage.UsageView.as_view(), name="usage"),

--- a/wagtail/admin/urls/pages.py
+++ b/wagtail/admin/urls/pages.py
@@ -42,6 +42,15 @@ urlpatterns = [
         name="type_use",
     ),
     path(
+        "create/<slug:app_label>/<slug:model_name>",
+        page_viewset_registry.as_view(
+            "choose_parent",
+            app_label_kwarg="app_label",
+            model_name_kwarg="model_name",
+        ),
+        name="choose_parent",
+    ),
+    path(
         "usage/<slug:content_type_app_name>/<slug:content_type_model_name>/results/",
         page_viewset_registry.as_view(
             "content_type_use_results",

--- a/wagtail/admin/views/pages/choose_parent.py
+++ b/wagtail/admin/views/pages/choose_parent.py
@@ -133,3 +133,23 @@ class ChooseParentView(WagtailAdminTemplateMixin, FormView):
         context["media"] = context["form"].media
         context["submit_button_label"] = self.submit_button_label
         return context
+
+
+class GenericChooseParentView(ChooseParentView):
+    index_url_name = "wagtailadmin_pages:type_use"
+
+    def dispatch(self, request, *args, **kwargs):
+        # A viewset may assign the "model" attribute to a superclass page model,
+        # so look up the most specific model class again based on the app_label
+        # and model_name in the URL kwargs.
+        self.model = ContentType.objects.get_by_natural_key(
+            self.kwargs.get("app_label"),
+            self.kwargs.get("model_name"),
+        ).model_class()
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_index_url(self):
+        return reverse(
+            self.index_url_name,
+            args=[self.kwargs.get("app_label"), self.kwargs.get("model_name")],
+        )

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -4,7 +4,7 @@ from django.db.models import F
 from django.forms import CheckboxSelectMultiple, RadioSelect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.utils.functional import cached_property, classproperty
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django_filters.filters import (
     ChoiceFilter,
@@ -331,12 +331,20 @@ class ExplorableIndexView(IndexView):
     reorder_button = None
     default_ordering = None
     base_filterset_class = GenericPageFilterSet
+    base_columns = PageListingMixin.base_columns.copy()
 
-    @classproperty
-    def base_columns(cls):
-        columns = [col for col in PageListingMixin.base_columns if col.name != "parent"]
+    @cached_property
+    def explorable_columns(self):
+        columns = [col for col in self.columns if col.name != "parent"]
         columns.append(NavigateToChildrenColumn("navigate", width="10%"))
         return columns
+
+    def get_table(self, object_list):
+        return self.table_class(
+            self.explorable_columns,
+            object_list,
+            **self.get_table_kwargs(),
+        )
 
     def get(self, request, parent_page_id=None):
         if parent_page_id:

--- a/wagtail/admin/views/pages/usage.py
+++ b/wagtail/admin/views/pages/usage.py
@@ -1,82 +1,43 @@
-from typing import Any
-
-from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
-from django.http import Http404
 from django.urls import reverse
-from django.utils.functional import cached_property, classproperty
 from django.utils.text import capfirst
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.views import generic
-from wagtail.admin.views.generic.base import BaseListingView
-from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
-from wagtail.admin.views.pages.listing import PageFilterSet, PageListingMixin
+from wagtail.admin.views.pages.listing import IndexView
 from wagtail.admin.views.pages.utils import (
     GenericPageBreadcrumbsMixin,
 )
 from wagtail.models import Page
-from wagtail.permissions import page_permission_policy
 
 
-class ContentTypeUseView(PageListingMixin, PermissionCheckedMixin, BaseListingView):
-    permission_policy = page_permission_policy
-    any_permission_required = {
-        "add",
-        "change",
-        "publish",
-        "bulk_delete",
-        "lock",
-        "unlock",
-    }
+class ContentTypeUseView(IndexView):
     index_url_name = "wagtailadmin_pages:type_use"
     index_results_url_name = "wagtailadmin_pages:type_use_results"
     page_title = _("Pages using")
     header_icon = "doc-empty-inverse"
-    paginate_by = 50
-    filterset_class = PageFilterSet
 
-    @classproperty
-    def columns(cls):
-        return [col for col in PageListingMixin.base_columns if col.name != "type"]
+    def get_table(self, object_list):
+        return self.table_class(
+            [col for col in self.columns if col.name != "type"],
+            object_list,
+            **self.get_table_kwargs(),
+        )
 
     def get(self, request, *, content_type_app_name, content_type_model_name):
-        try:
-            content_type = ContentType.objects.get_by_natural_key(
-                content_type_app_name, content_type_model_name
-            )
-        except ContentType.DoesNotExist as e:
-            raise Http404 from e
-
-        self.page_class = content_type.model_class()
-
-        # page_class must be a Page type and not some other random model
-        if not issubclass(self.page_class, Page):
-            raise Http404
-
+        # A viewset may assign the "model" attribute to a superclass page model,
+        # so look up the most specific model class again based on the app_label
+        # and model_name in the URL kwargs.
+        content_type = ContentType.objects.get_by_natural_key(
+            content_type_app_name, content_type_model_name
+        )
+        self.model = content_type.model_class()
         return super().get(request)
 
     def get_page_subtitle(self):
-        return self.page_class.get_verbose_name()
-
-    @cached_property
-    def verbose_name_plural(self):
-        return self.page_class._meta.verbose_name_plural
-
-    def get_base_queryset(self):
-        queryset = self.page_class._default_manager.all()
-        if (not self.is_searching) or getattr(
-            settings, "WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS", True
-        ):
-            queryset = queryset.filter(
-                pk__in=self.permission_policy.explorable_instances(
-                    self.request.user
-                ).values_list("pk", flat=True)
-            )
-
-        return self.annotate_queryset(queryset)
+        return self.model._meta.verbose_name
 
     def get_index_url(self):
         return reverse(
@@ -109,14 +70,9 @@ class ContentTypeUseView(PageListingMixin, PermissionCheckedMixin, BaseListingVi
             },
             {
                 "url": self.get_index_url(),
-                "label": capfirst(self.page_class._meta.verbose_name_plural),
+                "label": capfirst(self.model._meta.verbose_name_plural),
             },
         ]
-
-    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        context = super().get_context_data(**kwargs)
-        context["page_class"] = self.page_class
-        return context
 
 
 class UsageView(GenericPageBreadcrumbsMixin, generic.UsageView):

--- a/wagtail/admin/views/pages/usage.py
+++ b/wagtail/admin/views/pages/usage.py
@@ -39,6 +39,12 @@ class ContentTypeUseView(IndexView):
     def get_page_subtitle(self):
         return self.model._meta.verbose_name
 
+    def get_add_url(self):
+        return reverse(
+            "wagtailadmin_pages:choose_parent",
+            args=[self.model._meta.app_label, self.model._meta.model_name],
+        )
+
     def get_index_url(self):
         return reverse(
             self.index_url_name,

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -4,7 +4,10 @@ from django.http import Http404
 from django.urls import path
 from django.utils.functional import cached_property, classproperty
 
-from wagtail.admin.views.pages.choose_parent import ChooseParentView
+from wagtail.admin.views.pages.choose_parent import (
+    ChooseParentView,
+    GenericChooseParentView,
+)
 from wagtail.admin.views.pages.listing import (
     ExplorableIndexView,
     GenericPageFilterSet,
@@ -130,6 +133,11 @@ class PageViewSet(PageListingViewSet):
     For more information on how to use this class, see :ref:`custom_default_page_listings`.
     """
 
+    choose_parent_view_class = GenericChooseParentView
+    """
+    The view class to use for choosing the parent page when creating a new page of this page type;
+    must be a subclass of ``wagtail.admin.views.pages.choose_parent.GenericChooseParentView``.
+    """
     content_type_use_view_class = ContentTypeUseView
     """
     The view class to use for the flat per-page-type index view; must be a subclass of
@@ -146,6 +154,7 @@ class PageViewSet(PageListingViewSet):
     @cached_property
     def views(self):
         return {
+            "choose_parent": self.choose_parent_view,
             "content_type_use": self.content_type_use_view,
             "content_type_use_results": self.content_type_use_results_view,
             "index": self.index_view,

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -11,6 +11,7 @@ from wagtail.admin.views.pages.listing import (
     IndexView,
     PageFilterSet,
 )
+from wagtail.admin.views.pages.usage import ContentTypeUseView
 from wagtail.admin.viewsets.listing import ListingViewSetMixin
 from wagtail.models import Page
 from wagtail.utils.registry import ObjectTypeRegistry
@@ -126,9 +127,14 @@ class PageListingViewSet(ListingViewSetMixin, ViewSet):
 class PageViewSet(PageListingViewSet):
     """
     A viewset to define the views for pages of a specific type.
-    For more information on how to use this class, see :ref:`custom_page_explorer_listings`.
+    For more information on how to use this class, see :ref:`custom_default_page_listings`.
     """
 
+    content_type_use_view_class = ContentTypeUseView
+    """
+    The view class to use for the flat per-page-type index view; must be a subclass of
+    ``wagtail.admin.views.pages.usage.ContentTypeUseView``.
+    """
     index_view_class = ExplorableIndexView
     """
     The view class to use for the index view; must be a subclass of
@@ -140,12 +146,29 @@ class PageViewSet(PageListingViewSet):
     @cached_property
     def views(self):
         return {
+            "content_type_use": self.content_type_use_view,
+            "content_type_use_results": self.content_type_use_results_view,
             "index": self.index_view,
             "index_results": self.index_results_view,
         }
 
     def get_view_by_name(self, name):
         return self.views[name]
+
+    @cached_property
+    def content_type_use_view(self):
+        return self.construct_view(
+            self.content_type_use_view_class,
+            **self.get_index_view_kwargs(),
+        )
+
+    @cached_property
+    def content_type_use_results_view(self):
+        return self.construct_view(
+            self.content_type_use_view_class,
+            **self.get_index_view_kwargs(),
+            results_only=True,
+        )
 
     @cached_property
     def parent_models(self):
@@ -239,12 +262,25 @@ class PageViewSetRegistry(ObjectTypeRegistry):
         model = self.get_page_model_by_content_type_id(content_type_id)
         return self.get_by_parent_model(model)
 
+    def get_by_content_type_natural_key(self, app_label, model_name):
+        content_type = ContentType.objects.get_by_natural_key(app_label, model_name)
+        model = content_type.model_class() or Page
+        if not issubclass(model, Page):
+            raise Http404
+        return self.get_by_type(model)
+
     def register(self, cls, value=None, exact_class=False, parent_models=()):
         super().register(cls, value, exact_class)
         for parent_model in parent_models:
             self.values_by_parent_model[parent_model] = value
 
-    def as_view(self, view_name, parent_page_id_kwarg):
+    def as_view(
+        self,
+        view_name,
+        parent_page_id_kwarg=None,
+        app_label_kwarg=None,
+        model_name_kwarg=None,
+    ):
         """
         Create a view function that routes to the appropriate view based on the
         model of the page being accessed.
@@ -255,7 +291,14 @@ class PageViewSetRegistry(ObjectTypeRegistry):
 
         def view_router(request, *args, **kwargs):
             try:
-                viewset = self.get_by_parent_page_id(kwargs.get(parent_page_id_kwarg))
+                if parent_page_id_kwarg:
+                    viewset = self.get_by_parent_page_id(
+                        kwargs.get(parent_page_id_kwarg)
+                    )
+                elif app_label_kwarg and model_name_kwarg:
+                    viewset = self.get_by_content_type_natural_key(
+                        kwargs.get(app_label_kwarg), kwargs.get(model_name_kwarg)
+                    )
             except ObjectDoesNotExist as e:
                 # Page or ContentType not found
                 raise Http404 from e

--- a/wagtail/contrib/simple_translation/tests/test_views.py
+++ b/wagtail/contrib/simple_translation/tests/test_views.py
@@ -545,7 +545,7 @@ class TestPageListing(WagtailTestUtils, TestCase):
     def test_translate_button_displayed(self):
         url = reverse("wagtailadmin_explore", args=(self.en_homepage.pk,))
         response = self.client.get(url)
-        with self.assertNumQueries(42):
+        with self.assertNumQueries(43):
             response = self.client.get(url)
 
         soup = self.get_soup(response.content)

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -359,7 +359,7 @@ class EventPageViewSet(PageViewSet):
     parent_models = [EventIndex]
     icon = "calendar"
     list_display = PageViewSet.columns.copy()
-    list_display.insert(-1, "audience")
+    list_display.append("audience")
     list_filter = ["audience"]
     list_export = ["pk", "title", "audience", "date_from"]
     list_per_page = 10


### PR DESCRIPTION
<!-- Insert the issue number that you're fixing here, if any -->
Built on #14052.

### Description

Splitting into a separate PR as I'm not sure if this is too much magic, but I think this could be really useful...

The PageViewSet in this PR now uses the `explorable_` prefix (e.g. `explorable_index_view_class` etc.) for the explorer views customization. This allows us to reuse the non-prefixed `index_view` for flat listings, to be connected by default as the "content type usage" view. This means once you have a custom `PageViewSet`, you automatically get the explorable version, as well as the flat version (accessible from the page types usage report).

To test, after applying the bakerydemo commit in #14052, apply the following patch:

```py
diff --git a/bakerydemo/blog/views.py b/bakerydemo/blog/views.py
index 6987996..9f9cc02 100644
--- a/bakerydemo/blog/views.py
+++ b/bakerydemo/blog/views.py
@@ -16,8 +16,10 @@ class BlogPageFilterSet(PageViewSet.filterset_class):
 class BlogPageViewSet(PageViewSet):
     model = BlogPage
     icon = "comment"
-    columns = PageViewSet.columns.copy()
-    columns.insert(
+    list_display = PageViewSet.columns.copy()
+    list_display.append("date_published")
+    explorable_columns = PageViewSet.explorable_columns.copy()
+    explorable_columns.insert(
         -1,
         DateColumn(
             "date_published",
```

and then try to access the flat `BlogPage` listing via http://localhost:8000/admin/pages/usage/blog/blogpage/

I decided to only split off the `explorable_*` customization for the view class, `list_display`, and `columns`, while other customizations like the filtering, ordering, `list_per_page` etc. are shared. It's more likely that those other customizations are shared as much as possible anyway, and the reason why we have to split it for the explorer is mostly because the latter has the "explore children" column, as well as the ability to switch the bulk actions column with the reordering column.

If this is sound, I think it's worth getting this in for 7.4, so we can settle on using the `explorable_` prefix for explorer customizations when it's first introduced. Otherwise we'd have to use different namings (e.g. `content_type_use_*`) when we want to incorporate this PR, which isn't the most ergonomic...

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

Copilot for autocompletion.