### PR TITLE
Expose StreamBlock and ListBlock children's block id in template context

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Make audit log messages for scheduling/unscheduling generic (Sage Abdullah)
  * Stop converting AVIF and WebP images to PNG by default (Thibaud Colas)
  * Add rich text serializing to HTML support in the v2 API (Thibaud Colas)
+ * Expose the block `id` as a template context variable when rendering children of `StreamBlock` and `ListBlock` (Sage Abdullah)
  * Fix: Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
  * Fix: Prevent an error when approving a workflow that has been cancelled in a different session (Kailesh)
  * Fix: Accommodate multilingual sites in skipping the "choose parent" step when creating a new page from a flat page listing (Amrinder Singh)

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -40,6 +40,7 @@ For more details, refer to the [](permissions_reference) reference documentation
  * Make audit log messages for scheduling/unscheduling generic (Sage Abdullah)
  * Stop converting AVIF and WebP images to PNG by default (Thibaud Colas)
  * Add rich text [serializing to HTML](api_v2_rich_text) support in the v2 API (Thibaud Colas)
+ * Expose the block `id` [as a template context variable](streamfield_block_id_context_variable) when rendering children of `StreamBlock` and `ListBlock` (Sage Abdullah)
 
 ### Bug fixes
 

--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -449,6 +449,7 @@ Within the template, the block value is accessible as the variable `value`:
 </div>
 ```
 
+
 Since `first_name`, `surname`, `photo`, and `biography` are defined as blocks in their own right, this could also be written as:
 
 ```html+django
@@ -523,7 +524,33 @@ Like Django's `{% include %}` tag, `{% include_block %}` also allows passing add
 
 The syntax `{% include_block my_block with foo="bar" only %}` is also supported, to specify that no variables from the parent template other than `foo` will be passed to the child template.
 
+
+(streamfield_block_id_context_variable)=
+
+### Stable block identifiers
+
+As well as `value`, a block rendered as a child of a {class}`~wagtail.blocks.StreamBlock` or {class}`~wagtail.blocks.ListBlock` has its block `id` available as the template variable `id`. This is a stable identifier (stored as part of the stream or list data) that is unique within its parent, and can be used to generate unique `id` HTML attributes when the same block type appears more than once on a page. For example, for Q&A entries:
+
+```html+django
+<div class="faq" id="{{ id }}">
+    <h3>{{ value.question }}</h3>
+    {{ value.answer }}
+</div>
+```
+
+The `id` variable is only populated when the block is rendered as a stream or list child. An `id` that is already present in the render context (for example, passed explicitly through `{% include_block block with id="..." %}`) takes precedence over the block's own id.
+
+When rendering a {class}`~wagtail.blocks.ListBlock` through its default `<ul><li>` markup (for example, `{% include_block my_list_block %}`), the `id` is not passed to the child templates. To access the id of each list item, iterate over the block's `bound_blocks` and render each child through `{% include_block %}`:
+
+```html+django
+{% for child_block in my_list_block.value.bound_blocks %}
+    {% include_block child_block %}
+{% endfor %}
+```
+
 (streamfield_get_context)=
+
+### StreamField `get_context`
 
 As well as passing variables from the parent template, block subclasses can pass additional template variables of their own by overriding the `get_context` method:
 
@@ -546,6 +573,8 @@ class EventBlock(blocks.StructBlock):
 In this example, the variable `is_happening_today` will be made available within the block template. The `parent_context` keyword argument is available when the block is rendered through an `{% include_block %}` tag, and is a dict of variables passed from the calling template.
 
 (streamfield_get_template)=
