### PR TITLE
fix: Add aria-labelledby support to Draftail editor

### DIFF
--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -160,6 +160,7 @@ const initEditor = (selector, originalOptions, currentScript) => {
 
   const getSharedPropsFromOptions = (newOptions) => {
     let ariaDescribedBy = null;
+    let ariaLabelledBy = null;
     const enableHorizontalRule = newOptions.enableHorizontalRule
       ? {
           description: gettext('Horizontal line'),
@@ -193,10 +194,28 @@ const initEditor = (selector, originalOptions, currentScript) => {
       ...type,
     }));
 
+    const label = document.querySelector(`label[for="${field.id}"]`);
+    if (label) {
+      const labelId = label.id || `${field.id}-label`;
+      if (!label.id) {
+        label.id = labelId;
+      }
+      ariaLabelledBy = labelId;
+    }
+
+    const helpTextId = `${field.id}-helptext`;
+    if (document.getElementById(helpTextId)) {
+      ariaDescribedBy = helpTextId;
+    }
+
     // Only initialize the character count / max length on fields explicitly requiring it.
     if (field.hasAttribute('maxlength')) {
       const maxLengthID = `${field.id}-length`;
-      ariaDescribedBy = maxLengthID;
+      if (ariaDescribedBy) {
+        ariaDescribedBy += ` ${maxLengthID}`;
+      } else {
+        ariaDescribedBy = maxLengthID;
+      }
       controls = controls.concat([
         {
           meta: (props) => (
@@ -249,6 +268,7 @@ const initEditor = (selector, originalOptions, currentScript) => {
       maxListNesting: 4,
       stripPastedStyles: false,
       ariaDescribedBy,
+      ariaLabelledBy,
       ...newOptions,
       blockTypes: blockTypes.map(wrapWagtailIcon),
       inlineStyles: inlineStyles.map(wrapWagtailIcon),

--- a/client/src/components/Draftail/index.test.js
+++ b/client/src/components/Draftail/index.test.js
@@ -98,6 +98,78 @@ describe('Draftail', () => {
       expect(field.draftailEditor.props.ariaDescribedBy).toBe('test-length');
     });
 
+    it('ariaLabelledBy with existing label id', () => {
+      document.body.innerHTML = `
+        <label id="test-label" for="test">Test field label</label>
+        <input id="test" value="null" />
+      `;
+      const field = document.querySelector('#test');
+
+      draftail.initEditor('#test', {});
+
+      expect(field.draftailEditor.props.ariaLabelledBy).toBe('test-label');
+    });
+
+    it('ariaLabelledBy with label without id', () => {
+      document.body.innerHTML = `
+        <label for="test">Test field label</label>
+        <input id="test" value="null" />
+      `;
+      const field = document.querySelector('#test');
+      const label = document.querySelector('label');
+
+      draftail.initEditor('#test', {});
+
+      expect(label.id).toBe('test-label');
+      expect(field.draftailEditor.props.ariaLabelledBy).toBe('test-label');
+    });
+
+    it('ariaDescribedBy with help text', () => {
+      document.body.innerHTML = `
+        <input id="test" value="null" />
+        <div id="test-helptext">
+          <p>This is helpful text</p>
+        </div>
+      `;
+      const field = document.querySelector('#test');
+
+      draftail.initEditor('#test', {});
+
+      expect(field.draftailEditor.props.ariaDescribedBy).toBe('test-helptext');
+    });
+
+    it('ariaDescribedBy with help text and maxLength', () => {
+      document.body.innerHTML = `
+        <input id="test" value="null" maxlength="50" />
+        <div id="test-helptext">
+          <p>This is helpful text</p>
+        </div>
+      `;
+      const field = document.querySelector('#test');
+
+      draftail.initEditor('#test', {});
+
+      expect(field.draftailEditor.props.ariaDescribedBy).toBe(
+        'test-helptext test-length',
+      );
+    });
+
+    it('ariaLabelledBy and ariaDescribedBy together', () => {
+      document.body.innerHTML = `
+        <label id="test-label" for="test">Test field label</label>
+        <input id="test" value="null" />
+        <div id="test-helptext">
+          <p>This is helpful text</p>
+        </div>
+      `;
+      const field = document.querySelector('#test');
+
+      draftail.initEditor('#test', {});
+
+      expect(field.draftailEditor.props.ariaLabelledBy).toBe('test-label');
+      expect(field.draftailEditor.props.ariaDescribedBy).toBe('test-helptext');
+    });
+
     describe('selector conflicts', () => {
       it('fails to instantiate on the right field', () => {
         document.body.innerHTML =


### PR DESCRIPTION
Fixes #14205

### Problem

Axe reports `aria-input-field-name` on the Draftail editor because the interactive textbox element lacks an accessible name.

### Solution

This PR associates the editor textbox with the existing field label by:
- finding the label associated with the field input
- assigning a label id when missing using the existing naming convention
- passing that id to the editor so the textbox receives `aria-labelledby`

Also updates `aria-describedby` handling to include help text and combine descriptors when needed.

### Why this approach

- Targets the actual interactive element used by assistive tech.
- Reuses existing labeling conventions.
- Small, low-risk change in editor initialization.

### Reviewer focus

Please review:
- label lookup and id assignment behavior
- `aria-describedby` composition when help text and maxlength are both present

### Validation

- Added/updated unit tests for:
  - label id present
  - label id missing
  - help text described-by
  - help text + maxlength combination
- Ran relevant unit tests locally (pass)
- Built frontend assets locally (pass)
- Verified in browser/devtools that textbox now has `aria-labelledby`

### Out of scope

- No broader editor refactor
- No unrelated accessibility changes

### AI usage
Used GPT to understand the Draftail changes in [index.js](https://github.com/wagtail/wagtail/blob/main/client/src/components/Draftail/index.js) 