### PR TITLE
Implement inline userbar annotations for content checker highlights in preview

### DIFF
--- a/client/scss/components/_inline-userbar.scss
+++ b/client/scss/components/_inline-userbar.scss
@@ -9,9 +9,11 @@
   position: absolute;
   z-index: 9998;
   pointer-events: auto;
-  transform: translate(calc(var(--w-direction-factor) * -50%), -50%);
   top: var(--inline-userbar-top);
   inset-inline-start: var(--inline-userbar-inline-start);
+  // Counter-scale to remain legible when the preview iframe is scaled down.
+  transform: translate(calc(var(--w-direction-factor) * -50%), -50%)
+    scale(var(--inline-userbar-scale, 1));
 }
 
 .w-inline-userbar__toggle {

--- a/client/scss/components/_inline-userbar.scss
+++ b/client/scss/components/_inline-userbar.scss
@@ -1,0 +1,50 @@
+@use '../tools' as *;
+
+// <wagtail-inline-userbar> component, inserted as a sibling
+// after a target element so annotations follow DOM/tab order.
+// Risks conflicts with CSS sibling / hierarchy selectors (+, ~, :nth-child, :last-child).
+// stylelint-disable-next-line selector-type-no-unknown
+:host(wagtail-inline-userbar) {
+  position: absolute;
+  z-index: 9998;
+  pointer-events: auto;
+  transform: translate(calc(var(--w-direction-factor) * -50%), -50%);
+  top: var(--inline-userbar-top);
+  inset-inline-start: var(--inline-userbar-inline-start);
+}
+
+.w-inline-userbar__toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: theme('spacing.6');
+  height: theme('spacing.6');
+  border-radius: theme('borderRadius.full');
+  border: 2px solid theme('colors.white.DEFAULT');
+  background-color: theme('colors.critical.200');
+  cursor: pointer;
+  padding: 0;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  transition: transform 0.15s ease;
+
+  &:hover,
+  &:focus-visible {
+    @apply w-scale-110;
+
+    outline: 3px solid theme('colors.focus');
+    outline-offset: 1px;
+  }
+
+  svg {
+    width: theme('spacing.[3.5]');
+    height: theme('spacing.[3.5]');
+    fill: theme('colors.white.DEFAULT');
+    pointer-events: none;
+  }
+}
+
+.w-inline-userbar__content {
+  font-family: theme('fontFamily.sans');
+  max-width: 320px;
+  min-width: 200px;
+}

--- a/client/scss/components/_inline-userbar.scss
+++ b/client/scss/components/_inline-userbar.scss
@@ -1,4 +1,5 @@
 @use '../tools' as *;
+@use '../settings' as *;
 
 // <wagtail-inline-userbar> component, inserted as a sibling
 // after a target element so annotations follow DOM/tab order.
@@ -24,7 +25,7 @@
   background-color: theme('colors.critical.200');
   cursor: pointer;
   padding: 0;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: $userbar-box-shadow;
   transition: transform 0.15s ease;
 
   &:hover,
@@ -40,11 +41,13 @@
     height: theme('spacing.[3.5]');
     fill: theme('colors.white.DEFAULT');
     pointer-events: none;
+    position: relative;
+    top: -1px;
   }
 }
 
 .w-inline-userbar__content {
   font-family: theme('fontFamily.sans');
   max-width: 320px;
-  min-width: 200px;
+  min-width: 260px;
 }

--- a/client/scss/components/_userbar.scss
+++ b/client/scss/components/_userbar.scss
@@ -2,6 +2,7 @@
 @use 'sass:math';
 @use 'sass:string';
 @use '../tools' as *;
+@use '../settings' as *;
 
 // =============================================================================
 // Variables
@@ -9,9 +10,6 @@
 
 $size-home-button: 3.5em;
 $position: 2em;
-$box-shadow-props:
-  0 0 1px 0 rgba(107, 214, 230, 1),
-  0 1px 10px 0 rgba(107, 214, 230, 0.7);
 $max-items: 12;
 $userbar-radius: 6px;
 $userbar-z-index: 9999;
