### PR TITLE
Fix Collapse All button state reverting after switching tabs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Changelog
  * Use choice label when displaying choice fields in `SnippetViewSet`/`ModelViewSet`'s `list_display` (Srishti Jaiswal)
  * Add new content check `empty-meta-description` to validate meta description tags are not empty (Thibaud Colas)
  * Add `extractMetrics` method to `PreviewController` to retrieve content metrics from the preview panel (Thibaud Colas)
+ * Preserve "Collapse all" button state when switching between editor tabs (Raghad Dahi)
  * Fix: Handle nested inline models when displaying object usage information (Sage Abdullah, Kacper Walęga, Tian Jie Wong)
  * Fix: Avoid duplicate `get_object()` DB query in API detail view (Siddheshwar Kadam)
  * Fix: Ensure `ImageBlock` alt text populates on choosing a new image after unchecking decorative state (Pratham Jaiswal)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -965,6 +965,7 @@
 * Aditya Kammati
 * Kunal Hemnani
 * Aviral Sapra
+* Raghad Dahi
 
 ## Translators
 

--- a/client/src/components/Minimap/Minimap.test.tsx
+++ b/client/src/components/Minimap/Minimap.test.tsx
@@ -1,0 +1,56 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import Minimap from './Minimap';
+
+const makeContainer = (id: string) => {
+  const el = document.createElement('div');
+  el.id = id;
+  return el;
+};
+
+const defaultProps = {
+  container: makeContainer('container'),
+  anchorsContainer: makeContainer('tab-content'),
+  links: [],
+  onUpdate: () => {},
+  toggleAllPanels: () => {},
+};
+
+describe('Minimap', () => {
+  it('exists', () => {
+    expect(Minimap).toBeDefined();
+  });
+
+  it('defaults to expanded on first render and on new tabs', () => {
+    const tab1 = makeContainer('tab-content');
+    const tab2 = makeContainer('tab-promote');
+    const wrapper = shallow(
+      <Minimap {...defaultProps} anchorsContainer={tab1} />,
+    );
+
+    expect(wrapper.find('CollapseAll').prop('expanded')).toBe(true);
+
+    wrapper.find('CollapseAll').prop('onClick')();
+    expect(wrapper.find('CollapseAll').prop('expanded')).toBe(false);
+
+    wrapper.setProps({ anchorsContainer: tab2 });
+    expect(wrapper.find('CollapseAll').prop('expanded')).toBe(true);
+  });
+
+  it('preserves and isolates state per tab', () => {
+    const tab1 = makeContainer('tab-content');
+    const tab2 = makeContainer('tab-promote');
+    const wrapper = shallow(
+      <Minimap {...defaultProps} anchorsContainer={tab1} />,
+    );
+
+    wrapper.find('CollapseAll').prop('onClick')();
+
+    wrapper.setProps({ anchorsContainer: tab2 });
+    wrapper.find('CollapseAll').prop('onClick')();
+    expect(wrapper.find('CollapseAll').prop('expanded')).toBe(false);
+
+    wrapper.setProps({ anchorsContainer: tab1 });
+    expect(wrapper.find('CollapseAll').prop('expanded')).toBe(false);
+  });
+});

--- a/client/src/components/Minimap/Minimap.tsx
+++ b/client/src/components/Minimap/Minimap.tsx
@@ -120,7 +120,15 @@ const Minimap: React.FunctionComponent<MinimapProps> = ({
     [expanded, setExpanded],
   );
   // Collapse all yes/no state.
-  const [panelsExpanded, setPanelsExpanded] = useState<boolean>(true);
+  const [panelsExpandedByTab, setPanelsExpandedByTab] = useState<
+    Record<string, boolean>
+  >({});
+  const containerId = anchorsContainer?.id ?? '';
+  const panelsExpanded = panelsExpandedByTab[containerId] ?? true;
+  const setPanelsExpanded = (value: boolean) => {
+    setPanelsExpandedByTab((prev) => ({ ...prev, [containerId]: value }));
+  };
+
   const [intersections, setIntersections] = useState<LinkIntersections>({});
   const observer = useRef<IntersectionObserver | null>(null);
   const lastIntersections = useRef({});
@@ -194,12 +202,6 @@ const Minimap: React.FunctionComponent<MinimapProps> = ({
       obs.disconnect();
     };
   }, [links, container]);
-
-  useEffect(() => {
-    // Reset the "collapse all" when switching tabs.
-    setPanelsExpanded(true);
-  }, [anchorsContainer, setPanelsExpanded]);
-
   return (
     <div>
       <CollapseAll

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -57,6 +57,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Use choice label when displaying choice fields in `SnippetViewSet`/`ModelViewSet`'s `list_display` (Srishti Jaiswal)
  * Add new content check `empty-meta-description` to validate meta description tags are not empty (Thibaud Colas)
  * Add `extractMetrics` method to `PreviewController` to retrieve content metrics from the preview panel (Thibaud Colas)
+ * Preserve "Collapse all" button state when switching between editor tabs (Raghad Dahi)
 
 ### Bug fixes
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #14020 

### Description

- `Minimap.tsx:` Updated state logic to store a map of tab states.
- `Minimap.tsx`: Deleted `useEffect` that was resetting the button. 
- `Minimap.test.tsx`: Added new tests for state persistence and defaults.

<!-- Please describe the problem you're fixing. -->

### Testing
tested it on bakeydemo

https://github.com/user-attachments/assets/3be5ff55-c8f6-45b0-8600-7f289b5e7dfc


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Used Gemini to help write the code and the unit test files.