### PR TITLE
Update PreviewController for programmatic access to content checks and metrics

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changelog
  * Add `WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS` setting to disable permission filtering on page searches (Matt Westcott)
  * Use choice label when displaying choice fields in `SnippetViewSet`/`ModelViewSet`'s `list_display` (Srishti Jaiswal)
  * Add new content check `empty-meta-description` to validate meta description tags are not empty (Thibaud Colas)
+ * Add `extractMetrics` method to `PreviewController` to retrieve content metrics from the preview panel (Thibaud Colas)
  * Fix: Handle nested inline models when displaying object usage information (Sage Abdullah, Kacper Walęga, Tian Jie Wong)
  * Fix: Avoid duplicate `get_object()` DB query in API detail view (Siddheshwar Kadam)
  * Fix: Ensure `ImageBlock` alt text populates on choosing a new image after unchecking decorative state (Pratham Jaiswal)

--- a/client/src/controllers/PreviewController.test.js
+++ b/client/src/controllers/PreviewController.test.js
@@ -2543,6 +2543,28 @@ describe('PreviewController', () => {
       expect(content).toEqual(mockExtractedContent);
     });
 
+    it('should compute ContentMetrics on demand', async () => {
+      mockAxeResults();
+      await initializeOpenedPanel();
+      const controller = application.getControllerForElementAndIdentifier(
+        document.querySelector('[data-controller="w-preview"]'),
+        identifier,
+      );
+
+      const content = {
+        lang: 'en',
+        innerText: 'This is a simple one just over 10 words in length.',
+        innerHTML: '<p>This is a simple one just over 10 words in length.</p>',
+      };
+      const metrics = controller.extractMetrics(content);
+      expect(metrics).toMatchObject({
+        wordCount: 11,
+        readingTime: 0,
+        lixScore: expect.closeTo(11, 1),
+        readabilityScore: 'Good',
+      });
+    });
+
     it('should not require opening the panel to do content extraction', async () => {
       application = Application.start();
       application.register(identifier, PreviewController);

--- a/client/src/controllers/PreviewController.ts
+++ b/client/src/controllers/PreviewController.ts
@@ -898,6 +898,8 @@ export class PreviewController extends Controller<HTMLElement> {
       this.checkerRowTemplate!,
       () => this.newTabTarget.click(),
     );
+
+    return { results, issueCount };
   }
 
   /**

--- a/client/src/controllers/PreviewController.ts
+++ b/client/src/controllers/PreviewController.ts
@@ -12,7 +12,9 @@ import {
   renderCheckerResults,
 } from '../includes/contentChecker';
 import {
-  ContentExtractorOptions,
+  type ContentExtractorOptions,
+  type ContentMetrics,
+  type ExtractedContent,
   getLIXScore,
   getPreviewContent,
   getReadabilityScore,
@@ -909,15 +911,23 @@ export class PreviewController extends Controller<HTMLElement> {
     // previewed page shows an error response), skip doing anything with it.
     if (!content) return;
 
-    const wordCount = getWordCount(content.lang, content.innerText);
-    const readingTime = getReadingTime(content.lang, wordCount);
-    const lixScore = getLIXScore(content.lang, content.innerText);
-    const readabilityScore = getReadabilityScore(lixScore);
-    const metrics = { wordCount, readingTime, lixScore, readabilityScore };
+    const metrics = this.extractMetrics(content);
 
     this.dispatch('content', { detail: { content, metrics } });
 
     renderContentMetrics(metrics);
+  }
+
+  /**
+   * Computes content metrics (word count, reading time, LIX, readability) from
+   * extracted preview content.
+   */
+  extractMetrics(content: ExtractedContent): ContentMetrics {
+    const wordCount = getWordCount(content.lang, content.innerText);
+    const readingTime = getReadingTime(content.lang, wordCount);
+    const lixScore = getLIXScore(content.lang, content.innerText);
+    const readabilityScore = getReadabilityScore(lixScore);
+    return { wordCount, readingTime, lixScore, readabilityScore };
   }
 
   /**

--- a/client/src/includes/contentMetrics.ts
+++ b/client/src/includes/contentMetrics.ts
@@ -94,6 +94,7 @@ export const getReadabilityScore = (lixScore: number): string => {
 export interface ContentMetrics {
   wordCount: number;
   readingTime: number;
+  lixScore: number;
   readabilityScore: string;
 }
 

--- a/docs/extending/editor_api.md
+++ b/docs/extending/editor_api.md
@@ -18,6 +18,7 @@ The preview panel is powered by the [`PreviewController`](controller:PreviewCont
 ```javascript
 const previewController = window.wagtail.app.queryController('w-preview');
 const content = await previewController?.extractContent();
+const metrics = previewController?.extractMetrics(content);
 await previewController?.runContentChecks();
 ```
 

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -56,6 +56,7 @@ The Wagtail documentation now contains a new version of our official [package ma
  * Add [](wagtailadmin_page_search_filter_by_permissions) setting to disable permission filtering on page searches (Matt Westcott)
  * Use choice label when displaying choice fields in `SnippetViewSet`/`ModelViewSet`'s `list_display` (Srishti Jaiswal)
  * Add new content check `empty-meta-description` to validate meta description tags are not empty (Thibaud Colas)
+ * Add `extractMetrics` method to `PreviewController` to retrieve content metrics from the preview panel (Thibaud Colas)
 
 ### Bug fixes
 


### PR DESCRIPTION
Part of #11063 - introducing small API changes to allow for programmatic retrieval of:

- Built-in content metrics, via a new documented `extractMetrics` method.
- All content check results, by changing the return signature of the __undocumented__ `runAxeChecks` (renamed in #14123 from `runAccessibilityChecks`).

I would like us to formally support retrieving content check results but I don’t know if the current API is right. This might be better done with events than imperative APIs. And I’m not sure we should use the Axe results as-is.

Both methods will still be documented in our [Wagtail client-side components docs, PreviewController](https://docs.wagtail.org/en/stable/reference/ui/client/classes/controllers_PreviewController.PreviewController.html#runchecks).

### AI usage

Test written by Cursor