### PR TITLE
Fix #14184: Add aria-labelledby to userbar aside for accessibility

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -2,7 +2,7 @@
 <!-- Wagtail user bar embed code -->
 <template id="wagtail-userbar-template">
     {# In preview panels, we still render the userbar UI, but hidden by default. #}
-    <aside {% if request.in_preview_panel %}hidden{% endif %}>
+    <aside {% if request.in_preview_panel %}hidden{% endif %} aria-labelledby="wagtail-userbar-trigger">
         <div class="w-userbar w-userbar--{{ position|default:'bottom-right' }} {% admin_theme_classname %}" data-wagtail-userbar data-wagtail-userbar-origin="{{ origin|default:"" }}" part="userbar">
             {% block css %}
                 {% versioned_static 'wagtailadmin/css/core.css' as core_css_url %}

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -84,6 +84,8 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
                 f"//localhost{versioned_static('wagtailadmin/js/userbar.js')}",
             ],
         )
+        
+        self.assertIn('aria-labelledby="wagtail-userbar-trigger"', content)
 
     def test_userbar_does_not_break_without_request(self):
         template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}boom")
@@ -228,7 +230,8 @@ class TestUserbarTag(WagtailTestUtils, TestCase):
             )
         )
 
-        self.assertIn("<aside hidden>", content)
+        #self.assertIn("<aside hidden>", content)
+        self.assertIn('<aside hidden aria-labelledby="wagtail-userbar-trigger">', content)
 
 
 class TestAccessibilityCheckerConfig(WagtailTestUtils, TestCase):


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #14184 

### Description

<!-- Please describe the problem you're fixing. -->
The userbar template uses an `<aside>` element without giving it a label. So, to fix this, I added the `aria-labelledby="wagtail-userbar-trigger"` attribute to the `<aside>` tag.

I also added an accessibility regression test to verify the userbar complementary landmark is properly labeled for screen readers and also updated `test_userbar_hidden_in_preview_panel` that was strictly asserting the exact old HTML string `"<aside hidden>"`.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Used Gemini 3.1 for research
