### PR TITLE
Fix/draftail chrome scroll reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ coverage/
 
 *.db
 *.sqlite3
+/.codex-temp

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -65,6 +65,123 @@ const getSavedToolbar = () => {
   return saved;
 };
 
+const captureMainScroll = () => {
+  const scrollAreas = [
+    document.querySelector('#main'),
+    document.scrollingElement,
+    document.documentElement,
+    document.body,
+  ].filter(
+    (scrollArea, index, areas) =>
+      scrollArea && areas.indexOf(scrollArea) === index,
+  );
+  return {
+    positions: scrollAreas.map((scrollArea) => ({
+      scrollArea,
+      top: scrollArea.scrollTop,
+      left: scrollArea.scrollLeft,
+    })),
+    windowPosition: {
+      top: window.scrollY,
+      left: window.scrollX,
+    },
+  };
+};
+
+const restoreMainScroll = (scrollState) => {
+  scrollState.positions.forEach((position) => {
+    position.scrollArea.scrollTop = position.top;
+    position.scrollArea.scrollLeft = position.left;
+  });
+  window.scrollTo(
+    scrollState.windowPosition.left,
+    scrollState.windowPosition.top,
+  );
+};
+
+const preserveMainScroll = (callback, scrollState = captureMainScroll()) => {
+  const restore = () => restoreMainScroll(scrollState);
+
+  restore();
+
+  try {
+    callback();
+  } finally {
+    restore();
+    requestAnimationFrame(restore);
+
+    window.setTimeout(() => {
+      restore();
+      requestAnimationFrame(restore);
+    }, 0);
+
+    window.setTimeout(restore, 50);
+    window.setTimeout(restore, 150);
+  }
+};
+
+const rememberBlockToolbarScroll = (scrollStateRef, replace = false) => {
+  if (replace || !scrollStateRef.current) {
+    scrollStateRef.current = captureMainScroll();
+  }
+
+  return scrollStateRef.current;
+};
+
+const consumeBlockToolbarScroll = (scrollStateRef) => {
+  const scrollState = scrollStateRef.current;
+  scrollStateRef.current = null;
+  return scrollState;
+};
+
+const isBlockToolbarTrigger = (target) =>
+  target instanceof Element &&
+  Boolean(target.closest('.Draftail-BlockToolbar__trigger'));
+
+const preserveMainScrollOnBlockToolbarTrigger = (event, scrollStateRef) => {
+  if (isBlockToolbarTrigger(event.target)) {
+    const scrollState = rememberBlockToolbarScroll(scrollStateRef, true);
+    event.preventDefault();
+    preserveMainScroll(() => {}, scrollState);
+  }
+};
+
+const preserveMainScrollOnBlockToolbarTriggerKey = (event, scrollStateRef) => {
+  if (
+    [' ', 'Enter', 'Spacebar'].includes(event.key) &&
+    isBlockToolbarTrigger(event.target)
+  ) {
+    const scrollState = rememberBlockToolbarScroll(scrollStateRef, true);
+    preserveMainScroll(() => {}, scrollState);
+  }
+};
+
+const preserveMainScrollOnBlockToolbarFocus = (event, scrollStateRef) => {
+  if (
+    event.target instanceof Element &&
+    event.target.getAttribute('role') === 'combobox'
+  ) {
+    const scrollState = rememberBlockToolbarScroll(scrollStateRef);
+    preserveMainScroll(() => {}, scrollState);
+  }
+};
+
+const preserveBlockToolbarActionScroll = (callback, scrollStateRef) => {
+  const scrollState = consumeBlockToolbarScroll(scrollStateRef);
+  preserveMainScroll(callback, scrollState || captureMainScroll());
+};
+
+const onCompleteBlockToolbarAction = (props, nextState, scrollStateRef) => {
+  if (!nextState) {
+    scrollStateRef.current = null;
+    return;
+  }
+
+  preserveBlockToolbarActionScroll(() => {
+    props.onChange(nextState);
+  }, scrollStateRef);
+};
+
 /**
  * Scroll to keep the field on the same spot when switching toolbars,
  * and save the choice in localStorage.
@@ -158,7 +275,10 @@ const initEditor = (selector, originalOptions, currentScript) => {
     field.draftailEditor = ref;
   };
 
-  const getSharedPropsFromOptions = (newOptions) => {
+  const getSharedPropsFromOptions = (
+    newOptions,
+    blockToolbarScrollStateRef,
+  ) => {
     let ariaDescribedBy = null;
     const enableHorizontalRule = newOptions.enableHorizontalRule
       ? {
@@ -221,15 +341,49 @@ const initEditor = (selector, originalOptions, currentScript) => {
       },
       topToolbar: (props) => (
         <>
-          <BlockToolbar
-            {...props}
-            triggerIcon={ADD_ICON}
-            triggerLabel={comboBoxTriggerLabel}
-            comboLabel={comboBoxLabel}
-            comboPlaceholder={comboBoxLabel}
-            noResultsText={comboBoxNoResults}
-            ComboBoxComponent={ComboBox}
-          />
+          <div
+            onMouseDownCapture={(event) =>
+              preserveMainScrollOnBlockToolbarTrigger(
+                event,
+                blockToolbarScrollStateRef,
+              )
+            }
+            onKeyDownCapture={(event) =>
+              preserveMainScrollOnBlockToolbarTriggerKey(
+                event,
+                blockToolbarScrollStateRef,
+              )
+            }
+            onFocusCapture={(event) =>
+              preserveMainScrollOnBlockToolbarFocus(
+                event,
+                blockToolbarScrollStateRef,
+              )
+            }
+          >
+            <BlockToolbar
+              {...props}
+              onCompleteSource={(nextState) =>
+                onCompleteBlockToolbarAction(
+                  props,
+                  nextState,
+                  blockToolbarScrollStateRef,
+                )
+              }
+              addHR={() =>
+                preserveBlockToolbarActionScroll(
+                  props.addHR,
+                  blockToolbarScrollStateRef,
+                )
+              }
+              triggerIcon={ADD_ICON}
+              triggerLabel={comboBoxTriggerLabel}
+              comboLabel={comboBoxLabel}
+              comboPlaceholder={comboBoxLabel}
+              noResultsText={comboBoxNoResults}
+              ComboBoxComponent={ComboBox}
+            />
+          </div>
           <InlineToolbar
             {...props}
             pinButton={pinButton}
@@ -272,10 +426,14 @@ const initEditor = (selector, originalOptions, currentScript) => {
   }) => {
     // eslint-disable-next-line react-hooks/globals, react/hook-use-state
     [options, setOptions] = React.useState({ ...initialOptions });
+    const blockToolbarScrollStateRef = React.useRef(null);
 
     // If the field has a valid contentpath - ie is not an InlinePanel or under a ListBlock -
     // and the comments system is initialized then use CommentableEditor, otherwise plain DraftailEditor
-    const sharedProps = getSharedPropsFromOptions(options);
+    const sharedProps = getSharedPropsFromOptions(
+      options,
+      blockToolbarScrollStateRef,
+    );
     const editor =
       commentApp && contentPath !== '' ? (
         <Provider store={commentApp.store}>

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -109,14 +109,6 @@ const preserveMainScroll = (callback, scrollState = captureMainScroll()) => {
   } finally {
     restore();
     requestAnimationFrame(restore);
-
-    window.setTimeout(() => {
-      restore();
-      requestAnimationFrame(restore);
-    }, 0);
-
-    window.setTimeout(restore, 50);
-    window.setTimeout(restore, 150);
   }
 };
 

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -223,6 +223,11 @@ const initEditor = (selector, originalOptions, currentScript) => {
         <>
           <BlockToolbar
             {...props}
+            onCompleteSource={(nextState) => {
+              if (nextState) {
+                props.onChange(nextState);
+              }
+            }}
             triggerIcon={ADD_ICON}
             triggerLabel={comboBoxTriggerLabel}
             comboLabel={comboBoxLabel}

--- a/client/src/components/Draftail/index.test.js
+++ b/client/src/components/Draftail/index.test.js
@@ -1,3 +1,6 @@
+import { BlockToolbar, CommandPalette, InlineToolbar } from 'draftail';
+import React from 'react';
+
 import draftail, {
   Document,
   EmbedBlock,
@@ -8,6 +11,22 @@ import draftail, {
 
 window.comments = {
   getContentPath: jest.fn(),
+};
+
+const findComponent = (children, type) => {
+  const components = React.Children.toArray(children);
+  let component = components.find((child) => child.type === type);
+
+  if (component) {
+    return component;
+  }
+
+  components.some((child) => {
+    component = findComponent(child.props?.children, type);
+    return Boolean(component);
+  });
+
+  return component;
 };
 
 describe('Draftail', () => {
@@ -96,6 +115,44 @@ describe('Draftail', () => {
       draftail.initEditor('#test', {});
 
       expect(field.draftailEditor.props.ariaDescribedBy).toBe('test-length');
+    });
+
+    it('applies block toolbar changes without completing a source', () => {
+      document.body.innerHTML = '<input id="test" value="null" />';
+      const field = document.querySelector('#test');
+      const toolbarProps = {
+        onChange: jest.fn(),
+        onCompleteSource: jest.fn(),
+        onRequestSource: jest.fn(),
+        addHR: jest.fn(),
+      };
+      const nextState = {};
+
+      draftail.initEditor('#test', {});
+
+      const topToolbar = field.draftailEditor.props.topToolbar(toolbarProps);
+      const blockToolbar = findComponent(
+        topToolbar.props.children,
+        BlockToolbar,
+      );
+      const inlineToolbar = findComponent(
+        topToolbar.props.children,
+        InlineToolbar,
+      );
+      const commandToolbar =
+        field.draftailEditor.props.commandToolbar(toolbarProps);
+      const commandPalette = findComponent(commandToolbar, CommandPalette);
+
+      blockToolbar.props.onCompleteSource(nextState);
+
+      expect(toolbarProps.onChange).toHaveBeenCalledWith(nextState);
+      expect(toolbarProps.onCompleteSource).not.toHaveBeenCalled();
+      expect(inlineToolbar.props.onCompleteSource).toBe(
+        toolbarProps.onCompleteSource,
+      );
+      expect(commandPalette.props.onCompleteSource).toBe(
+        toolbarProps.onCompleteSource,
+      );
     });
 
     describe('selector conflicts', () => {

--- a/client/src/components/Draftail/index.test.js
+++ b/client/src/components/Draftail/index.test.js
@@ -13,6 +13,22 @@ window.comments = {
   getContentPath: jest.fn(),
 };
 
+const findComponent = (children, type) => {
+  const components = React.Children.toArray(children);
+  let component = components.find((child) => child.type === type);
+
+  if (component) {
+    return component;
+  }
+
+  components.some((child) => {
+    component = findComponent(child.props?.children, type);
+    return Boolean(component);
+  });
+
+  return component;
+};
+
 describe('Draftail', () => {
   describe('#initEditor', () => {
     beforeEach(() => {

--- a/client/src/components/Draftail/index.test.js
+++ b/client/src/components/Draftail/index.test.js
@@ -1,3 +1,6 @@
+import { BlockToolbar, InlineToolbar } from 'draftail';
+import React from 'react';
+
 import draftail, {
   Document,
   EmbedBlock,
@@ -8,6 +11,63 @@ import draftail, {
 
 window.comments = {
   getContentPath: jest.fn(),
+};
+
+const findComponent = (children, type) => {
+  const components = React.Children.toArray(children);
+  let component = components.find((child) => child.type === type);
+
+  if (component) {
+    return component;
+  }
+
+  components.some((child) => {
+    component = findComponent(child.props?.children, type);
+    return Boolean(component);
+  });
+
+  return component;
+};
+
+const getTopToolbarComponents = (
+  props = {},
+  html = '<input id="test" value="null" />',
+) => {
+  document.body.innerHTML = html;
+  const field = document.querySelector('#test');
+  const toolbarProps = {
+    onChange: jest.fn(),
+    onCompleteSource: jest.fn(),
+    onRequestSource: jest.fn(),
+    addHR: jest.fn(),
+    ...props,
+  };
+
+  draftail.initEditor('#test', {});
+
+  const topToolbar = field.draftailEditor.props.topToolbar(toolbarProps);
+  const toolbarComponents = React.Children.toArray(topToolbar.props.children);
+  const blockToolbarWrapper = toolbarComponents.find((component) =>
+    findComponent(component.props?.children, BlockToolbar),
+  );
+
+  return {
+    toolbarProps,
+    blockToolbarWrapper,
+    blockToolbar: findComponent(topToolbar.props.children, BlockToolbar),
+    inlineToolbar: findComponent(topToolbar.props.children, InlineToolbar),
+  };
+};
+
+const setWindowScroll = ({ top = 0, left = 0 }) => {
+  Object.defineProperty(window, 'scrollY', {
+    configurable: true,
+    value: top,
+  });
+  Object.defineProperty(window, 'scrollX', {
+    configurable: true,
+    value: left,
+  });
 };
 
 describe('Draftail', () => {
@@ -96,6 +156,340 @@ describe('Draftail', () => {
       draftail.initEditor('#test', {});
 
       expect(field.draftailEditor.props.ariaDescribedBy).toBe('test-length');
+    });
+
+    describe('topToolbar', () => {
+      let mockRAF;
+
+      beforeEach(() => {
+        jest.useFakeTimers();
+        mockRAF = jest
+          .spyOn(window, 'requestAnimationFrame')
+          .mockImplementation((callback) => callback());
+      });
+
+      afterEach(() => {
+        mockRAF.mockRestore();
+        window.scrollTo.mockClear();
+        setWindowScroll({});
+        jest.clearAllTimers();
+        jest.useRealTimers();
+      });
+
+      it('wraps block toolbar actions without changing inline toolbar actions', () => {
+        const {
+          toolbarProps,
+          blockToolbarWrapper,
+          blockToolbar,
+          inlineToolbar,
+        } = getTopToolbarComponents();
+
+        expect(blockToolbarWrapper.props.onMouseDownCapture).toBeDefined();
+        expect(blockToolbarWrapper.props.onKeyDownCapture).toBeDefined();
+        expect(blockToolbarWrapper.props.onFocusCapture).toBeDefined();
+        expect(blockToolbar.props.onCompleteSource).not.toBe(
+          toolbarProps.onCompleteSource,
+        );
+        expect(blockToolbar.props.addHR).not.toBe(toolbarProps.addHR);
+        expect(blockToolbar.props.onRequestSource).toBe(
+          toolbarProps.onRequestSource,
+        );
+
+        expect(inlineToolbar.props.onCompleteSource).toBe(
+          toolbarProps.onCompleteSource,
+        );
+        expect(inlineToolbar.props.addHR).toBe(toolbarProps.addHR);
+      });
+
+      it('preserves #main scroll around block type selection', () => {
+        const nextState = {};
+        const onChange = jest.fn(() => {
+          const scrollArea = document.querySelector('#main');
+          scrollArea.scrollTop = 0;
+          scrollArea.scrollLeft = 0;
+        });
+        const { blockToolbar } = getTopToolbarComponents(
+          { onChange },
+          '<main id="main"><input id="test" value="null" /></main>',
+        );
+        const scrollArea = document.querySelector('#main');
+        scrollArea.scrollTop = 600;
+        scrollArea.scrollLeft = 40;
+
+        blockToolbar.props.onCompleteSource(nextState);
+
+        expect(onChange).toHaveBeenCalledWith(nextState);
+        expect(scrollArea.scrollTop).toBe(600);
+        expect(scrollArea.scrollLeft).toBe(40);
+
+        scrollArea.scrollTop = 0;
+        scrollArea.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(scrollArea.scrollTop).toBe(600);
+        expect(scrollArea.scrollLeft).toBe(40);
+      });
+
+      it('preserves document scroll around block type selection', () => {
+        const nextState = {};
+        const onChange = jest.fn(() => {
+          document.documentElement.scrollTop = 0;
+          document.documentElement.scrollLeft = 0;
+        });
+        const { blockToolbar } = getTopToolbarComponents({
+          onChange,
+        });
+        document.documentElement.scrollTop = 600;
+        document.documentElement.scrollLeft = 40;
+
+        blockToolbar.props.onCompleteSource(nextState);
+
+        expect(onChange).toHaveBeenCalledWith(nextState);
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+
+        document.documentElement.scrollTop = 0;
+        document.documentElement.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+      });
+
+      it('preserves the scroll captured when opening the block toolbar', () => {
+        const nextState = {};
+        const onChange = jest.fn(() => {
+          document.documentElement.scrollTop = 0;
+          document.documentElement.scrollLeft = 0;
+        });
+        const { blockToolbarWrapper, blockToolbar } = getTopToolbarComponents({
+          onChange,
+        });
+        const trigger = document.createElement('button');
+        trigger.className = 'Draftail-BlockToolbar__trigger';
+
+        document.documentElement.scrollTop = 600;
+        document.documentElement.scrollLeft = 40;
+        blockToolbarWrapper.props.onMouseDownCapture({
+          target: trigger,
+          preventDefault: jest.fn(),
+        });
+
+        document.documentElement.scrollTop = 25;
+        document.documentElement.scrollLeft = 5;
+
+        blockToolbar.props.onCompleteSource(nextState);
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+
+        document.documentElement.scrollTop = 0;
+        document.documentElement.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+      });
+
+      it('keeps the opening scroll when combobox focus happens after a jump', () => {
+        const nextState = {};
+        const onChange = jest.fn(() => {
+          document.documentElement.scrollTop = 0;
+          document.documentElement.scrollLeft = 0;
+        });
+        const { blockToolbarWrapper, blockToolbar } = getTopToolbarComponents({
+          onChange,
+        });
+        const trigger = document.createElement('button');
+        trigger.className = 'Draftail-BlockToolbar__trigger';
+        const input = document.createElement('input');
+        input.setAttribute('role', 'combobox');
+
+        document.documentElement.scrollTop = 600;
+        document.documentElement.scrollLeft = 40;
+        blockToolbarWrapper.props.onMouseDownCapture({
+          target: trigger,
+          preventDefault: jest.fn(),
+        });
+
+        document.documentElement.scrollTop = 0;
+        document.documentElement.scrollLeft = 0;
+        blockToolbarWrapper.props.onFocusCapture({ target: input });
+
+        document.documentElement.scrollTop = 25;
+        document.documentElement.scrollLeft = 5;
+
+        blockToolbar.props.onCompleteSource(nextState);
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+      });
+
+      it('preserves window scroll around block type selection', () => {
+        const nextState = {};
+        const onChange = jest.fn();
+        const { blockToolbar } = getTopToolbarComponents({
+          onChange,
+        });
+        setWindowScroll({ top: 600, left: 40 });
+
+        blockToolbar.props.onCompleteSource(nextState);
+
+        expect(onChange).toHaveBeenCalledWith(nextState);
+        expect(window.scrollTo).toHaveBeenCalledWith(40, 600);
+
+        window.scrollTo.mockClear();
+        jest.runOnlyPendingTimers();
+
+        expect(window.scrollTo).toHaveBeenLastCalledWith(40, 600);
+      });
+
+      it('does not call Draftail source completion for block type selection', () => {
+        const nextState = {};
+        const { toolbarProps, blockToolbar } = getTopToolbarComponents();
+
+        blockToolbar.props.onCompleteSource(nextState);
+
+        expect(toolbarProps.onCompleteSource).not.toHaveBeenCalled();
+        expect(toolbarProps.onChange).toHaveBeenCalledWith(nextState);
+      });
+
+      it('preserves #main scroll around horizontal rule insertion', () => {
+        const addHR = jest.fn(() => {
+          const scrollArea = document.querySelector('#main');
+          scrollArea.scrollTop = 0;
+          scrollArea.scrollLeft = 0;
+        });
+        const { blockToolbar } = getTopToolbarComponents(
+          { addHR },
+          '<main id="main"><input id="test" value="null" /></main>',
+        );
+        const scrollArea = document.querySelector('#main');
+        scrollArea.scrollTop = 600;
+        scrollArea.scrollLeft = 40;
+
+        blockToolbar.props.addHR();
+
+        expect(addHR).toHaveBeenCalledTimes(1);
+        expect(scrollArea.scrollTop).toBe(600);
+        expect(scrollArea.scrollLeft).toBe(40);
+
+        scrollArea.scrollTop = 0;
+        scrollArea.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(scrollArea.scrollTop).toBe(600);
+        expect(scrollArea.scrollLeft).toBe(40);
+      });
+
+      it('preserves the scroll captured when opening before horizontal rule insertion', () => {
+        const addHR = jest.fn(() => {
+          document.documentElement.scrollTop = 0;
+          document.documentElement.scrollLeft = 0;
+        });
+        const { blockToolbarWrapper, blockToolbar } = getTopToolbarComponents({
+          addHR,
+        });
+        const trigger = document.createElement('button');
+        trigger.className = 'Draftail-BlockToolbar__trigger';
+
+        document.documentElement.scrollTop = 600;
+        document.documentElement.scrollLeft = 40;
+        blockToolbarWrapper.props.onMouseDownCapture({
+          target: trigger,
+          preventDefault: jest.fn(),
+        });
+
+        document.documentElement.scrollTop = 25;
+        document.documentElement.scrollLeft = 5;
+
+        blockToolbar.props.addHR();
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+
+        document.documentElement.scrollTop = 0;
+        document.documentElement.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+      });
+
+      it('preserves document scroll when opening the block toolbar', () => {
+        const { blockToolbarWrapper } = getTopToolbarComponents();
+        const trigger = document.createElement('button');
+        trigger.className = 'Draftail-BlockToolbar__trigger';
+        const preventDefault = jest.fn();
+        document.documentElement.scrollTop = 600;
+        document.documentElement.scrollLeft = 40;
+
+        blockToolbarWrapper.props.onMouseDownCapture({
+          target: trigger,
+          preventDefault,
+        });
+
+        expect(preventDefault).toHaveBeenCalledTimes(1);
+        document.documentElement.scrollTop = 0;
+        document.documentElement.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+      });
+
+      it('does not preserve scroll for other block toolbar clicks', () => {
+        const { blockToolbarWrapper } = getTopToolbarComponents();
+        const option = document.createElement('button');
+        const preventDefault = jest.fn();
+        document.documentElement.scrollTop = 600;
+
+        blockToolbarWrapper.props.onMouseDownCapture({
+          target: option,
+          preventDefault,
+        });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+        document.documentElement.scrollTop = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(document.documentElement.scrollTop).toBe(0);
+      });
+
+      it('preserves scroll when the block toolbar combobox receives focus', () => {
+        const { blockToolbarWrapper } = getTopToolbarComponents();
+        const input = document.createElement('input');
+        input.setAttribute('role', 'combobox');
+        document.documentElement.scrollTop = 600;
+        document.documentElement.scrollLeft = 40;
+
+        blockToolbarWrapper.props.onFocusCapture({ target: input });
+
+        document.documentElement.scrollTop = 0;
+        document.documentElement.scrollLeft = 0;
+        jest.runOnlyPendingTimers();
+
+        expect(document.documentElement.scrollTop).toBe(600);
+        expect(document.documentElement.scrollLeft).toBe(40);
+      });
+
+      it('runs block toolbar actions without #main', () => {
+        const nextState = {};
+        const onChange = jest.fn();
+        const addHR = jest.fn();
+        const { blockToolbar } = getTopToolbarComponents({
+          onChange,
+          addHR,
+        });
+
+        expect(() =>
+          blockToolbar.props.onCompleteSource(nextState),
+        ).not.toThrow();
+        expect(() => blockToolbar.props.addHR()).not.toThrow();
+
+        expect(onChange).toHaveBeenCalledWith(nextState);
+        expect(addHR).toHaveBeenCalledTimes(1);
+      });
     });
 
     describe('selector conflicts', () => {

--- a/client/src/components/Draftail/index.test.js
+++ b/client/src/components/Draftail/index.test.js
@@ -221,13 +221,6 @@ describe('Draftail', () => {
         expect(onChange).toHaveBeenCalledWith(nextState);
         expect(scrollArea.scrollTop).toBe(600);
         expect(scrollArea.scrollLeft).toBe(40);
-
-        scrollArea.scrollTop = 0;
-        scrollArea.scrollLeft = 0;
-        jest.runOnlyPendingTimers();
-
-        expect(scrollArea.scrollTop).toBe(600);
-        expect(scrollArea.scrollLeft).toBe(40);
       });
 
       it('preserves document scroll around block type selection', () => {
@@ -245,13 +238,6 @@ describe('Draftail', () => {
         blockToolbar.props.onCompleteSource(nextState);
 
         expect(onChange).toHaveBeenCalledWith(nextState);
-        expect(document.documentElement.scrollTop).toBe(600);
-        expect(document.documentElement.scrollLeft).toBe(40);
-
-        document.documentElement.scrollTop = 0;
-        document.documentElement.scrollLeft = 0;
-        jest.runOnlyPendingTimers();
-
         expect(document.documentElement.scrollTop).toBe(600);
         expect(document.documentElement.scrollLeft).toBe(40);
       });
@@ -279,13 +265,6 @@ describe('Draftail', () => {
         document.documentElement.scrollLeft = 5;
 
         blockToolbar.props.onCompleteSource(nextState);
-
-        expect(document.documentElement.scrollTop).toBe(600);
-        expect(document.documentElement.scrollLeft).toBe(40);
-
-        document.documentElement.scrollTop = 0;
-        document.documentElement.scrollLeft = 0;
-        jest.runOnlyPendingTimers();
 
         expect(document.documentElement.scrollTop).toBe(600);
         expect(document.documentElement.scrollLeft).toBe(40);
@@ -337,11 +316,6 @@ describe('Draftail', () => {
 
         expect(onChange).toHaveBeenCalledWith(nextState);
         expect(window.scrollTo).toHaveBeenCalledWith(40, 600);
-
-        window.scrollTo.mockClear();
-        jest.runOnlyPendingTimers();
-
-        expect(window.scrollTo).toHaveBeenLastCalledWith(40, 600);
       });
 
       it('does not call Draftail source completion for block type selection', () => {
@@ -373,13 +347,6 @@ describe('Draftail', () => {
         expect(addHR).toHaveBeenCalledTimes(1);
         expect(scrollArea.scrollTop).toBe(600);
         expect(scrollArea.scrollLeft).toBe(40);
-
-        scrollArea.scrollTop = 0;
-        scrollArea.scrollLeft = 0;
-        jest.runOnlyPendingTimers();
-
-        expect(scrollArea.scrollTop).toBe(600);
-        expect(scrollArea.scrollLeft).toBe(40);
       });
 
       it('preserves the scroll captured when opening before horizontal rule insertion', () => {
@@ -407,13 +374,6 @@ describe('Draftail', () => {
 
         expect(document.documentElement.scrollTop).toBe(600);
         expect(document.documentElement.scrollLeft).toBe(40);
-
-        document.documentElement.scrollTop = 0;
-        document.documentElement.scrollLeft = 0;
-        jest.runOnlyPendingTimers();
-
-        expect(document.documentElement.scrollTop).toBe(600);
-        expect(document.documentElement.scrollLeft).toBe(40);
       });
 
       it('preserves document scroll when opening the block toolbar', () => {
@@ -430,10 +390,6 @@ describe('Draftail', () => {
         });
 
         expect(preventDefault).toHaveBeenCalledTimes(1);
-        document.documentElement.scrollTop = 0;
-        document.documentElement.scrollLeft = 0;
-        jest.runOnlyPendingTimers();
-
         expect(document.documentElement.scrollTop).toBe(600);
         expect(document.documentElement.scrollLeft).toBe(40);
       });
@@ -464,10 +420,6 @@ describe('Draftail', () => {
         document.documentElement.scrollLeft = 40;
 
         blockToolbarWrapper.props.onFocusCapture({ target: input });
-
-        document.documentElement.scrollTop = 0;
-        document.documentElement.scrollLeft = 0;
-        jest.runOnlyPendingTimers();
 
         expect(document.documentElement.scrollTop).toBe(600);
         expect(document.documentElement.scrollLeft).toBe(40);


### PR DESCRIPTION
Fixes #14245 

## Description

This fixes a **Chrome-specific scroll reset** in the Wagtail admin rich text editor when applying block styles from Draftail’s block toolbar.

The issue happens during the block toolbar flow. When the user opens the `+` block toolbar and interacts with the combobox, **Chrome can move focus and reset the Wagtail admin scroll position before the selected block-style action finishes**. This causes the admin page to jump unexpectedly.

This change preserves the Wagtail admin scroll position only during block-toolbar interactions. The **scroll position is captured when the block toolbar is opened, restored during the toolbar focus/update cycl**e, and reused when the block-toolbar action completes.

## What changed

- **Captures the current Wagtail admin scroll positio**n when the Draftail block toolbar trigger is activated.
- **Restores** the captured scroll position during block-toolbar mouse, keyboard, and focus interactions.
- Reuses the stored scroll position when a block-toolbar action completes.
- Applies scroll preservation to block-style selection.
- Applies scroll preservation to horizontal rule insertion.
- **Clears the stored scroll state** when there is no completed toolbar action.
- Keeps the change scoped to block-toolbar actions only.

## What is intentionally unchanged

This change does not affect:

- InlineToolbar behavior
- inline style actions
- chooser or modal flows such as link, image, document, and embed
- non-block-toolbar Draftail interactions

## Implementation notes

The **scroll state is stored in a ref** so it can be captured during the initial block-toolbar interaction and reused later when the toolbar action completes.

The stored **scroll state is consumed after use to avoid accidentally reusing** an old scroll position for a later unrelated action.

The scroll restoration is intentionally limited to the minimum timing needed to fix the issue:

```js
restore();
requestAnimationFrame(restore);
```

This restores the scroll immediately after the action and once again before the browser paints the next frame, without using delayed restores that could interfere with user scrolling.

## Testing

Regression tests have been added for:

- opening the block toolbar trigger without resetting the admin scroll position
- focusing the block toolbar combobox without resetting the admin scroll position
- applying a block style without resetting the admin scroll position
- preserving the scroll position captured when the block toolbar was opened
- inserting a horizontal rule without resetting the admin scroll position
- keeping inline toolbar behavior unchanged
- running block toolbar actions when `#main` is not present

Verified with:

```text
npx jest client/src/components/Draftail/index.test.js --runInBand
npx eslint client/src/components/Draftail/index.js client/src/components/Draftail/index.test.js
```
Manual testing in Chrome:

1. Open a Wagtail page with a Draftail rich text editor.
2. Scroll the admin page down.
3. Open the Draftail block toolbar using the `+` trigger.
4. Select a block style.
5. Confirm the admin page does not jump to the top.
6. Repeat with horizontal rule insertion.
7. Confirm InlineToolbar actions still behave normally.
8. Confirm chooser and modal flows such as link, image, document, and embed still behave normally.

## Review focus

Please review the block toolbar flow in `client/src/components/Draftail/index.js`, especially:

- capturing scroll state when the block toolbar `+` trigger is activated
- preserving scroll when the block toolbar combobox receives focus
- consuming the stored scroll state when a block-toolbar action completes
- applying scroll preservation to block-style selection and horizontal rule insertion
- confirming the change is scoped only to block-toolbar actions
- confirming InlineToolbar and chooser/modal flows are unaffected

## AI usage

This pull request includes code written with the assistance of AI.

AI assistance was used to:

- **investigate the Draftail block** toolbar focus and scroll behavior
- understand the existing Draftail toolbar flow
- **implement the scroll preservation approach**
- add and update **regression tests**

The **generated code has been manually reviewed and understood by the author  before submission.**