### PR TITLE
Fix ValidationError crash on bulk publish with invalid pages

### DIFF
--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_publish.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_publish.py
@@ -235,11 +235,12 @@ class TestBulkPublish(WagtailTestUtils, TestCase):
         from wagtail.models import Revision
 
         original_publish = Revision.publish
+
         def mock_publish(self, *args, **kwargs):
             if self.object_id == str(falling_page.id):
                 raise ValidationError("Simulated validation error")
             return original_publish(self, *args, **kwargs)
-        
+
         with mock.patch.object(Revision, "publish", mock_publish):
             response = self.client.post(self.url)
 

--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_publish.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_publish.py
@@ -231,6 +231,7 @@ class TestBulkPublish(WagtailTestUtils, TestCase):
         falling_page = self.pages_to_be_published[0]
 
         from django.core.exceptions import ValidationError
+
         from wagtail.models import Revision
 
         original_publish = Revision.publish
@@ -422,6 +423,7 @@ class TestBulkPublishIncludingDescendants(WagtailTestUtils, TestCase):
         failing_grandchild = self.grandchildren_pages[self.pages_to_be_published[1]][0]
 
         from django.core.exceptions import ValidationError
+
         from wagtail.models import Revision
 
         original_publish = Revision.publish

--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_publish.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_publish.py
@@ -222,6 +222,38 @@ class TestBulkPublish(WagtailTestUtils, TestCase):
             'name="include_descendants"',
         )
 
+    def test_publish_view_post_with_validation_error(self):
+        """
+        This posts to the publish view, where one of the pages fails to
+        publish due to a ValidationError, and checks that the other pages
+        are published successfully and the failure is reported.
+        """
+        falling_page = self.pages_to_be_published[0]
+
+        from django.core.exceptions import ValidationError
+        from wagtail.models import Revision
+
+        original_publish = Revision.publish
+        def mock_publish(self, *args, **kwargs):
+            if self.object_id == str(falling_page.id):
+                raise ValidationError("Simulated validation error")
+            return original_publish(self, *args, **kwargs)
+        
+        with mock.patch.object(Revision, "publish", mock_publish):
+            response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, 302)
+        # The failing page should remain unpublished
+        self.assertFalse(SimplePage.objects.get(id=falling_page.id).live)
+        # Other pages should be published
+        for child_page in self.pages_to_be_published[1:]:
+            published_page = SimplePage.objects.get(id=child_page.id)
+            self.assertTrue(published_page.live)
+        # Check the success message mentions the failure
+        response = self.client.get(self.redirect_url)
+        html = response.content.decode()
+        self.assertIn("could not be published due to validation errors", html)
+
 
 class TestBulkPublishIncludingDescendants(WagtailTestUtils, TestCase):
     def setUp(self):
@@ -379,3 +411,51 @@ class TestBulkPublishIncludingDescendants(WagtailTestUtils, TestCase):
         for grandchild_pages in self.grandchildren_pages.values():
             for grandchild_page in grandchild_pages:
                 self.assertFalse(Page.objects.get(id=grandchild_page.id).live)
+
+    def test_publish_include_children_view_post_with_validation_error(self):
+        """
+        This posts to the publish view with include_descendants, where one
+        descendant fails to publish due to a ValidationError, and checks
+        that other pages/descendants are still published and the failure
+        is reported.
+        """
+        failing_grandchild = self.grandchildren_pages[self.pages_to_be_published[1]][0]
+
+        from django.core.exceptions import ValidationError
+        from wagtail.models import Revision
+
+        original_publish = Revision.publish
+
+        def mock_publish(self, *args, **kwargs):
+            if self.object_id == str(failing_grandchild.id):
+                raise ValidationError("Simulated validation error")
+            return original_publish(self, *args, **kwargs)
+
+        with mock.patch.object(Revision, "publish", mock_publish):
+            response = self.client.post(self.url, {"include_descendants": "on"})
+
+        self.assertEqual(response.status_code, 302)
+
+        # Parent pages should still be published
+        for child_page in self.pages_to_be_published:
+            published_child_page = SimplePage.objects.get(id=child_page.id)
+            self.assertTrue(published_child_page.live)
+
+        # The failing grandchild should remain unpublished
+        self.assertFalse(SimplePage.objects.get(id=failing_grandchild.id).live)
+
+        # Other grandchildren should be published
+        for child_page, grandchild_pages in self.grandchildren_pages.items():
+            for grandchild_page in grandchild_pages:
+                if grandchild_page.id == failing_grandchild.id:
+                    continue
+                published_grandchild_page = SimplePage.objects.get(
+                    id=grandchild_page.id
+                )
+                self.assertTrue(published_grandchild_page.live)
+
+        # Check the success message mentions the failure
+        self.redirect_url = reverse("wagtailadmin_explore", args=(self.root_page.id,))
+        response = self.client.get(self.redirect_url)
+        html = response.content.decode()
+        self.assertIn("could not be published due to validation errors", html)

