### PR TITLE
Ensure `ViewSet.menu_order` is respected when used in a `ViewSetGroup`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Show site name in site switcher dropdown in site settings editor (Jack Morgan)
  * Improve clarity of different task states in workflow details dialog (Dan Braghis)
  * Add `submenu_hook` attribute to `ViewSetGroup` for collecting submenu items registered via a hook (Hunzlah Malik, MariyaOT, Sage Abdullah)
+ * Respect `ViewSet.menu_order` when used in a `ViewSetGroup` (Sage Abdullah)
  * Use a more accessible label for blank values of `ChoiceBlock` (Sage Abdullah)
  * Use a more accessible label for blank values of dropdowns in locked page report filters (Sage Abdullah)
  * Make audit log messages for scheduling/unscheduling generic (Sage Abdullah)

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -91,6 +91,12 @@ For additional details on these changes, see:
 
 The [`SnippetChooserViewSet.widget_class`](wagtail.snippets.views.chooser.SnippetChooserViewSet.widget_class) attribute now correctly returns a widget class instead of an instance, consistent with [`ChooserViewSet.widget_class`](wagtail.admin.viewsets.chooser.ChooserViewSet.widget_class). This change may require updates to any customizations that relied on the previous behavior, such as an override in a `SnippetChooserViewSet` subclass that uses `super().widget_class`.
 
+### `ViewSet.menu_order` is now respected when used in a `ViewSetGroup`
+
+{class}`~wagtail.admin.viewsets.base.ViewSet`s that are registered as part of a {class}`~wagtail.admin.viewsets.base.ViewSetGroup` now have their {attr}`~wagtail.admin.viewsets.base.ViewSet.menu_order` respected instead of always using its position in [`ViewSetGroup.items`](wagtail.admin.viewsets.base.ViewSetGroup.items).
+
+If you rely on the previous behavior that used the `items` ordering, remove {attr}`~wagtail.admin.viewsets.base.ViewSet.menu_order` in your `ViewSet` definition.
+
 ## Upgrade considerations - changes to undocumented internals
 
 ### `request` argument to `Page._get_site_root_paths` is now `cache_object`

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -21,9 +21,7 @@ depth: 1
  * Show site name in site switcher dropdown in site settings editor (Jack Morgan)
  * Improve clarity of different task states in workflow details dialog (Dan Braghis)
  * Add `submenu_hook` attribute to `ViewSetGroup` for collecting submenu items registered via a hook (Hunzlah Malik, MariyaOT, Sage Abdullah)
- * Use a more accessible label for blank values of `ChoiceBlock` (Sage Abdullah)
- * Use a more accessible label for blank values of dropdowns in locked page report filters (Sage Abdullah)
- * Make audit log messages for scheduling/unscheduling generic (Sage Abdullah)
+ * Respect `ViewSet.menu_order` when used in a `ViewSetGroup` (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/menu.py
+++ b/wagtail/admin/menu.py
@@ -170,8 +170,14 @@ class WagtailMenuRegisterable:
     menu_name = ""
 
     #: An integer determining the order of the menu item, 0 being the first place.
-    #: By default, it will be the last item before Reports, whose order is 9000.
-    menu_order = 8999
+    #: If left unset, the order defaults to this item's position within its
+    #: containing group (such as a :class:`~wagtail.admin.viewsets.base.ViewSetGroup`),
+    #: if any. Otherwise, it is set to 8999, placing it as the last item before
+    #: Reports, whose order is 9000.
+    #:
+    #: .. versionchanged:: 8.0
+    #:    The value is now respected when the menu item is registered as part of a group.
+    menu_order = None
 
     #: The URL to be used for the menu item.
     menu_url = None
@@ -197,17 +203,25 @@ class WagtailMenuRegisterable:
         Returns a ``wagtail.admin.menu.MenuItem`` instance to be registered
         with the Wagtail admin.
 
-        The ``order`` parameter allows the method to be called from the outside
-        (e.g. a ``ViewSetGroup``) to create a sub menu item with
-        the correct order.
+        The ``order`` parameter allows specifying the order of the menu item when
+        creating the menu item if the :attr:`menu_order` attribute is not set.
         """
         return self.menu_item_class(
             label=self.menu_label,
             url=self.menu_url,
             name=self.menu_name,
             icon_name=self.menu_icon,
-            order=order if order is not None else self.menu_order,
+            order=self.get_menu_item_order(order),
         )
+
+    def get_menu_item_order(self, order=None):
+        """
+        Determines the order of the menu item, with the following precedence:
+        1. The ``menu_order`` attribute on this class or instance
+        2. The ``order`` argument passed to this method
+        3. The default value of 8999 if neither of the above are set
+        """
+        return next(o for o in [self.menu_order, order, 8999] if o is not None)
 
     @cached_property
     def menu_hook(self):
@@ -273,7 +287,7 @@ class WagtailMenuRegisterableGroup(WagtailMenuRegisterable):
             ),
             name=self.menu_name,
             icon_name=self.menu_icon,
-            order=order if order is not None else self.menu_order,
+            order=self.get_menu_item_order(order),
         )
 
 

--- a/wagtail/admin/tests/viewsets/test_base_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_base_viewset.py
@@ -49,7 +49,6 @@ class TestBaseViewSet(WagtailTestUtils, TestCase):
                 for item in misc_items
             ],
             [
-                ("wagtail.sidebar.LinkMenuItem", "the-calendar", "/admin/calendar/"),
                 ("wagtail.sidebar.LinkMenuItem", "the-greetings", "/admin/greetingz/"),
                 (
                     "wagtail.sidebar.LinkMenuItem",
@@ -61,6 +60,7 @@ class TestBaseViewSet(WagtailTestUtils, TestCase):
                     "submenu-hook-greetings",
                     "/admin/submenu_hook_greetingz/",
                 ),
+                ("wagtail.sidebar.LinkMenuItem", "the-calendar", "/admin/calendar/"),
             ],
         )
 

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -898,8 +898,9 @@ class SnippetViewSet(ModelViewSet):
 
         **Deprecated** - the preferred way to customise this is to define a ``menu_order`` property.
         """
-        # By default, put it at the last item before Reports, whose order is 9000.
-        return 8999
+        # Returning None defers to the default ordering applied by
+        # get_menu_item_order (just before Reports, whose order is 9000).
+        return None
 
     def get_menu_item_is_registered(self):
         return self.menu_item_is_registered

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -124,6 +124,7 @@ class CalendarViewSet(ViewSet):
     icon = "date"
     name = "calendar"
     template_name = "tests/misc/calendar.html"
+    menu_order = 9999
 
     def __init__(self, name=None, **kwargs):
         super().__init__(name, **kwargs)


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #11207

### Description

<!-- Please describe the problem you're fixing. -->
Now that #14275 has landed, it's even more important that a `ViewSet`'s `menu_order` is always respected, as the parent group may contain menu items added via hooks (not `items`).

This PR changes the `menu_order` class-level default value to `None`. If set to an integer, it will always take precedence. Otherwise, it will follow the order in `items` (if it's part of a group, i.e. previous behaviour), before finally falling back to the old default value of 8999.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Claude Sonnet 4.6 for local code review. Code written by me.