### PR TITLE
Clarify Wagtail XSS protections for uploaded documents

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@ Changelog
  * Docs: Fix panel classname and deprecated usage of `format_html` in `construct_homepage_panels` example (Andreas Nüßlein)
  * Docs: Add docs for `request.in_preview_panel` to explain its use (Raghad Dahi)
  * Docs: Update image format docs to encourage more intentional conversions (Thibaud Colas)
+ * Docs: Clarify Wagtail XSS protections for uploaded documents (Thibaud Colas)
  * Maintenance: Rename `request` argument to `cache_object` in `Page._get_site_root_paths()` for correctness (Kailesh)
  * Maintenance: Fix blank choice tests for Django 6.1 (Sage Abdullah)
  * Maintenance: Ignore `EMAIL_BACKEND` setting deprecation on Django 6.1 when running project template tests (Sage Abdullah)

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -85,15 +85,15 @@ Since the CSV format has no concept of formulae or macros, there is also no agre
 
 Wagtail's data exports default to XLSX, which can be loaded into spreadsheet software without any such issues. This minimizes the risk of a user handling CSV files insecurely, as they would have to explicitly choose CSV over the more familiar XLSX format.
 
-### Cross-site scripting through document uploads
+### Cross-site scripting through media uploads
 
-Any system that allows user-uploaded files is a potential security risk. Several historical reports have raised the issue that if uploads aren't properly secured, they can potentially lead to arbitrary code execution (via [Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/)).
+Any system that allows user-uploaded files is a potential security risk. Several historical reports have raised the issue that if image or document uploads aren't properly secured, they can potentially lead to arbitrary code execution (via [Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/)).
 
 When Wagtail serves these files itself (ie the content is returned in the response directly), the required protections are already in place. This can be done using the [dynamic image serve](using_images_outside_wagtail) view for images and by setting [](wagtaildocs_serve_method) to `serve_view`. However, when files are served from where they're being stored directly (such as directly from the AWS S3 bucket), Wagtail has little to no control over how the files are served. Instead, developers must make sure care is taken when configuring file storage to serve files. The relevant documentation for [images](svg_security_considerations) and [documents](documents_security_considerations) should be read before serving files directly from remote storage.
 
 Because the considerations needed for remote storage are already documented, we do not consider misconfiguration of storage, particularly when served directly from the media source, as a security vulnerability in Wagtail. This includes when using Django's built-in media serving capabilities via `MEDIA_URL`. Vulnerabilities in Wagtail's built-in serve views are still considered.
 
-Wagtail does not take any measures to block the execution of JavaScript within PDF documents. To the extent that browsers allow this, they do so in a locked-down sandbox environment with no access to the origin site or the network. The ability to open an alert box from a PDF does not in itself demonstrate a viable cross-site scripting attack, and we do not consider this to be a security vulnerability. However, we would be happy to consider reports that demonstrate actual exfiltration of user data through a PDF document.
+Wagtail does not sanitize JavaScript within HTML / SVG / PDF documents, though we do prevent its execution when serving files via Wagtail, using a strict [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy). To the extent that browsers allow JavaScript in PDFs, they do so in a locked-down sandbox environment with no access to the origin site or the network. The ability to open an alert box from a PDF does not in itself demonstrate a viable cross-site scripting attack, and we do not consider this to be a security vulnerability. However, we would be happy to consider reports that demonstrate actual exfiltration of user data through a PDF document.
 
 ### CVEs in third-party dependencies
 

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -85,7 +85,7 @@ Since the CSV format has no concept of formulae or macros, there is also no agre
 
 Wagtail's data exports default to XLSX, which can be loaded into spreadsheet software without any such issues. This minimizes the risk of a user handling CSV files insecurely, as they would have to explicitly choose CSV over the more familiar XLSX format.
 
-### Cross-site scripting through media uploads
+### Cross-site scripting through uploads
 
 Any system that allows user-uploaded files is a potential security risk. Several historical reports have raised the issue that if image or document uploads aren't properly secured, they can potentially lead to arbitrary code execution (via [Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/)).
 

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -85,15 +85,15 @@ Since the CSV format has no concept of formulae or macros, there is also no agre
 
 Wagtail's data exports default to XLSX, which can be loaded into spreadsheet software without any such issues. This minimizes the risk of a user handling CSV files insecurely, as they would have to explicitly choose CSV over the more familiar XLSX format.
 
-### Cross-site scripting through document uploads
+### Cross-site scripting through media uploads
 
-Any system that allows user-uploaded files is a potential security risk. Several historical reports have raised the issue that if uploads aren't properly secured, they can potentially lead to arbitrary code execution (via [Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/)).
+Any system that allows user-uploaded files is a potential security risk. Several historical reports have raised the issue that if image or document uploads aren't properly secured, they can potentially lead to arbitrary code execution (via [Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/)).
 
 When Wagtail serves these files itself (ie the content is returned in the response directly), the required protections are already in place. This can be done using the [dynamic image serve](using_images_outside_wagtail) view for images and by setting [](wagtaildocs_serve_method) to `serve_view`. However, when files are served from where they're being stored directly (such as directly from the AWS S3 bucket), Wagtail has little to no control over how the files are served. Instead, developers must make sure care is taken when configuring file storage to serve files. The relevant documentation for [images](svg_security_considerations) and [documents](documents_security_considerations) should be read before serving files directly from remote storage.
 
 Because the considerations needed for remote storage are already documented, we do not consider misconfiguration of storage, particularly when served directly from the media source, as a security vulnerability in Wagtail. This includes when using Django's built-in media serving capabilities via `MEDIA_URL`. Vulnerabilities in Wagtail's built-in serve views are still considered.
 
-Wagtail does not take any measures to block the execution of JavaScript within PDF documents. To the extent that browsers allow this, they do so in a locked-down sandbox environment with no access to the origin site or the network. The ability to open an alert box from a PDF does not in itself demonstrate a viable cross-site scripting attack, and we do not consider this to be a security vulnerability. However, we would be happy to consider reports that demonstrate actual exfiltration of user data through a PDF document.
+Wagtail does not sanitize JavaScript within HTML / SVG / PDF documents, though we do prevent its execution when serving files via Wagtail, using a strict [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy). To the extent that browsers allow JavaScript in PDFs, they do so in a locked-down sandbox environment with no access to the origin site or the network. The ability to open an alert box from a PDF does not in itself demonstrate a viable cross-site scripting attack, and we do not consider this to be a security vulnerability. However, we would be happy to consider reports that demonstrate actual exfiltration of user data through a PDF document.
 
 ### Privilege escalation by users with user management roles
 

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -58,6 +58,7 @@ For more details, refer to the [](permissions_reference) reference documentation
  * Update django-ninja code examples to use new Meta class implemented in django-ninja V1 (Jack Whitworth)
  * Document [`request.in_preview_panel`](custom_rendering_in_preview_panel) to explain its use (Raghad Dahi)
  * Update image format docs to encourage more intentional conversions (Thibaud Colas)
+ * Clarify Wagtail XSS protections for uploaded documents (Thibaud Colas)
 
 ### Maintenance
 


### PR DESCRIPTION
Part of the discussion on [Mitigating untrusted file upload security issues](https://github.com/wagtail/wagtail/discussions/12617). A few rewordings to make it clearer that:

- Our XSS mitigations are relevant both for documents (HTML / PDF / SVG) and SVG images.
- We do offer protection from XSS in uploaded media.

### AI usage

None