### PR TITLE
Handle Pillow detecting decompression bombs when validating pixel count

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
 * Fix: Prevent an error when approving a workflow that has been cancelled in a different session (Kailesh)
 * Fix: Accommodate multilingual sites in skipping the "choose parent" step when creating a new page from a flat page listing (Amrinder Singh)
 * Fix: Prevent error when moving a page to a destination with missing translations and `WAGTAILSIMPLETRANSLATION_SYNC_PAGE_TREE = True` (Sahil Kumar)
+* Fix: Handle Pillow detecting decompression bombs when validating image pixel count (Jake Howard, Sage Abdullah)
 * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
 * Maintenance: Rename `request` argument to `cache_object` in `Page._get_site_root_paths()` for correctness (Kailesh)
 

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -24,6 +24,7 @@ depth: 1
  * Prevent an error when approving a workflow that has been cancelled in a different session (Kailesh)
  * Accommodate multilingual sites in skipping the "choose parent" step when creating a new page from a flat page listing (Amrinder Singh)
  * Prevent error when moving a page to a destination with missing translations and `WAGTAILSIMPLETRANSLATION_SYNC_PAGE_TREE = True` (Sahil Kumar)
+ * Handle Pillow detecting decompression bombs when validating image pixel count (Jake Howard, Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/images/fields.py
+++ b/wagtail/images/fields.py
@@ -9,6 +9,7 @@ from django.forms.fields import FileField, ImageField
 from django.forms.widgets import FileInput
 from django.template.defaultfilters import filesizeformat
 from django.utils.translation import gettext_lazy as _
+from PIL import Image as PILImage
 
 from wagtail.images.utils import get_accept_attributes, get_allowed_image_extensions
 
@@ -117,12 +118,34 @@ class WagtailImageField(ImageField):
             )
 
     def check_image_pixel_size(self, f):
-        # Upload pixel size checking can be disabled by setting max upload pixel to None
+        try:
+            # Check the pixel size
+            width, height = f.image.get_size()
+        except (
+            PILImage.DecompressionBombWarning,
+            PILImage.DecompressionBombError,
+        ) as e:
+            # Pillow issues a warning for MAX_IMAGE_PIXELS, and raises an error
+            # for twice that value. Warnings can be turned into errors with a
+            # filter, so check the exception for accuracy.
+            pil_max = PILImage.MAX_IMAGE_PIXELS
+            if isinstance(e, PILImage.DecompressionBombError):
+                pil_max *= 2
+            max_pixels_count = min(self.max_image_pixels or pil_max, pil_max)
+            raise ValidationError(
+                self.error_messages["file_too_many_pixels"]
+                % {
+                    "num_pixels": _("unknown number"),
+                    "max_pixels_count": max_pixels_count,
+                },
+                code="file_too_many_pixels",
+            ) from None
+
+        # Upload pixel size checking can be disabled by setting max upload pixel to None.
+        # The image is still opened to see if the image library raises errors.
         if self.max_image_pixels is None:
             return
 
-        # Check the pixel size
-        width, height = f.image.get_size()
         frames = f.image.get_frame_count()
         num_pixels = width * height * frames
 

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import urllib
+import warnings
 from unittest.mock import patch
 
 from django.conf import settings
@@ -23,6 +24,7 @@ from django.utils.html import escape, escapejs
 from django.utils.http import RFC3986_SUBDELIMS, urlencode
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
+from PIL import Image as PILImage
 from willow.optimizers.base import OptimizerBase
 from willow.registry import registry
 
@@ -1206,6 +1208,48 @@ class TestImageAddView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
             "file",
             "This file has too many pixels (307200). Maximum pixels 1.",
         )
+
+    def test_add_pillow_too_many_pixels(self):
+        cases = [
+            # WAGTAILIMAGES_MAX_IMAGE_PIXELS, PILImage.MAX_IMAGE_PIXELS,
+            # image size, warnings filter action, expected error threshold
+            (None, 20, (5, 10), "default", 40),  # Two times the Pillow soft limit
+            (None, 20, (2, 11), "error", 20),  # Pillow soft limit becomes hard limit
+            (10, 4, (3, 3), "default", 8),  # Pillow hard limit < pixels < Wagtail limit
+        ]
+        for wagtail_limit, pillow_limit, image_size, warning_action, expected in cases:
+            with (
+                self.subTest(
+                    wagtail_limit=wagtail_limit,
+                    pillow_limit=pillow_limit,
+                    image_size=image_size,
+                    warning_action=warning_action,
+                ),
+                override_settings(WAGTAILIMAGES_MAX_IMAGE_PIXELS=wagtail_limit),
+                patch.object(PILImage, "MAX_IMAGE_PIXELS", pillow_limit),
+                warnings.catch_warnings(),
+            ):
+                warnings.simplefilter(warning_action, PILImage.DecompressionBombWarning)
+
+                file_content = get_test_image_file(size=image_size).file.getvalue()
+                response = self.post(
+                    {
+                        "title": "Test image",
+                        "file": SimpleUploadedFile("test.png", file_content),
+                    }
+                )
+
+                # Shouldn't redirect anywhere
+                self.assertEqual(response.status_code, 200)
+                self.assertTemplateUsed(response, "wagtailimages/images/add.html")
+
+                # The form should have an error
+                self.assertFormError(
+                    response.context["form"],
+                    "file",
+                    "This file has too many pixels (unknown number). "
+                    f"Maximum pixels {expected}.",
+                )
 
     def test_add_with_collections(self):
         root_collection = Collection.get_first_root_node()


### PR DESCRIPTION
### Description

When fetching the size of an image, if Pillow thinks this is a decompression bomb it will raise an exception. This happens before the pixel sizes are returned, so Wagtail can't run its own validation.

This PR catches the exception and returns a modified error message, rather than receiving an unhandled exception.

### AI usage

None
