### PR TITLE
Use format_html to replace legacy HTML string concat in photo type oembeds

### DIFF
--- a/wagtail/embeds/finders/instagram.py
+++ b/wagtail/embeds/finders/instagram.py
@@ -4,6 +4,8 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request
 
+from django.utils.html import format_html
+
 from wagtail.embeds.exceptions import EmbedException, EmbedNotFoundException
 
 from .oembed import OEmbedFinder
@@ -69,7 +71,7 @@ class InstagramOEmbedFinder(OEmbedFinder):
 
         # Convert photos into HTML
         if oembed["type"] == "photo":
-            html = '<img src="{}" alt="">'.format(oembed["url"])
+            html = format_html('<img src="{}" alt="">', oembed["url"])
         else:
             html = oembed.get("html")
 

--- a/wagtail/embeds/finders/oembed.py
+++ b/wagtail/embeds/finders/oembed.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 import requests
 from django.utils import timezone
+from django.utils.html import format_html
 
 from wagtail.embeds.exceptions import EmbedNotFoundException
 from wagtail.embeds.oembed_providers import all_providers
@@ -71,7 +72,7 @@ class OEmbedFinder(EmbedFinder):
 
         # Convert photos into HTML
         if oembed["type"] == "photo":
-            html = '<img src="{}" alt="">'.format(oembed["url"])
+            html = format_html('<img src="{}" alt="">', oembed["url"])
         else:
             html = oembed.get("html")
 

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import unittest
 import urllib.request
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from urllib.error import HTTPError, URLError
 
 import responses
@@ -520,11 +520,17 @@ class TestOembed(TestCase):
                     {"url": "https://www.youtube.com/watch/", "format": "json"}
                 ),
             ],
-            json={"type": "photo", "url": "http://www.example.com"},
+            json={
+                "type": "photo",
+                "url": "http://www.example.com/a.jpg?tag=<img>",
+            },
         )
         result = OEmbedFinder().find_embed("https://www.youtube.com/watch/")
         self.assertEqual(result["type"], "photo")
-        self.assertEqual(result["html"], '<img src="http://www.example.com" alt="">')
+        self.assertEqual(
+            result["html"],
+            '<img src="http://www.example.com/a.jpg?tag=&lt;img&gt;" alt="">',
+        )
 
     @responses.activate
     def test_oembed_return_values(self):
@@ -801,6 +807,21 @@ class TestInstagramOEmbed(TestCase):
             "https://graph.facebook.com/v11.0/instagram_oembed?url=https%3A%2F%2Finstagram.com%2Fp%2FCHeRxmnDSYe%2F&format=json",
         )
         self.assertEqual(request.get_header("Authorization"), "Bearer 123|abc")
+
+    @patch("urllib.request.urlopen")
+    def test_instagram_oembed_photo_embed(self, urlopen):
+        mock_resp = Mock()
+        mock_resp.read.return_value = (
+            b'{"type":"photo","url":"http://example.com/x.jpg?tag=<img>"}'
+        )
+        urlopen.return_value = mock_resp
+        result = InstagramOEmbedFinder(app_id="123", app_secret="abc").find_embed(
+            "https://instagram.com/p/CHeRxmnDSYe/"
+        )
+        self.assertEqual(
+            result["html"],
+            '<img src="http://example.com/x.jpg?tag=&lt;img&gt;" alt="">',
+        )
 
     def test_instagram_request_denied_401(self):
         err = HTTPError(


### PR DESCRIPTION
Those two call sites are getting flagged in security reports as stored XSS - Wagtail fetches external data and incorrectly concatenates it to HTML. This PR fixes that before the content is saved.

We don’t think this is worth treating as a security vulnerability, retrieving HTML from oEmbed providers is how those integrations are designed to start with. If an oEmbed provider was compromised / MitMed, it could just return a crafted `html` and not use `type: photo`. The changed code path removes an XSS sink but there is an even bigger one right next to it by design. Thank you to security researcher Rene Henningsen for bringing this to our attention!

### AI usage

Unit tests first draft done with Cursor, manually reviewed and cleaned up
