### PR TITLE
Update codecov CircleCI Orb to v6.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@5.4.3
+  codecov: codecov/codecov@6.0.0
 
 jobs:
   backend:


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes CircleCI frontend job error due to https://github.com/codecov/codecov-circleci-orb/issues/262

### Description

<!-- Please describe the problem you're fixing. -->
Codecov moved their Keybase account from http://keybase.io/codecovsecurity to https://keybase.io/codecovsecops, breaking the old versions of the orb.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None