### PR TITLE
Use choice labels in snippet listing

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changelog
  * Store preview data in new `FormState` model to improve compatibility with cookie-based sessions (Sage Abdullah)
  * Change StreamBlock options so groups are shown in declaration order of their blocks (Darshan Kerkar)
  * Add `WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS` setting to disable permission filtering on page searches (Matt Westcott)
+ * Use choice label when displaying choice fields in `SnippetViewSet`/`ModelViewSet`'s `list_display` (Srishti Jaiswal)
  * Fix: Handle nested inline models when displaying object usage information (Sage Abdullah, Kacper Walęga, Tian Jie Wong)
  * Fix: Avoid duplicate `get_object()` DB query in API detail view (Siddheshwar Kadam)
  * Fix: Ensure `ImageBlock` alt text populates on choosing a new image after unchecking decorative state (Pratham Jaiswal)

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -54,6 +54,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Add more informative error for `format-*` operations on SVG images (Ankit Kumar)
  * Change StreamBlock options so groups are shown in declaration order of their blocks (Darshan Kerkar)
  * Add [](wagtailadmin_page_search_filter_by_permissions) setting to disable permission filtering on page searches (Matt Westcott)
+ * Use choice label when displaying choice fields in `SnippetViewSet`/`ModelViewSet`'s `list_display` (Srishti Jaiswal)
 
 ### Bug fixes
 

--- a/docs/topics/snippets/customizing.md
+++ b/docs/topics/snippets/customizing.md
@@ -28,11 +28,11 @@ class Member(models.Model):
     name = models.CharField(max_length=255)
     shirt_size = models.CharField(max_length=5, choices=ShirtSize.choices, default=ShirtSize.MEDIUM)
 
-    def get_shirt_size_display(self):
-        return self.ShirtSize(self.shirt_size).label
+    def first_name(self):
+        return self.name.split()[0]
 
-    get_shirt_size_display.admin_order_field = "shirt_size"
-    get_shirt_size_display.short_description = "Size description"
+    first_name.admin_order_field = "name"
+    first_name.short_description = "First name"
 
 
 class MemberFilterSet(WagtailFilterSet):
@@ -56,7 +56,7 @@ from myapp.models import Member, MemberFilterSet
 class MemberViewSet(SnippetViewSet):
     model = Member
     icon = "user"
