### PR TITLE
Preserve admin scroll for Draftail block toolbar actions

### DIFF
--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -65,6 +65,123 @@ const getSavedToolbar = () => {
   return saved;
 };
 
+const captureMainScroll = () => {
+  const scrollAreas = [
+    document.querySelector('#main'),
+    document.scrollingElement,
+    document.documentElement,
+    document.body,
+  ].filter(
+    (scrollArea, index, areas) =>
+      scrollArea && areas.indexOf(scrollArea) === index,
+  );
+  return {
+    positions: scrollAreas.map((scrollArea) => ({
+      scrollArea,
+      top: scrollArea.scrollTop,
+      left: scrollArea.scrollLeft,
+    })),
+    windowPosition: {
+      top: window.scrollY,
+      left: window.scrollX,
+    },
+  };
+};
+
+const restoreMainScroll = (scrollState) => {
+  scrollState.positions.forEach((position) => {
+    position.scrollArea.scrollTop = position.top;
+    position.scrollArea.scrollLeft = position.left;
+  });
+  window.scrollTo(
+    scrollState.windowPosition.left,
+    scrollState.windowPosition.top,
+  );
+};
+
+const preserveMainScroll = (callback, scrollState = captureMainScroll()) => {
+  const restore = () => restoreMainScroll(scrollState);
+
+  restore();
+
+  try {
+    callback();
+  } finally {
+    restore();
+    requestAnimationFrame(restore);
+
+    window.setTimeout(() => {
+      restore();
+      requestAnimationFrame(restore);
+    }, 0);
+
+    window.setTimeout(restore, 50);
+    window.setTimeout(restore, 150);
+  }
+};
+
+const rememberBlockToolbarScroll = (scrollStateRef, replace = false) => {
+  if (replace || !scrollStateRef.current) {
+    scrollStateRef.current = captureMainScroll();
+  }
+
+  return scrollStateRef.current;
+};
+
+const consumeBlockToolbarScroll = (scrollStateRef) => {
+  const scrollState = scrollStateRef.current;
+  scrollStateRef.current = null;
+  return scrollState;
+};
+
+const isBlockToolbarTrigger = (target) =>
+  target instanceof Element &&
+  Boolean(target.closest('.Draftail-BlockToolbar__trigger'));
+
+const preserveMainScrollOnBlockToolbarTrigger = (event, scrollStateRef) => {
+  if (isBlockToolbarTrigger(event.target)) {
+    const scrollState = rememberBlockToolbarScroll(scrollStateRef, true);
+    event.preventDefault();
+    preserveMainScroll(() => {}, scrollState);
+  }
+};
+
+const preserveMainScrollOnBlockToolbarTriggerKey = (event, scrollStateRef) => {
+  if (
+    [' ', 'Enter', 'Spacebar'].includes(event.key) &&
+    isBlockToolbarTrigger(event.target)
+  ) {
+    const scrollState = rememberBlockToolbarScroll(scrollStateRef, true);
+    preserveMainScroll(() => {}, scrollState);
+  }
+};
+
+const preserveMainScrollOnBlockToolbarFocus = (event, scrollStateRef) => {
+  if (
+    event.target instanceof Element &&
+    event.target.getAttribute('role') === 'combobox'
+  ) {
+    const scrollState = rememberBlockToolbarScroll(scrollStateRef);
+    preserveMainScroll(() => {}, scrollState);
+  }
+};
+
+const preserveBlockToolbarActionScroll = (callback, scrollStateRef) => {
+  const scrollState = consumeBlockToolbarScroll(scrollStateRef);
+  preserveMainScroll(callback, scrollState || captureMainScroll());
+};
+
+const onCompleteBlockToolbarAction = (props, nextState, scrollStateRef) => {
+  if (!nextState) {
+    scrollStateRef.current = null;
+    return;
+  }
+
+  preserveBlockToolbarActionScroll(() => {
+    props.onChange(nextState);
+  }, scrollStateRef);
+};
+
 /**
  * Scroll to keep the field on the same spot when switching toolbars,
  * and save the choice in localStorage.
@@ -158,7 +275,10 @@ const initEditor = (selector, originalOptions, currentScript) => {
     field.draftailEditor = ref;
   };
 
-  const getSharedPropsFromOptions = (newOptions) => {
+  const getSharedPropsFromOptions = (
+    newOptions,
+    blockToolbarScrollStateRef,
+  ) => {
     let ariaDescribedBy = null;
     const enableHorizontalRule = newOptions.enableHorizontalRule
       ? {
@@ -221,15 +341,49 @@ const initEditor = (selector, originalOptions, currentScript) => {
       },
       topToolbar: (props) => (
         <>
-          <BlockToolbar
-            {...props}
-            triggerIcon={ADD_ICON}
-            triggerLabel={comboBoxTriggerLabel}
-            comboLabel={comboBoxLabel}
-            comboPlaceholder={comboBoxLabel}
-            noResultsText={comboBoxNoResults}
-            ComboBoxComponent={ComboBox}
-          />
+          <div
+            onMouseDownCapture={(event) =>
+              preserveMainScrollOnBlockToolbarTrigger(
+                event,
+                blockToolbarScrollStateRef,
+              )
+            }
+            onKeyDownCapture={(event) =>
+              preserveMainScrollOnBlockToolbarTriggerKey(
+                event,
+                blockToolbarScrollStateRef,
+              )
+            }
+            onFocusCapture={(event) =>
+              preserveMainScrollOnBlockToolbarFocus(
+                event,
+                blockToolbarScrollStateRef,
+              )
+            }
+          >
+            <BlockToolbar
+              {...props}
+              onCompleteSource={(nextState) =>
+                onCompleteBlockToolbarAction(
+                  props,
+                  nextState,
+                  blockToolbarScrollStateRef,
+                )
+              }
+              addHR={() =>
+                preserveBlockToolbarActionScroll(
+                  props.addHR,
+                  blockToolbarScrollStateRef,
+                )
+              }
+              triggerIcon={ADD_ICON}
+              triggerLabel={comboBoxTriggerLabel}
+              comboLabel={comboBoxLabel}
+              comboPlaceholder={comboBoxLabel}
+              noResultsText={comboBoxNoResults}
+              ComboBoxComponent={ComboBox}
+            />
+          </div>
           <InlineToolbar
             {...props}
             pinButton={pinButton}
@@ -272,10 +426,14 @@ const initEditor = (selector, originalOptions, currentScript) => {
   }) => {
     // eslint-disable-next-line react-hooks/globals, react/hook-use-state
     [options, setOptions] = React.useState({ ...initialOptions });
+    const blockToolbarScrollStateRef = React.useRef(null);
 
     // If the field has a valid contentpath - ie is not an InlinePanel or under a ListBlock -
     // and the comments system is initialized then use CommentableEditor, otherwise plain DraftailEditor
-    const sharedProps = getSharedPropsFromOptions(options);
+    const sharedProps = getSharedPropsFromOptions(
+      options,
+      blockToolbarScrollStateRef,
+    );
     const editor =
       commentApp && contentPath !== '' ? (
         <Provider store={commentApp.store}>

--- a/client/src/components/Draftail/index.test.js
+++ b/client/src/components/Draftail/index.test.js
@@ -1,3 +1,6 @@
+import { BlockToolbar, InlineToolbar } from 'draftail';
+import React from 'react';
+
 import draftail, {
   Document,
   EmbedBlock,
@@ -8,6 +11,63 @@ import draftail, {
 
 window.comments = {
   getContentPath: jest.fn(),
+};
+
+const findComponent = (children, type) => {
+  const components = React.Children.toArray(children);
+  let component = components.find((child) => child.type === type);
+
+  if (component) {
+    return component;
+  }
+
+  components.some((child) => {
+    component = findComponent(child.props?.children, type);
+    return Boolean(component);
+  });
+
+  return component;
+};
+
+const getTopToolbarComponents = (
+  props = {},
+  html = '<input id="test" value="null" />',
+) => {
+  document.body.innerHTML = html;
+  const field = document.querySelector('#test');
+  const toolbarProps = {
+    onChange: jest.fn(),
+    onCompleteSource: jest.fn(),
+    onRequestSource: jest.fn(),
+    addHR: jest.fn(),
+    ...props,
+  };
+
+  draftail.initEditor('#test', {});
+
+  const topToolbar = field.draftailEditor.props.topToolbar(toolbarProps);
+  const toolbarComponents = React.Children.toArray(topToolbar.props.children);
+  const blockToolbarWrapper = toolbarComponents.find((component) =>
+    findComponent(component.props?.children, BlockToolbar),
+  );
+
+  return {
+    toolbarProps,
+    blockToolbarWrapper,
+    blockToolbar: findComponent(topToolbar.props.children, BlockToolbar),
+    inlineToolbar: findComponent(topToolbar.props.children, InlineToolbar),
+  };
+};
+
+const setWindowScroll = ({ top = 0, left = 0 }) => {
+  Object.defineProperty(window, 'scrollY', {
+    configurable: true,
+    value: top,
+  });
+  Object.defineProperty(window, 'scrollX', {
+    configurable: true,
+    value: left,
+  });
 };
 
 describe('Draftail', () => {
@@ -96,6 +156,340 @@ describe('Draftail', () => {
       draftail.initEditor('#test', {});
 
       expect(field.draftailEditor.props.ariaDescribedBy).toBe('test-length');
+    });
+
+    describe('topToolbar', () => {
+      let mockRAF;
+
+      beforeEach(() => {
+        jest.useFakeTimers();
+        mockRAF = jest
+          .spyOn(window, 'requestAnimationFrame')
+          .mockImplementation((callback) => callback());
+      });
+
+      afterEach(() => {
+        mockRAF.mockRestore();
+        window.scrollTo.mockClear();
+        setWindowScroll({});
+        jest.clearAllTimers();
+        jest.useRealTimers();
+      });
+
+      it('wraps block toolbar actions without changing inline toolbar actions', () => {
+        const {
+          toolbarProps,
+          blockToolbarWrapper,
+          blockToolbar,
+          inlineToolbar,
+        } = getTopToolbarComponents();
+
+        expect(blockToolbarWrapper.props.onMouseDownCapture).toBeDefined();
+        expect(blockToolbarWrapper.props.onKeyDownCapture).toBeDefined();
+        expect(blockToolbarWrapper.props.onFocusCapture).toBeDefined();
+        expect(blockToolbar.props.onCompleteSource).not.toBe(
+          toolbarProps.onCompleteSource,
+        );
+        expect(blockToolbar.props.addHR).not.toBe(toolbarProps.addHR);
+        expect(blockToolbar.props.onRequestSource).toBe(
+          toolbarProps.onRequestSource,
+        );
+
+        expect(inlineToolbar.props.onCompleteSource).toBe(
+          toolbarProps.onCompleteSource,
+        );
+        expect(inlineToolbar.props.addHR).toBe(toolbarProps.addHR);
+      });
+
+      it('preserves #main scroll around block type selection', () => {
+        const nextState = {};
+        const onChange = jest.fn(() => {
+          const scrollArea = document.querySelector('#main');
+          scrollArea.scrollTop = 0;
+          scrollArea.scrollLeft = 0;
+        });
+        const { blockToolbar } = getTopToolbarComponents(
+          { onChange },
+          '<main id="main"><input id="test" value="null" /></main>',
+        );
+        const scrollArea = document.querySelector('#main');
+        scrollArea.scrollTop = 600;
+        scrollArea.scrollLeft = 40;
+
+        blockToolbar.props.onCompleteSource(nextState);
+
+        expect(onChange).toHaveBeenCalledWith(nextState);
+        expect(scrollArea.scrollTop).toBe(600);
+        expect(scrollArea.scrollLeft).toBe(40);
+
+        scrollArea.scrollTop = 0;
+        scrollArea.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(scrollArea.scrollTop).toBe(600);
+        expect(scrollArea.scrollLeft).toBe(40);
+      });
+
+      it('preserves document scroll around block type selection', () => {
+        const nextState = {};
+        const onChange = jest.fn(() => {
+          document.documentElement.scrollTop = 0;
+          document.documentElement.scrollLeft = 0;
+        });
+        const { blockToolbar } = getTopToolbarComponents({
+          onChange,
+        });
+        document.documentElement.scrollTop = 600;
+        document.documentElement.scrollLeft = 40;
+
+        blockToolbar.props.onCompleteSource(nextState);
+
+        expect(onChange).toHaveBeenCalledWith(nextState);
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+
+        document.documentElement.scrollTop = 0;
+        document.documentElement.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+      });
+
+      it('preserves the scroll captured when opening the block toolbar', () => {
+        const nextState = {};
+        const onChange = jest.fn(() => {
+          document.documentElement.scrollTop = 0;
+          document.documentElement.scrollLeft = 0;
+        });
+        const { blockToolbarWrapper, blockToolbar } = getTopToolbarComponents({
+          onChange,
+        });
+        const trigger = document.createElement('button');
+        trigger.className = 'Draftail-BlockToolbar__trigger';
+
+        document.documentElement.scrollTop = 600;
+        document.documentElement.scrollLeft = 40;
+        blockToolbarWrapper.props.onMouseDownCapture({
+          target: trigger,
+          preventDefault: jest.fn(),
+        });
+
+        document.documentElement.scrollTop = 25;
+        document.documentElement.scrollLeft = 5;
+
+        blockToolbar.props.onCompleteSource(nextState);
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+
+        document.documentElement.scrollTop = 0;
+        document.documentElement.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+      });
+
+      it('keeps the opening scroll when combobox focus happens after a jump', () => {
+        const nextState = {};
+        const onChange = jest.fn(() => {
+          document.documentElement.scrollTop = 0;
+          document.documentElement.scrollLeft = 0;
+        });
+        const { blockToolbarWrapper, blockToolbar } = getTopToolbarComponents({
+          onChange,
+        });
+        const trigger = document.createElement('button');
+        trigger.className = 'Draftail-BlockToolbar__trigger';
+        const input = document.createElement('input');
+        input.setAttribute('role', 'combobox');
+
+        document.documentElement.scrollTop = 600;
+        document.documentElement.scrollLeft = 40;
+        blockToolbarWrapper.props.onMouseDownCapture({
+          target: trigger,
+          preventDefault: jest.fn(),
+        });
+
+        document.documentElement.scrollTop = 0;
+        document.documentElement.scrollLeft = 0;
+        blockToolbarWrapper.props.onFocusCapture({ target: input });
+
+        document.documentElement.scrollTop = 25;
+        document.documentElement.scrollLeft = 5;
+
+        blockToolbar.props.onCompleteSource(nextState);
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+      });
+
+      it('preserves window scroll around block type selection', () => {
+        const nextState = {};
+        const onChange = jest.fn();
+        const { blockToolbar } = getTopToolbarComponents({
+          onChange,
+        });
+        setWindowScroll({ top: 600, left: 40 });
+
+        blockToolbar.props.onCompleteSource(nextState);
+
+        expect(onChange).toHaveBeenCalledWith(nextState);
+        expect(window.scrollTo).toHaveBeenCalledWith(40, 600);
+
+        window.scrollTo.mockClear();
+        jest.runOnlyPendingTimers();
+
+        expect(window.scrollTo).toHaveBeenLastCalledWith(40, 600);
+      });
+
+      it('does not call Draftail source completion for block type selection', () => {
+        const nextState = {};
+        const { toolbarProps, blockToolbar } = getTopToolbarComponents();
+
+        blockToolbar.props.onCompleteSource(nextState);
+
+        expect(toolbarProps.onCompleteSource).not.toHaveBeenCalled();
+        expect(toolbarProps.onChange).toHaveBeenCalledWith(nextState);
+      });
+
+      it('preserves #main scroll around horizontal rule insertion', () => {
+        const addHR = jest.fn(() => {
+          const scrollArea = document.querySelector('#main');
+          scrollArea.scrollTop = 0;
+          scrollArea.scrollLeft = 0;
+        });
+        const { blockToolbar } = getTopToolbarComponents(
+          { addHR },
+          '<main id="main"><input id="test" value="null" /></main>',
+        );
+        const scrollArea = document.querySelector('#main');
+        scrollArea.scrollTop = 600;
+        scrollArea.scrollLeft = 40;
+
+        blockToolbar.props.addHR();
+
+        expect(addHR).toHaveBeenCalledTimes(1);
+        expect(scrollArea.scrollTop).toBe(600);
+        expect(scrollArea.scrollLeft).toBe(40);
+
+        scrollArea.scrollTop = 0;
+        scrollArea.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(scrollArea.scrollTop).toBe(600);
+        expect(scrollArea.scrollLeft).toBe(40);
+      });
+
+      it('preserves the scroll captured when opening before horizontal rule insertion', () => {
+        const addHR = jest.fn(() => {
+          document.documentElement.scrollTop = 0;
+          document.documentElement.scrollLeft = 0;
+        });
+        const { blockToolbarWrapper, blockToolbar } = getTopToolbarComponents({
+          addHR,
+        });
+        const trigger = document.createElement('button');
+        trigger.className = 'Draftail-BlockToolbar__trigger';
+
+        document.documentElement.scrollTop = 600;
+        document.documentElement.scrollLeft = 40;
+        blockToolbarWrapper.props.onMouseDownCapture({
+          target: trigger,
+          preventDefault: jest.fn(),
+        });
+
+        document.documentElement.scrollTop = 25;
+        document.documentElement.scrollLeft = 5;
+
+        blockToolbar.props.addHR();
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+
+        document.documentElement.scrollTop = 0;
+        document.documentElement.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+      });
+
+      it('preserves document scroll when opening the block toolbar', () => {
+        const { blockToolbarWrapper } = getTopToolbarComponents();
+        const trigger = document.createElement('button');
+        trigger.className = 'Draftail-BlockToolbar__trigger';
+        const preventDefault = jest.fn();
+        document.documentElement.scrollTop = 600;
+        document.documentElement.scrollLeft = 40;
+
+        blockToolbarWrapper.props.onMouseDownCapture({
+          target: trigger,
+          preventDefault,
+        });
+
+        expect(preventDefault).toHaveBeenCalledTimes(1);
+        document.documentElement.scrollTop = 0;
+        document.documentElement.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+      });
+
+      it('does not preserve scroll for other block toolbar clicks', () => {
+        const { blockToolbarWrapper } = getTopToolbarComponents();
+        const option = document.createElement('button');
+        const preventDefault = jest.fn();
+        document.documentElement.scrollTop = 600;
+
+        blockToolbarWrapper.props.onMouseDownCapture({
+          target: option,
+          preventDefault,
+        });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+        document.documentElement.scrollTop = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(document.documentElement.scrollTop).toBe(0);
+      });
+
+      it('preserves scroll when the block toolbar combobox receives focus', () => {
+        const { blockToolbarWrapper } = getTopToolbarComponents();
+        const input = document.createElement('input');
+        input.setAttribute('role', 'combobox');
+        document.documentElement.scrollTop = 600;
+        document.documentElement.scrollLeft = 40;
+
+        blockToolbarWrapper.props.onFocusCapture({ target: input });
+
+        document.documentElement.scrollTop = 0;
+        document.documentElement.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+      });
+
+      it('runs block toolbar actions without #main', () => {
+        const nextState = {};
+        const onChange = jest.fn();
+        const addHR = jest.fn();
+        const { blockToolbar } = getTopToolbarComponents({
+          onChange,
+          addHR,
+        });
+
+        expect(() =>
+          blockToolbar.props.onCompleteSource(nextState),
+        ).not.toThrow();
+        expect(() => blockToolbar.props.addHR()).not.toThrow();
+
+        expect(onChange).toHaveBeenCalledWith(nextState);
+        expect(addHR).toHaveBeenCalledTimes(1);
+      });
     });
 
     describe('selector conflicts', () => {


### PR DESCRIPTION
Fixes #14245 

### Description

This fixes a Chrome scroll reset in the Wagtail admin rich text editor when applying block styles from Draftail's block toolbar.

The issue was caused by Chrome moving focus during the block toolbar flow and resetting the admin scroll position before the block-style action finished.
The fix preserves the scroll position captured when the block toolbar is opened, restores it through Draftail's focus and update cycle, and limits that
behavior to block-toolbar actions only.

This change:
- captures and restores the Wagtail admin scroll position during block-toolbar interactions
- applies scroll preservation to block style selection and horizontal rule insertion
- keeps `InlineToolbar` behavior unchanged
- leaves chooser and modal flows such as link, image, and embed unchanged
- adds regression tests covering toolbar open, combobox focus, block-style selection, and horizontal rule insertion

### Review focus

Please review the block toolbar flow in `client/src/components/Draftail/index.js`, especially:
- capturing scroll state when the `+` trigger opens the toolbar
- restoring that stored scroll state when a block-toolbar action completes
- limiting the change to block-toolbar actions without affecting inline styles or chooser flows

### AI usage

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.

AI assistance was used to:
- investigate the Draftail block toolbar focus and scroll behavior
- implement the scroll preservation fix
- add and update regression tests
- draft this pull request description

If you have the issue number, replace Fixes #14245 . with it directly.