+
+### StreamField `get_template`
 
 Similarly, a `get_template` method can be defined to dynamically select a template based on the block value:
 

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -643,7 +643,7 @@ class BoundBlock:
         an unrelated method that just happened to have that name - for example, when called on a
         PageChooserBlock it could end up calling page.render.
         """
-        return self.block.render(self.value, context=context)
+        return self.render(context)
 
     def id_for_label(self):
         return self.block.id_for_label(self.prefix)

--- a/wagtail/blocks/list_block.py
+++ b/wagtail/blocks/list_block.py
@@ -103,6 +103,12 @@ class ListValue(MutableSequence):
                 "id": self.id,
             }
 
+        def render(self, context=None):
+            context = context or {}
+            if "id" not in context:
+                context["id"] = self.id
+            return super().render(context)
+
     def __init__(self, list_block, values=None, bound_blocks=None):
         self.list_block = list_block
 

--- a/wagtail/blocks/list_block.py
+++ b/wagtail/blocks/list_block.py
@@ -104,7 +104,7 @@ class ListValue(MutableSequence):
             }
 
         def render(self, context=None):
-            context = context or {}
+            context = dict(context or {})
             if "id" not in context:
                 context["id"] = self.id
             return super().render(context)

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -553,6 +553,12 @@ class StreamValue(MutableSequence):
             else:
                 return (self.block.name, self.value)
 
+        def render(self, context=None):
+            context = context or {}
+            if "id" not in context:
+                context["id"] = self.id
+            return super().render(context)
+
     class RawDataView(MutableSequence):
         """
         Internal helper class to present the stream data in raw JSONish format. For backwards

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -554,7 +554,7 @@ class StreamValue(MutableSequence):
                 return (self.block.name, self.value)
 
         def render(self, context=None):
-            context = context or {}
+            context = dict(context or {})
             if "id" not in context:
                 context["id"] = self.id
             return super().render(context)

--- a/wagtail/test/testapp/templates/tests/blocks/heading_block.html
+++ b/wagtail/test/testapp/templates/tests/blocks/heading_block.html
@@ -1,1 +1,1 @@
-<h1{% if language %} lang="{{ language }}"{% endif %}{% if classname %} class="{{ classname }}"{% endif %}>{{ value }}</h1>
+<h1{% if id %} id="{{ id }}"{% endif %}{% if language %} lang="{{ language }}"{% endif %}{% if classname %} class="{{ classname }}"{% endif %}>{{ value }}</h1>

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -3535,6 +3535,43 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
         self.assertIn('<h1 lang="fr">Bonjour le monde!</h1>', html)
         self.assertIn('<h1 lang="fr">Au revoir le monde!</h1>', html)
 
