### PR TITLE
Introduce docker-entrypoint.sh to separate migrations from server start

### DIFF
--- a/wagtail/project_template/Dockerfile
+++ b/wagtail/project_template/Dockerfile
@@ -74,13 +74,10 @@ USER wagtail
 # Collect static files.
 RUN python manage.py collectstatic --noinput --clear
 
-# Runtime command that executes when "docker run" is called, it does the
-# following:
-#   1. Migrate the database.
-#   2. Start the application server.
-# WARNING:
-#   Migrating database at the same time as starting the server IS NOT THE BEST
-#   PRACTICE. The database should be migrated manually or using the release
-#   phase facilities of your hosting platform. This is used only so the
-#   Wagtail instance can be started with a simple "docker run" command.
-CMD set -xe; python manage.py migrate --noinput; gunicorn {{ project_name }}.wsgi:application
+# The entrypoint runs "python manage.py migrate" then starts the server.
+# For production deployments on platforms with a dedicated release phase
+# (Heroku, Fly.io, Render, Railway, etc.), set DJANGO_MIGRATE=0 and run
+# migrations as a separate step before launching the container. This avoids
+# running migrations on every replica startup and prevents race conditions.
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["gunicorn", "{{ project_name }}.wsgi:application"]

--- a/wagtail/project_template/docker-entrypoint.sh
+++ b/wagtail/project_template/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Run database migrations before starting the server.
+#
+# For production deployments on platforms that support a dedicated
+# "release phase" (e.g. Heroku Procfile, Fly.io deploy.yml, Render
+# pre-deploy command, Railway start command), set DJANGO_MIGRATE=0 and
+# run "python manage.py migrate --noinput" as the release step instead.
+# That avoids running migrations on every instance startup and prevents
+# race conditions in multi-replica deployments.
+if [ "${DJANGO_MIGRATE:-1}" = "1" ]; then
+    python manage.py migrate --noinput
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary

Addresses the remaining item in #13199 (the multi-stage build was resolved by #13613).

The project template Dockerfile combined `python manage.py migrate` and `gunicorn` in a single `CMD`, with an inline warning that this is not best practice. Running migrations inside the application process creates race conditions when multiple replicas start simultaneously and ties every container restart to a migration run.

This PR extracts the migration step into a `docker-entrypoint.sh` script and adopts the standard `ENTRYPOINT` / `CMD` Docker pattern.

## Changes

- `wagtail/project_template/docker-entrypoint.sh` (new): runs `migrate --noinput` by default; skips it when `DJANGO_MIGRATE=0`.
- `wagtail/project_template/Dockerfile`: switches from a compound `CMD` to `ENTRYPOINT ["/app/docker-entrypoint.sh"]` + `CMD ["gunicorn", "..."]`.

## Behaviour

| Scenario | How to configure |
|---|---|
| Simple `docker run` (dev/demo) | No change — migrations run automatically, same as before. |
| Production with release phase (Heroku, Fly.io, Render, Railway) | Set `DJANGO_MIGRATE=0` and run `python manage.py migrate --noinput` in the platform's release/pre-deploy step. |
| Running one-off management commands | `docker run --rm <image> python manage.py shell` — the entrypoint fires first; set `DJANGO_MIGRATE=0` to skip migration. |

## Areas for careful review

- The `ENTRYPOINT` form means `docker run <image> python manage.py shell` will run migrations first unless `DJANGO_MIGRATE=0` is set. This is a slight UX change but consistent with the "setup before serving" intent of an entrypoint.
- The `docker-entrypoint.sh` must be included in the project template distribution; check that the template packaging picks up `.sh` files.