### PR TITLE
Add a new BlockReference type for lazy and cyclic blocks

### DIFF
--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -445,14 +445,26 @@ export class StreamBlockDefinition {
     this.name = name;
     this.groupedChildBlockDefs = groupedChildBlockDefs;
     this.initialChildStates = initialChildStates;
-    this.childBlockDefsByName = {};
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    this.groupedChildBlockDefs.forEach(([group, blockDefs]) => {
-      blockDefs.forEach((blockDef) => {
-        this.childBlockDefsByName[blockDef.name] = blockDef;
-      });
-    });
     this.meta = meta;
+  }
+
+  /**
+   * Lazy map of child block definitions keyed by name. Built on first
+   * access so this can be constructed while children are still
+   * placeholders with unset `.name` (cyclic reconstruction via telepath _ref).
+   */
+  get childBlockDefsByName() {
+    if (this.childBlockDefsByNameCache === undefined) {
+      const map = {};
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      this.groupedChildBlockDefs.forEach(([group, blockDefs]) => {
+        blockDefs.forEach((blockDef) => {
+          map[blockDef.name] = blockDef;
+        });
+      });
+      this.childBlockDefsByNameCache = map;
+    }
+    return this.childBlockDefsByNameCache;
   }
 
   render(placeholder, prefix, initialState, initialError) {

--- a/client/src/components/StreamField/blocks/StructBlock.ts
+++ b/client/src/components/StreamField/blocks/StructBlock.ts
@@ -454,8 +454,9 @@ export class StructBlockDefinition {
   declare name: string;
   declare childBlockDefs: any[];
   declare meta: StructBlockDefinitionMeta;
-  declare childBlockDefsByName: Record<string, any>;
   declare collapsible: boolean;
+  // Backing field for the lazy ``childBlockDefsByName`` getter below.
+  private childBlockDefsByNameCache?: Record<string, any>;
 
   constructor(
     name: string,
@@ -464,16 +465,28 @@ export class StructBlockDefinition {
   ) {
     this.name = name;
     this.childBlockDefs = childBlockDefs;
-    this.childBlockDefsByName = childBlockDefs.reduce((map, blockDef) => {
-      map[blockDef.name] = blockDef;
-      return map;
-    }, {});
     this.meta = meta;
 
     // Always collapsible by default, but can be overridden e.g. when used in a
     // StreamBlock or ListBlock, in which case the collapsible behavior is
     // controlled by the parent block.
     this.collapsible = true;
+  }
+
+  /**
+   * Lazy map of child block definitions keyed by name. Built on first
+   * access so this can be constructed while children are still
+   * placeholders with unset `.name` (cyclic reconstruction via telepath _ref).
+   */
+  get childBlockDefsByName(): Record<string, any> {
+    if (this.childBlockDefsByNameCache === undefined) {
+      const map: Record<string, any> = {};
+      this.childBlockDefs.forEach((blockDef) => {
+        map[blockDef.name] = blockDef;
+      });
+      this.childBlockDefsByNameCache = map;
+    }
+    return this.childBlockDefsByNameCache;
   }
 
   render(

--- a/client/src/vendor/telepath-unpack.js
+++ b/client/src/vendor/telepath-unpack.js
@@ -1,0 +1,170 @@
+/* eslint-disable dot-notation, no-param-reassign */
+/**
+ * Backport of cyclic-graph support from the upstream telepath-unpack fork.
+ * Remove this file and the webpack alias once the fix is merged and released.
+ * See: https://github.com/wagtail/telepath-unpack/pull/5
+ */
+
+class Telepath {
+  constructor() {
+    this.constructors = {};
+  }
+
+  register(name, constructor) {
+    this.constructors[name] = constructor;
+  }
+
+  unpack(objData) {
+    const packedValuesById = {};
+    this.scanForIds(objData, packedValuesById);
+    const valuesById = {};
+    return this.unpackWithRefs(objData, packedValuesById, valuesById);
+  }
+
+  scanForIds(objData, packedValuesById) {
+    /* descend into objData, indexing any objects with an _id in packedValuesById */
+
+    if (objData === null || typeof objData !== 'object') {
+      /* primitive value - nothing to scan */
+      return;
+    }
+
+    if (Array.isArray(objData)) {
+      /* scan recursively */
+      objData.forEach((item) => this.scanForIds(item, packedValuesById));
+      return;
+    }
+
+    /* objData is an object / dict - check for reserved key names */
+    let hasReservedKeyNames = false;
+
+    if ('_id' in objData) {
+      hasReservedKeyNames = true;
+      /* index object in packedValuesById */
+      packedValuesById[objData['_id']] = objData;
+    }
+
+    if ('_type' in objData || '_val' in objData || '_ref' in objData) {
+      hasReservedKeyNames = true;
+    }
+
+    if ('_list' in objData) {
+      hasReservedKeyNames = true;
+      /* scan list items recursively */
+      objData['_list'].forEach((item) => this.scanForIds(item, packedValuesById));
+    }
+
+    if ('_args' in objData) {
+      hasReservedKeyNames = true;
+      /* scan arguments recursively */
+      objData['_args'].forEach((item) => this.scanForIds(item, packedValuesById));
+    }
+
+    if ('_dict' in objData) {
+      hasReservedKeyNames = true;
+      /* scan dict items recursively */
+      for (const [, val] of Object.entries(objData['_dict'])) {
+        this.scanForIds(val, packedValuesById);
+      }
+    }
+
+    if (!hasReservedKeyNames) {
+      /* scan as a plain dict */
+      for (const [, val] of Object.entries(objData)) {
+        this.scanForIds(val, packedValuesById);
+      }
+    }
+  }
+
+  unpackWithRefs(objData, packedValuesById, valuesById) {
+    if (objData === null || typeof objData !== 'object') {
+      /* primitive value - return unchanged */
+      return objData;
+    }
+
+    if (Array.isArray(objData)) {
+      /* unpack recursively */
+      return objData.map((item) =>
+        this.unpackWithRefs(item, packedValuesById, valuesById),
+      );
+    }
+
+    /* objData is an object / dict - check for reserved key names */
+    let result;
+
+    if ('_ref' in objData) {
+      if (objData['_ref'] in valuesById) {
+        /* use previously unpacked instance */
+        result = valuesById[objData['_ref']];
+      } else {
+        /* look up packed object and unpack it; this will populate valuesById as a side effect */
+        result = this.unpackWithRefs(
+          packedValuesById[objData['_ref']],
+          packedValuesById,
+          valuesById,
+        );
+      }
+    } else if ('_val' in objData) {
+      result = objData['_val'];
+    } else if ('_list' in objData) {
+      /* Create the array before unpacking items so that any back-reference
+       * resolved during unpacking finds it immediately, closing the cycle. */
+      result = [];
+      if ('_id' in objData) valuesById[objData['_id']] = result;
+      result.push(
+        ...objData['_list'].map((item) =>
+          this.unpackWithRefs(item, packedValuesById, valuesById),
+        ),
+      );
+    } else if ('_dict' in objData) {
+      /* Create the dict before unpacking values for the same reason. */
+      result = {};
+      if ('_id' in objData) valuesById[objData['_id']] = result;
+      for (const [key, val] of Object.entries(objData['_dict'])) {
+        result[key] = this.unpackWithRefs(val, packedValuesById, valuesById);
+      }
+    } else if ('_type' in objData) {
+      /* handle as a custom type */
+      const constructorId = objData['_type'];
+      const constructor = this.constructors[constructorId];
+      if (typeof constructor !== 'function') {
+        throw new Error(
+          `telepath encountered unknown object type ${constructorId}`,
+        );
+      }
+      if ('_id' in objData) {
+        /* Install a placeholder before unpacking args so that any back-reference
+         * resolved during arg unpacking finds it immediately, closing the cycle. */
+        const placeholder = Object.create(constructor.prototype);
+        valuesById[objData['_id']] = placeholder;
+        const args = objData['_args'].map((arg) =>
+          this.unpackWithRefs(arg, packedValuesById, valuesById),
+        );
+        Object.assign(placeholder, new constructor(...args));
+        return placeholder;
+      }
+      result = new constructor(
+        ...objData['_args'].map((arg) =>
+          this.unpackWithRefs(arg, packedValuesById, valuesById),
+        ),
+      );
+    } else if ('_id' in objData) {
+      throw new Error('telepath encountered object with _id but no type specified');
+    } else {
+      /* no reserved key names found, so unpack objData as a plain dict and return */
+      result = {};
+      for (const [key, val] of Object.entries(objData)) {
+        result[key] = this.unpackWithRefs(val, packedValuesById, valuesById);
+      }
+      return result;
+    }
+
+    if ('_id' in objData) {
+      valuesById[objData['_id']] = result;
+    }
+
+    return result;
+  }
+}
+
+module.exports = Telepath;

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -140,6 +140,14 @@ export default function exports(env, argv) {
         net: false,
         tls: false,
       },
+
+      // Backport of cyclic-graph support; https://github.com/wagtail/telepath-unpack/pull/5
+      // Can be deleted once that's merged.
+      alias: {
+        'telepath-unpack': path.resolve(
+          './client/src/vendor/telepath-unpack.js',
+        ),
+      },
     },
     externals: {
       jquery: 'jQuery',

--- a/wagtail/admin/telepath/__init__.py
+++ b/wagtail/admin/telepath/__init__.py
@@ -1,8 +1,56 @@
 from django import forms
-from telepath import Adapter, AdapterRegistry, JSContextBase
+from telepath import Adapter, AdapterRegistry, JSContextBase, ValueContext
+
+
+class CyclePlaceholder:
+    """
+    Backport of: https://github.com/wagtail/telepath/pull/15
+
+    Can be removed once that's merged.
+    """
+
+    def __init__(self):
+        self.id = None
+        self.seen = False
+        self.use_id = True
+
+    def emit(self):
+        return {"_ref": self.id}
+
+
+class WagtailValueContext(ValueContext):
+    """
+    Backport of: https://github.com/wagtail/telepath/pull/15
+
+    Can be removed once that's merged.
+    """
+
+    def build_node(self, val):
+        obj_id = id(val)
+        if obj_id in self.nodes:
+            existing_node = self.nodes[obj_id]
+            if existing_node.id is None:
+                existing_node.id = self.next_id
+                self.next_id += 1
+            return existing_node
+
+        placeholder = CyclePlaceholder()
+        self.nodes[obj_id] = placeholder
+        self.raw_values[obj_id] = val
+
+        node = self._build_new_node(val)
+
+        if placeholder.id is not None:
+            node.id = placeholder.id
+
+        self.nodes[obj_id] = node
+        return node
 
 
 class WagtailJSContextBase(JSContextBase):
+    def pack(self, obj):
+        return WagtailValueContext(self).build_node(obj).emit()
+
     @property
     def base_media(self):
         # Do not include the telepath.js file in the base media, as it is already included

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -2,6 +2,7 @@ import collections
 import itertools
 import json
 import re
+from contextvars import ContextVar
 from functools import lru_cache
 from importlib import import_module
 
@@ -16,13 +17,14 @@ from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
 
 from wagtail.admin.staticfiles import versioned_static
-from wagtail.admin.telepath import JSContext
+from wagtail.admin.telepath import Adapter, JSContext
 from wagtail.admin.telepath import register as register_telepath_adapter
 from wagtail.utils.templates import template_is_overridden
 
 __all__ = [
     "BaseBlock",
     "Block",
+    "BlockReference",
     "BoundBlock",
     "DeclarativeSubBlocksMetaclass",
     "BlockWidget",
@@ -97,6 +99,13 @@ class Block(metaclass=BaseBlock):
         Block.creation_counter += 1
         self.definition_prefix = "blockdef-%d" % self.creation_counter
         Block.definition_registry[self.definition_prefix] = self
+
+        # Stable identity of the graph node this block represents. The migration lookup
+        # builder keys on this to recognise a node it is already (de)serialising, and so
+        # break a cyclic definition. Defaults to id(self); blocks rebuilt from a cyclic
+        # lookup overwrite it with their lookup index, so the fresh instance produced on
+        # each reference resolution still presents a single identity.
+        self._definition_id = id(self)
 
         self.label = self.meta.label or ""
         self.is_deferred_validation = False
@@ -625,6 +634,188 @@ class Block(metaclass=BaseBlock):
         )
 
 
+# Targets currently being walked through a BlockReference (keyed on Block._definition_id),
+# so that a definition-level walk (check / deferred validation) over a cyclic graph
+# terminates when it re-reaches a target already on the stack.
+reference_walk_in_progress = ContextVar("block_reference_walk", default=None)
+
+# Pairs of (node, node) being compared by BlockReference.__eq__, so that equality of two
+# cyclic block graphs terminates instead of recursing forever.
+reference_eq_in_progress = ContextVar("block_reference_eq", default=None)
+
+
+class BlockReference:
+    """
+    A lazy stand-in for a block, resolved on first use. This is the single mechanism behind
+    forward references and cyclic block graphs; the target need not exist at declaration
+    time::
+
+        class CommentBlock(blocks.StructBlock):
+            text = blocks.CharBlock()
+            replies = blocks.ListBlock(blocks.BlockReference(lambda: CommentBlock))
+
+    It is a proxy, not a Block: value operations and ``child_blocks`` are forwarded to the
+    resolved target via ``__getattr__``, so at runtime it behaves exactly as the block it
+    points to; that recursion is bounded by the (finite) data. The definition-level walks a
+    parent triggers (``check`` and deferred validation) are forwarded too, so a referenced
+    block is validated and deferred just like a direct child. Each is wrapped in a visited
+    set so a cycle terminates when it re-reaches a target already on the stack; the block
+    family's own deferred-validation guard keeps the shared instances of a cyclic target
+    from being deferred twice. ``check`` additionally reports a resolution failure as
+    ``wagtailcore.E009``.
+
+    A reference does not appear in migrations: the lookup builder serialises it as its
+    target, so a back-edge becomes a plain index pointing at an ancestor.
+    """
+
+    def __init__(self, to):
+        self._to = to
+        self._resolved = None
+        self.name = ""
+        # Share Block's global creation counter so a class-level reference sorts correctly
+        # alongside Block instances in the declarative metaclass.
+        self.creation_counter = Block.creation_counter
+        Block.creation_counter += 1
+
+    def resolve(self):
+        # Resolve the target (a dotted import path, a Block subclass, or a callable
+        # returning either) to a block instance, once, and memoise it.
+        if self._resolved is None:
+            to = self._to
+            if isinstance(to, str):
+                module_name, _, class_name = to.rpartition(".")
+                to = getattr(import_module(module_name), class_name)
+            if isinstance(to, type):
+                self._resolved = to()
+            elif callable(to):
+                result = to()
+                self._resolved = result if isinstance(result, Block) else result()
+            else:
+                raise TypeError(
+                    "BlockReference expected a callable or dotted import path; got %r."
+                    % (self._to,)
+                )
+            if self.name:
+                self._resolved.set_name(self.name)
+        return self._resolved
+
+    @property
+    def __class__(self):
+        # Overriding __class__ to report the wrapped object's type is the same proxy trick
+        # Django uses in LazyObject: isinstance()-based dispatch elsewhere then treats a
+        # reference exactly like the block it points to. While the target is not yet resolvable
+        # -- a forward or self reference during class definition -- this falls back to the real
+        # type, so it never raises and the order of any isinstance() check stays irrelevant.
+        try:
+            return self.resolve().__class__
+        except Exception:  # noqa: BLE001 - not resolvable yet; behave as a plain reference
+            return type(self)
+
+    def __getattr__(self, name):
+        # Runs only for attributes not defined on the proxy. Guard the internal names so a
+        # half-initialised proxy (or a copy/pickle) does not recurse via resolve(); forward
+        # everything else (the whole value API and child_blocks) to the target.
+        if name in ("_to", "_resolved"):
+            raise AttributeError(name)
+        return getattr(self.resolve(), name)
+
+    def __eq__(self, other):
+        # __getattr__ does not forward dunders, so the comparison protocol is implemented
+        # here. Two references (or a reference and a block) are equal when their resolved
+        # targets are. Comparison is coinductive: record the (node, node) pairs on the
+        # comparison stack and, on meeting one again, treat it as equal (matched so far).
+        # Keyed on _definition_id so the fresh instances a lookup produces line up.
+        if isinstance(other, BlockReference):
+            other = other.resolve()
+        if not isinstance(other, Block):
+            return NotImplemented
+        resolved = self.resolve()
+
+        pair = (resolved._definition_id, other._definition_id)
+        seen = reference_eq_in_progress.get()
+        token = None
+        if seen is None:
+            seen = set()
+            token = reference_eq_in_progress.set(seen)
+        try:
+            if pair in seen:
+                return True
+            seen.add(pair)
+            try:
+                return resolved == other
+            finally:
+                seen.discard(pair)
+        finally:
+            if token is not None:
+                reference_eq_in_progress.reset(token)
+
+    # Defining __eq__ makes this unhashable by default, matching Block.
+    __hash__ = None
+
+    def set_name(self, name):
+        self.name = name
+        if self._resolved is not None:
+            self._resolved.set_name(name)
+
+    def check(self, **kwargs):
+        # A reference can fail to resolve in several ways (ImportError, AttributeError, a
+        # raising lambda). A check() must turn any such failure into an error to report and
+        # never raise, or `manage.py check` crashes with a traceback; the original exception
+        # is included so the message stays accurate.
+        try:
+            self.resolve()
+        except Exception as exc:  # noqa: BLE001 - a check reports failures, it must not raise
+            return [
+                checks.Error(
+                    "BlockReference could not resolve its target %r: %s"
+                    % (self._to, exc),
+                    obj=self,
+                    id="wagtailcore.E009",
+                )
+            ]
+        return self.forward_walk("check", [], **kwargs)
+
+    def defer_required_validation(self):
+        self.forward_walk("defer_required_validation", None)
+
+    def restore_deferred_validation(self):
+        self.forward_walk("restore_deferred_validation", None)
+
+    def forward_walk(self, method, on_reentry, **kwargs):
+        # Forward a definition-level walk to the target, but stop if the target is already
+        # being walked higher up the stack, so a cycle terminates. Keyed on _definition_id
+        # so the fresh instances a reference resolves to line up across the recursion.
+        target = self.resolve()
+        seen = reference_walk_in_progress.get()
+        token = None
+        if seen is None:
+            seen = set()
+            token = reference_walk_in_progress.set(seen)
+        try:
+            if target._definition_id in seen:
+                return on_reentry
+            seen.add(target._definition_id)
+            return getattr(target, method)(**kwargs)
+        finally:
+            if token is not None:
+                reference_walk_in_progress.reset(token)
+
+
+class BlockReferenceAdapter(Adapter):
+    """
+    Packs a BlockReference for the editor as its resolved target, so a reference is fully
+    transparent in the StreamField editor. The cyclic-graph support in WagtailJSContext (an
+    ``_ref`` back to an already-packed node) terminates the recursion when a shared block is
+    reached again.
+    """
+
+    def build_node(self, obj, context):
+        return context.build_node(obj.resolve())
+
+
+register_telepath_adapter(BlockReferenceAdapter(), BlockReference)
+
+
 class BoundBlock:
     def __init__(self, block, value, prefix=None, errors=None):
         self.block = block
@@ -670,7 +861,10 @@ class DeclarativeSubBlocksMetaclass(BaseBlock):
         # These are available on the class as `declared_blocks`
         current_blocks = []
         for key, value in list(attrs.items()):
-            if isinstance(value, Block):
+            # A BlockReference is a declarable child too. It is matched explicitly because
+            # at class definition its target may not be resolvable yet, so it does not present
+            # as its block class and isinstance(value, Block) alone would miss it.
+            if isinstance(value, (Block, BlockReference)):
                 current_blocks.append((key, value))
                 value.set_name(key)
                 attrs.pop(key)

--- a/wagtail/blocks/definition_lookup.py
+++ b/wagtail/blocks/definition_lookup.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from importlib import import_module
 
+from wagtail.blocks.base import BlockReference
+
 
 class BlockDefinitionLookup:
     """
@@ -30,22 +32,45 @@ class BlockDefinitionLookup:
     `construct_from_lookup(lookup, *args, **kwargs)`, where `lookup` is
     the `BlockDefinitionLookup` instance. The method should return a block instance
     constructed from the provided arguments (after performing any lookups).
+
+    A cyclic definition is represented by an index that points back to an ancestor still
+    being constructed; `get_block` hands back a lazy `BlockReference` for such a back-edge,
+    so reconstruction stays finite.
     """
 
     def __init__(self, blocks):
         self.blocks = blocks
         self.block_classes = {}
+        # Indexes currently being constructed (the construction stack). A child referring to
+        # an index already on the stack is a back-edge closing a cycle; get_block returns a
+        # lazy BlockReference for it rather than recursing, keeping construction finite.
+        self._constructing = set()
 
     def get_block(self, index):
-        path, args, kwargs = self.blocks[index]
-        try:
-            cls = self.block_classes[path]
-        except KeyError:
-            module_name, class_name = path.rsplit(".", 1)
-            module = import_module(module_name)
-            cls = self.block_classes[path] = getattr(module, class_name)
+        if index in self._constructing:
+            # Back-edge to an ancestor still being constructed: hand back a reference (a
+            # leaf) so reconstruction does not recurse forever. It resolves to a fresh block
+            # when a value operation needs it.
+            return BlockReference(lambda i=index: self.get_block(i))
 
-        return cls.construct_from_lookup(self, *args, **kwargs)
+        self._constructing.add(index)
+        try:
+            path, args, kwargs = self.blocks[index]
+            try:
+                cls = self.block_classes[path]
+            except KeyError:
+                module_name, class_name = path.rsplit(".", 1)
+                module = import_module(module_name)
+                cls = self.block_classes[path] = getattr(module, class_name)
+            block = cls.construct_from_lookup(self, *args, **kwargs)
+        finally:
+            self._constructing.discard(index)
+
+        # Give the block the node identity of its lookup index, so the builder recognises
+        # re-entry across the fresh instances a reference produces on each resolution
+        # (different id(), same index). See Block._definition_id.
+        block._definition_id = index
+        return block
 
 
 class BlockDefinitionLookupBuilder:
@@ -56,28 +81,68 @@ class BlockDefinitionLookupBuilder:
     def __init__(self):
         self.blocks = []
 
-        # Lookup table mapping the deconstructed tuple forms of blocks (as obtained from
-        # `block.deconstruct_with_lookup`) to their index in the `blocks` list. These
-        # tuples can be compared for equality, but not hashed, so we cannot use them as
-        # dict keys; instead, we index them on the first tuple element (the module path)
-        # and maintain a list of (index, deconstructed_tuple) pairs for each one.
+        # Index of each block fully added, keyed by node identity (block._definition_id), so
+        # the same node re-used in several places is stored once. Node identity (not id()) is
+        # required because a block rebuilt from a cyclic lookup yields a fresh instance on
+        # every reference resolution; those share a _definition_id but not an id(), and an
+        # id()-keyed builder would fail to recognise the cycle and recurse forever.
+        self.block_indexes_by_identity = {}
+
+        # Nodes whose deconstruction is in progress, keyed by _definition_id. The value is the
+        # slot reserved for the block (or None if nothing has needed it yet). Used to break
+        # cyclic graphs: a back-reference to a node still being deconstructed reserves its slot
+        # here instead of recursing forever.
+        self.pending_block_indexes = {}
+
+        # Already-stored definitions, for structural deduplication. The deconstructed tuples
+        # compare for equality but are not hashable, so we bucket them by their first element
+        # (the module path) and keep a list of (index, deconstructed_tuple) pairs per bucket.
         self.block_indexes_by_type = defaultdict(list)
 
     def add_block(self, block):
         """
-        Add a block to the lookup table, returning an index that can be used to refer to it
+        Add a block to the lookup table, returning an index that can be used to refer to it.
+
+        A BlockReference is serialised as its target, so a reference never becomes a table
+        entry of its own; a back-edge is simply an index pointing at an ancestor.
         """
+        identity = block._definition_id
+
+        # Case 1: already fully added.
+        if identity in self.block_indexes_by_identity:
+            return self.block_indexes_by_identity[identity]
+
+        # Case 2: a back-reference to a block still being deconstructed. Reserve a real slot
+        # for it now (a placeholder, filled in when its own add_block call completes).
+        if identity in self.pending_block_indexes:
+            reserved_index = self.pending_block_indexes[identity]
+            if reserved_index is None:
+                reserved_index = len(self.blocks)
+                self.blocks.append(None)
+                self.pending_block_indexes[identity] = reserved_index
+            return reserved_index
+
+        # Case 3: first encounter. Mark as pending (no slot yet), then deconstruct, which
+        # recurses into children and may reserve our slot via case 2.
+        self.pending_block_indexes[identity] = None
         deconstructed = block.deconstruct_with_lookup(self)
+        reserved_index = self.pending_block_indexes.pop(identity)
 
-        # Check if we've already seen this block definition
         block_indexes = self.block_indexes_by_type[deconstructed[0]]
-        for index, existing_deconstructed in block_indexes:
-            if existing_deconstructed == deconstructed:
-                return index
+        if reserved_index is None:
+            # Nothing referred back to us, so we may reuse an identical definition.
+            for existing_index, existing_deconstructed in block_indexes:
+                if existing_deconstructed == deconstructed:
+                    self.block_indexes_by_identity[identity] = existing_index
+                    return existing_index
+            index = len(self.blocks)
+            self.blocks.append(deconstructed)
+        else:
+            # A back-reference reserved this slot (a cycle); fill it in, without dedup.
+            index = reserved_index
+            self.blocks[index] = deconstructed
 
-        # If not, add it to the lookup table
-        index = len(self.blocks)
-        self.blocks.append(deconstructed)
+        self.block_indexes_by_identity[identity] = index
         block_indexes.append((index, deconstructed))
         return index
 

--- a/wagtail/blocks/list_block.py
+++ b/wagtail/blocks/list_block.py
@@ -13,6 +13,7 @@ from wagtail.admin.telepath import Adapter, register
 
 from .base import (
     Block,
+    BlockReference,
     BoundBlock,
     get_error_json_data,
     get_error_list_json_data,
@@ -149,8 +150,17 @@ class ListBlock(Block):
 
         self._has_default = hasattr(self.meta, "default")
         if not self._has_default:
-            # Default to a list consisting of one empty (i.e. default-valued) child item
-            self.meta.default = [self.child_block.get_default()]
+            if isinstance(self.child_block, BlockReference):
+                # A reference has no finite per-item default (it stands in for a cyclic
+                # target), so the list defaults to empty; being a sequence is what gives the
+                # cycle a finite default.
+                self.meta.default = []
+            else:
+                # Default to a list of one default-valued child item, but as a callable so
+                # it is evaluated lazily: a child that participates in a cycle can only
+                # produce a default once the surrounding block graph is fully built, which is
+                # not the case while it is being rebuilt from a definition lookup.
+                self.meta.default = lambda: [self.child_block.get_default()]
 
     # If a subclass of ListBlock overrides __init__, we cannot assume that the first argument is
     # the child block, and thus we cannot rely on the conversion applied in construct_from_lookup /
@@ -316,7 +326,14 @@ class ListBlock(Block):
                 else:
                     raw_values.append(list_child)
 
-        converted_values = self.child_block.bulk_to_python(raw_values)
+        if raw_values:
+            converted_values = self.child_block.bulk_to_python(raw_values)
+        else:
+            # With no values there is nothing to convert, so don't resolve the child block.
+            # For a BlockReference child this also prevents infinite recursion: resolving it
+            # to convert an empty list would build a fresh block whose own empty list would
+            # resolve again, and so on.
+            converted_values = []
 
         # split converted_values back into sub-lists of the original lengths
         result = []

--- a/wagtail/contrib/typed_table_block/tests.py
+++ b/wagtail/contrib/typed_table_block/tests.py
@@ -4,7 +4,10 @@ from django.test import TestCase
 
 from wagtail import blocks
 from wagtail.blocks.base import get_error_json_data
-from wagtail.blocks.definition_lookup import BlockDefinitionLookup
+from wagtail.blocks.definition_lookup import (
+    BlockDefinitionLookup,
+    BlockDefinitionLookupBuilder,
+)
 from wagtail.blocks.struct_block import StructBlockValidationError
 from wagtail.contrib.typed_table_block.blocks import (
     TypedTable,
@@ -560,3 +563,14 @@ class TestBlockDefinitionLookup(TestCase):
         self.assertTrue(text_block.required)
         country_block = struct_block.child_blocks["country"]
         self.assertIsInstance(country_block, blocks.ChoiceBlock)
+
+    def test_reference_round_trips(self):
+        class TableBlock(blocks.StructBlock):
+            table = TypedTableBlock(
+                [("cell", blocks.BlockReference(lambda: TableBlock))]
+            )
+
+        builder = BlockDefinitionLookupBuilder()
+        index = builder.add_block(TableBlock())
+        rebuilt = BlockDefinitionLookup(builder.get_lookup_as_dict()).get_block(index)
+        self.assertEqual(rebuilt.check(), [])

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -17,9 +17,12 @@ from django.utils.safestring import SafeData, mark_safe
 from django.utils.translation import gettext_lazy as _
 
 from wagtail import blocks
-from wagtail.admin.telepath import registry
+from wagtail.admin.telepath import JSContext, registry
 from wagtail.blocks.base import get_error_json_data
-from wagtail.blocks.definition_lookup import BlockDefinitionLookup
+from wagtail.blocks.definition_lookup import (
+    BlockDefinitionLookup,
+    BlockDefinitionLookupBuilder,
+)
 from wagtail.blocks.field_block import FieldBlockAdapter
 from wagtail.blocks.list_block import ListBlockAdapter, ListBlockValidationError
 from wagtail.blocks.static_block import StaticBlockAdapter
@@ -7240,3 +7243,379 @@ class TestBlockDefinitionLookup(TestCase):
         self.assertIsInstance(list_block, blocks.ListBlock)
         list_item_block = list_block.child_block
         self.assertIsInstance(list_item_block, blocks.CharBlock)
+
+    # Serialising and reconstructing block definitions that contain a cycle.
+
+    def test_self_referential_lookup_round_trip(self):
+        class CommentBlock(blocks.StructBlock):
+            text = blocks.CharBlock()
+            replies = blocks.ListBlock(blocks.BlockReference(lambda: CommentBlock))
+
+        builder = BlockDefinitionLookupBuilder()
+        index = builder.add_block(CommentBlock())
+        rebuilt = BlockDefinitionLookup(builder.get_lookup_as_dict()).get_block(index)
+
+        self.assertIsInstance(rebuilt, blocks.StructBlock)
+        self.assertEqual(rebuilt.check(), [])
+        child = rebuilt.child_blocks["replies"].child_block
+        self.assertIsInstance(child, blocks.BlockReference)
+        self.assertEqual(set(child.child_blocks), {"text", "replies"})
+
+    def test_mutual_reference_lookup_round_trip(self):
+        class AuthorBlock(blocks.StructBlock):
+            posts = blocks.ListBlock(blocks.BlockReference(lambda: PostBlock))
+
+        class PostBlock(blocks.StructBlock):
+            authors = blocks.ListBlock(blocks.BlockReference(lambda: AuthorBlock))
+
+        builder = BlockDefinitionLookupBuilder()
+        index = builder.add_block(AuthorBlock())
+        rebuilt = BlockDefinitionLookup(builder.get_lookup_as_dict()).get_block(index)
+
+        self.assertEqual(rebuilt.check(), [])
+        # The cycle closes one level deeper: the post is built directly, its author is a ref.
+        post = rebuilt.child_blocks["posts"].child_block
+        self.assertIsInstance(post, blocks.StructBlock)
+        self.assertEqual(set(post.child_blocks), {"authors"})
+        author = post.child_blocks["authors"].child_block
+        self.assertIsInstance(author, blocks.BlockReference)
+        self.assertEqual(set(author.child_blocks), {"posts"})
+
+    def test_reference_does_not_appear_in_lookup_table(self):
+        class CommentBlock(blocks.StructBlock):
+            text = blocks.CharBlock()
+            replies = blocks.ListBlock(blocks.BlockReference(lambda: CommentBlock))
+
+        builder = BlockDefinitionLookupBuilder()
+        builder.add_block(CommentBlock())
+        paths = [entry[0] for entry in builder.get_lookup_as_dict().values()]
+
+        self.assertNotIn("wagtail.blocks.BlockReference", paths)
+        self.assertCountEqual(
+            paths,
+            [
+                "wagtail.blocks.CharBlock",
+                "wagtail.blocks.ListBlock",
+                "wagtail.blocks.StructBlock",
+            ],
+        )
+
+    def test_multiple_references_to_one_block_deduplicated(self):
+        class Section(blocks.StructBlock):
+            items = blocks.ListBlock(blocks.BlockReference(lambda: Item))
+            related = blocks.ListBlock(blocks.BlockReference(lambda: Item))
+
+        class Item(blocks.StructBlock):
+            title = blocks.CharBlock()
+            children = blocks.ListBlock(blocks.BlockReference(lambda: Section))
+
+        builder = BlockDefinitionLookupBuilder()
+        builder.add_block(Section())
+        struct_entries = [
+            entry
+            for entry in builder.get_lookup_as_dict().values()
+            if entry and entry[0] == "wagtail.blocks.StructBlock"
+        ]
+        self.assertEqual(len(struct_entries), 2)  # one Section + one Item, not three
+
+    def test_round_trip_through_reserialization(self):
+        class CommentBlock(blocks.StructBlock):
+            text = blocks.CharBlock()
+            replies = blocks.ListBlock(blocks.BlockReference(lambda: CommentBlock))
+
+        builder = BlockDefinitionLookupBuilder()
+        index = builder.add_block(CommentBlock())
+        restored = BlockDefinitionLookup(builder.get_lookup_as_dict()).get_block(index)
+
+        builder2 = BlockDefinitionLookupBuilder()
+        index2 = builder2.add_block(restored)
+        rebuilt = BlockDefinitionLookup(builder2.get_lookup_as_dict()).get_block(index2)
+
+        self.assertEqual(rebuilt.check(), [])
+        child = rebuilt.child_blocks["replies"].child_block
+        self.assertEqual(set(child.child_blocks), {"text", "replies"})
+
+    def test_reconstruct_cycle_entered_through_its_own_list_block(self):
+        # When the same cyclic block appears more than once in a lookup, reconstruction can
+        # reach the cycle through its own ListBlock, whose child resolves to a fully built
+        # struct holding a back-edge to the still-constructing ListBlock. Building that
+        # ListBlock must not eagerly resolve the back-edge, and get_default() must build a
+        # fresh, terminating subtree afterwards.
+        class CommentBlock(blocks.StructBlock):
+            text = blocks.CharBlock()
+            replies = blocks.ListBlock(blocks.BlockReference(lambda: CommentBlock))
+
+        stream = blocks.StreamBlock(
+            [("a", CommentBlock()), ("b", CommentBlock(group="X"))]
+        )
+        builder = BlockDefinitionLookupBuilder()
+        index = builder.add_block(stream)
+        rebuilt = BlockDefinitionLookup(builder.get_lookup_as_dict()).get_block(index)
+
+        self.assertEqual(rebuilt.check(), [])
+        rebuilt.get_default()  # must not raise
+
+
+class TestBlockReference(SimpleTestCase):
+    def setUp(self):
+        class CommentBlock(blocks.StructBlock):
+            text = blocks.CharBlock(required=True)
+            replies = blocks.ListBlock(blocks.BlockReference(lambda: CommentBlock))
+
+        self.CommentBlock = CommentBlock
+
+    def test_reference_presents_as_its_target_class(self):
+        # isinstance() follows the resolved target, while type() stays BlockReference.
+        ref = blocks.BlockReference(lambda: blocks.CharBlock)
+        self.assertIsInstance(ref, blocks.CharBlock)
+        self.assertIsInstance(ref, blocks.Block)
+        self.assertIs(type(ref), blocks.BlockReference)
+
+        struct_ref = self.CommentBlock().child_blocks["replies"].child_block
+        self.assertIsInstance(struct_ref, blocks.StructBlock)
+        self.assertNotIsInstance(struct_ref, blocks.ListBlock)
+
+    def test_invalid_target_raises(self):
+        with self.assertRaises(TypeError):
+            blocks.BlockReference(42).resolve()
+
+    def test_dotted_path_target_resolves(self):
+        block = blocks.StructBlock(
+            [("text", blocks.BlockReference("wagtail.blocks.CharBlock"))]
+        )
+        child = block.child_blocks["text"]
+        self.assertIsInstance(child, blocks.BlockReference)
+        self.assertIsInstance(child, blocks.CharBlock)
+
+    def test_callable_target_can_return_a_configured_block(self):
+        # A callable returning a constructed instance keeps its arguments; returning the
+        # class (like the bare class and dotted-path forms) constructs it with no arguments.
+        optional = blocks.BlockReference(
+            lambda: blocks.CharBlock(required=False, max_length=5)
+        )
+        self.assertFalse(optional.required)
+        self.assertEqual(optional.field.max_length, 5)
+
+        default = blocks.BlockReference(lambda: blocks.CharBlock)
+        self.assertTrue(default.required)
+        self.assertIsNone(default.field.max_length)
+
+    def test_target_is_resolved_once_and_memoised(self):
+        ref = blocks.BlockReference(lambda: blocks.CharBlock)
+        self.assertIs(ref.resolve(), ref.resolve())
+
+    def test_set_name_propagates_through_resolution(self):
+        # A name set before resolution is remembered and applied to the target.
+        ref = blocks.BlockReference(lambda: blocks.CharBlock)
+        ref.set_name("foo")
+        self.assertEqual(ref.resolve().name, "foo")
+
+    def test_deepcopy_preserves_unresolved_reference(self):
+        # Copying must not force resolution; the copy is still an unresolved
+        # reference that resolves correctly afterwards.
+        ref = blocks.BlockReference(lambda: blocks.CharBlock)
+        copied = copy.deepcopy(ref)
+        self.assertIs(type(copied), blocks.BlockReference)
+        self.assertIsInstance(copied.resolve(), blocks.CharBlock)
+
+    def test_forward_reference(self):
+        class AccordionBlock(blocks.StructBlock):
+            heading = blocks.CharBlock()
+
+        class ContentBlock(blocks.StreamBlock):
+            accordion = AccordionBlock()
+            paragraph = blocks.RichTextBlock()
+
+        accordion = AccordionBlock(
+            [("content", blocks.BlockReference(lambda: ContentBlock))]
+        )
+        content = accordion.child_blocks["content"]
+        self.assertIsInstance(content, blocks.StreamBlock)
+        self.assertIn("accordion", content.child_blocks)
+
+    def test_self_referential_block_supports_core_operations(self):
+        block = self.CommentBlock()
+
+        self.assertEqual(block.check(), [])
+
+        default = block.get_default()
+        self.assertIn("text", default)
+        self.assertEqual(list(default["replies"]), [])
+
+        value = block.to_python(
+            {
+                "text": "L0",
+                "replies": [{"text": "L1", "replies": [{"text": "L2", "replies": []}]}],
+            }
+        )
+        self.assertEqual(value["replies"][0]["replies"][0]["text"], "L2")
+
+        prepped = block.get_prep_value(value)
+        self.assertEqual(
+            prepped["replies"][0]["value"]["replies"][0]["value"]["text"], "L2"
+        )
+
+    def test_mutual_reference_terminates(self):
+        class AuthorBlock(blocks.StructBlock):
+            name = blocks.CharBlock()
+            posts = blocks.ListBlock(blocks.BlockReference(lambda: PostBlock))
+
+        class PostBlock(blocks.StructBlock):
+            title = blocks.CharBlock()
+            authors = blocks.ListBlock(blocks.BlockReference(lambda: AuthorBlock))
+
+        self.assertEqual(AuthorBlock().check(), [])
+        self.assertEqual(list(AuthorBlock().get_default()["posts"]), [])
+
+    def test_value_from_datadict_terminates_on_cyclic_block(self):
+        block = self.CommentBlock()
+        data = {
+            "comment-text": "hello",
+            "comment-replies-count": "1",
+            "comment-replies-0-deleted": "",
+            "comment-replies-0-order": "0",
+            "comment-replies-0-id": "reply-1",
+            "comment-replies-0-value-text": "a reply",
+            # the nested reply has no replies of its own, ending the recursion
+            "comment-replies-0-value-replies-count": "0",
+        }
+        value = block.value_from_datadict(data, {}, "comment")
+        self.assertEqual(value["text"], "hello")
+        reply = list(value["replies"])[0]
+        self.assertEqual(reply["text"], "a reply")
+        self.assertEqual(list(reply["replies"]), [])
+
+    def test_deferred_validation_terminates_through_cycle(self):
+        # Empty required text passes while deferred, then fails once validation is restored.
+        block = self.CommentBlock()
+        value = block.to_python(
+            {"text": "ok", "replies": [{"text": "", "replies": []}]}
+        )
+        block.clean_deferred(value)
+        with self.assertRaises(ValidationError):
+            block.clean(value)
+
+        # The same across a mutual reference.
+        class AuthorBlock(blocks.StructBlock):
+            name = blocks.CharBlock(required=True)
+            posts = blocks.ListBlock(blocks.BlockReference(lambda: PostBlock))
+
+        class PostBlock(blocks.StructBlock):
+            authors = blocks.ListBlock(blocks.BlockReference(lambda: AuthorBlock))
+
+        author = AuthorBlock()
+        author_value = author.to_python({"name": "", "posts": []})
+        author.clean_deferred(author_value)
+        with self.assertRaises(ValidationError):
+            author.clean(author_value)
+
+    def test_deferred_validation_reaches_forward_referenced_block(self):
+        class PageBlock(blocks.StructBlock):
+            title = blocks.CharBlock()
+            author = blocks.BlockReference(lambda: AuthorBlock)
+
+        class AuthorBlock(blocks.StructBlock):
+            name = blocks.CharBlock(required=True)
+
+        block = PageBlock()
+        value = block.to_python({"title": "hi", "author": {"name": ""}})
+
+        block.clean_deferred(value)  # must not raise: the author's required is deferred
+
+        with self.assertRaises(ValidationError):
+            block.clean(value)  # restored: required is enforced again
+
+    def test_overridden_defer_restore_reached_through_reference(self):
+        # A target that overrides the deferred-validation hooks is still driven
+        # correctly when reached through a reference.
+        calls = []
+
+        class CustomBlock(blocks.StructBlock):
+            name = blocks.CharBlock(required=True)
+
+            def defer_required_validation(self):
+                calls.append("defer")
+                super().defer_required_validation()
+
+            def restore_deferred_validation(self):
+                calls.append("restore")
+                super().restore_deferred_validation()
+
+        class PageBlock(blocks.StructBlock):
+            custom = blocks.BlockReference(lambda: CustomBlock)
+
+        ref = PageBlock().child_blocks["custom"]
+        ref.defer_required_validation()
+        ref.restore_deferred_validation()
+        self.assertEqual(calls, ["defer", "restore"])
+
+    def test_streamblock_self_reference_terminates(self):
+        class SectionStream(blocks.StreamBlock):
+            text = blocks.CharBlock()
+            nested = blocks.BlockReference(lambda: SectionStream)
+
+        self.assertEqual(SectionStream().check(), [])
+        self.assertEqual(list(SectionStream().get_default()), [])
+
+    def test_extract_references_through_cycle(self):
+        class Node(blocks.StructBlock):
+            body = blocks.RichTextBlock()
+            children = blocks.ListBlock(blocks.BlockReference(lambda: Node))
+
+        block = Node()
+        value = block.to_python(
+            {
+                "body": '<a linktype="page" id="5">x</a>',
+                "children": [
+                    {"body": '<a linktype="page" id="9">y</a>', "children": []}
+                ],
+            }
+        )
+        found = {
+            (model, object_id, model_path)
+            for model, object_id, model_path, _ in block.extract_references(value)
+        }
+        self.assertEqual(
+            found,
+            {(Page, "5", "body"), (Page, "9", "children.item.body")},
+        )
+
+    def test_cyclic_block_equality(self):
+        class OtherBlock(blocks.StructBlock):
+            heading = blocks.CharBlock()
+            children = blocks.ListBlock(blocks.BlockReference(lambda: OtherBlock))
+
+        self.assertEqual(self.CommentBlock(), self.CommentBlock())
+        self.assertNotEqual(self.CommentBlock(), OtherBlock())
+
+        # Equal to the same definition rebuilt from a lookup, despite fresh references.
+        original = self.CommentBlock()
+        builder = BlockDefinitionLookupBuilder()
+        index = builder.add_block(original)
+        rebuilt = BlockDefinitionLookup(builder.get_lookup_as_dict()).get_block(index)
+        self.assertEqual(rebuilt, original)
+
+    def test_editor_pack_terminates_through_cycle(self):
+        class AuthorBlock(blocks.StructBlock):
+            posts = blocks.ListBlock(blocks.BlockReference(lambda: PostBlock))
+
+        class PostBlock(blocks.StructBlock):
+            authors = blocks.ListBlock(blocks.BlockReference(lambda: AuthorBlock))
+
+        # Packing must terminate; the cycle is broken by an _ref in the output.
+        self.assertTrue(
+            JSContext().pack(blocks.StreamBlock([("comment", self.CommentBlock())]))
+        )
+        self.assertTrue(
+            JSContext().pack(blocks.StreamBlock([("author", AuthorBlock())]))
+        )
+
+    def test_inherited_reference_resolves(self):
+        class BaseBlock(blocks.StructBlock):
+            children = blocks.ListBlock(blocks.BlockReference(lambda: BaseBlock))
+
+        class SubBlock(BaseBlock):
+            extra = blocks.CharBlock()
+
+        self.assertEqual(SubBlock().check(), [])
+        self.assertEqual(set(SubBlock().child_blocks), {"children", "extra"})


### PR DESCRIPTION
Fixes #13460 and https://wagtailcms.slack.com/archives/C81FGJR2S/p1778243274030779

### Description

This PR adds a new `BlockReference` type that allows you to define lazy & cyclic blocks. The BlockReference is a proxy that forwards calls to the original block and does the cyclic handling mostly under the hood. 

The proxy mirrors other lazy-object patterns used in other Python packages, such as Django's LazyObject where certain things where borrowed from.

I've tried to keep changes outside `BlockReference` minimal, but no changes simply isn't doable. The changes are backwards compatible though and the API does not change.

I've tried various patterns to accomplish this, but this one ended up the most clean in my opinion. Others added decorator guards to several methods and logic was scattered all over the place.

Examples:

```python
from wagtail import blocks

class CommentBlock(blocks.StructBlock):
    author = blocks.CharBlock()
    text = blocks.RichTextBlock()
    replies = blocks.ListBlock(blocks.BlockReference(lambda: CommentBlock))


class SectionBlock(blocks.StructBlock):
    title = blocks.CharBlock()
    body = blocks.StreamBlock([
        ("paragraph", blocks.RichTextBlock()),
        ("comments", blocks.ListBlock(CommentBlock())),
        ("section", blocks.BlockReference(lambda: SectionBlock)),
        ("embed", blocks.BlockReference("myapp.blocks.EmbedBlock")),
    ])
```

This PR depends on:
https://github.com/wagtail/telepath/pull/15
https://github.com/wagtail/telepath-unpack/pull/5

Both those are "backported" within this PR so it was easier to test for me, these can be removed once the PR's are merged in Telepath.


### AI usage

I have used AI to review the code (which sometimes altered my code), write tests and re-write my comments in better english.
