### PR TITLE
Use new MAILERS setting in project template on Django >= 6.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,12 +169,7 @@ jobs:
           wagtail start testproject
           cd testproject
           tee -a testproject/settings/local.py << EOF
-          from warnings import filterwarnings
           SILENCED_SYSTEM_CHECKS = ["wagtailadmin.W001"]
-          # Remove when https://github.com/wagtail/Willow/issues/166 is resolved
-          filterwarnings(
-              "ignore", "The AVIF support in this library is marked as deprecated"
-          )
           EOF
           python manage.py makemigrations --check --dry-run
           python manage.py migrate

--- a/docs/advanced_topics/add_to_django_project.md
+++ b/docs/advanced_topics/add_to_django_project.md
@@ -279,7 +279,8 @@ ADMINS = [
 MANAGERS = ADMINS
 
 # Default to dummy email backend. Configure dev/production/local backend
-# as per https://docs.djangoproject.com/en/stable/topics/email/#email-backends
+# as per https://docs.djangoproject.com/en/stable/topics/email/.
+# If you are using Django 6.1 or higher, configure the MAILERS setting instead.
 EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False

--- a/docs/deployment/flyio.md
+++ b/docs/deployment/flyio.md
@@ -408,6 +408,7 @@ The explanation of some of the code in your `mysite/settings/production.py` file
 4. `SECURE_SSL_REDIRECT = True` enforces HTTPS redirect. This ensures that all connections to the site are secure.
 5. `ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "*").split(",")` defines the hostnames that can access your site. It retrieves its values from the `DJANGO_ALLOWED_HOSTS` environment variable. If no specific hosts are defined, it defaults to allowing all hosts.
 6. `EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"` configures your site to use the console email backend. You can configure this to use a proper email backend for sending emails.
+   If you are using Django 6.1 or higher, refer to the [Django documentation](inv:django#topics/email) for using the `MAILERS` setting instead of `EMAIL_BACKEND`.
 7. `WAGTAIL_REDIRECTS_FILE_STORAGE = "cache"` configures the file storage for Wagtail's redirects. Here, you set it to use cache.
 
 Now, complete the configuration of your environment variables by modifying your `.env.production` file as follows:

--- a/wagtail/project_template/project_name/settings/dev.py
+++ b/wagtail/project_template/project_name/settings/dev.py
@@ -9,8 +9,18 @@ SECRET_KEY = "{{ secret_key }}"
 # SECURITY WARNING: define the correct hosts in production!
 ALLOWED_HOSTS = ["*"]
 
+{% spaceless %}
+{# Remove the if block when Django 6.0 support is dropped #}
+{% if django_version|slice:":3" <= "6.0" %}
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-
+{% else %}
+MAILERS = {
+    "default": {
+        "BACKEND": "django.core.mail.backends.console.EmailBackend",
+    },
+}
+{% endif %}
+{% endspaceless %}
 
 try:
     from .local import *

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -1,5 +1,6 @@
 import os
 
+from django import VERSION as DJANGO_VERSION
 from django.contrib.messages import constants as message_constants
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
@@ -214,7 +215,14 @@ WAGTAILSEARCH_BACKENDS = {
     }
 }
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+if DJANGO_VERSION < (6, 1):
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+else:
+    MAILERS = {
+        "default": {
+            "BACKEND": "django.core.mail.backends.console.EmailBackend",
+        },
+    }
 
 if os.environ.get("USE_EMAIL_USER_MODEL"):
     INSTALLED_APPS.append("wagtail.users")


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes tests against Django's main branch.

### Description

<!-- Please describe the problem you're fixing. -->
Django 6.1 will be released on 5 August 2026, according to [their roadmap](https://www.djangoproject.com/download/6.1/roadmap/). Wagtail 8.0 is currently slated for release on 3 August 2026. I think it would be great if we could add preliminary support for Django 6.1 so people can upgrade both Wagtail and Django as soon as the latest versions are released.

It would be even better if people who create a new Wagtail project after Django 6.1 is released will get the new Django 6.1-compatible settings that don't raise any deprecation warnings. However, this would be tricky to pull off, since the Django version that was installed when generating the new project might be different to the one listed in the generated project's requirements.txt. See review comments for details.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Copilot for autocompletion.