### PR TITLE
Use canonical URL for TED oEmbed provider

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Changelog
  * Fix: Accommodate multilingual sites in skipping the "choose parent" step when creating a new page from a flat page listing (Amrinder Singh)
  * Fix: Prevent error when moving a page to a destination with missing translations and `WAGTAILSIMPLETRANSLATION_SYNC_PAGE_TREE = True` (Sahil Kumar)
  * Fix: Handle Pillow detecting decompression bombs when validating image pixel count (Jake Howard, Sage Abdullah)
+ * Fix: Use canonical URL for TED oEmbed provider (Marquis Nobles)
  * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
  * Docs: Fix panel classname and deprecated usage of `format_html` in `construct_homepage_panels` example (Andreas Nüßlein)
  * Maintenance: Rename `request` argument to `cache_object` in `Page._get_site_root_paths()` for correctness (Kailesh)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -984,6 +984,7 @@
 * 0x1saac
 * Devansh Bordia
 * alanturing881
+* Marquis Nobles
 
 ## Translators
 

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -29,6 +29,7 @@ depth: 1
  * Accommodate multilingual sites in skipping the "choose parent" step when creating a new page from a flat page listing (Amrinder Singh)
  * Prevent error when moving a page to a destination with missing translations and `WAGTAILSIMPLETRANSLATION_SYNC_PAGE_TREE = True` (Sahil Kumar)
  * Handle Pillow detecting decompression bombs when validating image pixel count (Jake Howard, Sage Abdullah)
+ * Use canonical URL for TED oEmbed provider (Marquis Nobles)
 
 ### Documentation
 

--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -500,7 +500,7 @@ spotify = {
 
 
 ted = {
-    "endpoint": "https://www.ted.com/talks/oembed.{format}",
+    "endpoint": "https://www.ted.com/services/v1/oembed.{format}",
     "urls": [
         r"^https?://(?:www\.)?ted\.com/talks/.+$",
         r"^https?://(?:www\.)?ted\.com/talks/lang/[^#?/]+/.+$",


### PR DESCRIPTION
## Summary

The TED oEmbed provider points at the outdated `https://www.ted.com/talks/oembed.{format}`. The canonical endpoint (the [iamcal/oembed](https://github.com/iamcal/oembed/blob/master/providers/ted.yml) registry and oembed.com) is `https://www.ted.com/services/v1/oembed.{format}`.

## Current behavior

The old endpoint only works by accident: `/talks/oembed.json` returns a `301` redirect to `/services/v1/oembed.json`, which `requests` follows, so JSON embeds resolve today. But:

- `/talks/oembed.xml` returns `404` (the redirect only covers `.json`)
- every TED embed pays an extra redirect round-trip
- the legacy redirect shouldn't be relied on; TED is migrating this endpoint

Pointing directly at the canonical endpoint removes that dependency.

## Change

One line in `wagtail/embeds/oembed_providers.py`. No test references the endpoint. `CHANGELOG.txt` and release notes are left untouched per the committer-only convention in `docs/contributing/committing.md`.
