### PR TITLE
Document icon sprite setup for public pages

### DIFF
--- a/docs/advanced_topics/icons.md
+++ b/docs/advanced_topics/icons.md
@@ -57,6 +57,20 @@ Use an icon in a custom template:
 {% icon name="toucan" classname="..." title="..." %}
 ```
 
+If you want to use Wagtail's icons on public-facing pages, you also need to render the icon sprite and supporting script in your base template. A minimal setup looks like this:
+
+```html+django
+{% load wagtailadmin_tags static %}
+
+<body>
+    <div data-sprite></div>
+    <script src="{% versioned_static 'wagtailadmin/js/icons.js' %}" data-icon-url="{% icon_sprite_url %}"></script>
+    ...
+</body>
+```
+
+Without this snippet, the `{% icon %}` tag will render references to symbols that are only available in the admin.
+
 ## Changing icons via hooks
 
 ```python


### PR DESCRIPTION
## Summary
- document the icon sprite/script snippet needed when using Wagtail icons on public-facing pages
- place the guidance next to the existing  template-tag docs

## Testing
- not run (documentation-only change)

Closes #12665.