### PR TITLE
Persist collapsed panel state across page loads using localStorage

### DIFF
--- a/client/src/includes/panels.ts
+++ b/client/src/includes/panels.ts
@@ -1,5 +1,30 @@
 import { getElementByContentPath } from '../utils/contentPath';
 
+const PANEL_STATE_KEY_PREFIX = 'wagtail:panel-expansion';
+
+function getPanelStorageKey(toggle: HTMLButtonElement): string {
+  return `${PANEL_STATE_KEY_PREFIX}:${toggle.getAttribute('aria-controls')}`;
+}
+
+function savePanelState(toggle: HTMLButtonElement, expanded: boolean): void {
+  try {
+    window.localStorage.setItem(getPanelStorageKey(toggle), String(expanded));
+  } catch {
+    // localStorage may be unavailable (private browsing, storage quota).
+  }
+}
+
+function loadPanelState(toggle: HTMLButtonElement): boolean | null {
+  try {
+    const stored = window.localStorage.getItem(getPanelStorageKey(toggle));
+    if (stored === 'true') return true;
+    if (stored === 'false') return false;
+  } catch {
+    // localStorage may be unavailable.
+  }
+  return null;
+}
+
 /**
  * Switches a collapsible panel from expanded to collapsed, or vice versa.
  * Updates the DOM and fires custom events for other code to hook into.
@@ -70,21 +95,34 @@ export function initCollapsiblePanel(toggle: HTMLButtonElement) {
   const hasError = content.querySelector(
     '[aria-invalid="true"], .error, .w-field--error',
   );
-  const isCollapsed = hasCollapsed && !hasError;
+  // Never collapse a panel that has errors, regardless of saved state.
+  const savedState = hasError ? null : loadPanelState(toggle);
+  // Saved state takes priority over the CSS class; errors always win.
+  const isCollapsed =
+    savedState !== null ? !savedState : hasCollapsed && !hasError;
 
   if (isCollapsed) {
     togglePanel(false);
   }
 
-  toggle.addEventListener('click', togglePanel.bind(null, undefined));
+  toggle.addEventListener('click', () => {
+    togglePanel(undefined);
+    savePanelState(toggle, toggle.getAttribute('aria-expanded') === 'true');
+  });
 
   const heading = panel.querySelector<HTMLElement>('[data-panel-heading]');
   if (heading) {
-    heading.addEventListener('click', togglePanel.bind(null, undefined));
+    heading.addEventListener('click', () => {
+      togglePanel(undefined);
+      savePanelState(toggle, toggle.getAttribute('aria-expanded') === 'true');
+    });
   }
 
-  // Set the toggle back to expanded upon reveal.
-  content.addEventListener('beforematch', togglePanel.bind(null, true));
+  // Set the toggle back to expanded upon reveal (browser find-in-page).
+  content.addEventListener('beforematch', () => {
+    togglePanel(true);
+    savePanelState(toggle, true);
+  });
 
   toggle.dispatchEvent(
     new CustomEvent('wagtail:panel-init', {


### PR DESCRIPTION
## Summary

Fixes #14000.

When a user collapses a panel in the page editor, the preference is discarded on the next page load or draft save. Editors who work primarily on a subset of fields find it frustrating to re-collapse the same panels after every save.

This PR saves each panel's expanded/collapsed state to `localStorage` when the user interacts with the toggle (button, heading, or browser find-in-page reveal). On subsequent page loads, the saved state is restored during `initCollapsiblePanel`, overriding the CSS `collapsed` class.

Storage key format: `wagtail:panel-expansion:<aria-controls-id>`

## Changes

- `client/src/includes/panels.ts`:
  - Added `savePanelState` / `loadPanelState` helpers (localStorage, keyed by `aria-controls` id, failures silently caught).
  - `initCollapsiblePanel` reads saved state on init and prefers it over the CSS class.
  - All three toggle entry points (click, heading click, beforematch) save the new state after each toggle.

## Edge cases handled

- **Error fields**: panels containing `[aria-invalid="true"]`, `.error`, or `.w-field--error` always start expanded; their saved state is ignored so errors are never hidden.
- **Unavailable localStorage**: private browsing, storage quota exceeded, or security restrictions are all caught; the existing CSS-class fallback applies.
- **Initial state not written**: the setup phase never writes to localStorage, so visiting a page for the first time doesn't create spurious "expanded" entries.

## Areas for careful review

- Panel `aria-controls` ids need to be stable across pages of the same type for state to be shared. Confirm the ids generated by Wagtail's panel rendering are deterministic (field-name-based, not position-based).
- Consider whether separate users on the same browser sharing localStorage is desirable (likely yes — it matches preferences, not content).

---

> This pull request includes code written with the assistance of AI.
> The code has **not yet been reviewed** by a human.