### PR TITLE
Fix Draftail editor missing accessible name (aria-input-field-name)

### DIFF
--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -158,6 +158,15 @@ const initEditor = (selector, originalOptions, currentScript) => {
     field.draftailEditor = ref;
   };
 
+  // Associate the field's existing <label> with the editor's contenteditable element.
+  // StructBlock labels are generated without an id, so we assign one using the
+  // ${field.id}-label convention that formatted_field.html already uses for top-level fields.
+  const labelEl = document.querySelector(`label[for="${field.id}"]`);
+  if (labelEl && !labelEl.id) {
+    labelEl.id = `${field.id}-label`;
+  }
+  const ariaLabelledBy = labelEl ? labelEl.id : null;
+
   const getSharedPropsFromOptions = (newOptions) => {
     let ariaDescribedBy = null;
     const enableHorizontalRule = newOptions.enableHorizontalRule
@@ -249,6 +258,7 @@ const initEditor = (selector, originalOptions, currentScript) => {
       maxListNesting: 4,
       stripPastedStyles: false,
       ariaDescribedBy,
+      ariaLabelledBy,
       ...newOptions,
       blockTypes: blockTypes.map(wrapWagtailIcon),
       inlineStyles: inlineStyles.map(wrapWagtailIcon),


### PR DESCRIPTION
## Summary

Fixes #14205.

Axe reports an `aria-input-field-name` violation on the Draftail rich text editor: the existing `<label>` points (via `for`) at the hidden `<input>` that the editor replaces visually, so the `role="textbox"` contenteditable that assistive technologies actually interact with has no accessible name.

Draftail already accepts an `ariaLabelledBy` prop that wires `aria-labelledby` onto the contenteditable element. This PR wires it up in `initEditor`:

1. Query for `label[for="${field.id}"]` — the label already rendered by Wagtail's form machinery.
2. If the label has no `id` yet (the case inside StructBlock, whose labels are generated client-side by `StructBlock.ts` without ids), assign `${field.id}-label`, matching the convention used by `formatted_field.html` for top-level fields.
3. Pass the resolved label id as `ariaLabelledBy` in `getSharedPropsFromOptions`.

This covers both cases described in the issue:
- **Top-level fields**: `formatted_field.html` already emits `id="${field.id}-label"` on the label, so the query finds it and we reuse the existing id.
- **StructBlock fields**: the label is generated without an id; we assign one on the spot.

## Changes

- `client/src/components/Draftail/index.js`: compute `ariaLabelledBy` once in `initEditor` scope and forward it through `getSharedPropsFromOptions`.

## Areas for careful review

- The label id assignment is a DOM side-effect that happens once per editor init. Confirm this doesn't conflict with anything else that reads the label id (e.g. the "Add comment" button's `aria-describedby` in `formatted_field.html` already uses `label_id`, not the DOM id set here).
- `ariaLabelledBy` is placed before `...newOptions` so callers can override it if needed — consistent with how `ariaDescribedBy` is handled.
- If no matching label is found (edge case), `ariaLabelledBy` is `null` and Draftail ignores it, so there is no regression.

---

> This pull request includes code written with the assistance of AI.  
> The code has **not yet been reviewed** by a human.