### PR TITLE
Refactor pages' function-based views to class-based views

### DIFF
--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -333,6 +333,7 @@ Endpoints for the following views were added to the viewset:
    .. autoattribute:: revisions_unschedule_view_class
    .. autoattribute:: search_view_class
    .. autoattribute:: set_page_position_view_class
+   .. autoattribute:: set_privacy_view_class
    .. autoattribute:: unpublish_view_class
    .. autoattribute:: usage_view_class
    .. autoattribute:: workflow_action_view_class

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -323,6 +323,7 @@ Endpoints for the following views were added to the viewset:
    .. autoattribute:: index_view_class
    .. autoattribute:: lock_view_class
    .. autoattribute:: move_view_class
+   .. autoattribute:: move_confirm_view_class
    .. autoattribute:: unlock_view_class
    .. autoattribute:: preview_on_add_view_class
    .. autoattribute:: preview_on_edit_view_class

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -332,6 +332,7 @@ Endpoints for the following views were added to the viewset:
    .. autoattribute:: revisions_revert_view_class
    .. autoattribute:: revisions_unschedule_view_class
    .. autoattribute:: search_view_class
+   .. autoattribute:: set_page_position_view_class
    .. autoattribute:: unpublish_view_class
    .. autoattribute:: usage_view_class
    .. autoattribute:: workflow_action_view_class

--- a/wagtail/admin/tests/pages/test_page_viewset.py
+++ b/wagtail/admin/tests/pages/test_page_viewset.py
@@ -663,10 +663,6 @@ class TestCustomViews(WagtailTestUtils, TestCase):
                 args=[self.event_page.id, self.old_revision.pk],
             ),
             reverse(
-                "wagtailadmin_pages:set_page_position",
-                args=[self.event_page.id],
-            ),
-            reverse(
                 "wagtailadmin_pages:set_privacy",
                 args=[self.event_page.id],
             ),
@@ -708,7 +704,14 @@ class TestCustomViews(WagtailTestUtils, TestCase):
             ),
         ]
 
