### PR TITLE
Add pad-WxH image operation

### DIFF
--- a/wagtail/images/image_operations.py
+++ b/wagtail/images/image_operations.py
@@ -439,15 +439,14 @@ class PadOperation(FilterOperation):
     aspect ratio, then pads the remaining space with transparency to produce
     an image of exactly WxH pixels.
     """
+
     def construct(self, size):
         try:
             width_str, height_str = size.split("x")
             self.width = int(width_str)
             self.height = int(height_str)
         except (ValueError, AttributeError) as e:
-            raise ValueError(
-                "Image size must be in the format WxH"
-            ) from e
+            raise ValueError("Image size must be in the format WxH") from e
 
         if self.width < 1 or self.height < 1:
             raise ValueError("Image width and height must both be 1 or greater")

--- a/wagtail/images/image_operations.py
+++ b/wagtail/images/image_operations.py
@@ -431,3 +431,51 @@ class BackgroundColorOperation(FilterOperation):
 
     def run(self, willow, image, env):
         return willow.set_background_color_rgb(self.color)
+
+
+class PadOperation(FilterOperation):
+    """
+    Resizes the image to fit within the given dimensions while preserving
+    aspect ratio, then pads the remaining space with transparency to produce
+    an image of exactly WxH pixels.
+    """
+    def construct(self, size):
+        try:
+            width_str, height_str = size.split("x")
+            self.width = int(width_str)
+            self.height = int(height_str)
+        except (ValueError, AttributeError) as e:
+            raise ValueError(
+                "Image size must be in the format WxH"
+            ) from e
+
+        if self.width < 1 or self.height < 1:
+            raise ValueError("Image width and height must both be 1 or greater")
+
+    def run(self, willow, image, env):
+        from PIL import Image as PILImage
+        from willow.plugins.pillow import PillowImage
+
+        image_width, image_height = willow.get_size()
+
+        horz_scale = self.width / image_width
+        vert_scale = self.height / image_height
+
+        if horz_scale < vert_scale:
+            fit_width = self.width
+            fit_height = max(1, int(image_height * horz_scale))
+        else:
+            fit_width = max(1, int(image_width * vert_scale))
+            fit_height = self.height
+
+        if fit_width < image_width or fit_height < image_height:
+            willow = willow.resize((fit_width, fit_height))
+            image_width, image_height = fit_width, fit_height
+
+        pad_left = (self.width - image_width) // 2
+        pad_top = (self.height - image_height) // 2
+        pil_image = willow.get_pillow_image().convert("RGBA")
+        canvas = PILImage.new("RGBA", (self.width, self.height), (0, 0, 0, 0))
+        canvas.paste(pil_image, (pad_left, pad_top), pil_image)
+
+        return PillowImage(canvas)

--- a/wagtail/images/tests/test_image_operations.py
+++ b/wagtail/images/tests/test_image_operations.py
@@ -1099,3 +1099,132 @@ class TestCheckSize(TestCase):
                 (1, 1), allow_floating_point=False
             )
         )
+
+
+class TestPadOperation(TestCase):
+    def test_basic_spec_parsing(self):
+        op = image_operations.PadOperation("pad", "200x200")
+        self.assertEqual(op.width, 200)
+        self.assertEqual(op.height, 200)
+
+    def test_rejects_missing_dimensions(self):
+        self.assertRaises(
+            InvalidFilterSpecError, image_operations.PadOperation, "pad"
+        )
+
+    def test_rejects_single_number(self):
+        self.assertRaises(
+            InvalidFilterSpecError, image_operations.PadOperation, "pad", "200"
+        )
+
+    def test_rejects_non_numeric_dimensions(self):
+        self.assertRaises(
+            InvalidFilterSpecError, image_operations.PadOperation, "pad", "abcxdef"
+        )
+
+    def test_rejects_zero_width(self):
+        self.assertRaises(
+            InvalidFilterSpecError, image_operations.PadOperation, "pad", "0x200"
+        )
+
+    def test_rejects_zero_height(self):
+        self.assertRaises(
+            InvalidFilterSpecError, image_operations.PadOperation, "pad", "200x0"
+        )
+
+    def test_rejects_negative_dimensions(self):
+        self.assertRaises(
+            InvalidFilterSpecError, image_operations.PadOperation, "pad", "-10x200"
+        )
+
+    def test_rejects_extra_arguments(self):
+        # Background colour is set via the separate bgcolor filter, not inline
+        self.assertRaises(
+            InvalidFilterSpecError,
+            image_operations.PadOperation,
+            "pad",
+            "200x200",
+            "fff",
+        )
+
+    def test_wide_image_gets_vertical_padding(self):
+        image = Image.objects.create(
+            title="wide", file=get_test_image_file(colour="red", size=(400, 100))
+        )
+        fil = Filter(spec="pad-200x200")
+        result = fil.run(image, BytesIO())
+        self.assertEqual(result.get_size(), (200, 200))
+
+    def test_tall_image_gets_horizontal_padding(self):
+        image = Image.objects.create(
+            title="tall", file=get_test_image_file(colour="blue", size=(100, 400))
+        )
+        fil = Filter(spec="pad-200x200")
+        result = fil.run(image, BytesIO())
+        self.assertEqual(result.get_size(), (200, 200))
+
+    def test_exact_fit_requires_no_padding(self):
+        image = Image.objects.create(
+            title="exact", file=get_test_image_file(colour="green", size=(200, 200))
+        )
+        fil = Filter(spec="pad-200x200")
+        result = fil.run(image, BytesIO())
+        self.assertEqual(result.get_size(), (200, 200))
+
+    def test_small_image_is_padded_without_upscaling(self):
+        image = Image.objects.create(
+            title="small", file=get_test_image_file(colour="white", size=(50, 50))
+        )
+        fil = Filter(spec="pad-200x200")
+        result = fil.run(image, BytesIO())
+        self.assertEqual(result.get_size(), (200, 200))
+
+    def test_output_is_always_rgba(self):
+        # Even for RGB sources, pad outputs RGBA so bgcolor can be applied
+        image = Image.objects.create(
+            title="rgb", file=get_test_image_file(colour="blue", size=(400, 100))
+        )
+        fil = Filter(spec="pad-200x200")
+        result = fil.run(image, BytesIO())
+        self.assertEqual(result.get_pillow_image().mode, "RGBA")
+
+    def test_padding_area_is_transparent(self):
+        image = Image.objects.create(
+            title="wide", file=get_test_image_file(colour="red", size=(200, 50))
+        )
+        fil = Filter(spec="pad-200x200")
+        result = fil.run(image, BytesIO())
+        # The top-left corner sits in the padding band
+        _, _, _, a = result.get_pillow_image().getpixel((0, 0))
+        self.assertEqual(a, 0)
+
+    def test_bgcolor_fills_padding_area(self):
+        image = Image.objects.create(
+            title="wide", file=get_test_image_file(colour="red", size=(200, 50))
+        )
+        fil = Filter(spec="pad-200x200|bgcolor-fff")
+        result = fil.run(image, BytesIO())
+        pil = result.get_pillow_image()
+        self.assertEqual(pil.mode, "RGB")
+        # Corner should now be white instead of transparent
+        self.assertEqual(pil.getpixel((0, 0)), (255, 255, 255))
+
+    def test_jpeg_output_with_bgcolor(self):
+        image = Image.objects.create(title="j", file=get_test_image_file_jpeg())
+        fil = Filter(spec="pad-200x200|bgcolor-fff|format-jpeg")
+        out = fil.run(image, BytesIO())
+        self.assertEqual(out.format_name, "jpeg")
+
+    def test_png_output(self):
+        image = Image.objects.create(title="p", file=get_test_image_file())
+        fil = Filter(spec="pad-200x200|format-png")
+        out = fil.run(image, BytesIO())
+        self.assertEqual(out.format_name, "png")
+
+    def test_cache_key_does_not_vary(self):
+        # pad doesn't depend on focal point, so the cache key should be empty
+        image = Image(width=400, height=100)
+        fil = Filter(spec="pad-200x200")
+        self.assertEqual(fil.get_cache_key(image), "")
+
+

--- a/wagtail/images/tests/test_image_operations.py
+++ b/wagtail/images/tests/test_image_operations.py
@@ -1108,9 +1108,7 @@ class TestPadOperation(TestCase):
         self.assertEqual(op.height, 200)
 
     def test_rejects_missing_dimensions(self):
-        self.assertRaises(
-            InvalidFilterSpecError, image_operations.PadOperation, "pad"
-        )
+        self.assertRaises(InvalidFilterSpecError, image_operations.PadOperation, "pad")
 
     def test_rejects_single_number(self):
         self.assertRaises(
@@ -1226,5 +1224,3 @@ class TestPadOperation(TestCase):
         image = Image(width=400, height=100)
         fil = Filter(spec="pad-200x200")
         self.assertEqual(fil.get_cache_key(image), "")
-
-

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -119,6 +119,7 @@ def register_image_operations():
         ("avifquality", image_operations.AvifQualityOperation),
         ("format", image_operations.FormatOperation),
         ("bgcolor", image_operations.BackgroundColorOperation),
+        ("pad", image_operations.PadOperation),
     ]
 
 


### PR DESCRIPTION
Fixes #1694

### Description

Adds a `pad-WxH` image operation that resizes images to fit within the given dimensions while preserving aspect ratio, and pads the remaining space to produce an image of exactly WxH. This addresses the missing case where exact dimensions are required without cropping (unlike `fill`) and without losing aspect ratio (unlike forcing dimensions directly). The operation is implemented as a `FilterOperation`, since padding requires creating new pixels rather than applying geometric transforms.

Key behavior:
- scales image to fit within bounds (no upscaling)
- centers image within target dimensions
- pads remaining space using a transparent RGBA canvas
- returns a Pillow-backed Willow image

the output will be pure `RGBA` meaning that they will work with all of the other existing filters (i.e. `bgcolor`) when used in a filter specification.

<img width="905" height="1332" alt="image" src="https://github.com/user-attachments/assets/e9bc3454-676f-47e0-bf17-2e11f5dd0552" />

this is how i tested it 
### AI usage

Used AI assistance for reviewing edge cases, and writing tests.