### PR TITLE
Fix ResourceWarning from unclosed SpooledTemporaryFile in renditions

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -9,7 +9,7 @@ import re
 import time
 from collections import OrderedDict, defaultdict, namedtuple
 from collections.abc import Iterable
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from io import BytesIO
 from tempfile import SpooledTemporaryFile
 from typing import Any
@@ -65,6 +65,41 @@ IMAGE_FORMAT_EXTENSIONS = {
     "ico": ".ico",
     "heic": ".heic",
 }
+
+
+class ClosingSpooledTemporaryFile(File):
+    """
+    A File wrapper around a SpooledTemporaryFile that ensures the underlying
+    temporary file is closed once it is no longer needed, and also when this
+    object is garbage-collected.
+
+    generate_rendition_file() writes image data into a SpooledTemporaryFile
+    and wraps it in a File for Django's storage layer. After the rendition has
+    been fully saved — including dimension fields read from the file — the
+    SpooledTemporaryFile is no longer needed. Nothing in that pipeline closes
+    it explicitly, causing a ResourceWarning under ``-X dev`` / ``-W error``.
+
+    The caller (create_rendition) must call close() on this object once
+    get_or_create() has fully completed. __del__ acts as a safety net for
+    any code path where close() is not reached (e.g. an exception mid-save).
+
+    SpooledTemporaryFile cannot be re-opened once closed, so close() must
+    only be called after Django has finished reading dimensions from the file.
+    """
+
+    def _close_spooled_file(self):
+        """Close the underlying file, tolerating double-close calls."""
+        with suppress(Exception):
+            self.file.close()
+
+    def __del__(self):
+        """
+        Safety-net finaliser: close the file if the explicit close() call was
+        never reached (e.g. an exception occurred mid-save). We suppress all
+        exceptions deliberately — raising from __del__ produces an unraisable
+        exception, which is the exact problem we are fixing.
+        """
+        self._close_spooled_file()
 
 
 class SourceImageIOError(IOError):
@@ -582,24 +617,23 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
             raise Rendition.DoesNotExist from e
 
     def create_rendition(self, filter: Filter) -> AbstractRendition:
-        """
-        Creates and returns a ``Rendition`` instance with a ``file`` field
-        value (an image) reflecting the supplied ``filter`` value and focal
-        point values from this object.
+        rendition_file = None
 
-        This method is usually called by ``Image.get_rendition()``, after first
-        checking that a suitable rendition does not already exist.
+        def get_rendition_file():
+            nonlocal rendition_file
+            rendition_file = self.generate_rendition_file(filter)
+            return rendition_file
 
-        Note: If using custom image models, an instance of the custom rendition
-        model will be returned.
-        """
-        # Because of unique constraints applied to the model, we use
-        # get_or_create() to guard against race conditions
-        rendition, created = self.renditions.get_or_create(
-            filter_spec=filter.spec,
-            focal_point_key=filter.get_cache_key(self),
-            defaults={"file": self.generate_rendition_file(filter)},
-        )
+        try:
+            rendition, created = self.renditions.get_or_create(
+                filter_spec=filter.spec,
+                focal_point_key=filter.get_cache_key(self),
+                defaults={"file": get_rendition_file},
+            )
+        finally:
+            if rendition_file is not None:
+                rendition_file._close_spooled_file()
+
         return rendition
 
     def get_renditions(self, *filters: Filter | str) -> dict[str, AbstractRendition]:
@@ -853,11 +887,8 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         start_time = time.time()
 
         try:
-            generated_image = filter.run(
-                self,
-                SpooledTemporaryFile(max_size=settings.FILE_UPLOAD_MAX_MEMORY_SIZE),
-                source=source,
-            )
+            output = SpooledTemporaryFile(max_size=settings.FILE_UPLOAD_MAX_MEMORY_SIZE)
+            generated_image = filter.run(self, output, source=source)
 
             logger.debug(
                 "Generated '%s' rendition for image %d in %.1fms",
@@ -865,7 +896,9 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
                 self.pk,
                 (time.time() - start_time) * 1000,
             )
-        except:  # noqa:B901,E722
+        except:  # noqa: B901,E722
+            with suppress(Exception):
+                output.close()
             logger.debug(
                 "Failed to generate '%s' rendition for image %d",
                 filter.spec,
@@ -891,7 +924,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         ]
         output_filename = output_filename_without_extension + "." + output_extension
 
-        return File(generated_image.f, name=output_filename)
+        return ClosingSpooledTemporaryFile(generated_image.f, name=output_filename)
 
     def is_portrait(self):
         return self.width < self.height

