### PR TITLE
Add setting to disable permission filtering on page searches

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -342,6 +342,14 @@ WAGTAILADMIN_UNSAFE_PAGE_DELETION_LIMIT = 20
 
 This setting enables an additional confirmation step when deleting a page with a large number of child pages. If the number of pages is greater than or equal to this limit (10 by default), the user must enter the site name (as defined by `WAGTAIL_SITE_NAME`) to proceed.
 
+### `WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS`
+
+```python
+WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS = False
+```
+
+If false, searching for pages within the Wagtail admin interface will skip the usual permission filter for non-superusers and show all results over the entire page tree, rather than just pages the user has permission to edit. This is a workaround for very large sites using external search backends such as Elasticsearch, which cannot apply permission checks efficiently.
+
 (wagtailimages_all_settings)=
 
 ## Images

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -350,6 +350,10 @@ WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS = False
 
 If false, searching for pages within the Wagtail admin interface will skip the usual permission filter for non-superusers and show all results over the entire page tree, rather than just pages the user has permission to edit. This is a workaround for very large sites using external search backends such as Elasticsearch, which cannot apply permission checks efficiently.
 
+```{warning}
+Disabling this permission filter may expose information that would not otherwise be visible to editors. This should not be used on sites containing sensitive information that should not be accessible to all users of the Wagtail admin.
+```
+
 (wagtailimages_all_settings)=
 
 ## Images

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -354,6 +354,10 @@ If false, searching for pages within the Wagtail admin interface will skip the u
 Disabling this permission filter may expose information that would not otherwise be visible to editors. This should not be used on sites containing sensitive information that should not be accessible to all users of the Wagtail admin.
 ```
 
+```{versionadded} 7.4
+The `WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS` setting was added.
+```
+
 (wagtailimages_all_settings)=
 
 ## Images

--- a/wagtail/admin/tests/pages/test_content_type_use_view.py
+++ b/wagtail/admin/tests/pages/test_content_type_use_view.py
@@ -1,6 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.http import urlencode
 
@@ -114,3 +114,60 @@ class TestContentTypeUse(WagtailTestUtils, TestCase):
         )
         self.assertContains(response, delete_url)
         self.assertContains(response, "data-bulk-action-select-all-checkbox")
+
+    def test_search_filter_by_permission(self):
+        home = Page.objects.get(url_path="/home/")
+        independence_day = EventPage(
+            title="Christmas Island Independence Day",
+            slug="independence-day",
+            audience="public",
+            date_from="2024-12-01",
+            location="Christmas Island",
+            cost="Free",
+            live=True,
+        )
+        home.add_child(instance=independence_day)
+
+        group = Group.objects.get(name="Event editors")
+        self.user.is_superuser = False
+        self.user.save()
+        self.user.groups.add(group)
+
+        request_url = reverse(
+            "wagtailadmin_pages:type_use", args=("tests", "eventpage")
+        )
+        response = self.client.get(request_url, {"q": "Christmas"})
+        # The Event editors group should only see pages under the event index, which does not
+        # include the independence day page
+        page_ids = [result.pk for result in response.context["pages"]]
+        self.assertCountEqual(page_ids, [EventPage.objects.get(title="Christmas").pk])
+
+    @override_settings(WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS=False)
+    def test_search_filter_by_permission_disabled(self):
+        home = Page.objects.get(url_path="/home/")
+        independence_day = EventPage(
+            title="Christmas Island Independence Day",
+            slug="independence-day",
+            audience="public",
+            date_from="2024-12-01",
+            location="Christmas Island",
+            cost="Free",
+            live=True,
+        )
+        home.add_child(instance=independence_day)
+
+        group = Group.objects.get(name="Event editors")
+        self.user.is_superuser = False
+        self.user.save()
+        self.user.groups.add(group)
+
+        request_url = reverse(
+            "wagtailadmin_pages:type_use", args=("tests", "eventpage")
+        )
+        response = self.client.get(request_url, {"q": "Christmas"})
+        # With the permission filter disabled, the Event editors group should see
+        # both the Christmas page and the Christmas Island Independence Day page
+        page_ids = [result.pk for result in response.context["pages"]]
+        self.assertCountEqual(
+            page_ids, [EventPage.objects.get(title="Christmas").pk, independence_day.pk]
+        )

--- a/wagtail/admin/tests/pages/test_custom_listing.py
+++ b/wagtail/admin/tests/pages/test_custom_listing.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import Group
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from wagtail.models import Page
@@ -131,3 +132,32 @@ class TestCustomListing(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
         page_ids = [result.pk for result in response.context["pages"]]
         self.assertCountEqual(page_ids, [EventPage.objects.get(title="Christmas").pk])
+
+    @override_settings(WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS=False)
+    def test_search_disable_filter_by_permission(self):
+        home = Page.objects.get(url_path="/home/")
+        independence_day = EventPage(
+            title="Christmas Island Independence Day",
+            slug="independence-day",
+            audience="public",
+            date_from="2024-12-01",
+            location="Christmas Island",
+            cost="Free",
+            live=True,
+        )
+        home.add_child(instance=independence_day)
+
+        # make self.user a member of "Event editors" instead of a superuser -
+        # this group has access to the "Christmas" page but not the "Christmas Island Independence Day" page
+        # (as the latter is not within the Events index)
+        self.user.is_superuser = False
+        self.user.save()
+        self.user.groups.add(Group.objects.get(name="Event editors"))
+
+        response = self.client.get("/admin/event_pages/", {"q": "Christmas"})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
+        page_ids = [result.pk for result in response.context["pages"]]
+        self.assertCountEqual(
+            page_ids, [EventPage.objects.get(title="Christmas").pk, independence_day.pk]
+        )

--- a/wagtail/admin/tests/pages/test_custom_listing.py
+++ b/wagtail/admin/tests/pages/test_custom_listing.py
@@ -1,6 +1,9 @@
+from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.urls import reverse
 
+from wagtail.models import Page
+from wagtail.test.testapp.models import EventPage
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 
@@ -81,3 +84,50 @@ class TestCustomListing(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
                 f"{filtered_url}&export=csv",
             },
         )
+
+    def test_search(self):
+        home = Page.objects.get(url_path="/home/")
+        independence_day = EventPage(
+            title="Christmas Island Independence Day",
+            slug="independence-day",
+            audience="public",
+            date_from="2024-12-01",
+            location="Christmas Island",
+            cost="Free",
+            live=True,
+        )
+        home.add_child(instance=independence_day)
+
+        response = self.client.get("/admin/event_pages/", {"q": "Christmas"})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
+        page_ids = [result.pk for result in response.context["pages"]]
+        self.assertCountEqual(
+            page_ids, [independence_day.pk, EventPage.objects.get(title="Christmas").pk]
+        )
+
+    def test_search_filter_by_permission(self):
+        home = Page.objects.get(url_path="/home/")
+        independence_day = EventPage(
+            title="Christmas Island Independence Day",
+            slug="independence-day",
+            audience="public",
+            date_from="2024-12-01",
+            location="Christmas Island",
+            cost="Free",
+            live=True,
+        )
+        home.add_child(instance=independence_day)
+
+        # make self.user a member of "Event editors" instead of a superuser -
+        # this group has access to the "Christmas" page but not the "Christmas Island Independence Day" page
+        # (as the latter is not within the Events index)
+        self.user.is_superuser = False
+        self.user.save()
+        self.user.groups.add(Group.objects.get(name="Event editors"))
+
+        response = self.client.get("/admin/event_pages/", {"q": "Christmas"})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "wagtailadmin/pages/index.html")
+        page_ids = [result.pk for result in response.context["pages"]]
+        self.assertCountEqual(page_ids, [EventPage.objects.get(title="Christmas").pk])

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -685,6 +685,43 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
             "Search in '<span class=\"w-title-ellipsis\">New page (simple page)</span>'",
         )
 
+    def test_search_whole_tree_filter_by_permissions(self):
+        # Create a page that matches the search term but that the user doesn't have permission to see
+        restricted_page = SimplePage(
+            title="Restricted old page",
+            slug="restricted-old-page",
+            content="hello",
+        )
+        self.root_page.add_child(instance=restricted_page)
+
+        old_page_editors = Group.objects.create(name="Old page editors")
+        old_page_editors.permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            )
+        )
+        GroupPagePermission.objects.create(
+            group=old_page_editors,
+            page=self.old_page,
+            permission_type="change",
+        )
+        GroupPagePermission.objects.create(
+            group=old_page_editors,
+            page=self.new_page,
+            permission_type="change",
+        )
+        self.user.is_superuser = False
+        self.user.save()
+        self.user.groups.add(old_page_editors)
+
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=(self.new_page.id,)),
+            {"q": "old", "search_all": "1"},
+        )
+        self.assertEqual(response.status_code, 200)
+        page_ids = [page.id for page in response.context["pages"]]
+        self.assertEqual(page_ids, [self.old_page.id])
+
     def test_filter_by_page_type(self):
         new_page_child = SimplePage(
             title="New page child", slug="new-page-child", content="new page child"

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -722,6 +722,44 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         page_ids = [page.id for page in response.context["pages"]]
         self.assertEqual(page_ids, [self.old_page.id])
 
+    @override_settings(WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS=False)
+    def test_search_whole_tree_disable_filter_by_permissions(self):
+        # Create a page that matches the search term but that the user doesn't have permission to see
+        restricted_page = SimplePage(
+            title="Restricted old page",
+            slug="restricted-old-page",
+            content="hello",
+        )
+        self.root_page.add_child(instance=restricted_page)
+
+        old_page_editors = Group.objects.create(name="Old page editors")
+        old_page_editors.permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            )
+        )
+        GroupPagePermission.objects.create(
+            group=old_page_editors,
+            page=self.old_page,
+            permission_type="change",
+        )
+        GroupPagePermission.objects.create(
+            group=old_page_editors,
+            page=self.new_page,
+            permission_type="change",
+        )
+        self.user.is_superuser = False
+        self.user.save()
+        self.user.groups.add(old_page_editors)
+
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=(self.new_page.id,)),
+            {"q": "old", "search_all": "1"},
+        )
+        self.assertEqual(response.status_code, 200)
+        page_ids = [page.id for page in response.context["pages"]]
+        self.assertEqual(page_ids, [self.old_page.id, restricted_page.id])
+
     def test_filter_by_page_type(self):
         new_page_child = SimplePage(
             title="New page child", slug="new-page-child", content="new page child"

--- a/wagtail/admin/tests/pages/test_page_search.py
+++ b/wagtail/admin/tests/pages/test_page_search.py
@@ -3,6 +3,7 @@ from io import StringIO
 from django.contrib.auth.models import Group, Permission
 from django.core import management
 from django.test import TransactionTestCase, tag
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.http import urlencode
 
@@ -195,6 +196,49 @@ class TestPageSearch(WagtailTestUtils, TransactionTestCase):
         response = self.get({"q": "Hello"})
         page_ids = [page.id for page in response.context["pages"]]
         self.assertCountEqual(page_ids, [visible_page.id])
+
+    @override_settings(WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS=False)
+    def test_search_disable_filter_by_permissions(self):
+        # Create one page that a user has permission to view,
+        # and one that they don't have permission to view,
+        # and confirm that only the former appears in search results
+        root_page = Page.objects.get(id=2)
+        visible_page = root_page.add_child(
+            instance=SimplePage(
+                title="Hello from Cauldron Lake",
+                slug="bright-falls",
+                content="It's not a lake, it's an ocean",
+                live=True,
+                has_unpublished_changes=False,
+            )
+        )
+        invisible_page = root_page.add_child(
+            instance=SimplePage(
+                title="Hello from Twin Peaks",
+                slug="twin-peaks",
+                content="It's not a town, it's a state of mind",
+                live=True,
+                has_unpublished_changes=False,
+            )
+        )
+
+        self.user.is_superuser = False
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            )
+        )
+        self.user.save()
+        # add user to a Cauldron Lake group with permission to view the visible page
+        cauldron_lake_group = Group.objects.create(name="Cauldron Lake")
+        cauldron_lake_group.user_set.add(self.user)
+        GroupPagePermission.objects.create(
+            page=visible_page, permission_type="change", group=cauldron_lake_group
+        )
+
+        response = self.get({"q": "Hello"})
+        page_ids = [page.id for page in response.context["pages"]]
+        self.assertCountEqual(page_ids, [visible_page.id, invisible_page.id])
 
     def test_search_order_by_title(self):
         root_page = Page.objects.get(id=2)

--- a/wagtail/admin/tests/pages/test_page_search.py
+++ b/wagtail/admin/tests/pages/test_page_search.py
@@ -1,13 +1,13 @@
 from io import StringIO
 
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import Group, Permission
 from django.core import management
 from django.test import TransactionTestCase, tag
 from django.urls import reverse
 from django.utils.http import urlencode
 
 from wagtail.admin.staticfiles import versioned_static
-from wagtail.models import Page
+from wagtail.models import GroupPagePermission, Page
 from wagtail.test.testapp.models import EventIndex, SimplePage, SingleEventPage
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.timestamps import local_datetime
@@ -153,6 +153,48 @@ class TestPageSearch(WagtailTestUtils, TransactionTestCase):
         )
         self.user.save()
         self.assertRedirects(self.get(), "/admin/")
+
+    def test_search_filter_by_permissions(self):
+        # Create one page that a user has permission to view,
+        # and one that they don't have permission to view,
+        # and confirm that only the former appears in search results
+        root_page = Page.objects.get(id=2)
+        visible_page = root_page.add_child(
+            instance=SimplePage(
+                title="Hello from Cauldron Lake",
+                slug="bright-falls",
+                content="It's not a lake, it's an ocean",
+                live=True,
+                has_unpublished_changes=False,
+            )
+        )
+        root_page.add_child(
+            instance=SimplePage(
+                title="Hello from Twin Peaks",
+                slug="twin-peaks",
+                content="It's not a town, it's a state of mind",
+                live=True,
+                has_unpublished_changes=False,
+            )
+        )
+
+        self.user.is_superuser = False
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            )
+        )
+        self.user.save()
+        # add user to a Cauldron Lake group with permission to view the visible page
+        cauldron_lake_group = Group.objects.create(name="Cauldron Lake")
+        cauldron_lake_group.user_set.add(self.user)
+        GroupPagePermission.objects.create(
+            page=visible_page, permission_type="change", group=cauldron_lake_group
+        )
+
+        response = self.get({"q": "Hello"})
+        page_ids = [page.id for page in response.context["pages"]]
+        self.assertCountEqual(page_ids, [visible_page.id])
 
     def test_search_order_by_title(self):
         root_page = Page.objects.get(id=2)

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -287,11 +287,15 @@ class IndexView(PageListingMixin, generic.IndexView):
         return [col for col in PageListingMixin.columns if col.name != "type"]
 
     def get_base_queryset(self):
-        pages = self.model.objects.filter(depth__gt=1).filter(
-            pk__in=page_permission_policy.explorable_instances(
-                self.request.user
-            ).values_list("pk", flat=True)
-        )
+        pages = self.model.objects.filter(depth__gt=1)
+        if (not self.is_searching) or getattr(
+            settings, "WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS", True
+        ):
+            pages = pages.filter(
+                pk__in=page_permission_policy.explorable_instances(
+                    self.request.user
+                ).values_list("pk", flat=True)
+            )
         pages = self.annotate_queryset(pages)
         return pages
 
@@ -369,11 +373,14 @@ class ExplorableIndexView(IndexView):
         else:
             pages = self.parent_page.get_children()
 
-        pages = pages.filter(
-            pk__in=page_permission_policy.explorable_instances(
-                self.request.user
-            ).values_list("pk", flat=True)
-        )
+        if (not self.is_searching) or getattr(
+            settings, "WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS", True
+        ):
+            pages = pages.filter(
+                pk__in=page_permission_policy.explorable_instances(
+                    self.request.user
+                ).values_list("pk", flat=True)
+            )
         pages = self.annotate_queryset(pages)
         return pages
 

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.query import QuerySet
 from django.http import Http404
@@ -107,11 +108,15 @@ class SearchView(PageListingMixin, PermissionCheckedMixin, BaseListingView):
         return super().get(request)
 
     def get_queryset(self) -> QuerySet[Any]:
-        pages = self.all_pages = Page.objects.all().filter(
-            pk__in=page_permission_policy.explorable_instances(
-                self.request.user
-            ).values_list("pk", flat=True)
-        )
+        self.all_pages = Page.objects.all()
+
+        if getattr(settings, "WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS", True):
+            self.all_pages = self.all_pages.filter(
+                pk__in=page_permission_policy.explorable_instances(
+                    self.request.user
+                ).values_list("pk", flat=True)
+            )
+        pages = self.all_pages
         if self.show_locale_labels:
             pages = pages.select_related("locale")
 

--- a/wagtail/admin/views/pages/usage.py
+++ b/wagtail/admin/views/pages/usage.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
@@ -65,11 +66,16 @@ class ContentTypeUseView(PageListingMixin, PermissionCheckedMixin, BaseListingVi
         return self.page_class._meta.verbose_name_plural
 
     def get_base_queryset(self):
-        queryset = self.page_class._default_manager.all().filter(
-            pk__in=self.permission_policy.explorable_instances(
-                self.request.user
-            ).values_list("pk", flat=True)
-        )
+        queryset = self.page_class._default_manager.all()
+        if (not self.is_searching) or getattr(
+            settings, "WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS", True
+        ):
+            queryset = queryset.filter(
+                pk__in=self.permission_policy.explorable_instances(
+                    self.request.user
+                ).values_list("pk", flat=True)
+            )
+
         return self.annotate_queryset(queryset)
 
     def get_index_url(self):


### PR DESCRIPTION
Partial fix for #12770

### Description

Add a new setting `WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS` - when set to false, search results from the sidebar search, explorer view and custom page listing views are not filtered by `explorable_pages`, and include pages from the full tree regardless of user permission. This is a stopgap fix for the error seen in #12770 on very large sites using Elasticsearch, where the list of explorable pages is passed to Elasticsearch as a literal list.

A full fix would be to do the permission filtering on the Elasticsearch side using a 'descendants of' query that uses the `path` field - django-modelsearch is capable of this, but we would need improved django-treebeard signal handling to ensure that the `path` value indexed in Elasticsearch is kept in sync with tree moves - see https://github.com/django-treebeard/django-treebeard/issues/381.

### AI usage

Github Copilot for code completion