### PR TITLE
Fix #14361 - database is locked error in FormState concurrent preview requests

### DIFF
--- a/wagtail/admin/migrations/0007_formstate_unique_constraint.py
+++ b/wagtail/admin/migrations/0007_formstate_unique_constraint.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtailadmin", "0006_formstate"),
+    ]
+
+    operations = [
+        migrations.RemoveIndex(
+            model_name="formstate",
+            name="formstate_user_object",
+        ),
+        migrations.AddConstraint(
+            model_name="formstate",
+            constraint=models.UniqueConstraint(
+                fields=["user", "content_type", "object_id", "parent_object_id"],
+                name="formstate_user_object_unique",
+            ),
+        ),
+    ]

--- a/wagtail/admin/models.py
+++ b/wagtail/admin/models.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Count
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -162,14 +162,15 @@ class FormStateManager(models.Manager.from_queryset(FormStateQuerySet)):
         parent_object_id="",
         **kwargs,
     ):
-        return super().update_or_create(
-            content_type=ContentType.objects.get_for_model(
-                instance, for_concrete_model=False
-            ),
-            object_id=str(instance.pk or ""),
-            parent_object_id=parent_object_id,
-            **kwargs,
-        )
+        with transaction.atomic():
+            return super().update_or_create(
+                content_type=ContentType.objects.get_for_model(
+                    instance, for_concrete_model=False
+                ),
+                object_id=str(instance.pk or ""),
+                parent_object_id=parent_object_id,
+                **kwargs,
+            )
 
 
 class FormState(models.Model):
@@ -210,10 +211,10 @@ class FormState(models.Model):
     STALE_TIMEOUT = timezone.timedelta(hours=24)
 
     class Meta:
