### PR TITLE
Add missing `return` in example views for template components

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changelog
 * Fix: Prevent spurious migrations when there are missing child blocks in `StructBlock.Meta.form_layout` (Matthias Brück, Sage Abdullah)
 * Fix: Prevent error in usage views when using `gettext_lazy` for a model's `verbose_name` (James Biggs)
 * Fix: Prevent development markdown files from being added to virtual environment root upon installation (Dan Braghis)
+* Docs: Add missing `return` in example views for template components (Tibor Leupold)
 
 
 7.4.1 (19.05.2026)

--- a/docs/extending/template_components.md
+++ b/docs/extending/template_components.md
@@ -117,7 +117,7 @@ def welcome_page(request):
         WelcomePanel(),
     ]
 
-    render(request, 'my_app/welcome.html', {
+    return render(request, 'my_app/welcome.html', {
         'panels': panels,
     })
 ```
@@ -166,7 +166,7 @@ def welcome_page(request):
     for panel in panels:
         media += panel.media
 
-    render(request, 'my_app/welcome.html', {
+    return render(request, 'my_app/welcome.html', {
         'panels': panels,
         'media': media,
     })

--- a/docs/releases/7.4.2.md
+++ b/docs/releases/7.4.2.md
@@ -19,7 +19,7 @@ depth: 1
 
 ### Documentation
 
- * ...
+ * Add missing `return` in example views for template components (Tibor Leupold)
 
 ### Maintenance
 


### PR DESCRIPTION
### Description

The example view would not work as they implicitly returned `None`. The return value of the `render` shortcut needs to be returned from the view to make the view work.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None