### PR TITLE
Use more accessible labels for blank choices

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,8 @@ Changelog
  * Show site name in site switcher dropdown in site settings editor (Jack Morgan)
  * Improve clarity of different task states in workflow details dialog (Dan Braghis)
  * Add `submenu_hook` attribute to `ViewSetGroup` for collecting submenu items registered via a hook (Hunzlah Malik, MariyaOT, Sage Abdullah)
+ * Use a more accessible label for blank values of `ChoiceBlock` (Sage Abdullah)
+ * Use a more accessible label for blank values of dropdowns in locked page report filters (Sage Abdullah)
  * Fix: Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
  * Fix: Prevent an error when approving a workflow that has been cancelled in a different session (Kailesh)
  * Fix: Accommodate multilingual sites in skipping the "choose parent" step when creating a new page from a flat page listing (Amrinder Singh)

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -21,6 +21,8 @@ depth: 1
  * Show site name in site switcher dropdown in site settings editor (Jack Morgan)
  * Improve clarity of different task states in workflow details dialog (Dan Braghis)
  * Add `submenu_hook` attribute to `ViewSetGroup` for collecting submenu items registered via a hook (Hunzlah Malik, MariyaOT, Sage Abdullah)
+ * Use a more accessible label for blank values of `ChoiceBlock` (Sage Abdullah)
+ * Use a more accessible label for blank values of dropdowns in locked page report filters (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -134,12 +134,15 @@ class TestLockedPagesView(BaseReportViewTestCase):
 
         # Should render the filter inside the drilldown
         soup = self.get_soup(response.content)
-        locked_by_options = soup.select(
-            f"{self.drilldown_selector} select[name='locked_by'] option"
+        locked_by_select = soup.select_one(
+            f"{self.drilldown_selector} select[name='locked_by']"
         )
+        label = soup.select_one(f"label[for='{locked_by_select.get('id')}']")
+        locked_by_options = locked_by_select.select("option")
+        self.assertEqual(label.text.strip(), "Locked by")
         # No user locked anything, so there should be no option for the filter
         self.assertEqual(len(locked_by_options), 1)
-        self.assertEqual(locked_by_options[0].text, "---------")
+        self.assertEqual(locked_by_options[0].text, "Anyone")
         self.assertEqual(locked_by_options[0].get("value"), "")
         self.assertActiveFilterNotRendered(soup)
         self.assertPageTitle(soup, "Locked pages - Wagtail")
@@ -189,7 +192,7 @@ class TestLockedPagesView(BaseReportViewTestCase):
         )
         # The options should only display users who have locked pages
         self.assertEqual(len(locked_by_options), 2)
-        self.assertEqual(locked_by_options[0].text, "---------")
+        self.assertEqual(locked_by_options[0].text, "Anyone")
         self.assertIsNone(locked_by_options[0].value)
         self.assertEqual(locked_by_options[1].text, str(self.user))
         self.assertEqual(locked_by_options[1].get("value"), str(self.user.pk))

--- a/wagtail/admin/views/reports/locked_pages.py
+++ b/wagtail/admin/views/reports/locked_pages.py
@@ -22,9 +22,15 @@ def get_users_for_filter():
 
 
 class LockedPagesReportFilterSet(WagtailFilterSet):
-    locked_at = django_filters.DateFromToRangeFilter(widget=DateRangePickerWidget)
+    locked_at = django_filters.DateFromToRangeFilter(
+        label=_("Locked at"),
+        widget=DateRangePickerWidget,
+    )
     locked_by = django_filters.ModelChoiceFilter(
-        field_name="locked_by", queryset=lambda request: get_users_for_filter()
+        label=_("Locked by"),
+        empty_label=_("Anyone"),
+        field_name="locked_by",
+        queryset=lambda request: get_users_for_filter(),
     )
 
     class Meta:

--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -2,9 +2,9 @@ import copy
 import datetime
 from decimal import Decimal
 
+from django import VERSION as DJANGO_VERSION
 from django import forms
 from django.db.models import Model
-from django.db.models.fields import BLANK_CHOICE_DASH
 from django.utils.choices import CallableChoiceIterator
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
 from django.utils.encoding import force_str
@@ -589,7 +589,16 @@ class BaseChoiceBlock(FieldBlock):
                         break
 
             if not has_blank_choice:
-                return BLANK_CHOICE_DASH + local_choices
+                # Once we drop support for Django < 6.0, remove this and use the
+                # label from Django directly.
+                choice = [("", _("- Select an option -"))]
+
+                if DJANGO_VERSION >= (6, 1):
+                    from django.db.models.fields import BLANK_CHOICE_LABEL
+
+                    choice = [("", BLANK_CHOICE_LABEL)]
+
+                return choice + local_choices
 
             return local_choices
 

--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -589,7 +589,7 @@ class BaseChoiceBlock(FieldBlock):
                         break
 
             if not has_blank_choice:
-                # Once we drop support for Django < 6.0, remove this and use the
+                # Once we drop support for Django < 6.1, remove this and use the
                 # label from Django directly.
                 choice = [("", _("- Select an option -"))]
 

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -966,9 +966,7 @@ class TestRichTextBlock(TestCase):
 
 class TestChoiceBlock(WagtailTestUtils, SimpleTestCase):
     def setUp(self):
-        from django.db.models.fields import BLANK_CHOICE_DASH
-
-        self.blank_choice_dash_label = BLANK_CHOICE_DASH[0][1]
+        self.blank_choice_dash_label = "- Select an option -"
 
     def test_adapt_choice_block(self):
         block = blocks.ChoiceBlock(choices=[("tea", "Tea"), ("coffee", "Coffee")])
@@ -980,7 +978,7 @@ class TestChoiceBlock(WagtailTestUtils, SimpleTestCase):
         self.assertIsInstance(js_args[1], forms.Select)
         self.assertEqual(
             list(js_args[1].choices),
-            [("", "---------"), ("tea", "Tea"), ("coffee", "Coffee")],
+            [("", self.blank_choice_dash_label), ("tea", "Tea"), ("coffee", "Coffee")],
         )
         self.assertEqual(
             js_args[2],
@@ -1016,7 +1014,7 @@ class TestChoiceBlock(WagtailTestUtils, SimpleTestCase):
         self.assertIsInstance(js_args[1], forms.Select)
         self.assertEqual(
             list(js_args[1].choices),
-            [("", "---------"), ("tea", "Tea"), ("coffee", "Coffee")],
+            [("", self.blank_choice_dash_label), ("tea", "Tea"), ("coffee", "Coffee")],
         )
 
     def test_validate_required_choice_block(self):
@@ -1120,7 +1118,7 @@ class TestChoiceBlock(WagtailTestUtils, SimpleTestCase):
         self.assertEqual(
             list(js_args[1].choices),
             [
-                ("", "---------"),
+                ("", self.blank_choice_dash_label),
                 (
                     "Alcoholic",
                     [
@@ -1269,7 +1267,7 @@ class TestChoiceBlock(WagtailTestUtils, SimpleTestCase):
         self.assertEqual(
             list(js_args[1].choices),
             [
-                ("", "---------"),
+                ("", self.blank_choice_dash_label),
                 ("tea", "Tea"),
                 ("coffee", "Coffee"),
             ],
@@ -1400,7 +1398,7 @@ class TestChoiceBlock(WagtailTestUtils, SimpleTestCase):
         self.assertEqual(
             list(js_args[1].choices),
             [
-                ("", "---------"),
+                ("", self.blank_choice_dash_label),
                 ("tea", "Tea"),
                 ("coffee", "Coffee"),
             ],


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Built on #14196

### Description

<!-- Please describe the problem you're fixing. -->

This updates the default blank choice label for `ChoiceBlock`s. On Django >= 6.1, we use the label from Django directly. On older Django versions, we copy the same label into our own codebase.

This also updates the filters for the locked pages report so that it uses an accessible label for the empty choice, as [django-filter uses its own default](https://django-filter.readthedocs.io/en/stable/ref/settings.html#filters-empty-choice-label) (same as Django's old inaccessible one). I noticed we don't have explicitly translatable labels for these filters as well, so I added them.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Copilot for autocompletion.