### PR TITLE
Upgrade to modelsearch 1.3

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Add new content check `empty-meta-description` to validate meta description tags are not empty (Thibaud Colas)
  * Add `extractMetrics` method to `PreviewController` to retrieve content metrics from the preview panel (Thibaud Colas)
  * Preserve "Collapse all" button state when switching between editor tabs (Raghad Dahi)
+ * Upgrade modelsearch to 1.3 (Matt Westcott)
  * Fix: Handle nested inline models when displaying object usage information (Sage Abdullah, Kacper Walęga, Tian Jie Wong)
  * Fix: Avoid duplicate `get_object()` DB query in API detail view (Siddheshwar Kadam)
  * Fix: Ensure `ImageBlock` alt text populates on choosing a new image after unchecking decorative state (Pratham Jaiswal)

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -33,6 +33,10 @@ The preview feature has been improved to be more compatible with projects that u
 
 This feature was developed by Sage Abdullah. We would like to thank Personalkollen for their sponsorship of this feature.
 
+### Search enhancements
+
+The [Django Modelsearch](https://django-modelsearch.readthedocs.io/) library has been upgraded to version 1.3, bringing enhancements including support for fuzzy search on PostgreSQL, searching and filtering across related fields to any level of nesting, and ranking of results on Sqlite.
+
 ### Content personalization documentation
 
 [](content_personalization) is a new advanced how-to guide explaining how to meet common content personalization requirements with built-in features, such as combining [`BlockGroup`](wagtail.blocks.BlockGroup) in StreamField and [preview modes](wagtail.models.Page.preview_modes) to create segmented page sections. This guide was written by Thibaud Colas.

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -35,7 +35,7 @@ This feature was developed by Sage Abdullah. We would like to thank Personalkoll
 
 ### Search enhancements
 
-The [Django Modelsearch](https://django-modelsearch.readthedocs.io/) library has been upgraded to version 1.3, bringing enhancements including support for fuzzy search on PostgreSQL, searching and filtering across related fields to any level of nesting, and ranking of results on Sqlite.
+The [Django Modelsearch](https://django-modelsearch.readthedocs.io/) library has been upgraded to version 1.3, bringing enhancements including support for fuzzy search on PostgreSQL, searching and filtering across related fields to any level of nesting, and ranking of results on SQLite.
 
 ### Content personalization documentation
 

--- a/docs/topics/search/backends.md
+++ b/docs/topics/search/backends.md
@@ -2,7 +2,7 @@
 
 # Backends
 
-Wagtailsearch has support for multiple backends, giving you the choice between using the database for search or an external service such as Elasticsearch.
+Wagtail search has support for multiple backends, giving you the choice between using the database for search or an external service such as Elasticsearch.
 
 You can configure which backend to use with the `WAGTAILSEARCH_BACKENDS` setting:
 
@@ -12,6 +12,10 @@ WAGTAILSEARCH_BACKENDS = {
         'BACKEND': 'wagtail.search.backends.database',
     }
 }
+```
+
+```{note}
+Wagtail's search functionality is powered by the [Django ModelSearch](https://django-modelsearch.readthedocs.io/) library, which provides [additional configuration options](https://django-modelsearch.readthedocs.io/en/latest/backends.html) beyond those prevented here. When used within Wagtail, the `WAGTAILSEARCH_BACKENDS` setting should be used rather than `MODELSEARCH_BACKENDS`.
 ```
 
 (wagtailsearch_backends_auto_update)=
@@ -54,7 +58,7 @@ Here's a list of backends that Wagtail supports out of the box.
 The database search backend searches content in the database using the full-text search features of the database backend in use (such as PostgreSQL FTS, SQLite FTS5).
 This backend is intended to be used for development and also should be good enough to use in production on sites that don't require any Elasticsearch specific features.
 
-If you use the PostgreSQL database backend, you must add `django.contrib.postgres` to your [`INSTALLED_APPS`](inv:django:std:setting#INSTALLED_APPS) setting.
+If you use the PostgreSQL database backend, you must add `django.contrib.postgres` to your [`INSTALLED_APPS`](inv:django:std:setting#INSTALLED_APPS) setting. Under PostgreSQL, various additional configuration options are available, as detailed in the [ModelSearch PostgreSQL configuration documentation](https://django-modelsearch.readthedocs.io/en/latest/backends.html#postgresql-configuration).
 
 (wagtailsearch_backends_elasticsearch)=
 
@@ -264,7 +268,3 @@ WAGTAILSEARCH_BACKENDS = {
     }
 }
 ```
-
-## Rolling Your Own
-
-Wagtail's search implementation is provided by the [django-modelsearch](https://github.com/kaedroho/django-modelsearch) package, and backends implement the interface defined in `modelsearch/backends/base.py`. At a minimum, the backend's `search()` method must return a collection of objects or `model.objects.none()`.

--- a/docs/topics/search/indexing.md
+++ b/docs/topics/search/indexing.md
@@ -144,11 +144,12 @@ class Book(models.Model, index.Indexed):
 
         index.RelatedFields('author', [
             index.SearchField('name'),
+            index.FilterField('date_of_birth'),
         ]),
     ]
 ```
 
-This will allow you to search for books by their author's name.
+This will allow you to search for books by their author's name, or limit the search to books by authors born before or after a given date.
 
 It works the other way around as well. You can index an author's books, allowing an author to be searched for by the titles of books they've published:
 
@@ -168,11 +169,9 @@ class Author(models.Model, index.Indexed):
     ]
 ```
 
-#### Filtering on `index.RelatedFields`
-
-It's not possible to filter on any `index.FilterFields` within `index.RelatedFields` using the `QuerySet` API. Placing `index.FilterField` inside `index.RelatedFields` is valid, and will cause the appropriate field data to be stored at indexing time, but the `QuerySet` API does not currently support filters that span relations, and so there is no way to access these fields. However, it should be possible to use them by querying Elasticsearch manually.
-
-Filtering on `index.RelatedFields` with the `QuerySet` API is planned for a future release of Wagtail.
+```{versionadded} 7.4
+Filtering on related fields is now supported.
+```
 
 (wagtailsearch_indexing_callable_fields)=
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "telepath>=0.3.1,<1",
   "laces>=0.1,<0.2",
   "django-tasks>=0.9,<0.13",
-  "modelsearch>=1.1,<1.3",
+  "modelsearch>=1.3,<1.4",
 ]
 
 [project.urls]

