### PR TITLE
Fix chooser Edit link showing for users without edit permission

### DIFF
--- a/wagtail/admin/panels/field_panel.py
+++ b/wagtail/admin/panels/field_panel.py
@@ -336,6 +336,9 @@ class FieldPanel(Panel):
                 if widget_described_by_ids:
                     widget_attrs["aria-describedby"] = " ".join(widget_described_by_ids)
 
+                widget = self.bound_field.field.widget
+                if self.request and hasattr(widget, "request"):
+                    widget.request = self.request
                 rendered_field = self.bound_field.as_widget(attrs=widget_attrs)
 
             return {

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -135,9 +135,11 @@ class BaseChooser(widgets.Input):
         and the client-side rendering code (via telepath) that contains all the information needed
         for display. Typically this is a dict of id, title etc; it must be JSON-serialisable.
         """
+        request = getattr(self, "request", None)
+        user = getattr(request, "user", None) if request else None
         return {
             "id": instance.pk,
-            "edit_url": AdminURLFinder().get_edit_url(instance),
+            "edit_url": AdminURLFinder(user=user).get_edit_url(instance),
             self.display_title_key: self.get_display_title(instance),
         }
 


### PR DESCRIPTION
## Summary

Fixes #12801

When a page with a chooser field (e.g. `ForeignKey` to another model) is edited, the chooser widget incorrectly shows an **Edit** link even when the current user lacks permission to edit the chosen object. Clicking it leads to a permission error page.

The bug only affects the **initial render** of existing data — after choosing a new item through the chooser modal workflow, the Edit link is correctly hidden (because that code path passes `user` to `AdminURLFinder`).

## Root cause

In `BaseChooser.get_value_data_from_instance()`, `AdminURLFinder()` was called **without a `user` parameter**:

```python
"edit_url": AdminURLFinder().get_edit_url(instance),
```

From [`admin_url_finder.py`](https://github.com/wagtail/wagtail/blob/main/wagtail/admin/admin_url_finder.py):

> *If the user parameter is omitted, edit URLs are returned without considering permissions.*

So the edit URL was always returned regardless of the user's actual permissions.

## Fix

1. **`wagtail/admin/widgets/chooser.py`**: Read `self.request` (set by the panel layer) and pass `request.user` to `AdminURLFinder(user=user)` so it can check `change` permission before returning an edit URL.

2. **`wagtail/admin/panels/field_panel.py`**: Set `widget.request = self.request` in `FieldPanel.BoundPanel.get_editable_context_data()` before rendering, so the widget has access to the current request.

This mirrors how `ChosenResponseMixin.get_edit_item_url()` already works in the chooser view layer — it correctly passes `user=self.request.user` to `AdminURLFinder`.

## Notes

- The `request` attribute is set conditionally (`hasattr` guard) so this is backward-compatible with any usage outside of panel rendering.
- The `AdminURLFinder` already handles `user=None` gracefully (returns URL without permission check), so cases where request is unavailable still work as before.