### PR TITLE
Document more approaches to mitigating untrusted file uploads

### DIFF
--- a/docs/advanced_topics/documents/storing_and_serving.md
+++ b/docs/advanced_topics/documents/storing_and_serving.md
@@ -100,7 +100,7 @@ The `WAGTAILDOCS_MAX_UPLOAD_SIZE` setting was added.
 Wagtail does not perform anti-virus (AV) scanning on uploaded documents. For sites with a need for this kind of validation of Wagtail files, two common patterns are:
 
 - **Storage-side scanning** - when documents are stored in a remote bucket (such as Amazon S3), use a managed scanner that quarantines or deletes infected objects after upload.
-- **Editor-side scanning** - reject infected files before they are stored, by extending the upload form via [WAGTAILDOCS_DOCUMENT_FORM_BASE](wagtaildocs_document_form_base) and calling out to a scanner. Returning a `ValidationError` will surface the message to the editor.
+- **Editor-side scanning** - reject infected files before they are stored, by extending the upload form via [`WAGTAILDOCS_DOCUMENT_FORM_BASE`](wagtaildocs_document_form_base) and calling out to a scanner. Returning a `ValidationError` will surface the message to the editor.
 
 For most sites, storage-side scanning is the lowest-risk option as it does not block uploads on the scanner being available, and naturally extends to files written outside of Wagtail (for example by background tasks or other applications writing to the same object storage).
 

