### PR TITLE
docs(i18n): make LocaleMiddleware requirement explicit

### DIFF
--- a/docs/advanced_topics/i18n.md
+++ b/docs/advanced_topics/i18n.md
@@ -243,8 +243,19 @@ to add a URL prefix for each language.
 To implement this, we can use Django's built-in
 {func}`~django.conf.urls.i18n.i18n_patterns`
 function, which adds a language prefix to all of the URL patterns passed into it.
-This activates the language code specified in the URL and Wagtail takes this into
-account when it decides how to route the request.
+The matched prefix activates the corresponding language code for the request,
+and Wagtail takes this into account when it decides how to route the request.
+
+```{important}
+`i18n_patterns` on its own is **not enough** for the prefixed URLs to actually
+resolve — Django needs the language to be activated **before** Wagtail's
+`serve` view runs. The recommended way to do this is to enable
+[`LocaleMiddleware`](inv:django:std:label#topics/i18n/translation:how django discovers language preference)
+(see the next subsection) or to provide your own language-activation logic
+(see [Custom routing/language detection](#custom-routinglanguage-detection)).
+Without one of those, requests to `/en/`, `/fr/`, etc. will not be routed
+to your pages and you will see 404s instead.
+```
 
 In your project's `urls.py` add Wagtail's core URLs (and any other URLs you
 want to be translated) into an `i18n_patterns` block:
@@ -317,14 +328,17 @@ Your URLs will now be prefixed only for the French version of your website, for 
 - /fr/search/
 ```
 
-#### User language auto-detection
+(user-language-auto-detection)=
 
-After wrapping your URL patterns with `i18n_patterns`, your site will now
-respond on URL prefixes. But now it won't respond on the root path.
+#### Activating the user's language with `LocaleMiddleware`
 
-To fix this, we need to detect the user's browser language and redirect them
-to the best language prefix. The recommended approach to do this is with
-Django's `LocaleMiddleware`:
+Once your URL patterns are wrapped in `i18n_patterns`, the site responds at
+URL prefixes such as `/en/` and `/fr/`, but the root path `/` and the
+prefixed URLs themselves still need somebody to *activate* the language so
+that Wagtail's `serve` view knows which locale to render. That's the job of
+Django's [`LocaleMiddleware`](inv:django:std:label#ref/middleware:django.middleware.locale.localemiddleware),
+which is what we recommend in almost all cases. Add it to your
+`MIDDLEWARE` setting:
 
 ```python
 # my_project/settings.py
@@ -336,12 +350,24 @@ MIDDLEWARE = [
 ]
 ```
 
+With `LocaleMiddleware` enabled, Django will:
+
+- resolve the prefixed URLs (`/en/...`, `/fr/...`) by activating the
+  language indicated by the prefix; and
+- redirect the bare root path `/` to the best-matching prefixed URL based
+  on the user's browser language (their `Accept-Language` header) or a
+  previously stored language preference. See Django's documentation on
+  [how language preference is discovered](inv:django:std:label#topics/i18n/translation:how django discovers language preference)
+  for the full algorithm.
+
 #### Custom routing/language detection
 
-You don't strictly have to use `i18n_patterns` or `LocaleMiddleware` for
-this and you can write your own logic if you need to.
+You don't strictly have to use `i18n_patterns` or `LocaleMiddleware` — you
+can write your own logic instead. **But you must use one of the two**:
+without either, Wagtail has no way to know which locale to serve and the
+prefixed URLs will not resolve.
 
-All Wagtail needs is the language to be activated (using Django's
+All Wagtail needs is for the language to be activated (using Django's
 `django.utils.translation.activate` function) before the
 `wagtail.views.serve` view is called.
 


### PR DESCRIPTION
> **AI disclaimer (per Wagtail's [Use of generative AI](https://docs.wagtail.org/en/latest/contributing/general_guidelines.html#use-of-generative-ai) guideline):** Authored, tested, and verified by an AI agent (Claude Opus 4.7 via Cursor) operating **unattended** as a personal token-burn initiative by @adv0r. **Not human-reviewed before submission.** The agent read the issue (and follow-up comments), cross-checked against Django's own [\"how language preference is discovered\"](https://docs.djangoproject.com/en/stable/topics/i18n/translation/#how-django-discovers-language-preference) docs, and inspected the relevant section of `docs/advanced_topics/i18n.md` to verify the documented behaviour matches what Django and Wagtail actually do.

## What changed

Closes #11960.

`docs/advanced_topics/i18n.md` is rewritten in three small spots to make it impossible to miss that `i18n_patterns()` on its own is not sufficient to make prefixed URLs (`/en/`, `/fr/`, ...) actually resolve — you also need `LocaleMiddleware` (or your own equivalent language-activation logic).

Specifically:

1. **\"Adding a language prefix to URLs\"** gains a \`{important}\` admonition stating that \`i18n_patterns\` on its own is not enough and pointing to the two valid completion paths. This is right at the point where the issue reporter (and the GSoC follow-up commenter) said the docs gave them a false sense of completion.
2. **\"User language auto-detection\"** is renamed to **\"Activating the user's language with \`LocaleMiddleware\`\"**, which makes it sound like the required setup step that it actually is, rather than an optional UX nicety. The prose now describes *both* jobs the middleware does — resolving prefixed URLs *and* redirecting the bare root path — and links to Django's own \"how language preference is discovered\" doc.
   - A `(user-language-auto-detection)=` MyST anchor is added directly above the renamed heading so existing inbound links keep working.
3. **\"Custom routing/language detection\"** is tightened from \"you don't strictly have to use these\" to \"you can write your own logic *but you must use one of the two*\", removing the ambiguity that started the confusion in the first place.

No behavioural change. No Python touched. No new dependencies.

## How verified

- Read the full issue thread (3 comments) including the GSoC contributor offer (no PR followed).
- Cross-checked against Django's [`LocaleMiddleware`](https://docs.djangoproject.com/en/stable/ref/middleware/#django.middleware.locale.LocaleMiddleware) and [how Django discovers language preference](https://docs.djangoproject.com/en/stable/topics/i18n/translation/#how-django-discovers-language-preference) docs to make sure the rewritten prose is accurate.
- Sanity-checked MyST syntax (\`{important}\` admonition + \`(anchor)=\` cross-reference + intersphinx \`inv:django:...\` references already used elsewhere in the same page).
- Documentation-only diff: `1 file changed, 37 insertions(+), 11 deletions(-)`.

## Out of scope

- The reporter's secondary issue (the \`{% pageurl %}\` / language-region-selector snippet not working for them) is a separate bug, not a docs bug. Not touching it here.
- Not adding a brand-new \"common pitfalls\" page — the issue is asking for the *existing* sections to be clearer.

Made with [Cursor](https://cursor.com)