### PR TITLE
Create a registry for permission policies

### DIFF
--- a/wagtail/actions/publish_revision.py
+++ b/wagtail/actions/publish_revision.py
@@ -8,7 +8,6 @@ from django.core.exceptions import PermissionDenied
 from django.utils import timezone
 
 from wagtail.log_actions import log
-from wagtail.permission_policies.base import ModelPermissionPolicy
 from wagtail.signals import published
 from wagtail.utils.timestamps import ensure_utc
 
@@ -49,9 +48,11 @@ class PublishRevisionAction:
         log_action: bool = True,
         previous_revision: Revision | None = None,
     ):
+        from wagtail.permissions import policies_registry
+
         self.revision = revision
         self.object = self.revision.as_object()
-        self.permission_policy = ModelPermissionPolicy(type(self.object))
+        self.permission_policy = policies_registry.get(self.object)
         self.user = user
         self.changed = changed
         self.log_action = log_action

--- a/wagtail/admin/api/filters.py
+++ b/wagtail/admin/api/filters.py
@@ -2,7 +2,8 @@ from rest_framework.filters import BaseFilterBackend
 
 from wagtail import hooks
 from wagtail.api.v2.utils import BadRequestError, parse_boolean
-from wagtail.permissions import page_permission_policy
+from wagtail.models import Page
+from wagtail.permissions import policies_registry
 
 
 class HasChildrenFilter(BaseFilterBackend):
@@ -39,7 +40,8 @@ class ForExplorerFilter(BaseFilterBackend):
                 queryset = hook(parent_page, queryset, request)
 
             queryset = (
-                page_permission_policy.explorable_instances(request.user) & queryset
+                policies_registry.get_by_type(Page).explorable_instances(request.user)
+                & queryset
             )
 
         return queryset

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -9,7 +9,8 @@ from django.utils.translation import gettext as _
 from wagtail.admin import messages
 from wagtail.admin.localization import get_localized_response
 from wagtail.log_actions import LogContext
-from wagtail.permissions import page_permission_policy
+from wagtail.models import Page
+from wagtail.permissions import policies_registry
 
 
 def permission_denied(request):
@@ -104,7 +105,7 @@ def user_has_any_page_permission(user):
     Check if a user has any permission to add, edit, or otherwise manage any
     page.
     """
-    return page_permission_policy.user_has_any_permission(
+    return policies_registry.get_by_type(Page).user_has_any_permission(
         user, {"add", "change", "publish", "bulk_delete", "lock", "unlock"}
     )
 

--- a/wagtail/admin/forms/account.py
+++ b/wagtail/admin/forms/account.py
@@ -15,7 +15,8 @@ from wagtail.admin.localization import (
     get_available_admin_time_zones,
 )
 from wagtail.admin.widgets import SwitchInput
-from wagtail.permissions import page_permission_policy
+from wagtail.models import Page
+from wagtail.permissions import policies_registry
 from wagtail.users.models import UserProfile
 
 User = get_user_model()
@@ -25,7 +26,7 @@ class NotificationPreferencesForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        permission_policy = page_permission_policy
+        permission_policy = policies_registry.get_by_type(Page)
         if not permission_policy.user_has_permission(self.instance.user, "publish"):
             del self.fields["submitted_notifications"]
         if not permission_policy.user_has_permission(self.instance.user, "change"):

--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -5,7 +5,7 @@ from django.utils.translation import ngettext
 
 from wagtail.admin import widgets
 from wagtail.models import Page, PageViewRestriction
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 from .models import WagtailAdminModelForm
 from .view_restrictions import BaseViewRestrictionForm
@@ -16,7 +16,9 @@ class CopyForm(forms.Form):
         # CopyPage must be passed a 'page' kwarg indicating the page to be copied
         self.page = kwargs.pop("page")
         self.user = kwargs.pop("user")
-        can_publish = page_permission_policy.user_has_permission(self.user, "publish")
+        can_publish = policies_registry.get_by_type(Page).user_has_permission(
+            self.user, "publish"
+        )
 
         super().__init__(*args, **kwargs)
         self.fields["new_title"] = forms.CharField(

--- a/wagtail/admin/navigation.py
+++ b/wagtail/admin/navigation.py
@@ -1,10 +1,11 @@
 from django.conf import settings
 
-from wagtail.permissions import page_permission_policy
+from wagtail.models import Page
+from wagtail.permissions import policies_registry
 
 
 def get_site_for_user(user):
-    root_page = page_permission_policy.explorable_root_instance(user)
+    root_page = policies_registry.get_by_type(Page).explorable_root_instance(user)
     if root_page:
         root_site = root_page.get_site()
     else:

--- a/wagtail/admin/tests/test_editing_sessions.py
+++ b/wagtail/admin/tests/test_editing_sessions.py
@@ -11,6 +11,7 @@ from freezegun import freeze_time
 
 from wagtail.admin.models import EditingSession
 from wagtail.models import GroupPagePermission, Page, Workflow, WorkflowContentType
+from wagtail.models.pages import PageLogEntry
 from wagtail.test.testapp.models import (
     Advert,
     AdvertWithCustomPrimaryKey,
@@ -115,17 +116,19 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_ping_non_page_non_snippet_model(self):
-        editors = Group.objects.get(name="Editors")
+        # PageLogEntry is not a model that has a permissions policy, so we
+        # cannot check permissions for editing it, thus cannot ping it either
+        log_entry = PageLogEntry.objects.first()
         session = EditingSession.objects.create(
             user=self.user,
-            content_type=ContentType.objects.get_for_model(Group),
-            object_id=editors.pk,
+            content_type=ContentType.objects.get_for_model(PageLogEntry),
+            object_id=log_entry.pk,
             last_seen_at=TIMESTAMP_1,
         )
         response = self.client.post(
             reverse(
                 "wagtailadmin_editing_sessions:ping",
-                args=("auth", "group", str(editors.pk), session.id),
+                args=("wagtailcore", "pagelogentry", str(log_entry.pk), session.id),
             )
         )
         self.assertEqual(response.status_code, 404)

--- a/wagtail/admin/views/collection_privacy.py
+++ b/wagtail/admin/views/collection_privacy.py
@@ -5,12 +5,14 @@ from django.urls import reverse
 from wagtail.admin.forms.collections import CollectionViewRestrictionForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.models import Collection, CollectionViewRestriction
-from wagtail.permissions import collection_permission_policy
+from wagtail.permissions import policies_registry
 
 
 def set_privacy(request, collection_id):
     collection = get_object_or_404(Collection, id=collection_id)
-    if not collection_permission_policy.user_has_permission(request.user, "change"):
+    if not policies_registry.get_by_type(Collection).user_has_permission(
+        request.user, "change"
+    ):
         raise PermissionDenied
 
     # fetch restriction records in depth order so that ancestors appear first

--- a/wagtail/admin/views/collections.py
+++ b/wagtail/admin/views/collections.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy
 
 from wagtail import hooks
@@ -8,11 +9,10 @@ from wagtail.admin.forms.collections import CollectionForm
 from wagtail.admin.ui.tables import TitleColumn
 from wagtail.admin.views.generic import CreateView, DeleteView, EditView, IndexView
 from wagtail.models import Collection
-from wagtail.permissions import collection_permission_policy
+from wagtail.permissions import policies_registry
 
 
 class Index(IndexView):
-    permission_policy = collection_permission_policy
     model = Collection
     context_object_name = "collections"
     results_template_name = "wagtailadmin/collections/index_results.html"
@@ -31,6 +31,10 @@ class Index(IndexView):
         )
     ]
 
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
+
     def get_queryset(self):
         return self.permission_policy.instances_user_has_any_permission_for(
             self.request.user, ["add", "change", "delete"]
@@ -41,7 +45,6 @@ class Index(IndexView):
 
 
 class Create(CreateView):
-    permission_policy = collection_permission_policy
     model = Collection
     form_class = CollectionForm
     page_title = gettext_lazy("Add collection")
@@ -50,6 +53,10 @@ class Create(CreateView):
     edit_url_name = "wagtailadmin_collections:edit"
     index_url_name = "wagtailadmin_collections:index"
     header_icon = "folder-open-1"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_form(self, form_class=None):
         form = super().get_form(form_class)
@@ -68,7 +75,6 @@ class Create(CreateView):
 
 
 class Edit(EditView):
-    permission_policy = collection_permission_policy
     model = Collection
     form_class = CollectionForm
     template_name = "wagtailadmin/collections/edit.html"
@@ -79,6 +85,10 @@ class Edit(EditView):
     delete_url_name = "wagtailadmin_collections:delete"
     context_object_name = "collection"
     header_icon = "folder-open-1"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def _user_may_move_collection(self, user, instance):
         """
@@ -136,7 +146,6 @@ class Edit(EditView):
 
 
 class Delete(DeleteView):
-    permission_policy = collection_permission_policy
     model = Collection
     success_message = gettext_lazy("Collection '%(object)s' deleted.")
     index_url_name = "wagtailadmin_collections:index"
