### PR TITLE
Fix CI failures against Django's `main` branch

### DIFF
--- a/client/tests/integration/package-lock.json
+++ b/client/tests/integration/package-lock.json
@@ -10,7 +10,7 @@
         "axe-core": "^4.10.2",
         "jest": "^30.2.0",
         "jest-junit": "^16.0.0",
-        "playwright": "^1.58.2"
+        "playwright": "^1.61.1"
       }
     },
     "node_modules/@axe-core/playwright": {
@@ -3653,13 +3653,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3672,9 +3672,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/client/tests/integration/package.json
+++ b/client/tests/integration/package.json
@@ -6,6 +6,6 @@
     "axe-core": "^4.10.2",
     "jest": "^30.2.0",
     "jest-junit": "^16.0.0",
-    "playwright": "^1.58.2"
+    "playwright": "^1.61.1"
   }
 }

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1932,6 +1932,7 @@ class TestAPIDetailQueryCount(WagtailTestUtils, TestCase):
         self.client.force_login(self.user)
 
     def test_detail_view_does_not_duplicate_queries(self):
-        with self.assertNumQueries(16):
+        response = self.client.get("/api/main/pages/2/")
+        with self.assertNumQueries(10):
             response = self.client.get("/api/main/pages/2/")
             self.assertEqual(response.status_code, 200)

--- a/wagtail/contrib/sitemaps/tests.py
+++ b/wagtail/contrib/sitemaps/tests.py
@@ -12,6 +12,9 @@ from wagtail.test.testapp.models import EventIndex, SimplePage
 from .sitemap_generator import Sitemap
 
 
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+)
 class TestSitemapGenerator(TestCase):
     def setUp(self):
         self.home_page = Page.objects.get(id=2)
@@ -106,7 +109,7 @@ class TestSitemapGenerator(TestCase):
         req_protocol = request.scheme
 
         sitemap = Sitemap()
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(9):
             urls = [
                 url["location"]
                 for url in sitemap.get_urls(1, django_site, req_protocol)
@@ -123,8 +126,7 @@ class TestSitemapGenerator(TestCase):
 
         # pre-seed find_for_request cache, so that it's not counted towards the query count
         Site.find_for_request(request)
-
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(8):
             urls = [
                 url["location"]
                 for url in sitemap.get_urls(1, django_site, req_protocol)
@@ -139,7 +141,8 @@ class TestSitemapGenerator(TestCase):
         req_protocol = request.scheme
 
         sitemap = Sitemap()
-        with self.assertNumQueries(19):
+
+        with self.assertNumQueries(11):
             urls = [
                 url["location"]
                 for url in sitemap.get_urls(1, django_site, req_protocol)
@@ -157,8 +160,7 @@ class TestSitemapGenerator(TestCase):
 
         # pre-seed find_for_request cache, so that it's not counted towards the query count
         Site.find_for_request(request)
-
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(10):
             urls = [
                 url["location"]
                 for url in sitemap.get_urls(1, django_site, req_protocol)

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -595,6 +595,9 @@ class TestImageIndexView(WagtailTestUtils, TestCase):
         self.assertIsNotNone(link)
         self.assertEqual(link.text.strip(), "Used 0 times")
 
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+    )
     def test_order_by_usage_count(self):
         with self.captureOnCommitCallbacks(execute=True):
             VariousOnDeleteModel.objects.create(protected_image=self.kitten_image)
@@ -613,7 +616,7 @@ class TestImageIndexView(WagtailTestUtils, TestCase):
                 )
                 with (
                     self.subTest(layout=layout, ordering=ordering),
-                    self.assertNumQueries(22),
+                    self.assertNumQueries(12),
                 ):
                     response = self.client.get(
                         reverse("wagtailimages:index"),
@@ -2289,6 +2292,9 @@ class TestImageChooserView(WagtailTestUtils, TestCase):
         self.assertEqual(len(response.context["results"]), 1)
         self.assertEqual(response.context["results"][0], image)
 
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+    )
     def test_list_mode(self):
         image = Image.objects.create(
             title="Test image",
@@ -2299,7 +2305,7 @@ class TestImageChooserView(WagtailTestUtils, TestCase):
             VariousOnDeleteModel.objects.create(protected_image=image)
 
         response = self.get({"layout": "list"})
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(11):
             response = self.get({"layout": "list"})
 
         self.assertEqual(response.status_code, 200)

--- a/wagtail/tests/tests.py
+++ b/wagtail/tests/tests.py
@@ -28,6 +28,9 @@ from wagtail.templatetags.wagtailcore_tags import richtext, slugurl
 from wagtail.test.testapp.models import SimplePage
 
 
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+)
 class TestPageUrlTags(TestCase):
     fixtures = ["test.json"]
 
@@ -104,7 +107,7 @@ class TestPageUrlTags(TestCase):
         )
 
         # no 'request' object in context
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(1):
             result = tpl.render(template.Context({"page": page}))
         self.assertIn('<a href="/events/">Events</a>', result)
 
@@ -122,7 +125,7 @@ class TestPageUrlTags(TestCase):
 
         request = get_dummy_request()
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(2):
             result = tpl.render(template.Context({"page": page, "request": request}))
         self.assertIn('<a href="/events/">Events</a>', result)
 
@@ -140,7 +143,7 @@ class TestPageUrlTags(TestCase):
         # 'request' object in context, but site is None
         request = get_dummy_request()
         request.META["HTTP_HOST"] = "unknown.example.com"
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(2):
             result = tpl.render(template.Context({"page": page, "request": request}))
         self.assertIn('<a href="/events/">Events</a>', result)
 
@@ -204,7 +207,7 @@ class TestPageUrlTags(TestCase):
         self.assertEqual(result, "/events/")
 
         # 'request' object in context, but no 'site' attribute
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             result = slugurl(
                 template.Context({"request": get_dummy_request()}), "events"
             )
@@ -223,7 +226,7 @@ class TestPageUrlTags(TestCase):
             """{% load wagtailcore_tags %}<a href="{% fullpageurl page %}">Events</a>"""
         )
         page = Page.objects.get(url_path="/home/events/")
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(1):
             result = tpl.render(template.Context({"page": page}))
         self.assertIn('<a href="http://localhost/events/">Events</a>', result)
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->

### Description

<!-- Please describe the problem you're fixing. -->

- Fixes playwright browser install hanging on Node 26 https://github.com/microsoft/playwright/issues/40724, causing ui_tests on CircleCI to fail after 10 minutes.
- Update `assertNumQueries` to reflect cache framework optimisations in Django 6.2.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
GitHub Copilot for autocompletion.