### PR TITLE
Fix reusable blocks in StreamBlock and StructBlock losing their required state after deferred validation

### DIFF
--- a/wagtail/blocks/list_block.py
+++ b/wagtail/blocks/list_block.py
@@ -199,7 +199,8 @@ class ListBlock(Block):
 
     def defer_required_validation(self):
         super().defer_required_validation()
-        self.child_block.defer_required_validation()
+        if not self.child_block.is_deferred_validation:
+            self.child_block.defer_required_validation()
 
     def clean(self, value):
         # value is expected to be a ListValue, but if it's been assigned through external code it might
@@ -249,7 +250,8 @@ class ListBlock(Block):
         return ListValue(self, bound_blocks=result)
 
     def restore_deferred_validation(self):
-        self.child_block.restore_deferred_validation()
+        if self.child_block.is_deferred_validation:
+            self.child_block.restore_deferred_validation()
         super().restore_deferred_validation()
 
     def normalize(self, value):

--- a/wagtail/blocks/stream_block.py
+++ b/wagtail/blocks/stream_block.py
@@ -164,7 +164,13 @@ class BaseStreamBlock(Block):
     def defer_required_validation(self):
         super().defer_required_validation()
         for child_block in self.child_blocks.values():
-            child_block.defer_required_validation()
+            # A block may be reachable via multiple paths in the tree (e.g.
+            # a StructBlock subclass declares child blocks at class level
+            # and is used as more than one StreamBlock child type). Skip
+            # blocks that are already deferred to avoid clobbering the
+            # state captured on the first visit.
+            if not child_block.is_deferred_validation:
+                child_block.defer_required_validation()
 
     def clean(self, value):
         required = self.required and not self.is_deferred_validation
@@ -240,7 +246,8 @@ class BaseStreamBlock(Block):
 
     def restore_deferred_validation(self):
         for child_block in self.child_blocks.values():
-            child_block.restore_deferred_validation()
+            if child_block.is_deferred_validation:
+                child_block.restore_deferred_validation()
         super().restore_deferred_validation()
 
     def to_python(self, value):

--- a/wagtail/blocks/struct_block.py
+++ b/wagtail/blocks/struct_block.py
@@ -304,7 +304,8 @@ class BaseStructBlock(Block):
     def defer_required_validation(self):
         super().defer_required_validation()
         for block in self.child_blocks.values():
-            block.defer_required_validation()
+            if not block.is_deferred_validation:
+                block.defer_required_validation()
 
     def clean(self, value):
         result = []  # build up a list of (name, value) tuples to be passed to the StructValue constructor
@@ -322,7 +323,8 @@ class BaseStructBlock(Block):
 
     def restore_deferred_validation(self):
         for block in self.child_blocks.values():
-            block.restore_deferred_validation()
+            if block.is_deferred_validation:
+                block.restore_deferred_validation()
         super().restore_deferred_validation()
 
     def to_python(self, value):

--- a/wagtail/contrib/typed_table_block/blocks.py
+++ b/wagtail/contrib/typed_table_block/blocks.py
@@ -364,11 +364,13 @@ class BaseTypedTableBlock(Block):
     def defer_required_validation(self):
         super().defer_required_validation()
         for child_block in self.child_blocks.values():
-            child_block.defer_required_validation()
+            if not child_block.is_deferred_validation:
+                child_block.defer_required_validation()
 
     def restore_deferred_validation(self):
         for child_block in self.child_blocks.values():
-            child_block.restore_deferred_validation()
+            if child_block.is_deferred_validation:
+                child_block.restore_deferred_validation()
         super().restore_deferred_validation()
 
     class Meta:

--- a/wagtail/contrib/typed_table_block/tests.py
+++ b/wagtail/contrib/typed_table_block/tests.py
@@ -275,6 +275,20 @@ class TestTableBlock(TestCase):
             self.block.clean(blank_table)
         self.assertEqual(exc_info.exception.cell_errors[1][0].code, "required")
 
+    def test_defer_restores_required_for_shared_column_block(self):
+        # The same FieldBlock is used as more than one TypedTableBlock column,
+        # making it reachable via more than one path.
+        shared = blocks.CharBlock(required=True)
+        block = TypedTableBlock([("a", shared), ("b", shared)])
+        self.assertIs(block.child_blocks["a"], block.child_blocks["b"])
+
+        block.defer_required_validation()
+        self.assertFalse(shared.field.required)
+
+        block.restore_deferred_validation()
+        self.assertTrue(shared.required)
+        self.assertTrue(shared.field.required)
+
     def test_render(self):
         table = self.block.value_from_datadict(self.form_data, {}, "table")
         html = self.block.render(table)

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -3028,6 +3028,33 @@ class TestStructBlock(SimpleTestCase):
         with self.assertRaises(ValidationError):
             block.clean(value)
 
+    def test_clean_deferred_restores_required_for_shared_field_blocks(self):
+        # A StructBlock subclass that declares child blocks at class level
+        # shares those instances across all instantiations. Two HeroBlock
+        # children of OuterBlock therefore reference the same CharBlock,
+        # making it reachable via more than one path.
+        class HeroBlock(blocks.StructBlock):
+            title = blocks.CharBlock(required=True)
+
+        class OuterBlock(blocks.StructBlock):
+            a = HeroBlock()
+            b = HeroBlock()
+
+        block = OuterBlock()
+        shared_title = block.child_blocks["a"].child_blocks["title"]
+        self.assertIs(
+            shared_title,
+            block.child_blocks["b"].child_blocks["title"],
+        )
+
+        value = block.to_python({"a": {"title": ""}, "b": {"title": ""}})
+        block.clean_deferred(value)
+
+        self.assertTrue(shared_title.required)
+        self.assertTrue(shared_title.field.required)
+        with self.assertRaises(StructBlockValidationError):
+            block.clean(value)
+
     def test_non_block_validation_error(self):
         class LinkBlock(blocks.StructBlock):
             page = blocks.PageChooserBlock(required=False)