-    list_display = ["name", "shirt_size", "get_shirt_size_display", UpdatedAtColumn()]
+    list_display = ["name", "first_name", "shirt_size", UpdatedAtColumn()]
     list_per_page = 50
     copy_view_enabled = False
     inspect_view_enabled = True

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -259,10 +259,19 @@ class IndexView(
         if attr is None:
             sort_key = field_name
 
-        accessor = field_name
+        # If the model has a get_FOO_display() method for the field,
+        # use that as the accessor instead of the field name
+        get_foo_display = f"get_{field}_display"
+        if getattr(model_class, get_foo_display, None) is not None:
+            # Use the method name rather than the method itself,
+            # as it may be on a related model.
+            accessor = get_foo_display
+        else:
+            accessor = field
+
         # Build the dotted relation if needed, for use in multigetattr
         if relations:
-            accessor = ".".join(lookups)
+            accessor = ".".join(relations + [accessor])
         return column_class(
             accessor,
             label=capfirst(label),

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -811,6 +811,36 @@ class TestListViewWithCustomColumns(BaseSnippetViewSetTests):
         # The bulk actions column plus 6 columns defined in FullFeaturedSnippetViewSet
         self.assertEqual(len(headings), 7)
 
+    def test_choice_field_uses_choice_label_to_display(self):
+        response = self.get()
+        list_url = self.get_url("list")
+        sort_country_code_url = list_url + "?ordering=country_code"
+
+        soup = self.get_soup(response.content)
+        table = soup.select_one("main table")
+
+        # Find the Country code header
+        country_code_header = next(
+            (
+                header
+                for header in table.select("th")
+                if header.get_text(strip=True) == "Country code"
+            ),
+            None,
+        )
+        self.assertIsNotNone(country_code_header)
+
+        # Verify it's sortable
+        header_link = country_code_header.select_one("a")
+        self.assertIsNotNone(header_link)
+        self.assertEqual(header_link["href"], sort_country_code_url)
+
+        table_rows = table.select("tbody tr")
+        self.assertEqual(
+            [row.select("td")[2].get_text(strip=True) for row in table_rows],
+            ["Indonesia", "United Kingdom"],
+        )
+
     def test_falsy_value(self):
         # https://github.com/wagtail/wagtail/issues/10765
         response = self.get()
@@ -887,6 +917,24 @@ class TestRelatedFieldListDisplay(BaseSnippetViewSetTests):
         ]
         self.assertIn("Chosen snippet text", headers)
         self.assertContains(response, "<td>royale with cheese</td>", html=True)
+
+    def test_single_level_choice_relation_uses_choice_label(self):
+        self.ffs.country_code = FullFeaturedSnippet.CountryCode.INDONESIA
+        self.ffs.save()
+        self.scm = self.model.objects.create(advert=self.advert, full_featured=self.ffs)
+
+        response = self.client.get(self.get_url("list"))
+        self.assertEqual(response.status_code, 200)
+
+        soup = self.get_soup(response.content)
+        table = soup.select_one("main table")
+        headers = [header.get_text(strip=True) for header in table.select("th")]
+        self.assertIn("Chosen snippet country code", headers)
+        table_rows = table.select("tbody tr")
+        self.assertEqual(
+            [row.select("td")[3].get_text(strip=True) for row in table_rows],
+            ["Indonesia"],
+        )
 
     def test_multi_level_relation(self):
         self.scm = self.model.objects.create(advert=self.advert, full_featured=self.ffs)

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -1322,9 +1322,9 @@ class FullFeaturedSnippet(
     ClusterableModel,
 ):
     class CountryCode(models.TextChoices):
-        INDONESIA = "ID"
-        PHILIPPINES = "PH"
-        UNITED_KINGDOM = "UK"
+        INDONESIA = "ID", "Indonesia"
+        PHILIPPINES = "PH", "Philippines"
+        UNITED_KINGDOM = "UK", "United Kingdom"
 
     text = models.TextField()
     country_code = models.CharField(

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -411,6 +411,7 @@ class SnippetChooserModelViewSet(SnippetViewSet):
     list_display = [
         "__str__",
         "full_featured__text",
+        "full_featured__country_code",
         "full_featured__latest_revision__created_at",
     ]
     exclude_form_fields = []


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #10815 

### Description
<!-- Please describe the problem you're fixing. -->
This PR fixes snippet listing display for choice fields so the admin table shows human-readable labels (via get_FOO_display()) instead of raw stored values.

The implementation follows the approach discussed in the issue comments:https://github.com/wagtail/wagtail/issues/10815#issuecomment-2665754450 ,

While adding coverage for related choice fields in `test_single_level_choice_relation_uses_choice_label`, I found that related lookups failed when using `field_name` to build the display method name.

`field_name` can be a full lookup path (for e.g- `full_featured__country_code`)
Django choice display methods are based on the terminal field name (e.g- `get_country_code_display()`)
So, using `field_name `can produce an invalid method name for related fields, while using field (the final lookup segment) resolves correctly.
So I updated `field_name` -> `field`



<img width="1141" height="315" alt="Screenshot 2026-04-16 at 4 34 15 PM" src="https://github.com/user-attachments/assets/26edca2a-57d9-4c92-8af6-8f038c354b96" />

verified this behaviour in Bakerydemo: https://github.com/wagtail/wagtail/issues/10815#issuecomment-4256396230

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
I used Copilot for:
- understanding/debugging why the related-field test was failing
- autocomplete
