### PR TITLE
Docs: explain how to override default user avatar image

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -51,6 +51,7 @@ Changelog
  * Docs: Clarify the icon template tag is only for admin views (Aditya Kammati)
  * Docs: Add documentation for generic `published` and `unpublished` signals (Kunal Hemnani)
  * Docs: Improve organization of signals reference docs (Sage Abdullah)
+ * Docs: Add documentation for overriding the default user avatar image (Aviral Sapra)
  * Maintenance: Removed support for Django 4.2
  * Maintenance: Fix LocaleController test failures caused by differing timezone representations between Node versions (Saptami, Matt Westcott)
  * Maintenance: Fix frontend coverage upload to Codecov (Sage Abdullah)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -964,6 +964,7 @@
 * James Biggs
 * Aditya Kammati
 * Kunal Hemnani
+* Aviral Sapra
 
 ## Translators
 

--- a/docs/advanced_topics/customization/admin_templates.md
+++ b/docs/advanced_topics/customization/admin_templates.md
@@ -101,6 +101,16 @@ def get_profile_avatar(user, size):
 
 Additionally, you can use the default `size` parameter that is passed in to the hook if you need to attach it to a request or do any further processing on your image.
 
+### Overriding the default user avatar image
+
+To change the default user avatar image, override `wagtailadmin/images/default-user-avatar.png` by placing your custom avatar image in a [`static` file directory](inv:django#howto/static-files/index) with higher precedence than `wagtail.admin` (see [`INSTALLED_APPS`](inv:django:std:setting#INSTALLED_APPS) in your Django settings for ordering).
+
+You can verify the override with [`findstatic`](inv:django:std:django-admin#findstatic):
+
+```
+python manage.py findstatic wagtailadmin/images/default-user-avatar.png
+```
+
 (custom_user_interface_fonts)=
 
 ## Custom user interface fonts

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -92,6 +92,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Clarify the icon template tag is only for admin views (Aditya Kammati)
  * Add documentation for generic `published` and `unpublished` signals (Kunal Hemnani)
  * Improve organization of signals reference docs (Sage Abdullah)
+ * Add documentation for overriding the default user avatar image (Aviral Sapra)
 
 ### Maintenance
 


### PR DESCRIPTION
Fixes #14122

### Description

Adds documentation explaining how to override the default user avatar image (`wagtailadmin/images/default-user-avatar.png`) via static file override.

This clarifies a specific use case that was not explicitly documented, making it easier to understand how to customize the fallback avatar when no profile avatar or Gravatar is available.

All changes were manually reviewed, verified in the local documentation build, and adjusted to match Wagtail’s documentation style and accuracy.
### AI usage
Used AI assistance to help with wording and structuring the documentation. 
