### PR TITLE
Add "only_live" value for WAGTAILREDIRECTS_AUTO_CREATE to skip draft pages

### DIFF
--- a/docs/reference/contrib/redirects.md
+++ b/docs/reference/contrib/redirects.md
@@ -54,7 +54,21 @@ Overrides to the following `Page` methods are respected when generating redirect
 -   {meth}`~wagtail.models.Page.get_url_parts()`
 -   {meth}`~wagtail.models.Page.get_route_paths()`
 
-If you find the feature is not a good fit for your project, you can disable it by adding the following to your project settings:
+The feature can be configured via the `WAGTAILREDIRECTS_AUTO_CREATE` setting:
+
+| Value | Behaviour |
+| ----------- | --------- |
+| `True` (default) | Redirects are created for all pages, including draft pages, whenever their slug or URL path changes. |
+| `False` | Auto-creation is disabled entirely. |
+| `"only_live"` | Redirects are only created when the page being changed is live (published). This avoids creating spurious redirects from autosave slug changes on draft pages. |
+
+For example, to only create redirects for live pages:
+
+```python
+WAGTAILREDIRECTS_AUTO_CREATE = "only_live"
+```
+
+Or to disable the feature entirely:
 
 ```python
 WAGTAILREDIRECTS_AUTO_CREATE = False

--- a/wagtail/contrib/redirects/signal_handlers.py
+++ b/wagtail/contrib/redirects/signal_handlers.py
@@ -49,7 +49,10 @@ def autocreate_redirects_on_slug_change(
     # NB: `page_slug_changed` provides specific page instances,
     # so we do not need to 'upcast' them for create_redirects here
 
-    if not getattr(settings, "WAGTAILREDIRECTS_AUTO_CREATE", True):
+    auto_create = getattr(settings, "WAGTAILREDIRECTS_AUTO_CREATE", True)
+    if not auto_create:
+        return None
+    if auto_create == "only_live" and not instance.live:
         return None
 
     # Determine sites to create redirects for
@@ -69,7 +72,10 @@ def autocreate_redirects_on_page_move(
     url_path_before: str,
     **kwargs,
 ) -> None:
-    if not getattr(settings, "WAGTAILREDIRECTS_AUTO_CREATE", True):
+    auto_create = getattr(settings, "WAGTAILREDIRECTS_AUTO_CREATE", True)
+    if not auto_create:
+        return None
+    if auto_create == "only_live" and not instance.live:
         return None
 
     if url_path_after == url_path_before:

--- a/wagtail/contrib/redirects/tests/test_signal_handlers.py
+++ b/wagtail/contrib/redirects/tests/test_signal_handlers.py
@@ -239,3 +239,37 @@ class TestAutocreateRedirects(WagtailTestUtils, TestCase):
             self.trigger_page_slug_changed_signal(self.event_index)
         self.assertFalse(Redirect.objects.exists())
         self.assertEqual(len(PURGED_URLS), 0)
+
+    @override_settings(WAGTAILREDIRECTS_AUTO_CREATE="only_live")
+    def test_only_live_skips_draft_slug_change(self):
+        draft_page = Page.objects.get(url_path="/home/events/christmas/")
+        draft_page.live = False
+        draft_page.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            self.trigger_page_slug_changed_signal(draft_page)
+        self.assertFalse(Redirect.objects.exists())
+
+    @override_settings(WAGTAILREDIRECTS_AUTO_CREATE="only_live")
+    def test_only_live_creates_redirect_for_live_page(self):
+        with self.captureOnCommitCallbacks(execute=True):
+            self.trigger_page_slug_changed_signal(self.event_index)
+        self.assertTrue(Redirect.objects.exists())
+
+    @override_settings(WAGTAILREDIRECTS_AUTO_CREATE="only_live")
+    def test_only_live_skips_draft_page_move(self):
+        draft_page = Page.objects.get(url_path="/home/events/christmas/")
+        draft_page.live = False
+        draft_page.save()
+        url_path_before = draft_page.url_path
+        draft_page.url_path = "/home/moved/"
+        draft_page.save()
+        from wagtail.contrib.redirects.signal_handlers import (
+            autocreate_redirects_on_page_move,
+        )
+        with self.captureOnCommitCallbacks(execute=True):
+            autocreate_redirects_on_page_move(
+                instance=draft_page,
+                url_path_after=draft_page.url_path,
+                url_path_before=url_path_before,
+            )
+        self.assertFalse(Redirect.objects.exists())

--- a/wagtail/contrib/redirects/tests/test_signal_handlers.py
+++ b/wagtail/contrib/redirects/tests/test_signal_handlers.py
@@ -266,6 +266,7 @@ class TestAutocreateRedirects(WagtailTestUtils, TestCase):
         from wagtail.contrib.redirects.signal_handlers import (
             autocreate_redirects_on_page_move,
         )
+
         with self.captureOnCommitCallbacks(execute=True):
             autocreate_redirects_on_page_move(
                 instance=draft_page,


### PR DESCRIPTION
## Summary

Fixes #12582.

With autosave enabled, editing a draft page's slug triggers `page_slug_changed` which fires the auto-redirect signal handler. This creates a live redirect from the old slug path — potentially breaking the still-published URL of that page.

This PR adds a new `"only_live"` string value for the existing `WAGTAILREDIRECTS_AUTO_CREATE` setting. When set, redirects are only created when the page being changed is currently live (published). Draft page slug changes and moves are silently skipped.

```python
WAGTAILREDIRECTS_AUTO_CREATE = "only_live"
```

The approach follows the design discussed in the issue thread:
- Reuses the existing setting rather than adding a new one.
- Uses a lowercase string value, consistent with `WAGTAILADMIN_EXTERNAL_LINK_CONVERSION` and `WAGTAILDOCS_SERVE_METHOD`.
- `True` (default) and `False` keep their existing behaviour for backwards compatibility.

## Changes

- `wagtail/contrib/redirects/signal_handlers.py`: both `autocreate_redirects_on_slug_change` and `autocreate_redirects_on_page_move` check `auto_create == "only_live" and not instance.live` and return early if matched.
- `docs/reference/contrib/redirects.md`: replaces the one-liner example with a table documenting all three accepted values.
- `wagtail/contrib/redirects/tests/test_signal_handlers.py`: three new test cases covering `"only_live"` for slug change (draft skipped, live creates redirect) and page move (draft skipped).

## Areas for careful review

- Whether `True` should remain the default, or whether `"only_live"` should become the new default in 8.0 (a separate decision for maintainers).
- The `instance.live` check for `autocreate_redirects_on_page_move` reads from the DB record passed in — confirm this is the post-move state and accurately reflects liveness.