### PR TITLE
Drop AGENTS.md from packaged data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,6 @@ include = ["wagtail*"]
 
 [tool.setuptools.data-files]
 "." = [
-  "AGENTS.md",
   "CHANGELOG.txt",
   "CODE_OF_CONDUCT.md",
   "CONTRIBUTORS.md",


### PR DESCRIPTION
### Description

IMHO, AGENTS.md is purely for dev purposes and should be in the packaged release


### AI usage

This PR was lovingly handcrafted
