### PR TITLE
Prevent incorrect conflict notification when doing a manual save

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -115,6 +115,7 @@ Changelog
  * Fix: Pause SessionController pings during autosave to prevent conflict notification with own session (Sage Abdullah)
  * Fix: Ensure live preview does not get stuck when edits occur during an in-progress update (Aniket Singh)
  * Fix: Ensure only one autosave request can happen at a time to prevent incorrect conflict notifications with the current session (Sage Abdullah)
+ * Fix: Prevent incorrect concurrent editing conflict notifications when doing a manual save (Sage Abdullah)
 
 7.3.1 (03.03.2026)
 ~~~~~~~~~~~~~~~~~~
@@ -423,6 +424,7 @@ Changelog
  * Fix: Index the contents of image descriptions as well as titles, for CMS search (Advik Sharma)
  * Fix: Correctly escape the `sizes` attribute in responsive image template tags (Jake Howard)
  * Fix: Add accessible label to userbar aside element for accessibility (Kalash Kumari Thakur)
+ * Fix: Prevent incorrect concurrent editing conflict notifications when doing a manual save (Sage Abdullah)
 
 7.0.6 (03.03.2026)
 ~~~~~~~~~~~~~~~~~~

--- a/docs/releases/7.0.7.md
+++ b/docs/releases/7.0.7.md
@@ -20,6 +20,7 @@ depth: 1
  * Index the contents of image descriptions as well as titles, for CMS search (Advik Sharma)
  * Correctly escape the `sizes` attribute in responsive image template tags (Jake Howard)
  * Add accessible label to userbar aside element for accessibility (Kalash Kumari Thakur)
+ * Prevent incorrect concurrent editing conflict notifications when doing a manual save (Sage Abdullah)
 
 ### Documentation
 

--- a/docs/releases/7.3.2.md
+++ b/docs/releases/7.3.2.md
@@ -30,6 +30,7 @@ When a page is autosaved, the audit log entries created throughout the editing s
  * Pause SessionController pings during autosave to prevent conflict notification with own session (Sage Abdullah)
  * Ensure live preview does not get stuck when edits occur during an in-progress update (Aniket Singh)
  * Ensure only one autosave request can happen at a time to prevent incorrect conflict notifications with the current session (Sage Abdullah)
+ * Prevent incorrect concurrent editing conflict notifications when doing a manual save (Sage Abdullah)
 
 
 ### Documentation

--- a/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/editing_sessions/module.html
@@ -37,6 +37,7 @@
                  w-session:visible->w-session#ping
                  w-session:visible->w-session#addInterval
                  w-session:hidden->w-session#clearInterval
+                 beforeunload@window->w-session#pause
                  pagehide@window->w-action#sendBeacon
                  w-unsaved:add@document->w-session#setUnsavedChanges
                  w-unsaved:clear@document->w-session#setUnsavedChanges

--- a/wagtail/admin/tests/test_editing_sessions.py
+++ b/wagtail/admin/tests/test_editing_sessions.py
@@ -1719,6 +1719,30 @@ class TestModuleInEditView(WagtailTestUtils, TestCase):
         self.assertEqual(module.get("data-w-session-interval-value"), "30000")
         self.assertRevisionInput(module)
 
+        actions = set(module.get("data-action").split())
+        self.assertLessEqual(
+            {
+                # Disable when leaving the page to prevent false positive conflict
+                # alert when the user manually click Save and a ping is triggered
+                # before the new page is loaded (but after the revision has been
+                # created, which has a different ID and we have no way of knowing).
+                # Must use beforeunload, as pagehide is only fired when the browser
+                # has received the response for the new page, which is too late for
+                # our use case.
+                "beforeunload@window->w-session#pause",
+                # Release the session at the very last moment.
+                "pagehide@window->w-action#sendBeacon",
+                # Pause during autosaves to avoid race condition when a ping happens
+                # in between the autosave updating the revision and the client
+                # receiving the response.
+                "w-autosave:save@document->w-session#pause",
+                # Resume once autosave completes, regardless of result
+                "w-autosave:success@document->w-session#resume",
+                "w-autosave:error@document->w-session#resume",
+            },
+            actions,
+        )
+
 
 class TestModuleInEditViewWithRevisableSnippet(TestModuleInEditView):
     model = FullFeaturedSnippet


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes one more edge case which happens with manual saves, sorry for not including this with https://github.com/wagtail/wagtail/pull/14189...

### Description

This is handling a similar case to https://github.com/wagtail/wagtail/pull/13975/changes/896733bd348b42dd270292dd3119280eb078c82e, but for manual save.

<!-- Please describe the problem you're fixing. -->
If you do a manual save e.g. by clicking "Save draft", and a ping happens (and completes) *after* the server creates a new revision but _before_ the client receives the response for the new page, a conflict notification will appear.

To test:

```diff
diff --git a/wagtail/admin/auth.py b/wagtail/admin/auth.py
index 068d44f89c..a292ffa937 100644
--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -1,4 +1,5 @@
 from functools import wraps
+from time import sleep

 from django.conf import settings
 from django.core.exceptions import PermissionDenied
@@ -134,7 +135,12 @@ def require_admin_access(view_func):
         if user.has_perms(["wagtailadmin.access_admin"]):
             try:
                 with LogContext(user=user):
-                    return get_localized_response(view_func, request, *args, **kwargs)
+                    response = get_localized_response(
+                        view_func, request, *args, **kwargs
+                    )
+                    if request.method == "POST" and request.path.endswith("/edit/"):
+                        sleep(5)
+                    return response

             except PermissionDenied:
                 if request.headers.get("x-requested-with") == "XMLHttpRequest":
```

- Apply the above patch
- Click "Save draft"
- Switch between tabs to trigger a ping
	- or set a small enough value for `WAGTAIL_EDITING_SESSION_PING_INTERVAL`, smaller than the above `sleep()`
- Before this PR, you'll see a conflict notification with your own session. With this PR, you won't see it.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Copilot for autocompletion.