### PR TITLE
Fix admin crash when system time zone data is unavailable 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ Changelog
 7.4 LTS (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~~~~~
 
+ * Prevent admin from crashing with `ZoneInfoNotFoundError` on environments without system time zone data, and add `wagtailadmin.W005` system check to surface the issue at startup (Abhishek Shah)
  * Add `is_deferred_validation` flag to support skipping custom validation when saving drafts (Daniel Kirkham)
  * Update project template Dockerfile to build dependencies in a separate stage (Brylie Oxley, Akshat Gupta)
  * Add `include_root` parameter to admin pages API endpoint (Divyansh Mishra)

--- a/docs/deployment/under_the_hood.md
+++ b/docs/deployment/under_the_hood.md
@@ -71,6 +71,22 @@ Wagtail is designed to take advantage of Django's [cache framework](inv:django#t
 
 Wagtail supports any of Django's cache backend, however we recommend against using one tied to the specific process or environment Django is running (eg `FileBasedCache` or `LocMemCache`).
 
+(time_zone_data)=
+
+### Time zone data
+
+Wagtail stores per-user time zone preferences and uses Python's [`zoneinfo`](https://docs.python.org/3/library/zoneinfo.html) module (via Django) to resolve them. By default, `zoneinfo` reads time zone data from the system's tz database.
+
+Some hosting environments don't ship with system time zone data — for example, minimal Linux containers (such as `python:*-slim` Docker images), Windows hosts, and certain PaaS buildpacks. In those environments, looking up a time zone raises `zoneinfo.ZoneInfoNotFoundError`, which can break the Wagtail admin.
+
+To provide time zone data on those environments, install the [`tzdata`](https://pypi.org/project/tzdata/) package from PyPI:
+
+```sh
+pip install tzdata
+```
+
+Wagtail registers a Django [system check](inv:django#topics/checks) (`wagtailadmin.W005`) that runs on startup and warns when time zone data is unavailable, so issues are surfaced before they reach end users. Running `python manage.py check --deploy` as part of your deployment pipeline will surface this warning.
+
 ## Deployment tips
 
 Wagtail, and by extension Django, can be deployed in many different ways on many different platforms. There is no "best" way to deploy it, however here are some tips to ensure your site is as stable and maintainable as possible:

--- a/docs/releases/7.4.md
+++ b/docs/releases/7.4.md
@@ -119,6 +119,7 @@ Thank you to the Sites Conformes team at DINUM for supporting the project by com
  * Correctly HTML-escape URL in photo type oembeds (Thibaud Colas)
  * Ensure user with appropriate permissions can cancel a workflow task (Dan Braghis)
  * Correctly close the Pages menu panel when clicking sidebar search (Divyansh Mishra)
+ * Prevent admin from crashing with `ZoneInfoNotFoundError` on environments without system time zone data, and add `wagtailadmin.W005` system check to surface the issue at startup (Abhishek Shah)
 
 ### Documentation
 

--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -1,4 +1,5 @@
 import os
+import zoneinfo
 
 from django.core.checks import Error, Tags, Warning, register
 
@@ -270,3 +271,41 @@ def datetime_format_check(app_configs, **kwargs):
                 )
 
     return errors
+
+
+@register(Tags.compatibility)
+def tz_data_available_check(app_configs, **kwargs):
+    """
+    Warn if zoneinfo cannot load the project's TIME_ZONE.
+
+    Some hosting environments (e.g. minimal containers, Heroku-style
+    buildpacks) ship without system time zone data. Without it, the
+    Wagtail admin crashes with ZoneInfoNotFoundError when looking up
+    user-profile time zones.
+    """
+    from django.conf import settings
+
+    if not getattr(settings, "USE_TZ", True):
+        return []
+
+    time_zone = getattr(settings, "TIME_ZONE", None)
+    if not time_zone:
+        return []
+
+    try:
+        zoneinfo.ZoneInfo(time_zone)
+    except zoneinfo.ZoneInfoNotFoundError:
+        return [
+            Warning(
+                f"No time zone data is available to zoneinfo for TIME_ZONE={time_zone!r}.",
+                hint=(
+                    "Wagtail relies on zoneinfo for time zone handling. Some "
+                    "environments (e.g. minimal Linux containers, certain PaaS "
+                    "buildpacks) don't ship system time zone data. Install the "
+                    "`tzdata` package from PyPI in those environments: "
+                    "`pip install tzdata`."
+                ),
+                id="wagtailadmin.W005",
+            )
+        ]
+    return []

--- a/wagtail/admin/localization.py
+++ b/wagtail/admin/localization.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import types
 import zoneinfo
 
@@ -7,6 +8,47 @@ from django.utils.dates import MONTHS, WEEKDAYS, WEEKDAYS_ABBR
 from django.utils.timezone import override as override_tz
 from django.utils.translation import gettext as _
 from django.utils.translation import override
+
+logger = logging.getLogger(__name__)
+
+_WARNED_TIMEZONES = set()
+
+
+def _warn_missing_timezone(time_zone):
+    if time_zone in _WARNED_TIMEZONES:
+        return
+    _WARNED_TIMEZONES.add(time_zone)
+    logger.warning(
+        "Time zone %r could not be loaded by zoneinfo; falling back to the "
+        "default. Install the `tzdata` package from PyPI on environments "
+        "without system time zone data.",
+        time_zone,
+    )
+
+
+class _safe_override_tz:
+    """Wrap timezone.override; degrade gracefully if zoneinfo lacks tz data."""
+
+    def __init__(self, time_zone):
+        self.time_zone = time_zone
+        self._inner = None
+
+    def __enter__(self):
+        if not self.time_zone:
+            return self
+        try:
+            self._inner = override_tz(self.time_zone)
+            self._inner.__enter__()
+        except zoneinfo.ZoneInfoNotFoundError:
+            _warn_missing_timezone(self.time_zone)
+            self._inner = None
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._inner is not None:
+            return self._inner.__exit__(exc_type, exc_value, traceback)
+        return False
+
 
 # Wagtail languages with >=90% coverage
 # This list is manually maintained
@@ -126,7 +168,7 @@ def get_localized_response(view_func, request, *args, **kwargs):
         time_zone = user.wagtail_userprofile.get_current_time_zone()
     else:
         time_zone = settings.TIME_ZONE
-    with override_tz(time_zone):
+    with _safe_override_tz(time_zone):
         if preferred_language:
             with override(preferred_language):
                 response = view_func(request, *args, **kwargs)
@@ -145,7 +187,7 @@ def get_localized_response(view_func, request, *args, **kwargs):
             render = response.render
 
             def overridden_render(response):
-                with override_tz(time_zone):
+                with _safe_override_tz(time_zone):
                     if preferred_language:
                         with override(preferred_language):
                             return render()

--- a/wagtail/admin/tests/test_checks.py
+++ b/wagtail/admin/tests/test_checks.py
@@ -1,8 +1,11 @@
-from django.core.checks import Error
+import zoneinfo
+from unittest import mock
+
+from django.core.checks import Error, Warning
 from django.test import TestCase, override_settings
 from django.utils.formats import reset_format_cache
 
-from wagtail.admin.checks import datetime_format_check
+from wagtail.admin.checks import datetime_format_check, tz_data_available_check
 from wagtail.test.utils import WagtailTestUtils
 
 
@@ -140,3 +143,32 @@ class TestDateTimeChecks(WagtailTestUtils, TestCase):
             ),
         ]
         self.assertEqual(errors, expected_errors)