+    def test_list_child_render_exposes_id_in_context(self):
+        """
+        Rendering a ListChild should make its block id available to the child
+        block's template via the `id` context variable.
+        """
+        block = blocks.ListBlock(
+            blocks.CharBlock(template="tests/blocks/heading_block.html")
+        )
+        value = block.to_python(
+            [
+                {"type": "item", "value": "Hello world!", "id": "abc123"},
+                {"type": "item", "value": "Goodbye world!", "id": "def456"},
+            ]
+        )
+
+        html = value.bound_blocks[0].render()
+        self.assertEqual('<h1 id="abc123">Hello world!</h1>', html)
+
+        # the same functionality should be available through the alias `render_as_block`
+        html = value.bound_blocks[1].render_as_block()
+        self.assertEqual('<h1 id="def456">Goodbye world!</h1>', html)
+
+    def test_list_child_render_does_not_overwrite_existing_id_in_context(self):
+        """
+        An explicit `id` already present in the render context should take
+        precedence over the ListChild's own id.
+        """
+        block = blocks.ListBlock(
+            blocks.CharBlock(template="tests/blocks/heading_block.html")
+        )
+        value = block.to_python(
+            [{"type": "item", "value": "Hello world!", "id": "abc123"}]
+        )
+
+        html = value.bound_blocks[0].render(context={"id": "from-context"})
+        self.assertEqual('<h1 id="from-context">Hello world!</h1>', html)
+
     def test_get_api_representation_calls_same_method_on_children_with_context(self):
         """
         The get_api_representation method of a ListBlock should invoke
@@ -4496,6 +4533,51 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         # the same functionality should be available through the alias `render_as_block`
         html = value[0].render_as_block(context={"language": "fr"})
         self.assertEqual('<h1 lang="fr">Bonjour</h1>', html)
+
+    def test_stream_child_render_exposes_id_in_context(self):
+        """
+        Rendering a StreamChild should make its block id available to the child
+        block's template via the `id` context variable.
+        """
+        block = blocks.StreamBlock(
+            [
+                (
+                    "heading",
+                    blocks.CharBlock(template="tests/blocks/heading_block.html"),
+                ),
+                ("paragraph", blocks.CharBlock()),
+            ]
+        )
+        value = block.to_python([{"type": "heading", "value": "Hello", "id": "abc123"}])
+
+        html = value[0].render()
+        self.assertEqual('<h1 id="abc123">Hello</h1>', html)
+
+        # the same functionality should be available through the alias `render_as_block`
+        html = value[0].render_as_block()
+        self.assertEqual('<h1 id="abc123">Hello</h1>', html)
+
+        # rendering the whole stream should also expose each child's id
+        html = block.render(value)
+        self.assertIn('<h1 id="abc123">Hello</h1>', html)
+
+    def test_stream_child_render_does_not_overwrite_existing_id_in_context(self):
+        """
+        An explicit `id` already present in the render context should take
+        precedence over the StreamChild's own id.
+        """
+        block = blocks.StreamBlock(
+            [
+                (
+                    "heading",
+                    blocks.CharBlock(template="tests/blocks/heading_block.html"),
+                ),
+            ]
+        )
+        value = block.to_python([{"type": "heading", "value": "Hello", "id": "abc123"}])
+
+        html = value[0].render(context={"id": "from-context"})
+        self.assertEqual('<h1 id="from-context">Hello</h1>', html)
 
     def test_adapt(self):
         class ArticleBlock(blocks.StreamBlock):

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -3534,6 +3534,43 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
         self.assertIn('<h1 lang="fr">Bonjour le monde!</h1>', html)
         self.assertIn('<h1 lang="fr">Au revoir le monde!</h1>', html)
 
+    def test_list_child_render_exposes_id_in_context(self):
+        """
+        Rendering a ListChild should make its block id available to the child
+        block's template via the `id` context variable.
+        """
+        block = blocks.ListBlock(
+            blocks.CharBlock(template="tests/blocks/heading_block.html")
+        )
+        value = block.to_python(
+            [
+                {"type": "item", "value": "Hello world!", "id": "abc123"},
+                {"type": "item", "value": "Goodbye world!", "id": "def456"},
+            ]
+        )
+
+        html = value.bound_blocks[0].render()
+        self.assertEqual('<h1 id="abc123">Hello world!</h1>', html)
+
+        # the same functionality should be available through the alias `render_as_block`
+        html = value.bound_blocks[1].render_as_block()
+        self.assertEqual('<h1 id="def456">Goodbye world!</h1>', html)
+
+    def test_list_child_render_does_not_overwrite_existing_id_in_context(self):
+        """
+        An explicit `id` already present in the render context should take
+        precedence over the ListChild's own id.
+        """
+        block = blocks.ListBlock(
+            blocks.CharBlock(template="tests/blocks/heading_block.html")
+        )
+        value = block.to_python(
+            [{"type": "item", "value": "Hello world!", "id": "abc123"}]
+        )
+
+        html = value.bound_blocks[0].render(context={"id": "from-context"})
+        self.assertEqual('<h1 id="from-context">Hello world!</h1>', html)
+
     def test_get_api_representation_calls_same_method_on_children_with_context(self):
         """
         The get_api_representation method of a ListBlock should invoke
@@ -4495,6 +4532,51 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         # the same functionality should be available through the alias `render_as_block`
         html = value[0].render_as_block(context={"language": "fr"})
         self.assertEqual('<h1 lang="fr">Bonjour</h1>', html)
