### PR TITLE
Serve original image via protected admin view

### DIFF
--- a/wagtail/images/admin_urls.py
+++ b/wagtail/images/admin_urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
         name="url_generator_output",
     ),
     path("<int:image_id>/preview/<str:filter_spec>/", images.preview, name="preview"),
+    path("<int:image_id>/original_file/", images.original_file, name="original_file"),
     path("add/", images.CreateView.as_view(), name="add"),
     path("usage/<int:image_id>/", images.UsageView.as_view(), name="image_usage"),
     path("multiple/add/", multiple.AddView.as_view(), name="add_multiple"),

--- a/wagtail/images/templates/wagtailimages/images/_file_field.html
+++ b/wagtail/images/templates/wagtailimages/images/_file_field.html
@@ -1,8 +1,8 @@
 {% load i18n wagtailadmin_tags wagtailimages_tags l10n %}
 {% rawformattedfield field=field %}
-    {% image image original as original_image %}
 
-    <a href="{{ original_image.url }}">{% icon name="image" classname="default" %}{{ image.filename }}</a> ({{ original_image.width|unlocalize }}x{{ original_image.height|unlocalize }})<br /><br />
+    <a href="{% url 'wagtailimages:original_file' image.id %}">{{ image.filename }}</a>
+    ({{ image.width|unlocalize }}x{{ image.height|unlocalize }})
 
     {% trans "Change image file:" %}
     {{ field }}

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -54,11 +54,10 @@
                     <button class="button button-secondary no remove-focal-point" type="button">{% trans "Remove focal area" %}</button>
                 </div>
                 <div class="w-col-span-1">
-                    {% image image original as original_image %}
 
                     <dl>
                         <dt>{% trans "Max dimensions" %}</dt>
-                        <dd>{{ original_image.width|unlocalize }}x{{ original_image.height|unlocalize }}</dd>
+                        <dd>{{ image.width|unlocalize }}x{{ image.height|unlocalize }}</dd>
                         <dt>{% trans "Filesize" %}</dt>
                         <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
 

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1740,6 +1740,43 @@ class TestImageEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
             response, "Custom image with this Title and Collection already exists."
         )
 