+
+
+class TestTimeZoneDataCheck(TestCase):
+    def test_no_warning_when_zoneinfo_can_load_time_zone(self):
+        with override_settings(USE_TZ=True, TIME_ZONE="UTC"):
+            self.assertEqual(tz_data_available_check(None), [])
+
+    def test_warning_when_zoneinfo_cannot_load_time_zone(self):
+        with override_settings(USE_TZ=True, TIME_ZONE="Europe/London"):
+            with mock.patch(
+                "wagtail.admin.checks.zoneinfo.ZoneInfo",
+                side_effect=zoneinfo.ZoneInfoNotFoundError("no tz data"),
+            ):
+                errors = tz_data_available_check(None)
+
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], Warning)
+        self.assertEqual(errors[0].id, "wagtailadmin.W005")
+        self.assertIn("Europe/London", errors[0].msg)
+        self.assertIn("tzdata", errors[0].hint)
+
+    def test_no_warning_when_use_tz_disabled(self):
+        with override_settings(USE_TZ=False, TIME_ZONE="Europe/London"):
+            with mock.patch(
+                "wagtail.admin.checks.zoneinfo.ZoneInfo",
+                side_effect=zoneinfo.ZoneInfoNotFoundError("no tz data"),
+            ):
+                errors = tz_data_available_check(None)
+        self.assertEqual(errors, [])