-        indexes = [
-            models.Index(
+        constraints = [
+            models.UniqueConstraint(
                 fields=["user", "content_type", "object_id", "parent_object_id"],
-                name="formstate_user_object",
+                name="formstate_user_object_unique",
             ),
         ]
         ordering = ["-last_updated_at"]

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -862,7 +862,6 @@ class TestPreview(WagtailTestUtils, TestCase):
         self.assertEqual("Original desktop", radios[1]["aria-label"])
         self.assertTrue(radios[1].has_attr("checked"))
 
-    
 
 class TestFormStateConcurrency(WagtailTestUtils, TransactionTestCase):
     """
@@ -918,11 +917,10 @@ class TestFormStateConcurrency(WagtailTestUtils, TransactionTestCase):
 
         # There should be exactly ONE FormState row, not duplicates
         form_state_count = (
-            FormState.objects.filter(user=self.user)
-            .for_instance(specific_page)
-            .count()
+            FormState.objects.filter(user=self.user).for_instance(specific_page).count()
         )
         self.assertEqual(form_state_count, 1)
+
 
 class TestEnablePreview(WagtailTestUtils, TestCase):
     def setUp(self):

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -903,7 +903,7 @@ class TestFormStateConcurrency(WagtailTestUtils, TransactionTestCase):
                         "last_updated_at": timezone.now(),
                     },
                 )
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 errors.append(e)
 
         t1 = threading.Thread(target=call_update_or_create)

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -906,8 +906,6 @@ class TestPreview(WagtailTestUtils, TestCase):
         self.assertEqual(form_state_count, 1)
 
 
-
-
 class TestEnablePreview(WagtailTestUtils, TestCase):
     def setUp(self):
         self.root_page = Page.objects.get(id=2)

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -1,10 +1,11 @@
 import datetime
 import json
+import threading
 from functools import wraps
 
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase, override_settings
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -861,6 +862,51 @@ class TestPreview(WagtailTestUtils, TestCase):
         self.assertEqual("1280", radios[1]["data-device-width"])
         self.assertEqual("Original desktop", radios[1]["aria-label"])
         self.assertTrue(radios[1].has_attr("checked"))
+
+    def test_preview_on_edit_concurrent_requests_no_duplicate_form_state(self):
+        """
+        Repeated preview requests should not create duplicate FormState rows.
+        The UniqueConstraint on FormState ensures only one row exists per
+        (user, content_type, object_id, parent_object_id).
+        Regression test for: https://github.com/wagtail/wagtail/issues/XXXX
+        """
+        preview_url = reverse(
+            "wagtailadmin_pages:preview_on_edit", args=(self.event_page.id,)
+        )
+
+        # First request - creates the FormState row
+        response = self.client.post(preview_url, self.post_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(
+            response.content.decode(),
+            {"is_valid": True, "is_available": True},
+        )
+
+        # Verify exactly one FormState row was created
+        form_state_count = (
+            FormState.objects.filter(user=self.user)
+            .for_instance(self.event_page.specific)
+            .count()
+        )
+        self.assertEqual(form_state_count, 1)
+
+        # Second request - should UPDATE the existing row, not INSERT a duplicate
+        response = self.client.post(preview_url, self.post_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(
+            response.content.decode(),
+            {"is_valid": True, "is_available": True},
+        )
+
+        # Still exactly ONE FormState row - no duplicates
+        form_state_count = (
+            FormState.objects.filter(user=self.user)
+            .for_instance(self.event_page.specific)
+            .count()
+        )
+        self.assertEqual(form_state_count, 1)
+
+
 
 
 class TestEnablePreview(WagtailTestUtils, TestCase):

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -862,6 +862,7 @@ class TestPreview(WagtailTestUtils, TestCase):
         self.assertEqual("Original desktop", radios[1]["aria-label"])
         self.assertTrue(radios[1].has_attr("checked"))
 
+    
 
 class TestFormStateConcurrency(WagtailTestUtils, TransactionTestCase):
     """
@@ -917,10 +918,11 @@ class TestFormStateConcurrency(WagtailTestUtils, TransactionTestCase):
 
         # There should be exactly ONE FormState row, not duplicates
         form_state_count = (
-            FormState.objects.filter(user=self.user).for_instance(specific_page).count()
+            FormState.objects.filter(user=self.user)
+            .for_instance(specific_page)
+            .count()
         )
         self.assertEqual(form_state_count, 1)
-
 
 class TestEnablePreview(WagtailTestUtils, TestCase):
     def setUp(self):

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -4,7 +4,7 @@ from functools import wraps
 
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase, override_settings
+from django.test import TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -862,49 +862,67 @@ class TestPreview(WagtailTestUtils, TestCase):
         self.assertEqual("Original desktop", radios[1]["aria-label"])
         self.assertTrue(radios[1].has_attr("checked"))
 
-    def test_preview_on_edit_concurrent_requests_no_duplicate_form_state(self):
-        """
-        Repeated preview requests should not create duplicate FormState rows.
-        The UniqueConstraint on FormState ensures only one row exists per
-        (user, content_type, object_id, parent_object_id).
-        Regression test for: https://github.com/wagtail/wagtail/issues/XXXX
-        """
-        preview_url = reverse(
-            "wagtailadmin_pages:preview_on_edit", args=(self.event_page.id,)
-        )
+    
 
-        # First request - creates the FormState row
-        response = self.client.post(preview_url, self.post_data)
-        self.assertEqual(response.status_code, 200)
-        self.assertJSONEqual(
-            response.content.decode(),
-            {"is_valid": True, "is_available": True},
-        )
+class TestFormStateConcurrency(WagtailTestUtils, TransactionTestCase):
+    """
+    Uses TransactionTestCase so threads can actually commit to the database,
+    which is required to test concurrent access to FormState.
+    """
 
-        # Verify exactly one FormState row was created
+    fixtures = ["test.json"]
+
+    def setUp(self):
+        self.event_page = Page.objects.get(url_path="/home/events/christmas/")
+        self.user = self.login()
+
+    def test_update_or_create_by_instance_concurrent_no_duplicates(self):
+        """
+        Concurrent calls to update_or_create_by_instance should not create
+        duplicate FormState rows or raise database errors.
+        The UniqueConstraint on (user, content_type, object_id, parent_object_id)
+        combined with transaction.atomic() prevents race conditions.
+        Regression test for: https://github.com/wagtail/wagtail/issues/14361
+        """
+        import threading
+
+        from django.utils import timezone
+
+        specific_page = self.event_page.specific
+        errors = []
+        barrier = threading.Barrier(2)
+
+        def call_update_or_create():
+            try:
+                barrier.wait(timeout=5)
+                FormState.objects.update_or_create_by_instance(
+                    instance=specific_page,
+                    user=self.user,
+                    defaults={
+                        "data": "title=test&slug=test",
+                        "last_updated_at": timezone.now(),
+                    },
+                )
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=call_update_or_create)
+        t2 = threading.Thread(target=call_update_or_create)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        # No exceptions should have occurred (e.g. database is locked)
+        self.assertEqual(errors, [], f"Concurrent calls raised errors: {errors}")
+
+        # There should be exactly ONE FormState row, not duplicates
         form_state_count = (
             FormState.objects.filter(user=self.user)
-            .for_instance(self.event_page.specific)
+            .for_instance(specific_page)
             .count()
         )
         self.assertEqual(form_state_count, 1)
-
-        # Second request - should UPDATE the existing row, not INSERT a duplicate
-        response = self.client.post(preview_url, self.post_data)
-        self.assertEqual(response.status_code, 200)
-        self.assertJSONEqual(
-            response.content.decode(),
-            {"is_valid": True, "is_available": True},
-        )
-
-        # Still exactly ONE FormState row - no duplicates
-        form_state_count = (
-            FormState.objects.filter(user=self.user)
-            .for_instance(self.event_page.specific)
-            .count()
-        )
-        self.assertEqual(form_state_count, 1)
-
 
 class TestEnablePreview(WagtailTestUtils, TestCase):
     def setUp(self):

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -1,11 +1,10 @@
 import datetime
 import json
-import threading
 from functools import wraps
 
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.test import Client, TestCase, override_settings
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time


### PR DESCRIPTION
## What
Fixes the `sqlite3.OperationalError: database is locked` error that occurs 
when concurrent requests hit FormState.update_or_create_by_instance at the 
same time (e.g. live preview + autosave firing simultaneously).

## Why
Two bugs in the FormState model:
1. `update_or_create_by_instance` had no `transaction.atomic()` wrapper,
   allowing concurrent requests to race between the SELECT and INSERT/UPDATE.
2. The table only had a plain `Index`, not a `UniqueConstraint`, meaning
   PostgreSQL could end up with duplicate rows → `MultipleObjectsReturned`.

## Changes
- Added `transaction.atomic()` to `update_or_create_by_instance`
- Replaced plain `Index` with `UniqueConstraint` on `FormState.Meta`
- Added migration `0007_formstate_unique_constraint`
- Added regression test in `test_preview.py`

## AI usage
I used an AI assistant during this contribution to help write the regression test.
All generated code was reviewed, tested, and verified by me locally before submitting.


Fixes #14361