### PR TITLE
Introduce label_format to Panels and ListBlock

### DIFF
--- a/client/scss/components/_panel.scss
+++ b/client/scss/components/_panel.scss
@@ -61,6 +61,15 @@ $header-button-size: theme('spacing.6');
   overflow: hidden;
 }
 
+.w-panel__heading-summary {
+  @apply w-help-text;
+  margin-inline-start: theme('spacing.1');
+}
+
+[aria-expanded='true'] + .w-panel__heading .w-panel__heading-summary {
+  @apply w-sr-only;
+}
+
 .w-panel__anchor,
 .w-panel__toggle,
 .w-panel__controls .button.button--icon {

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -49,6 +49,29 @@ class ListChild extends BaseSequenceChild {
       opts,
     );
   }
+
+  getTextLabel(opts) {
+    const { labelFormat } = this.sequence.blockDef.meta;
+
+    // Allow using the empty string for the additional text in collapsed state
+    if (typeof labelFormat === 'string') {
+      /* use labelFormat - regexp replace any field references like '{first_name}'
+      with the text label of that sub-block */
+      return labelFormat.replace(/\{(\w+)\}/g, (_, blockName) => {
+        const child = this.block.childBlocks?.[blockName];
+        if (child && child.getTextLabel) {
+          /* to be strictly correct, we should be adjusting opts.maxLength to account for the overheads
+          in the format string, and dividing the remainder across all the placeholders in the string,
+          rather than just passing opts on to the child. But that would get complicated, and this is
+          better than nothing... */
+          return child.getTextLabel(opts);
+        }
+        return '';
+      });
+    }
+
+    return super.getTextLabel(opts);
+  }
 }
 
 /**

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -47,6 +47,9 @@ class DummyWidgetDefinition {
         getValue(widgetName);
         return `value: ${widgetName} - ${name}`;
       },
+      getTextLabel() {
+        return `label: ${name}`;
+      },
       focus() {
         focus(widgetName);
       },
@@ -754,5 +757,95 @@ describe('telepath: wagtail.blocks.ListBlock with StructBlock child', () => {
     expect(boundBlock.children.length).toEqual(1);
     expect(boundBlock.children[0].type).toEqual('heading_block');
     expect(document.querySelectorAll('[data-panel-toggle]').length).toBe(1);
+  });
+});
+
+describe('telepath: wagtail.blocks.ListBlock with labelFormat', () => {
+  const buildBoundBlock = (labelFormat) => {
+    const blockDef = new ListBlockDefinition(
+      'list',
+      new StructBlockDefinition(
+        'heading_block',
+        [
+          new FieldBlockDefinition(
+            'heading_text',
+            new DummyWidgetDefinition('Heading widget'),
+            {
+              label: 'Heading text',
+              required: true,
+              icon: 'placeholder',
+              classname: '',
+            },
+          ),
+          new FieldBlockDefinition(
+            'size',
+            new DummyWidgetDefinition('Size widget'),
+            {
+              label: 'Size',
+              required: false,
+              icon: 'placeholder',
+              classname: '',
+            },
+          ),
+        ],
+        {
+          label: 'Heading block',
+          required: false,
+          icon: 'title',
+          classname: 'struct-block',
+          formLayout: new BlockGroupDefinition({
+            children: [
+              ['heading_text', 'heading_text'],
+              ['size', 'size'],
+            ],
+            settings: [],
+          }),
+        },
+      ),
+      null,
+      {
+        label: 'Test listblock',
+        icon: 'placeholder',
+        classname: null,
+        labelFormat,
+      },
+    );
+
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    return blockDef.render($('#placeholder'), 'the-prefix', [
+      {
+        id: 'heading-block-1',
+        value: {
+          heading_text: 'Test heading text',
+          size: '123',
+        },
+      },
+    ]);
+  };
+
+  test('getTextLabel() returns text label according to labelFormat', () => {
+    const boundBlock = buildBoundBlock('{heading_text} - {size}');
+    expect(boundBlock.children[0].getTextLabel()).toBe(
+      'label: the-prefix-0-value-heading_text - label: the-prefix-0-value-size',
+    );
+  });
+
+  test('getTextLabel() gracefully handles bad variables in labelFormat', () => {
+    const boundBlock = buildBoundBlock('{bad_variable} - {size}');
+    expect(boundBlock.children[0].getTextLabel()).toBe(
+      ' - label: the-prefix-0-value-size',
+    );
+  });
+
+  test('getTextLabel() allows empty labelFormat', () => {
+    const boundBlock = buildBoundBlock('');
+    expect(boundBlock.children[0].getTextLabel()).toBe('');
+  });
+
+  test('getTextLabel() falls back to the child block when no labelFormat is set', () => {
+    const boundBlock = buildBoundBlock(undefined);
+    expect(boundBlock.children[0].getTextLabel()).toBe(
+      'label: the-prefix-0-value-heading_text',
+    );
   });
 });

--- a/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
@@ -30,7 +30,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-11111111-1111-1111-1111-111111111111-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-0-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-11111111-1111-1111-1111-111111111111-section" aria-labelledby="block-11111111-1111-1111-1111-111111111111-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -96,7 +96,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-22222222-2222-2222-2222-222222222222-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-1-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-22222222-2222-2222-2222-222222222222-section" aria-labelledby="block-22222222-2222-2222-2222-222222222222-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -162,7 +162,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-fake-uuid-v4-value-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-2-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-fake-uuid-v4-value-section" aria-labelledby="block-fake-uuid-v4-value-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -242,7 +242,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered downward 1`]
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-22222222-2222-2222-2222-222222222222-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-1-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-22222222-2222-2222-2222-222222222222-section" aria-labelledby="block-22222222-2222-2222-2222-222222222222-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -308,7 +308,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered downward 1`]
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-11111111-1111-1111-1111-111111111111-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-0-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-11111111-1111-1111-1111-111111111111-section" aria-labelledby="block-11111111-1111-1111-1111-111111111111-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -388,7 +388,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered upward 1`] =
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-22222222-2222-2222-2222-222222222222-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-1-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-22222222-2222-2222-2222-222222222222-section" aria-labelledby="block-22222222-2222-2222-2222-222222222222-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -454,7 +454,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered upward 1`] =
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-11111111-1111-1111-1111-111111111111-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-0-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-11111111-1111-1111-1111-111111111111-section" aria-labelledby="block-11111111-1111-1111-1111-111111111111-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -534,7 +534,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be split 1`] = `
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-11111111-1111-1111-1111-111111111111-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-0-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-11111111-1111-1111-1111-111111111111-section" aria-labelledby="block-11111111-1111-1111-1111-111111111111-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -600,7 +600,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be split 1`] = `
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-undefined-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-2-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-undefined-section" aria-labelledby="block-undefined-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -666,7 +666,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be split 1`] = `
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-22222222-2222-2222-2222-222222222222-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-1-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-22222222-2222-2222-2222-222222222222-section" aria-labelledby="block-22222222-2222-2222-2222-222222222222-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -746,7 +746,7 @@ exports[`telepath: wagtail.blocks.ListBlock deleteBlock() deletes a block 1`] = 
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-11111111-1111-1111-1111-111111111111-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-0-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-11111111-1111-1111-1111-111111111111-section" aria-labelledby="block-11111111-1111-1111-1111-111111111111-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -812,7 +812,7 @@ exports[`telepath: wagtail.blocks.ListBlock deleteBlock() deletes a block 1`] = 
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-22222222-2222-2222-2222-222222222222-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-1-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-22222222-2222-2222-2222-222222222222-section" aria-labelledby="block-22222222-2222-2222-2222-222222222222-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -892,7 +892,7 @@ exports[`telepath: wagtail.blocks.ListBlock it renders correctly 1`] = `
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-11111111-1111-1111-1111-111111111111-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-0-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-11111111-1111-1111-1111-111111111111-section" aria-labelledby="block-11111111-1111-1111-1111-111111111111-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -958,7 +958,7 @@ exports[`telepath: wagtail.blocks.ListBlock it renders correctly 1`] = `
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-22222222-2222-2222-2222-222222222222-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-1-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-22222222-2222-2222-2222-222222222222-section" aria-labelledby="block-22222222-2222-2222-2222-222222222222-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -1038,7 +1038,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError passes error messages to ch
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-11111111-1111-1111-1111-111111111111-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-0-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-11111111-1111-1111-1111-111111111111-section" aria-labelledby="block-11111111-1111-1111-1111-111111111111-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -1104,7 +1104,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError passes error messages to ch
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-22222222-2222-2222-2222-222222222222-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-1-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-22222222-2222-2222-2222-222222222222-section" aria-labelledby="block-22222222-2222-2222-2222-222222222222-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -1184,7 +1184,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError renders non-block errors 1`
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-11111111-1111-1111-1111-111111111111-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-0-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-11111111-1111-1111-1111-111111111111-section" aria-labelledby="block-11111111-1111-1111-1111-111111111111-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -1250,7 +1250,7 @@ exports[`telepath: wagtail.blocks.ListBlock setError renders non-block errors 1`
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-22222222-2222-2222-2222-222222222222-heading" data-panel-heading="">
               <span class="c-sf-block__type"></span>
               <span class="w-required-mark" data-panel-required="">*</span>
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-1-value</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-22222222-2222-2222-2222-222222222222-section" aria-labelledby="block-22222222-2222-2222-2222-222222222222-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">
@@ -1330,7 +1330,7 @@ exports[`telepath: wagtail.blocks.ListBlock with StructBlock child it renders th
             <h2 class="w-panel__heading w-panel__heading--label" aria-level="3" id="block-heading-block-1-heading" data-panel-heading="">
               <span class="c-sf-block__type">Heading block</span>
               
-              <span data-panel-heading-text="" class="c-sf-block__title"></span>
+              <span data-panel-heading-text="" class="c-sf-block__title">label: the-prefix-0-value-heading_text</span>
             </h2>
             <a class="w-panel__anchor w-panel__anchor--suffix" href="#block-heading-block-1-section" aria-labelledby="block-heading-block-1-heading">
               <svg class="icon icon-link w-panel__icon" aria-hidden="true">

--- a/client/src/controllers/PanelLabelController.test.js
+++ b/client/src/controllers/PanelLabelController.test.js
@@ -1,0 +1,172 @@
+import { Application } from '@hotwired/stimulus';
+import { PanelLabelController } from './PanelLabelController';
+
+const flushAsync = () =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+describe('PanelLabelController', () => {
+  let application;
+
+  const setEditHandler = (fieldValues) => {
+    window.wagtail = window.wagtail || {};
+    window.wagtail.editHandler = {
+      getPanelByName(name) {
+        if (!(name in fieldValues)) return null;
+        return {
+          getBoundWidget() {
+            return {
+              getTextLabel() {
+                return fieldValues[name];
+              },
+            };
+          },
+        };
+      },
+    };
+  };
+
+  const setHtml = (formatValue, headingText, fields) => {
+    document.body.innerHTML = `
+      <section data-controller="w-panel-label" data-w-panel-label-format-value="${formatValue}">
+        <h2><button data-panel-toggle></button><span data-panel-heading-text>${headingText}</span></h2>
+        ${fields}
+      </section>
+    `;
+  };
+
+  const togglePanel = () => {
+    document
+      .querySelector('[data-panel-toggle]')
+      .dispatchEvent(
+        new CustomEvent('wagtail:panel-toggle', { bubbles: true }),
+      );
+  };
+
+  const start = () => {
+    application = Application.start();
+    application.register('w-panel-label', PanelLabelController);
+  };
+
+  afterEach(() => {
+    application?.stop();
+    delete window.wagtail;
+  });
+
+  test('setCollapsedLabelText() renders the format from bound widget labels', async () => {
+    setEditHandler({ first_name: 'Ada', last_name: 'Lovelace' });
+    setHtml(
+      '{first_name} {last_name}',
+      'Name',
+      `<input name="first_name" value="Ada">
+       <input name="last_name" value="Lovelace">`,
+    );
+    start();
+    await flushAsync();
+
+    const heading = document.querySelector('h2');
+    expect(heading.children[1].textContent).toBe('Name');
+    expect(
+      document.querySelector('[data-panel-heading-text]').textContent,
+    ).toBe('Ada Lovelace');
+  });
+
+  test('setCollapsedLabelText() re-renders on wagtail:panel-toggle', async () => {
+    const fieldValues = { first_name: '', last_name: '' };
+    setEditHandler(fieldValues);
+    setHtml(
+      '{first_name} {last_name}',
+      'Name',
+      `<input name="first_name" value="">
+       <input name="last_name" value="">`,
+    );
+    start();
+    await flushAsync();
+
+    const summary = document.querySelector('[data-panel-heading-text]');
+    expect(summary.textContent).toBe(' ');
+
+    fieldValues.first_name = 'Grace';
+    fieldValues.last_name = 'Hopper';
+    document
+      .querySelector('[name="first_name"]')
+      .dispatchEvent(new Event('input', { bubbles: true }));
+    expect(summary.textContent).toBe(' ');
+
+    togglePanel();
+    expect(summary.textContent).toBe('Grace Hopper');
+  });
+
+  test('connect() does nothing without a heading-text element', async () => {
+    setEditHandler({ title: 'Hello' });
+    document.body.innerHTML = `
+      <section data-controller="w-panel-label" data-w-panel-label-format-value="{title}">
+        <input name="title" value="My post">
+      </section>
+    `;
+    start();
+    await flushAsync();
+    expect(document.querySelector('.w-panel__heading-summary')).toBeNull();
+  });
+
+  test('setCollapsedLabelText() gracefully handles a missing editHandler', async () => {
+    setHtml('{title}', 'Title', `<input name="title" value="ignored">`);
+    start();
+    await flushAsync();
+    expect(
+      document.querySelector('[data-panel-heading-text]').textContent,
+    ).toBe('');
+  });
+
+  test('setCollapsedLabelText() uses telepath-packed widgets when widgetsId is set', async () => {
+    const originalTelepath = window.telepath;
+    window.telepath = {
+      unpack: () => ({
+        first_name: {
+          getByName(name, container) {
+            return {
+              getTextLabel() {
+                return container.querySelector(`[name="${name}"]`)?.value || '';
+              },
+            };
+          },
+        },
+        last_name: {
+          getByName(name, container) {
+            return {
+              getTextLabel() {
+                const value =
+                  container.querySelector(`[name="${name}"]`)?.value || '';
+                return value ? value.toUpperCase() : '';
+              },
+            };
+          },
+        },
+      }),
+    };
+
+    const scriptId = 'id_authors-LABEL_FORMAT_WIDGETS';
+    document.body.innerHTML = `
+      <script type="application/json" id="${scriptId}">{}</script>
+      <section data-controller="w-panel-label"
+               data-w-panel-label-format-value="{first_name} {last_name}"
+               data-w-panel-label-widgets-id-value="${scriptId}"
+               data-w-panel-label-field-prefix-value="authors-0">
+        <h2><button data-panel-toggle></button><span data-panel-heading-text>Author</span></h2>
+        <input name="authors-0-first_name" value="Ada">
+        <input name="authors-0-last_name" value="Lovelace">
+      </section>
+    `;
+
+    start();
+    await flushAsync();
+    togglePanel();
+
+    expect(
+      document.querySelector('[data-panel-heading-text]').textContent,
+    ).toBe('Ada LOVELACE');
+
+    window.telepath = originalTelepath;
+  });
+});

--- a/client/src/controllers/PanelLabelController.test.js
+++ b/client/src/controllers/PanelLabelController.test.js
@@ -54,7 +54,7 @@ describe('PanelLabelController', () => {
     delete window.wagtail;
   });
 
-  test('setCollapsedLabelText() renders the format from bound widget labels', async () => {
+  test('renders the format string from bound widget labels on connect', async () => {
     setEditHandler({ first_name: 'Ada', last_name: 'Lovelace' });
     setHtml(
       '{first_name} {last_name}',
@@ -72,7 +72,7 @@ describe('PanelLabelController', () => {
     ).toBe('Ada Lovelace');
   });
 
-  test('setCollapsedLabelText() re-renders on wagtail:panel-toggle', async () => {
+  test('re-renders on the wagtail:panel-toggle event', async () => {
     const fieldValues = { first_name: '', last_name: '' };
     setEditHandler(fieldValues);
     setHtml(
@@ -89,16 +89,13 @@ describe('PanelLabelController', () => {
 
     fieldValues.first_name = 'Grace';
     fieldValues.last_name = 'Hopper';
-    document
-      .querySelector('[name="first_name"]')
-      .dispatchEvent(new Event('input', { bubbles: true }));
     expect(summary.textContent).toBe(' ');
 
     togglePanel();
     expect(summary.textContent).toBe('Grace Hopper');
   });
 
-  test('connect() does nothing without a heading-text element', async () => {
+  test('does nothing without a heading-text element', async () => {
     setEditHandler({ title: 'Hello' });
     document.body.innerHTML = `
       <section data-controller="w-panel-label" data-w-panel-label-format-value="{title}">
@@ -110,7 +107,7 @@ describe('PanelLabelController', () => {
     expect(document.querySelector('.w-panel__heading-summary')).toBeNull();
   });
 
-  test('setCollapsedLabelText() gracefully handles a missing editHandler', async () => {
+  test('gracefully handles a missing edit handler', async () => {
     setHtml('{title}', 'Title', `<input name="title" value="ignored">`);
     start();
     await flushAsync();
@@ -119,7 +116,39 @@ describe('PanelLabelController', () => {
     ).toBe('');
   });
 
-  test('setCollapsedLabelText() uses telepath-packed widgets when widgetsId is set', async () => {
+  test('lazily unpacks the page-wide edit handler from #w-edit-handler-data', async () => {
+    const originalTelepath = window.telepath;
+    window.telepath = {
+      unpack: () => ({
+        getPanelByName(name) {
+          if (name !== 'title') return null;
+          return {
+            getBoundWidget() {
+              return { getTextLabel: () => 'Unpacked title' };
+            },
+          };
+        },
+      }),
+    };
+
+    document.body.innerHTML = `
+      <script type="application/json" id="w-edit-handler-data">{}</script>
+      <section data-controller="w-panel-label" data-w-panel-label-format-value="{title}">
+        <h2><button data-panel-toggle></button><span data-panel-heading-text>Title</span></h2>
+      </section>
+    `;
+    start();
+    await flushAsync();
+
+    expect(
+      document.querySelector('[data-panel-heading-text]').textContent,
+    ).toBe('Unpacked title');
+    expect(window.wagtail.editHandler).toBeDefined();
+
+    window.telepath = originalTelepath;
+  });
+
+  test('uses telepath-packed widgets when widgetsId is set', async () => {
     const originalTelepath = window.telepath;
     window.telepath = {
       unpack: () => ({

--- a/client/src/controllers/PanelLabelController.ts
+++ b/client/src/controllers/PanelLabelController.ts
@@ -1,114 +1,160 @@
 import { Controller } from '@hotwired/stimulus';
 
-const resolveEditHandler = (): Promise<any> => {
-  const read = () => (window as any).wagtail?.editHandler ?? null;
-  if (read()) return Promise.resolve(read());
-  return new Promise((resolve) => {
-    const afterReady = () => requestAnimationFrame(() => resolve(read()));
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', afterReady, { once: true });
-    } else {
-      afterReady();
-    }
-  });
-};
+declare global {
+  interface Window {
+    wagtail: any;
+  }
+}
 
+const EDIT_HANDLER_DATA_ID = 'w-edit-handler-data';
+
+/**
+ * Renders an interpolated summary of a panel's field values into its
+ * collapsed heading, based on a format string such as
+ * `"{first_name} {last_name}"`.
+ *
+ * Bound widgets are resolved from one of two sources:
+ *  - When `widgetsIdValue` is set, the widgets are read from a telepath-packed
+ *    `<script type="application/json">` element by that id. This is used by
+ *    `InlinePanel` rows, where each row reuses the formset's empty-form widgets.
+ *  - Otherwise, they are resolved from the page-wide edit handler exposed at
+ *    `window.wagtail.editHandler`, lazily unpacked from the
+ *    `#w-edit-handler-data` script element on first access.
+ *
+ * @example
+ * ```html
+ * <section
+ *   data-controller="w-panel-label"
+ *   data-w-panel-label-format-value="{first_name} {last_name}"
+ * >
+ *   <h2>
+ *     <button data-panel-toggle></button>
+ *     <span data-panel-heading-text>Name</span>
+ *   </h2>
+ * </section>
+ * ```
+ */
 export class PanelLabelController extends Controller<HTMLElement> {
   static values = {
+    fieldPrefix: { default: '', type: String },
     format: { default: '', type: String },
     widgetsId: { default: '', type: String },
-    fieldPrefix: { default: '', type: String },
   };
 
-  declare formatValue: string;
-  declare widgetsIdValue: string;
-  declare fieldPrefixValue: string;
+  /** Prefix prepended to packed-widget field names (e.g. `authors-0`). */
+  declare readonly fieldPrefixValue: string;
+  /** Format string with `{field_name}` placeholders to interpolate. */
+  declare readonly formatValue: string;
+  /** Id of a telepath-packed widgets script element; if blank, the page-wide edit handler is used instead. */
+  declare readonly widgetsIdValue: string;
 
-  summary: HTMLElement | null = null;
-  editHandler: any = null;
-  cachedWidgets: any = undefined;
+  /** The element receiving the interpolated summary text. */
+  summary?: HTMLElement;
+  /** Cached unpacked widget map for the `widgetsIdValue` source. */
+  widgets?: Record<string, any> | null;
 
-  getWidgets() {
-    if (this.cachedWidgets !== undefined) return this.cachedWidgets;
-    const element = this.widgetsIdValue
-      ? document.getElementById(this.widgetsIdValue)
-      : null;
-    if (!element || !(window as any).telepath) {
-      this.cachedWidgets = null;
-      return null;
-    }
-    try {
-      this.cachedWidgets = (window as any).telepath.unpack(
-        JSON.parse(element.textContent || ''),
-      );
-    } catch (error) {
-      this.cachedWidgets = null;
-    }
-    return this.cachedWidgets;
-  }
-
-  getFieldLabel(name: string): string {
-    if (this.widgetsIdValue) {
-      const widget = this.getWidgets()?.[name];
-      if (widget && widget.getByName) {
-        const fullName = this.fieldPrefixValue
-          ? `${this.fieldPrefixValue}-${name}`
-          : name;
-        return (
-          widget.getByName(fullName, this.element).getTextLabel({
-            maxLength: 50,
-          }) || ''
-        );
-      }
-      return '';
-    }
-    const panel = this.editHandler?.getPanelByName?.(name);
-    const widget = panel?.getBoundWidget?.();
-    if (widget && widget.getTextLabel) {
-      return widget.getTextLabel({ maxLength: 50 }) || '';
-    }
-    return '';
-  }
-
-  setCollapsedLabelText = () => {
-    if (!this.summary) return;
-    this.summary.textContent = this.formatValue.replace(
-      /\{(\w+)\}/g,
-      (_, name) => this.getFieldLabel(name),
-    );
-  };
-
-  async connect() {
-    const headingText = this.element.querySelector<HTMLElement>(
+  /**
+   * Moves the existing heading text into a sibling span so the original
+   * element can be repurposed as a live summary, then renders the initial
+   * summary text and listens for collapse/expand events to re-render.
+   */
+  connect() {
+    const heading = this.element.querySelector<HTMLElement>(
       '[data-panel-heading-text]',
     );
-    if (!headingText) return;
+    if (!heading) return;
 
     const staticHeading = document.createElement('span');
-    while (headingText.firstChild) {
-      staticHeading.appendChild(headingText.firstChild);
-    }
-    headingText.parentNode?.insertBefore(staticHeading, headingText);
-    headingText.classList.add('w-panel__heading-summary');
-    this.summary = headingText;
+    while (heading.firstChild) staticHeading.appendChild(heading.firstChild);
+    heading.parentNode?.insertBefore(staticHeading, heading);
+    heading.classList.add('w-panel__heading-summary');
+    this.summary = heading;
 
-    const toggle = this.element.querySelector('[data-panel-toggle]');
-    toggle?.addEventListener(
-      'wagtail:panel-toggle',
-      this.setCollapsedLabelText,
-    );
+    this.element
+      .querySelector('[data-panel-toggle]')
+      ?.addEventListener('wagtail:panel-toggle', this.render);
 
-    if (!this.widgetsIdValue) {
-      this.editHandler = await resolveEditHandler();
-    }
-    this.setCollapsedLabelText();
+    this.render();
   }
 
   disconnect() {
-    const toggle = this.element.querySelector('[data-panel-toggle]');
-    toggle?.removeEventListener(
-      'wagtail:panel-toggle',
-      this.setCollapsedLabelText,
+    this.element
+      .querySelector('[data-panel-toggle]')
+      ?.removeEventListener('wagtail:panel-toggle', this.render);
+  }
+
+  /**
+   * Interpolates the format string with each referenced field's text label
+   * and writes the result into the summary element.
+   */
+  render = () => {
+    if (!this.summary) return;
+    this.summary.textContent = this.formatValue.replace(
+      /\{(\w+)\}/g,
+      (_, name) =>
+        this.getBoundWidget(name)?.getTextLabel?.({ maxLength: 50 }) || '',
     );
+  };
+
+  /**
+   * Resolves a bound widget for the given field name, from the configured
+   * source (packed widgets or the page-wide edit handler).
+   */
+  getBoundWidget(name: string) {
+    if (this.widgetsIdValue) {
+      const widget = this.getPackedWidgets()?.[name];
+      if (!widget?.getByName) return null;
+      const fullName = this.fieldPrefixValue
+        ? `${this.fieldPrefixValue}-${name}`
+        : name;
+      return widget.getByName(fullName, this.element);
+    }
+    return (
+      this.getEditHandler()?.getPanelByName?.(name)?.getBoundWidget?.() ?? null
+    );
+  }
+
+  /**
+   * Lazily unpacks the telepath-packed widgets script referenced by
+   * `widgetsIdValue`, caching the result on this controller instance.
+   */
+  getPackedWidgets() {
+    if (this.widgets !== undefined) return this.widgets;
+    const element = document.getElementById(this.widgetsIdValue);
+    if (!element || !window.telepath) {
+      this.widgets = null;
+      return null;
+    }
+    try {
+      this.widgets = window.telepath.unpack(
+        JSON.parse(element.textContent || ''),
+      );
+    } catch (error) {
+      this.widgets = null;
+    }
+    return this.widgets;
+  }
+
+  /**
+   * Returns the page-wide edit handler, unpacking it from
+   * `#w-edit-handler-data` on first access if it has not already been
+   * initialised. The result is cached on `window.wagtail.editHandler` so
+   * subsequent callers (including `wagtailadmin.js`) reuse the same instance.
+   */
+  getEditHandler() {
+    const wagtail = window.wagtail ?? (window.wagtail = {});
+    if (wagtail.editHandler) return wagtail.editHandler;
+
+    const element = document.getElementById(EDIT_HANDLER_DATA_ID);
+    if (!element || !window.telepath) return null;
+
+    try {
+      wagtail.editHandler = window.telepath.unpack(
+        JSON.parse(element.textContent || ''),
+      );
+    } catch (error) {
+      return null;
+    }
+    return wagtail.editHandler;
   }
 }

--- a/client/src/controllers/PanelLabelController.ts
+++ b/client/src/controllers/PanelLabelController.ts
@@ -1,0 +1,114 @@
+import { Controller } from '@hotwired/stimulus';
+
+const resolveEditHandler = (): Promise<any> => {
+  const read = () => (window as any).wagtail?.editHandler ?? null;
+  if (read()) return Promise.resolve(read());
+  return new Promise((resolve) => {
+    const afterReady = () => requestAnimationFrame(() => resolve(read()));
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', afterReady, { once: true });
+    } else {
+      afterReady();
+    }
+  });
+};
+
+export class PanelLabelController extends Controller<HTMLElement> {
+  static values = {
+    format: { default: '', type: String },
+    widgetsId: { default: '', type: String },
+    fieldPrefix: { default: '', type: String },
+  };
+
+  declare formatValue: string;
+  declare widgetsIdValue: string;
+  declare fieldPrefixValue: string;
+
+  summary: HTMLElement | null = null;
+  editHandler: any = null;
+  cachedWidgets: any = undefined;
+
+  getWidgets() {
+    if (this.cachedWidgets !== undefined) return this.cachedWidgets;
+    const element = this.widgetsIdValue
+      ? document.getElementById(this.widgetsIdValue)
+      : null;
+    if (!element || !(window as any).telepath) {
+      this.cachedWidgets = null;
+      return null;
+    }
+    try {
+      this.cachedWidgets = (window as any).telepath.unpack(
+        JSON.parse(element.textContent || ''),
+      );
+    } catch (error) {
+      this.cachedWidgets = null;
+    }
+    return this.cachedWidgets;
+  }
+
+  getFieldLabel(name: string): string {
+    if (this.widgetsIdValue) {
+      const widget = this.getWidgets()?.[name];
+      if (widget && widget.getByName) {
+        const fullName = this.fieldPrefixValue
+          ? `${this.fieldPrefixValue}-${name}`
+          : name;
+        return (
+          widget.getByName(fullName, this.element).getTextLabel({
+            maxLength: 50,
+          }) || ''
+        );
+      }
+      return '';
+    }
+    const panel = this.editHandler?.getPanelByName?.(name);
+    const widget = panel?.getBoundWidget?.();
+    if (widget && widget.getTextLabel) {
+      return widget.getTextLabel({ maxLength: 50 }) || '';
+    }
+    return '';
+  }
+
+  setCollapsedLabelText = () => {
+    if (!this.summary) return;
+    this.summary.textContent = this.formatValue.replace(
+      /\{(\w+)\}/g,
+      (_, name) => this.getFieldLabel(name),
+    );
+  };
+
+  async connect() {
+    const headingText = this.element.querySelector<HTMLElement>(
+      '[data-panel-heading-text]',
+    );
+    if (!headingText) return;
+
+    const staticHeading = document.createElement('span');
+    while (headingText.firstChild) {
+      staticHeading.appendChild(headingText.firstChild);
+    }
+    headingText.parentNode?.insertBefore(staticHeading, headingText);
+    headingText.classList.add('w-panel__heading-summary');
+    this.summary = headingText;
+
+    const toggle = this.element.querySelector('[data-panel-toggle]');
+    toggle?.addEventListener(
+      'wagtail:panel-toggle',
+      this.setCollapsedLabelText,
+    );
+
+    if (!this.widgetsIdValue) {
+      this.editHandler = await resolveEditHandler();
+    }
+    this.setCollapsedLabelText();
+  }
+
+  disconnect() {
+    const toggle = this.element.querySelector('[data-panel-toggle]');
+    toggle?.removeEventListener(
+      'wagtail:panel-toggle',
+      this.setCollapsedLabelText,
+    );
+  }
+}

--- a/client/src/controllers/PanelLabelController.ts
+++ b/client/src/controllers/PanelLabelController.ts
@@ -72,22 +72,22 @@ export class PanelLabelController extends Controller<HTMLElement> {
 
     this.element
       .querySelector('[data-panel-toggle]')
-      ?.addEventListener('wagtail:panel-toggle', this.render);
+      ?.addEventListener('wagtail:panel-toggle', this.updateSummary);
 
-    this.render();
+    this.updateSummary();
   }
 
   disconnect() {
     this.element
       .querySelector('[data-panel-toggle]')
-      ?.removeEventListener('wagtail:panel-toggle', this.render);
+      ?.removeEventListener('wagtail:panel-toggle', this.updateSummary);
   }
 
   /**
    * Interpolates the format string with each referenced field's text label
    * and writes the result into the summary element.
    */
-  render = () => {
+  updateSummary = () => {
     if (!this.summary) return;
     this.summary.textContent = this.formatValue.replace(
       /\{(\w+)\}/g,

--- a/client/src/controllers/index.ts
+++ b/client/src/controllers/index.ts
@@ -20,6 +20,7 @@ import { InitController } from './InitController';
 import { KeyboardController } from './KeyboardController';
 import { LocaleController } from './LocaleController';
 import { OrderableController } from './OrderableController';
+import { PanelLabelController } from './PanelLabelController';
 import { PreviewController } from './PreviewController';
 import { ProgressController } from './ProgressController';
 import { RevealController } from './RevealController';
@@ -62,6 +63,7 @@ export const coreControllerDefinitions: Definition[] = [
   { controllerConstructor: KeyboardController, identifier: 'w-kbd' },
   { controllerConstructor: LocaleController, identifier: 'w-locale' },
   { controllerConstructor: OrderableController, identifier: 'w-orderable' },
+  { controllerConstructor: PanelLabelController, identifier: 'w-panel-label' },
   { controllerConstructor: PreviewController, identifier: 'w-preview' },
   { controllerConstructor: ProgressController, identifier: 'w-progress' },
   { controllerConstructor: RevealController, identifier: 'w-breadcrumbs' },

--- a/docs/reference/panels.md
+++ b/docs/reference/panels.md
@@ -65,6 +65,10 @@ Here are some built-in panel types that you can use in your panel definitions. T
     .. attribute:: FieldPanel.attrs (optional)
 
         Allows a dictionary containing HTML attributes to be set on the rendered panel. If you assign a value of ``True`` or ``False`` to an attribute, it will be rendered as an HTML5 boolean attribute.
+
+    .. attribute:: FieldPanel.label_format (optional)
+
+        A summary shown next to the panel's heading when it is collapsed and in the minimap. Set a string with the field name in braces to interpolate its current value, for example ``label_format="{title}"``. Only takes effect when the ``FieldPanel`` is a direct child of an ``ObjectList`` (or ``TabbedInterface``).
 ```
 
 ````{note}
@@ -105,6 +109,10 @@ Instead of
 
         Allows a dictionary containing HTML attributes to be set on the rendered panel. If you assign a value of ``True`` or ``False`` to an attribute, it will be rendered as an HTML5 boolean attribute.
 
+    .. attribute:: MultiFieldPanel.label_format (optional)
+
+        A summary shown next to the panel's ``heading`` when it is collapsed and in the minimap. Set a string with field names in braces to interpolate their current values, for example ``label_format="{first_name} {last_name}"``.
+
 ```
 
 (inline_panels)=
@@ -139,6 +147,10 @@ Instead of
     .. attribute:: InlinePanel.attrs (optional)
 
         Allows a dictionary containing HTML attributes to be set on the rendered panel. If you assign a value of ``True`` or ``False`` to an attribute, it will be rendered as an HTML5 boolean attribute.
+
+    .. attribute:: InlinePanel.label_format (optional)
+
+        A summary shown next to each child panel's ``label`` when it is collapsed and in the minimap. Set a string with field names in braces to interpolate the current value of fields on the inline form, for example ``label_format="{first_name} {last_name}"``.
 
 ```
 

--- a/docs/reference/streamfield/blocks.md
+++ b/docs/reference/streamfield/blocks.md
@@ -568,6 +568,8 @@ All block definitions have the following methods and properties that can be over
     :param max_num: Maximum number of sub-blocks that the list may have.
     :param search_index: If false (default true), the content of this block will not be indexed for searching.
     :param collapsed: When true, all sub-blocks are initially collapsed.
+    :param label_format:
+     Determines the summary label shown for each item when collapsed in the editing interface, when the sub-block is a ``StructBlock``. By default, each item shows the default label for its sub-block; set a format string here using ``{field_name}`` placeholders for the sub-block's fields, for example ``label_format = "{ingredient} ({amount})"``. To hide the summary label entirely, set this to the empty string ``""``.
 
 
 .. autoclass:: wagtail.blocks.StreamBlock

--- a/wagtail/admin/panels/base.py
+++ b/wagtail/admin/panels/base.py
@@ -67,6 +67,7 @@ class Panel:
     :param base_form_class: The base form class to use for the panel. Defaults to the model's ``base_form_class``, before falling back to :class:`~wagtail.admin.forms.WagtailAdminModelForm`. This is only relevant for the top-level panel.
     :param icon: The name of the icon to display next to the panel heading.
     :param attrs: A dictionary of HTML attributes to add to the panel's HTML element.
+    :param label_format: A summary shown next to the panel's ``heading`` when it is collapsed and in the minimap. Set a string here with field names contained in braces - for example ``label_format = "{first_name} {last_name}"`` - to interpolate the current value of those fields. Only takes effect for panels that render their own collapsible heading.
     """
 
     BASE_ATTRS = {}
@@ -79,12 +80,14 @@ class Panel:
         base_form_class=None,
         icon="",
         attrs=None,
+        label_format=None,
     ):
         self.heading = heading
         self.classname = classname
         self.help_text = help_text
         self.base_form_class = base_form_class
         self.icon = icon
+        self.label_format = label_format
         self.model = None
         self.attrs = self.BASE_ATTRS.copy()
 
@@ -109,6 +112,7 @@ class Panel:
             "classname": self.classname,
             "help_text": self.help_text,
             "base_form_class": self.base_form_class,
+            "label_format": self.label_format,
         }
 
     def get_form_options(self):
@@ -258,7 +262,16 @@ class Panel:
 
         @property
         def attrs(self):
-            return self.panel.attrs
+            if not self.panel.label_format:
+                return self.panel.attrs
+
+            attrs = dict(self.panel.attrs)
+            controllers = attrs.get("data-controller", "").split()
+            if "w-panel-label" not in controllers:
+                controllers.append("w-panel-label")
+            attrs["data-controller"] = " ".join(controllers)
+            attrs["data-w-panel-label-format-value"] = self.panel.label_format
+            return attrs
 
         @property
         def icon(self):

--- a/wagtail/admin/panels/inline_panel.py
+++ b/wagtail/admin/panels/inline_panel.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import re
 
 from django import forms
 from django.forms.formsets import DELETION_FIELD_NAME, ORDERING_FIELD_NAME
@@ -7,6 +8,7 @@ from django.utils.functional import cached_property
 from django.utils.text import capfirst
 
 from wagtail.admin import compare
+from wagtail.admin.telepath import JSContext
 from wagtail.admin.telepath import register as register_telepath_adapter
 
 from .base import Panel, get_form_for_model
@@ -133,14 +135,14 @@ class InlinePanel(Panel):
                         attrs={"value": index + 1}
                     )
 
-                self.children.append(
-                    self.child_edit_handler.get_bound_panel(
-                        instance=subform.instance,
-                        request=self.request,
-                        form=subform,
-                        prefix=("%s-%d" % (self.prefix, index)),
-                    )
+                child = self.child_edit_handler.get_bound_panel(
+                    instance=subform.instance,
+                    request=self.request,
+                    form=subform,
+                    prefix=("%s-%d" % (self.prefix, index)),
                 )
+                child.label_format_attrs = self.get_row_label_format_attrs(subform)
+                self.children.append(child)
 
             # if this formset is valid, it may have been re-ordered; respect that
             # in case the parent form errored and we need to re-render
@@ -160,6 +162,21 @@ class InlinePanel(Panel):
                 form=empty_form,
                 prefix=("%s-__prefix__" % self.prefix),
             )
+            self.empty_child.label_format_attrs = self.get_row_label_format_attrs(
+                empty_form
+            )
+
+        def get_row_label_format_attrs(self, subform):
+            if not self.panel.label_format:
+                return {}
+            return {
+                "data-controller": "w-panel-label",
+                "data-w-panel-label-format-value": str(self.panel.label_format),
+                "data-w-panel-label-widgets-id-value": (
+                    f"id_{self.formset.prefix}-LABEL_FORMAT_WIDGETS"
+                ),
+                "data-w-panel-label-field-prefix-value": subform.prefix,
+            }
 
         def get_comparison(self):
             field_comparisons = []
@@ -185,6 +202,22 @@ class InlinePanel(Panel):
 
         telepath_adapter_name = "wagtail.panels.InlinePanel"
 
+        @property
+        def attrs(self):
+            return self.panel.attrs
+
+        @cached_property
+        def label_format_widgets(self):
+            if not self.panel.label_format:
+                return {}
+            referenced = re.findall(r"\{(\w+)\}", str(self.panel.label_format))
+            empty_form = self.empty_child.form
+            return {
+                name: empty_form.fields[name].widget
+                for name in referenced
+                if name in empty_form.fields
+            }
+
         def js_opts(self):
             return {
                 "type": type(self.panel).__name__,
@@ -199,6 +232,13 @@ class InlinePanel(Panel):
             context = super().get_context_data(parent_context)
             context["options_json"] = json.dumps(self.js_opts())
             context["can_order"] = self.formset.can_order
+            if self.label_format_widgets:
+                context["label_format_widgets_data"] = JSContext().pack(
+                    self.label_format_widgets
+                )
+                context["label_format_widgets_id"] = (
+                    f"id_{self.formset.prefix}-LABEL_FORMAT_WIDGETS"
+                )
             return context
 
         def telepath_pack(self, context):

--- a/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
@@ -40,6 +40,10 @@
     {% endblock %}
 </div>
 
+{% if label_format_widgets_data %}
+    {{ label_format_widgets_data|json_script:label_format_widgets_id }}
+{% endif %}
+
 {% block js_init %}
     <script>
         (function() {

--- a/wagtail/admin/templates/wagtailadmin/panels/inline_panel_child.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/inline_panel_child.html
@@ -14,7 +14,7 @@
     {% fragment as heading %}
         {{ self.label|capfirst }}<span data-inline-panel-child-count></span>
     {% endfragment %}
-    {% panel id=panel_id heading=heading heading_size="label" heading_level="3" header_controls=header_controls %}
+    {% panel id=panel_id heading=heading heading_size="label" heading_level="3" header_controls=header_controls attrs=child.label_format_attrs %}
         {% if child.form.non_field_errors %}
             <ul>
                 {% for error in child.form.non_field_errors %}

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -13,6 +13,7 @@ from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils.html import escape, json_script
+from django.utils.translation import gettext_lazy
 from freezegun import freeze_time
 
 from wagtail.admin.forms import WagtailAdminModelForm, WagtailAdminPageForm
@@ -1047,6 +1048,44 @@ class TestFieldPanel(TestCase):
         self.assertIn("request=<WSGIRequest: GET '/'>", field_panel_repr)
         self.assertIn("form=EventPageForm", field_panel_repr)
 
+    def test_label_format(self):
+        panel = FieldPanel("title", label_format="{title}").bind_to_model(EventPage)
+        bound_panel = self._get_bound_panel(panel)
+        attrs = bound_panel.attrs
+        self.assertIn("w-panel-label", attrs["data-controller"].split())
+        self.assertEqual(attrs["data-w-panel-label-format-value"], "{title}")
+
+    def test_label_format_default(self):
+        bound_panel = self._get_bound_panel(self.end_date_panel)
+        attrs = bound_panel.attrs
+        self.assertNotIn("data-w-panel-label-format-value", attrs)
+        self.assertNotIn("w-panel-label", attrs.get("data-controller", "").split())
+
+    def test_label_format_preserves_existing_data_controller(self):
+        panel = FieldPanel(
+            "title",
+            label_format="{title}",
+            attrs={"data-controller": "w-other"},
+        ).bind_to_model(EventPage)
+        bound_panel = self._get_bound_panel(panel)
+        controllers = bound_panel.attrs["data-controller"].split()
+        self.assertIn("w-other", controllers)
+        self.assertIn("w-panel-label", controllers)
+
+    def test_label_format_clone(self):
+        panel = FieldPanel("title", label_format="{title}")
+        self.assertEqual(panel.clone().label_format, "{title}")
+
+    def test_label_format_supports_lazy_translation(self):
+        panel = FieldPanel(
+            "title", label_format=gettext_lazy("Title: {title}")
+        ).bind_to_model(EventPage)
+        bound_panel = self._get_bound_panel(panel)
+        self.assertEqual(
+            str(bound_panel.attrs["data-w-panel-label-format-value"]),
+            "Title: {title}",
+        )
+
 
 class TestFieldRowPanel(TestCase):
     def setUp(self):
@@ -1562,6 +1601,56 @@ class TestInlinePanel(WagtailTestUtils, TestCase):
         self.assertEqual(panel.heading, "Social links")
         # Label is the singular term, derived from the related model's verbose_name
         self.assertEqual(panel.label, "social link")
+
+    def get_inline_bound_panel(self, label_format=None):
+        object_list = ObjectList(
+            [InlinePanel("speakers", label="speaker", label_format=label_format)]
+        ).bind_to_model(EventPage)
+        event_page = EventPage.objects.get(slug="christmas")
+        form = object_list.get_form_class()(instance=event_page)
+        return object_list.get_bound_panel(
+            instance=event_page, form=form, request=self.request
+        )
+
+    def test_label_format(self):
+        bound_panel = self.get_inline_bound_panel(
+            label_format="{first_name} {last_name}"
+        )
+        inline_panel = bound_panel.children[0]
+        row_attrs = inline_panel.children[0].label_format_attrs
+        self.assertEqual(row_attrs["data-controller"], "w-panel-label")
+        self.assertEqual(
+            row_attrs["data-w-panel-label-format-value"],
+            "{first_name} {last_name}",
+        )
+        self.assertEqual(
+            row_attrs["data-w-panel-label-widgets-id-value"],
+            "id_speakers-LABEL_FORMAT_WIDGETS",
+        )
+        self.assertEqual(
+            row_attrs["data-w-panel-label-field-prefix-value"], "speakers-0"
+        )
+        self.assertIn(
+            'id="id_speakers-LABEL_FORMAT_WIDGETS"', bound_panel.render_html()
+        )
+
+    def test_label_format_default(self):
+        bound_panel = self.get_inline_bound_panel()
+        inline_panel = bound_panel.children[0]
+        self.assertEqual(inline_panel.children[0].label_format_attrs, {})
+        self.assertNotIn(
+            'id="id_speakers-LABEL_FORMAT_WIDGETS"', bound_panel.render_html()
+        )
+
+    def test_label_format_clone(self):
+        panel = InlinePanel("speakers", label_format="{first_name}")
+        self.assertEqual(panel.clone().label_format, "{first_name}")
+
+    def test_label_format_supports_lazy_translation(self):
+        bound_panel = self.get_inline_bound_panel(
+            label_format=gettext_lazy("Speaker: {first_name} {last_name}")
+        )
+        self.assertIn("Speaker: {first_name} {last_name}", bound_panel.render_html())
 
     def test_inline_panel_order_with_min_num(self):
         event_page = EventPage.objects.get(slug="christmas")

--- a/wagtail/blocks/list_block.py
+++ b/wagtail/blocks/list_block.py
@@ -453,6 +453,7 @@ class ListBlock(Block):
         min_num = None
         max_num = None
         collapsed = False
+        label_format = None
 
     MUTABLE_META_ATTRIBUTES = ["min_num", "max_num"]
 
@@ -481,6 +482,10 @@ class ListBlockAdapter(Adapter):
 
         if block.meta.max_num is not None:
             meta["maxNum"] = block.meta.max_num
+
+        # Check specifically for None to allow for empty string
+        if block.meta.label_format is not None:
+            meta["labelFormat"] = block.meta.label_format
 
         return [
             block.name,

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -3553,6 +3553,20 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
             },
         )
 
+    def test_adapt_label_format(self):
+        class LinkBlock(blocks.StructBlock):
+            title = blocks.CharBlock()
+            link = blocks.URLBlock()
+
+        cases = [None, "", "{title} ({link})"]
+        for case in cases:
+            with self.subTest(label_format=case):
+                block = blocks.ListBlock(LinkBlock, label_format=case)
+                block.set_name("test_listblock")
+                js_args = ListBlockAdapter().js_args(block)
+
+                self.assertEqual(js_args[3].get("labelFormat"), case)
+
     def test_searchable_content(self):
         class LinkBlock(blocks.StructBlock):
             title = blocks.CharBlock()


### PR DESCRIPTION
Fixes #11892 

Also partially solves #10483  - it adds support for label_format on ListBlock, but it does not provide the ability to hide the items on the MiniMap.

### Description

This PR adds the `label_format` API to Panels and ListBlock.


### AI usage

I used AI to write tests (told it to look at existing StructBlock test), the docs changes and to pre-review the code based on the existing StructBlock implementation.


## Preview

InlinePanel
<img width="1510" height="819" alt="image" src="https://github.com/user-attachments/assets/17f94124-cf4a-4631-8c1f-52aa777ae521" />

Regular FieldPanel
<img width="1510" height="242" alt="image" src="https://github.com/user-attachments/assets/0e92be81-b55d-4c24-8e8c-fa650ad7ac27" />

MultiFIeldPanel's
<img width="1510" height="384" alt="image" src="https://github.com/user-attachments/assets/0b2be0c6-9f00-4b5a-b01a-62d5a3801a77" />

ListBlock
<img width="1514" height="476" alt="image" src="https://github.com/user-attachments/assets/91599e43-8a23-4c18-be51-d1585e4cfeeb" />

<img width="1004" height="195" alt="image" src="https://github.com/user-attachments/assets/fdc721e1-d8dc-4b75-bee4-7f14936aa768" />

FYI: The reason the ListBlock has no icon is because the bakerydemo uses a icon on that block that doesn't exist (icon = "tick")