### PR TITLE
Add the ability to specify `submenu_hook` to viewset groups

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
 * Make `Button` component render a `<button>` element when no URL is supplied (Nayeli De Jesus, LB (Ben Johnston), Sage Abdullah)
 * Show site name in site switcher dropdown in site settings editor (Jack Morgan)
 * Improve clarity of different task states in workflow details dialog (Dan Braghis)
+* Add `submenu_hook` attribute to `ViewSetGroup` for collecting submenu items registered via a hook (Hunzlah Malik, MariyaOT, Sage Abdullah)
 * Fix: Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
 * Fix: Prevent an error when approving a workflow that has been cancelled in a different session (Kailesh)
 * Fix: Accommodate multilingual sites in skipping the "choose parent" step when creating a new page from a flat page listing (Amrinder Singh)

--- a/docs/extending/admin_views.md
+++ b/docs/extending/admin_views.md
@@ -314,6 +314,54 @@ def register_viewset():
 
 This will result in a top-level menu item "Agenda" with the two viewsets' menu items as sub-items, e.g. "Calendar" and "Events".
 
+### Collecting submenu items via hooks in a `ViewSetGroup`
+
+In addition to explicitly listing `ViewSet`s in a {class}`~wagtail.admin.viewsets.base.ViewSetGroup`’s `items`, you can also configure a group to collect submenu items via hooks by setting the `submenu_hook` name. This allows you to combine arbitrary menu items and viewsets into the same menu group.
+
+For example, using the same `AgendaViewSetGroup` above, add the following `submenu_hook`:
+
+```{code-block} python
+:emphasize-lines: 4
+
+class AgendaViewSetGroup(ViewSetGroup):
+    ...
+    # Hook name for collecting submenu items
+    submenu_hook = "register_agenda_submenu"
+```
+
+You can then register arbitrary menu items or viewsets from a different module to be part of the group's menu using the specified hook name:
+
+```{code-block} python
+:emphasize-lines: 8, 19-22
+
+# other_app/views.py
+class TimelineViewSet(ViewSet):
+    menu_label = "Timeline"
+    icon = "calendar-alt"
+    name = "timeline"
+    # Add the viewset's menu item inside the "Agenda" group's menu.
+    # This takes precedence over add_to_admin_menu and add_to_settings_menu.
+    menu_hook = "register_agenda_submenu"
+    ...
+
+
+# other_app/wagtail_hooks.py
+@hooks.register("register_admin_viewset")
+def register_viewset():
+    # The viewset needs to be registered on its own, as it is not part of
+    # AgendaViewSetGroup.items. However, it will be added to the Agenda menu group.
+    return TimelineViewSet()
+
+@hooks.register("register_agenda_submenu")
+def register_calendar_menu_item():
+    # Register an arbitrary menu item to the Agenda menu group.
+    return MenuItem("Planner", reverse("planner"), icon_name="edit")
+```
+
+With this setup, the `AgendaViewSetGroup` will appear as a top-level menu item "Agenda", which contains "Calendar" and "Events" from `AgendaViewSetGroup.items`, as well as "Timeline" and "Planner" from the `register_agenda_submenu` hooks.
+
+This approach is useful when the items you want in the group are registered from a different module, such as a pluggable app that cannot modify the group's `items` directly, or when you want to include arbitrary menu items rather than only viewsets.
+
 For further customizations, refer to the {class}`~wagtail.admin.viewsets.base.ViewSetGroup` documentation.
 
 ## Adding links in admin views

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -56,6 +56,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: menu_order
    .. autoattribute:: menu_item_class
    .. autoattribute:: add_to_admin_menu
