### PR TITLE
 Add accessible label to userbar aside element for accessibility

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -110,6 +110,7 @@ Changelog
  * Fix: Group audit log entries for autosave operations in page history view (Sage Abdullah)
  * Fix: Retain page explorer header buttons when searching or filtering (Sage Abdullah)
  * Fix: Correctly escape the `sizes` attribute in responsive image template tags (Jake Howard)
+ * Fix: Add accessible label to userbar aside element for accessibility (Kalash Kumari Thakur)
 
 7.3.1 (03.03.2026)
 ~~~~~~~~~~~~~~~~~~
@@ -417,6 +418,7 @@ Changelog
 
  * Fix: Index the contents of image descriptions as well as titles, for CMS search (Advik Sharma)
  * Fix: Correctly escape the `sizes` attribute in responsive image template tags (Jake Howard)
+ * Fix: Add accessible label to userbar aside element for accessibility (Kalash Kumari Thakur)
 
 7.0.6 (03.03.2026)
 ~~~~~~~~~~~~~~~~~~

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -968,6 +968,7 @@
 * Raghad Dahi
 * Divyansh Mishra
 * mikko2577
+* Kalash Kumari Thakur
 
 ## Translators
 

--- a/docs/releases/7.0.7.md
+++ b/docs/releases/7.0.7.md
@@ -19,6 +19,7 @@ depth: 1
 
  * Index the contents of image descriptions as well as titles, for CMS search (Advik Sharma)
  * Correctly escape the `sizes` attribute in responsive image template tags (Jake Howard)
+ * Add accessible label to userbar aside element for accessibility (Kalash Kumari Thakur)
 
 ### Documentation
 

--- a/docs/releases/7.3.2.md
+++ b/docs/releases/7.3.2.md
@@ -26,6 +26,7 @@ When a page is autosaved, the audit log entries created throughout the editing s
  * Avoid creating a new editing session when updating UI elements after an autosave (Sage Abdullah)
  * Retain page explorer header buttons when searching or filtering (Sage Abdullah)
  * Correctly escape the `sizes` attribute in responsive image template tags (Jake Howard)
+ * Add accessible label to userbar aside element for accessibility (Kalash Kumari Thakur)
 
 
 ### Documentation

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -2,7 +2,7 @@
 <!-- Wagtail user bar embed code -->
 <template id="wagtail-userbar-template">
     {# In preview panels, we still render the userbar UI, but hidden by default. #}
-    <aside {% if request.in_preview_panel %}hidden{% endif %}>
+    <aside {% if request.in_preview_panel %}hidden{% endif %} aria-labelledby="wagtail-userbar-trigger">
         <div class="w-userbar w-userbar--{{ position|default:'bottom-right' }} {% admin_theme_classname %}" data-wagtail-userbar data-wagtail-userbar-origin="{{ origin|default:"" }}" part="userbar">
             {# Styles and icons for all userbar components. #}
             <div data-userbar-assets>

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -233,6 +233,9 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
         self.assertIsNotNone(aside)
         self.assertIn("hidden", aside.attrs)
         self.assertEqual(aside.get("aria-labelledby"), "wagtail-userbar-trigger")
+        trigger = soup.find(id="wagtail-userbar-trigger")
+        self.assertIsNotNone(trigger)
+        self.assertEqual(trigger.get_text(strip=True), "View Wagtail quick actions")
 
     def test_userbar_aside_has_aria_labelledby(self):
         template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")
@@ -249,6 +252,9 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
         aside = soup.find("aside")
         self.assertIsNotNone(aside)
         self.assertEqual(aside.get("aria-labelledby"), "wagtail-userbar-trigger")
+        trigger = soup.find(id="wagtail-userbar-trigger")
+        self.assertIsNotNone(trigger)
+        self.assertEqual(trigger.get_text(strip=True), "View Wagtail quick actions")
 
 
 class TestContentCheckerConfig(WagtailTestUtils, TestCase):

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -237,25 +237,6 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
         self.assertIsNotNone(trigger)
         self.assertEqual(trigger.get_text(strip=True), "View Wagtail quick actions")
 
-    def test_userbar_aside_has_aria_labelledby(self):
-        template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")
-        content = template.render(
-            Context(
-                {
-                    PAGE_TEMPLATE_VAR: self.homepage,
-                    "request": self.dummy_request(self.user),
-                }
-            )
-        )
-
-        soup = self.get_soup(content)
-        aside = soup.find("aside")
-        self.assertIsNotNone(aside)
-        self.assertEqual(aside.get("aria-labelledby"), "wagtail-userbar-trigger")
-        trigger = soup.find(id="wagtail-userbar-trigger")
-        self.assertIsNotNone(trigger)
-        self.assertEqual(trigger.get_text(strip=True), "View Wagtail quick actions")
-
 
 class TestContentCheckerConfig(WagtailTestUtils, TestCase):
     def setUp(self):

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -228,7 +228,11 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
             )
         )
 
-        self.assertIn("<aside hidden>", content)
+        soup = self.get_soup(content)
+        aside = soup.find("aside")
+        self.assertIsNotNone(aside)
+        self.assertIn("hidden", aside.attrs)
+        self.assertEqual(aside.get("aria-labelledby"), "wagtail-userbar-trigger")
 
     def test_userbar_aside_has_aria_labelledby(self):
         template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -230,6 +230,22 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
 
         self.assertIn("<aside hidden>", content)
 
+    def test_userbar_aside_has_aria_labelledby(self):
+        template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")
+        content = template.render(
+            Context(
+                {
+                    PAGE_TEMPLATE_VAR: self.homepage,
+                    "request": self.dummy_request(self.user),
+                }
+            )
+        )
+
+        soup = self.get_soup(content)
+        aside = soup.find("aside")
+        self.assertIsNotNone(aside)
+        self.assertEqual(aside.get("aria-labelledby"), "wagtail-userbar-trigger")
+
 
 class TestContentCheckerConfig(WagtailTestUtils, TestCase):
     def setUp(self):


### PR DESCRIPTION
### Fixes: #14184

## Summary

The Wagtail userbar template renders an `<aside>` element without an accessible label. When multiple complementary landmarks exist on a page, screen readers cannot distinguish between them.

This PR adds an `aria-labelledby` attribute referencing the existing userbar toggle button (`wagtail-userbar-trigger`) so the landmark is properly labelled according to ARIA accessibility guidance.

## Changes

- Added `aria-labelledby="wagtail-userbar-trigger"` to the userbar `<aside>` element in: `wagtail/admin/templates/wagtailadmin/userbar/base.html`
- Added a unit test ensuring the rendered userbar contains the `aria-labelledby` attribute.

## AI usage

- Used Grok to understand the issue and plan the implementation. 
