### PR TITLE
Fix incorrect parameter name in reference index docstring

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -985,6 +985,7 @@
 * Devansh Bordia
 * alanturing881
 * Marquis Nobles
+* Eesh Saxena
 
 ## Translators
 

--- a/wagtail/models/reference_index.py
+++ b/wagtail/models/reference_index.py
@@ -684,10 +684,10 @@ class ReferenceIndex(models.Model):
         they are found on for each given object.
 
         Args:
-            object: An iterable of model instances to fetch ReferenceIndex records for
+            objects: An iterable of model instances to fetch ReferenceIndex records for
 
         Returns:
-            An dict that maps a model instance to a ReferenceGroups object
+            A dict that maps a model instance to a ReferenceGroups object
         """
         references = cls.get_references_to_in_bulk(objects)
         grouped_references = references.group_by_source_object_in_bulk()


### PR DESCRIPTION
### Description

`ReferenceIndex.get_grouped_references_to_in_bulk()` accepts an iterable argument named `objects`, but its docstring documented the parameter as `object` (singular), copied from the sibling `get_grouped_references_to()` method which does take a single `object`. This corrects the parameter name so the docstring matches the signature, and fixes "An dict" -> "A dict" in the same `Returns` description.

Documentation-only change; no runtime behaviour is affected.

### AI usage

Partial. An AI assistant helped spot the docstring parameter-name mismatch (via a script comparing documented `Args` against function signatures) and draft the wording. I reviewed and verified the change against the method signature manually.