@@ -81,7 +79,7 @@ $positions: (
   border-radius: 50%;
   padding: 0;
   cursor: pointer;
-  box-shadow: $box-shadow-props;
+  box-shadow: $userbar-box-shadow;
   transition: all 0.2s ease-in-out;
   font-size: 1rem;
   text-decoration: none;

--- a/client/scss/core.scss
+++ b/client/scss/core.scss
@@ -138,6 +138,7 @@ These are classes for components.
 @use 'components/preview-error';
 @use 'components/form-side';
 @use 'components/content-checker';
+@use 'components/inline-userbar';
 @use 'components/userbar';
 @use 'components/breadcrumbs';
 @use 'components/pill';

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -46,3 +46,7 @@ $mobile-nav-indent: 50px;
 $menu-transition-duration: 150ms;
 
 $focus-outline-width: 3px;
+
+$userbar-box-shadow:
+  0 0 1px 0 rgba(107, 214, 230, 1),
+  0 1px 10px 0 rgba(107, 214, 230, 0.7);

--- a/client/src/controllers/PreviewController.ts
+++ b/client/src/controllers/PreviewController.ts
@@ -524,6 +524,25 @@ export class PreviewController extends Controller<HTMLElement> {
       this.deviceWidthPropertyValue,
       deviceWidth as string,
     );
+    this.sendScaleToIframe();
+  }
+
+  /**
+   * Send the current preview scale ratio to the iframe so inline
+   * annotations can apply an inverse transform to remain legible.
+   * Mirrors the CSS formula: min(1, panel-width / device-width).
+   */
+  private sendScaleToIframe() {
+    const panelWidth = this.element.clientWidth;
+    const deviceWidth = parseFloat(
+      this.element.style.getPropertyValue(this.deviceWidthPropertyValue),
+    );
+    if (!panelWidth || !deviceWidth || !this.iframeTarget.contentWindow) return;
+    const ratio = Math.max(1, deviceWidth / panelWidth);
+    this.iframeTarget.contentWindow.postMessage(
+      { wagtail: { type: 'w-preview:set-scale', scale: ratio } },
+      '*',
+    );
   }
 
   /**
@@ -546,12 +565,13 @@ export class PreviewController extends Controller<HTMLElement> {
    * This is used to maintain the simulated device width as the side panel is resized.
    */
   observePanelSize() {
-    const resizeObserver = new ResizeObserver((entries) =>
+    const resizeObserver = new ResizeObserver((entries) => {
       this.element.style.setProperty(
         this.panelWidthPropertyValue,
         entries[0].contentRect.width.toString(),
-      ),
-    );
+      );
+      this.sendScaleToIframe();
+    });
     resizeObserver.observe(this.element);
     return resizeObserver;
   }
@@ -864,6 +884,10 @@ export class PreviewController extends Controller<HTMLElement> {
       if (data?.type !== 'w-userbar:axe-ready')
         return this.contentChecksPromise;
     }
+
+    // The iframe's userbar has finished initialising and annotations now
+    // exist, so send the current scale for counter-scaling.
+    this.sendScaleToIframe();
 
     // If the content checks are already running, wait for them to finish before
     // re-running them, as Axe does not allow concurrent runs.

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -1,6 +1,8 @@
+import { InlineUserbar } from '../../includes/inlineUserbar';
 import { Userbar } from '../../includes/userbar';
 
 customElements.define('wagtail-userbar', Userbar);
+customElements.define('wagtail-inline-userbar', InlineUserbar);
 
 window.wagtail = window.wagtail || {};
 window.wagtail.userbar = document.querySelector('wagtail-userbar');

--- a/client/src/includes/contentChecker.test.ts
+++ b/client/src/includes/contentChecker.test.ts
@@ -5,6 +5,7 @@ import {
   checkEmptyMetaDescription,
   checkImageAltText,
   getCheckerReport,
+  getViolationMessage,
   registerCustomCheck,
   sortAxeViolations,
 } from './contentChecker';
@@ -61,6 +62,52 @@ describe('sortAxeViolations', () => {
       mockViolations.db,
       mockViolations.third,
     ]);
+  });
+});
+
+describe('getViolationMessage', () => {
+  const violation = {
+    id: 'heading-order',
+    help: 'Headings should not skip levels',
+    description: 'Ensure the order of headings is semantically correct',
+  };
+
+  it('uses Wagtail custom messages when available', () => {
+    const messages = {
+      'heading-order': {
+        error_name: 'Incorrect heading hierarchy',
+        help_text: 'Avoid skipping levels',
+      },
+    };
+    const result = getViolationMessage(violation, messages);
+    expect(result.name).toBe('Incorrect heading hierarchy');
+    expect(result.helpText).toBe('Avoid skipping levels');
+  });
+
+  it('falls back to axe defaults when no custom messages exist', () => {
+    const result = getViolationMessage(violation, {});
+    expect(result.name).toBe('Headings should not skip levels');
+    expect(result.helpText).toBe(
+      'Ensure the order of headings is semantically correct',
+    );
+  });
+
+  it('handles string-type messages', () => {
+    const messages = { 'heading-order': 'Bad headings' };
+    const result = getViolationMessage(violation, messages);
+    expect(result.name).toBe('Bad headings');
+    expect(result.helpText).toBe(
+      'Ensure the order of headings is semantically correct',
+    );
+  });
+
+  it('falls back to axe help when error_name is empty', () => {
+    const messages = {
+      'heading-order': { error_name: '', help_text: 'Custom help' },
+    };
+    const result = getViolationMessage(violation, messages);
+    expect(result.name).toBe('Headings should not skip levels');
+    expect(result.helpText).toBe('Custom help');
   });
 });
 

