### PR TITLE
Fix page header buttons disappearing after searching or filtering the page explorer

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ Changelog
  * Fix: Correctly HTML-escape page title in approval/rejection notification emails (Matt Westcott)
  * Fix: Correctly HTML-escape URL in photo type oembeds (Thibaud Colas)
  * Fix: Ensure user with appropriate permissions can cancel a workflow task (Dan Braghis)
+ * Fix: Retain page explorer header buttons when searching or filtering (Sage Abdullah)
  * Docs: Add documentation for the `filter_spec` parameter of `ImageRenditionField` (Soumya-codr)
  * Docs: Add guide for testing document upload forms (Wenli Tsai, Bhavesh Sharma)
  * Docs: Document the `nested_default_fields` attribute on API viewsets (Deepanshu Tevathiya)

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -72,6 +72,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Correctly HTML-escape page title in approval/rejection notification emails (Matt Westcott)
  * Correctly HTML-escape URL in photo type oembeds (Thibaud Colas)
  * Ensure user with appropriate permissions can cancel a workflow task (Dan Braghis)
+ * Retain page explorer header buttons when searching or filtering (Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/pages/explorable_index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/explorable_index_results.html
@@ -1,6 +1,15 @@
 {% extends "wagtailadmin/pages/index_results.html" %}
 {% load wagtailadmin_tags i18n %}
 
+{% block filter_partials %}
+    {% comment %}
+        The explorable index view does not follow the generic mechanism for rendering the header buttons.
+        It also does not have any header buttons that need re-rendering, so don't render the fragment
+        to avoid overwriting the existing buttons with a blank fragment.
+    {% endcomment %}
+    {% include "wagtailadmin/shared/listing/filter_partials.html" with render_buttons_fragment=False %}
+{% endblock %}
+
 {% block before_results %}
     {% if not is_searching and not is_filtering %}
         {% comment %}

--- a/wagtail/admin/templates/wagtailadmin/pages/index_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index_results.html
@@ -1,6 +1,8 @@
 {% load wagtailadmin_tags %}
 
-{% include "wagtailadmin/shared/listing/filter_partials.html" %}
+{% block filter_partials %}
+    {% include "wagtailadmin/shared/listing/filter_partials.html" %}
+{% endblock %}
 
 <form id="page-reorder-form">
     {% csrf_token %}

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -129,6 +129,14 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         )
         self.assertContains(response, f'href="{expected_new_page_copy_url}"')
 
+        soup = self.get_soup(response.content)
+        header_buttons = soup.select_one(
+            'template[data-controller="w-teleport"]'
+            '[data-w-teleport-target-value="#w-slim-header-buttons"]'
+            '[data-w-teleport-mode-value="innerHTML"]'
+        )
+        self.assertIsNone(header_buttons)
+
         self.assertContains(response, "1-3 of 3")
 
     def test_explore_root(self):
@@ -829,6 +837,35 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
             "Date updated: Jan. 1, 2015 - any",
             "latest_revision_created_at_from=2015-01-01",
         )
+
+    def test_filter_by_date_updated_results(self):
+        new_page_child = SimplePage(
+            title="New page child",
+            slug="new-page-child",
+            content="new page child",
+            latest_revision_created_at=local_datetime(2016, 1, 1),
+        )
+        self.new_page.add_child(instance=new_page_child)
+
+        response = self.client.get(
+            reverse("wagtailadmin_explore_results", args=(self.root_page.id,)),
+            {"latest_revision_created_at_from": "2015-01-01"},
+        )
+        self.assertEqual(response.status_code, 200)
+        page_ids = {page.id for page in response.context["pages"]}
+        self.assertEqual(page_ids, {self.new_page.id, new_page_child.id})
+        self.assertContainsActiveFilter(
+            response,
+            "Date updated: Jan. 1, 2015 - any",
+            "latest_revision_created_at_from=2015-01-01",
+        )
+        soup = self.get_soup(response.content)
+        header_buttons = soup.select_one(
+            'template[data-controller="w-teleport"]'
+            '[data-w-teleport-target-value="#w-slim-header-buttons"]'
+            '[data-w-teleport-mode-value="innerHTML"]'
+        )
+        self.assertIsNone(header_buttons)
 
     def test_filter_by_owner(self):
         barry = self.create_user(


### PR DESCRIPTION
Regression in #13700. I should've caught this sooner 🤦 

<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->

### Description

<!-- Please describe the problem you're fixing. -->

After searching or filtering the page explorer, the buttons in the header disappear, leaving only one "Sort item order" option.

This is because the explorable listings use its own mechanism to render the header buttons instead of defining it from the view class: https://github.com/wagtail/wagtail/blob/68990d0bbd41080dd85bba22d98eff1be0c6d0f1/wagtail/admin/templates/wagtailadmin/pages/explorable_index.html#L5-L8

Previously, the results template would only reload the active filters, not the header buttons (because the explorable listings are not likely to have buttons that need reloading): https://github.com/wagtail/wagtail/blob/b55a95d83acff5895b2c48894a5b1e7ad2dd2273/wagtail/admin/templates/wagtailadmin/pages/index_results.html

However, in #13700, we added the header buttons refresh partial to allow buttons to be reloaded upon search/filtering for custom (flat) page listings. Since the `explorable_index_results.html` tmeplate extends `index_results.html` template, the same partial gets applied to the explorable results. The explorable view doesn't define the buttons in the "standard" way, so the resulting fragment only has one button (the "reorder" button from the generic view).

This PR fixes it by adding a `filter_partials` block in `index_results.html`, that is then overridden in `explorable_index_results.html` to not include the header buttons fragment.

The changes here will be made redundant by #14052 in which we refactor the explorable listings' header buttons rendering to use the standardised generic mechanism. However, we still need this for backporting to 7.3.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Copilot for autocomplete