### PR TITLE
Set required_on_save for overriding field_type documentation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,7 @@ Changelog
 8.0 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~
 
-* ...
+* Set `FieldPanel(required_on_save=True)` for `AbstractFormField`'s `field_type` field (Alex Tomkins)
 
 
 7.4 LTS (05.05.2026)

--- a/docs/reference/contrib/forms/customization.md
+++ b/docs/reference/contrib/forms/customization.md
@@ -704,6 +704,7 @@ First, make the new field type available in the page editor by changing your `Fo
 -   Create a new set of choices which includes the original `FORM_FIELD_CHOICES` along with new field types you want to make available.
 -   Each choice must contain a unique key and a human-readable name of the field, for example `('slug', 'URL Slug')`
 -   Override the `field_type` field in your `FormField` model with `choices` attribute using these choices.
+    - If you also override the model's `panels` with your own (instead of extending `AbstractFormField.panels`), make sure to also set [`required_on_save = True`](wagtail.admin.panels.FieldPanel.required_on_save) on the panel for `field_type`.
 -   You will need to run `./manage.py makemigrations` and `./manage.py migrate` after this step.
 
 Then, create and use a new form builder class.

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -14,7 +14,7 @@ depth: 1
 
 ### Other features
 
- * ...
+ * Set `FieldPanel(required_on_save=True)` for `AbstractFormField`'s `field_type` field (Alex Tomkins)
 
 ### Bug fixes
 

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -94,6 +94,8 @@ class AbstractFormField(Orderable):
         verbose_name=_("field type"), max_length=16, choices=FORM_FIELD_CHOICES
     )
     # field_type must be populated for previews to build the form field.
+    # Set required_on_save=True on the model field in case the FieldPanel has
+    # been overridden.
     field_type.required_on_save = True
     required = models.BooleanField(verbose_name=_("required"), default=True)
     choices = models.TextField(
@@ -118,7 +120,10 @@ class AbstractFormField(Orderable):
         FieldPanel("label"),
         FieldPanel("help_text"),
         FieldPanel("required"),
-        FieldPanel("field_type", classname="formbuilder-type"),
+        # field_type must be populated for previews to build the form field.
+        # Set required_on_save=True on the field panel in case the model field
+        # has been overridden.
+        FieldPanel("field_type", classname="formbuilder-type", required_on_save=True),
         FieldPanel("choices", classname="formbuilder-choices"),
         FieldPanel("default_value", classname="formbuilder-default"),
     ]


### PR DESCRIPTION
Fixes #14219

### Description

Minor documentation issue. When I saw this on one of our sites as a Sentry bug - I was slightly baffled as I knew it had been fixed in Wagtail. However - if you override the form builder with custom fields, then `field_type.required_on_save` needs to be set on the overridden `FormField`.

To test: follow instructions in #14219, and just uncomment the commented `field_type` line.

### AI usage

None.
