### PR TITLE
Update CodeQL action to latest template from GitHub

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,15 +13,21 @@ jobs:
       contents: read # to fetch code (actions/checkout)
       security-events: write # to upload SARIF results (github/codeql-action/analyze)
 
-    name: Analyze
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
       fail-fast: false
       matrix:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
-        language: ['javascript', 'python']
+        include:
+          # https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options#languages-to-be-analyzed
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
 
     steps:
       - name: Checkout repository
@@ -30,9 +36,12 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{matrix.language}}'


### PR DESCRIPTION
Part of [Independent security audit - report highlights #14173](https://github.com/wagtail/wagtail/discussions/14173). Updates our CodeQL configuration so it matches what GitHub would generate if we were to set it up from scratch today. Specific changes:

- language: javascript to javascript-typescript.
- GitHub Actions scanning
- v1 -> v4

I also copy-pasted related but unclear changes, that I’m not sure are necessary, but I thought we might as well more closely match the source.

### AI usage

None