### PR TITLE
Set up zizmor to lint GitHub Actions for security gotchas

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['**']
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read # Only needed for private repos. Needed to clone the repo.
+      actions: read # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,4 @@
-name: GitHub Actions Security Analysis with zizmor 🌈
+name: zizmor
 
 on:
   push:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -153,6 +153,7 @@ Changelog
  * Maintenance: Switch StreamField block rendering to use `w-block-` prefixes for block type class names (Kalash Kumari Thakur)
  * Maintenance: Upgrade CodeQL security scanning to cover more parts of the codebase (Thibaud Colas)
  * Maintenance: Upgrade django-modelcluster to 6.5 to fix issues with duplicated inline children (Alex Tomkins, Matt Westcott)
+ * Maintenance: Set up zizmor to lint GitHub Actions for security gotchas (Dan Braghis)
 
 7.3.3 (15.06.2026)
 ~~~~~~~~~~~~~~~~~~

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -45,6 +45,7 @@ depth: 1
  * Add `one` and `not` match support to `RulesController` (LB (Ben Johnston))
  * Refactor pages' function-based views to class-based views (Sage Abdullah)
  * Add CI job for testing with latest versions of all dependencies (Sage Abdullah)
+ * Set up zizmor to lint GitHub Actions for security gotchas (Dan Braghis)
 
 ## Upgrade considerations - removal of deprecated features from Wagtail 6.4 - 7.3
 


### PR DESCRIPTION
### Description

zizmor is a static analysis tool for GitHub Actions. This PR adds it as a GH Action
See https://docs.zizmor.sh/integrations/#github-actions

Note that #14208 (and follow-up) would solve some of the things zizmor flags


### AI usage

This PR was lovingly hand-crafted