### PR TITLE
Fix markdown files landing in venv root by removing data-files from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,15 +115,6 @@ include = ["wagtail*"]
 "wagtail" = ["**/*"]
 "*" = [".dockerignore"]
 
-[tool.setuptools.data-files]
-"." = [
-  "AGENTS.md",
-  "CHANGELOG.txt",
-  "CODE_OF_CONDUCT.md",
-  "CONTRIBUTORS.md",
-  "SPONSORS.md",
-]
-
 [tool.setuptools.exclude-package-data]
 "wagtail" = [
   "*.md",


### PR DESCRIPTION
## Summary

Fixes #14259.

`[tool.setuptools.data-files]` with `"." = [...]` installs `AGENTS.md`, `CHANGELOG.txt`, `CODE_OF_CONDUCT.md`, `CONTRIBUTORS.md`, and `SPONSORS.md` at the root of the target virtual environment, polluting it with project-level files that carry no runtime value for end users.

The fix removes the entire section. setuptools itself [discourages `data-files`](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#:~:text=data%2Dfiles,the%20package%20directories.), and none of these files need to be installed when a user runs `pip install wagtail`.

## Changes

- `pyproject.toml`: remove `[tool.setuptools.data-files]` section entirely.

## Areas for careful review

- Confirm no downstream tooling or CI relies on these files being present in the installed package.
- Check if CHANGELOG.txt or AGENTS.md is referenced from any installed entry-point or runtime code path.

---

> This pull request includes code written with the assistance of AI.  
> The code has **not yet been reviewed** by a human.