### PR TITLE
Add aria-label to icon-only action buttons

### DIFF
--- a/client/src/components/StreamField/blocks/ActionButtons.ts
+++ b/client/src/components/StreamField/blocks/ActionButtons.ts
@@ -21,7 +21,13 @@ export abstract class ActionButton {
 
   render(container, position = 'after') {
     this.dom = $(`
-      <button type="button" class="button button--icon text-replace white" data-streamfield-action="${this.labelIdentifier}" title="${h(this.label)}">
+      <button
+      type="button"
+      class="button button--icon text-replace white"
+      data-streamfield-action="${this.labelIdentifier}"
+      title="${h(this.label)}"
+      aria-label="${h(this.label)}"
+      >
         <svg class="icon icon-${h(this.icon)}" aria-hidden="true">
           <use href="#icon-${h(this.icon)}"></use>
         </svg>


### PR DESCRIPTION
Fixes #12174

### Description

Adds an `aria-label` attribute to icon-only action buttons in StreamField to improve accessibility for screen reader users.

Previously, these buttons relied on the `title` attribute for context, which is not consistently announced by assistive technologies.

### AI usage

Used ChatGPT for guidance while understanding the codebase, accessibility issue, and Git workflow.
