### PR TITLE
Add `pointer-events: none` to icons inside buttons to prevent click capture. Fix #14194

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Changelog
  * Fix: Prevent error when moving a page to a destination with missing translations and `WAGTAILSIMPLETRANSLATION_SYNC_PAGE_TREE = True` (Sahil Kumar)
  * Fix: Handle Pillow detecting decompression bombs when validating image pixel count (Jake Howard, Sage Abdullah)
  * Fix: Use canonical URL for TED oEmbed provider (Marquis Nobles)
+ * Fix: Prevent icons from capturing clicks inside buttons (Maciek Baron)
  * Fix: Prevent stale content types from breaking audit log message formatting (Thibaud Colas)
  * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
  * Docs: Fix panel classname and deprecated usage of `format_html` in `construct_homepage_panels` example (Andreas Nüßlein)

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -293,6 +293,10 @@
     }
   }
 
+  .icon {
+    pointer-events: none; // ensure icons don't interfere with button interactions
+  }
+
   // Larger viewport width adjustments
 
   @include media-breakpoint-up(sm) {

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -35,6 +35,7 @@ depth: 1
  * Handle Pillow detecting decompression bombs when validating image pixel count (Jake Howard, Sage Abdullah)
  * Use canonical URL for TED oEmbed provider (Marquis Nobles)
  * Prevent stale content types from breaking audit log message formatting (Thibaud Colas)
+ * Prevent icons from capturing clicks inside buttons (Maciek Baron)
 
 ### Documentation
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #14194 

### Description

As described in the issue, currently and SVG icon inside a button interferes with click events.

This change adds `pointer-events: none` to icons inside buttons.

A child combinator (`>`) could be considered for improved CSS performance, however a descendant combinator makes this more flexible in case the icon happens to be nested in something for any reason.

### AI usage

None
