### PR TITLE
Drop the setuptools data-files clause from pyproject.toml

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
 
 * Fix: Prevent spurious migrations when there are missing child blocks in `StructBlock.Meta.form_layout` (Matthias Brück, Sage Abdullah)
 * Fix: Prevent error in usage views when using `gettext_lazy` for a model's `verbose_name` (James Biggs)
+* Fix: Prevent development markdown files from being added to virtual environment root upon installation (Dan Braghis)
 
 
 7.4.1 (19.05.2026)

--- a/docs/releases/7.4.2.md
+++ b/docs/releases/7.4.2.md
@@ -15,6 +15,7 @@ depth: 1
 
  * Prevent spurious migrations when there are missing child blocks in `StructBlock.Meta.form_layout` (Matthias Brück, Sage Abdullah)
  * Prevent error in usage views when using `gettext_lazy` for a model's `verbose_name` (James Biggs)
+ * Prevent development markdown files from being added to virtual environment root upon installation (Dan Braghis)
 
 ### Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,15 +115,6 @@ include = ["wagtail*"]
 "wagtail" = ["**/*"]
 "*" = [".dockerignore"]
 
-[tool.setuptools.data-files]
-"." = [
-  "AGENTS.md",
-  "CHANGELOG.txt",
-  "CODE_OF_CONDUCT.md",
-  "CONTRIBUTORS.md",
-  "SPONSORS.md",
-]
-
 [tool.setuptools.exclude-package-data]
 "wagtail" = [
   "*.md",
@@ -133,7 +124,6 @@ include = ["wagtail*"]
   "static_src/**",
   "**/static_src/**",
 ]
-
 
 [tool.setuptools.dynamic]
 version = { attr = "wagtail.__version__" }


### PR DESCRIPTION
Fixes #14259

### Description

This fixes an unintended effect of the markdown files ending up in the virtual environment root when installing Wagtail.

`data-files` is also actively discouraged. See
https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#:~:text=data%2Dfiles,the%20package%20directories.

### AI usage

This PR was lovingly handcrafted.