### PR TITLE
docs: clarify that the icon tag is for admin templates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,6 +47,7 @@ Changelog
  * Docs: Add content personalization how-to guide (Thibaud Colas)
  * Docs: Add new package maintenance guidelines (Thibaud Colas)
  * Docs: Fix use of `format_html` in `insert_global_admin_js` example (Lasse Schmieding)
+ * Docs: Clarify the icon template tag is only for admin views (Aditya Kammati)
  * Maintenance: Removed support for Django 4.2
  * Maintenance: Fix LocaleController test failures caused by differing timezone representations between Node versions (Saptami, Matt Westcott)
  * Maintenance: Fix frontend coverage upload to Codecov (Sage Abdullah)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -962,6 +962,7 @@
 * Nirmal Kumar
 * Darshan Kerkar
 * James Biggs
+* Aditya Kammati
 
 ## Translators
 

--- a/docs/advanced_topics/icons.md
+++ b/docs/advanced_topics/icons.md
@@ -57,7 +57,7 @@ Use an icon in a custom template:
 {% icon name="toucan" classname="..." title="..." %}
 ```
 
-The `{% icon %}` tag is only usable within Wagtail's admin interface, including admin template overrides and the user bar. For public-facing templates, manage your own icon assets instead of depending on Wagtail's internal admin sprite implementation.
+The `{% icon %}` tag is only usable within Wagtail's admin interface, including admin template overrides and the user bar. Avoid depending on it or its icon sprite for public-facing templates.
 
 ## Changing icons via hooks
 

--- a/docs/advanced_topics/icons.md
+++ b/docs/advanced_topics/icons.md
@@ -57,6 +57,8 @@ Use an icon in a custom template:
 {% icon name="toucan" classname="..." title="..." %}
 ```
 
+The `{% icon %}` tag is only usable within Wagtail's admin interface, including admin template overrides and the user bar. For public-facing templates, manage your own icon assets instead of depending on Wagtail's internal admin sprite implementation.
+
 ## Changing icons via hooks
 
 ```python

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -88,6 +88,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Fix ordering of image rendition documentation (Seb Corbin)
  * Remove references to now-addressed Django accessibility issues (Nirmal Kumar)
  * Fix use of `format_html` in `insert_global_admin_js` example (Lasse Schmieding)
+ * Clarify the icon template tag is only for admin views (Aditya Kammati)
 
 ### Maintenance
 


### PR DESCRIPTION
Fixes #12665.

### Description

Clarify that the icon template tag is intended for Wagtail's admin interface, including admin template overrides and the user bar, and steer public-facing templates toward managing their own icon assets instead of depending on the admin sprite internals.

### AI usage

AI assistance was used during drafting and iteration. The final change direction and wording were manually revised to match the issue discussion and maintainer guidance.