### PR TITLE
docs: add cross-links to admin UI component references

### DIFF
--- a/docs/advanced_topics/customization/admin_templates.md
+++ b/docs/advanced_topics/customization/admin_templates.md
@@ -17,6 +17,13 @@ INSTALLED_APPS = (
 )
 ```
 
+## Reusing admin UI components
+
+When overriding admin templates, prefer reusing Wagtail's existing UI building blocks so your customizations stay consistent with the rest of the admin and are easier to maintain during upgrades.
+
+-   For server-side template tags and components such as dialogs, dropdowns, and other reusable patterns, see [](ui_components).
+-   For client-side JavaScript and Stimulus controllers used by the admin interface, see [](javascript_components).
+
 (custom_branding)=
 
 ## Custom branding

--- a/docs/contributing/ui_guidelines.md
+++ b/docs/contributing/ui_guidelines.md
@@ -148,6 +148,8 @@ We use [Prettier](https://prettier.io/) for formatting and [ESLint](https://esli
 
 Wagtail uses [Stimulus](https://stimulus.hotwired.dev/) as a lightweight framework to attach interactive behavior to DOM elements via `data-` attributes.
 
+For contributor-facing implementation guidance, continue with this page. For the generated reference documentation covering the available JavaScript components and controllers, see [](javascript_components).
+
 ### Why Stimulus
 
 Stimulus is a lightweight framework that allows developers to create interactive UI elements in a simple way. It makes it easy to do small-scale reactivity via changes to data attributes and does not require developers to 'init' things everywhere, unlike JQuery. It also provides an alternative to using inline script tag usage and window globals which reduces complexity in the codebase.

--- a/docs/extending/admin_views.md
+++ b/docs/extending/admin_views.md
@@ -58,6 +58,8 @@ Currently, this view is outputting a plain HTML fragment. Let's insert this into
 The base template and HTML structure are not considered a stable part of Wagtail's API and may change in future releases.
 ```
 
+If you need reusable admin UI building blocks while extending this template, refer to [](ui_components) for server-side template tags and components, and [](javascript_components) for the client-side JavaScript and Stimulus reference.
+
 Update `views.py` as follows:
 
 ```python

--- a/docs/extending/template_components.md
+++ b/docs/extending/template_components.md
@@ -38,6 +38,8 @@ A (possibly empty) :doc:`form media <django:topics/forms/media>` object defining
 
 The preferred way to create a component is to define a subclass of `wagtail.admin.ui.components.Component` and specify a `template_name` attribute on it. The rendered template will then be used as the component's HTML representation:
 
+For a catalog of the reusable admin-facing template tags and UI patterns you can combine with these components, see [](ui_components).
+
 ```python
 from wagtail.admin.ui.components import Component
 


### PR DESCRIPTION
## Summary
- add a reusable admin UI components note to the admin template customization docs
- cross-link the existing server-side UI components and JavaScript components references from related admin extension docs
- add a Stimulus section pointer to the generated JavaScript components reference

Fixes #14148

## Testing
- not run locally (doc8 and sphinx are not installed in this environment)
- verified the referenced docs targets exist in the repository: `ui_components` and `javascript_components`