### PR TITLE
Add automatic sizes attribute for lazy-loaded responsive images

### DIFF
--- a/wagtail/images/templatetags/wagtailimages_tags.py
+++ b/wagtail/images/templatetags/wagtailimages_tags.py
@@ -179,6 +179,9 @@ class SrcsetImageNode(ImageNode):
         for key in self.attrs:
             resolved_attrs[key] = self.attrs[key].resolve(context)
 
+        if resolved_attrs.get("loading") == "lazy" and "sizes" not in resolved_attrs:
+            resolved_attrs["sizes"] = "auto, 100vw"
+
         return ResponsiveImage(renditions, resolved_attrs).__html__()
 
 


### PR DESCRIPTION
Fixes #14193

### Description

This change automatically applies `sizes="auto, 100vw"` to responsive images rendered through `srcset_image` when:

* `loading="lazy"` is enabled
* no explicit `sizes` attribute is provided

This keeps existing `sizes` values unchanged for backwards compatibility while improving the default developer experience for responsive image generation.

### AI usage

Used AI assistance for understanding the issue discussion, exploring the relevant implementation area, and refining the final change.
