### PR TITLE
Modify Page and Collection manager to subclass upstream Treebeard manager

### DIFF
--- a/wagtail/models/media.py
+++ b/wagtail/models/media.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
-from treebeard.mp_tree import MP_Node
+from treebeard.mp_tree import MP_Node, MP_NodeManager
 
 from wagtail.query import TreeQuerySet
 from wagtail.search import index
@@ -30,7 +30,7 @@ class CollectionQuerySet(TreeQuerySet):
         ]
 
 
-class BaseCollectionManager(models.Manager):
+class BaseCollectionManager(MP_NodeManager):
     def get_queryset(self):
         return CollectionQuerySet(self.model).order_by("path")
 

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -36,7 +36,7 @@ from modelcluster.fields import ParentalKey
 from modelcluster.models import (
     ClusterableModel,
 )
-from treebeard.mp_tree import MP_Node
+from treebeard.mp_tree import MP_Node, MP_NodeManager
 
 from wagtail.actions.copy_for_translation import CopyPageForTranslationAction
 from wagtail.actions.copy_page import CopyPageAction
@@ -141,7 +141,7 @@ def get_streamfield_names(model_class):
     )
 
 
-class BasePageManager(models.Manager):
+class BasePageManager(MP_NodeManager):
     def get_queryset(self):
         return self._queryset_class(self.model).order_by("path")
 


### PR DESCRIPTION
### Description

Modifies the model managers used by `Page` and `Collection` models to subclass the upstream Treebeard model manager. This is a [documented requirement](https://django-treebeard.readthedocs.io/en/latest/caveats.html#overriding-the-default-manager) for Treebeard, and as of version 5.3 will report a [warning](https://github.com/django-treebeard/django-treebeard/commit/bd8b2483c359f0ad459b0c36f21e5a5b6e0036b1) when Django runs checks. 

This should have no functional impact, since Wagtail overrides the `get_queryset()` method on the manager anyway. It will be necessary in the next major release of Treebeard, which will move many class methods currently residing on the model class (e.g., `add_root`, `get_tree`) into the model manager, for consistency with Django's design patterns.

### AI usage

None
