### PR TITLE
Improve discoverability of JavaScript component docs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,6 +47,7 @@ Changelog
  * Docs: Add content personalization how-to guide (Thibaud Colas)
  * Docs: Add new package maintenance guidelines (Thibaud Colas)
  * Docs: Fix use of `format_html` in `insert_global_admin_js` example (Lasse Schmieding)
+ * Docs: Mention front-end component names in Sphinx docs for discoverability (Aditya Kammati)
  * Maintenance: Removed support for Django 4.2
  * Maintenance: Fix LocaleController test failures caused by differing timezone representations between Node versions (Saptami, Matt Westcott)
  * Maintenance: Fix frontend coverage upload to Codecov (Sage Abdullah)

--- a/client/README.md
+++ b/client/README.md
@@ -7,6 +7,8 @@
 
 Wagtail's JavaScript components are documented using [TypeDoc](https://typedoc.org). This documentation is automatically generated from the source code and provides detailed information about the available components, their methods, and properties. At this stage, the documentation is not exhaustive and may include internal APIs that are not accessible by external code. We are working on improving the code and documentation to make it more comprehensive and user-friendly in the future.
 
+If you are looking for a specific controller or class, search for its full name on [docs.wagtail.org](https://docs.wagtail.org) first. For example, queries such as `ClipboardController`, `DialogController`, `DropdownController`, `PreviewController`, `RulesController`, or `TooltipController` should lead you here, from where you can continue into the full JavaScript reference.
+
 <!-- INTRO:END -->
 
 <!-- STABILITY:START -->

--- a/client/README.md
+++ b/client/README.md
@@ -7,8 +7,6 @@
 
 Wagtail's JavaScript components are documented using [TypeDoc](https://typedoc.org). This documentation is automatically generated from the source code and provides detailed information about the available components, their methods, and properties. At this stage, the documentation is not exhaustive and may include internal APIs that are not accessible by external code. We are working on improving the code and documentation to make it more comprehensive and user-friendly in the future.
 
-If you are looking for a specific controller or class, search for its full name on [docs.wagtail.org](https://docs.wagtail.org) first. For example, queries such as `ClipboardController`, `DialogController`, `DropdownController`, `PreviewController`, `RulesController`, or `TooltipController` should lead you here, from where you can continue into the full JavaScript reference.
-
 <!-- INTRO:END -->
 
 <!-- STABILITY:START -->

--- a/docs/reference/ui/components.md
+++ b/docs/reference/ui/components.md
@@ -2,7 +2,9 @@
 
 # UI components
 
-This document provides a reference for Wagtail's user interface (UI) components, which are used to build the features within the CMS. A demonstration of these components are available through the [Styleguide app](styleguide) and the [pattern library](pattern_library).
+This document provides a reference for Wagtail's user interface (UI) components, which are used to build the features within the CMS. A demonstration of these components is available through the [Styleguide app](styleguide) and the [pattern library](pattern_library).
+
+For JavaScript-powered components and Stimulus controllers, search by the controller or class name and follow the JavaScript reference from [](javascript_components). This is particularly helpful for components such as `ClipboardController`, `DialogController`, `DropdownController`, `PreviewController`, `RulesController`, and `TooltipController`.
 
 ````{note}
 ```{include} ../../../client/README.md

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -88,6 +88,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Fix ordering of image rendition documentation (Seb Corbin)
  * Remove references to now-addressed Django accessibility issues (Nirmal Kumar)
  * Fix use of `format_html` in `insert_global_admin_js` example (Lasse Schmieding)
+ * Mention front-end component names in Sphinx docs for discoverability (Aditya Kammati)
 
 ### Maintenance
 


### PR DESCRIPTION
## Summary
- add searchable controller/class names to the shared JavaScript components intro
- add a pointer from the main UI components page into the JavaScript reference
- focus on docs discoverability instead of changing the search infrastructure

## Testing
- not run (documentation-only change)

Closes #14147.