### PR TITLE
Add CI job for testing with latest versions of all dependencies

### DIFF
--- a/.github/latest-deps-overrides.txt
+++ b/.github/latest-deps-overrides.txt
@@ -1,0 +1,40 @@
+# Overrides for the latest-deps CI workflow.
+#
+# Lists dependencies that have an upper version bound in pyproject.toml,
+# with their upper bound removed. To be used in CI via `uv --override`,
+# to be an early warning when a future version of one of these packages
+# breaks Wagtail. When adding an upper bound to pyproject.toml, add the
+# package name here too.
+
+# Runtime dependencies ([project.dependencies])
+django-modelcluster
+django-permissionedforms
+django-taggit
+django-treebeard
+djangorestframework
+draftjs_exporter
+beautifulsoup4
+Willow[heif]
+requests
+openpyxl
+telepath
+laces
+django-tasks
+modelsearch
+
+# Testing dependencies ([project.optional-dependencies.testing])
+# Linter exact pins (ruff, doc8, semgrep, curlylint, djhtml) are
+# intentionally omitted, as they should be handled separately.
+Jinja2
+boto3
+azure-mgmt-cdn
+azure-mgmt-frontdoor
+responses
+polib
+tblib
+
+# Documentation dependencies ([project.optional-dependencies.docs])
+pyenchant
+sphinxcontrib-spelling
+sphinx-wagtail-theme
+myst_parser

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -1,0 +1,92 @@
+name: Test against latest dependencies
+
+# Resolves Wagtail's dependencies with the upper bounds stripped via
+# .github/latest-deps-overrides.txt, then runs the test suite and builds
+# the docs. This acts as an early warning when a future major version of
+# a capped dependency breaks Wagtail. Failures here are informational,
+# not release-blocking — they mean someone should investigate whether to
+# lift a cap, add compatibility code, or pin tighter.
+
+# Pre-releases are enabled so we catch breakage in release candidates before
+# they ship as stable.
+
+on:
+  schedule:
+    # Mondays at 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Latest dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          allow-prereleases: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Install Wagtail with overrides applied
+        run: |
+          uv pip install --system \
+            --overrides .github/latest-deps-overrides.txt \
+            --prerelease=allow \
+            --upgrade \
+            -e '.[testing,docs]'
+
+      - name: Summarize installed versions
+        run: |
+          # Full list to workflow logs for debugging.
+          uv pip list --system
+
+          # Focused summary in the GitHub Actions UI: a table of the
+          # capped (overridden) deps and the versions the resolver
+          # picked. If a resolved version is past the cap in
+          # pyproject.toml, the cap may be safe to lift.
+          {
+            echo '## Resolved versions of capped dependencies'
+            echo ''
+            echo 'Overridden in `.github/latest-deps-overrides.txt`. Compare these against the upper bounds in `pyproject.toml` to decide whether a range can be widened.'
+            echo ''
+            echo '| Package | Resolved version |'
+            echo '| --- | --- |'
+            grep -v '^#' .github/latest-deps-overrides.txt \
+              | grep -v '^[[:space:]]*$' \
+              | sed 's/\[.*\]//' \
+              | while read -r pkg; do
+                  version=$(uv pip show --system "$pkg" 2>/dev/null | awk '/^Version:/ {print $2}')
+                  echo "| \`$pkg\` | ${version:-not installed} |"
+                done
+            echo ''
+            echo '<details><summary>Full installed package list</summary>'
+            echo ''
+            echo '```'
+            uv pip list --system
+            echo '```'
+            echo ''
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run Django system checks
+        run: |
+          DJANGO_SETTINGS_MODULE=wagtail.test.settings django-admin check
+
+      - name: Run tests
+        run: |
+          python runtests.py --parallel
+
+      - name: Build docs
+        run: |
+          make -C docs html

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -48,27 +48,21 @@ jobs:
 
       - name: Summarize installed versions
         run: |
+          # `packaging` is used by the summary script to parse pyproject.toml
+          # constraints. It's transitively available already, but installing
+          # explicitly keeps the dependency visible.
+          uv pip install --system packaging
+
           # Full list to workflow logs for debugging.
           uv pip list --system
 
-          # Focused summary in the GitHub Actions UI: a table of the
-          # capped (overridden) deps and the versions the resolver
-          # picked. If a resolved version is past the cap in
-          # pyproject.toml, the cap may be safe to lift.
+          # Markdown summary for the GitHub Actions UI. Packages that
+          # resolved past their cap in pyproject.toml are shown first;
+          # the rest go into a collapsed details block.
+          python3 scripts/latest-deps-summary.py >> "$GITHUB_STEP_SUMMARY"
+
+          # Full installed package list, collapsed.
           {
-            echo '## Resolved versions of capped dependencies'
-            echo ''
-            echo 'Overridden in `.github/latest-deps-overrides.txt`. Compare these against the upper bounds in `pyproject.toml` to decide whether a range can be widened.'
-            echo ''
-            echo '| Package | Resolved version |'
-            echo '| --- | --- |'
-            grep -v '^#' .github/latest-deps-overrides.txt \
-              | grep -v '^[[:space:]]*$' \
-              | sed 's/\[.*\]//' \
-              | while read -r pkg; do
-                  version=$(uv pip show --system "$pkg" 2>/dev/null | awk '/^Version:/ {print $2}')
-                  echo "| \`$pkg\` | ${version:-not installed} |"
-                done
             echo ''
             echo '<details><summary>Full installed package list</summary>'
             echo ''

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -13,7 +13,7 @@ name: Test against latest dependencies
 on:
   schedule:
     # Mondays at 06:00 UTC
-    - cron: '0 6 * * 1'
+    - cron: '39 5 * * 1,3'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -84,3 +84,14 @@ jobs:
       - name: Build docs
         run: |
           make -C docs html
+
+      - name: Notify Slack on failure
+        if: ${{ failure() && env.SLACK_WEBHOOK_URL != '' }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEPENDENCY_DASHBOARD_WEBHOOK_URL }}
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "Tests with latest versions of all dependencies failed.\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -76,6 +76,7 @@ Changelog
  * Add `routablefullpageurl` template tag (Pravin Kamble)
  * Add support for customizing page explorer views per page type using `PageViewSet` (Sage Abdullah)
  * Enhance page content type usage view with custom listings and ability to create new pages (Sage Abdullah)
+ * Add CI job for testing with latest versions of all dependencies (Sage Abdullah)
  * Fix: CVE-2026-44197: Improper permission handling when comparing revisions (Seoyoung Kang, Jake Howard)
  * Fix: CVE-2026-44198: Improper permission handling when viewing page history (Seoyoung Kang, Jake Howard, Dan Braghis)
  * Fix: CVE-2026-44199: Improper permission handling when deleting form submissions (Vishal Shukla, Jake Howard)

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -44,6 +44,7 @@ depth: 1
  * Use uv with lockfile in CI configurations (Sage Abdullah)
  * Add `one` and `not` match support to `RulesController` (LB (Ben Johnston))
  * Refactor pages' function-based views to class-based views (Sage Abdullah)
+ * Add CI job for testing with latest versions of all dependencies (Sage Abdullah)
 
 ## Upgrade considerations - removal of deprecated features from Wagtail 6.4 - 7.3
 

--- a/scripts/latest-deps-summary.py
+++ b/scripts/latest-deps-summary.py
@@ -60,7 +60,7 @@ if exceeded:
     print()
     print(
         "These packages resolved to a version outside their bound in "
-        "`pyproject.toml`. If this run is green, the cap may be safe to lift."
+        "`pyproject.toml`. If this run is green, the cap may be safe to extend."
     )
     print()
     print("| Package | Cap | Resolved |")

--- a/scripts/latest-deps-summary.py
+++ b/scripts/latest-deps-summary.py
@@ -1,0 +1,85 @@
+"""Build the GitHub Actions job summary for the latest-deps CI workflow.
+
+For each package listed in .github/latest-deps-overrides.txt, look up the
+constraint declared in pyproject.toml and the version installed in the current
+environment. Packages that resolved to a version outside their cap are shown
+prominently — they are the actionable signal that the cap may be safe to lift.
+The rest are folded into a collapsed details block.
+
+Markdown output goes to stdout, to be appended to $GITHUB_STEP_SUMMARY.
+"""
+
+# ruff: noqa: T201
+
+from importlib.metadata import PackageNotFoundError, version
+
+import tomllib
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+
+with open(".github/latest-deps-overrides.txt") as f:
+    overridden = set()
+    for raw in f:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        overridden.add(canonicalize_name(Requirement(line).name))
+
+with open("pyproject.toml", "rb") as f:
+    data = tomllib.load(f)
+
+deps = list(data["project"].get("dependencies", []))
+for extra_deps in data["project"].get("optional-dependencies", {}).values():
+    deps.extend(extra_deps)
+
+caps = {}
+for dep_str in deps:
+    req = Requirement(dep_str)
+    if canonicalize_name(req.name) in overridden:
+        caps[canonicalize_name(req.name)] = req
+
+exceeded = []
+within = []
+for canonical in sorted(overridden):
+    req = caps.get(canonical)
+    if req is None:
+        continue
+    try:
+        resolved = Version(version(req.name))
+    except PackageNotFoundError:
+        continue
+    row = (req.name, str(req.specifier), str(resolved))
+    if req.specifier.contains(resolved, prereleases=True):
+        within.append(row)
+    else:
+        exceeded.append(row)
+
+if exceeded:
+    print("## Resolved past the cap")
+    print()
+    print(
+        "These packages resolved to a version outside their bound in "
+        "`pyproject.toml`. If this run is green, the cap may be safe to lift."
+    )
+    print()
+    print("| Package | Cap | Resolved |")
+    print("| --- | --- | --- |")
+    for name, cap, resolved in exceeded:
+        print(f"| `{name}` | `{cap}` | **`{resolved}`** |")
+    print()
+else:
+    print("## Resolved versions of capped dependencies")
+    print()
+    print("No overridden package resolved past its cap this run.")
+    print()
+
+if within:
+    print("<details><summary>Resolved within the existing cap</summary>")
+    print()
+    print("| Package | Cap | Resolved |")
+    print("| --- | --- | --- |")
+    for name, cap, resolved in within:
+        print(f"| `{name}` | `{cap}` | `{resolved}` |")
+    print()
+    print("</details>")


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Work towards #12897, built on #14252

### Description

<!-- Please describe the problem you're fixing. -->
This adds a new CI job that runs the tests (only on SQLite) every Monday at 6AM UTC with the upper boundaries on our dependencies removed. When the job is finished, the summary on GitHub will show the installed packages, with a dedicated table for packages that resolved beyond our boundaries.

An example result of the job can be seen at my fork: https://github.com/laymonage/wagtail/actions/runs/26457260417

It's failing at the moment, but it will likely be fixed by #13953.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Claude Code with Claude Opus 4.7 and xhigh thinking effort.

Changes were reviewed by me through chats with Claude, as well as manual review and testing.