### PR TITLE
Add missing `request` to `get_preview_template` in settings docs

### DIFF
--- a/docs/reference/contrib/settings.md
+++ b/docs/reference/contrib/settings.md
@@ -412,7 +412,7 @@ from myproject.home.models import HomePage
 
 @register_setting
 class GenericSocialMediaSettings(PreviewableMixin, BaseGenericSetting):
-    def get_preview_template(self, preview_mode):
+    def get_preview_template(self, request, mode_name):
         # Custom template specifically for this setting's preview
         return "settings/generic/social_media.html"
 


### PR DESCRIPTION
### Description

Add missing `request` to `get_preview_template` method in previewable settings example, which is needed https://docs.wagtail.org/en/stable/reference/models.html#wagtail.models.PreviewableMixin.get_preview_template

### AI usage

None