--- a/wagtail/search/management/commands/enable_fuzzystrmatch.py
+++ b/wagtail/search/management/commands/enable_fuzzystrmatch.py
@@ -1,0 +1,1 @@
+from modelsearch.management.commands.enable_fuzzystrmatch import *  # noqa: F403

--- a/wagtail/search/management/commands/enable_trigram.py
+++ b/wagtail/search/management/commands/enable_trigram.py
@@ -1,0 +1,1 @@
+from modelsearch.management.commands.enable_trigram import *  # noqa: F403

--- a/wagtail/search/management/commands/enable_unaccent.py
+++ b/wagtail/search/management/commands/enable_unaccent.py
@@ -1,0 +1,1 @@
+from modelsearch.management.commands.enable_unaccent import *  # noqa: F403

--- a/wagtail/search/migrations/0010_add_text_fields.py
+++ b/wagtail/search/migrations/0010_add_text_fields.py
@@ -1,5 +1,6 @@
 from django.db import connection, migrations, models
 
+# Copied from 0003_add_text_fields in modelsearch
 
 class Migration(migrations.Migration):
     dependencies = [

--- a/wagtail/search/migrations/0010_add_text_fields.py
+++ b/wagtail/search/migrations/0010_add_text_fields.py
@@ -1,0 +1,42 @@
+from django.db import connection, migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("wagtailsearch", "0009_remove_ngram_autocomplete"),
+    ]
+
+    if connection.vendor == "postgresql":
+        operations = [
+            migrations.AddField(
+                model_name="indexentry",
+                name="title_text",
+                field=models.TextField(default=""),
+            ),
+            migrations.AddField(
+                model_name="indexentry",
+                name="body_text",
+                field=models.TextField(default=""),
+            ),
+            # GIN trigram indexes are created by the enable_trigram
+            # management command, not here. The reverse SQL drops them on
+            # migration rollback.
+            migrations.RunSQL(
+                sql=migrations.RunSQL.noop,
+                reverse_sql="DROP INDEX IF EXISTS modelsearch_title_text_trgm;",
+            ),
+            migrations.RunSQL(
+                sql=migrations.RunSQL.noop,
+                reverse_sql="DROP INDEX IF EXISTS modelsearch_body_text_trgm;",
+            ),
+            migrations.RunSQL(
+                sql=migrations.RunSQL.noop,
+                reverse_sql="DROP INDEX IF EXISTS modelsearch_title_text_unaccent_trgm;",
+            ),
+            migrations.RunSQL(
+                sql=migrations.RunSQL.noop,
+                reverse_sql="DROP INDEX IF EXISTS modelsearch_body_text_unaccent_trgm;",
+            ),
+        ]
+    else:
+        operations = []


### PR DESCRIPTION
### Description

Upgrade to modelsearch 1.3.x - supports filtering by related fields, fuzzy matching on postgres and more. Added migrations and stubs for management commands to the `wagtail.search` app so that putting `wagtail.search` rather than `modelsearch` in INSTALLED_APPS continues to work.

~(opening as draft as we should also update documentation, although that could potentially happen in the 7.4 feature freeze)~ Docs added.

### AI usage

None
