### PR TITLE
Fix live preview getting stuck when edits occur during an in-progress update

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -112,6 +112,7 @@ Changelog
  * Fix: Retain page explorer header buttons when searching or filtering (Sage Abdullah)
  * Fix: Correctly escape the `sizes` attribute in responsive image template tags (Jake Howard)
  * Fix: Add accessible label to userbar aside element for accessibility (Kalash Kumari Thakur)
+ * Fix: Ensure live preview does not get stuck when edits occur during an in-progress update (Aniket Singh)
 
 7.3.1 (03.03.2026)
 ~~~~~~~~~~~~~~~~~~

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -969,6 +969,7 @@
 * Divyansh Mishra
 * mikko2577
 * Kalash Kumari Thakur
+* Aniket Singh
 
 ## Translators
 

--- a/client/src/controllers/PreviewController.test.js
+++ b/client/src/controllers/PreviewController.test.js
@@ -1498,6 +1498,53 @@ describe('PreviewController', () => {
       });
     });
 
+    it('should continue to auto-update when changes are made during an in-progress update', async () => {
+      // Regression test for https://github.com/wagtail/wagtail/issues/14121
+      const element = document.querySelector('[data-controller="w-preview"]');
+      element.setAttribute('data-w-preview-auto-update-interval-value', '500');
+
+      const input = document.querySelector('input[name="title"');
+
+      // First change — starts the first preview update
+      input.value = 'First change';
+      fetch.mockResponseSuccessJSON(validAvailableResponse);
+
+      // w-unsaved check interval (≤500ms) + notify debounce (530ms) = 1030ms
+      await jest.advanceTimersByTimeAsync(1030);
+      expect(element.getAttribute('data-w-preview-stale-value')).toBe('true');
+      // setPreviewDataLazy debounce fires, first fetch is sent
+      await jest.advanceTimersByTimeAsync(500);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(element.getAttribute('data-w-preview-stale-value')).toBe('false');
+
+      // Second change while the first update's iframe is still loading
+      input.value = 'Second change';
+      fetch.mockResponseSuccessJSON(validAvailableResponse);
+
+      await jest.advanceTimersByTimeAsync(1030);
+      expect(element.getAttribute('data-w-preview-stale-value')).toBe('true');
+      // setPreviewDataLazy fires but setPreviewData() returns early because
+      // updatePromise is still pending (iframe not yet loaded)
+      await jest.advanceTimersByTimeAsync(500);
+      expect(global.fetch).toHaveBeenCalledTimes(1); // still only 1 fetch
+      expect(element.getAttribute('data-w-preview-stale-value')).toBe('true');
+
+      // Complete the first update; finishUpdate() now re-schedules
+      // setPreviewDataLazy() because staleValue is still true.
+      // expectIframeReloaded() resets fetch.mockClear() at the end.
+      await expectIframeReloaded();
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(element.getAttribute('data-w-preview-stale-value')).toBe('true');
+      // Should send the second update after a debounce
+      await jest.advanceTimersByTimeAsync(500);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(element.getAttribute('data-w-preview-stale-value')).toBe('false');
+
+      await expectIframeReloaded();
+      expect(element.getAttribute('data-w-preview-stale-value')).toBe('false');
+    });
+
     it('should not auto-update when auto-update interval is set to 0', async () => {
       const element = document.querySelector('[data-controller="w-preview"]');
       // The test setup sets the auto-update interval to 0 (disabled)

--- a/client/src/controllers/PreviewController.test.js
+++ b/client/src/controllers/PreviewController.test.js
@@ -1498,6 +1498,51 @@ describe('PreviewController', () => {
       });
     });
 