--- a/docs/advanced_topics/documents/storing_and_serving.md
+++ b/docs/advanced_topics/documents/storing_and_serving.md
@@ -12,7 +12,7 @@ Wagtail uses the [`STORAGES["default"]`](inv:django#STORAGES) setting to determi
 
 Document serving is controlled by the [WAGTAILDOCS_SERVE_METHOD](wagtaildocs_serve_method) method. It provides a number of serving methods which trade some of the strictness of the permission check that occurs when normally handling a document request for performance.
 
-The serving methods provided are `direct`, `redirect` and `serve_view`, with `redirect` method being the default when `WAGTAILDOCS_SERVE_METHOD` is unspecified or set to `None`. For example:
+The serving methods provided are `direct`, `redirect` and `serve_view`. When `WAGTAILDOCS_SERVE_METHOD` is unspecified or set to `None`, Wagtail picks the default based on the active storage backend: `serve_view` for local storage, and `redirect` for remote storage backends that expose a URL but not a local filesystem path. For example:
 
 ```python
 WAGTAILDOCS_SERVE_METHOD = "redirect"

--- a/docs/advanced_topics/documents/storing_and_serving.md
+++ b/docs/advanced_topics/documents/storing_and_serving.md
@@ -34,9 +34,10 @@ When using the `serve_view` method:
 -   Documents are served as downloads rather than displayed in the browser (unless specified explicitly via [](wagtaildocs_inline_content_types)) - this ensures that if the document is a type that can contain scripts (such as HTML or SVG), the browser is prevented from executing them.
 -   However, since the document is served through the Django application server, this may consume more server resources than serving the document directly from the web server.
 
-The alternative serve methods `'direct'` and `'redirect'` work by serving the documents directly from `MEDIA_ROOT`. This means it is not possible to block direct access to the `documents` subdirectory, and so users may bypass permission checks by accessing the direct URL. Also, in the case that users with access to the Wagtail admin are not fully trusted, you will need to take additional steps to prevent the execution of scripts in documents:
+The alternative serve methods `'direct'` and `'redirect'` work by serving the documents directly from `MEDIA_ROOT`. This means it is not possible to block direct access to the `documents` subdirectory, and so users may bypass permission checks by accessing the direct URL. Also, in the case that users with access to the Wagtail admin are not fully trusted, you will need to take additional steps to prevent common issues such as execution of scripts in documents:
 
 -   The [](wagtaildocs_extensions) setting may be used to restrict uploaded documents to an "allow list" of safe types.
+-   The [](wagtaildocs_max_upload_size) setting may be used to bound the size of uploaded documents and limit denial-of-service risk.
 -   The web server can be configured to return a `Content-Security-Policy: default-src 'none'` header for files within the `documents` subdirectory, which will prevent the execution of scripts in those files.
 -   The web server can be configured to return a `Content-Disposition: attachment` header for files within the `documents` subdirectory, which will force the browser to download the file rather than displaying it inline.
 
@@ -75,6 +76,20 @@ It also validates the extensions using Django's {class}`~django.core.validators.
 
 ```python
 WAGTAILDOCS_EXTENSIONS = ['pdf', 'docx']
+```
+
+## File size
+
+Use the [WAGTAILDOCS_MAX_UPLOAD_SIZE](wagtaildocs_max_upload_size) setting to limit how large uploaded documents can be (in bytes). This helps protect against denial-of-service from oversized uploads. For example:
+
+```python
+WAGTAILDOCS_MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10MB
+```
+
+If unset, Wagtail allows any file size (subject to Django's [`DATA_UPLOAD_MAX_MEMORY_SIZE`](inv:django#DATA_UPLOAD_MAX_MEMORY_SIZE) and [`FILE_UPLOAD_MAX_MEMORY_SIZE`](inv:django#FILE_UPLOAD_MAX_MEMORY_SIZE), and any limits enforced by your web server or storage backend).
+
+```{versionadded} 7.4
+The `WAGTAILDOCS_MAX_UPLOAD_SIZE` setting was added.
 ```
 
 ## Document password required template

--- a/docs/advanced_topics/documents/storing_and_serving.md
+++ b/docs/advanced_topics/documents/storing_and_serving.md
@@ -40,6 +40,7 @@ The alternative serve methods `'direct'` and `'redirect'` work by serving the do
 -   The [](wagtaildocs_max_upload_size) setting may be used to bound the size of uploaded documents and limit denial-of-service risk.
 -   The web server can be configured to return a `Content-Security-Policy: default-src 'none'` header for files within the `documents` subdirectory, which will prevent the execution of scripts in those files.
 -   The web server can be configured to return a `Content-Disposition: attachment` header for files within the `documents` subdirectory, which will force the browser to download the file rather than displaying it inline.
+-   See [](document_antivirus_scanning) for guidance on rejecting malicious uploads before they are stored.
 
 If a remote ("cloud") storage backend is used, the serve method will default to `'redirect'` and the document will be served directly from the cloud storage file url. In this case (as with `'direct'`), Wagtail has less control over how the file is served and users may be able to bypass permission checks, and scripts within documents may be executed (depending on the cloud storage service's configuration). However, whilst cross-site scripts attacks are still possible, the impact is reduced as the document is usually served from a different domain to the main site.
 
@@ -91,6 +92,17 @@ If unset, Wagtail allows any file size (subject to Django's [`DATA_UPLOAD_MAX_ME
 ```{versionadded} 7.4
 The `WAGTAILDOCS_MAX_UPLOAD_SIZE` setting was added.
 ```
+
+(document_antivirus_scanning)=
+
+## Anti-virus scanning
+
+Wagtail does not perform anti-virus (AV) scanning on uploaded documents. For sites with a need for this kind of validation of Wagtail files, two common patterns are:
+
+- **Storage-side scanning** - when documents are stored in a remote bucket (such as Amazon S3), use a managed scanner that quarantines or deletes infected objects after upload.
+- **Editor-side scanning** - reject infected files before they are stored, by extending the upload form via [WAGTAILDOCS_DOCUMENT_FORM_BASE](wagtaildocs_document_form_base) and calling out to a scanner. Returning a `ValidationError` will surface the message to the editor.
+
+For most sites, storage-side scanning is the lowest-risk option as it does not block uploads on the scanner being available, and naturally extends to files written outside of Wagtail (for example by background tasks or other applications writing to the same object storage).
 
 ## Document password required template
 

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -179,3 +179,6 @@ WAGTAILADMIN_BASE_URL = "http://example.com"
 # if untrusted users are allowed to upload files -
 # see https://docs.wagtail.org/en/stable/advanced_topics/deploying.html#user-uploaded-files
 WAGTAILDOCS_EXTENSIONS = ['csv', 'docx', 'key', 'odt', 'pdf', 'pptx', 'rtf', 'txt', 'xlsx', 'zip']
+
+# Maximum upload size for documents in bytes.
+WAGTAILDOCS_MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10MB


### PR DESCRIPTION
Part of [Independent security audit - report highlights #14173](https://github.com/wagtail/wagtail/discussions/14173), and follow-up to #13987 and #12617. This contains 4 related but different changes:

- Small clarification of the default for `WAGTAILDOCS_SERVE_METHOD`
- New docs sub-section about AV scanning options
- New docs sub-section about the security benefit of `WAGTAILDOCS_MAX_UPLOAD_SIZE`
- Adding a default docs max upload size to our project template

### AI usage

AI-generated first drafts, reviewed and edited