### PR TITLE
Fix blank choice tests for Django 6.1

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Changelog
 * Fix: Handle Pillow detecting decompression bombs when validating image pixel count (Jake Howard, Sage Abdullah)
 * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
 * Maintenance: Rename `request` argument to `cache_object` in `Page._get_site_root_paths()` for correctness (Kailesh)
+* Maintenance: Fix blank choice tests for Django 6.1 (Sage Abdullah)
 
 
 7.4.1 (19.05.2026)

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -33,6 +33,7 @@ depth: 1
 ### Maintenance
 
  * Rename `request` argument to `cache_object` in `Page._get_site_root_paths()` for correctness (Kailesh)
+ * Fix blank choice tests for Django 6.1 (Sage Abdullah)
 
 ## Upgrade considerations - removal of deprecated features from Wagtail 6.4 - 7.3
 

--- a/wagtail/admin/tests/test_filters.py
+++ b/wagtail/admin/tests/test_filters.py
@@ -51,24 +51,38 @@ class TestFilteredModelChoiceField(WagtailTestUtils, TestCase):
 
         form = UserForm()
         html = str(form["users"])
-        expected_html = """
-            <select name="users" data-widget="filtered-select" data-filter-field="id_group" required id="id_users">
-                <option value="" selected>---------</option>
-                <option value="{david}" data-filter-value="{musicians},{actors}">{david_username}</option>
-                <option value="{kevin}" data-filter-value="{actors}">{kevin_username}</option>
-                <option value="{morten}" data-filter-value="{musicians}">{morten_username}</option>
-            </select>
-        """.format(
-            david=self.david.pk,
-            kevin=self.kevin.pk,
-            morten=self.morten.pk,
-            musicians=self.musicians.pk,
-            actors=self.actors.pk,
-            david_username=self.david.get_username(),
-            kevin_username=self.kevin.get_username(),
-            morten_username=self.morten.get_username(),
+        options_data = [
+            (
+                self.david.pk,
+                self.david.get_username(),
+                [self.musicians.pk, self.actors.pk],
+            ),
+            (self.kevin.pk, self.kevin.get_username(), [self.actors.pk]),
+            (self.morten.pk, self.morten.get_username(), [self.musicians.pk]),
+        ]
+        soup = self.get_soup(html)
+        select = soup.select_one("select[name=users]")
+        self.assertIsNotNone(select)
+        self.assertLessEqual(
+            {
+                "data-widget": "filtered-select",
+                "data-filter-field": "id_group",
+                "required": "",
+                "id": "id_users",
+            }.items(),
+            select.attrs.items(),
         )
-        self.assertHTMLEqual(html, expected_html)
+        options = select.select("option")
+        self.assertEqual(len(options), 4)
+        self.assertEqual(options[0].get("value"), "")
+        for option, (value, text, filter_values) in zip(options[1:], options_data):
+            self.assertEqual(option.get("value"), str(value))
+            self.assertEqual(option.text, text)
+            # No ordering guarantee, so use assertCountEqual
+            self.assertCountEqual(
+                option.get("data-filter-value").split(","),
+                [str(filter_value) for filter_value in filter_values],
+            )
 
     def test_with_callable(self):
         class UserForm(forms.Form):
@@ -80,21 +94,35 @@ class TestFilteredModelChoiceField(WagtailTestUtils, TestCase):
 
         form = UserForm()
         html = str(form["users"])
-        expected_html = """
-            <select name="users" data-widget="filtered-select" data-filter-field="id_group" required id="id_users">
-                <option value="" selected>---------</option>
-                <option value="{david}" data-filter-value="{actors},{musicians}">{david_username}</option>
-                <option value="{kevin}" data-filter-value="{actors}">{kevin_username}</option>
-                <option value="{morten}" data-filter-value="{musicians}">{morten_username}</option>
-            </select>
-        """.format(
-            david=self.david.pk,
-            kevin=self.kevin.pk,
-            morten=self.morten.pk,
-            musicians=self.musicians.pk,
-            actors=self.actors.pk,
-            david_username=self.david.get_username(),
-            kevin_username=self.kevin.get_username(),
-            morten_username=self.morten.get_username(),
+
+        options_data = [
+            (
+                self.david.pk,
+                self.david.get_username(),
+                [self.actors.pk, self.musicians.pk],
+            ),
+            (self.kevin.pk, self.kevin.get_username(), [self.actors.pk]),
+            (self.morten.pk, self.morten.get_username(), [self.musicians.pk]),
+        ]
+        soup = self.get_soup(html)
+        select = soup.select_one("select[name=users]")
+        self.assertIsNotNone(select)
+        self.assertLessEqual(
+            {
+                "data-widget": "filtered-select",
+                "data-filter-field": "id_group",
+                "required": "",
+                "id": "id_users",
+            }.items(),
+            select.attrs.items(),
         )
-        self.assertHTMLEqual(html, expected_html)
+        options = select.select("option")
+        self.assertEqual(len(options), 4)
+        self.assertEqual(options[0].get("value"), "")
+        for option, (value, text, filter_values) in zip(options[1:], options_data):
+            self.assertEqual(option.get("value"), str(value))
+            self.assertEqual(option.text, text)
+            self.assertEqual(
+                option.get("data-filter-value").split(","),
+                [str(filter_value) for filter_value in filter_values],
+            )


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes current tests against Django's main branch

### Description

<!-- Please describe the problem you're fixing. -->
There are still a few things in our codebase that expect the non-accessible `-------` label. I'll update this in a separate PR.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Copilot for autocompletion.