### PR TITLE
Fix broken API doc links to AccessibilityItem in release notes

### DIFF
--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -50,7 +50,7 @@ The [built-in accessibility checker](authoring_accessible_content) has been upda
  * 5 more Axe rules enabled by default.
  * Sorting of checker results according to their position on the page.
  * Highlight styles to more easily identify elements with errors.
- * Configuration APIs in {class}`~wagtail.admin.userbar.AccessibilityItem` for simpler customization of the checks performed.
+ * Configuration APIs in {class}`~wagtail.admin.userbar.ContentCheckerItem` for simpler customization of the checks performed.
 
 Those improvements were implemented by Albina Starykova as part of an [Outreachy internship](https://wagtail.org/blog/introducing-wagtails-new-accessibility-checker/), with support from mentors Thibaud Colas, Sage Abdullah, and Joshua Munn.
 

--- a/docs/releases/7.1.md
+++ b/docs/releases/7.1.md
@@ -205,7 +205,7 @@ The [](init_new_page_signal) signal, previously defined in `wagtail.admin.signal
 
 ### `AccessibilityItem` now accepts an `in_editor` argument
 
-The `AccessibilityItem` user bar item now accepts an {attr}`~wagtail.admin.userbar.AccessibilityItem.in_editor` argument, which is set to `True` when it is instantiated within the page editor. If you [customized the accessibility checker](built_in_content_checker), you should update your code to pass this argument when creating an instance of your `AccessibilityItem` subclass.
+The `AccessibilityItem` user bar item now accepts an {attr}`~wagtail.admin.userbar.ContentCheckerItem.in_editor` argument, which is set to `True` when it is instantiated within the page editor. If you [customized the accessibility checker](built_in_content_checker), you should update your code to pass this argument when creating an instance of your `AccessibilityItem` subclass.
 
 ```diff
  @hooks.register('construct_wagtail_userbar')


### PR DESCRIPTION
These need to be repointed to ContentCheckerItem following the rename in #14123, otherwise the documentation fails to build.

### AI usage

None
