### PR TITLE
Add WAGTAILUSERS_PASSWORD_RESET_ENABLED setting

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -620,6 +620,14 @@ WAGTAIL_PASSWORD_RESET_ENABLED = True
 
 This specifies whether users are allowed to reset their passwords. Defaults to the same as `WAGTAIL_PASSWORD_MANAGEMENT_ENABLED`. Password reset emails will be sent from the address specified in Django's `DEFAULT_FROM_EMAIL` setting.
 
+### `WAGTAILUSERS_PASSWORD_RESET_ENABLED`
+
+```python
+WAGTAILUSERS_PASSWORD_RESET_ENABLED = True
+```
+
+This specifies whether the "Forgotten password?" link is shown on the admin login page and whether the password reset views are accessible (enabled by default). When set, this takes precedence over `WAGTAIL_PASSWORD_RESET_ENABLED`. Set this to False (along with `WAGTAILUSERS_PASSWORD_ENABLED` and `WAGTAIL_PASSWORD_MANAGEMENT_ENABLED`) if your users are authenticated through an external system such as LDAP.
+
 ### `WAGTAILUSERS_PASSWORD_ENABLED`
 
 ```python

--- a/wagtail/admin/tests/test_password_reset.py
+++ b/wagtail/admin/tests/test_password_reset.py
@@ -46,6 +46,23 @@ class TestUserPasswordReset(WagtailTestUtils, TestCase):
         # Check that the user received a 404
         self.assertEqual(response.status_code, 404)
 
+    @override_settings(WAGTAILUSERS_PASSWORD_RESET_ENABLED=False)
+    def test_login_has_no_password_reset_option_when_wagtailusers_setting_disabled(
+        self,
+    ):
+        response = self.client.get(reverse("wagtailadmin_login"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Forgotten password?")
+
+    @override_settings(WAGTAILUSERS_PASSWORD_RESET_ENABLED=False)
+    def test_password_reset_view_disabled_when_wagtailusers_setting_disabled(self):
+        """
+        This tests that the password reset view responds with a 404
+        when setting WAGTAILUSERS_PASSWORD_RESET_ENABLED is False
+        """
+        response = self.client.get(reverse("wagtailadmin_password_reset"))
+        self.assertEqual(response.status_code, 404)
+
     @override_settings(ROOT_URLCONF="wagtail.admin.urls")
     def test_email_found_default_url(self):
         response = self.client.post(

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -67,6 +67,11 @@ def email_management_enabled():
 
 
 def password_reset_enabled():
+    wagtailusers_setting = getattr(
+        settings, "WAGTAILUSERS_PASSWORD_RESET_ENABLED", None
+    )
+    if wagtailusers_setting is not None:
+        return wagtailusers_setting
     return getattr(
         settings, "WAGTAIL_PASSWORD_RESET_ENABLED", password_management_enabled()
     )


### PR DESCRIPTION
Fixes #14026.

## Summary

Adds `WAGTAILUSERS_PASSWORD_RESET_ENABLED` as a setting that gates both the 'Forgotten password?' link on the admin login page and the password reset views.

## Context

Issue #14026 reports that setting `WAGTAILUSERS_PASSWORD_RESET_ENABLED = False` does not hide the 'Forgotten password?' link. This is because that setting does not actually exist in Wagtail today — the reporter reasonably inferred it from the existing `WAGTAILUSERS_PASSWORD_ENABLED` setting, but the equivalent reset-specific setting is currently named `WAGTAIL_PASSWORD_RESET_ENABLED` (admin-namespace, not users-namespace).

This PR introduces `WAGTAILUSERS_PASSWORD_RESET_ENABLED` as an alias that, when explicitly set, takes precedence over `WAGTAIL_PASSWORD_RESET_ENABLED`. This restores naming consistency with the existing `WAGTAILUSERS_PASSWORD_ENABLED` setting.

## Changes

- `wagtail/admin/views/account.py`: `password_reset_enabled()` now checks `WAGTAILUSERS_PASSWORD_RESET_ENABLED` first, falling back to the existing `WAGTAIL_PASSWORD_RESET_ENABLED` → `password_management_enabled()` chain.
- `wagtail/admin/tests/test_password_reset.py`: adds two tests mirroring the existing `WAGTAIL_PASSWORD_RESET_ENABLED=False` coverage — one asserting the login link is absent, one asserting the reset view returns 404.
- `docs/reference/settings.md`: documents the new setting.

Because `password_reset_enabled()` is already called by both `LoginView.get_context_data()` and `PasswordResetEnabledViewMixin.dispatch()`, a single change in that helper covers both the login-page link and the reset-view URL.

## Backward compatibility

Fully backward-compatible. Existing deployments using `WAGTAIL_PASSWORD_RESET_ENABLED` continue to work unchanged; the new setting only takes effect when explicitly set.

## Testing

- New unit tests pass (`wagtail.admin.tests.test_password_reset`: 10 tests, all OK)
- Existing `test_account_management` suite still passes (63 tests, no regression)
- Manually verified in a fresh Wagtail project: with `WAGTAILUSERS_PASSWORD_RESET_ENABLED = False`, the 'Forgotten password?' link no longer appears on `/admin/login/` and `/admin/password_reset/` returns 404.
- `make lint` passes cleanly (ruff, curlylint, djhtml, semgrep, eslint, stylelint, prettier, tsc, doc8).

## AI disclaimer

This pull request includes code written with the assistance of AI (Claude). This code was reviewed, tested, and verified by me.