### PR TITLE
Ensure only one autosave request can happen at a time to prevent incorrect conflict notifications with the current session

### DIFF
--- a/client/src/controllers/AutosaveController.test.js
+++ b/client/src/controllers/AutosaveController.test.js
@@ -11,6 +11,9 @@ jest.useFakeTimers();
 
 describe('AutosaveController', () => {
   let application;
+  // rAF doesn't work with jest fake timers
+  // https://github.com/jestjs/jest/issues/5147
+  const mockRAF = jest.fn((callback) => callback());
 
   const setup = async (inner = '') => {
     document.body.innerHTML = /* html */ `
@@ -43,6 +46,7 @@ describe('AutosaveController', () => {
   beforeEach(() => {
     fetch.mockReset();
     jest.spyOn(window.history, 'replaceState');
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(mockRAF);
   });
 
   afterEach(() => {
@@ -51,6 +55,7 @@ describe('AutosaveController', () => {
     document.body.innerHTML = '';
     fetch.mockReset();
     window.history.replaceState.mockRestore();
+    window.requestAnimationFrame.mockRestore();
     jest.clearAllTimers();
   });
 
@@ -73,12 +78,6 @@ describe('AutosaveController', () => {
       });
 
       const unsavedEvent = await dispatchUnsaved(form);
-      // rAF doesn't work with jest fake timers
-      // https://github.com/jestjs/jest/issues/5147
-      const mockRAF = jest.fn((callback) => callback());
-      jest
-        .spyOn(window, 'requestAnimationFrame')
-        .mockImplementationOnce(mockRAF);
       await jest.advanceTimersByTimeAsync(500);
 
       expect(fetch).toHaveBeenCalledTimes(1);
@@ -120,6 +119,102 @@ describe('AutosaveController', () => {
 
       expect(blockSave).toHaveBeenCalledTimes(1);
       expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('does not submit when the first autosave has not completed', async () => {
+      const form = await setup();
+      expect(form.getAttribute('data-w-autosave-revision-id-value')).toBeNull();
+
+      fetch.mockResponseSuccessJSON(
+        JSON.stringify({ success: true, pk: 123, revision_id: 456 }),
+      );
+      // Mock a second response in case the controller (incorrectly) makes a
+      // second fetch before the first one resolves.
+      fetch.mockResponseSuccessJSON(
+        JSON.stringify({ success: true, pk: 123, revision_id: 456 }),
+      );
+
+      // Use sync advanceTimersByTime and avoid `await` between the two events
+      // so that microtasks don't flush — this keeps the first fetch's
+      // response pending while we trigger the second autosave.
+      dispatchUnsaved(form);
+      jest.advanceTimersByTime(500);
+      dispatchUnsaved(form);
+      jest.advanceTimersByTime(500);
+
+      // No second fetch should have been issued because the first response
+      // (and its revision_id) hasn't been processed yet.
+      expect(fetch).toHaveBeenCalledTimes(1);
+
+      // Now flush microtasks so the first fetch resolves and the controller
+      // processes its response.
+      await jest.advanceTimersByTimeAsync(0);
+
+      const [, init] = fetch.mock.calls[0];
+      const payload = Array.from(init.body.entries());
+      expect(payload).toEqual(
+        expect.arrayContaining([['title', 'Autosave title']]),
+      );
+      expect(payload).not.toEqual(
+        expect.arrayContaining([['overwrite_revision_id', '456']]),
+      );
+      expect(form.getAttribute('data-w-autosave-revision-id-value')).toBe(
+        '456',
+      );
+    });
+
+    it('does not submit when an existing (non-first) request has not completed', async () => {
+      const form = await setup();
+      expect(form.getAttribute('data-w-autosave-revision-id-value')).toBeNull();
+
+      // Set up the first autosave and let it complete so we have a revision_id
+      fetch.mockResponseSuccessJSON(
+        JSON.stringify({ success: true, pk: 123, revision_id: 456 }),
+      );
+      await dispatchUnsaved(form);
+      await jest.advanceTimersByTimeAsync(500);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      const [, init] = fetch.mock.calls[0];
+      const payload = Array.from(init.body.entries());
+      expect(payload).toEqual(
+        expect.arrayContaining([['title', 'Autosave title']]),
+      );
+      expect(payload).not.toEqual(
+        expect.arrayContaining([['overwrite_revision_id', '456']]),
+      );
+      expect(form.getAttribute('data-w-autosave-revision-id-value')).toBe(
+        '456',
+      );
+
+      fetch.mockReset();
+      const saveHandler = jest.fn();
+      form.addEventListener('w-autosave:save', saveHandler);
+
+      const events = [...Array(5).keys()].map(() => {
+        // Mock a response in case the controller (incorrectly) makes a  fetch
+        // before the existing one resolves.
+        fetch.mockResponseSuccessJSON(
+          JSON.stringify({ success: true, pk: 123, revision_id: 456 }),
+        );
+        // Use sync advanceTimersByTime and avoid `await` between events so that
+        // microtasks don't flush — this keeps the existing fetch's response
+        // pending while we trigger the next autosave.
+        const event = dispatchUnsaved(form);
+        jest.advanceTimersByTime(500);
+        return event;
+      });
+
+      // Wait for the final debounce
+      await jest.advanceTimersByTimeAsync(500);
+      form.removeEventListener('w-autosave:save', saveHandler);
+
+      // Only two requests from the loop should be fired: the first one and the
+      // last one (the intermediate ones are ignored).
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(saveHandler).toHaveBeenCalledTimes(2);
+      expect(saveHandler.mock.calls[0][0].detail.trigger).toBe(await events[0]);
+      expect(saveHandler.mock.calls[1][0].detail.trigger).toBe(await events[4]);
     });
 
     it('allows changing the interval value for the debounce', async () => {

--- a/client/src/controllers/AutosaveController.ts
+++ b/client/src/controllers/AutosaveController.ts
@@ -130,6 +130,10 @@ export class AutosaveController extends Controller<
     state: { type: String, default: 'idle' as AutosaveState },
   };
 
+  /**
+   * Maximum number of attempts to retry a save request that failed due to a
+   * network error. See {@link AutosaveController.retryTimes}.
+   */
   static maxRetries = 5;
 
   declare readonly hasPartialsTarget: boolean;
@@ -169,7 +173,16 @@ export class AutosaveController extends Controller<
    * save, another save will be immediately triggered with the latest event.
    */
   lastTriggerEvent?: Event;
+  /**
+   * The timer before retrying a save request that failed due to a network error.
+   * Increases 2 seconds exponentially to the power of
+   * {@link AutosaveController.retryTimes}.
+   */
   retryTimeout: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * The number of times the current save request has been retried.
+   * Limited to {@link AutosaveController.maxRetries}.
+   */
   retryTimes = 0;
   /**
    * The promise of the currently running save request, if any. Used to prevent

--- a/client/src/controllers/AutosaveController.ts
+++ b/client/src/controllers/AutosaveController.ts
@@ -155,8 +155,28 @@ export class AutosaveController extends Controller<
    */
   declare stateValue: AutosaveState;
 
+  /**
+   * The last event that triggered a save, used to ensure that if multiple saves
+   * are triggered while a save is still in progress, only one additional save
+   * will be triggered after the first one finishes, and it will use the latest
+   * event's data.
+   *
+   * This is necessary to prevent multiple saves from being triggered in quick
+   * succession and overwhelming the server, while still ensuring that the
+   * latest data is saved.
+   *
+   * It is reset after each save finishes, and if it has changed during the
+   * save, another save will be immediately triggered with the latest event.
+   */
+  lastTriggerEvent?: Event;
   retryTimeout: ReturnType<typeof setTimeout> | null = null;
   retryTimes = 0;
+  /**
+   * The promise of the currently running save request, if any. Used to prevent
+   * multiple concurrent save requests, which can cause race conditions and
+   * other unintended consequences.
+   */
+  submitPromise: Promise<void> | null = null;
 
   initialize(): void {
     this.submit = this.submit.bind(this);
@@ -170,17 +190,33 @@ export class AutosaveController extends Controller<
    */
   async save(event?: Event) {
     if (!this.activeValue || !(this.element instanceof HTMLFormElement)) return;
+    this.lastTriggerEvent = event;
+    if (this.submitPromise) {
+      // Prevent starting a new save request while one is already in progress.
+      return;
+    }
     const formData = new FormData(this.element);
     if (this.revisionIdValue) {
       formData.set('overwrite_revision_id', `${this.revisionIdValue}`);
     }
 
-    this.submit(
+    this.submitPromise = this.submit(
       this.dispatch('save', {
         cancelable: true,
         detail: { formData, trigger: event },
       }) as CustomEvent<AutosaveSaveDetail>,
-    );
+    ).finally(() => {
+      this.submitPromise = null;
+      if (this.lastTriggerEvent === event) {
+        // The latest trigger event is the same one that just finished saving,
+        // so we can reset it and not trigger another save.
+        this.lastTriggerEvent = undefined;
+      } else {
+        // Another save was triggered while this one was still running, so we
+        // should trigger another save to ensure the latest data is saved.
+        this.save(this.lastTriggerEvent);
+      }
+    });
   }
 
   /**
@@ -193,7 +229,7 @@ export class AutosaveController extends Controller<
   submit: DebouncibleFunction<
     (event: CustomEvent<AutosaveSaveDetail>) => Promise<void>
   > = async ({ defaultPrevented, detail: { formData, trigger: event } }) => {
-    if (defaultPrevented) return;
+    if (defaultPrevented) return Promise.resolve();
     const form = this.element as HTMLFormElement;
     const requestInit: RequestInit = {
       method: form.method,
@@ -252,16 +288,20 @@ export class AutosaveController extends Controller<
       this.clearRetries();
 
       // Ensure any UI updates have finished before dispatching the success event
-      requestAnimationFrame(() =>
-        this.dispatch('success', {
-          cancelable: false,
-          detail: {
-            response,
-            data: response,
-            trigger: event,
-          },
-        }),
-      );
+      // and return a promise that only resolves after the event is dispatched.
+      return new Promise((resolve) => {
+        requestAnimationFrame(() => {
+          this.dispatch('success', {
+            cancelable: false,
+            detail: {
+              response,
+              data: response,
+              trigger: event,
+            },
+          });
+          resolve();
+        });
+      });
     } catch (error) {
       let type: KnownErrorCode;
       let text: string;
@@ -341,6 +381,7 @@ export class AutosaveController extends Controller<
         });
       }
     }
+    return Promise.resolve();
   };
 
   /**

--- a/client/src/utils/debounce.ts
+++ b/client/src/utils/debounce.ts
@@ -37,12 +37,12 @@ export const debounce = <F extends AnyFunction>(
     window.clearTimeout(timeoutId);
     if (typeof wait !== 'number' || Number.isNaN(wait)) {
       try {
-        return Promise.resolve<ReturnType<F>>(func(...args));
+        return Promise.resolve<Awaited<ReturnType<F>>>(func(...args));
       } catch (error) {
         return Promise.reject(error);
       }
     } else {
-      return new Promise<ReturnType<F>>((resolve, reject) => {
+      return new Promise<Awaited<ReturnType<F>>>((resolve, reject) => {
         timeoutId = window.setTimeout(() => {
           try {
             resolve(func(...args));
@@ -69,7 +69,7 @@ type AnyFunction = FunctionType<any, any>;
 
 /** A function that has been debounced. */
 export interface DebouncedFunction<F extends AnyFunction> {
-  (...args: Parameters<F>): Promise<ReturnType<F>>;
+  (...args: Parameters<F>): Promise<Awaited<ReturnType<F>>>;
   cancel(): void;
   restore(): F;
 }


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes an issue where autosave gets immediately paused due to a "conflict with another session", even if it's the user's own current session.

### Description

<!-- Please describe the problem you're fixing. -->

This happens if a new request happens while the very first autosave request hasn't completed with a successful response. The following scenario seems to be a common occurrence:

- Make an edit so that an autosave request is triggered (you see the "Saving…" indicator)
- While the server has not responded (which could take a few seconds on bigger websites or slower connections),
  - Make a small edit and immediately stop so that the debounce timer elapses, which would trigger another request
  - If you want, do it a few more times so that you have multiple requests running in parallel. But in theory two concurrent requests (including the first one) should be enough.
- Observe that after the first request completes, the controller will have the `revision-id-value` correctly.
- However, since the second request was fired before the autosave revision ID was obtained, the server assumes this is a "new" session. This second request has the revision ID and timestamp of the initially loaded revision (not the autosave one that was just created), so the server rejects it as if a different session has updated the page.
- The controller detects an `invalid_revision` error and deactivates autosave and dispatches an event, which causes the error message in the footer to be shown.
- You might notice that the concurrent editing notifications in the header do not show a conflict. This is because it uses a separate ping mechanism, and it was paused while an autosave was still in progress. When the first autosave finishes, it receives the autosave revision ID correctly, so the ping endpoint knows that it's the same session.



### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Copilot for autocompletion, Claude Agent on Zed with Claude Opus 4.7 used to help in writing tests.