### PR TITLE
Ignore EMAIL_BACKEND setting deprecation in project template tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,9 +171,10 @@ jobs:
           tee -a testproject/settings/local.py << EOF
           from warnings import filterwarnings
           SILENCED_SYSTEM_CHECKS = ["wagtailadmin.W001"]
-          # Remove when https://github.com/wagtail/Willow/issues/166 is resolved
+          # Remove when the project template is updated to use Django 6.1+
+          # and the MAILERS setting.
           filterwarnings(
-              "ignore", "The AVIF support in this library is marked as deprecated"
+              "ignore", "The EMAIL_BACKEND setting is deprecated."
           )
           EOF
           python manage.py makemigrations --check --dry-run


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes tests against Django's main branch since https://github.com/django/django/pull/21231.

### Description

<!-- Please describe the problem you're fixing. -->
I don't think we can proceed with the direction in #14238 due to https://github.com/wagtail/wagtail/pull/14238#discussion_r3273394743. For now, I think the best course of action is to ignore the deprecation warning for now, but we'll need to make sure we update the project template's settings when we update the requirements.txt to use Wagtail 6.1+.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None