### PR TITLE
Update audit logs docs to match implementation

### DIFF
--- a/docs/deployment/under_the_hood.md
+++ b/docs/deployment/under_the_hood.md
@@ -79,6 +79,19 @@ Wagtail, and by extension Django, can be deployed in many different ways on many
 
 Django has a [deployment checklist](inv:django#howto/deployment/checklist) which runs through everything you should have done or should be aware of before deploying a Django application.
 
+### Logging and monitoring
+
+In production, you'll typically want logs and metrics from several layers. Wagtail itself contributes:
+
+- The [audit log](audit_log) for sensitive CMS actions such as create, edit, delete, publish, and move.
+- Standard Django logging for request errors and form validation failures, configured via the Django [`LOGGING`](inv:django#LOGGING) setting.
+
+Common production additions include:
+
+- Error and performance monitoring. Instrumenting the Django application to better understand its runtime behavior.
+- Web server, reverse proxy, or CDN logs. For request volume, status codes, and rate limiting.
+- Web Application Firewall (WAF) logs. For attack-pattern detection.
+
 ### Performance optimization
 
 Your production site should be as fast and performant as possible. For tips on how to ensure Wagtail performs as well as possible, take a look at our [performance tips](performance_overview).

--- a/docs/extending/audit_log.md
+++ b/docs/extending/audit_log.md
@@ -59,18 +59,20 @@ When adding logging, you need to log the action or actions that happen to the ob
 | `wagtail.create`                  | The object was created                                                           |
 | `wagtail.edit`                    | The object was edited (for pages, saved as a draft)                              |
 | `wagtail.delete`                  | The object was deleted. Will only surface in the Site History for administrators |
-| `wagtail.publish`                 | The page was published                                                           |
+| `wagtail.publish`                 | The object was published                                                         |
 | `wagtail.publish.schedule`        | The draft is scheduled for publishing                                            |
 | `wagtail.publish.scheduled`       | Draft published via `publish_scheduled` management command                       |
 | `wagtail.schedule.cancel`         | Draft scheduled for publishing canceled via "Cancel scheduled publish"           |
-| `wagtail.unpublish`               | The page was unpublished                                                         |
-| `wagtail.unpublish.scheduled`     | Page unpublished via `publish_scheduled` management command                      |
-| `wagtail.lock`                    | Page was locked                                                                  |
-| `wagtail.unlock`                  | Page was unlocked                                                                |
+| `wagtail.unpublish`               | The object was unpublished                                                       |
+| `wagtail.unpublish.scheduled`     | Object unpublished via `publish_scheduled` management command                    |
+| `wagtail.lock`                    | Object was locked                                                                |
+| `wagtail.unlock`                  | Object was unlocked                                                              |
 | `wagtail.rename`                  | A page was renamed                                                               |
-| `wagtail.revert`                  | The page was reverted to a previous draft                                        |
+| `wagtail.revert`                  | The object was reverted to a previous draft                                      |
 | `wagtail.copy`                    | The page was copied to a new location                                            |
 | `wagtail.copy_for_translation`    | The page was copied into a new locale for translation                            |
+| `wagtail.create_alias`            | An alias of the page was created                                                 |
+| `wagtail.convert_alias`           | An alias was converted into an ordinary page                                     |
 | `wagtail.move`                    | The page was moved to a new location                                             |
 | `wagtail.reorder`                 | The order of the page under its parent was changed                               |
 | `wagtail.view_restriction.create` | The page was restricted                                                          |
@@ -81,6 +83,13 @@ When adding logging, you need to log the action or actions that happen to the ob
 | `wagtail.workflow.reject`         | The draft was rejected, and changes were requested at a Workflow Task            |
 | `wagtail.workflow.resume`         | The draft was resubmitted to the workflow                                        |
 | `wagtail.workflow.cancel`         | The workflow was canceled                                                        |
+| `wagtail.comments.create`         | A comment was added to a field on the page                                       |
+| `wagtail.comments.edit`           | A comment was edited                                                             |
+| `wagtail.comments.resolve`        | A comment was resolved                                                           |
+| `wagtail.comments.delete`         | A comment was deleted                                                            |
+| `wagtail.comments.create_reply`   | A reply was added to a comment                                                   |
+| `wagtail.comments.edit_reply`     | A reply to a comment was edited                                                  |
+| `wagtail.comments.delete_reply`   | A reply to a comment was deleted                                                 |
 
 ## Log context
 


### PR DESCRIPTION
Part of [Independent security audit - report highlights #14173](https://github.com/wagtail/wagtail/discussions/14173). I reviewed page actions and how they compare to what we document as present in audit logs docs to more closely match current implementation,

- Some actions that were page-only are now also available for other models via DraftStateMixin, RevisionMixin, etc
- 2x alias-specific actions were missing
- The commenting actions were missing

### AI usage

Fully AI-driven review of implementation vs. docs. Manual content updates.