### PR TITLE
docs(templates): document request.in_preview_panel

### DIFF
--- a/docs/topics/writing_templates.md
+++ b/docs/topics/writing_templates.md
@@ -323,7 +323,7 @@ The user bar is also available as a [template component](template_components), w
 
 ## Varying output between preview and live
 
-Sometimes you may wish to vary the template output depending on whether the page is being previewed or viewed live. For example, if you have visitor-tracking code such as Google Analytics in place on your site, it's a good idea to leave this out when previewing, so that editor activity doesn't appear in your analytics reports. Wagtail provides a `request.is_preview` variable to distinguish between preview and live:
+Sometimes you may wish to vary the template output depending on whether the page is being previewed or viewed live. For example, if you have visitor-tracking code such as Google Analytics in place on your site, it's a good idea to leave this out when previewing, so that editor activity doesn't appear in your analytics reports. Wagtail provides a `request.is_preview` (also referred to as `is_preview`) variable to distinguish between preview and live:
 
 ```html+django
 {% if not request.is_preview %}
@@ -336,6 +336,22 @@ Sometimes you may wish to vary the template output depending on whether the page
 
 If the page is being previewed, `request.preview_mode` can be used to determine the specific preview mode being used,
 if the page supports [multiple preview modes](wagtail.models.Page.preview_modes).
+
+(in_preview_panel)=
+
+### Detecting the in-page preview panel
+
+In addition to `request.is_preview`, Wagtail sets a separate `request.in_preview_panel` (also referred to as `in_preview_panel`) flag to `True` whenever a page or snippet is being rendered inside the live preview side panel of the Wagtail admin (the panel that appears next to the edit form). It is `False` when the same content is previewed in its own browser tab or window, and absent (which evaluates as falsy) on regular front-end requests.
+
+This is useful for tweaking the rendered template so that links and forms behave sensibly inside the constrained preview panel. The most common pattern is to force every link to open in a new tab, so that clicks made by editors do not navigate the preview panel itself away from the page being edited:
+
+```html+django
+{% if request.in_preview_panel %}
+    <base target="_blank">
+{% endif %}
+```
+
+`request.in_preview_panel` is set on every preview request handled by Wagtail's generic preview view (it is derived from the `?in_preview_panel=true` query parameter that the admin sends when rendering the side-panel preview). It implies `request.is_preview` is also true, so the panel-only flag can safely be used as an additional, more specific check on top of the general preview check.
 
 (template_fragment_caching)=
 


### PR DESCRIPTION
> **AI disclaimer (per Wagtail's [Use of generative AI](https://docs.wagtail.org/en/latest/contributing/general_guidelines.html#use-of-generative-ai) guideline):** This pull request was authored, tested, and verified by an AI agent (Claude Opus 4.7 via Cursor) operating **unattended** as a personal token-burn initiative by @adv0r. It is **not human-reviewed before submission**. The agent read the issue, the linked release notes, the call sites of `in_preview_panel` in `wagtail/admin/views/generic/preview.py` and `wagtail/admin/userbar.py`, and the bakery demo / project template to verify the documented behaviour. Please treat it accordingly — feedback / closure / requested rewrites all welcome.

## What changed

Closes #14007.

`docs/topics/writing_templates.md` gains a dedicated subsection under *Varying output between preview and live* that documents the `request.in_preview_panel` flag (previously only mentioned in v4.0.0 release notes). The subsection:

- explains when `request.in_preview_panel` is `True` vs `False` vs absent,
- documents the canonical \`{% if request.in_preview_panel %}<base target=\"_blank\">{% endif %}\` pattern from the project template and bakery demo,
- mentions the relationship with `request.is_preview` (preview-panel implies preview, not vice versa),
- uses **both** the bare \`in_preview_panel\` and the qualified \`request.in_preview_panel\` spellings so the section is findable via either search query, as the issue specifically requests.

A MyST cross-reference anchor \`(in_preview_panel)=\` is added so other pages can deep-link to the new section.

The original `request.is_preview` paragraph gains a parallel "(also referred to as `is_preview`)" parenthetical for the same findability reason.

## How verified

- Read the issue body, the existing v4.0.0 release notes mention, and the live docs.
- Cross-checked against the actual sources:
  - `wagtail/admin/views/generic/preview.py:118` — sets `in_preview_panel` from `?in_preview_panel=true`.
  - `wagtail/admin/userbar.py:342` — `getattr(request, \"in_preview_panel\", False)` confirms the "absent on regular requests" behaviour.
  - `wagtail/admin/tests/test_userbar.py:218` — confirms `is_preview=True, in_preview_panel=True` is the canonical preview-panel state.
- Sanity-checked the markdown / MyST syntax (anchor + section heading + fenced `html+django` block).
- Documentation-only change (no Python imports, no migrations, no front-end touched).

## Out of scope

- Not changing the underlying behaviour or adding a new template tag — the issue explicitly asks to **document** the existing flag.
- Not adding similar docs for `request.is_preview` beyond the one parenthetical, since it was already documented in the same section.

Made with [Cursor](https://cursor.com)