--- a/wagtail/admin/tests/test_localization.py
+++ b/wagtail/admin/tests/test_localization.py
@@ -1,0 +1,53 @@
+import zoneinfo
+from unittest import mock
+
+from django.test import TestCase
+
+from wagtail.admin import localization
+
+
+class TestSafeOverrideTimeZone(TestCase):
+    def setUp(self):
+        localization._WARNED_TIMEZONES.clear()
+
+    def test_falls_back_when_zoneinfo_raises(self):
+        with mock.patch.object(
+            localization,
+            "override_tz",
+            side_effect=zoneinfo.ZoneInfoNotFoundError("no tz data"),
+        ):
+            with self.assertLogs(localization.logger, level="WARNING") as captured:
+                with localization._safe_override_tz("Europe/London"):
+                    pass
+
+        self.assertEqual(len(captured.output), 1)
+        self.assertIn("Europe/London", captured.output[0])
+        self.assertIn("tzdata", captured.output[0])
+
+    def test_warning_logged_once_per_timezone(self):
+        with mock.patch.object(
+            localization,
+            "override_tz",
+            side_effect=zoneinfo.ZoneInfoNotFoundError("no tz data"),
+        ):
+            with self.assertLogs(localization.logger, level="WARNING") as captured:
+                with localization._safe_override_tz("Europe/London"):
+                    pass
+                with localization._safe_override_tz("Europe/London"):
+                    pass
+                with localization._safe_override_tz("Asia/Tokyo"):
+                    pass
+
+        self.assertEqual(len(captured.output), 2)
+        self.assertIn("Europe/London", captured.output[0])
+        self.assertIn("Asia/Tokyo", captured.output[1])
+
+    def test_no_op_when_time_zone_is_none(self):
+        with mock.patch.object(localization, "override_tz") as inner:
+            with localization._safe_override_tz(None):
+                pass
+        inner.assert_not_called()
+
+    def test_delegates_to_override_tz_when_available(self):
+        with localization._safe_override_tz("UTC"):
+            pass


### PR DESCRIPTION
Fixes #14142

### Description

Implements the two-part fix outlined by @thibaudcolas in the issue, plus the startup check suggested by @allcaps:

1. **Graceful fallback** (`wagtail/admin/localization.py`) — wraps `timezone.override` so a missing system tz no longer 500s the admin. Logs a warning once per missing time zone.  
2. **System check** (`wagtail/admin/checks.py`, `wagtailadmin.W005`) — runs on startup (incl. `manage.py check --deploy`) and warns when `zoneinfo` cannot load `settings.TIME_ZONE`, with a hint pointing at `pip install tzdata`.  
3. **Docs** — new "Time zone data" subsection under Infrastructure Requirements in `docs/deployment/under_the_hood.md`.

Tests added in `wagtail/admin/tests/test_localization.py` (4) and `wagtail/admin/tests/test_checks.py` (3). Release note in `docs/releases/7.4.md` and `CHANGELOG.txt`.

Deliberately did **not** add `tzdata` as a hard dependency (per the discussion that closed #14143).

### AI usage

None