+    it('should continue to auto-update when changes are made during an in-progress update', async () => {
+      // Regression test for https://github.com/wagtail/wagtail/issues/14121
+      const element = document.querySelector('[data-controller="w-preview"]');
+      element.setAttribute('data-w-preview-auto-update-interval-value', '500');
+
+      const input = document.querySelector('input[name="title"');
+
+      // First change — starts the first preview update
+      input.value = 'First change';
+      fetch.mockResponseSuccessJSON(validAvailableResponse);
+
+      // w-unsaved check interval (≤500ms) + notify debounce (530ms) = 1030ms
+      await jest.advanceTimersByTimeAsync(1030);
+      expect(element.getAttribute('data-w-preview-stale-value')).toBe('true');
+      // setPreviewDataLazy debounce fires, first fetch is sent
+      await jest.advanceTimersByTimeAsync(500);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(element.getAttribute('data-w-preview-stale-value')).toBe('false');
+
+      // Second change while the first update's iframe is still loading
+      input.value = 'Second change';
+      fetch.mockResponseSuccessJSON(validAvailableResponse);
+
+      await jest.advanceTimersByTimeAsync(1030);
+      expect(element.getAttribute('data-w-preview-stale-value')).toBe('true');
+      // setPreviewDataLazy fires but setPreviewData() returns early because
+      // updatePromise is still pending (iframe not yet loaded)
+      await jest.advanceTimersByTimeAsync(500);
+      expect(global.fetch).toHaveBeenCalledTimes(1); // still only 1 fetch
+      expect(element.getAttribute('data-w-preview-stale-value')).toBe('true');
+
+      // Complete the first update; finishUpdate() now re-schedules
+      // setPreviewDataLazy() because staleValue is still true.
+      // expectIframeReloaded() resets fetch.mockClear() at the end.
+      await expectIframeReloaded();
+
+      await jest.advanceTimersByTimeAsync(500);
+      // Second fetch has now been sent (count=1, reset by expectIframeReloaded)
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(element.getAttribute('data-w-preview-stale-value')).toBe('false');
+
+      await expectIframeReloaded();
+      expect(element.getAttribute('data-w-preview-stale-value')).toBe('false');
+    });
+
     it('should not auto-update when auto-update interval is set to 0', async () => {
       const element = document.querySelector('[data-controller="w-preview"]');
       // The test setup sets the auto-update interval to 0 (disabled)

--- a/client/src/controllers/PreviewController.ts
+++ b/client/src/controllers/PreviewController.ts
@@ -587,6 +587,17 @@ export class PreviewController extends Controller<HTMLElement> {
   }
 
   /**
+   * Automatically updates the preview if it is stale and auto-update is enabled.
+   * @returns whether the data is valid
+   */
+  async autoUpdateStalePreview() {
+    if (this.ready && this.staleValue && this.shouldAutoUpdate) {
+      return this.setPreviewDataLazy();
+    }
+    return undefined;
+  }
+
+  /**
    * Marks the preview data as stale, indicating it needs an update.
    * Accepts an optional `stale` parameter to explicitly override the value.
    */
@@ -594,10 +605,8 @@ export class PreviewController extends Controller<HTMLElement> {
     this.staleValue = event?.params?.stale ?? true;
   }
 
-  staleValueChanged(newValue: boolean) {
-    if (this.ready && newValue && this.shouldAutoUpdate) {
-      this.setPreviewDataLazy();
-    }
+  staleValueChanged() {
+    this.autoUpdateStalePreview();
   }
 
   autoUpdateIntervalValueChanged(newValue?: number) {
@@ -1006,9 +1015,7 @@ export class PreviewController extends Controller<HTMLElement> {
     // If the preview data became stale while this update was in progress
     // (e.g. the user kept editing during the fetch/iframe load), schedule
     // another update now that we are free to do so.
-    if (this.staleValue && this.shouldAutoUpdate) {
-      this.setPreviewDataLazy();
-    }
+    this.autoUpdateStalePreview();
   }
 
   /**

--- a/client/src/controllers/PreviewController.ts
+++ b/client/src/controllers/PreviewController.ts
@@ -969,6 +969,13 @@ export class PreviewController extends Controller<HTMLElement> {
     this.#reloadPromiseResolve?.();
     this.reloadPromise = null;
     this.#reloadPromiseResolve = null;
+
+    // If the preview data became stale while this update was in progress
+    // (e.g. the user kept editing during the fetch/iframe load), schedule
+    // another update now that we are free to do so.
+    if (this.staleValue && this.shouldAutoUpdate) {
+      this.setPreviewDataLazy();
+    }
   }
 
   /**

--- a/client/src/controllers/PreviewController.ts
+++ b/client/src/controllers/PreviewController.ts
@@ -1002,6 +1002,13 @@ export class PreviewController extends Controller<HTMLElement> {
     this.#reloadPromiseResolve?.();
     this.reloadPromise = null;
     this.#reloadPromiseResolve = null;
+
+    // If the preview data became stale while this update was in progress
+    // (e.g. the user kept editing during the fetch/iframe load), schedule
+    // another update now that we are free to do so.
+    if (this.staleValue && this.shouldAutoUpdate) {
+      this.setPreviewDataLazy();
+    }
   }
 
   /**

--- a/docs/releases/7.3.2.md
+++ b/docs/releases/7.3.2.md
@@ -27,6 +27,7 @@ When a page is autosaved, the audit log entries created throughout the editing s
  * Retain page explorer header buttons when searching or filtering (Sage Abdullah)
  * Correctly escape the `sizes` attribute in responsive image template tags (Jake Howard)
  * Add accessible label to userbar aside element for accessibility (Kalash Kumari Thakur)
+ * Ensure live preview does not get stuck when edits occur during an in-progress update (Aniket Singh)
 
 
 ### Documentation


### PR DESCRIPTION
## Summary

Fixes #14121.

When a user keeps editing a StreamField rich text block while a preview update (fetch + iframe reload) is already in progress, the preview panel gets permanently stuck and stops auto-updating.

**Root cause:** `setPreviewData()` sets `staleValue = false` immediately when it starts. If further edits happen during the fetch/iframe load, `staleValue` is set back to `true` and `setPreviewDataLazy()` fires — but returns early because `updatePromise` is still pending. Once `finishUpdate()` eventually runs and clears `updatePromise`, `staleValue` is already `true`, so `staleValueChanged()` does not fire, and no new update is ever scheduled.

This was a regression introduced in the consolidation commit (`0cfc833981`). The old `PreviewController.hasChanges()` approach did not update `formPayload` while a fetch was pending, so the next interval correctly detected the outstanding change. The new event-driven path using `staleValue` has no equivalent re-trigger mechanism.

**Fix:** At the end of `finishUpdate()`, check if `staleValue` is still `true` (indicating changes arrived while the update was in progress) and, if so, re-schedule `setPreviewDataLazy()`.

## Changes

- [`client/src/controllers/PreviewController.ts`](client/src/controllers/PreviewController.ts) — add stale re-schedule in `finishUpdate()`
- [`client/src/controllers/PreviewController.test.js`](client/src/controllers/PreviewController.test.js) — regression test covering the exact scenario

## Test plan

- [ ] Run `npx jest PreviewController` — all 42 tests pass
- [ ] Manually reproduce: open a page with a StreamField rich text block, open the preview panel, type rapidly, confirm the preview continues to update