+
+    def test_stream_child_render_exposes_id_in_context(self):
+        """
+        Rendering a StreamChild should make its block id available to the child
+        block's template via the `id` context variable.
+        """
+        block = blocks.StreamBlock(
+            [
+                (
+                    "heading",
+                    blocks.CharBlock(template="tests/blocks/heading_block.html"),
+                ),
+                ("paragraph", blocks.CharBlock()),
+            ]
+        )
+        value = block.to_python([{"type": "heading", "value": "Hello", "id": "abc123"}])
+
+        html = value[0].render()
+        self.assertEqual('<h1 id="abc123">Hello</h1>', html)
+
+        # the same functionality should be available through the alias `render_as_block`
+        html = value[0].render_as_block()
+        self.assertEqual('<h1 id="abc123">Hello</h1>', html)
+
+        # rendering the whole stream should also expose each child's id
+        html = block.render(value)
+        self.assertIn('<h1 id="abc123">Hello</h1>', html)
+
+    def test_stream_child_render_does_not_overwrite_existing_id_in_context(self):
+        """
+        An explicit `id` already present in the render context should take
+        precedence over the StreamChild's own id.
+        """
+        block = blocks.StreamBlock(
+            [
+                (
+                    "heading",
+                    blocks.CharBlock(template="tests/blocks/heading_block.html"),
+                ),
+            ]
+        )
+        value = block.to_python([{"type": "heading", "value": "Hello", "id": "abc123"}])
+
+        html = value[0].render(context={"id": "from-context"})
+        self.assertEqual('<h1 id="from-context">Hello</h1>', html)
 
     def test_adapt(self):
         class ArticleBlock(blocks.StreamBlock):

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -3571,6 +3571,32 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
         html = value.bound_blocks[0].render(context={"id": "from-context"})
         self.assertEqual('<h1 id="from-context">Hello world!</h1>', html)
 
+    def test_list_child_render_does_not_leak_id_across_siblings(self):
+        """
+        Rendering sibling ListChild blocks through the same context dict must
+        not leak one child's `id` onto the others. Regression test for the
+        context mutation bug where the first child's `id` was written into the
+        shared context and reused by every subsequent child.
+        """
+        block = blocks.ListBlock(
+            blocks.CharBlock(template="tests/blocks/heading_block.html")
+        )
+        value = block.to_python(
+            [
+                {"type": "item", "value": "First", "id": "aaa111"},
+                {"type": "item", "value": "Second", "id": "bbb222"},
+                {"type": "item", "value": "Third", "id": "ccc333"},
+            ]
+        )
+
+        context = {"language": "fr"}
+        html = "".join(child.render(context=context) for child in value.bound_blocks)
+        self.assertIn('<h1 id="aaa111" lang="fr">First</h1>', html)
+        self.assertIn('<h1 id="bbb222" lang="fr">Second</h1>', html)
+        self.assertIn('<h1 id="ccc333" lang="fr">Third</h1>', html)
+        # the caller's context dict must not be mutated with a stray `id`
+        self.assertNotIn("id", context)
+
     def test_get_api_representation_calls_same_method_on_children_with_context(self):
         """
         The get_api_representation method of a ListBlock should invoke
@@ -4577,6 +4603,38 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
 
         html = value[0].render(context={"id": "from-context"})
         self.assertEqual('<h1 id="from-context">Hello</h1>', html)
+
+    def test_stream_child_render_does_not_leak_id_across_siblings(self):
+        """
+        Rendering sibling StreamChild blocks through the same context dict must
+        not leak one child's `id` onto the others. Regression test for the
+        context mutation bug where the first child's `id` was written into the
+        shared context and reused by every subsequent child.
+        """
+        block = blocks.StreamBlock(
+            [
+                (
+                    "heading",
+                    blocks.CharBlock(template="tests/blocks/heading_block.html"),
+                ),
+            ]
+        )
+        value = block.to_python(
+            [
+                {"type": "heading", "value": "First", "id": "aaa111"},
+                {"type": "heading", "value": "Second", "id": "bbb222"},
+                {"type": "heading", "value": "Third", "id": "ccc333"},
+            ]
+        )
+
+        # rendering the whole stream passes the same context to each child
+        context = {"language": "fr"}
+        html = block.render(value, context=context)
+        self.assertIn('<h1 id="aaa111" lang="fr">First</h1>', html)
+        self.assertIn('<h1 id="bbb222" lang="fr">Second</h1>', html)
+        self.assertIn('<h1 id="ccc333" lang="fr">Third</h1>', html)
+        # the caller's context dict must not be mutated with a stray `id`
+        self.assertNotIn("id", context)
 
     def test_adapt(self):
         class ArticleBlock(blocks.StreamBlock):


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #12181.

### Description

<!-- Please describe the problem you're fixing. -->
I've updated this per https://github.com/wagtail/wagtail/issues/12181#issuecomment-4663845724.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

Copilot for autocompletion. Claude Opus 4.7 via Claude Code in VSCode was used to help write the tests.