### PR TITLE
Docs: add section on customizing StreamField block API output

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,6 +42,7 @@ Changelog
  * Docs: Add docs for `request.in_preview_panel` to explain its use (Raghad Dahi)
  * Docs: Update image format docs to encourage more intentional conversions (Thibaud Colas)
  * Docs: Clarify Wagtail XSS protections for uploaded documents (Thibaud Colas)
+ * Docs: Add section on customizing StreamField block API output with `get_api_representation` (Pranith Beeram)
  * Maintenance: Formalized support for Django 6.1
  * Maintenance: Rename `request` argument to `cache_object` in `Page._get_site_root_paths()` for correctness (Kailesh)
  * Maintenance: Fix blank choice tests for Django 6.1 (Sage Abdullah)

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -244,6 +244,94 @@ This adds two fields to the API (other fields omitted for brevity):
     "published_date_display": "Thursday 06 April 2017"
 }
 ```
+### Customising StreamField block API output
+
+When a `StreamField` is serialized for the API, Wagtail calls
+`get_api_representation(value, context)` on each block. You can
+override this method in your own block classes to control exactly
+what gets included in the JSON response.
+
+By default, blocks that reference other objects (such as `ImageChooserBlock`)
+return just the related object's primary key, an integer. For example, a page
+with this model:
+
+```python
+# blog/models.py
+from wagtail.models import Page
+from wagtail.fields import StreamField
+from wagtail.blocks import CharBlock, ImageChooserBlock
+
+class BlogPage(Page):
+    body = StreamField([
+        ("heading", CharBlock()),
+        ("photo",   ImageChooserBlock()),
+    ])
+```
+
+produces this API output by default:
+
+```json
+{
+    "body": [
+        {"type": "heading", "value": "Hello world", "id": "abc123"},
+        {"type": "photo",   "value": 42,            "id": "def456"}
+    ]
+}
+```
+
+The `"value": 42` is only the image's database ID. To return richer data,
+subclass the block and override `get_api_representation`:
+
+```python
+# blog/blocks.py
+from wagtail.images.blocks import ImageChooserBlock
+
+class APIImageChooserBlock(ImageChooserBlock):
+    def get_api_representation(self, value, context=None):
+        # value is the fully-loaded Image object, not just the integer ID
+        return {
+            "id":    value.id,
+            "title": value.title,
+            "url":   value.file.url,
+        }
+```
+
+Use this block in your page model:
+
+```python
+# blog/models.py
+from wagtail.models import Page
+from wagtail.fields import StreamField
+from wagtail.blocks import CharBlock
+from .blocks import APIImageChooserBlock
+
+class BlogPage(Page):
+    body = StreamField([
+        ("heading", CharBlock()),
+        ("photo",   APIImageChooserBlock()),
+    ])
+```
+
+The API now returns the full image data inline, with no second request needed:
+
+```json
+{
+    "body": [
+        {"type": "heading", "value": "Hello world", "id": "abc123"},
+        {"type": "photo", "value": {
+            "id":    42,
+            "title": "Sunset over the mountains",
+            "url":   "/media/images/sunset.jpg"
+        }, "id": "def456"}
+    ]
+}
+```
+
+This approach works for any block type. `StreamBlock`, `StructBlock`, and
+`ListBlock` all recursively call `get_api_representation` on their children,
+so overriding it on a leaf block applies automatically everywhere that block
+is used.
+
 
 ### Rich text in the API
 

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -253,6 +253,94 @@ This adds two fields to the API (other fields omitted for brevity):
     "published_date_display": "Thursday 06 April 2017"
 }
 ```
