### PR TITLE
Correctly escape the `sizes` attribute in responsive image template tags

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -109,6 +109,7 @@ Changelog
  * Fix: Avoid creating a new editing session when updating UI elements after an autosave (Sage Abdullah)
  * Fix: Group audit log entries for autosave operations in page history view (Sage Abdullah)
  * Fix: Retain page explorer header buttons when searching or filtering (Sage Abdullah)
+ * Fix: Correctly escape the `sizes` attribute in responsive image template tags (Jake Howard)
 
 7.3.1 (03.03.2026)
 ~~~~~~~~~~~~~~~~~~
@@ -415,6 +416,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~~
 
  * Fix: Index the contents of image descriptions as well as titles, for CMS search (Advik Sharma)
+ * Fix: Correctly escape the `sizes` attribute in responsive image template tags (Jake Howard)
 
 7.0.6 (03.03.2026)
 ~~~~~~~~~~~~~~~~~~

--- a/docs/releases/7.0.7.md
+++ b/docs/releases/7.0.7.md
@@ -18,6 +18,7 @@ depth: 1
 ### Bug fixes
 
  * Index the contents of image descriptions as well as titles, for CMS search (Advik Sharma)
+ * Correctly escape the `sizes` attribute in responsive image template tags (Jake Howard)
 
 ### Documentation
 

--- a/docs/releases/7.3.2.md
+++ b/docs/releases/7.3.2.md
@@ -25,6 +25,7 @@ When a page is autosaved, the audit log entries created throughout the editing s
  * Index the contents of image descriptions as well as titles, for CMS search (Advik Sharma)
  * Avoid creating a new editing session when updating UI elements after an autosave (Sage Abdullah)
  * Retain page explorer header buttons when searching or filtering (Sage Abdullah)
+ * Correctly escape the `sizes` attribute in responsive image template tags (Jake Howard)
 
 
 ### Documentation

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1299,7 +1299,6 @@ class Picture(ResponsiveImage):
 
         attrs = self.attrs or {}
 
-        sizes = f'sizes="{attrs["sizes"]}" ' if "sizes" in attrs else ""
         fallback_format = self.get_fallback_format()
         fallback_renditions = self.formats[fallback_format]
 
@@ -1307,9 +1306,12 @@ class Picture(ResponsiveImage):
 
         for fmt in self.source_format_order:
             if fmt.name != fallback_format and fmt.name in self.formats:
-                srcset = self.get_width_srcset(self.formats[fmt.name])
-                mime = fmt.mime_type
-                sources.append(f'<source srcset="{srcset}" {sizes}type="{mime}">')
+                source_attrs = {
+                    "srcset": self.get_width_srcset(self.formats[fmt.name]),
+                    "sizes": attrs.get("sizes"),
+                    "type": fmt.mime_type,
+                }
+                sources.append(f"<source{flatatt(source_attrs)}>")
 
         if len(fallback_renditions) > 1:
             attrs["srcset"] = self.get_width_srcset(fallback_renditions)

--- a/wagtail/images/tests/test_templatetags.py
+++ b/wagtail/images/tests/test_templatetags.py
@@ -360,6 +360,19 @@ class PictureTagTestCase(ImagesTestCase):
         """
         self.assertHTMLEqual(rendered, expected)
 
+    def test_picture_sizes_attribute_escaped(self):
+        rendered = self.render(
+            "{% picture myimage width-{200,400} sizes=size_value %}",
+            {
+                "myimage": self.image,
+                "size_value": '100vw" onload="alert(1)',
+            },
+        )
+        self.assertIn(
+            'sizes="100vw&quot; onload=&quot;alert(1)"',
+            rendered,
+        )
+
     def test_picture_formats_only(self):
         filename_jpeg = get_test_image_filename(self.image, "format-jpeg")
         filename_webp = get_test_image_filename(self.image, "format-webp")


### PR DESCRIPTION
### Description

Previously, the `sizes` attribute wasn't correctly escaped, which could potentially lead to HTML injection.

This was reported to the Security team, but deemed not a security issue since `sizes` should not be user-controlled.

### AI usage

None
