### PR TITLE
Send confirmation email after password reset

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/password_changed_email.txt
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/password_changed_email.txt
@@ -1,0 +1,8 @@
+{% load i18n %}
+{% trans "Hello" %} {{ user.get_username }},
+
+{% trans "This email is to confirm that your password has been successfully reset." %}
+
+{% trans "If you did not reset your password, please alert your site administrator immediately." %}
+
+

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/password_changed_email.txt
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/password_changed_email.txt
@@ -1,8 +1,6 @@
 {% load i18n %}
-{% trans "Hello" %} {{ user.get_username }},
+{% blocktrans with username=user.get_username %}Hello {{ username }},{% endblocktrans %}
 
-{% trans "This email is to confirm that your password has been successfully reset." %}
+{% blocktrans %}This email is to confirm that your password has been successfully reset.{% endblocktrans %}
 
-{% trans "If you did not reset your password, please alert your site administrator immediately." %}
-
-
+{% blocktrans %}If you did not reset your password, please alert your site administrator immediately.{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/password_changed_email_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/password_changed_email_subject.txt
@@ -1,2 +1,2 @@
 {% load i18n %}
-{% trans "Password Reset Confirmation" %}
+{% trans "Password reset confirmation" %}

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/password_changed_email_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/password_changed_email_subject.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% trans "Password Reset Confirmation" %}

--- a/wagtail/admin/tests/test_password_reset.py
+++ b/wagtail/admin/tests/test_password_reset.py
@@ -101,3 +101,42 @@ class TestUserPasswordReset(WagtailTestUtils, TestCase):
         self.assertNotIn(
             "Your username (in case you've forgotten)", mail.outbox[0].body
         )
+
+    def test_confirmation_email_sent_after_password_reset(self):
+        """
+        This tests that a confirmation email is sent to the user after
+        their password has been successfully reset.
+        """
+        # request the reset email
+        self.client.post(
+            reverse("wagtailadmin_password_reset"),
+            {"email": "siteeditor@example.com"},
+        )
+
+        # get the reset link from the email body
+        self.assertEqual(len(mail.outbox), 1)
+        email_body = mail.outbox[0].body
+        # extract the URL from the email body
+        reset_url = [
+            line for line in email_body.splitlines() if "password_reset/confirm" in line
+        ][0].strip()
+
+        # follow the reset link
+        response = self.client.get(reset_url)
+        # Django redirects to a session-based URL
+        confirm_url = response["Location"]
+
+        # submit the new password
+        self.client.post(
+            confirm_url,
+            {
+                "new_password1": "newpassword123!",
+                "new_password2": "newpassword123!",
+            },
+        )
+
+        # check confirmation email was sent
+        self.assertEqual(len(mail.outbox), 2)
+        confirmation_email = mail.outbox[1]
+        self.assertIn("siteeditor@example.com", confirmation_email.to)
+        self.assertIn("Password reset confirmation", confirmation_email.subject)

--- a/wagtail/admin/tests/test_password_reset.py
+++ b/wagtail/admin/tests/test_password_reset.py
@@ -101,3 +101,42 @@ class TestUserPasswordReset(PageFixturesMixin, WagtailTestUtils, TestCase):
         self.assertNotIn(
             "Your username (in case you've forgotten)", mail.outbox[0].body
         )
+
+    def test_confirmation_email_sent_after_password_reset(self):
+        """
+        This tests that a confirmation email is sent to the user after
+        their password has been successfully reset.
+        """
+        # request the reset email
+        self.client.post(
+            reverse("wagtailadmin_password_reset"),
+            {"email": "siteeditor@example.com"},
+        )
+
+        # get the reset link from the email body
+        self.assertEqual(len(mail.outbox), 1)
+        email_body = mail.outbox[0].body
+        # extract the URL from the email body
+        reset_url = [
+            line for line in email_body.splitlines() if "password_reset/confirm" in line
+        ][0].strip()
+
+        # follow the reset link
+        response = self.client.get(reset_url)
+        # Django redirects to a session-based URL
+        confirm_url = response["Location"]
+
+        # submit the new password
+        self.client.post(
+            confirm_url,
+            {
+                "new_password1": "newpassword123!",
+                "new_password2": "newpassword123!",
+            },
+        )
+
+        # check confirmation email was sent
+        self.assertEqual(len(mail.outbox), 2)
+        confirmation_email = mail.outbox[1]
+        self.assertIn("siteeditor@example.com", confirmation_email.to)
+        self.assertIn("Password reset confirmation", confirmation_email.subject)

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -4,6 +4,7 @@ from functools import cached_property
 from django.conf import settings
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth import views as auth_views
+from django.core.mail import send_mail
 from django.db import transaction
 from django.forms import Media
 from django.http import Http404
@@ -366,6 +367,26 @@ class PasswordResetConfirmView(
 ):
     template_name = "wagtailadmin/account/password_reset/confirm.html"
     success_url = reverse_lazy("wagtailadmin_password_reset_complete")
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        user = form.user
+        context = {"user": user}
+        subject = render_to_string(
+            "wagtailadmin/account/password_reset/password_changed_email_subject.txt",
+            context,
+        ).strip()
+        message = render_to_string(
+            "wagtailadmin/account/password_reset/password_changed_email.txt",
+            context,
+        )
+        send_mail(
+            subject,
+            message,
+            settings.DEFAULT_FROM_EMAIL,
+            [user.email],
+        )
+        return response
 
 
 class PasswordResetCompleteView(


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #4099

### Description
This PR adds the ability to send a confirmation email to the user after their password has been 
successfully reset.

- Added `form_valid()` to `PasswordResetConfirmView` in `account.py`
  to send a confirmation email after the password is saved.

- Added `password_changed_email.txt` template for the email body.

- Added `password_changed_email_subject.txt` template for the subject.
<!-- Please describe the problem you're fixing. -->

### Testing
Tested it in bakerydemo by resetting the admin password and logging in with the new password.

> Subject: Password Reset Confirmation
> From: webmaster@localhost
> To: admin@example.com
> 
> Hello admin,
> 
> This email is to confirm that your password has been successfully reset.
> 
> If you did not reset your password, please alert your site administrator immediately.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Used Claude.ai in understanding `account.py`