+### Customising StreamField block API output
+
+When a `StreamField` is serialized for the API, Wagtail calls
+`get_api_representation(value, context)` on each block. You can
+override this method in your own block classes to control exactly
+what gets included in the JSON response.
+
+By default, blocks that reference other objects (such as `ImageChooserBlock`)
+return just the related object's primary key, an integer. For example, a page
+with this model:
+
+```python
+# blog/models.py
+from wagtail.models import Page
+from wagtail.fields import StreamField
+from wagtail.blocks import CharBlock, ImageChooserBlock
+
+class BlogPage(Page):
+    body = StreamField([
+        ("heading", CharBlock()),
+        ("photo",   ImageChooserBlock()),
+    ])
+```
+
+produces this API output by default:
+
+```json
+{
+    "body": [
+        {"type": "heading", "value": "Hello world", "id": "abc123"},
+        {"type": "photo",   "value": 42,            "id": "def456"}
+    ]
+}
+```
+
+The `"value": 42` is only the image's database ID. To return richer data,
+subclass the block and override `get_api_representation`:
+
+```python
+# blog/blocks.py
+from wagtail.images.blocks import ImageChooserBlock
+
+class APIImageChooserBlock(ImageChooserBlock):
+    def get_api_representation(self, value, context=None):
+        # value is the fully-loaded Image object, not just the integer ID
+        return {
+            "id":    value.id,
+            "title": value.title,
+            "url":   value.file.url,
+        }
+```
+
+Use this block in your page model:
+
+```python
+# blog/models.py
+from wagtail.models import Page
+from wagtail.fields import StreamField
+from wagtail.blocks import CharBlock
+from .blocks import APIImageChooserBlock
+
+class BlogPage(Page):
+    body = StreamField([
+        ("heading", CharBlock()),
+        ("photo",   APIImageChooserBlock()),
+    ])
+```
+
+The API now returns the full image data inline, with no second request needed:
+
+```json
+{
+    "body": [
+        {"type": "heading", "value": "Hello world", "id": "abc123"},
+        {"type": "photo", "value": {
+            "id":    42,
+            "title": "Sunset over the mountains",
+            "url":   "/media/images/sunset.jpg"
+        }, "id": "def456"}
+    ]
+}
+```
+
+This approach works for any block type. `StreamBlock`, `StructBlock`, and
+`ListBlock` all recursively call `get_api_representation` on their children,
+so overriding it on a leaf block applies automatically everywhere that block
+is used.
+
 
 (api_v2_rich_text)=
 

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -253,16 +253,12 @@ This adds two fields to the API (other fields omitted for brevity):
     "published_date_display": "Thursday 06 April 2017"
 }
 ```
-### Customising StreamField block API output
 
-When a `StreamField` is serialized for the API, Wagtail calls
-`get_api_representation(value, context)` on each block. You can
-override this method in your own block classes to control exactly
-what gets included in the JSON response.
+(apiv2_streamfield_configuration)=
 
-By default, blocks that reference other objects (such as `ImageChooserBlock`)
-return just the related object's primary key, an integer. For example, a page
-with this model:
+### StreamField blocks in the API
+
+When a StreamField block’s value is serialized for the API, by default Wagtail uses the same representation as it does for the database. For example, this model:
 
 ```python
 # blog/models.py
@@ -270,11 +266,14 @@ from wagtail.models import Page
 from wagtail.fields import StreamField
 from wagtail.blocks import CharBlock, ImageChooserBlock
 
+
 class BlogPage(Page):
-    body = StreamField([
-        ("heading", CharBlock()),
-        ("photo",   ImageChooserBlock()),
-    ])
+    body = StreamField(
+        [
+            ("heading", CharBlock()),
+            ("photo", ImageChooserBlock()),
+        ]
+    )
 ```
 
 produces this API output by default:
@@ -288,59 +287,27 @@ produces this API output by default:
 }
 ```
 
-The `"value": 42` is only the image's database ID. To return richer data,
-subclass the block and override `get_api_representation`:
+`CharBlock` produces a string value, and an `ImageChooserBlock` reference corresponds to the primary key of the image.
+
+#### `get_api_representation` for custom block serialization
+
+To return richer data, you can define `get_api_representation` in `StructBlock`. Here is another example, returning the full image data inline rather than just the ID:
 
 ```python
 # blog/blocks.py
 from wagtail.images.blocks import ImageChooserBlock
 
+
 class APIImageChooserBlock(ImageChooserBlock):
     def get_api_representation(self, value, context=None):
         # value is the fully-loaded Image object, not just the integer ID
         return {
-            "id":    value.id,
+            "id": value.id,
             "title": value.title,
-            "url":   value.file.url,
         }
 ```
 