--- a/wagtail/images/tests/test_closing_spooled_file.py
+++ b/wagtail/images/tests/test_closing_spooled_file.py
@@ -1,0 +1,141 @@
+import gc
+import warnings
+from tempfile import SpooledTemporaryFile
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from wagtail.images.models import ClosingSpooledTemporaryFile, Filter
+
+from .utils import Image, get_test_image_file
+
+
+class ClosingSpooledTemporaryFileChunksTests(TestCase):
+    def _make_file(self, data=b"hello world"):
+        spooled = SpooledTemporaryFile()
+        spooled.write(data)
+        spooled.seek(0)
+        return ClosingSpooledTemporaryFile(spooled)
+
+    def test_chunks_yields_all_data(self):
+        f = self._make_file(b"abcde")
+        result = b"".join(f.chunks(chunk_size=2))
+        self.assertEqual(result, b"abcde")
+
+    def test_chunks_does_not_auto_close(self):
+        f = self._make_file()
+        self.assertFalse(f.file.closed)
+        list(f.chunks())
+        self.assertFalse(f.file.closed)
+
+    def test_chunks_close_is_idempotent(self):
+        f = self._make_file()
+        list(f.chunks())
+        list(f.chunks())
+
+
+class ClosingSpooledTemporaryFileReadTests(TestCase):
+    def _make_file(self, data=b"hello world"):
+        spooled = SpooledTemporaryFile()
+        spooled.write(data)
+        spooled.seek(0)
+        return ClosingSpooledTemporaryFile(spooled)
+
+    def test_read_all_does_not_auto_close(self):
+        f = self._make_file(b"data")
+        result = f.read()
+        self.assertEqual(result, b"data")
+        self.assertFalse(f.file.closed)
+
+    def test_read_in_loop_does_not_auto_close(self):
+        f = self._make_file(b"abcde")
+        chunks = []
+        while True:
+            chunk = f.read(2)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        self.assertEqual(b"".join(chunks), b"abcde")
+        self.assertFalse(f.file.closed)
+
+    def test_partial_read_does_not_close(self):
+        f = self._make_file(b"abcde")
+        chunk = f.read(3)
+        self.assertEqual(chunk, b"abc")
+        self.assertFalse(f.file.closed)
+
+
+class ClosingSpooledTemporaryFileDelTests(TestCase):
+    def test_del_closes_unconsumed_file(self):
+        spooled = SpooledTemporaryFile()
+        spooled.write(b"never read")
+        f = ClosingSpooledTemporaryFile(spooled)
+        self.assertFalse(spooled.closed)
+        del f
+        gc.collect()
+        self.assertTrue(spooled.closed)
+
+    def test_no_resource_warning_on_gc(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ResourceWarning)
+            spooled = SpooledTemporaryFile()
+            spooled.write(b"data")
+            f = ClosingSpooledTemporaryFile(spooled)
+            del f
+            gc.collect()
+
+
+class RenditionSpooledFileLeakTests(TestCase):
+    def setUp(self):
+        self.image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(colour="red"),
+        )
+
+    def test_get_rendition_no_resource_warning(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ResourceWarning)
+            self.image.get_rendition("fill-50x50")
+            gc.collect()
+
+    def test_existing_rendition_no_resource_warning(self):
+        self.image.get_rendition("fill-50x50")  # warm up — create it
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ResourceWarning)
+            self.image.get_rendition("fill-50x50")
+            gc.collect()
+
+    def test_callable_default_not_invoked_when_rendition_exists(self):
+        self.image.get_rendition("fill-50x50")
+        with patch.object(
+            type(self.image), "create_rendition", wraps=self.image.create_rendition
+        ) as mock_create:
+            self.image.get_rendition("fill-50x50")
+
+        mock_create.assert_not_called()
+
+
+class GenerateRenditionFileFailureTests(TestCase):
+    def setUp(self):
+        self.image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(colour="blue"),
+        )
+
+    def test_spooled_file_closed_on_filter_run_failure(self):
+        captured = []
+
+        def capturing_run(img, output, source=None):
+            captured.append(output)
+            raise RuntimeError("simulated filter failure")
+
+        with patch.object(Filter, "run", side_effect=capturing_run):
+            with self.assertRaises(RuntimeError):
+                self.image.generate_rendition_file(Filter(spec="fill-50x50"))
+
+        self.assertEqual(len(captured), 1)
+        self.assertTrue(
+            captured[0].closed,
+            "SpooledTemporaryFile must be closed after filter.run() raises",
+        )


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #14055 


### Description

<!-- Please describe the problem you're fixing. -->
Running tests with python -X dev -W error raises a ResourceWarning about an unclosed file, which under strict test configurations surfaces as pytest.PytestUnraisableExceptionWarning.
The root cause is generate_rendition_file() creating a SpooledTemporaryFile, writing image data into it, and returning it wrapped in a File — but nothing ever closing it afterwards. Three independent leak paths existed:

Normal path — after storage.save() and update_dimension_fields() both complete, the SpooledTemporaryFile is simply never closed.
Existing-rendition / race-condition path — Python evaluates function arguments eagerly, so defaults={"file": self.generate_rendition_file(filter)} created and leaked a SpooledTemporaryFile even when get_or_create() found an existing rendition and never touched defaults.
filter.run() failure path — if filter.run() raised, the SpooledTemporaryFile was created but no wrapper existed yet to close it.

Changes:

Added ClosingSpooledTemporaryFile(File), a thin wrapper with an explicit _close_spooled_file() method and a __del__ safety net for exception paths.
Rewrote create_rendition() to pass generate_rendition_file as a callable via a nested function, so it is only invoked when Django actually inserts a new row. A try/finally block closes the file after get_or_create() fully completes (i.e. after both storage write and dimension read are done).
Added explicit output.close() in generate_rendition_file()'s except block to handle the filter.run() failure path.

Note: closing during chunks() or read() was intentionally avoided — Django reads image dimensions from the file immediately after storage.save() completes, so closing there breaks update_dimension_fields().
Tests added in wagtail/images/tests/test_closing_spooled_file.py covering all three leak paths and the ClosingSpooledTemporaryFile class behaviour.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None