@@ -147,6 +156,10 @@ class Delete(DeleteView):
         "Are you sure you want to delete this collection?"
     )
     header_icon = "folder-open-1"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_queryset(self):
         return self.permission_policy.instances_user_has_permission_for(

--- a/wagtail/admin/views/editing_sessions.py
+++ b/wagtail/admin/views/editing_sessions.py
@@ -14,6 +14,7 @@ from wagtail.admin.models import EditingSession
 from wagtail.admin.ui.editing_sessions import EditingSessionsList
 from wagtail.admin.utils import get_user_display_name
 from wagtail.models import Page, Revision, RevisionMixin, WorkflowMixin
+from wagtail.permissions import policies_registry
 
 
 @require_POST
@@ -31,11 +32,9 @@ def ping(request, app_label, model_name, object_id, session_id):
     if isinstance(obj, Page):
         can_edit = obj.permissions_for_user(request.user).can_edit()
     else:
-        try:
-            permission_policy = model.snippet_viewset.permission_policy
-        except AttributeError as e:
-            # model is neither a Page nor a snippet
-            raise Http404 from e
+        if not (permission_policy := policies_registry.get_by_type(model)):
+            # Model likely was not registered with Wagtail
+            raise Http404
 
         can_edit = permission_policy.user_has_permission_for_instance(
             request.user, "change", obj

--- a/wagtail/admin/views/generic/multiple_upload.py
+++ b/wagtail/admin/views/generic/multiple_upload.py
@@ -7,16 +7,18 @@ from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.functional import cached_property
 from django.views.decorators.vary import vary_on_headers
 from django.views.generic.base import TemplateView, View
 
 from wagtail.admin.views.generic import PermissionCheckedMixin
 from wagtail.models import UploadedFile
+from wagtail.permissions import policies_registry
 
 
 class AddView(PermissionCheckedMixin, TemplateView):
     # subclasses need to provide:
-    # - permission_policy
+    # - permission_policy (if one does not exist in the registry for the model)
     # - template_name
 
     # - edit_object_url_name
@@ -43,6 +45,10 @@ class AddView(PermissionCheckedMixin, TemplateView):
         self.model = self.get_model()
 
         return super().dispatch(request)
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def save_object(self, form):
         return form.save()
@@ -210,6 +216,10 @@ class EditView(View):
     http_method_names = ["post"]
     edit_form_template_name = "wagtailadmin/generic/multiple_upload/edit_form.html"
 
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
+
     def save_object(self, form):
         form.save()
 
@@ -272,6 +282,10 @@ class DeleteView(View):
     # - context_object_id_name
 
     http_method_names = ["post"]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def post(self, request, *args, **kwargs):
         object_id = kwargs[self.pk_url_kwarg]

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -8,6 +8,7 @@ from django.db.models import Exists, IntegerField, Max, OuterRef, Q
 from django.db.models.functions import Cast
 from django.forms import Media
 from django.http import Http404, HttpResponse
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import TemplateView
 
@@ -26,7 +27,7 @@ from wagtail.models import (
     WorkflowState,
     get_default_page_content_type,
 )
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 User = get_user_model()
 
@@ -236,6 +237,7 @@ class LockedPagesPanel(Component):
     def get_context_data(self, parent_context):
         request = parent_context["request"]
         context = super().get_context_data(parent_context)
+        permissions_policy = policies_registry.get_by_type(Page)
         context.update(
             {
                 "locked_pages": Page.objects.filter(
@@ -244,7 +246,7 @@ class LockedPagesPanel(Component):
                 )
                 .order_by("-locked_at", "-latest_revision_created_at", "-pk")
                 .specific(defer=True),
-                "can_remove_locks": page_permission_policy.user_has_permission(
+                "can_remove_locks": permissions_policy.user_has_permission(
                     request.user, "unlock"
                 ),
                 "request": request,
@@ -295,7 +297,10 @@ class RecentEditsPanel(Component):
 class HomeView(WagtailAdminTemplateMixin, TemplateView):
     template_name = "wagtailadmin/home.html"
     page_title = _("Dashboard")
-    permission_policy = page_permission_policy
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Page)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/wagtail/admin/views/pages/choose_parent.py
+++ b/wagtail/admin/views/pages/choose_parent.py
@@ -12,7 +12,7 @@ from wagtail.admin.forms.pages import ParentChooserForm
 from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
 from wagtail.admin.views.generic.mixins import LocaleMixin
 from wagtail.models import Page
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 
 class ChooseParentView(LocaleMixin, WagtailAdminTemplateMixin, FormView):
@@ -20,6 +20,10 @@ class ChooseParentView(LocaleMixin, WagtailAdminTemplateMixin, FormView):
     model = Page
     index_url_name = None
     page_title = gettext_lazy("Choose parent")
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_valid_parent_pages(self, user):
         """
@@ -50,7 +54,7 @@ class ChooseParentView(LocaleMixin, WagtailAdminTemplateMixin, FormView):
 
             perms = {
                 perm
-                for perm in page_permission_policy.get_cached_permissions_for_user(user)
+                for perm in self.permission_policy.get_cached_permissions_for_user(user)
                 if perm.permission.codename == "add_page"
             }
 

--- a/wagtail/admin/views/pages/history.py
+++ b/wagtail/admin/views/pages/history.py
@@ -2,6 +2,7 @@ import django_filters
 from django.core.exceptions import PermissionDenied
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy
 
 from wagtail.admin.views.generic import history
@@ -10,7 +11,7 @@ from wagtail.admin.views.pages.utils import (
 )
 from wagtail.admin.widgets import BooleanRadioSelect
 from wagtail.models import Page, PageLogEntry
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 
 class PageHistoryFilterSet(history.HistoryFilterSet):
@@ -69,7 +70,6 @@ class PageHistoryView(GenericPageBreadcrumbsMixin, history.HistoryView):
     filterset_class = PageHistoryFilterSet
     model = Page
     pk_url_kwarg = "page_id"
-    permission_policy = page_permission_policy
     history_url_name = "wagtailadmin_pages:history"
     history_results_url_name = "wagtailadmin_pages:history_results"
     edit_url_name = "wagtailadmin_pages:edit"
@@ -77,6 +77,10 @@ class PageHistoryView(GenericPageBreadcrumbsMixin, history.HistoryView):
     revisions_revert_url_name = "wagtailadmin_pages:revisions_revert"
     revisions_compare_url_name = "wagtailadmin_pages:revisions_compare"
     revisions_unschedule_url_name = "wagtailadmin_pages:revisions_unschedule"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_object(self):
         page = get_object_or_404(self.model, id=self.pk).specific

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -37,7 +37,7 @@ from wagtail.admin.ui.tables.pages import (
 from wagtail.admin.views import generic
 from wagtail.admin.widgets.button import HeaderButton
 from wagtail.models import Page, PageLogEntry, Site, get_page_content_types
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 
 class SiteFilter(ModelMultipleChoiceFilter):
@@ -267,7 +267,6 @@ class PageListingMixin:
 
 
 class IndexView(PageListingMixin, generic.IndexView):
-    permission_policy = page_permission_policy
     any_permission_required = {
         "add",
         "change",
@@ -283,6 +282,10 @@ class IndexView(PageListingMixin, generic.IndexView):
     base_filterset_class = PageFilterSet
     default_ordering = "-latest_revision_created_at"
     base_columns = [col for col in PageListingMixin.base_columns if col.name != "type"]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     @cached_property
     def columns(self):
@@ -302,7 +305,7 @@ class IndexView(PageListingMixin, generic.IndexView):
             settings, "WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS", True
         ):
             pages = pages.filter(
-                pk__in=page_permission_policy.explorable_instances(
+                pk__in=self.permission_policy.explorable_instances(
                     self.request.user
                 ).values_list("pk", flat=True)
             )
@@ -425,7 +428,7 @@ class ExplorableIndexView(IndexView):
             settings, "WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS", True
         ):
             pages = pages.filter(
-                pk__in=page_permission_policy.explorable_instances(
+                pk__in=self.permission_policy.explorable_instances(
                     self.request.user
                 ).values_list("pk", flat=True)
             )

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.query import QuerySet
 from django.http import Http404
-from django.utils.functional import classproperty
+from django.utils.functional import cached_property, classproperty
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.ui.tables.pages import (
@@ -14,7 +14,7 @@ from wagtail.admin.views.generic.base import BaseListingView
 from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
 from wagtail.admin.views.pages.listing import PageListingMixin
 from wagtail.models import Page
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 from wagtail.search.query import MATCH_ALL
 from wagtail.search.utils import parse_query_string
 
@@ -45,7 +45,6 @@ def page_filter_search(q, pages, all_pages=None, ordering=None):
 
 
 class SearchView(PageListingMixin, PermissionCheckedMixin, BaseListingView):
-    permission_policy = page_permission_policy
     any_permission_required = {
         "add",
         "change",
@@ -74,6 +73,10 @@ class SearchView(PageListingMixin, PermissionCheckedMixin, BaseListingView):
         columns = PageListingMixin.base_columns.copy()
         columns.append(NavigateToChildrenColumn("navigate", width="10%"))
         return columns
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get(self, request):
         self.content_types = []
@@ -112,7 +115,7 @@ class SearchView(PageListingMixin, PermissionCheckedMixin, BaseListingView):
 
         if getattr(settings, "WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS", True):
             self.all_pages = self.all_pages.filter(
-                pk__in=page_permission_policy.explorable_instances(
+                pk__in=self.permission_policy.explorable_instances(
                     self.request.user
                 ).values_list("pk", flat=True)
             )

--- a/wagtail/admin/views/pages/utils.py
+++ b/wagtail/admin/views/pages/utils.py
@@ -9,7 +9,8 @@ from wagtail.admin.utils import (  # noqa: F401
     get_latest_str,
     get_valid_next_url_from_request,
 )
-from wagtail.permissions import page_permission_policy
+from wagtail.models import Page
+from wagtail.permissions import policies_registry
 
 
 def get_breadcrumbs_items_for_page(
@@ -22,7 +23,7 @@ def get_breadcrumbs_items_for_page(
 ):
     # find the closest common ancestor of the pages that this user has direct explore permission
     # (i.e. add/edit/publish/lock) over; this will be the root of the breadcrumb
-    cca = page_permission_policy.explorable_root_instance(user)
+    cca = policies_registry.get_by_type(Page).explorable_root_instance(user)
     if not cca:
         return []
 

--- a/wagtail/admin/views/reports/aging_pages.py
+++ b/wagtail/admin/views/reports/aging_pages.py
@@ -8,7 +8,6 @@ from wagtail.admin.filters import ContentTypeFilter, WagtailFilterSet
 from wagtail.admin.widgets import AdminDateInput
 from wagtail.coreutils import get_content_type_label
 from wagtail.models import Page, PageLogEntry, get_page_content_types
-from wagtail.permissions import page_permission_policy
 from wagtail.users.utils import get_deleted_user_display_name
 
 from .base import PageReportView
@@ -99,7 +98,7 @@ class AgingPagesView(PageReportView):
             page=OuterRef("pk"), action__exact="wagtail.publish"
         )
         self.queryset = (
-            page_permission_policy.instances_user_has_permission_for(
+            self.permission_policy.instances_user_has_permission_for(
                 self.request.user, "publish"
             )
             .exclude(last_published_at__isnull=True)

--- a/wagtail/admin/views/reports/base.py
+++ b/wagtail/admin/views/reports/base.py
@@ -1,8 +1,10 @@
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.views.generic import BaseListingView, PermissionCheckedMixin
 from wagtail.admin.views.mixins import SpreadsheetExportMixin
-from wagtail.permissions import page_permission_policy
+from wagtail.models import Page
+from wagtail.permissions import policies_registry
 
 
 class ReportView(SpreadsheetExportMixin, PermissionCheckedMixin, BaseListingView):
@@ -50,4 +52,8 @@ class PageReportView(ReportView):
         "content_type.model_class._meta.verbose_name.title",
     ]
     context_object_name = "pages"
-    permission_policy = page_permission_policy
+    model = Page
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)

--- a/wagtail/admin/views/reports/locked_pages.py
+++ b/wagtail/admin/views/reports/locked_pages.py
@@ -7,7 +7,6 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.filters import DateRangePickerWidget, WagtailFilterSet
 from wagtail.models import Page
-from wagtail.permissions import page_permission_policy
 
 from .base import PageReportView
 
@@ -53,7 +52,7 @@ class LockedPagesView(PageReportView):
     def get_queryset(self):
         pages = (
             (
-                page_permission_policy.instances_user_has_permission_for(
+                self.permission_policy.instances_user_has_permission_for(
                     self.request.user, "change"
                 )
                 | Page.objects.filter(locked_by=self.request.user)

--- a/wagtail/admin/views/reports/page_types_usage.py
+++ b/wagtail/admin/views/reports/page_types_usage.py
@@ -2,13 +2,14 @@ import django_filters
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, F, OuterRef, Q, Subquery
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.filters import WagtailFilterSet
 from wagtail.admin.views.reports import ReportView
 from wagtail.coreutils import get_content_languages
 from wagtail.models import Page, Site, get_page_models
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 
 def _get_locale_choices():
@@ -102,8 +103,11 @@ class PageTypesUsageReportView(ReportView):
     filterset_class = PageTypesUsageReportFilterSet
     index_url_name = "wagtailadmin_reports:page_types_usage"
     index_results_url_name = "wagtailadmin_reports:page_types_usage_results"
-    permission_policy = page_permission_policy
     any_permission_required = ["add", "change", "publish"]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Page)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/wagtail/admin/views/reports/workflows.py
+++ b/wagtail/admin/views/reports/workflows.py
@@ -20,13 +20,14 @@ from wagtail.admin.utils import get_latest_str
 from wagtail.admin.widgets.button import HeaderButton
 from wagtail.coreutils import get_content_type_label
 from wagtail.models import (
+    Page,
     Task,
     TaskState,
     Workflow,
     WorkflowState,
     get_default_page_content_type,
 )
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 from wagtail.snippets.models import get_editable_models
 
 from .base import ReportView
@@ -40,7 +41,7 @@ def get_requested_by_queryset(request):
 
 
 def get_editable_page_ids_query(request):
-    pages = page_permission_policy.instances_user_has_permission_for(
+    pages = policies_registry.get_by_type(Page).instances_user_has_permission_for(
         request.user, "change"
     )
     # Need to cast the page ids to string because Postgres doesn't support
@@ -144,7 +145,6 @@ class WorkflowView(ReportView):
     filterset_class = WorkflowReportFilterSet
     index_url_name = "wagtailadmin_reports:workflow"
     index_results_url_name = "wagtailadmin_reports:workflow_results"
-    permission_policy = page_permission_policy
     any_permission_required = ["add", "change", "publish"]
 
     export_headings = {
@@ -163,6 +163,10 @@ class WorkflowView(ReportView):
         "requested_by",
         "created_at",
     ]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Page)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -223,7 +227,6 @@ class WorkflowTasksView(ReportView):
     filterset_class = WorkflowTasksReportFilterSet
     index_url_name = "wagtailadmin_reports:workflow_tasks"
     index_results_url_name = "wagtailadmin_reports:workflow_tasks_results"
-    permission_policy = page_permission_policy
     any_permission_required = ["add", "change", "publish"]
 
     export_headings = {
@@ -244,6 +247,10 @@ class WorkflowTasksView(ReportView):
         "finished_at",
         "finished_by",
     ]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Page)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -19,7 +19,6 @@ from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
 
 from wagtail.admin import messages
-from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.filters import (
     MultipleContentTypeFilter,
     WagtailFilterSet,
@@ -46,15 +45,9 @@ from wagtail.models import (
     WorkflowState,
     WorkflowTask,
 )
-from wagtail.permissions import (
-    page_permission_policy,
-    task_permission_policy,
-    workflow_permission_policy,
-)
+from wagtail.permissions import policies_registry
 from wagtail.snippets.models import get_workflow_enabled_models
 from wagtail.workflows import get_task_types
-
-task_permission_checker = PermissionPolicyChecker(task_permission_policy)
 
 
 class WorkflowTitleColumn(TitleColumn):
@@ -112,7 +105,6 @@ class WorkflowFilterSet(BaseWorkflowFilterSet):
 
 
 class Index(IndexView):
-    permission_policy = workflow_permission_policy
     model = Workflow
     context_object_name = "workflows"
     template_name = "wagtailadmin/workflows/index.html"
@@ -145,6 +137,10 @@ class Index(IndexView):
     filterset_class = WorkflowFilterSet
     paginate_by = 20
 
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
+
     def show_disabled(self):
         return self.filters.form.cleaned_data.get("show_disabled") == "true"
 
@@ -165,7 +161,6 @@ class Index(IndexView):
 
 
 class Create(CreateView):
-    permission_policy = workflow_permission_policy
     model = Workflow
     page_title = _("New workflow")
     template_name = "wagtailadmin/workflows/create.html"
@@ -175,6 +170,10 @@ class Create(CreateView):
     index_url_name = "wagtailadmin_workflows:index"
     header_icon = "tasks"
     edit_handler = None
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_edit_handler(self):
         if not self.edit_handler:
@@ -257,7 +256,6 @@ class Create(CreateView):
 
 
 class Edit(EditView):
-    permission_policy = workflow_permission_policy
     model = Workflow
     page_title = _("Editing workflow")
     template_name = "wagtailadmin/workflows/edit.html"
@@ -273,6 +271,10 @@ class Edit(EditView):
     header_more_buttons = []
     edit_handler = None
     MAX_PAGES = 5
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_edit_handler(self):
         if not self.edit_handler:
@@ -384,7 +386,6 @@ class Edit(EditView):
 
 
 class Disable(DeleteView):
-    permission_policy = workflow_permission_policy
     model = Workflow
     page_title = _("Disable workflow")
     template_name = "wagtailadmin/workflows/confirm_disable.html"
@@ -394,6 +395,10 @@ class Disable(DeleteView):
     delete_url_name = "wagtailadmin_workflows:disable"
     index_url_name = "wagtailadmin_workflows:index"
     header_icon = "tasks"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     @property
     def get_edit_url(self):
@@ -419,7 +424,6 @@ class Disable(DeleteView):
 
 
 class WorkflowUsageView(PageListingMixin, PermissionCheckedMixin, BaseListingView):
-    permission_policy = workflow_permission_policy
     any_permission_required = {"add", "change", "delete", "view"}
     pk_url_kwarg = "pk"
     index_url_name = "wagtailadmin_workflows:usage"
@@ -429,13 +433,17 @@ class WorkflowUsageView(PageListingMixin, PermissionCheckedMixin, BaseListingVie
     page_title = _("Usage")
     filterset_class = GenericPageFilterSet
 
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Workflow)
+
     def dispatch(self, request, *args, **kwargs):
         self.object = self.get_object()
 
-        # We set workflow_permission_policy as the main permission policy for this view
+        # We set Workflow's permission_policy as the main permission policy for this view
         # for consistency with the other workflow views. However, since we are listing
         # page objects in this view, we want to ensure the user has a page permission.
-        if not page_permission_policy.user_has_any_permission(
+        if not policies_registry.get_by_type(Page).user_has_any_permission(
             request.user,
             {"add", "change", "publish", "bulk_delete", "lock", "unlock"},
         ):
@@ -471,9 +479,11 @@ class WorkflowUsageView(PageListingMixin, PermissionCheckedMixin, BaseListingVie
         return get_object_or_404(Workflow, id=self.kwargs.get(self.pk_url_kwarg))
 
     def get_base_queryset(self):
-        editable_pages = page_permission_policy.instances_user_has_permission_for(
-            self.request.user, "change"
-        ).filter(depth__gt=1)
+        editable_pages = (
+            policies_registry.get_by_type(Page)
+            .instances_user_has_permission_for(self.request.user, "change")
+            .filter(depth__gt=1)
+        )
         pages = self.object.all_pages() & editable_pages
         pages = self.annotate_queryset(pages)
         return pages
@@ -485,7 +495,9 @@ def enable_workflow(request, pk):
     workflow = get_object_or_404(Workflow, id=pk)
 
     # Check permissions
-    if not workflow_permission_policy.user_has_permission(request.user, "add"):
+    if not policies_registry.get_by_type(Workflow).user_has_permission(
+        request.user, "add"
+    ):
         raise PermissionDenied
 
     # Set workflow to active if inactive
@@ -515,7 +527,9 @@ def remove_workflow(request, page_pk, workflow_pk=None):
     page = get_object_or_404(Page, id=page_pk)
 
     # Check permissions
-    if not workflow_permission_policy.user_has_permission(request.user, "change"):
+    if not policies_registry.get_by_type(Workflow).user_has_permission(
+        request.user, "change"
+    ):
         raise PermissionDenied
 
     if hasattr(page, "workflowpage"):
@@ -568,7 +582,6 @@ class TaskFilterSet(BaseWorkflowFilterSet):
 
 
 class TaskIndex(IndexView):
-    permission_policy = task_permission_policy
     model = Task
     context_object_name = "tasks"
     template_name = "wagtailadmin/workflows/task_index.html"
@@ -597,6 +610,10 @@ class TaskIndex(IndexView):
     filterset_class = TaskFilterSet
     paginate_by = 50
 
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
+
     def show_disabled(self):
         return self.filters.form.cleaned_data.get("show_disabled") == "true"
 
@@ -623,7 +640,7 @@ class TaskIndex(IndexView):
 
 
 def select_task_type(request):
-    if not task_permission_policy.user_has_permission(request.user, "add"):
+    if not policies_registry.get_by_type(Task).user_has_permission(request.user, "add"):
         raise PermissionDenied
 
     task_types = [
@@ -656,7 +673,6 @@ def select_task_type(request):
 
 
 class CreateTask(CreateView):
-    permission_policy = task_permission_policy
     page_title = _("New workflow task")
     template_name = "wagtailadmin/workflows/create_task.html"
     success_message = _("Task '%(object)s' created.")
@@ -682,6 +698,10 @@ class CreateTask(CreateView):
             raise Http404
 
         return model
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_form_class(self):
         return get_task_form_class(self.model)
@@ -712,7 +732,6 @@ class CreateTask(CreateView):
 
 
 class EditTask(EditView):
-    permission_policy = task_permission_policy
     template_name = "wagtailadmin/workflows/edit_task.html"
     success_message = _("Task '%(object)s' updated.")
     add_url_name = "wagtailadmin_workflows:select_task_type"
@@ -728,6 +747,10 @@ class EditTask(EditView):
     @cached_property
     def model(self):
         return type(self.get_object())
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     @cached_property
     def page_title(self):
@@ -776,7 +799,6 @@ class EditTask(EditView):
 
 
 class DisableTask(DeleteView):
-    permission_policy = task_permission_policy
     model = Task
     page_title = _("Disable task")
     template_name = "wagtailadmin/workflows/confirm_disable_task.html"
@@ -786,6 +808,10 @@ class DisableTask(DeleteView):
     delete_url_name = "wagtailadmin_workflows:disable_task"
     index_url_name = "wagtailadmin_workflows:task_index"
     header_icon = "thumbtack"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -816,7 +842,7 @@ def enable_task(request, pk):
     task = get_object_or_404(Task, id=pk)
 
     # Check permissions
-    if not task_permission_policy.user_has_permission(request.user, "add"):
+    if not policies_registry.get_by_type(Task).user_has_permission(request.user, "add"):
         raise PermissionDenied
 
     # Set workflow to active if inactive
@@ -859,7 +885,7 @@ class BaseTaskChooserView(TemplateView):
     def dispatch(self, request):
         self.task_models = get_task_types()
         self.can_create = (
-            task_permission_policy.user_has_permission(request.user, "add")
+            policies_registry.get_by_type(Task).user_has_permission(request.user, "add")
             and len(self.task_models) != 0
         )
         return super().dispatch(request)

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -19,7 +19,8 @@ from wagtail.admin.views import generic
 from wagtail.admin.views.generic import history, usage
 from wagtail.admin.viewsets.listing import ListingViewSetMixin
 from wagtail.models import ReferenceIndex
-from wagtail.permissions import ModelPermissionPolicy
+from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permissions import policies_registry
 
 from .base import ViewSet, ViewSetGroup
 
@@ -120,7 +121,7 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
         ):
             self.sort_order_field = self.model.sort_order_field
 
-    @property
+    @cached_property
     def permission_policy(self):
         return ModelPermissionPolicy(self.model)
 
@@ -581,6 +582,7 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
 
     def register_permissions(self):
         hooks.register("register_permissions", self.get_permissions_to_register)
+        policies_registry.register(self.model, self.permission_policy)
 
     def get_urlpatterns(self):
         conv = self.pk_path_converter

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -55,12 +55,7 @@ from wagtail.admin.viewsets import viewsets
 from wagtail.admin.viewsets.pages import base_page_viewset
 from wagtail.admin.widgets import ButtonWithDropdownFromHook
 from wagtail.models import Collection, Page, Task, Workflow
-from wagtail.permissions import (
-    collection_permission_policy,
-    page_permission_policy,
-    task_permission_policy,
-    workflow_permission_policy,
-)
+from wagtail.permissions import policies_registry
 from wagtail.templatetags.wagtailcore_tags import (
     wagtail_feature_release_editor_guide_link,
     wagtail_feature_release_whats_new_link,
@@ -80,7 +75,9 @@ class ExplorerMenuItem(MenuItem):
 
     def get_context(self, request):
         context = super().get_context(request)
-        start_page = page_permission_policy.explorable_root_instance(request.user)
+        start_page = policies_registry.get_by_type(Page).explorable_root_instance(
+            request.user
+        )
 
         if start_page:
             context["start_page_id"] = start_page.id
@@ -88,7 +85,9 @@ class ExplorerMenuItem(MenuItem):
         return context
 
     def render_component(self, request):
-        start_page = page_permission_policy.explorable_root_instance(request.user)
+        start_page = policies_registry.get_by_type(Page).explorable_root_instance(
+            request.user
+        )
 
         if start_page:
             return PageExplorerMenuItemComponent(
@@ -170,7 +169,7 @@ def register_collection_permissions_panel():
 
 class CollectionsMenuItem(MenuItem):
     def is_shown(self, request):
-        return collection_permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Collection).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -191,7 +190,7 @@ class WorkflowsMenuItem(MenuItem):
         if not getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True):
             return False
 
-        return workflow_permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Workflow).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -201,7 +200,7 @@ class WorkflowTasksMenuItem(MenuItem):
         if not getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True):
             return False
 
-        return task_permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Task).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -842,35 +841,40 @@ def register_core_features(features):
 
 class LockedPagesMenuItem(MenuItem):
     def is_shown(self, request):
-        return page_permission_policy.user_has_permission(request.user, "unlock")
+        return policies_registry.get_by_type(Page).user_has_permission(
+            request.user, "unlock"
+        )
 
 
 class WorkflowReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return getattr(
-            settings, "WAGTAIL_WORKFLOW_ENABLED", True
-        ) and page_permission_policy.user_has_any_permission(
-            request.user, ["add", "change", "publish"]
+        return getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True) and (
+            policies_registry.get_by_type(Page).user_has_any_permission(
+                request.user, ["add", "change", "publish"]
+            )
         )
 
 
 class SiteHistoryReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return page_permission_policy.explorable_root_instance(request.user) is not None
+        return (
+            policies_registry.get_by_type(Page).explorable_root_instance(request.user)
+            is not None
+        )
 
 
 class AgingPagesReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return getattr(
-            settings, "WAGTAIL_AGING_PAGES_ENABLED", True
-        ) and page_permission_policy.user_has_any_permission(
-            request.user, ["add", "change", "publish"]
+        return getattr(settings, "WAGTAIL_AGING_PAGES_ENABLED", True) and (
+            policies_registry.get_by_type(Page).user_has_any_permission(
+                request.user, ["add", "change", "publish"]
+            )
         )
 
 
 class PageTypesReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return page_permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Page).user_has_any_permission(
             request.user, ["add", "change", "publish"]
         )
 
@@ -1157,24 +1161,33 @@ register_admin_url_finder(Page, PageAdminURLFinder)
 
 
 class CollectionAdminURLFinder(ModelAdminURLFinder):
-    permission_policy = collection_permission_policy
     edit_url_name = "wagtailadmin_collections:edit"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Collection)
 
 
 register_admin_url_finder(Collection, CollectionAdminURLFinder)
 
 
 class WorkflowAdminURLFinder(ModelAdminURLFinder):
-    permission_policy = workflow_permission_policy
     edit_url_name = "wagtailadmin_workflows:edit"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Workflow)
 
 
 register_admin_url_finder(Workflow, WorkflowAdminURLFinder)
 
 
 class WorkflowTaskAdminURLFinder(ModelAdminURLFinder):
-    permission_policy = task_permission_policy
     edit_url_name = "wagtailadmin_workflows:edit_task"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Task)
 
 
 register_admin_url_finder(Task, WorkflowTaskAdminURLFinder)

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -4,8 +4,8 @@ from django.contrib.contenttypes.models import ContentType
 
 from wagtail import hooks
 from wagtail.coreutils import safe_snake_case
-from wagtail.models import get_page_models
-from wagtail.permissions import page_permission_policy
+from wagtail.models import Page, get_page_models
+from wagtail.permissions import policies_registry
 
 
 def get_field_clean_name(label):
@@ -29,9 +29,8 @@ def get_forms_for_user(user):
     """
     Return a queryset of form pages that this user is allowed to access the submissions for
     """
-    editable_forms = page_permission_policy.instances_user_has_permission_for(
-        user, "change"
-    )
+    permission_policy = policies_registry.get_by_type(Page)
+    editable_forms = permission_policy.instances_user_has_permission_for(user, "change")
     editable_forms = editable_forms.filter(content_type__in=get_form_types())
 
     # Apply hooks

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -8,7 +8,7 @@ from django.forms import CheckboxSelectMultiple
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.utils.functional import classproperty
+from django.utils.functional import cached_property, classproperty
 from django.utils.translation import gettext, gettext_lazy, ngettext
 from django.views.generic import TemplateView
 from django_filters import DateFromToRangeFilter
@@ -28,7 +28,7 @@ from wagtail.admin.views.pages.listing import PageFilterSet, PageListingMixin
 from wagtail.contrib.forms.models import FormMixin
 from wagtail.contrib.forms.utils import get_form_types, get_forms_for_user
 from wagtail.models import Page
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 
 def get_submissions_list_view(request, *args, **kwargs):
@@ -66,7 +66,6 @@ class FormPageFilterSet(PageFilterSet):
 class FormPagesListView(PageListingMixin, PermissionCheckedMixin, BaseListingView):
     """Lists the available form pages for the current user"""
 
-    permission_policy = page_permission_policy
     any_permission_required = {
         "add",
         "change",
@@ -87,6 +86,10 @@ class FormPagesListView(PageListingMixin, PermissionCheckedMixin, BaseListingVie
     model = Page
     is_searchable = True
     filterset_class = FormPageFilterSet
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     @classproperty
     def columns(self):

--- a/wagtail/contrib/redirects/apps.py
+++ b/wagtail/contrib/redirects/apps.py
@@ -18,3 +18,11 @@ class WagtailRedirectsAppConfig(AppConfig):
 
         post_page_move.connect(autocreate_redirects_on_page_move)
         page_slug_changed.connect(autocreate_redirects_on_slug_change)
+
+        from wagtail.permission_policies import ModelPermissionPolicy
+        from wagtail.permissions import register_permission_policy
+
+        from .models import Redirect
+
+        permission_policy = ModelPermissionPolicy(Redirect)
+        register_permission_policy(Redirect, permission_policy)

--- a/wagtail/contrib/redirects/permissions.py
+++ b/wagtail/contrib/redirects/permissions.py
@@ -1,4 +1,12 @@
-from wagtail.contrib.redirects.models import Redirect
-from wagtail.permission_policies import ModelPermissionPolicy
+import warnings
 
-permission_policy = ModelPermissionPolicy(Redirect)
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.permissions import policies_registry
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
+
+warnings.warn(
+    "wagtail.contrib.redirects.permissions.permission_policy is deprecated. "
+    "Use wagtail.permissions.policies_registry.get_by_type(Redirect) instead.",
+    RemovedInWagtail90Warning,
+)
+permission_policy = policies_registry.get_by_type(Redirect)

--- a/wagtail/contrib/redirects/tests/test_permissions.py
+++ b/wagtail/contrib/redirects/tests/test_permissions.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permissions import policies_registry
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
+
+
+class TestRedirectPermissions(TestCase):
+    def test_permissions_direct_import_deprecated(self):
+        with self.assertWarnsMessage(
+            RemovedInWagtail90Warning,
+            "wagtail.contrib.redirects.permissions.permission_policy is deprecated. "
+            "Use wagtail.permissions.policies_registry.get_by_type(Redirect) instead.",
+        ):
+            from wagtail.contrib.redirects.permissions import permission_policy
+
+            self.assertIsInstance(permission_policy, ModelPermissionPolicy)
+            self.assertIs(permission_policy.model, Redirect)
+
+    def test_get_from_registry(self):
+        permission_policy = policies_registry.get_by_type(Redirect)
+        self.assertIsInstance(permission_policy, ModelPermissionPolicy)
+        self.assertIs(permission_policy.model, Redirect)

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -25,7 +25,6 @@ from wagtail.contrib.redirects.forms import (
     RedirectForm,
 )
 from wagtail.contrib.redirects.models import Redirect
-from wagtail.contrib.redirects.permissions import permission_policy
 from wagtail.contrib.redirects.utils import (
     get_file_storage,
     get_format_cls_by_extension,
@@ -35,8 +34,19 @@ from wagtail.contrib.redirects.utils import (
 )
 from wagtail.log_actions import log
 from wagtail.models import Site
+from wagtail.permissions import policies_registry
 
-permission_checker = PermissionPolicyChecker(permission_policy)
+
+class RedirectPermissionPolicyChecker(PermissionPolicyChecker):
+    def __init__(self):
+        pass
+
+    @cached_property
+    def policy(self):
+        return policies_registry.get_by_type(Redirect)
+
+
+permission_checker = RedirectPermissionPolicyChecker()
 
 
 class RedirectTargetColumn(Column):
@@ -62,7 +72,6 @@ class RedirectTargetColumn(Column):
 class IndexView(generic.IndexView):
     template_name = "wagtailredirects/index.html"
     results_template_name = "wagtailredirects/index_results.html"
-    permission_policy = permission_policy
     model = Redirect
     header_icon = "redirect"
     add_item_label = gettext_lazy("Add redirect")
@@ -117,6 +126,10 @@ class IndexView(generic.IndexView):
         "get_is_permanent_display": _("Type"),
     }
 
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
+
     def get_base_queryset(self):
         return super().get_base_queryset().select_related("redirect_page", "site")
 
@@ -137,7 +150,6 @@ class IndexView(generic.IndexView):
 class EditView(generic.EditView):
     model = Redirect
     form_class = RedirectForm
-    permission_policy = permission_policy
     template_name = "wagtailredirects/edit.html"
     index_url_name = "wagtailredirects:index"
     edit_url_name = "wagtailredirects:edit"
@@ -145,6 +157,10 @@ class EditView(generic.EditView):
     pk_url_kwarg = "redirect_id"
     error_message = gettext_lazy("The redirect could not be saved due to errors.")
     header_icon = "redirect"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_success_message(self):
         return _("Redirect '%(redirect_title)s' updated.") % {
@@ -169,11 +185,14 @@ class EditView(generic.EditView):
 class DeleteView(generic.DeleteView):
     model = Redirect
     pk_url_kwarg = "redirect_id"
-    permission_policy = permission_policy
     template_name = "wagtailredirects/confirm_delete.html"
     index_url_name = "wagtailredirects:index"
     delete_url_name = "wagtailredirects:delete"
     header_icon = "redirect"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def delete_action(self):
         super().delete_action()
@@ -188,13 +207,16 @@ class DeleteView(generic.DeleteView):
 class CreateView(generic.CreateView):
     model = Redirect
     form_class = RedirectForm
-    permission_policy = permission_policy
     template_name = "wagtailredirects/add.html"
     add_url_name = "wagtailredirects:add"
     index_url_name = "wagtailredirects:index"
     edit_url_name = "wagtailredirects:edit"
     error_message = gettext_lazy("The redirect could not be created due to errors.")
     header_icon = "redirect"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_success_message(self, instance):
         return _("Redirect '%(redirect_title)s' added.") % {

--- a/wagtail/contrib/redirects/wagtail_hooks.py
+++ b/wagtail/contrib/redirects/wagtail_hooks.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import Permission
 from django.urls import include, path, reverse
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
@@ -9,7 +10,7 @@ from wagtail.admin.admin_url_finder import (
 )
 from wagtail.admin.menu import MenuItem
 from wagtail.contrib.redirects import urls
-from wagtail.contrib.redirects.permissions import permission_policy
+from wagtail.permissions import policies_registry
 
 from .models import Redirect
 
@@ -23,7 +24,7 @@ def register_admin_urls():
 
 class RedirectsMenuItem(MenuItem):
     def is_shown(self, request):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Redirect).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -49,7 +50,10 @@ def register_permissions():
 
 class RedirectAdminURLFinder(ModelAdminURLFinder):
     edit_url_name = "wagtailredirects:edit"
-    permission_policy = permission_policy
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Redirect)
 
 
 register_admin_url_finder(Redirect, RedirectAdminURLFinder)

--- a/wagtail/contrib/search_promotions/views/settings.py
+++ b/wagtail/contrib/search_promotions/views/settings.py
@@ -19,7 +19,7 @@ from wagtail.admin.views import generic
 from wagtail.contrib.search_promotions import forms, models
 from wagtail.contrib.search_promotions.models import Query, SearchPromotion
 from wagtail.log_actions import log
-from wagtail.permission_policies.base import ModelPermissionPolicy
+from wagtail.permissions import policies_registry
 from wagtail.search.utils import normalise_query_string
 
 
@@ -35,7 +35,6 @@ class IndexView(generic.IndexView):
     page_title = gettext_lazy("Promoted search results")
     header_icon = "pick"
     paginate_by = 20
-    permission_policy = ModelPermissionPolicy(SearchPromotion)
     index_url_name = "wagtailsearchpromotions:index"
     index_results_url_name = "wagtailsearchpromotions:index_results"
     search_fields = ["query_string"]
@@ -63,6 +62,10 @@ class IndexView(generic.IndexView):
         ),
     ]
 
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(SearchPromotion)
+
     def get_base_queryset(self):
         # Use a subquery to filter out the Query objects that do not have a
         # SearchPromotion instead of using .filter(editors_picks__isnull=False).
@@ -86,12 +89,15 @@ class IndexView(generic.IndexView):
 
 class SearchPromotionCreateEditMixin:
     model = Query
-    permission_policy = ModelPermissionPolicy(SearchPromotion)
     index_url_name = "wagtailsearchpromotions:index"
     edit_url_name = "wagtailsearchpromotions:edit"
     form_class = forms.QueryForm
     header_icon = "pick"
     page_subtitle = gettext_lazy("Promoted search result")
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(SearchPromotion)
 
     def get_success_message(self, instance=None):
         return self.success_message % {"query": instance}
@@ -196,7 +202,6 @@ class EditView(SearchPromotionCreateEditMixin, generic.EditView):
 
 class DeleteView(generic.DeleteView):
     model = Query
-    permission_policy = ModelPermissionPolicy(SearchPromotion)
     pk_url_kwarg = "query_id"
     context_object_name = "query"
     success_message = gettext_lazy("Editor's picks deleted.")
@@ -204,6 +209,10 @@ class DeleteView(generic.DeleteView):
     delete_url_name = "wagtailsearchpromotions:delete"
     header_icon = "pick"
     template_name = "wagtailsearchpromotions/confirm_delete.html"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(SearchPromotion)
 
     def delete_action(self):
         editors_picks = self.object.editors_picks.all()

--- a/wagtail/contrib/search_promotions/wagtail_hooks.py
+++ b/wagtail/contrib/search_promotions/wagtail_hooks.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import Permission
 from django.urls import include, path, reverse
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
@@ -10,6 +11,7 @@ from wagtail.admin.admin_url_finder import (
 from wagtail.admin.menu import AdminOnlyMenuItem, MenuItem
 from wagtail.contrib.search_promotions import admin_urls
 from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permissions import policies_registry
 
 from .models import SearchPromotion
 
@@ -65,10 +67,13 @@ def register_permissions():
 
 
 class SearchPromotionAdminURLFinder(ModelAdminURLFinder):
-    permission_policy = ModelPermissionPolicy(SearchPromotion)
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(SearchPromotion)
 
     def construct_edit_url(self, instance):
         return reverse("wagtailsearchpromotions:edit", args=(instance.query.id,))
 
 
 register_admin_url_finder(SearchPromotion, SearchPromotionAdminURLFinder)
+policies_registry.register(SearchPromotion, ModelPermissionPolicy(SearchPromotion))

--- a/wagtail/contrib/settings/registry.py
+++ b/wagtail/contrib/settings/registry.py
@@ -9,6 +9,7 @@ from wagtail.admin.admin_url_finder import (
     register_admin_url_finder,
 )
 from wagtail.admin.menu import MenuItem
+from wagtail.permissions import policies_registry
 
 from .forms import SitePermissionForm
 
@@ -16,7 +17,7 @@ from .forms import SitePermissionForm
 class SettingMenuItem(MenuItem):
     def __init__(self, model, icon="cog", classname="", **kwargs):
         self.model = model
-        self.permission_policy = self.model.get_permission_policy()
+        self.permission_policy = policies_registry.get_by_type(model)
         super().__init__(
             label=capfirst(model._meta.verbose_name),
             url=reverse(
@@ -98,6 +99,7 @@ class Registry(list):
 
         # Register an admin URL finder
         permission_policy = model.get_permission_policy()
+        policies_registry.register(model, permission_policy)
 
         if issubclass(model, BaseSiteSetting):
             finder_class = type(

--- a/wagtail/contrib/settings/tests/generic/test_model.py
+++ b/wagtail/contrib/settings/tests/generic/test_model.py
@@ -1,6 +1,8 @@
 from django.test import TestCase, override_settings
 
 from wagtail.models import Site
+from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permissions import policies_registry
 from wagtail.test.testapp.models import ImportantPagesGenericSetting
 
 from .base import GenericSettingsTestMixin
@@ -121,3 +123,14 @@ class GenericSettingModelTestCase(GenericSettingsTestMixin, TestCase):
             str(ImportantPagesGenericSetting.load()),
             "important pages settings",
         )
+
+    def test_permission_policy_registered(self):
+        self.assertIsInstance(
+            ImportantPagesGenericSetting.get_permission_policy(),
+            ModelPermissionPolicy,
+        )
+        registered = policies_registry.get_by_type(ImportantPagesGenericSetting)
+        # get_permission_policy() creates a new instance each time, so we can't
+        # assertIs, but we can check that they are similar
+        self.assertIsInstance(registered, ModelPermissionPolicy)
+        self.assertIs(registered.model, ImportantPagesGenericSetting)

--- a/wagtail/contrib/settings/tests/site_specific/test_model.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_model.py
@@ -3,6 +3,8 @@ import pickle
 from django.test import RequestFactory, TestCase, override_settings
 
 from wagtail.models import Site
+from wagtail.permission_policies.sites import SitePermissionPolicy
+from wagtail.permissions import policies_registry
 from wagtail.test.testapp.models import ImportantPagesSiteSetting, TestSiteSetting
 
 from .base import SiteSettingsTestMixin
@@ -223,3 +225,14 @@ class SettingModelTestCase(SiteSettingsTestMixin, TestCase):
                 self.assertEqual(settings.get_page_url("test_attribute"), "")
                 # when called indirectly via shortcut
                 self.assertEqual(settings.page_url.test_attribute, "")
+
+    def test_permission_policy_registered(self):
+        self.assertIsInstance(
+            ImportantPagesSiteSetting.get_permission_policy(),
+            SitePermissionPolicy,
+        )
+        registered = policies_registry.get_by_type(ImportantPagesSiteSetting)
+        # get_permission_policy() creates a new instance each time, so we can't
+        # assertIs, but we can check that they are similar
+        self.assertIsInstance(registered, SitePermissionPolicy)
+        self.assertIs(registered.model, ImportantPagesSiteSetting)

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -17,6 +17,7 @@ from wagtail.admin.ui.side_panels import ChecksSidePanel, PreviewSidePanel
 from wagtail.admin.views import generic
 from wagtail.admin.views.generic import preview
 from wagtail.models import PreviewableMixin, Site
+from wagtail.permissions import policies_registry
 
 from .forms import SiteSwitchForm
 from .models import BaseGenericSetting, BaseSiteSetting
@@ -57,7 +58,7 @@ def redirect_to_relevant_instance(request, app_name, model_name):
         # Redirect the user to the edit page for the current site
         # (or the current request does not correspond to a site, the first site in the list)
         site = Site.find_for_request(request)
-        permission_policy = model.get_permission_policy()
+        permission_policy = policies_registry.get_by_type(model)
         if not site or not permission_policy.user_has_permission_for_instance(
             request.user, "change", site
         ):
@@ -109,7 +110,7 @@ class EditView(generic.EditView):
         self.app_name = app_name
         self.model_name = model_name
         self.model = get_model_from_url_params(app_name, model_name)
-        self.permission_policy = self.model.get_permission_policy()
+        self.permission_policy = policies_registry.get_by_type(self.model)
         self.pk = kwargs.get(self.pk_url_kwarg)
         super().setup(request, app_name, model_name, *args, **kwargs)
         self.object = self.get_object()
@@ -205,7 +206,7 @@ class PreviewOnEdit(preview.PreviewOnEdit):
         self.app_name = app_name
         self.model_name = model_name
         self.model = get_model_from_url_params(app_name, model_name)
-        self.permission_policy = self.model.get_permission_policy()
+        self.permission_policy = policies_registry.get_by_type(self.model)
         self.pk = kwargs.get("pk")
         super().setup(request, app_name, model_name, *args, **kwargs)
 

--- a/wagtail/documents/__init__.py
+++ b/wagtail/documents/__init__.py
@@ -31,3 +31,15 @@ def get_document_model():
             "WAGTAILDOCS_DOCUMENT_MODEL refers to model '%s' that has not been installed"
             % model_string
         ) from e
+
+
+def get_permission_policy():
+    from wagtail.permission_policies.collections import (
+        CollectionOwnershipPermissionPolicy,
+    )
+
+    return CollectionOwnershipPermissionPolicy(
+        get_document_model_string(),
+        auth_model="wagtaildocs.Document",
+        owner_field_name="uploaded_by_user",
+    )

--- a/wagtail/documents/apps.py
+++ b/wagtail/documents/apps.py
@@ -27,3 +27,12 @@ class WagtailDocsAppConfig(AppConfig):
         from wagtail.models.reference_index import ReferenceIndex
 
         ReferenceIndex.register_model(Document)
+
+        from wagtail.permissions import register_permission_policy
+
+        from . import get_permission_policy
+        from .models import AbstractDocument
+
+        # Register the default permission policy with the abstract model to ease
+        # testing when a custom model is applied via @override_settings.
+        register_permission_policy(AbstractDocument, get_permission_policy())

--- a/wagtail/documents/apps.py
+++ b/wagtail/documents/apps.py
@@ -31,8 +31,5 @@ class WagtailDocsAppConfig(AppConfig):
         from wagtail.permissions import register_permission_policy
 
         from . import get_permission_policy
-        from .models import AbstractDocument
 
-        # Register the default permission policy with the abstract model to ease
-        # testing when a custom model is applied via @override_settings.
-        register_permission_policy(AbstractDocument, get_permission_policy())
+        register_permission_policy(Document, get_permission_policy())

--- a/wagtail/documents/forms.py
+++ b/wagtail/documents/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.conf import settings
 from django.forms.models import modelform_factory
+from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
 
@@ -11,12 +12,11 @@ from wagtail.admin.forms.collections import (
 )
 from wagtail.admin.forms.tags import validate_tag_length
 from wagtail.admin.widgets import AdminTagWidget
+from wagtail.documents import get_document_model
 from wagtail.documents.fields import WagtailDocumentField
 from wagtail.documents.models import Document
-from wagtail.documents.permissions import (
-    permission_policy as documents_permission_policy,
-)
 from wagtail.models import Collection
+from wagtail.permissions import policies_registry
 from wagtail.search import index as search_index
 
 
@@ -37,8 +37,6 @@ def formfield_for_dbfield(db_field, **kwargs):
 
 
 class BaseDocumentForm(BaseCollectionMemberForm):
-    permission_policy = documents_permission_policy
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.original_file = self.instance.file
@@ -48,6 +46,10 @@ class BaseDocumentForm(BaseCollectionMemberForm):
             self.fields["file"].widget.attrs["data-w-sync-target-value"] = (
                 f"#{self['title'].id_for_label}"
             )
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_document_model())
 
     def save(self, commit=True):
         if "file" in self.changed_data:

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -13,6 +13,7 @@ from django.utils.translation import gettext_lazy as _
 from taggit.managers import TaggableManager
 
 from wagtail.models import CollectionMember, ReferenceIndex
+from wagtail.permissions import policies_registry
 from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
 from wagtail.utils.file import hash_filelike
@@ -179,9 +180,11 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
         return reverse("wagtaildocs:document_usage", args=(self.id,))
 
     def is_editable_by_user(self, user):
-        from wagtail.documents.permissions import permission_policy
+        from wagtail.documents import get_document_model
 
-        return permission_policy.user_has_permission_for_instance(user, "change", self)
+        return policies_registry.get_by_type(
+            get_document_model()
+        ).user_has_permission_for_instance(user, "change", self)
 
     @property
     def content_type(self):

--- a/wagtail/documents/permissions.py
+++ b/wagtail/documents/permissions.py
@@ -1,8 +1,12 @@
-from wagtail.documents import get_document_model_string
-from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
+import warnings
 
-permission_policy = CollectionOwnershipPermissionPolicy(
-    get_document_model_string(),
-    auth_model="wagtaildocs.Document",
-    owner_field_name="uploaded_by_user",
+from wagtail.documents import get_document_model
+from wagtail.permissions import policies_registry
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
+
+warnings.warn(
+    "wagtail.documents.permissions.permission_policy is deprecated. "
+    "Use wagtail.permissions.policies_registry.get_by_type(get_document_model()) instead.",
+    RemovedInWagtail90Warning,
 )
+permission_policy = policies_registry.get_by_type(get_document_model())

--- a/wagtail/documents/tests/__init__.py
+++ b/wagtail/documents/tests/__init__.py
@@ -1,0 +1,18 @@
+from django.test.signals import setting_changed
+
+from wagtail.documents import get_document_model, get_permission_policy
+from wagtail.permissions import policies_registry
+
+
+def update_permission_policy(signal, sender, setting, **kwargs):
+    """
+    Register the permission policy when the `WAGTAILDOCS_DOCUMENT_MODEL` setting changes.
+    This is useful in tests where we override the document model setting and expect the
+    permission policy to have changed accordingly.
+    """
+
+    if setting == "WAGTAILDOCS_DOCUMENT_MODEL":
+        policies_registry.register(get_document_model(), get_permission_policy())
+
+
+setting_changed.connect(update_permission_policy)

--- a/wagtail/documents/tests/test_models.py
+++ b/wagtail/documents/tests/test_models.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.files.base import ContentFile
 from django.db import transaction
 from django.test import TestCase, TransactionTestCase, tag
+from django.test.signals import setting_changed
 from django.test.utils import override_settings
 
 from wagtail.documents import (
@@ -12,10 +13,12 @@ from wagtail.documents import (
     models,
     signal_handlers,
 )
+from wagtail.documents.tests import update_permission_policy
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.models import Collection, GroupCollectionPermission
 from wagtail.test.testapp.models import CustomDocument, ReimportedDocumentModel
 from wagtail.test.utils import WagtailTestUtils
+from wagtail.test.utils.decorators import disconnect_signal_receiver
 
 
 @tag("transaction")
@@ -299,12 +302,18 @@ class TestGetDocumentModel(WagtailTestUtils, TestCase):
         del settings.WAGTAILDOCS_DOCUMENT_MODEL
         self.assertEqual(get_document_model_string(), "wagtaildocs.Document")
 
+    @disconnect_signal_receiver(
+        signal=setting_changed, receiver=update_permission_policy
+    )
     @override_settings(WAGTAILDOCS_DOCUMENT_MODEL="tests.UnknownModel")
     def test_unknown_get_document_model(self):
         """Test get_document_model with an unknown model"""
         with self.assertRaises(ImproperlyConfigured):
             get_document_model()
 
+    @disconnect_signal_receiver(
+        signal=setting_changed, receiver=update_permission_policy
+    )
     @override_settings(WAGTAILDOCS_DOCUMENT_MODEL="invalid-string")
     def test_invalid_get_document_model(self):
         """Test get_document_model with an invalid model string"""

--- a/wagtail/documents/tests/test_permissions.py
+++ b/wagtail/documents/tests/test_permissions.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+
+from wagtail.documents import get_document_model
+from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
+from wagtail.permissions import policies_registry
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
+
+
+class TestDocumentPermissions(TestCase):
+    def test_permissions_direct_import_deprecated(self):
+        model = get_document_model()
+        with self.assertWarnsMessage(
+            RemovedInWagtail90Warning,
+            "wagtail.documents.permissions.permission_policy is deprecated. "
+            "Use wagtail.permissions.policies_registry.get_by_type(get_document_model()) instead.",
+        ):
+            from wagtail.documents.permissions import permission_policy
+
+            self.assertIsInstance(
+                permission_policy,
+                CollectionOwnershipPermissionPolicy,
+            )
+            self.assertIs(permission_policy.model, model)
+
+    def test_get_from_registry(self):
+        model = get_document_model()
+        permission_policy = policies_registry.get_by_type(model)
+        self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
+        self.assertIs(permission_policy.model, model)

--- a/wagtail/documents/tests/test_permissions.py
+++ b/wagtail/documents/tests/test_permissions.py
@@ -1,8 +1,9 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from wagtail.documents import get_document_model
 from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
 from wagtail.permissions import policies_registry
+from wagtail.test.testapp.models import CustomDocument
 from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
 
@@ -27,3 +28,9 @@ class TestDocumentPermissions(TestCase):
         permission_policy = policies_registry.get_by_type(model)
         self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
         self.assertIs(permission_policy.model, model)
+
+    @override_settings(WAGTAILDOCS_DOCUMENT_MODEL="tests.CustomDocument")
+    def test_get_from_registry_with_custom_model(self):
+        permission_policy = policies_registry.get_by_type(CustomDocument)
+        self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
+        self.assertIs(permission_policy.model, CustomDocument)

--- a/wagtail/documents/views/bulk_actions/add_to_collection.py
+++ b/wagtail/documents/views/bulk_actions/add_to_collection.py
@@ -2,7 +2,9 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
+from wagtail.documents import get_document_model
 from wagtail.documents.views.bulk_actions.document_bulk_action import DocumentBulkAction
+from wagtail.permissions import policies_registry
 
 
 class CollectionForm(forms.Form):
@@ -11,9 +13,9 @@ class CollectionForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields["collection"] = forms.ModelChoiceField(
             label=_("Collection"),
-            queryset=DocumentBulkAction.permission_policy.collections_user_has_permission_for(
-                user, "add"
-            ),
+            queryset=policies_registry.get_by_type(
+                get_document_model()
+            ).collections_user_has_permission_for(user, "add"),
         )
 
 

--- a/wagtail/documents/views/bulk_actions/document_bulk_action.py
+++ b/wagtail/documents/views/bulk_actions/document_bulk_action.py
@@ -1,13 +1,16 @@
+from django.utils.functional import cached_property
+
 from wagtail.admin.views.bulk_action import BulkAction
 from wagtail.documents import get_document_model
-from wagtail.documents.permissions import (
-    permission_policy as documents_permission_policy,
-)
+from wagtail.permissions import policies_registry
 
 
 class DocumentBulkAction(BulkAction):
-    permission_policy = documents_permission_policy
     models = [get_document_model()]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_all_objects_in_listing_query(self, parent_id):
         listing_objects = self.permission_policy.instances_user_has_permission_for(

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -21,7 +21,7 @@ from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.admin.widgets import BaseChooser, BaseChooserAdapter
 from wagtail.blocks import ChooserBlock
 from wagtail.documents import get_document_model, get_document_model_string
-from wagtail.documents.permissions import permission_policy
+from wagtail.permissions import policies_registry
 
 
 class DocumentChosenResponseMixin(ChosenResponseMixin):
@@ -120,10 +120,13 @@ class DocumentChooseResultsView(
 
 
 class DocumentChosenView(ChosenViewMixin, DocumentChosenResponseMixin, View):
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
+
     def get_object(self, pk):
         item = super().get_object(pk)
-
-        if not permission_policy.user_has_permission_for_instance(
+        if not self.permission_policy.user_has_permission_for_instance(
             self.request.user, "choose", item
         ):
             raise PermissionDenied
@@ -138,8 +141,12 @@ class DocumentChosenView(ChosenViewMixin, DocumentChosenResponseMixin, View):
 class DocumentChosenMultipleView(
     ChosenMultipleViewMixin, DocumentChosenResponseMixin, View
 ):
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
+
     def get_objects(self, pks):
-        return permission_policy.instances_user_has_any_permission_for(
+        return self.permission_policy.instances_user_has_any_permission_for(
             self.request.user, ["choose"]
         ).filter(pk__in=pks)
 
@@ -205,7 +212,6 @@ class DocumentChooserViewSet(ChooserViewSet):
     base_widget_class = BaseAdminDocumentChooser
     widget_telepath_adapter_class = DocumentChooserAdapter
     base_block_class = BaseDocumentChooserBlock
-    permission_policy = permission_policy
 
     icon = "doc-full-inverse"
     choose_one_text = _("Choose a document")
@@ -213,6 +219,10 @@ class DocumentChooserViewSet(ChooserViewSet):
     create_action_clicked_label = _("Uploading…")
     choose_another_text = _("Choose another document")
     edit_item_text = _("Edit this document")
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_document_model())
 
 
 viewset = DocumentChooserViewSet(

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -141,15 +141,6 @@ class IndexView(generic.IndexView):
             )
         return columns
 
-    @cached_property
-    def collections(self):
-        collections = policies_registry.get_by_type(
-            self.model
-        ).collections_user_has_any_permission_for(self.request.user, ["add", "change"])
-        if len(collections) < 2:
-            collections = None
-        return collections
-
     def get_next_url(self):
         next_url = self.index_url
         request_query_string = self.request.META.get("QUERY_STRING")

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -9,7 +9,6 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, ngettext
 
 from wagtail.admin import messages
-from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.filters import BaseMediaFilterSet
 from wagtail.admin.ui.tables import (
     BulkActionsCheckboxColumn,
@@ -24,10 +23,9 @@ from wagtail.admin.utils import get_valid_next_url_from_request, set_query_param
 from wagtail.admin.views import generic
 from wagtail.documents import get_document_model
 from wagtail.documents.forms import get_document_form
-from wagtail.documents.permissions import permission_policy
 from wagtail.models import ReferenceIndex
+from wagtail.permissions import policies_registry
 
-permission_checker = PermissionPolicyChecker(permission_policy)
 Document = get_document_model()
 
 
@@ -51,7 +49,9 @@ class DocumentTable(Table):
 
 
 class DocumentsFilterSet(BaseMediaFilterSet):
-    permission_policy = permission_policy
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Document)
 
     class Meta:
         model = Document
@@ -59,7 +59,6 @@ class DocumentsFilterSet(BaseMediaFilterSet):
 
 
 class IndexView(generic.IndexView):
-    permission_policy = permission_policy
     any_permission_required = ["add", "change", "delete"]
     context_object_name = "documents"
     page_title = gettext_lazy("Documents")
@@ -78,6 +77,10 @@ class IndexView(generic.IndexView):
     model = get_document_model()
     add_item_label = gettext_lazy("Add a document")
     show_other_searches = True
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_base_queryset(self):
         # Get documents (filtered by user permission)
@@ -140,9 +143,9 @@ class IndexView(generic.IndexView):
 
     @cached_property
     def collections(self):
-        collections = permission_policy.collections_user_has_any_permission_for(
-            self.request.user, ["add", "change"]
-        )
+        collections = policies_registry.get_by_type(
+            self.model
+        ).collections_user_has_any_permission_for(self.request.user, ["add", "change"])
         if len(collections) < 2:
             collections = None
         return collections
@@ -195,7 +198,6 @@ class IndexView(generic.IndexView):
 
 
 class CreateView(generic.CreateView):
-    permission_policy = permission_policy
     index_url_name = "wagtaildocs:index"
     add_url_name = "wagtaildocs:add"
     edit_url_name = "wagtaildocs:edit"
@@ -208,6 +210,10 @@ class CreateView(generic.CreateView):
         # Use a property instead of setting this as a class attribute so it is
         # accessed at request-time, thus can be tested with override_settings
         return get_document_model()
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_form_class(self):
         return get_document_form(self.model)
@@ -227,7 +233,6 @@ class CreateView(generic.CreateView):
 
 
 class EditView(generic.EditView):
-    permission_policy = permission_policy
     pk_url_kwarg = "document_id"
     error_message = gettext_lazy("The document could not be saved due to errors.")
     template_name = "wagtaildocs/documents/edit.html"
@@ -240,6 +245,10 @@ class EditView(generic.EditView):
     @cached_property
     def model(self):
         return get_document_model()
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_form_class(self):
         return get_document_form(self.model)
@@ -300,13 +309,16 @@ class EditView(generic.EditView):
 class DeleteView(generic.DeleteView):
     model = get_document_model()
     pk_url_kwarg = "document_id"
-    permission_policy = permission_policy
     permission_required = "delete"
     header_icon = "doc-full-inverse"
     usage_url_name = "wagtaildocs:document_usage"
     delete_url_name = "wagtaildocs:delete"
     index_url_name = "wagtaildocs:index"
     page_title = gettext_lazy("Delete document")
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def user_has_permission(self, permission):
         return self.permission_policy.user_has_permission_for_instance(
@@ -332,11 +344,14 @@ class DeleteView(generic.DeleteView):
 class UsageView(generic.UsageView):
     model = get_document_model()
     pk_url_kwarg = "document_id"
-    permission_policy = permission_policy
     permission_required = "change"
     header_icon = "doc-full-inverse"
     index_url_name = "wagtaildocs:index"
     edit_url_name = "wagtaildocs:edit"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def user_has_permission(self, permission):
         return self.permission_policy.user_has_permission_for_instance(

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -1,7 +1,6 @@
 import os.path
 
 from django.urls import reverse
-from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy
 
@@ -15,7 +14,6 @@ from wagtail.admin.views.generic.multiple_upload import (
 )
 from wagtail.admin.views.generic.multiple_upload import DeleteView as BaseDeleteView
 from wagtail.admin.views.generic.multiple_upload import EditView as BaseEditView
-from wagtail.permissions import policies_registry
 
 from .. import get_document_model
 from ..forms import get_document_form, get_document_multi_form
@@ -47,10 +45,6 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
             },
             {"url": "", "label": self.get_page_title()},
         ]
-
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(self.model)
 
     def get_model(self):
         return get_document_model()
@@ -93,10 +87,6 @@ class EditView(BaseEditView):
     edit_object_url_name = "wagtaildocs:edit_multiple"
     delete_object_url_name = "wagtaildocs:delete_multiple"
 
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(self.model)
-
     def get_model(self):
         return get_document_model()
 
@@ -107,10 +97,6 @@ class EditView(BaseEditView):
 class DeleteView(BaseDeleteView):
     pk_url_kwarg = "doc_id"
     context_object_id_name = "doc_id"
-
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(self.model)
 
     def get_model(self):
         return get_document_model()

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -1,6 +1,7 @@
 import os.path
 
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy
 
@@ -14,14 +15,13 @@ from wagtail.admin.views.generic.multiple_upload import (
 )
 from wagtail.admin.views.generic.multiple_upload import DeleteView as BaseDeleteView
 from wagtail.admin.views.generic.multiple_upload import EditView as BaseEditView
+from wagtail.permissions import policies_registry
 
 from .. import get_document_model
 from ..forms import get_document_form, get_document_multi_form
-from ..permissions import permission_policy
 
 
 class AddView(WagtailAdminTemplateMixin, BaseAddView):
-    permission_policy = permission_policy
     template_name = "wagtaildocs/multiple/add.html"
     header_icon = "doc-full-inverse"
     page_title = gettext_lazy("Add documents")
@@ -47,6 +47,10 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
             },
             {"url": "", "label": self.get_page_title()},
         ]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_model(self):
         return get_document_model()
@@ -82,13 +86,16 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
 
 
 class EditView(BaseEditView):
-    permission_policy = permission_policy
     pk_url_kwarg = "doc_id"
     edit_object_form_prefix = "doc"
     context_object_name = "doc"
     context_object_id_name = "doc_id"
     edit_object_url_name = "wagtaildocs:edit_multiple"
     delete_object_url_name = "wagtaildocs:delete_multiple"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_model(self):
         return get_document_model()
@@ -98,9 +105,12 @@ class EditView(BaseEditView):
 
 
 class DeleteView(BaseDeleteView):
-    permission_policy = permission_policy
     pk_url_kwarg = "doc_id"
     context_object_id_name = "doc_id"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_model(self):
         return get_document_model()

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.template.response import TemplateResponse
 from django.urls import include, path, reverse, reverse_lazy
 from django.utils.cache import add_never_cache_headers
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
@@ -18,7 +19,6 @@ from wagtail.admin.site_summary import SummaryItem
 from wagtail.documents import admin_urls, get_document_model
 from wagtail.documents.api.admin.views import DocumentsAdminAPIViewSet
 from wagtail.documents.forms import GroupDocumentPermissionFormSet
-from wagtail.documents.permissions import permission_policy
 from wagtail.documents.rich_text import DocumentLinkHandler
 from wagtail.documents.rich_text.contentstate import (
     ContentstateDocumentLinkConversionRule,
@@ -31,7 +31,10 @@ from wagtail.documents.views.bulk_actions import (
 )
 from wagtail.documents.views.chooser import viewset as chooser_viewset
 from wagtail.models import BaseViewRestriction
+from wagtail.permissions import policies_registry
 from wagtail.wagtail_hooks import require_wagtail_login
+
+Document = get_document_model()
 
 
 @hooks.register("register_admin_urls")
@@ -48,7 +51,7 @@ def construct_admin_api(router):
 
 class DocumentsMenuItem(MenuItem):
     def is_shown(self, request):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Document).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -102,14 +105,16 @@ class DocumentsSummaryItem(SummaryItem):
         site_name = get_site_for_user(self.request.user)["site_name"]
 
         return {
-            "total_docs": permission_policy.instances_user_has_any_permission_for(
+            "total_docs": policies_registry.get_by_type(Document)
+            .instances_user_has_any_permission_for(
                 self.request.user, {"add", "change", "delete", "choose"}
-            ).count(),
+            )
+            .count(),
             "site_name": site_name,
         }
 
     def is_shown(self):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Document).user_has_any_permission(
             self.request.user, ["add", "change", "delete"]
         )
 
@@ -121,7 +126,7 @@ def add_documents_summary_item(request, items):
 
 class DocsSearchArea(SearchArea):
     def is_shown(self, request):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Document).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -201,7 +206,10 @@ def check_view_restrictions(document, request):
 
 class DocumentAdminURLFinder(ModelAdminURLFinder):
     edit_url_name = "wagtaildocs:edit"
-    permission_policy = permission_policy
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Document)
 
 
 register_admin_url_finder(get_document_model(), DocumentAdminURLFinder)

--- a/wagtail/images/__init__.py
+++ b/wagtail/images/__init__.py
@@ -32,3 +32,15 @@ def get_image_model():
             "WAGTAILIMAGES_IMAGE_MODEL refers to model '%s' that has not been installed"
             % model_string
         ) from e
+
+
+def get_permission_policy():
+    from wagtail.permission_policies.collections import (
+        CollectionOwnershipPermissionPolicy,
+    )
+
+    return CollectionOwnershipPermissionPolicy(
+        get_image_model(),
+        auth_model="wagtailimages.Image",
+        owner_field_name="uploaded_by_user",
+    )

--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -46,3 +46,9 @@ class WagtailImagesAppConfig(AppConfig):
         from wagtail.models.reference_index import ReferenceIndex
 
         ReferenceIndex.register_model(Image)
+
+        from wagtail.permissions import register_permission_policy
+
+        from . import get_permission_policy
+
+        register_permission_policy(Image, get_permission_policy())

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -4,6 +4,7 @@ from django import forms
 from django.conf import settings
 from django.db import models
 from django.forms.models import modelform_factory
+from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext as _
 
@@ -14,11 +15,12 @@ from wagtail.admin.forms.collections import (
 )
 from wagtail.admin.forms.tags import validate_tag_length
 from wagtail.admin.widgets import AdminTagWidget
+from wagtail.images import get_image_model
 from wagtail.images.fields import WagtailImageField
 from wagtail.images.formats import get_image_formats
 from wagtail.images.models import Image
-from wagtail.images.permissions import permission_policy as images_permission_policy
 from wagtail.models import Collection
+from wagtail.permissions import policies_registry
 from wagtail.search import index as search_index
 
 
@@ -40,8 +42,6 @@ def formfield_for_dbfield(db_field, **kwargs):
 
 
 class BaseImageForm(BaseCollectionMemberForm):
-    permission_policy = images_permission_policy
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.original_file = self.instance.file
@@ -51,6 +51,10 @@ class BaseImageForm(BaseCollectionMemberForm):
             self.fields["file"].widget.attrs["data-w-sync-target-value"] = (
                 f"#{self['title'].id_for_label}"
             )
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
     def save(self, commit=True):
         if "file" in self.changed_data:

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -35,6 +35,7 @@ from taggit.managers import TaggableManager
 
 from wagtail import hooks
 from wagtail.coreutils import string_to_ascii
+from wagtail.images import get_image_model
 from wagtail.images.exceptions import (
     InvalidFilterSpecError,
     UnknownOutputImageFormatError,
@@ -48,6 +49,7 @@ from wagtail.images.image_operations import (
 from wagtail.images.rect import Rect
 from wagtail.images.utils import to_svg_safe_spec
 from wagtail.models import CollectionMember, ReferenceIndex
+from wagtail.permissions import policies_registry
 from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
 from wagtail.utils.file import hash_filelike
@@ -915,8 +917,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         return getattr(self, "description", None) or self.title
 
     def is_editable_by_user(self, user):
-        from wagtail.images.permissions import permission_policy
-
+        permission_policy = policies_registry.get_by_type(get_image_model())
         return permission_policy.user_has_permission_for_instance(user, "change", self)
 
     class Meta:

--- a/wagtail/images/permissions.py
+++ b/wagtail/images/permissions.py
@@ -1,46 +1,12 @@
-from django.dispatch import receiver
-from django.test.signals import setting_changed
+import warnings
 
 from wagtail.images import get_image_model
-from wagtail.images.models import Image
-from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
+from wagtail.permissions import policies_registry
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
-permission_policy = None
-
-
-class ImagesPermissionPolicyGetter:
-    """
-    A helper to retrieve the current permission policy dynamically.
-    Following the descriptor protocol, this should be used as a class attribute::
-
-        class MyImageView(PermissionCheckedMixin, ...):
-            permission_policy = ImagesPermissionPolicyGetter()
-    """
-
-    def __get__(self, obj, objtype=None):
-        return permission_policy
-
-
-def set_permission_policy():
-    """Sets the permission policy for the current image model."""
-
-    global permission_policy
-    permission_policy = CollectionOwnershipPermissionPolicy(
-        get_image_model(), auth_model=Image, owner_field_name="uploaded_by_user"
-    )
-
-
-@receiver(setting_changed)
-def update_permission_policy(signal, sender, setting, **kwargs):
-    """
-    Updates the permission policy when the `WAGTAILIMAGES_IMAGE_MODEL` setting changes.
-    This is useful in tests where we override the base image model and expect the
-    permission policy to have changed accordingly.
-    """
-
-    if setting == "WAGTAILIMAGES_IMAGE_MODEL":
-        set_permission_policy()
-
-
-# Set the permission policy for the first time.
-set_permission_policy()
+warnings.warn(
+    "wagtail.images.permissions.permission_policy is deprecated. "
+    "Use wagtail.permissions.policies_registry.get_by_type(get_image_model()) instead.",
+    RemovedInWagtail90Warning,
+)
+permission_policy = policies_registry.get_by_type(get_image_model())

--- a/wagtail/images/tests/__init__.py
+++ b/wagtail/images/tests/__init__.py
@@ -1,0 +1,18 @@
+from django.test.signals import setting_changed
+
+from wagtail.images import get_image_model, get_permission_policy
+from wagtail.permissions import policies_registry
+
+
+def update_permission_policy(signal, sender, setting, **kwargs):
+    """
+    Register the permission policy when the `WAGTAILIMAGES_IMAGE_MODEL` setting changes.
+    This is useful in tests where we override the image model setting and expect the
+    permission policy to have changed accordingly.
+    """
+
+    if setting == "WAGTAILIMAGES_IMAGE_MODEL":
+        policies_registry.register(get_image_model(), get_permission_policy())
+
+
+setting_changed.connect(update_permission_policy)

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 from unittest.mock import patch
 
 from django.conf import settings
+from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import SimpleUploadedFile, TemporaryUploadedFile
@@ -4310,6 +4311,32 @@ class TestURLGeneratorViewOutput(WagtailTestUtils, TestCase):
         )
         self.assertEqual(preview_url, expected_preview_url)
 
+    def test_get_no_collection_permissions(self):
+        # Remove privileges from user
+        self.user.is_superuser = False
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            ),
+            Permission.objects.get(
+                content_type__app_label="wagtailimages",
+                codename=get_permission_codename("change", Image._meta),
+            ),
+        )
+        self.user.save()
+
+        # With only admin access and model-level permissions, the user gets
+        # redirected to the home page due to insufficient permissions to view
+        # the image URL generator at all
+        response = self.client.get(
+            reverse(
+                "wagtailimages:url_generator_output",
+                args=(self.image.id,),
+            )
+            + "?filter_method=fill&width=800&height=600"
+        )
+        self.assertRedirects(response, reverse("wagtailadmin_home"))
+
     def test_get_bad_permissions(self):
         """
         This tests that the view gives a 403 if a user without correct permissions attempts to access it
@@ -4321,6 +4348,20 @@ class TestURLGeneratorViewOutput(WagtailTestUtils, TestCase):
                 content_type__app_label="wagtailadmin", codename="access_admin"
             )
         )
+        image_changers_group = Group.objects.create(name="Image changers")
+        change_permission = Permission.objects.get(
+            content_type__app_label="wagtailimages", codename="change_image"
+        )
+        root_collection = Collection.get_first_root_node()
+        new_collection = root_collection.add_child(
+            instance=Collection(name="New collection")
+        )
+        GroupCollectionPermission.objects.create(
+            group=image_changers_group,
+            collection=new_collection,
+            permission=change_permission,
+        )
+        self.user.groups.add(image_changers_group)
         self.user.save()
 
         # Get
@@ -4334,6 +4375,9 @@ class TestURLGeneratorViewOutput(WagtailTestUtils, TestCase):
 
         # Check response
         self.assertEqual(response.status_code, 403)
+        # With admin access, model-level image permission, but only permissions
+        # for a different collection, the user should get an image-specific
+        # error message
         self.assertEqual(
             response.content.decode(),
             "You do not have permission to generate a URL for this image.",

--- a/wagtail/images/tests/test_permissions.py
+++ b/wagtail/images/tests/test_permissions.py
@@ -1,0 +1,36 @@
+from django.test import TestCase, override_settings
+
+from wagtail.images import get_image_model
+from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
+from wagtail.permissions import policies_registry
+from wagtail.test.testapp.models import CustomImage
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
+
+
+class TestImagePermissions(TestCase):
+    def test_permissions_direct_import_deprecated(self):
+        model = get_image_model()
+        with self.assertWarnsMessage(
+            RemovedInWagtail90Warning,
+            "wagtail.images.permissions.permission_policy is deprecated. "
+            "Use wagtail.permissions.policies_registry.get_by_type(get_image_model()) instead.",
+        ):
+            from wagtail.images.permissions import permission_policy
+
+            self.assertIsInstance(
+                permission_policy,
+                CollectionOwnershipPermissionPolicy,
+            )
+            self.assertIs(permission_policy.model, model)
+
+    def test_get_from_registry(self):
+        model = get_image_model()
+        permission_policy = policies_registry.get_by_type(model)
+        self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
+        self.assertIs(permission_policy.model, model)
+
+    @override_settings(WAGTAILIMAGES_IMAGE_MODEL="tests.CustomImage")
+    def test_get_from_registry_with_custom_model(self):
+        permission_policy = policies_registry.get_by_type(CustomImage)
+        self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
+        self.assertIs(permission_policy.model, CustomImage)

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -23,8 +23,8 @@ from wagtail.images.fields import WagtailImageField
 from wagtail.images.formats import Format, get_image_format, register_image_format
 from wagtail.images.forms import get_image_form
 from wagtail.images.models import Image as WagtailImage
-from wagtail.images.permissions import update_permission_policy
 from wagtail.images.rect import Rect, Vector
+from wagtail.images.tests import update_permission_policy
 from wagtail.images.utils import generate_signature, verify_signature
 from wagtail.images.views.serve import ServeView
 from wagtail.test.testapp.models import CustomImage, CustomImageFilePath

--- a/wagtail/images/views/bulk_actions/add_to_collection.py
+++ b/wagtail/images/views/bulk_actions/add_to_collection.py
@@ -2,18 +2,19 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
+from wagtail.images import get_image_model
 from wagtail.images.views.bulk_actions.image_bulk_action import ImageBulkAction
+from wagtail.permissions import policies_registry
 
 
 class CollectionForm(forms.Form):
     def __init__(self, *args, **kwargs):
         user = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
+        permission_policy = policies_registry.get_by_type(get_image_model())
         self.fields["collection"] = forms.ModelChoiceField(
             label=_("Collection"),
-            queryset=ImageBulkAction.permission_policy.collections_user_has_permission_for(
-                user, "add"
-            ),
+            queryset=permission_policy.collections_user_has_permission_for(user, "add"),
         )
 
 

--- a/wagtail/images/views/bulk_actions/image_bulk_action.py
+++ b/wagtail/images/views/bulk_actions/image_bulk_action.py
@@ -1,11 +1,16 @@
+from django.utils.functional import cached_property
+
 from wagtail.admin.views.bulk_action import BulkAction
 from wagtail.images import get_image_model
-from wagtail.images.permissions import permission_policy as images_permission_policy
+from wagtail.permissions import policies_registry
 
 
 class ImageBulkAction(BulkAction):
-    permission_policy = images_permission_policy
     models = [get_image_model()]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_all_objects_in_listing_query(self, parent_id):
         listing_objects = self.permission_policy.instances_user_has_permission_for(

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -8,7 +8,6 @@ from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import View
 
-from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.models import popular_tags_for_model
 from wagtail.admin.ui.tables import (
@@ -33,11 +32,9 @@ from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.images import get_image_model
 from wagtail.images.formats import get_image_format
 from wagtail.images.forms import ImageInsertionForm, get_image_form
-from wagtail.images.permissions import permission_policy
 from wagtail.images.utils import find_image_duplicates
 from wagtail.models import ReferenceIndex
-
-permission_checker = PermissionPolicyChecker(permission_policy)
+from wagtail.permissions import policies_registry
 
 
 class ImageChosenResponseMixin(ChosenResponseMixin):
@@ -60,7 +57,10 @@ class ImageCreationFormMixin(CreationFormMixin):
     creation_tab_id = "upload"
     create_action_label = _("Upload")
     create_action_clicked_label = _("Uploading…")
-    permission_policy = permission_policy
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
     def get_creation_form_class(self):
         return get_image_form(self.model)
@@ -94,9 +94,8 @@ class BaseImageChooseView(BaseChooseView):
     def get_object_list(self):
         # Get images (filtered by user permission)
         images = (
-            permission_policy.instances_user_has_any_permission_for(
-                self.request.user, ["choose"]
-            )
+            policies_registry.get_by_type(get_image_model())
+            .instances_user_has_any_permission_for(self.request.user, ["choose"])
             .select_related("collection")
             .prefetch_renditions("max-165x165")
         )
@@ -222,7 +221,7 @@ class ImageChooseResultsView(
 class ImageChosenView(ChosenViewMixin, ImageChosenResponseMixin, View):
     def get_object(self, pk):
         item = super().get_object(pk)
-
+        permission_policy = policies_registry.get_by_type(self.model)
         if not permission_policy.user_has_permission_for_instance(
             self.request.user, "choose", item
         ):
@@ -236,8 +235,12 @@ class ImageChosenView(ChosenViewMixin, ImageChosenResponseMixin, View):
 
 
 class ImageChosenMultipleView(ChosenMultipleViewMixin, ImageChosenResponseMixin, View):
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
+
     def get_objects(self, pks):
-        return permission_policy.instances_user_has_any_permission_for(
+        return self.permission_policy.instances_user_has_any_permission_for(
             self.request.user, ["choose"]
         ).filter(pk__in=pks)
 
@@ -275,7 +278,7 @@ class ImageUploadViewMixin(SelectFormatResponseMixin, CreateViewMixin):
             duplicates = find_image_duplicates(
                 image=image,
                 user=request.user,
-                permission_policy=permission_policy,
+                permission_policy=self.permission_policy,
             )
             existing_image = duplicates.first()
             if existing_image:
@@ -392,7 +395,6 @@ class ImageChooserViewSet(ChooserViewSet):
     chosen_multiple_view_class = ImageChosenMultipleView
     create_view_class = ImageUploadView
     select_format_view_class = ImageSelectFormatView
-    permission_policy = permission_policy
     register_widget = False
     preserve_url_parameters = ChooserViewSet.preserve_url_parameters + [
         "select_format",
@@ -405,6 +407,10 @@ class ImageChooserViewSet(ChooserViewSet):
     create_action_clicked_label = _("Uploading…")
     choose_another_text = _("Choose another image")
     edit_item_text = _("Edit this image")
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
     @property
     def select_format_view(self):

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -19,7 +19,6 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, ngettext
 
 from wagtail.admin import messages
-from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.filters import BaseMediaFilterSet
 from wagtail.admin.ui.tables import (
     BaseColumn,
@@ -35,11 +34,9 @@ from wagtail.images import get_image_model
 from wagtail.images.exceptions import InvalidFilterSpecError
 from wagtail.images.forms import URLGeneratorForm, get_image_form
 from wagtail.images.models import Filter, SourceImageIOError
-from wagtail.images.permissions import permission_policy
 from wagtail.images.utils import generate_signature
 from wagtail.models import ReferenceIndex, Site
-
-permission_checker = PermissionPolicyChecker(permission_policy)
+from wagtail.permissions import policies_registry
 
 Image = get_image_model()
 
@@ -47,7 +44,9 @@ USAGE_PAGE_SIZE = getattr(settings, "WAGTAILIMAGES_USAGE_PAGE_SIZE", 20)
 
 
 class ImagesFilterSet(BaseMediaFilterSet):
-    permission_policy = permission_policy
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Image)
 
     class Meta:
         model = Image
@@ -67,7 +66,6 @@ class IndexView(generic.IndexView):
     }
     default_ordering = "-created_at"
     context_object_name = "images"
-    permission_policy = permission_policy
     any_permission_required = ["add", "change", "delete"]
     model = Image
     filterset_class = ImagesFilterSet
@@ -81,6 +79,10 @@ class IndexView(generic.IndexView):
     edit_url_name = "wagtailimages:edit"
     template_name = "wagtailimages/images/index.html"
     results_template_name = "wagtailimages/images/index_results.html"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_paginate_by(self, queryset):
         return getattr(settings, "WAGTAILIMAGES_INDEX_PAGE_SIZE", 30)
@@ -97,7 +99,7 @@ class IndexView(generic.IndexView):
     def get_base_queryset(self):
         # Get images (filtered by user permission)
         images = (
-            permission_policy.instances_user_has_any_permission_for(
+            self.permission_policy.instances_user_has_any_permission_for(
                 self.request.user, ["change", "delete"]
             )
             .select_related("collection")
@@ -237,7 +239,6 @@ class TitleColumnWithFilename(TitleColumn):
 
 
 class EditView(generic.EditView):
-    permission_policy = permission_policy
     pk_url_kwarg = "image_id"
     error_message = gettext_lazy("The image could not be saved due to errors.")
     template_name = "wagtailimages/images/edit.html"
@@ -252,6 +253,10 @@ class EditView(generic.EditView):
     def model(self):
         return get_image_model()
 
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
+
     def get_form_class(self):
         return get_image_form(self.model)
 
@@ -262,7 +267,7 @@ class EditView(generic.EditView):
 
     def get_object(self, queryset=None):
         obj = super().get_object(queryset)
-        if not permission_policy.user_has_permission_for_instance(
+        if not self.permission_policy.user_has_permission_for_instance(
             self.request.user, "change", obj
         ):
             raise PermissionDenied
@@ -332,6 +337,10 @@ class URLGeneratorView(generic.InspectView):
         "The filter options you have selected are not valid."
     )
 
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
+
     def get_page_subtitle(self):
         return self.object.title
 
@@ -351,7 +360,7 @@ class URLGeneratorView(generic.InspectView):
 
         self.object = get_object_or_404(self.model, id=image_id)
 
-        if not permission_policy.user_has_permission_for_instance(
+        if not self.permission_policy.user_has_permission_for_instance(
             request.user, "change", self.object
         ):
             if self.output_only:
@@ -434,9 +443,10 @@ class URLGeneratorView(generic.InspectView):
 
 
 def preview(request, image_id, filter_spec):
-    image = get_object_or_404(get_image_model(), id=image_id)
+    model = get_image_model()
+    image = get_object_or_404(model, id=image_id)
 
-    if not permission_policy.user_has_permission_for_instance(
+    if not policies_registry.get_by_type(model).user_has_permission_for_instance(
         request.user, "change", image
     ):
         raise PermissionDenied
@@ -468,7 +478,6 @@ def preview(request, image_id, filter_spec):
 class DeleteView(generic.DeleteView):
     model = get_image_model()
     pk_url_kwarg = "image_id"
-    permission_policy = permission_policy
     permission_required = "delete"
     header_icon = "image"
     template_name = "wagtailimages/images/confirm_delete.html"
@@ -476,6 +485,10 @@ class DeleteView(generic.DeleteView):
     delete_url_name = "wagtailimages:delete"
     index_url_name = "wagtailimages:index"
     page_title = gettext_lazy("Delete image")
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def user_has_permission(self, permission):
         return self.permission_policy.user_has_permission_for_instance(
@@ -499,7 +512,6 @@ class DeleteView(generic.DeleteView):
 
 
 class CreateView(generic.CreateView):
-    permission_policy = permission_policy
     index_url_name = "wagtailimages:index"
     add_url_name = "wagtailimages:add"
     edit_url_name = "wagtailimages:edit"
@@ -510,6 +522,10 @@ class CreateView(generic.CreateView):
     @cached_property
     def model(self):
         return get_image_model()
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_form_class(self):
         return get_image_form(self.model)
@@ -530,7 +546,6 @@ class UsageView(generic.UsageView):
     model = get_image_model()
     paginate_by = USAGE_PAGE_SIZE
     pk_url_kwarg = "image_id"
-    permission_policy = permission_policy
     permission_required = "change"
     header_icon = "image"
     index_url_name = "wagtailimages:index"
@@ -538,6 +553,10 @@ class UsageView(generic.UsageView):
 
     def get_base_object_queryset(self):
         return super().get_base_object_queryset().select_related("uploaded_by_user")
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def user_has_permission(self, permission):
         return self.permission_policy.user_has_permission_for_instance(

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -2,7 +2,6 @@ import os.path
 
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy
 
@@ -23,7 +22,6 @@ from wagtail.images.utils import (
     get_accept_attributes,
     get_allowed_image_extensions,
 )
-from wagtail.permissions import policies_registry
 
 
 class AddView(WagtailAdminTemplateMixin, BaseAddView):
@@ -52,10 +50,6 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
             },
             {"url": "", "label": self.get_page_title()},
         ]
-
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(get_image_model())
 
     def get_model(self):
         return get_image_model()
@@ -132,10 +126,6 @@ class EditView(BaseEditView):
     edit_object_url_name = "wagtailimages:edit_multiple"
     delete_object_url_name = "wagtailimages:delete_multiple"
 
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(get_image_model())
-
     def get_model(self):
         return get_image_model()
 
@@ -146,10 +136,6 @@ class EditView(BaseEditView):
 class DeleteView(BaseDeleteView):
     pk_url_kwarg = "image_id"
     context_object_id_name = "image_id"
-
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(get_image_model())
 
     def get_model(self):
         return get_image_model()

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -2,6 +2,7 @@ import os.path
 
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy
 
@@ -17,16 +18,15 @@ from wagtail.admin.views.generic.multiple_upload import DeleteView as BaseDelete
 from wagtail.admin.views.generic.multiple_upload import EditView as BaseEditView
 from wagtail.images import get_image_model
 from wagtail.images.forms import get_image_form, get_image_multi_form
-from wagtail.images.permissions import ImagesPermissionPolicyGetter, permission_policy
 from wagtail.images.utils import (
     find_image_duplicates,
     get_accept_attributes,
     get_allowed_image_extensions,
 )
+from wagtail.permissions import policies_registry
 
 
 class AddView(WagtailAdminTemplateMixin, BaseAddView):
-    permission_policy = ImagesPermissionPolicyGetter()
     template_name = "wagtailimages/multiple/add.html"
     header_icon = "image"
     page_title = gettext_lazy("Add images")
@@ -52,6 +52,10 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
             },
             {"url": "", "label": self.get_page_title()},
         ]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
     def get_model(self):
         return get_image_model()
@@ -121,13 +125,16 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
 
 
 class EditView(BaseEditView):
-    permission_policy = permission_policy
     pk_url_kwarg = "image_id"
     edit_object_form_prefix = "image"
     context_object_name = "image"
     context_object_id_name = "image_id"
     edit_object_url_name = "wagtailimages:edit_multiple"
     delete_object_url_name = "wagtailimages:delete_multiple"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
     def get_model(self):
         return get_image_model()
@@ -137,9 +144,12 @@ class EditView(BaseEditView):
 
 
 class DeleteView(BaseDeleteView):
-    permission_policy = permission_policy
     pk_url_kwarg = "image_id"
     context_object_id_name = "image_id"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
     def get_model(self):
         return get_image_model()

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -1,4 +1,5 @@
 from django.urls import include, path, reverse, reverse_lazy
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
@@ -15,7 +16,6 @@ from wagtail.admin.site_summary import SummaryItem
 from wagtail.images import admin_urls, get_image_model, image_operations
 from wagtail.images.api.admin.views import ImagesAdminAPIViewSet
 from wagtail.images.forms import GroupImagePermissionFormSet
-from wagtail.images.permissions import permission_policy
 from wagtail.images.rich_text import ImageEmbedHandler
 from wagtail.images.rich_text.contentstate import ContentstateImageConversionRule
 from wagtail.images.rich_text.editor_html import EditorHTMLImageConversionRule
@@ -25,6 +25,7 @@ from wagtail.images.views.bulk_actions import (
     DeleteBulkAction,
 )
 from wagtail.images.views.chooser import viewset as chooser_viewset
+from wagtail.permissions import policies_registry
 
 
 @hooks.register("register_admin_urls")
@@ -41,7 +42,7 @@ def construct_admin_api(router):
 
 class ImagesMenuItem(MenuItem):
     def is_shown(self, request):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(get_image_model()).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -130,14 +131,16 @@ class ImagesSummaryItem(SummaryItem):
         site_name = get_site_for_user(self.request.user)["site_name"]
 
         return {
-            "total_images": permission_policy.instances_user_has_any_permission_for(
+            "total_images": policies_registry.get_by_type(get_image_model())
+            .instances_user_has_any_permission_for(
                 self.request.user, {"add", "change", "delete", "choose"}
-            ).count(),
+            )
+            .count(),
             "site_name": site_name,
         }
 
     def is_shown(self):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(get_image_model()).user_has_any_permission(
             self.request.user, ["add", "change", "delete"]
         )
 
@@ -149,7 +152,7 @@ def add_images_summary_item(request, items):
 
 class ImagesSearchArea(SearchArea):
     def is_shown(self, request):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(get_image_model()).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -185,7 +188,10 @@ def describe_collection_docs(collection):
 
 class ImageAdminURLFinder(ModelAdminURLFinder):
     edit_url_name = "wagtailimages:edit"
-    permission_policy = permission_policy
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
 
 register_admin_url_finder(get_image_model(), ImageAdminURLFinder)

--- a/wagtail/locales/views.py
+++ b/wagtail/locales/views.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
 from django.core.exceptions import PermissionDenied
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy, ngettext_lazy
 
 from wagtail.admin import messages
@@ -9,7 +10,7 @@ from wagtail.admin.views import generic
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.coreutils import get_content_languages
 from wagtail.models import Locale
-from wagtail.permissions import locale_permission_policy
+from wagtail.permissions import policies_registry
 
 from .forms import LocaleForm
 from .utils import get_locale_usage
@@ -127,7 +128,6 @@ class DeleteView(generic.DeleteView):
 class LocaleViewSet(ModelViewSet):
     icon = "site"
     model = Locale
-    permission_policy = locale_permission_policy
     add_to_reference_index = False
 
     index_view_class = IndexView
@@ -140,6 +140,10 @@ class LocaleViewSet(ModelViewSet):
     copy_view_enabled = False
 
     template_prefix = "wagtaillocales/"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Locale)
 
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(

--- a/wagtail/locales/wagtail_hooks.py
+++ b/wagtail/locales/wagtail_hooks.py
@@ -3,7 +3,8 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
-from wagtail.permissions import site_permission_policy
+from wagtail.models import Site
+from wagtail.permissions import policies_registry
 
 from .views import LocaleViewSet
 
@@ -15,7 +16,7 @@ def register_viewset():
 
 class LocalesMenuItem(MenuItem):
     def is_shown(self, request):
-        return site_permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Site).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -2187,10 +2187,10 @@ class GroupPagePermission(models.Model):
 
 class PagePermissionTester:
     def __init__(self, user, page):
-        from wagtail.permissions import page_permission_policy
+        from wagtail.permissions import policies_registry
 
         self.user = user
-        self.permission_policy = page_permission_policy
+        self.permission_policy = policies_registry.get(page)
         self.page = page
         self.page_is_root = page.depth == 1  # Equivalent to page.is_root()
 
@@ -2602,9 +2602,10 @@ class PageLogEntryManager(BaseLogEntryManager):
         return super().log_action(instance, action, **kwargs)
 
     def viewable_by_user(self, user):
-        from wagtail.permissions import page_permission_policy
+        from wagtail.permissions import policies_registry
 
-        explorable_instances = page_permission_policy.explorable_instances(user)
+        permission_policy = policies_registry.get_by_type(Page)
+        explorable_instances = permission_policy.explorable_instances(user)
         q = Q(page__in=explorable_instances.values_list("pk", flat=True))
 
         root_page_permissions = Page.get_first_root_node().permissions_for_user(user)

--- a/wagtail/permissions.py
+++ b/wagtail/permissions.py
@@ -1,7 +1,16 @@
 from wagtail.models import Collection, Locale, Page, Site, Task, Workflow
 from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permission_policies.base import BasePermissionPolicy
 from wagtail.permission_policies.collections import CollectionManagementPermissionPolicy
 from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.utils.registry import ObjectTypeRegistry
+
+policies_registry = ObjectTypeRegistry[BasePermissionPolicy]()
+
+
+def register_permission_policy(model, policy):
+    policies_registry.register(model, value=policy)
+
 
 page_permission_policy = PagePermissionPolicy(Page)
 site_permission_policy = ModelPermissionPolicy(Site)
@@ -9,3 +18,10 @@ collection_permission_policy = CollectionManagementPermissionPolicy(Collection)
 task_permission_policy = ModelPermissionPolicy(Task)
 workflow_permission_policy = ModelPermissionPolicy(Workflow)
 locale_permission_policy = ModelPermissionPolicy(Locale)
+
+register_permission_policy(Page, page_permission_policy)
+register_permission_policy(Site, site_permission_policy)
+register_permission_policy(Collection, collection_permission_policy)
+register_permission_policy(Task, task_permission_policy)
+register_permission_policy(Workflow, workflow_permission_policy)
+register_permission_policy(Locale, locale_permission_policy)

--- a/wagtail/sites/views.py
+++ b/wagtail/sites/views.py
@@ -1,10 +1,11 @@
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.ui.tables import Column, StatusFlagColumn, TitleColumn
 from wagtail.admin.views import generic
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.models import Site
-from wagtail.permissions import site_permission_policy
+from wagtail.permissions import policies_registry
 from wagtail.sites.forms import SiteForm
 
 
@@ -53,7 +54,6 @@ class DeleteView(generic.DeleteView):
 class SiteViewSet(ModelViewSet):
     icon = "site"
     model = Site
-    permission_policy = site_permission_policy
     add_to_reference_index = False
 
     index_view_class = IndexView
@@ -62,6 +62,10 @@ class SiteViewSet(ModelViewSet):
     delete_view_class = DeleteView
 
     template_prefix = "wagtailsites/"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(

--- a/wagtail/sites/wagtail_hooks.py
+++ b/wagtail/sites/wagtail_hooks.py
@@ -3,7 +3,8 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
-from wagtail.permissions import site_permission_policy
+from wagtail.models import Site
+from wagtail.permissions import policies_registry
 
 from .views import SiteViewSet
 
@@ -15,7 +16,7 @@ def register_viewset():
 
 class SitesMenuItem(MenuItem):
     def is_shown(self, request):
-        return site_permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Site).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 

--- a/wagtail/snippets/bulk_actions/delete.py
+++ b/wagtail/snippets/bulk_actions/delete.py
@@ -8,7 +8,6 @@ from django.utils.translation import ngettext
 from wagtail.admin.views.bulk_action.mixins import ReferenceIndexMixin
 from wagtail.admin.views.generic import BeforeAfterHookMixin
 from wagtail.snippets.bulk_actions.snippet_bulk_action import SnippetBulkAction
-from wagtail.snippets.permissions import get_permission_name
 
 
 class DeleteBulkAction(BeforeAfterHookMixin, ReferenceIndexMixin, SnippetBulkAction):
@@ -50,12 +49,9 @@ class DeleteBulkAction(BeforeAfterHookMixin, ReferenceIndexMixin, SnippetBulkAct
         return self.run_hook("after_delete_snippet", self.request, objects)
 
     def check_perm(self, snippet):
-        if getattr(self, "can_delete_items", None) is None:
-            # since snippets permissions are not enforced per object, makes sense to just check once per model request
-            self.can_delete_items = self.request.user.has_perm(
-                get_permission_name("delete", self.model)
-            )
-        return self.can_delete_items
+        return self.permission_policy.user_has_permission_for_instance(
+            self.request.user, "delete", snippet
+        )
 
     @classmethod
     def execute_action(cls, objects, user=None, **kwargs):

--- a/wagtail/snippets/bulk_actions/snippet_bulk_action.py
+++ b/wagtail/snippets/bulk_actions/snippet_bulk_action.py
@@ -1,7 +1,8 @@
-from django.utils.functional import classproperty
+from django.utils.functional import cached_property, classproperty
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.views.bulk_action import BulkAction
+from wagtail.permissions import policies_registry
 from wagtail.snippets.models import get_snippet_models
 
 
@@ -17,6 +18,10 @@ class SnippetBulkAction(BulkAction):
         # get_snippet_models() at import time could result in either a circular
         # import or an incomplete list of models.
         return get_snippet_models()
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def object_context(self, snippet):
         return {

--- a/wagtail/snippets/permissions.py
+++ b/wagtail/snippets/permissions.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_permission_codename
 
+from wagtail.permissions import policies_registry
 from wagtail.snippets.models import get_snippet_models
 
 
@@ -29,7 +30,7 @@ def user_can_access_snippets(user, models=None):
         models = get_snippet_models()
 
     for model in models:
-        if model.snippet_viewset.permission_policy.user_has_any_permission(
+        if policies_registry.get_by_type(model).user_has_any_permission(
             user, {"add", "change", "delete", "view"}
         ):
             return True

--- a/wagtail/snippets/tests/test_bulk_actions/test_bulk_delete.py
+++ b/wagtail/snippets/tests/test_bulk_actions/test_bulk_delete.py
@@ -119,6 +119,31 @@ class TestSnippetDeleteView(WagtailTestUtils, TestCase):
         for snippet in self.test_snippets:
             self.assertTrue(self.snippet_model.objects.filter(pk=snippet.pk).exists())
 
+    def test_delete_with_custom_permissions(self):
+        self.user.first_name = "[FORBIDDEN]"
+        self.user.last_name = "Joe"
+        self.user.save()
+
+        response = self.client.get(self.get_url())
+        self.assertEqual(response.status_code, 200)
+
+        html = response.content.decode()
+        self.assertInHTML(
+            "<p>You don't have permission to delete these full-featured snippets</p>",
+            html,
+        )
+
+        for snippet in self.test_snippets:
+            self.assertInHTML(f"<li>{snippet.text}</li>", html)
+
+        response = self.client.post(self.get_url())
+        # User should be redirected back to the index
+        self.assertEqual(response.status_code, 302)
+
+        # Snippets should not be deleted
+        for snippet in self.test_snippets:
+            self.assertTrue(self.snippet_model.objects.filter(pk=snippet.pk).exists())
+
     def test_before_bulk_action_hook_get(self):
         with self.register_hook(
             "before_bulk_action", lambda *args: HttpResponse("Overridden!")

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -33,6 +33,7 @@ from wagtail.documents.tests.utils import get_test_document_file
 from wagtail.images import get_image_model
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.models import Locale, Workflow, WorkflowContentType
+from wagtail.permissions import policies_registry
 from wagtail.snippets.blocks import SnippetChooserBlock
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet
@@ -49,6 +50,7 @@ from wagtail.test.testapp.models import (
     SnippetChooserModel,
     VariousOnDeleteModel,
 )
+from wagtail.test.testapp.wagtail_hooks import FullFeaturedPermissionPolicy
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 from wagtail.utils.timestamps import render_timestamp
@@ -1806,6 +1808,11 @@ class TestCustomPermissionPolicy(BaseSnippetViewSetTests):
         self.assertEqual(self.user.get_full_name(), "[FORBIDDEN] Joe")
         response = self.client.get(self.get_url("edit", args=(quote(self.object.pk),)))
         self.assertRedirects(response, reverse("wagtailadmin_home"))
+
+    def test_registered_policy(self):
+        permission_policy = policies_registry.get_by_type(self.model)
+        self.assertIsInstance(permission_policy, FullFeaturedPermissionPolicy)
+        self.assertIs(permission_policy, self.model.snippet_viewset.permission_policy)
 
 
 class TestSnippetIndexViewBreadcrumbs(SimpleTestCase):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -43,6 +43,7 @@ from wagtail.models import (
     RevisionMixin,
     WorkflowMixin,
 )
+from wagtail.permissions import policies_registry
 from wagtail.snippets.action_menu import SnippetActionMenu
 from wagtail.snippets.models import SnippetAdminURLFinder, get_snippet_models
 from wagtail.snippets.side_panels import SnippetStatusSidePanel
@@ -110,7 +111,7 @@ class ModelIndexView(generic.BaseListingView):
         return super().dispatch(request, *args, **kwargs)
 
     def get_list_url(self, model):
-        if model.snippet_viewset.permission_policy.user_has_any_permission(
+        if policies_registry.get_by_type(model).user_has_any_permission(
             self.request.user,
             {"add", "change", "delete", "view"},
         ):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -43,7 +43,6 @@ from wagtail.models import (
     RevisionMixin,
     WorkflowMixin,
 )
-from wagtail.permissions import ModelPermissionPolicy
 from wagtail.snippets.action_menu import SnippetActionMenu
 from wagtail.snippets.models import SnippetAdminURLFinder, get_snippet_models
 from wagtail.snippets.side_panels import SnippetStatusSidePanel
@@ -660,10 +659,6 @@ class SnippetViewSet(ModelViewSet):
             {"view_name": "revisions_revert"},
         )
         return revisions_revert_view_class
-
-    @property
-    def permission_policy(self):
-        return ModelPermissionPolicy(self.model)
 
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -24,7 +24,7 @@ from wagtail.admin.ui.tables import BooleanColumn, UpdatedAtColumn
 from wagtail.admin.utils import set_query_params
 from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail.admin.widgets import Button
-from wagtail.permission_policies.base import ModelPermissionPolicy
+from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.snippets.bulk_actions.snippet_bulk_action import SnippetBulkAction
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.chooser import SnippetChooserViewSet

--- a/wagtail/users/views/bulk_actions/user_bulk_action.py
+++ b/wagtail/users/views/bulk_actions/user_bulk_action.py
@@ -1,9 +1,10 @@
 from django.contrib.auth import get_user_model
 from django.db.models import Q
+from django.utils.functional import cached_property
 
 from wagtail.admin.views.bulk_action import BulkAction
 from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
-from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permissions import policies_registry
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
 
@@ -12,8 +13,11 @@ User = get_user_model()
 
 class UserBulkAction(PermissionCheckedMixin, BulkAction):
     models = [User]
-    permission_policy = ModelPermissionPolicy(User)
     any_permission_required = ["add", "change", "delete"]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(User)
 
     def get_all_objects_in_listing_query(self, parent_id):
         listing_objects = self.model.objects.all().values_list("pk", flat=True)

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -36,6 +36,7 @@ from wagtail.admin.widgets.button import (
     ButtonWithDropdown,
 )
 from wagtail.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
+from wagtail.permissions import policies_registry
 from wagtail.search import index
 from wagtail.users.forms import UserCreationForm, UserEditForm
 from wagtail.users.utils import user_can_delete_user
@@ -370,7 +371,7 @@ class UserViewSet(ModelViewSet):
     def search_area_class(self):
         class UsersSearchArea(SearchArea):
             def is_shown(search_area, request):
-                return self.permission_policy.user_has_any_permission(
+                return policies_registry.get_by_type(User).user_has_any_permission(
                     request.user, {"add", "change", "delete"}
                 )
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Rebase of #11268, minimal implementation of https://github.com/wagtail/rfcs/pull/102 that doesn't try to answer the questions around `PagePermissionTester` (i.e. that class is still page-specific).

Fixes #13859. Fixes (maybe) #2907?

### Description

<!-- Please describe the problem you're fixing. -->
This adds a `policies_registry` to `wagtail.permissions`, which is an instance of `ObjectTypeRegistry` that maps a model to a permission policy instance.

Instead of instantiating permission policies in various places and/or importing them from specific modules e.g. `wagtail.images.permissions`, we register the default permission policies for our built-in models to the registry. We also do the same for user-registered models such as snippets and models in `ModelViewSet`s.

Then, every time a permission policy for any model is needed, we can get them from the registry at request time anywhere in the codebase, instead of having to know the model in advance and importing the default policy instance at startup. This allows the permission policies to be overridable, even for built-in models. It also helps in enforcing consistent permission policies throughout Wagtail where the "canonical" permission policy may be otherwise difficult to obtain, e.g. to fix issues like #13859.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
GitHub Copilot for autocompletion.