### PR TITLE
Add missing wagtail-inline-userbar exclude

### DIFF
--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -396,7 +396,12 @@ class TestContentCheckerConfig(WagtailTestUtils, TestCase):
                         # Override via class attribute
                         ".sr-only",
                         # Should include the default exclude selectors
-                        {"fromShadowDom": ["wagtail-userbar"]},
+                        {
+                            "fromShadowDom": [
+                                "wagtail-userbar",
+                                "wagtail-inline-userbar",
+                            ]
+                        },
                         # Override via method
                         "[data-please-ignore]",
                     ],

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -48,7 +48,9 @@ class ContentCheckerItem(BaseItem):
     axe_exclude = []
 
     # Make sure that the userbar is not tested.
-    _axe_default_exclude = [{"fromShadowDom": ["wagtail-userbar"]}]
+    _axe_default_exclude = [
+        {"fromShadowDom": ["wagtail-userbar", "wagtail-inline-userbar"]}
+    ]
 
     #: A list of `axe-core tags <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#axe-core-tags>`_
     #: or a list of `axe-core rule IDs <https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md>`_


### PR DESCRIPTION
Follow-up to #12187. I forgot our custom elements should be explicitly excluded from Axe. Spotted while testing #14186.

### AI usage

None