+   .. autoattribute:: submenu_hook
    .. automethod:: get_menu_item
 ```
 

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -19,6 +19,7 @@ depth: 1
  * Make `Button` component render a `<button>` element when no URL is supplied (Nayeli De Jesus, LB (Ben Johnston), Sage Abdullah)
  * Show site name in site switcher dropdown in site settings editor (Jack Morgan)
  * Improve clarity of different task states in workflow details dialog (Dan Braghis)
+ * Add `submenu_hook` attribute to `ViewSetGroup` for collecting submenu items registered via a hook (Hunzlah Malik, MariyaOT, Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/menu.py
+++ b/wagtail/admin/menu.py
@@ -240,6 +240,12 @@ class WagtailMenuRegisterableGroup(WagtailMenuRegisterable):
     menu_icon = "folder-open-inverse"
     add_to_admin_menu = True
 
+    #: The hook name for adding submenu items to this group.
+    #: Other registerables (e.g. ``ViewSet``) with a matching :attr:`.menu_hook`
+    #: or a ``MenuItem`` instance returned by a Wagtail hook of the same name
+    #: will be added to this group's menu.
+    submenu_hook = None
+
     def __init__(self):
         """
         When initialising, instantiate the classes (or use the instances)
@@ -261,7 +267,10 @@ class WagtailMenuRegisterableGroup(WagtailMenuRegisterable):
     def get_menu_item(self, order=None):
         return SubmenuMenuItem(
             label=self.menu_label,
-            menu=Menu(items=self.get_submenu_items()),
+            menu=Menu(
+                register_hook_name=self.submenu_hook,
+                items=self.get_submenu_items(),
+            ),
             name=self.menu_name,
             icon_name=self.menu_icon,
             order=order if order is not None else self.menu_order,

--- a/wagtail/admin/tests/viewsets/test_base_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_base_viewset.py
@@ -1,3 +1,5 @@
+import json
+
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -9,12 +11,58 @@ class TestBaseViewSet(WagtailTestUtils, TestCase):
     def setUp(self):
         self.user = self.login()
 
+    def get_main_menu_items(self, response):
+        # The top-level sidebar menu items.
+        soup = self.get_soup(response.content)
+        sidebar_props = json.loads(soup.select_one("#wagtail-sidebar-props").text)
+        main_menu_module = next(
+            module
+            for module in sidebar_props["modules"]
+            if module["_type"] == "wagtail.sidebar.MainMenuModule"
+        )
+        return main_menu_module["_args"][0]
+
+    def get_submenu_items(self, menu_items, name):
+        # The child items of the named SubMenuItem within `menu_items`.
+        submenu = next(
+            item
+            for item in menu_items
+            if item["_type"] == "wagtail.sidebar.SubMenuItem"
+            and item["_args"][0]["name"] == name
+        )
+        return submenu["_args"][1]
+
     def test_menu_items(self):
         response = self.client.get(reverse("wagtailadmin_home"))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Miscellaneous")
-        self.assertContains(response, "The Calendar")
-        self.assertContains(response, "The Greetings")
+
+        main_menu = self.get_main_menu_items(response)
+        misc_items = self.get_submenu_items(main_menu, "miscellaneous")
+
+        # The Miscellaneous group's submenu contains its explicit `items` first
+        # (in declaration order), followed by the items collected via its
+        # `submenu_hook`: a ViewSet (via its `menu_hook`) and a plain MenuItem
+        # (returned directly from the hook). Both serialize as LinkMenuItems.
+        self.assertEqual(
+            [
+                (item["_type"], item["_args"][0]["name"], item["_args"][0]["url"])
+                for item in misc_items
+            ],
+            [
+                ("wagtail.sidebar.LinkMenuItem", "the-calendar", "/admin/calendar/"),
+                ("wagtail.sidebar.LinkMenuItem", "the-greetings", "/admin/greetingz/"),
+                (
+                    "wagtail.sidebar.LinkMenuItem",
+                    "submenu-hook-planner",
+                    "/admin/planner/",
+                ),
+                (
+                    "wagtail.sidebar.LinkMenuItem",
+                    "submenu-hook-greetings",
+                    "/admin/submenu_hook_greetingz/",
+                ),
+            ],
+        )
 
     def test_calendar_index_view(self):
         url = reverse("calendar:index")
@@ -38,6 +86,16 @@ class TestBaseViewSet(WagtailTestUtils, TestCase):
         response = self.client.get(url)
         self.assertEqual(url, "/admin/greetingz/")
         self.assertContains(response, "Greetings")
+        self.assertContains(response, "Welcome to this greetings page, Gordon Freeman!")
+
+    def test_submenu_hook_greetings_view(self):
+        self.user.first_name = "Gordon"
+        self.user.last_name = "Freeman"
+        self.user.save()
+        url = reverse("submenu_hook_greetings:index")
+        response = self.client.get(url)
+        self.assertEqual(url, "/admin/submenu_hook_greetingz/")
+        self.assertContains(response, "Submenu Hook Greetings")
         self.assertContains(response, "Welcome to this greetings page, Gordon Freeman!")
 
     def test_method_injection(self):

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -184,6 +184,25 @@ class GreetingsViewSet(ViewSet):
 class MiscellaneousViewSetGroup(ViewSetGroup):
     items = (CalendarViewSet, GreetingsViewSet)
     menu_label = "Miscellaneous"
+    submenu_hook = "register_submenu_greetings"
+
+
+class SubmenuHookGreetingsViewSet(ViewSet):
+    menu_label = "Submenu Hook Greetings"
+    icon = "user"
+    url_namespace = "submenu_hook_greetings"
+    url_prefix = "submenu_hook_greetingz"
+    menu_hook = "register_submenu_greetings"
+
+    def index(self, request):
+        return render(
+            request,
+            "tests/misc/greetings.html",
+            {"page_title": "Submenu Hook Greetings", "header_icon": self.icon},
+        )
+
+    def get_urlpatterns(self):
+        return [path("", self.index, name="index")]
 
 
 class JSONStreamModelViewSet(ModelViewSet):

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -42,6 +42,7 @@ from wagtail.test.testapp.views import (
     JSONModelViewSetGroup,
     MiscellaneousViewSetGroup,
     SearchTestModelViewSet,
+    SubmenuHookGreetingsViewSet,
     ToyViewSetGroup,
     advert_chooser_viewset,
     animated_advert_chooser_viewset,
@@ -255,9 +256,19 @@ def add_broken_links_summary_item(request, items):
 def register_viewsets():
     return [
         MiscellaneousViewSetGroup(),
+        # Registered on its own, but collected into MiscellaneousViewSetGroup's
+        # submenu via its `menu_hook` matching the group's `submenu_hook`.
+        SubmenuHookGreetingsViewSet(),
         JSONModelViewSetGroup(),
         SearchTestModelViewSet(name="searchtest"),
     ]
+
+
+@hooks.register("register_submenu_greetings")
+def register_submenu_greetings_menu_item():
+    # An arbitrary MenuItem (not a ViewSet) collected into the
+    # MiscellaneousViewSetGroup submenu via its `submenu_hook`.
+    return MenuItem("Submenu Hook Planner", "/admin/planner/", icon_name="edit")
 
 
 @hooks.register("register_admin_viewset")


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Rebase of #13349, fixes #13235. Also credits the original author of #13236.

### Description

<!-- Please describe the problem you're fixing. -->

Add a `submenu_hook` attribute that is then passed to the `Menu` instance for the `ViewSetGroup`'s menu, which allows code outside of the group to add menu items inside the group.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Claude Code agent on VSCode with default model and default thinking mode used to help review the code and suggest test and docs improvements