--- a/client/src/includes/contentChecker.ts
+++ b/client/src/includes/contentChecker.ts
@@ -42,16 +42,37 @@ export const sortAxeViolations = (violations: Result[]) =>
  * Wagtail's Axe configuration object. This should reflect what's returned by
  * `wagtail.admin.userbar.ContentCheckerItem.get_axe_configuration()`.
  */
-interface ErrorMessage {
+export interface ErrorMessage {
   error_name: string;
   help_text: string;
 }
+
+export interface ErrorMessages {
+  [key: string]: string | ErrorMessage;
+}
+
 export interface WagtailAxeConfiguration {
   context: ContextObject;
   options: RunOptions;
-  messages: Record<string, ErrorMessage>;
+  messages: ErrorMessages;
   spec: Spec;
 }
+
+/**
+ * Resolve the display name and help text for a violation, preferring
+ * Wagtail's custom messages over axe defaults.
+ */
+export const getViolationMessage = (
+  violation: { id: string; help: string; description: string },
+  messages: ErrorMessages,
+): { name: string; helpText: string } => {
+  const msg = messages[violation.id];
+  const name =
+    (typeof msg === 'string' ? msg : msg?.error_name) || violation.help;
+  const helpText =
+    (typeof msg !== 'string' && msg?.help_text) || violation.description;
+  return { name, helpText };
+};
 
 /**
  * Get the Axe configuration from the page.
@@ -212,15 +233,12 @@ export const renderCheckerResults = (
         ) as HTMLDivElement;
         errorName.id = `w-content-checker__name-${nodeCounter}`;
 
-        // Display custom error messages supplied by Wagtail if available,
-        // fallback to default error message from Axe
-        const messages = config.messages[violation.id];
-
-        const name =
-          (typeof messages === 'string' ? messages : messages?.error_name) ||
-          violation.help;
+        const { name, helpText } = getViolationMessage(
+          violation,
+          config.messages,
+        );
         errorName.textContent = name;
-        errorHelp.textContent = messages?.help_text || violation.description;
+        errorHelp.textContent = helpText;
 
         // Special-case when displaying results within the admin interface.
         const isInCMS = node.target[0] === '#w-preview-iframe';

--- a/client/src/includes/inlineUserbar.ts
+++ b/client/src/includes/inlineUserbar.ts
@@ -1,0 +1,199 @@
+import type { Result } from 'axe-core';
+import type { ErrorMessages } from './contentChecker';
+import tippy, { type Instance, type Props } from 'tippy.js';
+import { hideTooltipOnEsc } from '../controllers/TooltipController';
+import { getViolationMessage } from './contentChecker';
+
+let nextAnnotationId = 0;
+
+/**
+ * Lightweight inline annotation that displays CMS information or interactions
+ * related to a specific page element.
+ */
+export class InlineUserbar extends HTMLElement {
+  declare tippyInstance: Instance<Props>;
+  declare toggle: HTMLButtonElement;
+  declare targetElement: HTMLElement;
+  declare resizeObserver: ResizeObserver;
+
+  connectedCallback() {
+    const userbarShadow = document.querySelector('wagtail-userbar')?.shadowRoot;
+    if (!userbarShadow) return;
+
+    const wrapperTemplate = userbarShadow.querySelector<HTMLTemplateElement>(
+      `#w-inline-userbar-template`,
+    );
+    if (!wrapperTemplate) return;
+
+    const shadowRoot = this.attachShadow({ mode: 'open' });
+
+    this.targetElement = document.querySelector(
+      this.getAttribute('data-selector')!,
+    ) as HTMLElement;
+
+    this.copyUIAssets(userbarShadow, shadowRoot);
+    shadowRoot.appendChild(wrapperTemplate.content.cloneNode(true));
+
+    // Give each annotation landmark a label matching its toggle button.
+    nextAnnotationId += 1;
+
+    this.toggle = shadowRoot.querySelector(
+      '[data-inline-userbar-toggle]',
+    ) as HTMLButtonElement;
+    this.toggle.id = `w-inline-userbar-toggle-${nextAnnotationId}`;
+    const aside = shadowRoot.querySelector('aside') as HTMLElement;
+    aside.setAttribute('aria-labelledby', this.toggle.id);
+
+    const contentTemplate = userbarShadow.querySelector(
+      `#w-inline-userbar-content-checker-template`,
+    ) as HTMLTemplateElement;
+    const content = shadowRoot.querySelector(
+      '[data-inline-userbar-content]',
+    ) as HTMLElement;
+    content.appendChild(contentTemplate.content.cloneNode(true));
+
+    const nameEl = shadowRoot.querySelector(
+      '[data-content-checker-name]',
+    ) as HTMLSpanElement;
+    const helpEl = shadowRoot.querySelector(
+      '[data-content-checker-help]',
+    ) as HTMLDivElement;
+    nameEl.textContent = this.getAttribute('data-error-name') || '';
+    helpEl.textContent = this.getAttribute('data-help-text') || '';
+
+    content.hidden = false;
+
+    this.tippyInstance = tippy(this.toggle, {
+      content,
+      trigger: 'click',
+      interactive: true,
+      arrow: true,
+      maxWidth: 350,
+      placement: 'bottom',
+      theme: 'dropdown',
+      plugins: [hideTooltipOnEsc],
+      appendTo: () => shadowRoot as unknown as Element,
+      onShow: () => this.toggleTargetOutline(true),
+      onHide: () => this.toggleTargetOutline(false),
+    });
+
+    this.positionAtTarget();
+  }
+
+  /**
+   * Clone stylesheets and icons from the main userbar to guarantee parity.
+   */
+  private copyUIAssets(source: ShadowRoot, target: ShadowRoot) {
+    const assets = source.querySelector<HTMLElement>('[data-userbar-assets]');
+    if (assets) target.appendChild(assets.cloneNode(true));
+  }
+
+  private positionAtTarget() {
+    const selector = this.dataset.selector;
+    if (!selector) return;
+
+    const updatePosition = () => {
+      const targetRect = this.targetElement.getBoundingClientRect();
+
+      // Compute position relative to offsetParent, since position:absolute
+      // is resolved against the nearest positioned ancestor, not the viewport.
+      const offsetParent = this.offsetParent as HTMLElement | null;
+      const parentRect = offsetParent
+        ? offsetParent.getBoundingClientRect()
+        : { top: 0, left: 0 };
+
+      this.style.setProperty(
+        '--inline-userbar-top',
+        `${targetRect.bottom - parentRect.top}px`,
+      );
+      this.style.setProperty(
+        '--inline-userbar-inline-start',
+        `${targetRect.right - parentRect.left}px`,
+      );
+    };
+
+    updatePosition();
+
+    this.resizeObserver = new ResizeObserver(updatePosition);
+    this.resizeObserver.observe(this.targetElement);
+  }
+
+  /**
+   * Scroll the target element into view, show the outline, and move focus
+   * to the toggle button. Used by the checker results dialog's crosshair
+   * button to navigate the user to the annotation.
+   */
+  focusToggle() {
+    this.targetElement.style.scrollMargin = '6.25rem';
+    this.targetElement.scrollIntoView();
+    this.toggleTargetOutline(true);
+    this.toggle.focus();
+  }
+
+  toggleTargetOutline(outline: boolean) {
+    if (outline) {
+      this.targetElement.style.outline = '1px solid #CD4444';
+      this.targetElement.style.boxShadow = '0px 0px 12px 1px #FF0000';
+    } else {
+      this.targetElement.style.outline = '';
+      this.targetElement.style.boxShadow = '';
+    }
+  }
+
+  disconnectedCallback() {
+    this.toggleTargetOutline(false);
+    this.tippyInstance.destroy();
+    this.resizeObserver.disconnect();
+  }
+
+  /**
+   * Create annotation elements for content checker violations and insert
+   * them right after each problem element so keyboard tab order follows
+   * document reading order. Returns the created elements for cleanup.
+   */
+  static createAnnotations(
+    violations: Result[],
+    messages: ErrorMessages,
+  ): InlineUserbar[] {
+    const annotations: InlineUserbar[] = [];
+
+    for (const violation of violations) {
+      for (const node of violation.nodes) {
+        const selectorParts = node.target.filter(
+          (part) => part !== '#w-preview-iframe',
+        );
+        const selector = Array.isArray(selectorParts[0])
+          ? selectorParts[0].join(' ')
+          : selectorParts.join(' ');
+
+        const targetElement = document.querySelector<HTMLElement>(selector);
+
+        if (targetElement) {
+          const { name, helpText } = getViolationMessage(violation, messages);
+
+          const el = document.createElement(
+            'wagtail-inline-userbar',
+          ) as InlineUserbar;
+          el.setAttribute('data-selector', selector);
+          el.setAttribute('data-error-name', name);
+          el.setAttribute('data-help-text', helpText);
+
+          // Risk of conflicts with sibling / hierarchy selectors (+, ~, :nth-child, :last-child).
+          targetElement.insertAdjacentElement('afterend', el);
+          annotations.push(el);
+        }
+      }
+    }
+
+    return annotations;
+  }
+
+  /**
+   * Remove all inline userbar annotations from the page.
+   */
+  static clearAnnotations(annotations: InlineUserbar[]) {
+    for (const el of annotations) {
+      el.remove();
+    }
+  }
+}

--- a/client/src/includes/inlineUserbar.ts
+++ b/client/src/includes/inlineUserbar.ts
@@ -145,11 +145,11 @@ export class InlineUserbar extends HTMLElement {
    * to the toggle button. Used by the checker results dialog's crosshair
    * button to navigate the user to the annotation.
    */
-  focusToggle() {
+  focusTarget() {
     this.targetElement.style.scrollMargin = '6.25rem';
     this.targetElement.scrollIntoView();
     this.toggleTargetOutline(true);
-    this.toggle.focus();
+    this.targetElement.focus();
   }
 
   /**

--- a/client/src/includes/inlineUserbar.ts
+++ b/client/src/includes/inlineUserbar.ts
@@ -15,6 +15,7 @@ export class InlineUserbar extends HTMLElement {
   declare toggle: HTMLButtonElement;
   declare targetElement: HTMLElement;
   declare resizeObserver: ResizeObserver;
+  private currentScale = 1;
 
   connectedCallback() {
     const userbarShadow = document.querySelector('wagtail-userbar')?.shadowRoot;
@@ -69,12 +70,30 @@ export class InlineUserbar extends HTMLElement {
       interactive: true,
       arrow: true,
       maxWidth: 350,
-      placement: 'bottom',
+      placement: 'bottom-end',
       theme: 'dropdown',
       plugins: [hideTooltipOnEsc],
-      appendTo: () => shadowRoot as unknown as Element,
+      appendTo: () => aside,
       onShow: () => this.toggleTargetOutline(true),
       onHide: () => this.toggleTargetOutline(false),
+      // Tippy uses getBoundingClientRect which returns viewport-scaled
+      // coordinates. When a CSS transform scales the host, the popper's
+      // local coordinate space differs from the viewport. Dividing by the
+      // current scale converts back to local coordinates.
+      getReferenceClientRect: () => {
+        const rect = this.toggle.getBoundingClientRect();
+        const scale = this.currentScale;
+        return {
+          width: rect.width / scale,
+          height: rect.height / scale,
+          top: rect.top / scale,
+          bottom: rect.bottom / scale,
+          left: rect.left / scale,
+          right: rect.right / scale,
+          x: rect.x / scale,
+          y: rect.y / scale,
+        } as DOMRect;
+      },
     });
 
     this.positionAtTarget();
@@ -89,33 +108,36 @@ export class InlineUserbar extends HTMLElement {
   }
 
   private positionAtTarget() {
-    const selector = this.dataset.selector;
-    if (!selector) return;
+    if (!this.targetElement) return;
 
-    const updatePosition = () => {
-      const targetRect = this.targetElement.getBoundingClientRect();
+    this.updatePosition();
 
-      // Compute position relative to offsetParent, since position:absolute
-      // is resolved against the nearest positioned ancestor, not the viewport.
-      const offsetParent = this.offsetParent as HTMLElement | null;
-      const parentRect = offsetParent
-        ? offsetParent.getBoundingClientRect()
-        : { top: 0, left: 0 };
-
-      this.style.setProperty(
-        '--inline-userbar-top',
-        `${targetRect.bottom - parentRect.top}px`,
-      );
-      this.style.setProperty(
-        '--inline-userbar-inline-start',
-        `${targetRect.right - parentRect.left}px`,
-      );
-    };
-
-    updatePosition();
-
-    this.resizeObserver = new ResizeObserver(updatePosition);
+    this.resizeObserver = new ResizeObserver(() => this.updatePosition());
     this.resizeObserver.observe(this.targetElement);
+  }
+
+  /**
+   * Recompute the annotation's position relative to its target element.
+   */
+  updatePosition() {
+    if (!this.targetElement) return;
+    const targetRect = this.targetElement.getBoundingClientRect();
+
+    // Compute position relative to offsetParent, since position:absolute
+    // is resolved against the nearest positioned ancestor, not the viewport.
+    const offsetParent = this.offsetParent as HTMLElement | null;
+    const parentRect = offsetParent
+      ? offsetParent.getBoundingClientRect()
+      : { top: 0, left: 0 };
+
+    this.style.setProperty(
+      '--inline-userbar-top',
+      `${targetRect.bottom - parentRect.top}px`,
+    );
+    this.style.setProperty(
+      '--inline-userbar-inline-start',
+      `${targetRect.right - parentRect.left}px`,
+    );
   }
 
   /**
@@ -128,6 +150,16 @@ export class InlineUserbar extends HTMLElement {
     this.targetElement.scrollIntoView();
     this.toggleTargetOutline(true);
     this.toggle.focus();
+  }
+
+  /**
+   * Counteract the preview iframe's CSS scaling to keep annotations legible.
+   */
+  setScale(scale: number) {
+    this.currentScale = scale;
+    this.style.setProperty('--inline-userbar-scale', String(scale));
+    this.updatePosition();
+    this.tippyInstance?.popperInstance?.update();
   }
 
   toggleTargetOutline(outline: boolean) {

--- a/client/src/includes/userbar.ts
+++ b/client/src/includes/userbar.ts
@@ -6,7 +6,7 @@
 
 import { Application } from '@hotwired/stimulus';
 import A11yDialog from 'a11y-dialog';
-import axe, { Check } from 'axe-core';
+import axe, { AxeResults, Check } from 'axe-core';
 
 import { DialogController } from '../controllers/DialogController';
 import { TeleportController } from '../controllers/TeleportController';
@@ -20,6 +20,7 @@ import {
   renderCheckerResults,
 } from './contentChecker';
 import { contentExtractorPluginInstance } from './contentMetrics';
+import { InlineUserbar } from './inlineUserbar';
 import { wagtailPreviewPlugin } from './previewPlugin';
 
 /**
@@ -36,6 +37,7 @@ export class Userbar extends HTMLElement {
   /** Target origin for cross-domain `window.postMessage` calls. */
   declare origin: string;
   declare axeConfig: WagtailAxeConfiguration | null;
+  private annotations: InlineUserbar[] = [];
 
   connectedCallback() {
     const template = document.querySelector<HTMLTemplateElement>(
@@ -436,16 +438,8 @@ export class Userbar extends HTMLElement {
     const rowTemplate = this.shadowRoot.querySelector<HTMLTemplateElement>(
       '#w-content-checker-row-template',
     );
-    const outlineTemplate = this.shadowRoot.querySelector<HTMLTemplateElement>(
-      '#w-content-checker-outline-template',
-    );
 
-    if (
-      !this.axeConfig ||
-      !checkerResultsBox ||
-      !rowTemplate ||
-      !outlineTemplate
-    ) {
+    if (!this.axeConfig || !checkerResultsBox || !rowTemplate) {
       return;
     }
 
@@ -470,61 +464,19 @@ export class Userbar extends HTMLElement {
     });
 
     const onClickSelector = (selectorName: string) => {
-      const targetElement = document.querySelector<HTMLElement>(selectorName);
-      const outlineContainer = this.shadowRoot?.querySelector<HTMLElement>(
-        '[data-content-checker-outline-container]',
+      const annotation = this.annotations.find(
+        (el) => el.dataset.selector === selectorName,
       );
-      if (outlineContainer?.firstElementChild) {
-        outlineContainer.removeChild(outlineContainer.firstElementChild);
+      if (annotation) {
+        annotation.focusToggle();
+      } else {
+        const targetElement = document.querySelector<HTMLElement>(selectorName);
+        if (targetElement) {
+          targetElement.style.scrollMargin = '6.25rem';
+          targetElement.scrollIntoView();
+          targetElement.focus();
+        }
       }
-      outlineContainer?.appendChild(outlineTemplate.content.cloneNode(true));
-      const currentOutline = this.shadowRoot?.querySelector<HTMLElement>(
-        '[data-content-checker-outline]',
-      );
-      if (
-        !this.shadowRoot ||
-        !targetElement ||
-        !currentOutline ||
-        !outlineContainer
-      )
-        return;
-
-      const styleOutline = () => {
-        const rect = targetElement.getBoundingClientRect();
-        currentOutline.style.cssText = `
-        top: ${
-          rect.height < 5
-            ? `${rect.top + window.scrollY - 2.5}px`
-            : `${rect.top + window.scrollY}px`
-        };
-        left: ${
-          rect.width < 5
-            ? `${rect.left + window.scrollX - 2.5}px`
-            : `${rect.left + window.scrollX}px`
-        };
-        width: ${Math.max(rect.width, 5)}px;
-        height: ${Math.max(rect.height, 5)}px;
-        position: absolute;
-        z-index: 129;
-        outline: 1px solid #CD4444;
-        box-shadow: 0px 0px 12px 1px #FF0000;
-        pointer-events: none;
-        `;
-      };
-
-      styleOutline();
-
-      window.addEventListener('resize', styleOutline);
-
-      targetElement.style.scrollMargin = '6.25rem';
-      targetElement.scrollIntoView();
-      targetElement.focus();
-
-      checkerResultsBox.addEventListener('hide', () => {
-        currentOutline.style.cssText = '';
-
-        window.removeEventListener('resize', styleOutline);
-      });
     };
 
     renderCheckerResults(
@@ -535,6 +487,8 @@ export class Userbar extends HTMLElement {
       onClickSelector,
     );
 
+    this.createAnnotations(results, this.axeConfig);
+
     // Notify the parent window when the userbar (and thus Axe) has been
     // initialized and is ready, so that it can re-run Axe against this window.
     // We do this here instead of in connectedCallback() or initializeAxe() to
@@ -544,6 +498,21 @@ export class Userbar extends HTMLElement {
     // This also allows custom code in the frontend to trigger a re-run of the
     // checks both in the frontend and in the editor by calling this method.
     this.postAxeReady();
+  }
+
+  private createAnnotations(
+    results: AxeResults,
+    config: WagtailAxeConfiguration,
+  ) {
+    InlineUserbar.clearAnnotations(this.annotations);
+    this.annotations = [];
+
+    if (!results.violations.length) return;
+
+    this.annotations = InlineUserbar.createAnnotations(
+      results.violations,
+      config.messages,
+    );
   }
 
   get inCrossOriginIframe() {
@@ -596,6 +565,8 @@ export class Userbar extends HTMLElement {
   }
 
   disconnectedCallback() {
+    InlineUserbar.clearAnnotations(this.annotations);
+    this.annotations = [];
     if (this.inCrossOriginIframe) {
       window.removeEventListener('message', this.handleMessage);
     }

--- a/client/src/includes/userbar.ts
+++ b/client/src/includes/userbar.ts
@@ -464,14 +464,7 @@ export class Userbar extends HTMLElement {
         (el) => el.dataset.selector === selectorName,
       );
       if (annotation) {
-        annotation.focusToggle();
-      } else {
-        const targetElement = document.querySelector<HTMLElement>(selectorName);
-        if (targetElement) {
-          targetElement.style.scrollMargin = '6.25rem';
-          targetElement.scrollIntoView();
-          targetElement.focus();
-        }
+        annotation.focusTarget();
       }
     };
 

--- a/client/src/includes/userbar.ts
+++ b/client/src/includes/userbar.ts
@@ -65,15 +65,13 @@ export class Userbar extends HTMLElement {
       return;
     }
 
-    const inCrossOriginIframe = this.inCrossOriginIframe;
-
     // Get the origin from the data attribute only if we are in a cross-origin
     // iframe, as it's only needed in that case. Using the data attribute in a
     // same-origin iframe will cause issues if it is not set to the correct
     // value, which can happen in page previews if the page's site root host is
     // different from the host where the admin is accessed.
     const origin =
-      (inCrossOriginIframe &&
+      (this.inCrossOriginIframe &&
         userbar.getAttribute('data-wagtail-userbar-origin')) ||
       '';
     // Use URL() and the current origin as a base, to allow both absolute and
@@ -332,11 +330,9 @@ export class Userbar extends HTMLElement {
     this.handleMessage = this.handleMessage.bind(this);
     this.onWindowLoad = this.onWindowLoad.bind(this);
 
-    // If we are in a cross-origin iframe, request the parent to restore the
-    // scroll position of the preview panel's previous iframe to this one.
-    if (inCrossOriginIframe) {
-      window.addEventListener('message', this.handleMessage);
-    }
+    // Listen for messages from the parent window (e.g. preview scale).
+    // Also handles scroll position restoration in cross-origin iframes.
+    window.addEventListener('message', this.handleMessage);
 
     // The page may already be loaded, e.g. when the userbar is loaded via AJAX.
     // In this case, we need to call the initialisation function immediately.
@@ -559,6 +555,12 @@ export class Userbar extends HTMLElement {
         window.scrollTo({ top: data.y, left: data.x, behavior: 'instant' });
         break;
 
+      case 'w-preview:set-scale':
+        for (const annotation of this.annotations) {
+          annotation.setScale(data.scale);
+        }
+        break;
+
       default:
         break;
     }
@@ -567,8 +569,6 @@ export class Userbar extends HTMLElement {
   disconnectedCallback() {
     InlineUserbar.clearAnnotations(this.annotations);
     this.annotations = [];
-    if (this.inCrossOriginIframe) {
-      window.removeEventListener('message', this.handleMessage);
-    }
+    window.removeEventListener('message', this.handleMessage);
   }
 }

--- a/client/src/utils/message.ts
+++ b/client/src/utils/message.ts
@@ -50,11 +50,22 @@ export interface SetScrollPosition extends MessageWithOrigin {
   y: number;
 }
 
+/**
+ * Sent by the CMS to the preview iframe with the inverse of the current
+ * preview scale ratio, so inline annotations can apply it directly as a
+ * counter-scale transform to remain legible at any simulated device size.
+ */
+export interface SetScale {
+  type: 'w-preview:set-scale';
+  scale: number;
+}
+
 export type WagtailMessage =
   | AxeReady
   | RequestScroll
   | GetScrollPosition
-  | SetScrollPosition;
+  | SetScrollPosition
+  | SetScale;
 
 /**
  * Parses a message event that may contain a Wagtail message.

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -4,15 +4,15 @@
     {# In preview panels, we still render the userbar UI, but hidden by default. #}
     <aside {% if request.in_preview_panel %}hidden{% endif %}>
         <div class="w-userbar w-userbar--{{ position|default:'bottom-right' }} {% admin_theme_classname %}" data-wagtail-userbar data-wagtail-userbar-origin="{{ origin|default:"" }}" part="userbar">
-            {% block css %}
-                {% versioned_static 'wagtailadmin/css/core.css' as core_css_url %}
-                <link rel="stylesheet" href="{% build_absolute_url core_css_url %}">
-                {# For headless userbar: the contents of the hook also need absolute URLs #}
-                {% hook_output 'insert_global_admin_css' %}
-                {{ media.css }}
-            {% endblock %}
-            <div class="w-userbar-nav">
-
+            {# Styles and icons for all userbar components. #}
+            <div data-userbar-assets>
+                {% block css %}
+                    {% versioned_static 'wagtailadmin/css/core.css' as core_css_url %}
+                    <link rel="stylesheet" href="{% build_absolute_url core_css_url %}">
+                    {# For headless userbar: the contents of the hook also need absolute URLs #}
+                    {% hook_output 'insert_global_admin_css' %}
+                    {{ media.css }}
+                {% endblock %}
                 <svg class="w-hidden">
                     <defs>
                         {% block icons %}
@@ -24,9 +24,12 @@
                             {% include "wagtailadmin/icons/check.svg" %}
                             {% include "wagtailadmin/icons/cross.svg" %}
                             {% include "wagtailadmin/icons/crosshairs.svg" %}
+                            {% include "wagtailadmin/icons/warning.svg" %}
                         {% endblock %}
                     </defs>
                 </svg>
+            </div>
+            <div class="w-userbar-nav">
 
                 <button aria-controls="wagtail-userbar-items" aria-haspopup="true" class="w-userbar-trigger" id="wagtail-userbar-trigger" data-wagtail-userbar-trigger>
                     {% block branding_logo %}{% include "wagtailadmin/logo.html" with classname="w-userbar-icon" %}{% endblock %}
@@ -42,6 +45,19 @@
             </div>
         </div>
         <div data-content-checker-outline-container></div>
+        {# Generic inline userbar wrapper for inline content annotations. #}
+        {# Initialized by the main userbar. #}
+        <template id="w-inline-userbar-template">
+            {# Unique landmark label set in JS. #}
+            <aside>
+                <div class="w-inline-userbar {% admin_theme_classname %}" part="userbar">
+                    <button type="button" class="w-inline-userbar__toggle" data-inline-userbar-toggle aria-label="{% trans 'Show issue' %}">
+                        {% icon name="warning" classname="w-inline-userbar__icon" %}
+                    </button>
+                    <div class="w-inline-userbar__content" data-inline-userbar-content hidden></div>
+                </div>
+            </aside>
+        </template>
     </aside>
 </template>
 <wagtail-userbar></wagtail-userbar>

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -49,8 +49,8 @@
         {# Initialized by the main userbar. #}
         <template id="w-inline-userbar-template">
             {# Unique landmark label set in JS. #}
-            <aside>
-                <div class="w-inline-userbar {% admin_theme_classname %}" part="userbar">
+            <aside class="{% admin_theme_classname %}">
+                <div class="w-inline-userbar" part="userbar">
                     <button type="button" class="w-inline-userbar__toggle" data-inline-userbar-toggle aria-label="{% trans 'Show issue' %}">
                         {% icon name="warning" classname="w-inline-userbar__icon" %}
                     </button>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_content_checker.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_content_checker.html
@@ -29,7 +29,16 @@
             </button>
         </div>
     </template>
-    <template id="w-content-checker-outline-template">
-        <div class="w-content-checker__outline" data-content-checker-outline></div>
+    {# Content template for inline-userbar checker annotations. #}
+    {# Appended into the generic [data-inline-userbar-content] slot by JS. #}
+    <template id="w-inline-userbar-content-checker-template">
+        <div class="w-content-checker__row">
+            <div>
+                <h3 class="w-content-checker__header">
+                    <span class="w-content-checker__name" data-content-checker-name></span>
+                </h3>
+                <div class="w-content-checker__help" data-content-checker-help></div>
+            </div>
+        </div>
     </template>
 {% endblock %}


### PR DESCRIPTION
Implements #12187. This introduces a new `wagtail-inline-userbar` web component that works similarly to the existing userbar: renders on the page with its UI as encapsulated as possible. The component is intended for future reuse as a generic annotation in the future (positioning, toggle of a dropdown) - for #13175. For now it only displays content check annotations:

<img width="910" height="552" alt="Screenshot 2026-04-21 at 12 20 24" src="https://github.com/user-attachments/assets/47847cc4-b148-4115-97a6-a81aabdc7f3c" />

### AI usage

First draft with Cursor, manually edited and reviewed.