### PR TITLE
Make SiteSwitchForm ordering test collation-independent

### DIFF
--- a/wagtail/contrib/settings/tests/site_specific/test_forms.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_forms.py
@@ -19,7 +19,7 @@ class TestSiteSwitchFormOrdering(TestCase):
         )
         # Site with name
         site_3 = Site.objects.create(
-            hostname="alfa.com", site_name="Alfa Website", root_page=self.root_page
+            hostname="alfa.com", site_name="AAA Website", root_page=self.root_page
         )
         # Site with non-standard port
         site_4 = Site.objects.create(
@@ -31,7 +31,7 @@ class TestSiteSwitchFormOrdering(TestCase):
         site_1, site_2, site_3, site_4 = self._create_sites()
         form = SiteSwitchForm(site_1, TestSiteSetting, sites=Site.objects.all())
         expected_choices = [
-            (f"/admin/settings/tests/testsitesetting/{site_3.id}/", "Alfa Website"),
+            (f"/admin/settings/tests/testsitesetting/{site_3.id}/", "AAA Website"),
             (f"/admin/settings/tests/testsitesetting/{site_4.id}/", "alfa.com:5678"),
             (
                 f"/admin/settings/tests/testsitesetting/{site_2.id}/",


### PR DESCRIPTION


<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes current tests after #13608.

### Description

<!-- Please describe the problem you're fixing. -->

The test behaves differently depending on the collation used on the system. It passes locally on my macOS machine on both SQLite on Postgres (via Postgres.app), but it fails on CI with Postgres. After switching to Postgres in Docker locally, I can reproduce the failure.

According to Claude's diagnostics:

> On macOS -- both SQLite's binary collation and Postgres using
> the system collation library -- comparison is effectively code-point
> based, so the space (0x20) sorts before "." (0x2e). On Linux glibc
> collations such as CI's en_US.UTF-8, spaces and punctuation are
> ignorable, which flips the two and fails the assertion.

Rename the site to "AAA Website" so its key differs from "alfa.com" at the first letter, giving a stable order under any database collation.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Assisted-by Claude Opus 4.8 using Claude Code agent on VSCode.