### PR TITLE
Enable flake8-bandit ruff rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 'v0.15.20'
     hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-check
       - id: ruff-format
 
   - repo: https://github.com/astral-sh/ty-pre-commit

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ Changelog
  * Maintenance: Refactor pages' function-based views to class-based views (Sage Abdullah)
  * Maintenance: Add renovate configuration to automate Python dependencies management (Sage Abdullah)
  * Maintenance: Use Renovate to update GitHub Actions dependencies pins (Sage Abdullah)
+ * Maintenance: Enable flake8-bandit security-focused linting rules (Storm Heg)
 
 
 7.4.2 (15.06.2026)

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -58,6 +58,7 @@ Wagtail 8.0 introduces a new API transport layer at `/api/v3/`, built on [Django
  * Pin all GitHub Actions dependencies to specific versions (Thibaud Colas)
  * Add renovate configuration to automate Python dependencies management (Sage Abdullah)
  * Use Renovate to update GitHub Actions dependencies pins (Sage Abdullah)
+ * Enable flake8-bandit security-focused linting rules (Storm Heg)
 
 ## Upgrade considerations - removal of deprecated features from Wagtail 6.4 - 7.3
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -30,7 +30,7 @@ ignore = ["D100", "D101", "D102", "D103", "D105", "N806", "E501"]
 select = ["E", "F", "I", "S", "T20", "BLE", "C4", "B006", "B904"]
 
 [lint.per-file-ignores]
-"wagtail/test/*" = [
+"wagtail/test/**" = [
   "S101",  # Assert allowed in tests
   "S105",  # Hardcoded password assignments allowed in tests
   "S106",  # Hardcoded password assignments allowed in tests

--- a/ruff.toml
+++ b/ruff.toml
@@ -21,9 +21,10 @@ ignore = ["D100", "D101", "D102", "D103", "D105", "N806", "E501"]
 # E: pycodestyle errors
 # F: Pyflakes
 # I: isort
+# S: flake8-bandit
 # T20: flake8-print
 # BLE: flake8-blind-except
 # C4: flake8-comprehensions
 # B006: Do not use mutable data structures for argument defaults
 # B904: Within an `except` clause, raise exceptions with `raise ... from err`
-select = ["E", "F", "I", "T20", "BLE", "C4", "B006", "B904"]
+select = ["E", "F", "I", "T20", "S", "BLE", "C4", "B006", "B904"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -27,7 +27,7 @@ ignore = ["D100", "D101", "D102", "D103", "D105", "N806", "E501"]
 # C4: flake8-comprehensions
 # B006: Do not use mutable data structures for argument defaults
 # B904: Within an `except` clause, raise exceptions with `raise ... from err`
-select = ["E", "F", "I", "T20", "S", "BLE", "C4", "B006", "B904"]
+select = ["E", "F", "I", "S", "T20", "BLE", "C4", "B006", "B904"]
 
 [lint.per-file-ignores]
 "wagtail/test/*" = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -28,3 +28,29 @@ ignore = ["D100", "D101", "D102", "D103", "D105", "N806", "E501"]
 # B006: Do not use mutable data structures for argument defaults
 # B904: Within an `except` clause, raise exceptions with `raise ... from err`
 select = ["E", "F", "I", "T20", "S", "BLE", "C4", "B006", "B904"]
+
+[lint.per-file-ignores]
+"wagtail/test/*" = [
+  "S101",  # Assert allowed in tests
+  "S105",  # Hardcoded password assignments allowed in tests
+  "S106",  # Hardcoded password assignments allowed in tests
+  "S301",  # Use of pickle allowed in tests
+  "S308",  # Mark safe is often necessary in tests
+  "S324",  # Any hashlib usage is allowed in tests, no need to use a secure hash functions only
+]
+"test_*" = [
+  "S101",  # Assert allowed in tests
+  "S105",  # Hardcoded password assignments allowed in tests
+  "S106",  # Hardcoded password assignments allowed in tests
+  "S301",  # Use of pickle allowed in tests
+  "S308",  # Mark safe is often necessary in tests
+  "S324",  # Any hashlib usage is allowed in tests, no need to use a secure hash functions only
+]
+"tests.py" = [
+  "S101",  # Assert allowed in tests
+  "S105",  # Hardcoded password assignments allowed in tests
+  "S106",  # Hardcoded password assignments allowed in tests
+  "S301",  # Use of pickle allowed in tests
+  "S308",  # Mark safe is often necessary in tests
+  "S324",  # Any hashlib usage is allowed in tests, no need to use a secure hash functions only
+]

--- a/scripts/get-translator-credits.py
+++ b/scripts/get-translator-credits.py
@@ -1,18 +1,12 @@
 import re
-import subprocess
 from collections import defaultdict
+from pathlib import Path
 
 from babel import Locale
 
 authors_by_locale = defaultdict(set)
 
-file_listing = subprocess.Popen(
-    "find ./wagtail -iname *.po", shell=True, stdout=subprocess.PIPE
-)
-
-for file_listing_line in file_listing.stdout:
-    filename = file_listing_line.strip()
-
+for filename in Path("wagtail").rglob("*.po"):
     # extract locale string from filename
     locale = re.search(r"locale/(\w+)/LC_MESSAGES", str(filename)).group(1)
     if locale == "en":

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools.command.sdist import sdist as base_sdist
 class sdist(base_sdist):
     def compile_assets(self):
         try:
-            subprocess.check_call(["npm", "run", "build"])
+            subprocess.check_call(["npm", "run", "build"])  # noqa: S603, S607 - no untrusted input. Starting process from partial path is fine.
         except (OSError, subprocess.CalledProcessError) as e:
             print("Error compiling assets: " + str(e))  # noqa: T201
             raise SystemExit(1) from e

--- a/wagtail/admin/compare.py
+++ b/wagtail/admin/compare.py
@@ -296,7 +296,7 @@ class BaseSequenceBlockComparison(BlockComparison):
             classes = " ".join(classes)
             comparisons_html.append(f'<div class="{classes}">{block_rendered}</div>')
 
-        return mark_safe("\n".join(comparisons_html))
+        return mark_safe("\n".join(comparisons_html))  # noqa: S308
 
 
 class StreamBlockComparison(BaseSequenceBlockComparison):
@@ -792,7 +792,7 @@ class TextDiff:
                     )
                 )
 
-        return mark_safe(self.separator.join(html))
+        return mark_safe(self.separator.join(html))  # noqa: S308
 
 
 def diff_text(a, b):

--- a/wagtail/admin/icons.py
+++ b/wagtail/admin/icons.py
@@ -33,7 +33,7 @@ def get_icons():
 
 @lru_cache(maxsize=None)
 def get_icon_sprite_hash():
-    return hashlib.sha1(get_icons().encode()).hexdigest()[:8]
+    return hashlib.sha1(get_icons().encode()).hexdigest()[:8]  # noqa: S324 -  use of sha1 is acceptable here and has no security purpose
 
 
 def get_icon_sprite_url():

--- a/wagtail/admin/panels/base.py
+++ b/wagtail/admin/panels/base.py
@@ -309,14 +309,14 @@ class Panel:
                 if field_name not in rendered_fields
             ]
 
-            return mark_safe("".join(missing_fields_html))
+            return mark_safe("".join(missing_fields_html))  # noqa: S308 - expected to return safe HTML
 
         def render_form_content(self):
             """
             Render this as an 'object', ensuring that all fields necessary for a valid form
             submission are included
             """
-            return mark_safe(self.render_html() + self.render_missing_fields())
+            return mark_safe(self.render_html() + self.render_missing_fields())  # noqa: S308 - arguments already contain trusted HTML
 
         def __repr__(self):
             return "<{} with model={} instance={} request={} form={}>".format(

--- a/wagtail/admin/rich_text/converters/contentstate_models.py
+++ b/wagtail/admin/rich_text/converters/contentstate_models.py
@@ -10,7 +10,7 @@ class Block:
         self.type = typ
         self.depth = depth
         self.text = ""
-        self.key = key if key else "".join(random.choice(ALPHANUM) for _ in range(5))
+        self.key = key if key else "".join(random.choice(ALPHANUM) for _ in range(5))  # noqa: S311 - random not used cryptographically
         self.inline_style_ranges = []
         self.entity_ranges = []
 

--- a/wagtail/admin/rich_text/converters/html_to_contentstate.py
+++ b/wagtail/admin/rich_text/converters/html_to_contentstate.py
@@ -121,10 +121,10 @@ class BlockElementHandler:
         state.has_preceding_nonatomic_block = True
 
     def handle_endtag(self, name, state, contentState):
-        assert not state.current_inline_styles, (
+        assert not state.current_inline_styles, (  # noqa: S101 - TODO: replace with explicit check?
             "End of block reached without closing inline style elements"
         )
-        assert not state.current_entity_ranges, (
+        assert not state.current_entity_ranges, (  # noqa: S101 - TODO: replace with explicit check?
             "End of block reached without closing entity elements"
         )
         state.current_block = None
@@ -137,7 +137,7 @@ class ListItemElementHandler(BlockElementHandler):
         pass  # skip setting self.block_type
 
     def create_block(self, name, attrs, state, contentstate):
-        assert state.list_item_type is not None, (
+        assert state.list_item_type is not None, (  # noqa: S101 - TODO: replace with explicit check?
             "%s element found outside of an enclosing list element" % name
         )
         return Block(
@@ -168,7 +168,7 @@ class InlineStyleElementHandler:
 
     def handle_endtag(self, name, state, contentstate):
         inline_style_range = state.current_inline_styles.pop()
-        assert inline_style_range.style == self.style
+        assert inline_style_range.style == self.style  # noqa: S101 - TODO: replace with explicit check?
         inline_style_range.length = (
             len(state.current_block.text) - inline_style_range.offset
         )
@@ -388,7 +388,7 @@ class HtmlToContentStateHandler(HTMLParser):
         if not self.open_elements:
             return  # avoid a pop from an empty list if we have an extra end tag
         expected_name, element_handler = self.open_elements.pop()
-        assert name == expected_name, "Unmatched tags: expected {}, got {}".format(
+        assert name == expected_name, "Unmatched tags: expected {}, got {}".format(  # noqa: S101 - TODO: replace with explicit check?
             expected_name,
             name,
         )

--- a/wagtail/admin/search.py
+++ b/wagtail/admin/search.py
@@ -133,7 +133,7 @@ class Search:
         for item in search_areas:
             rendered_search_areas.append(item.render_html(request, query, current))
 
-        return mark_safe("".join(rendered_search_areas))  # noqa: S308 - TODO: investigate if susceptible to XSS
+        return mark_safe("".join(rendered_search_areas))  # noqa: S308 - individual items are template-rendered HTML
 
 
 admin_search_areas = Search(

--- a/wagtail/admin/search.py
+++ b/wagtail/admin/search.py
@@ -133,7 +133,7 @@ class Search:
         for item in search_areas:
             rendered_search_areas.append(item.render_html(request, query, current))
 
-        return mark_safe("".join(rendered_search_areas))
+        return mark_safe("".join(rendered_search_areas))  # noqa: S308 - TODO: investigate if susceptible to XSS
 
 
 admin_search_areas = Search(

--- a/wagtail/admin/staticfiles.py
+++ b/wagtail/admin/staticfiles.py
@@ -32,7 +32,7 @@ except AttributeError:
 if use_version_strings:
     # INSTALLED_APPS is used as a unique value to distinguish Wagtail apps
     # and avoid exposing the Wagtail version directly
-    VERSION_HASH = hashlib.sha1(
+    VERSION_HASH = hashlib.sha1(  # noqa: S324 -  use of sha1 is acceptable here for non-security purposes
         "".join([__version__] + list(settings.INSTALLED_APPS)).encode(),
     ).hexdigest()[:8]
 else:

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -989,7 +989,7 @@ class FragmentNode(template.Node):
         # Then, use mark_safe because the SafeString returned by
         # NodeList.render() is lost after stripping.
         if self.stripped:
-            fragment = mark_safe(fragment.strip())  # noqa: S308 - TODO: investigate if susceptible to XSS
+            fragment = mark_safe(fragment.strip())  # noqa: S308 - Template-rendered HTML is safe
         context[self.target_var] = fragment
         return ""
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -310,7 +310,7 @@ def hook_output(hook_name):
     """
     snippets = [fn() for fn in hooks.get_hooks(hook_name)]
 
-    return mark_safe("".join(snippets))
+    return mark_safe("".join(snippets))  # noqa: S308 - not this function's responsibility to escape unsafe content
 
 
 @register.simple_tag
@@ -989,7 +989,7 @@ class FragmentNode(template.Node):
         # Then, use mark_safe because the SafeString returned by
         # NodeList.render() is lost after stripping.
         if self.stripped:
-            fragment = mark_safe(fragment.strip())
+            fragment = mark_safe(fragment.strip())  # noqa: S308 - TODO: investigate if susceptible to XSS
         context[self.target_var] = fragment
         return ""
 

--- a/wagtail/admin/ui/tables/pages.py
+++ b/wagtail/admin/ui/tables/pages.py
@@ -138,7 +138,7 @@ class NavigateToChildrenColumn(BaseColumn):
         # This column has no header, as the cell's function will vary between "explore child pages"
         # and "add child page", and this link provides all the signposting needed. Render it as a
         # <td> rather than <th> as headings cannot be empty (https://dequeuniversity.com/rules/axe/4.9/empty-table-header).
-        return mark_safe("<td></td>")
+        return mark_safe("<td></td>")  # noqa: S308 - no security implications
 
 
 class PageTable(OrderableTableMixin, Table):

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -897,7 +897,7 @@ class RevisionsRevertMixin:
             "created_at": render_timestamp(self.revision.created_at),
             "user": user_avatar,
         }
-        message = mark_safe(message_string % message_data)  # noqa: S308 - TODO: investigate if susceptible to XSS
+        message = mark_safe(message_string % message_data)  # noqa: S308 - no user input
         return message
 
     def _add_warning_message(self):

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -897,7 +897,7 @@ class RevisionsRevertMixin:
             "created_at": render_timestamp(self.revision.created_at),
             "user": user_avatar,
         }
-        message = mark_safe(message_string % message_data)
+        message = mark_safe(message_string % message_data)  # noqa: S308 - TODO: investigate if susceptible to XSS
         return message
 
     def _add_warning_message(self):

--- a/wagtail/admin/views/page_privacy.py
+++ b/wagtail/admin/views/page_privacy.py
@@ -56,7 +56,7 @@ class SetPrivacyView(ModelFormMixin, ProcessFormView):
                 BaseViewRestriction.NONE,
                 format_html(
                     "<span>{}</span>",
-                    mark_safe(
+                    mark_safe(  # noqa: S308 - TODO: investigate if susceptible to XSS (through translations)
                         _(
                             "Privacy is inherited from the ancestor page - %(ancestor_page)s"
                         )

--- a/wagtail/admin/views/pages/revisions.py
+++ b/wagtail/admin/views/pages/revisions.py
@@ -61,7 +61,7 @@ class RevisionsRevertView(EditView):
             {"user": self.previous_revision.user},
         )
 
-        return mark_safe(  # noqa: S308 - TODO: investigate if susceptible to XSS
+        return mark_safe(  # noqa: S308 - uses template-rendered HTML
             _(
                 "You are viewing a previous version of this page from <b>%(created_at)s</b> by %(user)s"
             )

--- a/wagtail/admin/views/pages/revisions.py
+++ b/wagtail/admin/views/pages/revisions.py
@@ -61,7 +61,7 @@ class RevisionsRevertView(EditView):
             {"user": self.previous_revision.user},
         )
 
-        return mark_safe(
+        return mark_safe(  # noqa: S308 - TODO: investigate if susceptible to XSS
             _(
                 "You are viewing a previous version of this page from <b>%(created_at)s</b> by %(user)s"
             )

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -167,7 +167,7 @@ class BaseChooser(widgets.Input):
 
         js = self.render_js_init(id_, name, value_data)
         out = f"{widget_html}<script>{js}</script>"
-        return mark_safe(out)
+        return mark_safe(out)  # noqa: S308 - TODO: investigate if susceptible to XSS
 
     @property
     def base_js_init_options(self):

--- a/wagtail/blocks/base.py
+++ b/wagtail/blocks/base.py
@@ -311,7 +311,7 @@ class Block(metaclass=BaseBlock):
         else:
             new_context = self.get_context(value, parent_context=dict(context))
 
-        return mark_safe(render_to_string(template, new_context))
+        return mark_safe(render_to_string(template, new_context))  # noqa: S308 - rendered template marked as safe
 
     def get_preview_context(self, value, parent_context=None):
         """

--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -846,10 +846,10 @@ class RawHTMLBlock(FieldBlock):
         return self.normalize(self._evaluate_callable(self.meta.default or ""))
 
     def to_python(self, value):
-        return mark_safe(value)
+        return mark_safe(value)  # noqa: S308 - raw html is allowed
 
     def normalize(self, value):
-        return mark_safe(value)
+        return mark_safe(value)  # noqa: S308 - raw html is allowed
 
     def get_prep_value(self, value):
         # explicitly convert to a plain string, just in case we're using some serialisation method
@@ -861,7 +861,7 @@ class RawHTMLBlock(FieldBlock):
         return str(value) + ""
 
     def value_from_form(self, value):
-        return mark_safe(value)
+        return mark_safe(value)  # noqa: S308 - raw html is allowed
 
     class Meta:
         icon = "code"

--- a/wagtail/blocks/struct_block.py
+++ b/wagtail/blocks/struct_block.py
@@ -530,7 +530,7 @@ class BaseStructBlock(Block):
         context = self.get_form_context(
             self.get_default(), prefix="__PREFIX__", errors=None
         )
-        return mark_safe(render_to_string(self.meta.form_template, context))
+        return mark_safe(render_to_string(self.meta.form_template, context))  # noqa: S308 - rendered template is safe
 
     def get_description(self):
         return super().get_description() or getattr(self.meta, "help_text", "")

--- a/wagtail/contrib/frontend_cache/backends/cloudflare.py
+++ b/wagtail/contrib/frontend_cache/backends/cloudflare.py
@@ -64,11 +64,7 @@ class CloudflareBackend(BaseBackend):
 
             data = {"files": urls}
 
-            response = requests.post(
-                purge_url,
-                json=data,
-                headers=headers,
-            )
+            response = requests.post(purge_url, json=data, headers=headers, timeout=30)
 
             try:
                 response_json = response.json()

--- a/wagtail/contrib/frontend_cache/backends/http.py
+++ b/wagtail/contrib/frontend_cache/backends/http.py
@@ -50,7 +50,7 @@ class HTTPBackend(BaseBackend):
         )
 
         try:
-            urlopen(request)
+            urlopen(request)  # noqa: S310 - scheme is controlled through configured backend LOCATION
         except HTTPError as e:
             logger.error(
                 "Couldn't purge '%s' from HTTP cache. HTTPError: %d %s",

--- a/wagtail/contrib/simple_translation/forms.py
+++ b/wagtail/contrib/simple_translation/forms.py
@@ -115,7 +115,7 @@ class SubmitTranslationForm(forms.Form):
                     len(disabled_locales),
                 )
                 help_text += "</a>"
-                self.fields["locales"].help_text = mark_safe(help_text)
+                self.fields["locales"].help_text = mark_safe(help_text)  # noqa: S308 - TODO: should this be rewritten to format_html?
 
             # For pages, if there is one locale or all locales are disabled.
             hide_select_all = (

--- a/wagtail/coreutils.py
+++ b/wagtail/coreutils.py
@@ -425,7 +425,7 @@ def safe_md5(data=b"", usedforsecurity=True):
     to use the digest for secure purposes and to please just go ahead and
     allow it to happen.
     """
-    return md5(data, usedforsecurity=usedforsecurity)
+    return md5(data, usedforsecurity=usedforsecurity)  # noqa: S324 -  several places in Wagtail require MD5
 
 
 class BatchProcessor:

--- a/wagtail/embeds/finders/facebook.py
+++ b/wagtail/embeds/finders/facebook.py
@@ -70,12 +70,12 @@ class FacebookOEmbedFinder(OEmbedFinder):
             params["omitscript"] = "true"
 
         # Configure request
-        request = Request(endpoint + "?" + urlencode(params))
+        request = Request(endpoint + "?" + urlencode(params))  # noqa: S310 - scheme controlled through configured endpoints, not exploitable
         request.add_header("Authorization", f"Bearer {self.app_id}|{self.app_secret}")
 
         # Perform request
         try:
-            r = urllib_request.urlopen(request)
+            r = urllib_request.urlopen(request)  # noqa: S310 - scheme controlled through configured endpoints, not exploitable
         except (HTTPError, URLError) as e:
             if isinstance(e, HTTPError) and e.code == 404:
                 raise EmbedNotFoundException from e

--- a/wagtail/embeds/finders/instagram.py
+++ b/wagtail/embeds/finders/instagram.py
@@ -54,12 +54,12 @@ class InstagramOEmbedFinder(OEmbedFinder):
             params["omitscript"] = "true"
 
         # Configure request
-        request = Request(endpoint + "?" + urlencode(params))
+        request = Request(endpoint + "?" + urlencode(params))  # noqa: S310 - scheme controlled through configured endpoints, not exploitable
         request.add_header("Authorization", f"Bearer {self.app_id}|{self.app_secret}")
 
         # Perform request
         try:
-            r = urllib_request.urlopen(request)
+            r = urllib_request.urlopen(request)  # noqa: S310 - scheme controlled through configured endpoints, not exploitable
         except (HTTPError, URLError) as e:
             if isinstance(e, HTTPError) and e.code == 404:
                 raise EmbedNotFoundException from e

--- a/wagtail/embeds/finders/oembed.py
+++ b/wagtail/embeds/finders/oembed.py
@@ -59,7 +59,10 @@ class OEmbedFinder(EmbedFinder):
         # Perform request
         try:
             r = requests.get(
-                endpoint, params=params, headers={"User-agent": "Mozilla/5.0"}
+                endpoint,
+                params=params,
+                headers={"User-agent": "Mozilla/5.0"},
+                timeout=10,
             )
             r.raise_for_status()
             oembed = r.json()

--- a/wagtail/embeds/templatetags/wagtailembeds_tags.py
+++ b/wagtail/embeds/templatetags/wagtailembeds_tags.py
@@ -11,6 +11,6 @@ register = template.Library()
 def embed_tag(url, max_width=None):
     try:
         embed = embeds.get_embed(url, max_width=max_width)
-        return mark_safe(embed.html)
+        return mark_safe(embed.html)  # noqa: S308 - we need to render the html we get back from the embed provider
     except EmbedException:
         return ""

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1230,7 +1230,7 @@ class ResponsiveImage:
         return self.renditions[0].img_tag(attrs)
 
     def __str__(self):
-        return mark_safe(self.__html__())
+        return mark_safe(self.__html__())  # noqa: S308 - TODO: investigate if susceptible to XSS
 
     def __bool__(self):
         return bool(self.renditions)
@@ -1295,7 +1295,7 @@ class Picture(ResponsiveImage):
     def __html__(self):
         # If there aren’t multiple formats, render a vanilla img tag with srcset.
         if not self.formats:
-            return mark_safe(f"<picture>{super().__html__()}</picture>")
+            return mark_safe(f"<picture>{super().__html__()}</picture>")  # noqa: S308 - TODO: investigate if susceptible to XSS
 
         attrs = self.attrs or {}
 
@@ -1319,7 +1319,7 @@ class Picture(ResponsiveImage):
         # The first rendition is the "base" / "fallback" image.
         fallback = fallback_renditions[0].img_tag(attrs)
 
-        return mark_safe(f"<picture>{''.join(sources)}{fallback}</picture>")
+        return mark_safe(f"<picture>{''.join(sources)}{fallback}</picture>")  # noqa: S308 - TODO: investigate if susceptible to XSS
 
 
 class AbstractRendition(ImageFileMixin, models.Model):
@@ -1466,7 +1466,7 @@ class AbstractRendition(ImageFileMixin, models.Model):
         if extra_attributes:
             attrs.update(extra_attributes)
 
-        return mark_safe(f"<img{flatatt(attrs)}>")
+        return mark_safe(f"<img{flatatt(attrs)}>")  # noqa: S308 - no security implications
 
     def __html__(self):
         return self.img_tag()

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1230,7 +1230,7 @@ class ResponsiveImage:
         return self.renditions[0].img_tag(attrs)
 
     def __str__(self):
-        return mark_safe(self.__html__())  # noqa: S308 - TODO: investigate if susceptible to XSS
+        return mark_safe(self.__html__())  # noqa: S308 - flatatt-rendered attributes are escaped
 
     def __bool__(self):
         return bool(self.renditions)
@@ -1295,7 +1295,7 @@ class Picture(ResponsiveImage):
     def __html__(self):
         # If there aren’t multiple formats, render a vanilla img tag with srcset.
         if not self.formats:
-            return mark_safe(f"<picture>{super().__html__()}</picture>")  # noqa: S308 - TODO: investigate if susceptible to XSS
+            return mark_safe(f"<picture>{super().__html__()}</picture>")  # noqa: S308 - flatatt-rendered attributes are escaped
 
         attrs = self.attrs or {}
 
@@ -1319,7 +1319,7 @@ class Picture(ResponsiveImage):
         # The first rendition is the "base" / "fallback" image.
         fallback = fallback_renditions[0].img_tag(attrs)
 
-        return mark_safe(f"<picture>{''.join(sources)}{fallback}</picture>")  # noqa: S308 - TODO: investigate if susceptible to XSS
+        return mark_safe(f"<picture>{''.join(sources)}{fallback}</picture>")  # noqa: S308 - flatatt-rendered attributes are escaped
 
 
 class AbstractRendition(ImageFileMixin, models.Model):

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1185,7 +1185,7 @@ class Filter:
         if not vary_string:
             return ""
 
-        return hashlib.sha1(vary_string.encode("utf-8")).hexdigest()[:8]
+        return hashlib.sha1(vary_string.encode("utf-8")).hexdigest()[:8]  # noqa: S324 -  use of sha1 is acceptable here to generate a short hash for cache key
 
     def __eq__(self, value):
         if isinstance(value, Filter):

--- a/wagtail/jinja2tags.py
+++ b/wagtail/jinja2tags.py
@@ -78,7 +78,7 @@ class WagtailCoreExtension(Extension):
         if context.eval_ctx.autoescape:
             return escape(result)
         else:
-            return Markup(result)
+            return Markup(result)  # noqa: S704 - result is safe
 
 
 # Nicer import names

--- a/wagtail/locks.py
+++ b/wagtail/locks.py
@@ -180,14 +180,14 @@ class WorkflowLock(BaseLock):
                 )
                 # Make sure message is correctly capitalised even if it
                 # starts with model_name.
-                workflow_info = mark_safe(capfirst(workflow_info))
+                workflow_info = mark_safe(capfirst(workflow_info))  # noqa: S308 - TODO: investigate if susceptible to XSS
 
             reviewers_info = capfirst(
                 _("Only reviewers for this task can edit the %(model_name)s.")
                 % {"model_name": self.model_name}
             )
 
-            return mark_safe(workflow_info + " " + reviewers_info)
+            return mark_safe(workflow_info + " " + reviewers_info)  # noqa: S308 - TODO: investigate if susceptible to XSS
 
     def get_icon(self, user, can_lock=False):
         if can_lock:
@@ -254,7 +254,7 @@ class ScheduledForPublishLock(BaseLock):
             title=scheduled_revision.object_str,
             datetime=render_timestamp(scheduled_revision.approved_go_live_at),
         )
-        return mark_safe(capfirst(message))
+        return mark_safe(capfirst(message))  # noqa: S308 - message is properly escaped
 
     def get_locked_by(self, user):
         return _("Locked by schedule")

--- a/wagtail/locks.py
+++ b/wagtail/locks.py
@@ -180,14 +180,14 @@ class WorkflowLock(BaseLock):
                 )
                 # Make sure message is correctly capitalised even if it
                 # starts with model_name.
-                workflow_info = mark_safe(capfirst(workflow_info))  # noqa: S308 - TODO: investigate if susceptible to XSS
+                workflow_info = mark_safe(capfirst(workflow_info))  # noqa: S308 - correctly uses format_html
 
             reviewers_info = capfirst(
                 _("Only reviewers for this task can edit the %(model_name)s.")
                 % {"model_name": self.model_name}
             )
 
-            return mark_safe(workflow_info + " " + reviewers_info)  # noqa: S308 - TODO: investigate if susceptible to XSS
+            return mark_safe(workflow_info + " " + reviewers_info)  # noqa: S308 - correctly uses format_html, model_name is developer-controlled
 
     def get_icon(self, user, can_lock=False):
         if can_lock:

--- a/wagtail/models/media.py
+++ b/wagtail/models/media.py
@@ -123,8 +123,8 @@ class Collection(MP_Node):
             # NOTE: &#x21b3 is the hex HTML entity for ↳.
             return format_html(
                 "{indent}{icon} {name}",
-                indent=mark_safe("&nbsp;" * 4 * display_depth),
-                icon=mark_safe("&#x21b3"),
+                indent=mark_safe("&nbsp;" * 4 * display_depth),  # noqa S308 - no security implications
+                icon=mark_safe("&#x21b3"),  # noqa S308 - no security implications
                 name=self.name,
             )
         # Output unicode plain-text version

--- a/wagtail/models/media.py
+++ b/wagtail/models/media.py
@@ -123,8 +123,8 @@ class Collection(MP_Node):
             # NOTE: &#x21b3 is the hex HTML entity for ↳.
             return format_html(
                 "{indent}{icon} {name}",
-                indent=mark_safe("&nbsp;" * 4 * display_depth),  # noqa S308 - no security implications
-                icon=mark_safe("&#x21b3"),  # noqa S308 - no security implications
+                indent=mark_safe("&nbsp;" * 4 * display_depth),  # noqa: S308 - no security implications
+                icon=mark_safe("&#x21b3"),  # noqa: S308 - no security implications
                 name=self.name,
             )
         # Output unicode plain-text version

--- a/wagtail/models/view_restrictions.py
+++ b/wagtail/models/view_restrictions.py
@@ -13,7 +13,7 @@ from django.utils.translation import gettext_lazy as _
 
 class BaseViewRestriction(models.Model):
     NONE = "none"
-    PASSWORD = "password"
+    PASSWORD = "password"  # noqa: S105 -  false positive
     GROUPS = "groups"
     LOGIN = "login"
 

--- a/wagtail/rich_text/__init__.py
+++ b/wagtail/rich_text/__init__.py
@@ -94,7 +94,7 @@ class RichText:
         )
 
     def __str__(self):
-        return mark_safe(self.__html__())
+        return mark_safe(self.__html__())  # noqa: S308 - needs to be safe
 
     def __bool__(self):
         return bool(self.source)

--- a/wagtail/test/customuser/fields.py
+++ b/wagtail/test/customuser/fields.py
@@ -43,7 +43,7 @@ class ConvertedValueField(models.IntegerField):
     def pre_save(self, instance, add):
         value = getattr(instance, self.attname, None)
         if not value:
-            value = ConvertedValue(random.randint(LOWER_BOUND, UPPER_BOUND))
+            value = ConvertedValue(random.randint(LOWER_BOUND, UPPER_BOUND))  # noqa: S311 - random not used cryptographically
             setattr(instance, self.attname, value)
         return value
 

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -207,7 +207,7 @@ ALLOWED_HOSTS = [
     "testserver",
     "other.example.com",
     "127.0.0.1",
-    "0.0.0.0",
+    "0.0.0.0",  # noqa: S104 -  false positive, test setting
 ]
 
 WAGTAILSEARCH_BACKENDS = {

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -58,7 +58,7 @@ if DATABASES["default"]["ENGINE"] == "django.db.backends.mysql":
     DATABASES["default"]["TEST"]["COLLATION"] = "utf8mb4_general_ci"
 
 
-SECRET_KEY = "not needed"
+SECRET_KEY = "not needed"  # noqa: S105 -  false positive, test setting
 
 ROOT_URLCONF = "wagtail.test.urls"
 

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -442,7 +442,7 @@ class EventPage(Page):
         index.FilterField("audience"),
     ]
 
-    password_required_template = "tests/event_page_password_required.html"
+    password_required_template = "tests/event_page_password_required.html"  # noqa: S105 -  false positive
     base_form_class = EventPageForm
 
     content_panels = [

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -2625,7 +2625,7 @@ class GenericSnippetNoFieldIndexPage(GenericSnippetPage):
 def random_quotable_pk():
     quote_chrs = '":/_#?;@&=+$,"[]<>%\n\\'
     components = (quote_chrs, string.ascii_letters, string.digits)
-    return "".join(random.choice(components[i % len(components)]) for i in range(10))
+    return "".join(random.choice(components[i % len(components)]) for i in range(10))  # noqa: S311 - random not used cryptographically
 
 
 # Models to be registered with a ModelViewSet

--- a/wagtail/test/utils/wagtail_tests.py
+++ b/wagtail/test/utils/wagtail_tests.py
@@ -32,7 +32,7 @@ class WagtailTestUtils:
 
         return user_model.objects.create_superuser(**user_data)
 
-    def login(self, user=None, username=None, password="password"):
+    def login(self, user=None, username=None, password="password"):  # noqa: S107 - usage in tests allowed
         # wrapper for self.client.login that works interchangeably for user models
         # with email as the username field; in this case it will use the passed username
         # plus '@example.com'

--- a/wagtail/tests/streamfield_migrations/test_migrations.py
+++ b/wagtail/tests/streamfield_migrations/test_migrations.py
@@ -234,7 +234,7 @@ class TestNullStreamField(BaseMigrationTest):
         # Bypass StreamField/StreamBlock processing that cast a None stream field value
         # to the empty StreamValue, and set the underlying JSON to null.
         with connection.cursor() as cursor:
-            cursor.execute(f"UPDATE {self.model._meta.db_table} SET content = 'null'")
+            cursor.execute(f"UPDATE {self.model._meta.db_table} SET content = 'null'")  # noqa: S608 - no injection risk
 
     def assert_null_content(self):
         """

--- a/wagtail/users/forms.py
+++ b/wagtail/users/forms.py
@@ -106,7 +106,7 @@ class UserForm(UsernameForm):
 
         if self.password_enabled:
             if self.password_required:
-                self.fields["password1"].help_text = mark_safe(  # noqa S308 - password validator help text is trusted
+                self.fields["password1"].help_text = mark_safe(  # noqa: S308 - password validator help text is trusted
                     password_validators_help_text_html()
                 )
                 self.fields["password1"].required = True

--- a/wagtail/users/forms.py
+++ b/wagtail/users/forms.py
@@ -106,7 +106,7 @@ class UserForm(UsernameForm):
 
         if self.password_enabled:
             if self.password_required:
-                self.fields["password1"].help_text = mark_safe(
+                self.fields["password1"].help_text = mark_safe(  # noqa S308 - password validator help text is trusted
                     password_validators_help_text_html()
                 )
                 self.fields["password1"].required = True

--- a/wagtail/utils/file.py
+++ b/wagtail/utils/file.py
@@ -21,7 +21,7 @@ def hash_filelike(filelike):
     if hasattr(hashlib, "file_digest"):
         hasher = hashlib.file_digest(filelike, hashlib.sha1)
     else:
-        hasher = hashlib.sha1()
+        hasher = hashlib.sha1()  # noqa: S324 -  use of sha1 is acceptable here for non-security purposes
         while True:
             data = filelike.read(HASH_READ_SIZE)
             if not data:

--- a/wagtail/utils/version.py
+++ b/wagtail/utils/version.py
@@ -38,8 +38,8 @@ def get_complete_version(version=None):
     if version is None:
         from wagtail import VERSION as version
     else:
-        assert len(version) == 5
-        assert version[3] in ("dev", "alpha", "beta", "rc", "final")
+        assert len(version) == 5  # noqa: S101 - TODO: replace with explicit check?
+        assert version[3] in ("dev", "alpha", "beta", "rc", "final")  # noqa: S101 - TODO: replace with explicit check?
 
     return version
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Discussed with the core team. Enabling these security-focused linting rules strengthens our security posture and helps us better meet the requirements around static code analysis as required for OpenSSF best practices certification. See #14287 for more info on that.

### Description

This PR enables the [`S` category of linting rules in ruff](https://docs.astral.sh/ruff/rules/#flake8-bandit-s), which are derived from flake8-bandit. [Bandit](https://bandit.readthedocs.io/en/latest/) is a tool designed to find common security vulnerabilities in Python code.

## Reviewer notes

I've exempted all our current use of `mark_safe`, some of it is obviously safe and for other usage it is hard to determine. In those cases, I have left `TODO:` comments. Perhaps those code paths could be explored by our security team as part of an internal audit?

### AI usage

Used GitHub Copilot to fix a few instances of things that trigger bandit, they don't represent actual vulnerabilities.