--- a/wagtail/admin/views/bulk_action/base_bulk_action.py
+++ b/wagtail/admin/views/bulk_action/base_bulk_action.py
@@ -149,7 +149,7 @@ class BulkAction(ABC, FormView):
             )
             if before_hook_result is not None:
                 return before_hook_result
-            num_parent_objects, num_child_objects = self.execute_action(
+            num_parent_objects, num_child_objects, *_ = self.execute_action(
                 objects, **self.get_execution_context()
             )
             after_hook_result = self.__run_after_hooks(
@@ -158,7 +158,7 @@ class BulkAction(ABC, FormView):
             if after_hook_result is not None:
                 return after_hook_result
             success_message = self.get_success_message(
-                num_parent_objects, num_child_objects
+                num_parent_objects, num_child_objects, *_
             )
             if success_message is not None:
                 messages.success(request, success_message)

--- a/wagtail/admin/views/pages/bulk_actions/publish.py
+++ b/wagtail/admin/views/pages/bulk_actions/publish.py
@@ -83,7 +83,9 @@ class PublishBulkAction(PageBulkAction):
             num_failed_objects,
         ) % {"num_failed_objects": num_failed_objects}
 
-    def get_success_message(self, num_parent_objects, num_child_objects, num_failed_objects):
+    def get_success_message(
+        self, num_parent_objects, num_child_objects, num_failed_objects
+    ):
         include_descendants = self.cleaned_form.cleaned_data["include_descendants"]
         if include_descendants and num_child_objects > 0:
             message = _("%(parent_pages)s and %(child_pages)s have been published") % {

--- a/wagtail/admin/views/pages/bulk_actions/publish.py
+++ b/wagtail/admin/views/pages/bulk_actions/publish.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
@@ -38,13 +39,16 @@ class PublishBulkAction(PageBulkAction):
 
     @classmethod
     def execute_action(cls, objects, include_descendants=False, user=None, **kwargs):
-        num_parent_objects, num_child_objects = 0, 0
+        num_parent_objects, num_child_objects, num_failed_objects = 0, 0, 0
         for page in objects:
             revision = page.get_latest_revision() or page.specific.save_revision(
                 user=user
             )
-            revision.publish(user=user)
-            num_parent_objects += 1
+            try:
+                revision.publish(user=user)
+                num_parent_objects += 1
+            except ValidationError:
+                num_failed_objects += 1
 
             if include_descendants:
                 for draft_descendant_page in (
@@ -64,22 +68,36 @@ class PublishBulkAction(PageBulkAction):
                             draft_descendant_page.get_latest_revision()
                             or draft_descendant_page.save_revision(user=user)
                         )
-                        draft_descendant_revision.publish(user=user)
-                        num_child_objects += 1
+                        try:
+                            draft_descendant_revision.publish(user=user)
+                            num_child_objects += 1
+                        except ValidationError:
+                            num_failed_objects += 1
 
-        return num_parent_objects, num_child_objects
+        return num_parent_objects, num_child_objects, num_failed_objects
 
-    def get_success_message(self, num_parent_objects, num_child_objects):
+    def get_failed_page_text(self, num_failed_objects):
+        return ngettext(
+            "%(num_failed_objects)d page could not be published due to validation errors",
+            "%(num_failed_objects)d pages could not be published due to validation errors",
+            num_failed_objects,
+        ) % {"num_failed_objects": num_failed_objects}
+
+    def get_success_message(self, num_parent_objects, num_child_objects, num_failed_objects):
         include_descendants = self.cleaned_form.cleaned_data["include_descendants"]
         if include_descendants and num_child_objects > 0:
-            # Translators: This forms a message such as "1 page and 3 child pages have been published"
-            return _("%(parent_pages)s and %(child_pages)s have been published") % {
+            message = _("%(parent_pages)s and %(child_pages)s have been published") % {
                 "parent_pages": self.get_parent_page_text(num_parent_objects),
                 "child_pages": self.get_child_page_text(num_child_objects),
             }
         else:
-            return ngettext(
+            message = ngettext(
                 "%(num_parent_objects)d page has been published",
                 "%(num_parent_objects)d pages have been published",
                 num_parent_objects,
             ) % {"num_parent_objects": num_parent_objects}
+
+        if num_failed_objects > 0:
+            message += ". " + self.get_failed_page_text(num_failed_objects)
+
+        return message


### PR DESCRIPTION
Fixes #14253

### Description

When bulk publishing pages, if a page has a required field left blank, a `ValidationError` was raised and caused a 500 error instead of showing a proper message to the user.

This fix catches `ValidationError` in `execute_action` and counts failed pages separately. The user now sees a message like "2 pages published. 1 page could not be published due to validation errors."

### AI usage

Claude assisted with debugging.