### PR TITLE
Add guideline for AI agents to only include relevant commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ The main developer documentation for Wagtail lives in the `docs/contributing` di
 - Describe the "why" of the changes, why the proposed solution is the right one.
 - Highlight areas of the proposed changes that require careful review.
 - Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution.
+- Do not add commits that are unrelated to the purpose of the PR. Check the commit history against the latest upstream main branch before pushing to ensure that only relevant commits are included in the PR.
 
 ### AI/Agent disclosure template (copy/paste & edit):
 
@@ -18,4 +19,4 @@ The main developer documentation for Wagtail lives in the `docs/contributing` di
 
 ### StreamField and StreamBlock template access
 
-- Wagtail's StreamBlock and StreamField use the same template syntax, but they differ from standard Django field access. When you use StreamField and other custom block types in Wagtail templates, you usually need to use the value property in your data variables. 
+- Wagtail's StreamBlock and StreamField use the same template syntax, but they differ from standard Django field access. When you use StreamField and other custom block types in Wagtail templates, you usually need to use the value property in your data variables.


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Not sure if this helps, but worth a try...

### Description

<!-- Please describe the problem you're fixing. -->
We tend to see AI-driven PRs that include commits/changes from other PRs by the same contributor. If they rely on using agents and don't take the time to review their own commits, maybe we can try to stop this issue before the PR gets submitted, so we don't waste time with the back-and-forth.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Copilot for autocompletion.