@@ -4528,6 +4555,91 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
             catcher.exception.as_json_data(),
             {"blockErrors": {0: {"messages": ["This field is required."]}}},
         )
+
+    def test_clean_deferred_restores_required_for_shared_field_blocks(self):
+        # A StructBlock subclass that declares child blocks at class level
+        # shares those instances across all instantiations. Two HeroBlock
+        # child types in this StreamBlock therefore reference the same
+        # CharBlock, making it reachable via more than one path.
+        class HeroBlock(blocks.StructBlock):
+            title = blocks.CharBlock(required=True)
+
+        class MyStream(blocks.StreamBlock):
+            hero = HeroBlock()
+            featured = HeroBlock()
+
+        block = MyStream()
+
+        # Sanity check: both HeroBlock instances reference the same
+        # class-level CharBlock instance.
+        shared_title = block.child_blocks["hero"].child_blocks["title"]
+        self.assertIs(
+            shared_title,
+            block.child_blocks["featured"].child_blocks["title"],
+        )
+        self.assertTrue(shared_title.required)
+
+        value = block.to_python([{"type": "hero", "value": {"title": ""}}])
+        block.clean_deferred(value)
+
+        # After clean_deferred, the shared CharBlock must be restored to
+        # required=True, and a subsequent non-deferred clean must reject
+        # empty values.
+        self.assertTrue(shared_title.required)
+        self.assertTrue(shared_title.field.required)
+        with self.assertRaises(blocks.StreamBlockValidationError) as catcher:
+            block.clean(value)
+        self.assertEqual(
+            catcher.exception.as_json_data(),
+            {
+                "blockErrors": {
+                    0: {
+                        "blockErrors": {
+                            "title": {"messages": ["This field is required."]},
+                        }
+                    }
+                }
+            },
+        )
+
+    def test_clean_deferred_with_field_block_aliased_to_multiple_children(self):
+        # The same FieldBlock instance is used as more than one direct
+        # StreamBlock child type, making it reachable via more than one path.
+        shared = blocks.CharBlock(required=True)
+        block = blocks.StreamBlock([("a", shared), ("b", shared)])
+        self.assertIs(block.child_blocks["a"], block.child_blocks["b"])
+
+        value = block.to_python([{"type": "a", "value": ""}])
+        block.clean_deferred(value)
+
+        self.assertTrue(shared.required)
+        self.assertTrue(shared.field.required)
+        with self.assertRaises(blocks.StreamBlockValidationError):
+            block.clean(value)
+
+    def test_clean_deferred_with_field_block_shared_with_list_block_child(self):
+        # The same FieldBlock is used both as a direct StreamBlock child
+        # and as the child_block of a sibling ListBlock, making it reachable
+        # via more than one path.
+        shared = blocks.CharBlock(required=True)
+        block = blocks.StreamBlock(
+            [
+                ("direct", shared),
+                ("inside_list", blocks.ListBlock(shared)),
+            ]
+        )
+        self.assertIs(
+            block.child_blocks["direct"],
+            block.child_blocks["inside_list"].child_block,
+        )
+
+        value = block.to_python([{"type": "direct", "value": ""}])
+        block.clean_deferred(value)
+
+        self.assertTrue(shared.required)
+        self.assertTrue(shared.field.required)
+        with self.assertRaises(blocks.StreamBlockValidationError):
+            block.clean(value)
 
     def test_validation_errors(self):
         class ValidatedBlock(blocks.StreamBlock):


### PR DESCRIPTION


<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes https://wagtailcms.slack.com/archives/C81FGJR2S/p1779280491492459

### Description

<!-- Please describe the problem you're fixing. -->
Fixes an issue where a block instance used multiple times (e.g. by composing `StructBlock` or `StreamBlock`) would have its `defer_required_validation()` method run twice in a single validation. For `FieldBlock`, this means the `_original_required` attribute that we use to store the original value of `required` (prior to deferred validation) becomes corrupted, as it would store the current `required=False` from the other placement of the same instance somewhere else in the `StreamBlock`/`StructBlock` tree. This results in a required block becoming permanently non-required after a deferred validation.

A very simple way to reproduce this in bakerydemo is by adding the following:

```diff
diff --git a/bakerydemo/base/blocks.py b/bakerydemo/base/blocks.py
index 224d4cc..68002b7 100644
--- a/bakerydemo/base/blocks.py
+++ b/bakerydemo/base/blocks.py
@@ -150,6 +150,7 @@ class BaseStreamBlock(StreamBlock):
     )
     image_block = CaptionedImageBlock()
     block_quote = BlockQuote()
+    block_quote_v2 = BlockQuote()
     embed_block = EmbedBlock(
         help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
         icon="media",
```

and then edit a blog post, and add both a "Block quote" and a "Block quote v2". After saving a draft and reloading, you'll see the "Text" field becomes optional in both blocks.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Claude Agent on Zed with default mode, default model, and Xhigh thinking was used to identify the fix and write the code.

~~The code has been manually reviewed by me, but I have yet to reproduce this in a fresh project. I'll do that shortly.~~ I was able to replicate this on bakerydemo with the above code, which I think should be enough to demonstrate the issue, but let me know if you'd like to see a reproduction with a fresh project.

For those interested, the conversation history can be found at https://gist.github.com/laymonage/c3e23e9099e3292fdd2fb77be34b3373