### PR TITLE
Fix grammar in multi-tenancy documentation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -986,6 +986,7 @@
 * alanturing881
 * Marquis Nobles
 * Eesh Saxena
+* Thomas Herman
 
 ## Translators
 

--- a/docs/advanced_topics/multi_site_multi_instance_multi_tenancy.md
+++ b/docs/advanced_topics/multi_site_multi_instance_multi_tenancy.md
@@ -83,7 +83,7 @@ Permission configuration for built-in models like Sites, Site settings and Users
 
 Python, Django, and Wagtail allow you to override, extend and customize functionality. Here are some ideas that may help you create a multi-tenancy solution for your site:
 
--   Django allows to override templates, this also works in the Wagtail admin.
+-   Django allows you to override templates. This also works in the Wagtail admin.
 -   A custom user model can be used to link users to a specific site.
 -   Custom admin views can provide more restrictive user management.
 


### PR DESCRIPTION
### Description

This fixes a small grammar error on the multi-site, multi-instance and multi-tenancy page.

The line previously read "Django allows to override templates, this also works in the Wagtail admin." The phrase "allows to" is missing its object, and the two clauses were joined with a comma splice. I have changed it to "Django allows you to override templates. This also works in the Wagtail admin."

This also makes the line consistent with the sentence directly above it, which already reads "Python, Django, and Wagtail allow you to override, extend and customize functionality."

### AI usage

I used an AI assistant to help me locate the grammar error and to guide me through the contribution workflow. The wording of the fix and this description were reviewed and confirmed by me.