+    def test_original_file_view_admin_can_access(self):
+        """
+        Logged-in admin can access the original file view
+        and gets a file response
+        """
+        response = self.client.get(
+            reverse("wagtailimages:original_file", args=(self.image.id,))
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_original_file_view_anonymous_redirected(self):
+        """
+        Anonymous user is redirected to login
+        """
+        self.client.logout()
+        response = self.client.get(
+            reverse("wagtailimages:original_file", args=(self.image.id,))
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/admin/login/", response["Location"])
+
+    def test_original_file_view_does_not_create_rendition(self):
+        """
+        Accessing the original file view must NOT create an 'original' rendition
+        """
+        self.client.get(reverse("wagtailimages:original_file", args=(self.image.id,)))
+        self.assertFalse(self.image.renditions.filter(filter_spec="original").exists())
+
+    def test_original_file_view_invalid_image_returns_404(self):
+        """
+        Requesting a non-existent image ID returns 404
+        """
+        response = self.client.get(
+            reverse("wagtailimages:original_file", args=(999999,))
+        )
+        self.assertEqual(response.status_code, 404)
+
 
 @override_settings(WAGTAILIMAGES_IMAGE_MODEL="tests.CustomImage")
 class TestImageEditViewWithCustomImageModel(WagtailTestUtils, TestCase):

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1800,6 +1800,43 @@ class TestImageEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
             response, "Custom image with this Title and Collection already exists."
         )
 
+    def test_original_file_view_admin_can_access(self):
+        """
+        Logged-in admin can access the original file view
+        and gets a file response
+        """
+        response = self.client.get(
+            reverse("wagtailimages:original_file", args=(self.image.id,))
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_original_file_view_anonymous_redirected(self):
+        """
+        Anonymous user is redirected to login
+        """
+        self.client.logout()
+        response = self.client.get(
+            reverse("wagtailimages:original_file", args=(self.image.id,))
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/admin/login/", response["Location"])
+
+    def test_original_file_view_does_not_create_rendition(self):
+        """
+        Accessing the original file view must NOT create an 'original' rendition
+        """
+        self.client.get(reverse("wagtailimages:original_file", args=(self.image.id,)))
+        self.assertFalse(self.image.renditions.filter(filter_spec="original").exists())
+
+    def test_original_file_view_invalid_image_returns_404(self):
+        """
+        Requesting a non-existent image ID returns 404
+        """
+        response = self.client.get(
+            reverse("wagtailimages:original_file", args=(999999,))
+        )
+        self.assertEqual(response.status_code, 404)
+
 
 @override_settings(WAGTAILIMAGES_IMAGE_MODEL="tests.CustomImage")
 class TestImageEditViewWithCustomImageModel(WagtailTestUtils, TestCase):

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -1,4 +1,5 @@
 import json
+import mimetypes
 import os
 from tempfile import SpooledTemporaryFile
 
@@ -442,6 +443,23 @@ def preview(request, image_id, filter_spec):
         return HttpResponse(
             "Invalid filter spec: " + filter_spec, content_type="text/plain", status=400
         )
+
+
+@permission_checker.require("change")
+def original_file(request, image_id):
+    image = get_object_or_404(get_image_model(), id=image_id)
+
+    try:
+        file = image.file.open("rb")
+    except IOError:
+        return HttpResponse("Not found", status=404)
+
+    content_type, _ = mimetypes.guess_type(image.file.name)
+    response = FileResponse(
+        file, content_type=content_type or "application/octet-stream"
+    )
+    response["Content-Disposition"] = f'inline; filename="{image.filename}"'
+    return response
 
 
 class DeleteView(generic.DeleteView):

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -1,4 +1,5 @@
 import json
+import mimetypes
 import os
 from tempfile import SpooledTemporaryFile
 
@@ -460,6 +461,23 @@ def preview(request, image_id, filter_spec):
     temp_image.seek(0)
     response = FileResponse(temp_image)
     response["Content-Type"] = "image/" + image.format_name
+    return response
+
+
+@permission_checker.require("change")
+def original_file(request, image_id):
+    image = get_object_or_404(get_image_model(), id=image_id)
+
+    try:
+        file = image.file.open("rb")
+    except IOError:
+        return HttpResponse("Not found", status=404)
+
+    content_type, _ = mimetypes.guess_type(image.file.name)
+    response = FileResponse(
+        file, content_type=content_type or "application/octet-stream"
+    )
+    response["Content-Disposition"] = f'inline; filename="{image.filename}"'
     return response
 
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #14137

### Description
Clicking the file link in the admin image panel was generating an original rendition, making the full-resolution image publicly accessible via a predictable URL.

This fixes it by serving the original image through a protected admin-only Django view instead of generating a rendition.
Changes:

- `views/images.py `: added `original_file` view that serves the image file directly, only accessible to logged-in admins.

- `admin_urls.py`: registered the new URL pattern for the view.

- `file_field.html `: removed `{% image image original %}`, replaced file link with new protected view URL.

- `edit.html`: removed `{% image image original %},` replaced `original_image.width/height `with `image.width/height `directly.

- `test_admin_views.py` :added tests to verify admin access, anonymous redirect, no rendition created, and 404 on invalid image.

<!-- Please describe the problem you're fixing. -->

### Testing 

- Testing logged in 

<img width="1914" height="862" alt="Screenshot From 2026-04-20 22-34-05" src="https://github.com/user-attachments/assets/284e79b5-47c0-4d67-b50f-583d7c871cd0" />

- Testing in incognito mode

<img width="1914" height="862" alt="Screenshot From 2026-04-20 22-33-51" src="https://github.com/user-attachments/assets/5fa0ce48-f1d4-4adf-be02-0aaa5fba6442" />

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
- Autocomplete in PyCharm.
- claude.ai in writing unit tests and understanding the files.