### PR TITLE
Fix non-deterministic ordering of missing child blocks

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,12 @@ Changelog
 * Maintenance: Fix blank choice tests for Django 6.1 (Sage Abdullah)
 
 
+7.4.2 (xx.xx.xxxx) - IN DEVELOPMENT
+~~~~~~~~~~~~~~~~~~
+
+* Fix: Prevent spurious migrations when there are missing child blocks in `StructBlock.Meta.form_layout` (Matthias Brück, Sage Abdullah)
+
+
 7.4.1 (19.05.2026)
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/7.4.2.md
+++ b/docs/releases/7.4.2.md
@@ -1,0 +1,24 @@
+# Wagtail 7.4.2 release notes - IN DEVELOPMENT
+
+_Unreleased_
+
+```{contents}
+---
+local:
+depth: 1
+---
+```
+
+## What's new
+
+### Bug fixes
+
+ * Prevent spurious migrations when there are missing child blocks in `StructBlock.Meta.form_layout` (Matthias Brück, Sage Abdullah)
+
+### Documentation
+
+ * ...
+
+### Maintenance
+
+ * ...

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -7,6 +7,7 @@ Release notes
    upgrading
    release_process
    8.0
+   7.4.2
    7.4.1
    7.4
    7.3.2

--- a/wagtail/blocks/struct_block.py
+++ b/wagtail/blocks/struct_block.py
@@ -255,10 +255,11 @@ class BaseStructBlock(Block):
         # Reorder child_blocks to match form_layout, appending any missing
         # blocks to the end
         sorted_block_names = self.meta.form_layout.get_sorted_block_names()
-        missing_block_names = self.child_blocks.keys() - set(sorted_block_names)
+        sorted_set = set(sorted_block_names)
+        missing_block_names = [k for k in self.child_blocks if k not in sorted_set]
         self.child_blocks = collections.OrderedDict(
             (name, self.child_blocks[name])
-            for name in (sorted_block_names + list(missing_block_names))
+            for name in (sorted_block_names + missing_block_names)
         )
 
     @classmethod

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -2783,6 +2783,37 @@ class TestStructBlock(SimpleTestCase):
         )
         self.assertIsInstance(block.child_blocks["description"], blocks.TextBlock)
 
+    def test_with_multiple_missing_blocks_in_form_layout(self):
+        # Regression test for https://github.com/wagtail/wagtail/issues/14242:
+        # when more than one block is missing from form_layout, those blocks
+        # (including any added via local_blocks) must be appended to
+        # child_blocks in a stable order to avoid spurious migrations
+        # across runs. To reproduce the failure against the un-fixed code,
+        # run this test with a certain seed, e.g. PYTHONHASHSEED=1.
+        class ArticleBlock(blocks.StructBlock):
+            title = blocks.CharBlock()
+            link = blocks.URLBlock()
+            description = blocks.TextBlock()
+            author = blocks.CharBlock()
+            published_date = blocks.DateBlock()
+
+            class Meta:
+                form_layout = BlockGroup(children=["link"])
+
+        block = ArticleBlock(local_blocks=[("extra", blocks.CharBlock())])
+
+        self.assertEqual(
+            list(block.child_blocks.keys()),
+            ["link", "title", "description", "author", "published_date", "extra"],
+        )
+        self.assertIsInstance(block.child_blocks["extra"], blocks.CharBlock)
+
+        _, args, _ = block.deconstruct()
+        self.assertEqual(
+            [name for name, _block in args[0]],
+            ["link", "title", "description", "author", "published_date", "extra"],
+        )
+
     def test_adapt_with_get_form_layout(self):
         class LinkBlock(blocks.StructBlock):
             title = blocks.CharBlock()


### PR DESCRIPTION

Fixes #14242

### Description
Replace the set-based difference with a list comprehension that preserves base_blocks insertion order.


### AI usage
The initial suggestion of a fix has been provided by AI. I looked into the changes and confirmed it.