### PR TITLE
Handle expired admin sessions in chooser modal responses

### DIFF
--- a/client/src/entrypoints/admin/modal-workflow.js
+++ b/client/src/entrypoints/admin/modal-workflow.js
@@ -108,7 +108,16 @@ function ModalWorkflow(opts) {
   };
 
   self.loadResponseText = function loadResponseText(responseText) {
-    const response = JSON.parse(responseText);
+    let response;
+    try {
+      response = JSON.parse(responseText);
+    } catch (error) {
+      if (typeof responseText === 'string' && responseText.trim().startsWith('<')) {
+        window.location.reload();
+        return;
+      }
+      throw error;
+    }
     self.loadBody(response);
   };
 


### PR DESCRIPTION
Fixes #5048

### Description

When a Wagtail admin session expires and a chooser modal (for example Page Chooser or Image Chooser) is opened, the request is redirected to the login page. Because the browser automatically follows the redirect, the modal receives HTML instead of JSON.

The existing code attempts to parse the response using `JSON.parse(responseText)`, which throws an error when the response is actually the login page HTML. This results in the modal workflow failing silently with no feedback to the user.

This change wraps the JSON parsing in a `try/catch` block and detects unexpected HTML responses. When detected, the page is reloaded so that Django can redirect the user to the login page normally.

This prevents the chooser UI from failing silently when the session expires.

### AI usage

AI tools were used only to help improve the wording of the PR description.