-Use this block in your page model:
-
-```python
-# blog/models.py
-from wagtail.models import Page
-from wagtail.fields import StreamField
-from wagtail.blocks import CharBlock
-from .blocks import APIImageChooserBlock
-
-class BlogPage(Page):
-    body = StreamField([
-        ("heading", CharBlock()),
-        ("photo",   APIImageChooserBlock()),
-    ])
-```
-
-The API now returns the full image data inline, with no second request needed:
-
-```json
-{
-    "body": [
-        {"type": "heading", "value": "Hello world", "id": "abc123"},
-        {"type": "photo", "value": {
-            "id":    42,
-            "title": "Sunset over the mountains",
-            "url":   "/media/images/sunset.jpg"
-        }, "id": "def456"}
-    ]
-}
-```
-
-This approach works for any block type. `StreamBlock`, `StructBlock`, and
-`ListBlock` all recursively call `get_api_representation` on their children,
-so overriding it on a leaf block applies automatically everywhere that block
-is used.
-
+The API now returns the full image data inline, with no second request needed. This approach works for all blocks based on StructBlock, no matter where they are in the block hierarchy.
 
 (api_v2_rich_text)=
 

--- a/docs/advanced_topics/api/v3/streamfield.md
+++ b/docs/advanced_topics/api/v3/streamfield.md
@@ -38,7 +38,7 @@ The `value` representation depends on the block type:
 -   **RichTextBlock** — rich text, using the input and output formats described in [](api_v3_rich_text).
 -   **Chooser and leaf blocks** (for example image and page choosers) — a scalar value such as the object's ID, or another widget-compatible value.
 
-Custom blocks can customise how they are read back through the API by defining `get_api_representation()`, which takes precedence over the default representation.
+Custom blocks can customise how they are read back through the API by [defining `get_api_representation(value, context=None)`](apiv2_streamfield_configuration), which takes precedence over the default representation.
 
 ## Writing StreamField values
 

--- a/docs/reference/streamfield/blocks.md
+++ b/docs/reference/streamfield/blocks.md
@@ -534,6 +534,10 @@ All block definitions have the following methods and properties that can be over
      A list of block names or ``BlockGroup`` instances to determine the order in which sub-blocks are displayed in the editing interface. Alternatively, a ``BlockGroup`` instance can be provided instead of a list, to define a group of ``children`` and ``settings`` blocks. See :ref:`structblock_custom_order_and_grouping` and :class:`BlockGroup` for more details.
 
     .. automethod:: get_form_layout
+    
+    .. automethod:: get_api_representation
+
+    For more information, see :ref:`apiv2_streamfield_configuration`.
 
 
 .. autoclass:: wagtail.blocks.ListBlock

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -100,6 +100,7 @@ Many thanks to tinyb0y for reporting this issue. For further details, please see
  * Document [`request.in_preview_panel`](custom_rendering_in_preview_panel) to explain its use (Raghad Dahi)
  * Update image format docs to encourage more intentional conversions (Thibaud Colas)
  * Clarify Wagtail XSS protections for uploaded documents (Thibaud Colas)
+ * Add section on customizing StreamField block API output with `get_api_representation` (Pranith Beeram)
 
 ### Maintenance
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #3454 

### Description

Add documentation for `get_api_representation` in the API v2 configuration guide. This method has existed but was never documented, leaving developers without a known way to customize StreamField block output in the API.  

The new section covers:

- How to override `get_api_representation` on any block subclass
- Before/after JSON output so the effect is immediately clear

### AI usage

Used Claude to understand the codebase, trace the request flow from the API serializer through to the block method, and construct the before/after examples used in the documentation
