### PR TITLE
Remove 'safe' filter from page title in approved/rejected email body

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/notifications/approved.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/approved.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans trimmed with title=revision.content_object.get_admin_display_title|safe %}The page "{{ title }}" has been approved.{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed with title=revision.content_object.get_admin_display_title %}The page "{{ title }}" has been approved.{% endblocktrans %}</p>
     <p>{% trans "You can view the page here:" %} <a href="{{ revision.content_object.full_url }}">{{ revision.content_object.full_url }}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/rejected.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/rejected.html
@@ -3,6 +3,6 @@
 {% base_url_setting default="" as base_url %}
 
 {% block content %}
-    <p>{% blocktrans trimmed with title=revision.content_object.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed with title=revision.content_object.get_admin_display_title %}The page "{{ title }}" has been rejected.{% endblocktrans %}</p>
     <p>{% trans "You can edit the page here:"%} <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' revision.object_id %}">{{ base_url }}{% url 'wagtailadmin_pages:edit' revision.object_id %}</a></p>
 {% endblock %}


### PR DESCRIPTION
### Description

The templates for the HTML body of 'approved' and 'rejected' notification emails wrongly use a `|safe` filter on the page title, probably copied over from the plain text template.

This does not present a security issue (because if email clients are executing scripts in HTML emails, they have bigger problems) but could result in badly-rendered emails if the page title contains the characters < > &.

(no tests included, as this would effectively be "test that Django works")

### AI usage

None