-        post_only_urls = [
+        post_200_urls = [
+            reverse(
+                "wagtailadmin_pages:set_page_position",
+                args=[self.event_page.id],
+            ),
+        ]
+
+        post_302_urls = [
             reverse(
                 "wagtailadmin_pages:lock",
                 args=[self.event_page.id],
@@ -721,7 +724,8 @@ class TestCustomViews(WagtailTestUtils, TestCase):
 
         cases = [
             (self.client.get, urls, 200),
-            (self.client.post, post_only_urls, 302),
+            (self.client.post, post_200_urls, 200),
+            (self.client.post, post_302_urls, 302),
         ]
 
         for method, urls, expected_status in cases:

--- a/wagtail/admin/tests/pages/test_reorder_page.py
+++ b/wagtail/admin/tests/pages/test_reorder_page.py
@@ -54,7 +54,7 @@ class TestPageReorder(WagtailTestUtils, TestCase):
         response = self.client.get(
             reverse("wagtailadmin_pages:set_page_position", args=(self.child_1.id,))
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 405)
 
         # Ensure page order does not change:
         child_slugs = self.index_page.get_children().values_list("slug", flat=True)

--- a/wagtail/admin/tests/test_privacy.py
+++ b/wagtail/admin/tests/test_privacy.py
@@ -119,12 +119,17 @@ class TestSetPrivacyView(WagtailTestUtils, TestCase):
             "wagtailadmin_pages:edit",
             args=(self.private_page.pk,),
         )
-        html = response.json()["html"]
-        self.assertIn(
-            f"<span>Privacy is inherited from the ancestor page - "
-            f'<a href="{parent_edit_url}">Private page (simple page)</a></span>',
-            html,
+        json = response.json()
+        soup = self.get_soup(json["html"])
+        first_option_label = soup.select_one("label[for='id_restriction_type_0']")
+        self.assertIsNotNone(first_option_label)
+        self.assertEqual(
+            first_option_label.text.strip(),
+            "Privacy is inherited from the ancestor page - Private page (simple page)",
         )
+        ancestor_link = first_option_label.find("a", href=parent_edit_url)
+        self.assertIsNotNone(ancestor_link)
+        self.assertEqual(ancestor_link.text.strip(), "Private page (simple page)")
 
     def test_set_password_restriction(self):
         """
@@ -142,7 +147,9 @@ class TestSetPrivacyView(WagtailTestUtils, TestCase):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '"is_public": false')
+        json = response.json()
+        self.assertEqual(json["step"], "set_privacy_done")
+        self.assertEqual(json["is_public"], False)
 
         # Check that a page restriction has been created
         self.assertTrue(
@@ -175,11 +182,52 @@ class TestSetPrivacyView(WagtailTestUtils, TestCase):
 
         # Check response
         self.assertEqual(response.status_code, 200)
+        json = response.json()
+        self.assertEqual(json["step"], "set_privacy")
 
         # Check that a form error was raised
         self.assertFormError(
             response.context["form"], "password", "This field is required."
         )
+
+    def test_set_password_restriction_password_unset_on_private_child(self):
+        post_data = {
+            "restriction_type": "password",
+            "password": "",
+            "groups": [],
+        }
+        response = self.client.post(
+            reverse(
+                "wagtailadmin_pages:set_privacy", args=(self.private_child_page.id,)
+            ),
+            post_data,
+        )
+
+        # Check response
+        self.assertEqual(response.status_code, 200)
+        json = response.json()
+        self.assertEqual(json["step"], "set_privacy")
+
+        # Check that a form error was raised
+        self.assertFormError(
+            response.context["form"], "password", "This field is required."
+        )
+
+        # Check that the ancestor message is shown in the re-rendered form
+        soup = self.get_soup(json["html"])
+        parent_edit_url = reverse(
+            "wagtailadmin_pages:edit",
+            args=(self.private_page.pk,),
+        )
+        first_option_label = soup.select_one("label[for='id_restriction_type_0']")
+        self.assertIsNotNone(first_option_label)
+        self.assertEqual(
+            first_option_label.text.strip(),
+            "Privacy is inherited from the ancestor page - Private page (simple page)",
+        )
+        ancestor_link = first_option_label.find("a", href=parent_edit_url)
+        self.assertIsNotNone(ancestor_link)
+        self.assertEqual(ancestor_link.text.strip(), "Private page (simple page)")
 
     def test_unset_password_restriction(self):
         """
@@ -197,7 +245,9 @@ class TestSetPrivacyView(WagtailTestUtils, TestCase):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '"is_public": true')
+        json = response.json()
+        self.assertEqual(json["step"], "set_privacy_done")
+        self.assertEqual(json["is_public"], True)
 
         # Check that the page restriction has been deleted
         self.assertFalse(
@@ -288,7 +338,9 @@ class TestSetPrivacyView(WagtailTestUtils, TestCase):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '"is_public": false')
+        json = response.json()
+        self.assertEqual(json["step"], "set_privacy_done")
+        self.assertEqual(json["is_public"], False)
 
         # Check that a page restriction has been created
         self.assertTrue(
@@ -347,7 +399,9 @@ class TestSetPrivacyView(WagtailTestUtils, TestCase):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '"is_public": true')
+        json = response.json()
+        self.assertEqual(json["step"], "set_privacy_done")
+        self.assertEqual(json["is_public"], True)
 
         # Check that the page restriction has been deleted
         self.assertFalse(

--- a/wagtail/admin/views/page_privacy.py
+++ b/wagtail/admin/views/page_privacy.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
+from django.views.generic.edit import ModelFormMixin, ProcessFormView
 
 from wagtail.admin.forms.pages import PageViewRestrictionForm
 from wagtail.admin.modal_workflow import render_modal_workflow
@@ -11,77 +12,45 @@ from wagtail.models import Page, PageViewRestriction
 from wagtail.models.view_restrictions import BaseViewRestriction
 
 
-def set_privacy(request, page_id):
-    page = get_object_or_404(Page, id=page_id).specific_deferred
-    page_perms = page.permissions_for_user(request.user)
-    if not page_perms.can_set_view_restrictions():
-        raise PermissionDenied
+class SetPrivacyView(ModelFormMixin, ProcessFormView):
+    form_class = PageViewRestrictionForm
 
-    restrictions = page.get_view_restrictions().order_by("-page__depth")
-    if restrictions:
-        if restrictions[0].page.id == page.id:
-            restriction = restrictions[0]
-            if len(restrictions) > 1:
-                restriction_on_ancestor = restrictions[1]
+    def dispatch(self, request, page_id, *args, **kwargs):
+        self.page = get_object_or_404(Page, id=page_id).specific_deferred
+        page_perms = self.page.permissions_for_user(request.user)
+        if not page_perms.can_set_view_restrictions():
+            raise PermissionDenied
+
+        restrictions = self.page.get_view_restrictions().order_by("-page__depth")
+        if restrictions:
+            if restrictions[0].page.id == self.page.id:
+                self.restriction = restrictions[0]
+                if len(restrictions) > 1:
+                    self.restriction_on_ancestor = restrictions[1]
+                else:
+                    self.restriction_on_ancestor = None
             else:
-                restriction_on_ancestor = None
+                self.restriction = None
+                self.restriction_on_ancestor = restrictions[0]
         else:
-            restriction = None
-            restriction_on_ancestor = restrictions[0]
-    else:
-        restriction = None
-        restriction_on_ancestor = None
+            self.restriction = None
+            self.restriction_on_ancestor = None
 
-    if request.method == "POST":
-        form = PageViewRestrictionForm(
-            request.POST,
-            instance=restriction,
-            private_page_options=page.private_page_options,
-        )
-        if form.is_valid():
-            if form.cleaned_data["restriction_type"] == PageViewRestriction.NONE:
-                # remove any existing restriction
-                if restriction:
-                    restriction.delete(user=request.user)
-            else:
-                restriction = form.save(commit=False)
-                restriction.page = page
-                restriction.save(user=request.user)
-                # Save the groups many-to-many field
-                form.save_m2m()
+        self.object = self.restriction
 
-            return render_modal_workflow(
-                request,
-                None,
-                None,
-                None,
-                json_data={
-                    "step": "set_privacy_done",
-                    "is_public": (form.cleaned_data["restriction_type"] == "none"),
-                },
-            )
+        return super().dispatch(request, page_id, *args, **kwargs)
 
-    else:  # request is a GET
-        if restriction:
-            form = PageViewRestrictionForm(
-                instance=restriction,
-                private_page_options=page.private_page_options,
-            )
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
 
-        else:
-            # no current view restrictions on this page
-            form = PageViewRestrictionForm(
-                initial={"restriction_type": "none"},
-                private_page_options=page.private_page_options,
-            )
-
-        if restriction_on_ancestor:
+        if self.restriction_on_ancestor:
             ancestor_page_link = format_html(
                 '<a href="{url}">{title}</a>',
                 url=reverse(
-                    "wagtailadmin_pages:edit", args=[restriction_on_ancestor.page_id]
+                    "wagtailadmin_pages:edit",
+                    args=[self.restriction_on_ancestor.page_id],
                 ),
-                title=restriction_on_ancestor.page.specific_deferred.get_admin_display_title(),
+                title=self.restriction_on_ancestor.page.specific_deferred.get_admin_display_title(),
             )
             inherit_from_parent_choice = (
                 BaseViewRestriction.NONE,
@@ -99,23 +68,64 @@ def set_privacy(request, page_id):
                 inherit_from_parent_choice
             ] + list(form.fields["restriction_type"].choices[1:])
 
-    if len(page.private_page_options) == 0:
+        return form
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["private_page_options"] = self.page.private_page_options
+        return kwargs
+
+    def get_initial(self):
+        if not self.restriction:
+            return {"restriction_type": "none"}
+        return super().get_initial()
+
+    def form_valid(self, form):
+        if form.cleaned_data["restriction_type"] == PageViewRestriction.NONE:
+            # remove any existing restriction
+            if self.restriction:
+                self.restriction.delete(user=self.request.user)
+        else:
+            restriction = form.save(commit=False)
+            restriction.page = self.page
+            restriction.save(user=self.request.user)
+            # Save the groups many-to-many field
+            form.save_m2m()
+
         return render_modal_workflow(
-            request,
-            "wagtailadmin/page_privacy/no_privacy.html",
+            self.request,
             None,
+            None,
+            None,
+            json_data={
+                "step": "set_privacy_done",
+                "is_public": (form.cleaned_data["restriction_type"] == "none"),
+            },
         )
-    else:
-        return render_modal_workflow(
-            request,
-            "wagtailadmin/shared/set_privacy.html",
-            None,
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
             {
                 "action_url": reverse(
-                    "wagtailadmin_pages:set_privacy", args=(page.pk,)
+                    "wagtailadmin_pages:set_privacy", args=(self.page.pk,)
                 ),
-                "object": page,
-                "form": form,
-            },
+                "object": self.page,
+            }
+        )
+        return context
+
+    def render_to_response(self, context, **response_kwargs):
+        if len(self.page.private_page_options) == 0:
+            return render_modal_workflow(
+                self.request,
+                "wagtailadmin/page_privacy/no_privacy.html",
+                None,
+            )
+        return render_modal_workflow(
+            self.request,
+            "wagtailadmin/shared/set_privacy.html",
+            template_vars=context,
             json_data={"step": "set_privacy"},
+            **response_kwargs,
         )

--- a/wagtail/admin/views/pages/convert_alias.py
+++ b/wagtail/admin/views/pages/convert_alias.py
@@ -1,8 +1,9 @@
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.shortcuts import get_object_or_404, redirect
-from django.template.response import TemplateResponse
+from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
+from django.views.generic import TemplateView
 
 from wagtail import hooks
 from wagtail.actions.convert_alias import ConvertAliasPageAction
@@ -11,43 +12,46 @@ from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.models import Page
 
 
-def convert_alias(request, page_id):
-    page = get_object_or_404(Page, id=page_id, alias_of_id__isnull=False).specific
-    if not page.permissions_for_user(request.user).can_edit():
-        raise PermissionDenied
+class ConvertAliasView(TemplateView):
+    template_name = "wagtailadmin/pages/confirm_convert_alias.html"
 
-    with transaction.atomic():
+    @method_decorator(transaction.atomic)
+    def dispatch(self, request, page_id, *args, **kwargs):
+        self.page = get_object_or_404(
+            Page, id=page_id, alias_of_id__isnull=False
+        ).specific
+        if not self.page.permissions_for_user(request.user).can_edit():
+            raise PermissionDenied
+
         for fn in hooks.get_hooks("before_convert_alias_page"):
-            result = fn(request, page)
+            result = fn(request, self.page)
             if hasattr(result, "status_code"):
                 return result
 
-        next_url = get_valid_next_url_from_request(request)
+        self.next_url = get_valid_next_url_from_request(request)
+        return super().dispatch(request, page_id, *args, **kwargs)
 
-        if request.method == "POST":
-            action = ConvertAliasPageAction(page, user=request.user)
-            action.execute(skip_permission_checks=True)
+    def post(self, request, *args, **kwargs):
+        action = ConvertAliasPageAction(self.page, user=request.user)
+        action.execute(skip_permission_checks=True)
 
-            messages.success(
-                request,
-                _("Page '%(page_title)s' has been converted into an ordinary page.")
-                % {"page_title": page.get_admin_display_title()},
-            )
+        messages.success(
+            request,
+            _("Page '%(page_title)s' has been converted into an ordinary page.")
+            % {"page_title": self.page.get_admin_display_title()},
+        )
 
-            for fn in hooks.get_hooks("after_convert_alias_page"):
-                result = fn(request, page)
-                if hasattr(result, "status_code"):
-                    return result
+        for fn in hooks.get_hooks("after_convert_alias_page"):
+            result = fn(request, self.page)
+            if hasattr(result, "status_code"):
+                return result
 
-            if next_url:
-                return redirect(next_url)
-            return redirect("wagtailadmin_pages:edit", page.id)
+        if self.next_url:
+            return redirect(self.next_url)
+        return redirect("wagtailadmin_pages:edit", self.page.id)
 
-    return TemplateResponse(
-        request,
-        "wagtailadmin/pages/confirm_convert_alias.html",
-        {
-            "page": page,
-            "next": next_url,
-        },
-    )
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page"] = self.page
+        context["next_url"] = self.next_url
+        return context

--- a/wagtail/admin/views/pages/copy.py
+++ b/wagtail/admin/views/pages/copy.py
@@ -2,7 +2,7 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
-from django.views.generic import TemplateView
+from django.views.generic import FormView
 
 from wagtail import hooks
 from wagtail.actions.copy_page import CopyPageAction
@@ -13,7 +13,7 @@ from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.models import Page
 
 
-class CopyView(TemplateView):
+class CopyView(FormView):
     template_name = "wagtailadmin/pages/copy.html"
 
     def dispatch(self, request, page_id, *args, **kwargs):
@@ -25,9 +25,6 @@ class CopyView(TemplateView):
         # Parent page defaults to parent of source page
         self.parent_page = self.page.get_parent()
 
-        form_class = getattr(self.page.specific_class, "copy_form_class", CopyForm)
-        self.form = form_class(request.POST or None, user=request.user, page=self.page)
-
         self.next_url = get_valid_next_url_from_request(request)
 
         for fn in hooks.get_hooks("before_copy_page"):
@@ -37,85 +34,91 @@ class CopyView(TemplateView):
 
         return super().dispatch(request, page_id, *args, **kwargs)
 
+    def get_form_class(self):
+        return getattr(self.page.specific_class, "copy_form_class", CopyForm)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["user"] = self.request.user
+        kwargs["page"] = self.page
+        return kwargs
+
     def post(self, request, page_id, *args, **kwargs):
         # Prefill parent_page in case the form is invalid (as prepopulated value for the form field,
         # because ModelChoiceField seems to not fall back to the user given value)
         self.parent_page = Page.objects.get(id=request.POST["new_parent_page"])
+        return super().post(request, page_id, *args, **kwargs)
 
-        if self.form.is_valid():
-            # Receive the parent page (this should never be empty)
-            if self.form.cleaned_data["new_parent_page"]:
-                self.parent_page = self.form.cleaned_data["new_parent_page"]
+    def form_valid(self, form):
+        # Receive the parent page (this should never be empty)
+        if form.cleaned_data["new_parent_page"]:
+            self.parent_page = form.cleaned_data["new_parent_page"]
 
-            # Re-check if the user has permission to publish subpages on the new parent
-            can_publish = self.parent_page.permissions_for_user(
-                request.user
-            ).can_publish_subpage()
-            keep_live = can_publish and self.form.cleaned_data.get("publish_copies")
+        # Re-check if the user has permission to publish subpages on the new parent
+        can_publish = self.parent_page.permissions_for_user(
+            self.request.user
+        ).can_publish_subpage()
+        keep_live = can_publish and form.cleaned_data.get("publish_copies")
 
-            # Copy the page
-            if self.form.cleaned_data.get("alias"):
-                action = CreatePageAliasAction(
-                    self.page.specific,
-                    recursive=self.form.cleaned_data.get("copy_subpages"),
-                    parent=self.parent_page,
-                    update_slug=self.form.cleaned_data["new_slug"],
-                    user=request.user,
-                )
-                new_page = action.execute(skip_permission_checks=True)
-            else:
-                action = CopyPageAction(
-                    page=self.page,
-                    recursive=self.form.cleaned_data.get("copy_subpages"),
-                    to=self.parent_page,
-                    update_attrs={
-                        "title": self.form.cleaned_data["new_title"],
-                        "slug": self.form.cleaned_data["new_slug"],
-                    },
-                    keep_live=keep_live,
-                    user=request.user,
-                )
-                new_page = action.execute()
-
-            # Give a success message back to the user
-            edit_button = messages.button(
-                reverse("wagtailadmin_pages:edit", args=(new_page.id,)),
-                _("Edit"),
+        # Copy the page
+        if form.cleaned_data.get("alias"):
+            action = CreatePageAliasAction(
+                self.page.specific,
+                recursive=form.cleaned_data.get("copy_subpages"),
+                parent=self.parent_page,
+                update_slug=form.cleaned_data["new_slug"],
+                user=self.request.user,
             )
-            if self.form.cleaned_data.get("copy_subpages"):
-                messages.success(
-                    request,
-                    _("Page '%(page_title)s' and %(subpages_count)s subpages copied.")
-                    % {
-                        "page_title": self.page.specific_deferred.get_admin_display_title(),
-                        "subpages_count": new_page.get_descendants().count(),
-                    },
-                    buttons=[edit_button],
-                )
-            else:
-                messages.success(
-                    request,
-                    _("Page '%(page_title)s' copied.")
-                    % {
-                        "page_title": self.page.specific_deferred.get_admin_display_title()
-                    },
-                    buttons=[edit_button],
-                )
+            new_page = action.execute(skip_permission_checks=True)
+        else:
+            action = CopyPageAction(
+                page=self.page,
+                recursive=form.cleaned_data.get("copy_subpages"),
+                to=self.parent_page,
+                update_attrs={
+                    "title": form.cleaned_data["new_title"],
+                    "slug": form.cleaned_data["new_slug"],
+                },
+                keep_live=keep_live,
+                user=self.request.user,
+            )
+            new_page = action.execute()
 
-            for fn in hooks.get_hooks("after_copy_page"):
-                result = fn(request, self.page, new_page)
-                if hasattr(result, "status_code"):
-                    return result
+        # Give a success message back to the user
+        edit_button = messages.button(
+            reverse("wagtailadmin_pages:edit", args=(new_page.id,)),
+            _("Edit"),
+        )
+        if form.cleaned_data.get("copy_subpages"):
+            messages.success(
+                self.request,
+                _("Page '%(page_title)s' and %(subpages_count)s subpages copied.")
+                % {
+                    "page_title": self.page.specific_deferred.get_admin_display_title(),
+                    "subpages_count": new_page.get_descendants().count(),
+                },
+                buttons=[edit_button],
+            )
+        else:
+            messages.success(
+                self.request,
+                _("Page '%(page_title)s' copied.")
+                % {"page_title": self.page.specific_deferred.get_admin_display_title()},
+                buttons=[edit_button],
+            )
 
-            # Redirect to explore of parent page
-            if self.next_url:
-                return redirect(self.next_url)
-            return redirect("wagtailadmin_explore", self.parent_page.id)
-        return self.render_to_response(self.get_context_data())
+        for fn in hooks.get_hooks("after_copy_page"):
+            result = fn(self.request, self.page, new_page)
+            if hasattr(result, "status_code"):
+                return result
+
+        # Redirect to explore of parent page
+        if self.next_url:
+            return redirect(self.next_url)
+        return redirect("wagtailadmin_explore", self.parent_page.id)
 
     def get_context_data(self, **kwargs):
-        return {
-            "page": self.page,
-            "form": self.form,
-            "next": self.next_url,
-        }
+        context = super().get_context_data(**kwargs)
+        context["page"] = self.page
+        context["next"] = self.next_url
+        return context

--- a/wagtail/admin/views/pages/copy.py
+++ b/wagtail/admin/views/pages/copy.py
@@ -1,8 +1,8 @@
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
-from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import gettext as _
+from django.views.generic import TemplateView
 
 from wagtail import hooks
 from wagtail.actions.copy_page import CopyPageAction
@@ -13,60 +13,64 @@ from wagtail.admin.utils import get_valid_next_url_from_request
 from wagtail.models import Page
 
 
-def copy(request, page_id):
-    page = get_object_or_404(Page, id=page_id)
-    page_perms = page.permissions_for_user(request.user)
-    if not page_perms.can_copy():
-        raise PermissionDenied
+class CopyView(TemplateView):
+    template_name = "wagtailadmin/pages/copy.html"
 
-    # Parent page defaults to parent of source page
-    parent_page = page.get_parent()
+    def dispatch(self, request, page_id, *args, **kwargs):
+        self.page = get_object_or_404(Page, id=page_id)
+        page_perms = self.page.permissions_for_user(request.user)
+        if not page_perms.can_copy():
+            raise PermissionDenied
 
-    form_class = getattr(page.specific_class, "copy_form_class", CopyForm)
-    form = form_class(request.POST or None, user=request.user, page=page)
+        # Parent page defaults to parent of source page
+        self.parent_page = self.page.get_parent()
 
-    next_url = get_valid_next_url_from_request(request)
+        form_class = getattr(self.page.specific_class, "copy_form_class", CopyForm)
+        self.form = form_class(request.POST or None, user=request.user, page=self.page)
 
-    for fn in hooks.get_hooks("before_copy_page"):
-        result = fn(request, page)
-        if hasattr(result, "status_code"):
-            return result
+        self.next_url = get_valid_next_url_from_request(request)
 
-    # Check if user is submitting
-    if request.method == "POST":
+        for fn in hooks.get_hooks("before_copy_page"):
+            result = fn(request, self.page)
+            if hasattr(result, "status_code"):
+                return result
+
+        return super().dispatch(request, page_id, *args, **kwargs)
+
+    def post(self, request, page_id, *args, **kwargs):
         # Prefill parent_page in case the form is invalid (as prepopulated value for the form field,
         # because ModelChoiceField seems to not fall back to the user given value)
-        parent_page = Page.objects.get(id=request.POST["new_parent_page"])
+        self.parent_page = Page.objects.get(id=request.POST["new_parent_page"])
 
-        if form.is_valid():
+        if self.form.is_valid():
             # Receive the parent page (this should never be empty)
-            if form.cleaned_data["new_parent_page"]:
-                parent_page = form.cleaned_data["new_parent_page"]
+            if self.form.cleaned_data["new_parent_page"]:
+                self.parent_page = self.form.cleaned_data["new_parent_page"]
 
             # Re-check if the user has permission to publish subpages on the new parent
-            can_publish = parent_page.permissions_for_user(
+            can_publish = self.parent_page.permissions_for_user(
                 request.user
             ).can_publish_subpage()
-            keep_live = can_publish and form.cleaned_data.get("publish_copies")
+            keep_live = can_publish and self.form.cleaned_data.get("publish_copies")
 
             # Copy the page
-            if form.cleaned_data.get("alias"):
+            if self.form.cleaned_data.get("alias"):
                 action = CreatePageAliasAction(
-                    page.specific,
-                    recursive=form.cleaned_data.get("copy_subpages"),
-                    parent=parent_page,
-                    update_slug=form.cleaned_data["new_slug"],
+                    self.page.specific,
+                    recursive=self.form.cleaned_data.get("copy_subpages"),
+                    parent=self.parent_page,
+                    update_slug=self.form.cleaned_data["new_slug"],
                     user=request.user,
                 )
                 new_page = action.execute(skip_permission_checks=True)
             else:
                 action = CopyPageAction(
-                    page=page,
-                    recursive=form.cleaned_data.get("copy_subpages"),
-                    to=parent_page,
+                    page=self.page,
+                    recursive=self.form.cleaned_data.get("copy_subpages"),
+                    to=self.parent_page,
                     update_attrs={
-                        "title": form.cleaned_data["new_title"],
-                        "slug": form.cleaned_data["new_slug"],
+                        "title": self.form.cleaned_data["new_title"],
+                        "slug": self.form.cleaned_data["new_slug"],
                     },
                     keep_live=keep_live,
                     user=request.user,
@@ -78,12 +82,12 @@ def copy(request, page_id):
                 reverse("wagtailadmin_pages:edit", args=(new_page.id,)),
                 _("Edit"),
             )
-            if form.cleaned_data.get("copy_subpages"):
+            if self.form.cleaned_data.get("copy_subpages"):
                 messages.success(
                     request,
                     _("Page '%(page_title)s' and %(subpages_count)s subpages copied.")
                     % {
-                        "page_title": page.specific_deferred.get_admin_display_title(),
+                        "page_title": self.page.specific_deferred.get_admin_display_title(),
                         "subpages_count": new_page.get_descendants().count(),
                     },
                     buttons=[edit_button],
@@ -92,26 +96,26 @@ def copy(request, page_id):
                 messages.success(
                     request,
                     _("Page '%(page_title)s' copied.")
-                    % {"page_title": page.specific_deferred.get_admin_display_title()},
+                    % {
+                        "page_title": self.page.specific_deferred.get_admin_display_title()
+                    },
                     buttons=[edit_button],
                 )
 
             for fn in hooks.get_hooks("after_copy_page"):
-                result = fn(request, page, new_page)
+                result = fn(request, self.page, new_page)
                 if hasattr(result, "status_code"):
                     return result
 
             # Redirect to explore of parent page
-            if next_url:
-                return redirect(next_url)
-            return redirect("wagtailadmin_explore", parent_page.id)
+            if self.next_url:
+                return redirect(self.next_url)
+            return redirect("wagtailadmin_explore", self.parent_page.id)
+        return self.render_to_response(self.get_context_data())
 
-    return TemplateResponse(
-        request,
-        "wagtailadmin/pages/copy.html",
-        {
-            "page": page,
-            "form": form,
-            "next": next_url,
-        },
-    )
+    def get_context_data(self, **kwargs):
+        return {
+            "page": self.page,
+            "form": self.form,
+            "next": self.next_url,
+        }

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -5,12 +5,12 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
-from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
+from django.views.generic import TemplateView
 from django.views.generic.base import View
 
 from wagtail.admin import messages
@@ -37,39 +37,46 @@ from wagtail.models import (
 from wagtail.signals import init_new_page
 
 
-def add_subpage(request, parent_page_id):
-    parent_page = get_object_or_404(Page, id=parent_page_id).specific
-    if not parent_page.permissions_for_user(request.user).can_add_subpage():
-        raise PermissionDenied
+class AddSubpageView(TemplateView):
+    template_name = "wagtailadmin/pages/add_subpage.html"
 
-    page_types = [
-        (
-            model.get_verbose_name(),
-            model._meta.app_label,
-            model._meta.model_name,
-            model.get_page_description(),
+    def dispatch(self, request, parent_page_id, *args, **kwargs):
+        self.parent_page = get_object_or_404(Page, id=parent_page_id).specific
+        if not self.parent_page.permissions_for_user(request.user).can_add_subpage():
+            raise PermissionDenied
+
+        self.page_types = [
+            (
+                model.get_verbose_name(),
+                model._meta.app_label,
+                model._meta.model_name,
+                model.get_page_description(),
+            )
+            for model in type(self.parent_page).creatable_subpage_models()
+            if model.can_create_at(self.parent_page)
+        ]
+        # sort by lower-cased version of verbose name
+        self.page_types.sort(key=lambda page_type: page_type[0].lower())
+
+        if len(self.page_types) == 1:
+            # Only one page type is available - redirect straight to the create form rather than
+            # making the user choose
+            verbose_name, app_label, model_name, description = self.page_types[0]
+            return redirect(
+                "wagtailadmin_pages:add", app_label, model_name, self.parent_page.id
+            )
+        return super().dispatch(request, parent_page_id, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "parent_page": self.parent_page,
+                "page_types": self.page_types,
+                "next": get_valid_next_url_from_request(self.request),
+            }
         )
-        for model in type(parent_page).creatable_subpage_models()
-        if model.can_create_at(parent_page)
-    ]
-    # sort by lower-cased version of verbose name
-    page_types.sort(key=lambda page_type: page_type[0].lower())
-
-    if len(page_types) == 1:
-        # Only one page type is available - redirect straight to the create form rather than
-        # making the user choose
-        verbose_name, app_label, model_name, description = page_types[0]
-        return redirect("wagtailadmin_pages:add", app_label, model_name, parent_page.id)
-
-    return TemplateResponse(
-        request,
-        "wagtailadmin/pages/add_subpage.html",
-        {
-            "parent_page": parent_page,
-            "page_types": page_types,
-            "next": get_valid_next_url_from_request(request),
-        },
-    )
+        return context
 
 
 class CreateView(

--- a/wagtail/admin/views/pages/delete.py
+++ b/wagtail/admin/views/pages/delete.py
@@ -2,9 +2,10 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.shortcuts import get_object_or_404, redirect
-from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
+from django.views.generic import TemplateView
 
 from wagtail import hooks
 from wagtail.actions.delete_page import DeletePageAction
@@ -14,51 +15,56 @@ from wagtail.admin.views.pages.utils import type_to_delete_confirmation
 from wagtail.models import Page, ReferenceIndex
 
 
-def delete(request, page_id):
-    page = get_object_or_404(Page, id=page_id).specific
-    if not page.permissions_for_user(request.user).can_delete():
-        raise PermissionDenied
+class DeleteView(TemplateView):
+    template_name = "wagtailadmin/pages/confirm_delete.html"
 
-    wagtail_site_name = getattr(settings, "WAGTAIL_SITE_NAME", "wagtail")
-    with transaction.atomic():
+    @method_decorator(transaction.atomic)
+    def dispatch(self, request, page_id, *args, **kwargs):
+        self.page = get_object_or_404(Page, id=page_id).specific
+        if not self.page.permissions_for_user(request.user).can_delete():
+            raise PermissionDenied
+
+        self.wagtail_site_name = getattr(settings, "WAGTAIL_SITE_NAME", "wagtail")
         for fn in hooks.get_hooks("before_delete_page"):
-            result = fn(request, page)
+            result = fn(request, self.page)
             if hasattr(result, "status_code"):
                 return result
 
-        next_url = get_valid_next_url_from_request(request)
+        self.next_url = get_valid_next_url_from_request(request)
 
-        pages_to_delete = {page}
+        self.pages_to_delete = {self.page}
 
         # The `construct_translated_pages_to_cascade_actions` hook returns translation and
         # alias pages when the action is set to "delete"
         if getattr(settings, "WAGTAIL_I18N_ENABLED", False):
             for fn in hooks.get_hooks("construct_translated_pages_to_cascade_actions"):
-                fn_pages = fn([page], "delete")
+                fn_pages = fn([self.page], "delete")
                 if fn_pages and isinstance(fn_pages, dict):
                     for additional_pages in fn_pages.values():
-                        pages_to_delete.update(additional_pages)
+                        self.pages_to_delete.update(additional_pages)
 
-        pages_to_delete = list(pages_to_delete)
-        usage = ReferenceIndex.get_references_to(page).group_by_source_object()
+        self.pages_to_delete = list(self.pages_to_delete)
+        self.usage = ReferenceIndex.get_references_to(
+            self.page
+        ).group_by_source_object()
 
         if request.method == "POST":
-            if usage.is_protected:
+            if self.usage.is_protected:
                 raise PermissionDenied
 
             continue_deleting = type_to_delete_confirmation(request)
 
             if continue_deleting:
-                parent_id = page.get_parent().id
+                parent_id = self.page.get_parent().id
                 # Delete the source page.
-                action = DeletePageAction(page, user=request.user)
+                action = DeletePageAction(self.page, user=request.user)
                 # Permission checks are done above, so skip them in execute.
                 action.execute(skip_permission_checks=True)
 
                 # Delete translation and alias pages if they have the same parent page.
                 if getattr(settings, "WAGTAIL_I18N_ENABLED", False):
-                    parent_page_translations = page.get_parent().get_translations()
-                    for page_or_alias in pages_to_delete:
+                    parent_page_translations = self.page.get_parent().get_translations()
+                    for page_or_alias in self.pages_to_delete:
                         if page_or_alias.get_parent() in parent_page_translations:
                             action = DeletePageAction(page_or_alias, user=request.user)
                             # Permission checks are done above, so skip them in execute.
@@ -67,50 +73,48 @@ def delete(request, page_id):
                 messages.success(
                     request,
                     _("Page '%(page_title)s' deleted.")
-                    % {"page_title": page.get_admin_display_title()},
+                    % {"page_title": self.page.get_admin_display_title()},
                 )
 
                 for fn in hooks.get_hooks("after_delete_page"):
-                    result = fn(request, page)
+                    result = fn(request, self.page)
                     if hasattr(result, "status_code"):
                         return result
 
-                if next_url:
-                    return redirect(next_url)
+                if self.next_url:
+                    return redirect(self.next_url)
                 return redirect("wagtailadmin_explore", parent_id)
+        return self.render_to_response(self.get_context_data())
 
-    descendant_count = page.get_descendant_count()
-    return TemplateResponse(
-        request,
-        "wagtailadmin/pages/confirm_delete.html",
-        {
-            "page": page,
+    def get_context_data(self, **kwargs):
+        descendant_count = self.page.get_descendant_count()
+        return {
+            "page": self.page,
             "descendant_count": descendant_count,
-            "next": next_url,
-            "model_opts": page._meta,
-            "usage_url": reverse("wagtailadmin_pages:usage", args=(page.id,))
+            "next": self.next_url,
+            "model_opts": self.page._meta,
+            "usage_url": reverse("wagtailadmin_pages:usage", args=(self.page.id,))
             + "?describe_on_delete=1",
-            "usage_count": usage.count(),
-            "is_protected": usage.is_protected,
+            "usage_count": self.usage.count(),
+            "is_protected": self.usage.is_protected,
             # if the number of pages ( child pages + current page) exceeds this limit, then confirm before delete.
             "type_to_confirm_before_delete": (descendant_count + 1)
             >= getattr(settings, "WAGTAILADMIN_UNSAFE_PAGE_DELETION_LIMIT", 10),
-            "wagtail_site_name": wagtail_site_name,
+            "wagtail_site_name": self.wagtail_site_name,
             # note that while pages_to_delete may contain a mix of translated pages
             # and aliases, we count the "translations" only, as aliases are similar
             # to symlinks, so they should just follow the source
             "translation_count": len(
                 [
                     translation.id
-                    for translation in pages_to_delete
-                    if not translation.alias_of_id and translation.id != page.id
+                    for translation in self.pages_to_delete
+                    if not translation.alias_of_id and translation.id != self.page.id
                 ]
             ),
             "translation_descendant_count": sum(
                 [
                     translation.get_descendants().filter(alias_of__isnull=True).count()
-                    for translation in pages_to_delete
+                    for translation in self.pages_to_delete
                 ]
             ),
-        },
-    )
+        }

--- a/wagtail/admin/views/pages/delete.py
+++ b/wagtail/admin/views/pages/delete.py
@@ -47,44 +47,44 @@ class DeleteView(TemplateView):
         self.usage = ReferenceIndex.get_references_to(
             self.page
         ).group_by_source_object()
+        return super().dispatch(request, page_id, *args, **kwargs)
 
-        if request.method == "POST":
-            if self.usage.is_protected:
-                raise PermissionDenied
+    def post(self, request, *args, **kwargs):
+        if self.usage.is_protected:
+            raise PermissionDenied
 
-            continue_deleting = type_to_delete_confirmation(request)
+        if not type_to_delete_confirmation(request):
+            return self.render_to_response(self.get_context_data())
 
-            if continue_deleting:
-                parent_id = self.page.get_parent().id
-                # Delete the source page.
-                action = DeletePageAction(self.page, user=request.user)
-                # Permission checks are done above, so skip them in execute.
-                action.execute(skip_permission_checks=True)
+        parent_id = self.page.get_parent().id
+        # Delete the source page.
+        action = DeletePageAction(self.page, user=request.user)
+        # Permission checks are done above, so skip them in execute.
+        action.execute(skip_permission_checks=True)
 
-                # Delete translation and alias pages if they have the same parent page.
-                if getattr(settings, "WAGTAIL_I18N_ENABLED", False):
-                    parent_page_translations = self.page.get_parent().get_translations()
-                    for page_or_alias in self.pages_to_delete:
-                        if page_or_alias.get_parent() in parent_page_translations:
-                            action = DeletePageAction(page_or_alias, user=request.user)
-                            # Permission checks are done above, so skip them in execute.
-                            action.execute(skip_permission_checks=True)
+        # Delete translation and alias pages if they have the same parent page.
+        if getattr(settings, "WAGTAIL_I18N_ENABLED", False):
+            parent_page_translations = self.page.get_parent().get_translations()
+            for page_or_alias in self.pages_to_delete:
+                if page_or_alias.get_parent() in parent_page_translations:
+                    action = DeletePageAction(page_or_alias, user=request.user)
+                    # Permission checks are done above, so skip them in execute.
+                    action.execute(skip_permission_checks=True)
 
-                messages.success(
-                    request,
-                    _("Page '%(page_title)s' deleted.")
-                    % {"page_title": self.page.get_admin_display_title()},
-                )
+        messages.success(
+            request,
+            _("Page '%(page_title)s' deleted.")
+            % {"page_title": self.page.get_admin_display_title()},
+        )
 
-                for fn in hooks.get_hooks("after_delete_page"):
-                    result = fn(request, self.page)
-                    if hasattr(result, "status_code"):
-                        return result
+        for fn in hooks.get_hooks("after_delete_page"):
+            result = fn(request, self.page)
+            if hasattr(result, "status_code"):
+                return result
 
-                if self.next_url:
-                    return redirect(self.next_url)
-                return redirect("wagtailadmin_explore", parent_id)
-        return self.render_to_response(self.get_context_data())
+        if self.next_url:
+            return redirect(self.next_url)
+        return redirect("wagtailadmin_explore", parent_id)
 
     def get_context_data(self, **kwargs):
         descendant_count = self.page.get_descendant_count()

--- a/wagtail/admin/views/pages/move.py
+++ b/wagtail/admin/views/pages/move.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
-from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.generic.base import TemplateView
@@ -61,66 +60,74 @@ class MoveChooseDestinationView(TemplateView, FormMixin):
         return self.form_invalid(form)
 
 
-def move_confirm(request, page_to_move_id, destination_id):
-    page_to_move = get_object_or_404(Page, id=page_to_move_id).specific
-    # Needs .specific_deferred because the .get_admin_display_title method is called in template
-    destination = get_object_or_404(Page, id=destination_id).specific_deferred
-    i18n_enabled = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
+class MoveConfirmView(TemplateView):
+    template_name = "wagtailadmin/pages/confirm_move.html"
 
-    if not Page._slug_is_available(page_to_move.slug, destination, page=page_to_move):
-        messages.error(
-            request,
-            _(
-                "The slug '%(page_slug)s' is already in use at the selected parent page. Make sure the slug is unique and try again."
+    def dispatch(self, request, page_to_move_id, destination_id, *args, **kwargs):
+        self.page_to_move = get_object_or_404(Page, id=page_to_move_id).specific
+        # Needs .specific_deferred because the .get_admin_display_title method is called in template
+        self.destination = get_object_or_404(Page, id=destination_id).specific_deferred
+        self.i18n_enabled = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
+
+        if not Page._slug_is_available(
+            self.page_to_move.slug, self.destination, page=self.page_to_move
+        ):
+            messages.error(
+                request,
+                _(
+                    "The slug '%(page_slug)s' is already in use at the selected parent page. Make sure the slug is unique and try again."
+                )
+                % {"page_slug": self.page_to_move.slug},
             )
-            % {"page_slug": page_to_move.slug},
+            return redirect(
+                "wagtailadmin_pages:move",
+                self.page_to_move.id,
+            )
+
+        for fn in hooks.get_hooks("before_move_page"):
+            result = fn(request, self.page_to_move, self.destination)
+            if hasattr(result, "status_code"):
+                return result
+
+        self.pages_to_move = {self.page_to_move}
+
+        # The `construct_translated_pages_to_cascade_actions` hook returns translation and
+        # alias pages when the action is set to "move"
+        if self.i18n_enabled:
+            for fn in hooks.get_hooks("construct_translated_pages_to_cascade_actions"):
+                fn_pages = fn([self.page_to_move], "move")
+                if fn_pages and isinstance(fn_pages, dict):
+                    for additional_pages in fn_pages.values():
+                        self.pages_to_move.update(additional_pages)
+
+        self.pages_to_move = list(self.pages_to_move)
+        return super().dispatch(
+            request, page_to_move_id, destination_id, *args, **kwargs
         )
-        return redirect(
-            "wagtailadmin_pages:move",
-            page_to_move.id,
-        )
 
-    for fn in hooks.get_hooks("before_move_page"):
-        result = fn(request, page_to_move, destination)
-        if hasattr(result, "status_code"):
-            return result
-
-    pages_to_move = {page_to_move}
-
-    # The `construct_translated_pages_to_cascade_actions` hook returns translation and
-    # alias pages when the action is set to "move"
-    if i18n_enabled:
-        for fn in hooks.get_hooks("construct_translated_pages_to_cascade_actions"):
-            fn_pages = fn([page_to_move], "move")
-            if fn_pages and isinstance(fn_pages, dict):
-                for additional_pages in fn_pages.values():
-                    pages_to_move.update(additional_pages)
-
-    pages_to_move = list(pages_to_move)
-
-    if request.method == "POST":
-        if i18n_enabled:
+    def post(self, request, *args, **kwargs):
+        if self.i18n_enabled:
             # Get the list of translations of the page's original parent, which we
             # will use to determine whether translations will also be moved
-            parent_page_translations = page_to_move.get_parent().get_translations()
+            parent_page_translations = self.page_to_move.get_parent().get_translations()
 
         # any invalid moves *should* be caught by the permission check in the action
         # class, so don't bother to catch InvalidMoveToDescendant
         action = MovePageAction(
-            page_to_move, destination, pos="last-child", user=request.user
+            self.page_to_move, self.destination, pos="last-child", user=request.user
         )
         action.execute()
 
-        if i18n_enabled:
+        if self.i18n_enabled:
             # Move translation and alias pages if they have the same parent page.
-            for translation in pages_to_move:
+            for translation in self.pages_to_move:
                 if translation.get_parent() in parent_page_translations:
                     # Move the translated or alias page to its translated or
                     # alias "destination" page. The destination may not have
                     # been translated to the translation's locale, e.g. if it
                     # was created while the tree was not synced, so check for
                     # that before trying to move the page.
-                    destination_translation = destination.get_translation_or_none(
+                    destination_translation = self.destination.get_translation_or_none(
                         translation.locale
                     )
                     if destination_translation:
@@ -135,34 +142,36 @@ def move_confirm(request, page_to_move_id, destination_id):
         messages.success(
             request,
             _("Page '%(page_title)s' moved.")
-            % {"page_title": page_to_move.get_admin_display_title()},
+            % {"page_title": self.page_to_move.get_admin_display_title()},
             buttons=[
                 messages.button(
-                    reverse("wagtailadmin_pages:edit", args=(page_to_move.id,)),
+                    reverse("wagtailadmin_pages:edit", args=(self.page_to_move.id,)),
                     _("Edit"),
                 )
             ],
         )
 
         for fn in hooks.get_hooks("after_move_page"):
-            result = fn(request, page_to_move)
+            result = fn(request, self.page_to_move)
             if hasattr(result, "status_code"):
                 return result
 
-        return redirect("wagtailadmin_explore", destination.id)
+        return redirect("wagtailadmin_explore", self.destination.id)
 
-    return TemplateResponse(
-        request,
-        "wagtailadmin/pages/confirm_move.html",
-        {
-            "page_to_move": page_to_move,
-            "destination": destination,
-            "translations_to_move_count": len(
-                [
-                    translation.id
-                    for translation in pages_to_move
-                    if not translation.alias_of_id and translation.id != page_to_move.id
-                ]
-            ),
-        },
-    )
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "page_to_move": self.page_to_move,
+                "destination": self.destination,
+                "translations_to_move_count": len(
+                    [
+                        translation.id
+                        for translation in self.pages_to_move
+                        if not translation.alias_of_id
+                        and translation.id != self.page_to_move.id
+                    ]
+                ),
+            },
+        )
+        return context

--- a/wagtail/admin/views/pages/ordering.py
+++ b/wagtail/admin/views/pages/ordering.py
@@ -1,18 +1,19 @@
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
+from django.views import View
 
 from wagtail.models import Page
 
 
-def set_page_position(request, page_to_move_id):
-    page_to_move = get_object_or_404(Page, id=page_to_move_id)
-    parent_page = page_to_move.get_parent()
+class SetPagePositionView(View):
+    def post(self, request, page_to_move_id, *args, **kwargs):
+        page_to_move = get_object_or_404(Page, id=page_to_move_id)
+        parent_page = page_to_move.get_parent()
 
-    if not parent_page.permissions_for_user(request.user).can_reorder_children():
-        raise PermissionDenied
+        if not parent_page.permissions_for_user(request.user).can_reorder_children():
+            raise PermissionDenied
 
-    if request.method == "POST":
         # Get position parameter
         position = request.GET.get("position", None)
 
@@ -41,4 +42,4 @@ def set_page_position(request, page_to_move_id):
             # Move page to end
             page_to_move.move(parent_page, pos="last-child", user=request.user)
 
-    return HttpResponse("")
+        return HttpResponse("")

--- a/wagtail/admin/views/pages/preview.py
+++ b/wagtail/admin/views/pages/preview.py
@@ -6,23 +6,25 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
 from django.utils.translation import gettext
+from django.views import View
 
 from wagtail.admin.views.generic.preview import PreviewOnEdit as GenericPreviewOnEdit
 from wagtail.models import Page
 
 
-def view_draft(request, page_id):
-    page = get_object_or_404(Page, id=page_id).get_latest_revision_as_object()
-    perms = page.permissions_for_user(request.user)
-    if not (perms.can_publish() or perms.can_edit()):
-        raise PermissionDenied
+class ViewDraftView(View):
+    def dispatch(self, request, page_id, *args, **kwargs):
+        page = get_object_or_404(Page, id=page_id).get_latest_revision_as_object()
+        perms = page.permissions_for_user(request.user)
+        if not (perms.can_publish() or perms.can_edit()):
+            raise PermissionDenied
 
-    try:
-        preview_mode = request.GET.get("mode", page.default_preview_mode)
-    except IndexError as e:
-        raise PermissionDenied from e
+        try:
+            preview_mode = request.GET.get("mode", page.default_preview_mode)
+        except IndexError as e:
+            raise PermissionDenied from e
 
-    return page.make_preview_request(request, preview_mode)
+        return page.make_preview_request(request, preview_mode)
 
 
 class PreviewOnEditView(GenericPreviewOnEdit):

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -26,7 +26,7 @@ from wagtail.admin.views.pages.listing import (
     PageFilterSet,
 )
 from wagtail.admin.views.pages.lock import LockView, UnlockView
-from wagtail.admin.views.pages.move import MoveChooseDestinationView, move_confirm
+from wagtail.admin.views.pages.move import MoveChooseDestinationView, MoveConfirmView
 from wagtail.admin.views.pages.ordering import set_page_position
 from wagtail.admin.views.pages.preview import (
     PreviewOnCreateView,
@@ -239,6 +239,12 @@ class PageViewSet(PageListingViewSet):
     must be a subclass of
     ``wagtail.admin.views.pages.move.MoveChooseDestinationView``.
     """
+    move_confirm_view_class = MoveConfirmView
+    """
+    The view class to use for the confirmation view when moving a page;
+    must be a subclass of
+    ``wagtail.admin.views.pages.move.MoveConfirmView``.
+    """
     preview_on_add_view_class = PreviewOnCreateView
     """
     The view class to use for the preview on create view; must be a subclass of
@@ -425,7 +431,9 @@ class PageViewSet(PageListingViewSet):
     def move_view(self):
         return self.construct_view(self.move_view_class)
 
-    move_confirm_view = staticmethod(move_confirm)
+    @cached_property
+    def move_confirm_view(self):
+        return self.construct_view(self.move_confirm_view_class)
 
     @cached_property
     def preview_on_add_view(self):

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -12,7 +12,7 @@ from wagtail.admin.views.pages.choose_parent import (
 from wagtail.admin.views.pages.convert_alias import convert_alias
 from wagtail.admin.views.pages.copy import copy
 from wagtail.admin.views.pages.create import CreateView, add_subpage
-from wagtail.admin.views.pages.delete import delete
+from wagtail.admin.views.pages.delete import DeleteView
 from wagtail.admin.views.pages.edit import EditView
 from wagtail.admin.views.pages.history import (
     PageHistoryView,
@@ -193,6 +193,11 @@ class PageViewSet(PageListingViewSet):
     must be a subclass of
     ``wagtail.admin.views.pages.workflow.ConfirmWorkflowCancellationView``.
     """
+    delete_view_class = DeleteView
+    """
+    The view class to use for the delete view; must be a subclass of
+    ``wagtail.admin.views.pages.delete.DeleteView``.
+    """
     edit_view_class = EditView
     """
     The view class to use for the edit view; must be a subclass of
@@ -372,7 +377,9 @@ class PageViewSet(PageListingViewSet):
 
     copy_view = staticmethod(copy)
 
-    delete_view = staticmethod(delete)
+    @cached_property
+    def delete_view(self):
+        return self.construct_view(self.delete_view_class)
 
     @cached_property
     def edit_view(self):

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -10,7 +10,7 @@ from wagtail.admin.views.pages.choose_parent import (
     GenericChooseParentView,
 )
 from wagtail.admin.views.pages.convert_alias import convert_alias
-from wagtail.admin.views.pages.copy import copy
+from wagtail.admin.views.pages.copy import CopyView
 from wagtail.admin.views.pages.create import CreateView, add_subpage
 from wagtail.admin.views.pages.delete import DeleteView
 from wagtail.admin.views.pages.edit import EditView
@@ -192,6 +192,11 @@ class PageViewSet(PageListingViewSet):
     The view class to use for confirming the cancellation of a workflow;
     must be a subclass of
     ``wagtail.admin.views.pages.workflow.ConfirmWorkflowCancellationView``.
+    """
+    copy_view_class = CopyView
+    """
+    The view class to use for the copy view; must be a subclass of
+    ``wagtail.admin.views.pages.copy.CopyView``.
     """
     delete_view_class = DeleteView
     """
@@ -375,7 +380,9 @@ class PageViewSet(PageListingViewSet):
 
     convert_alias_view = staticmethod(convert_alias)
 
-    copy_view = staticmethod(copy)
+    @cached_property
+    def copy_view(self):
+        return self.construct_view(self.copy_view_class)
 
     @cached_property
     def delete_view(self):

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -31,7 +31,7 @@ from wagtail.admin.views.pages.ordering import SetPagePositionView
 from wagtail.admin.views.pages.preview import (
     PreviewOnCreateView,
     PreviewOnEditView,
-    view_draft,
+    ViewDraftView,
 )
 from wagtail.admin.views.pages.revisions import (
     RevisionsCompareView,
@@ -302,6 +302,11 @@ class PageViewSet(PageListingViewSet):
     The view class to use for the usage view; must be a subclass of
     ``wagtail.admin.views.pages.usage.UsageView``.
     """
+    view_draft_view_class = ViewDraftView
+    """
+    The view class to use for the view draft view; must be a subclass of
+    ``wagtail.admin.views.pages.preview.ViewDraftView``.
+    """
     workflow_action_view_class = WorkflowActionView
     """
     The view class to use for performing a workflow action; must be a subclass of
@@ -490,7 +495,9 @@ class PageViewSet(PageListingViewSet):
     def usage_view(self):
         return self.construct_view(self.usage_view_class)
 
-    view_draft_view = staticmethod(view_draft)
+    @cached_property
+    def view_draft_view(self):
+        return self.construct_view(self.view_draft_view_class)
 
     @cached_property
     def workflow_action_view(self):

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -9,7 +9,7 @@ from wagtail.admin.views.pages.choose_parent import (
     ChooseParentView,
     GenericChooseParentView,
 )
-from wagtail.admin.views.pages.convert_alias import convert_alias
+from wagtail.admin.views.pages.convert_alias import ConvertAliasView
 from wagtail.admin.views.pages.copy import CopyView
 from wagtail.admin.views.pages.create import AddSubpageView, CreateView
 from wagtail.admin.views.pages.delete import DeleteView
@@ -198,6 +198,11 @@ class PageViewSet(PageListingViewSet):
     must be a subclass of
     ``wagtail.admin.views.pages.workflow.ConfirmWorkflowCancellationView``.
     """
+    convert_alias_view_class = ConvertAliasView
+    """
+    The view class to use for the convert alias view; must be a subclass of
+    ``wagtail.admin.views.pages.convert_alias.ConvertAliasView``.
+    """
     copy_view_class = CopyView
     """
     The view class to use for the copy view; must be a subclass of
@@ -385,7 +390,9 @@ class PageViewSet(PageListingViewSet):
     def confirm_workflow_cancellation_view(self):
         return self.construct_view(self.confirm_workflow_cancellation_view_class)
 
-    convert_alias_view = staticmethod(convert_alias)
+    @cached_property
+    def convert_alias_view(self):
+        return self.construct_view(self.convert_alias_view_class)
 
     @cached_property
     def copy_view(self):

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -11,7 +11,7 @@ from wagtail.admin.views.pages.choose_parent import (
 )
 from wagtail.admin.views.pages.convert_alias import convert_alias
 from wagtail.admin.views.pages.copy import CopyView
-from wagtail.admin.views.pages.create import CreateView, add_subpage
+from wagtail.admin.views.pages.create import AddSubpageView, CreateView
 from wagtail.admin.views.pages.delete import DeleteView
 from wagtail.admin.views.pages.edit import EditView
 from wagtail.admin.views.pages.history import (
@@ -180,6 +180,11 @@ class PageViewSet(PageListingViewSet):
     """
     The view class to use for the create view; must be a subclass of
     ``wagtail.admin.views.pages.create.CreateView``.
+    """
+    add_subpage_view_class = AddSubpageView
+    """
+    The view class to use for the add subpage view; must be a subclass of
+    ``wagtail.admin.views.pages.create.AddSubpageView``.
     """
     collect_workflow_action_data_view_class = CollectWorkflowActionDataView
     """
@@ -368,7 +373,9 @@ class PageViewSet(PageListingViewSet):
     def add_view(self):
         return self.construct_view(self.add_view_class)
 
-    add_subpage_view = staticmethod(add_subpage)
+    @cached_property
+    def add_subpage_view(self):
+        return self.construct_view(self.add_subpage_view_class)
 
     @cached_property
     def collect_workflow_action_data_view(self):

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -4,7 +4,7 @@ from django.http import Http404
 from django.urls import path
 from django.utils.functional import cached_property, classproperty
 
-from wagtail.admin.views.page_privacy import set_privacy
+from wagtail.admin.views.page_privacy import SetPrivacyView
 from wagtail.admin.views.pages.choose_parent import (
     ChooseParentView,
     GenericChooseParentView,
@@ -287,6 +287,11 @@ class PageViewSet(PageListingViewSet):
     The view class to use for the set page position view; must be a subclass of
     ``wagtail.admin.views.pages.ordering.SetPagePositionView``.
     """
+    set_privacy_view_class = SetPrivacyView
+    """
+    The view class to use for the set privacy view; must be a subclass of
+    ``wagtail.admin.views.page_privacy.SetPrivacyView``.
+    """
     unlock_view_class = UnlockView
     """
     The view class to use for unlocking a page; must be a subclass of
@@ -481,7 +486,9 @@ class PageViewSet(PageListingViewSet):
     def set_page_position_view(self):
         return self.construct_view(self.set_page_position_view_class)
 
-    set_privacy_view = staticmethod(set_privacy)
+    @cached_property
+    def set_privacy_view(self):
+        return self.construct_view(self.set_privacy_view_class)
 
     @cached_property
     def unlock_view(self):

--- a/wagtail/admin/viewsets/pages.py
+++ b/wagtail/admin/viewsets/pages.py
@@ -27,7 +27,7 @@ from wagtail.admin.views.pages.listing import (
 )
 from wagtail.admin.views.pages.lock import LockView, UnlockView
 from wagtail.admin.views.pages.move import MoveChooseDestinationView, MoveConfirmView
-from wagtail.admin.views.pages.ordering import set_page_position
+from wagtail.admin.views.pages.ordering import SetPagePositionView
 from wagtail.admin.views.pages.preview import (
     PreviewOnCreateView,
     PreviewOnEditView,
@@ -282,6 +282,11 @@ class PageViewSet(PageListingViewSet):
 
     This is only used by the base ``Page`` model's viewset.
     """
+    set_page_position_view_class = SetPagePositionView
+    """
+    The view class to use for the set page position view; must be a subclass of
+    ``wagtail.admin.views.pages.ordering.SetPagePositionView``.
+    """
     unlock_view_class = UnlockView
     """
     The view class to use for unlocking a page; must be a subclass of
@@ -467,7 +472,9 @@ class PageViewSet(PageListingViewSet):
     def search_results_view(self):
         return self.construct_view(self.search_view_class, results_only=True)
 
-    set_page_position_view = staticmethod(set_page_position)
+    @cached_property
+    def set_page_position_view(self):
+        return self.construct_view(self.set_page_position_view_class)
 
     set_privacy_view = staticmethod(set_privacy)
 


### PR DESCRIPTION
Useful for views of a specific instance, e.g. edit views.<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Built on #14203. This work gets us closer towards #8365, but I did not refactor the view's templates to use the generic ones (with breadcrumbs etc.), as that still needs some decisions around UI. This should help us achieve that eventually, though.

### Description

<!-- Please describe the problem you're fixing. -->

Wasn't sure if it's worth refactoring all these views, but I think it's nice for completeness' sake. I also uncovered a minor bug in the set privacy dialog view, which can be seen in detail in one of the commits.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Copilot for autocompletion.
After refactoring the set privacy view, I used Claude Opus 4.7 agent via Zed to confirm there were no regressions. It then found that the refactored view fixed the aforementioned issue, which I verified to be the case.