### PR TITLE
Fix help text rendering position in FieldRowPanel

### DIFF
--- a/wagtail/admin/panels/group.py
+++ b/wagtail/admin/panels/group.py
@@ -187,6 +187,13 @@ class FieldRowPanel(PanelGroup):
     class BoundPanel(PanelGroup.BoundPanel):
         template_name = "wagtailadmin/panels/field_row_panel.html"
 
+        @cached_property
+        def children(self):
+            children = super().children
+            for child in children:
+                child.help_text_after_input = True
+            return children
+
 
 class MultiFieldPanel(PanelGroup):
     class BoundPanel(PanelGroup.BoundPanel):

--- a/wagtail/admin/templates/wagtailadmin/panels/field_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/field_panel.html
@@ -1,2 +1,2 @@
 {% load wagtailadmin_tags i18n %}
-{% include "wagtailadmin/shared/field.html" with show_label=False help_text=self.help_text %}
+{% include "wagtailadmin/shared/field.html" with show_label=False help_text=self.help_text help_text_after_input=self.help_text_after_input %}

--- a/wagtail/admin/templates/wagtailadmin/shared/formatted_field.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/formatted_field.html
@@ -37,11 +37,13 @@
             {% endif %}
         </div>
 
+        {% if not help_text_after_input %}
         <div class="w-field__help" {% if help_text_id %}id="{{ help_text_id }}"{% endif %} data-field-help>
             {% if help_text %}
                 <div class="help">{{ help_text }}</div>
             {% endif %}
         </div>
+        {% endif %}
 
         {# Separate container for the widget with prefix icon and suffix comment button #}
         <div class="w-field__input" data-field-input>
@@ -58,5 +60,13 @@
                 </button>
             {% endif %}
         </div>
+
+        {% if help_text_after_input %}
+        <div class="w-field__help" {% if help_text_id %}id="{{ help_text_id }}"{% endif %} data-field-help>
+            {% if help_text %}
+                <div class="help">{{ help_text }}</div>
+            {% endif %}
+        </div>
+        {% endif %}
     </div>
 </div>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1206,6 +1206,7 @@ def formattedfield(
     error_message_id=None,
     wrapper_id=None,
     attrs=None,
+    help_text_after_input=False,
 ):
     """
     Renders a form field in standard Wagtail admin layout.
@@ -1244,6 +1245,7 @@ def formattedfield(
         "required": field and field.field.required,
         "contentpath": field.name if field else "",
         "help_text": help_text or (field and field.help_text) or "",
+        "help_text_after_input": help_text_after_input,
     }
 
     if help_text_id:
@@ -1298,6 +1300,7 @@ def formattedfieldfromcontext(context):
         "label_text",
         "error_message_id",
         "wrapper_id",
+        "help_text_after_input",
     ):
         if arg in context:
             kwargs[arg] = context[arg]


### PR DESCRIPTION
## Description

Fixes #10554.

when a field inside `FieldRowPanel` has `help_text`, the help text was rendering above the input instead of below it, breaking the row layout. this happened because the `formatted_field.html` template renders the help block before the input block in the DOM.

## Previous attempt

my first PR (#14132) tried to fix this with CSS `order` — @laymonage rightly pointed out that this breaks accessibility since screen readers would see a different order than whats on screen. this PR fixes it properly at the template level instead.

## Approach

added a `help_text_after_input` flag that `FieldRowPanel.BoundPanel` sets on its child panels. the `formatted_field.html` template conditionally renders help text after the input when this flag is set. DOM order matches visual order so screen readers work correctly.

regular field panels are unaffected — the flag defaults to falsy.

## Files changed

- `wagtail/admin/panels/group.py` — `FieldRowPanel.BoundPanel.children` sets `help_text_after_input=True` on child panels
- `wagtail/admin/templates/wagtailadmin/panels/field_panel.html` — passes the flag through
- `wagtail/admin/templatetags/wagtailadmin_tags.py` — accepts `help_text_after_input` param in `formattedfield` and `formattedfieldfromcontext`
- `wagtail/admin/templates/wagtailadmin/shared/formatted_field.html` — conditionally renders help text after input when flag is set

## Testing

tested with CharField, IntegerField, and fields with/without help_text inside FieldRowPanel. regular panels render the same as before.

## AI Disclosure

i used claude to help explore the codebase structure and understand the template tag pipeline. all code changes were written and reviewed by me.