### PR TITLE
Fix help text rendering position in FieldRowPanel

### DIFF
--- a/client/scss/components/forms/_field-row.scss
+++ b/client/scss/components/forms/_field-row.scss
@@ -24,6 +24,17 @@
     margin-top: 0;
   }
 
+  // Ensure help text renders below the input, not above it,
+  // so that inputs in a row stay vertically aligned.
+  .w-field {
+    display: flex;
+    flex-direction: column;
+
+    .w-field__help {
+      order: 1;
+    }
+  }
+
   // Support explicit sizing of child columns.
   // This isn’t equivalent to 12-column grid – instead, there will be as many columns as calculated from usage of those classes.
   // For example, a `<div class="col6"/><div class="col3"/>` will generate a 9-column grid, with one item taking two thirds of the space.


### PR DESCRIPTION
Fixes #10554.

when a field inside `FieldRowPanel` has `help_text`, the help text was showing up above the input instead of below it. this happened because the template renders the help block before the input block in the DOM, and theres no css reordering happening inside row panels.

fixed it by making `.w-field` inside `.w-field-row` a flex column and setting `order: 1` on `.w-field__help` so it visually moves below the input. no DOM changes, scoped only to row panels so regular fields arent affected.

tested with CharField, IntegerField, and fields with/without help_text — all render correctly now.