### PR TITLE
Ensure submit to workflow menu item uses the workflow name when creating pages

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ Changelog
  * Fix: Correctly HTML-escape page title in approval/rejection notification emails (Matt Westcott)
  * Fix: Correctly HTML-escape URL in photo type oembeds (Thibaud Colas)
  * Fix: Ensure user with appropriate permissions can cancel a workflow task (Dan Braghis)
+ * Fix: Ensure "submit to workflow" menu item uses the workflow name when creating pages (Sage Abdullah)
  * Docs: Add documentation for the `filter_spec` parameter of `ImageRenditionField` (Soumya-codr)
  * Docs: Add guide for testing document upload forms (Wenli Tsai, Bhavesh Sharma)
  * Docs: Document the `nested_default_fields` attribute on API viewsets (Deepanshu Tevathiya)

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -72,6 +72,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Correctly HTML-escape page title in approval/rejection notification emails (Matt Westcott)
  * Correctly HTML-escape URL in photo type oembeds (Thibaud Colas)
  * Ensure user with appropriate permissions can cancel a workflow task (Dan Braghis)
+ * Ensure "submit to workflow" menu item uses the workflow name when creating pages (Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -129,8 +129,11 @@ class SubmitForModerationMenuItem(ActionMenuItem):
             context["label"] = _("Resubmit to %(task_name)s") % {
                 "task_name": workflow_state.current_task_state.task.name
             }
-        elif page:
-            workflow = page.get_workflow()
+        else:
+            # If the page is being created, use the parent page to determine the
+            # associated workflow, otherwise use the page itself
+            workflow_page = page if page and page.pk else context["parent_page"]
+            workflow = workflow_page.get_workflow()
             if workflow:
                 context["label"] = _("Submit to %(workflow_name)s") % {
                     "workflow_name": workflow.name

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -208,7 +208,7 @@ class TestPageCreation(WagtailTestUtils, TestCase):
             # test that workflow actions are shown
             self.assertContains(
                 response,
-                '<button type="submit" name="action-submit" value="Submit for moderation" class="button">',
+                '<button type="submit" name="action-submit" value="Submit to Moderators approval" class="button">',
             )
 
             self.assertEqual(handler.call_count, 1)
@@ -225,7 +225,7 @@ class TestPageCreation(WagtailTestUtils, TestCase):
             )
         )
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, 'value="Submit for moderation"')
+        self.assertNotContains(response, 'value="Submit to Moderators approval"')
 
     def test_create_multipart(self):
         """
@@ -2297,7 +2297,7 @@ class TestPageCreation(WagtailTestUtils, TestCase):
 
     def test_display_moderation_button_by_default(self):
         """
-        Tests that by default the "Submit for Moderation" button is shown in the action menu.
+        Tests that by default the "Submit to Moderators approval" button is shown in the action menu.
         """
         response = self.client.get(
             reverse(
@@ -2307,15 +2307,15 @@ class TestPageCreation(WagtailTestUtils, TestCase):
         )
         self.assertContains(
             response,
-            '<button type="submit" name="action-submit" value="Submit for moderation" class="button">'
+            '<button type="submit" name="action-submit" value="Submit to Moderators approval" class="button">'
             '<svg class="icon icon-resubmit icon" aria-hidden="true"><use href="#icon-resubmit"></use></svg>'
-            "Submit for moderation</button>",
+            "Submit to Moderators approval</button>",
         )
 
     @override_settings(WAGTAIL_WORKFLOW_ENABLED=False)
     def test_hide_moderation_button(self):
         """
-        Tests that if WAGTAIL_WORKFLOW_ENABLED is set to False, the "Submit for Moderation" button is not shown.
+        Tests that if WAGTAIL_WORKFLOW_ENABLED is set to False, the "Submit to Moderators approval" button is not shown.
         """
         response = self.client.get(
             reverse(
@@ -2325,7 +2325,7 @@ class TestPageCreation(WagtailTestUtils, TestCase):
         )
         self.assertNotContains(
             response,
-            '<button type="submit" name="action-submit" value="Submit for moderation" class="button">Submit for moderation</button>',
+            '<button type="submit" name="action-submit" value="Submit to Moderators approval" class="button">Submit to Moderators approval</button>',
         )
 
     def test_create_sets_locale_to_parent_locale(self):


### PR DESCRIPTION


<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #14019

### Description

<!-- Please describe the problem you're fixing. -->
Pretty self-explanatory.

This doesn't affect snippets, as we already fall back to the model's associated workflow when creating a snippet (and we don't officially support per-instance workflow association anyway):

https://github.com/wagtail/wagtail/blob/9c62f53bc19d8335090e6115aa51db61a6619ee7/wagtail/snippets/action_menu.py#L125-L133

https://github.com/wagtail/wagtail/blob/9c62f53bc19d8335090e6115aa51db61a6619ee7/wagtail/snippets/tests/test_workflows.py#L62-L69

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Copilot for autocompletion