### PR TITLE
Add generic create, edit, and delete action classes

### DIFF
--- a/wagtail/actions/__init__.py
+++ b/wagtail/actions/__init__.py
@@ -1,0 +1,17 @@
+from wagtail.actions.base import BaseAction
+from wagtail.actions.create import CreateAction, CreatePermissionError
+from wagtail.actions.delete import DeleteAction, DeletePermissionError
+from wagtail.actions.edit import EditAction, EditPermissionError
+from wagtail.actions.registry import ActionRegistry, action_registry
+
+__all__ = [
+    "BaseAction",
+    "CreateAction",
+    "CreatePermissionError",
+    "EditAction",
+    "EditPermissionError",
+    "DeleteAction",
+    "DeletePermissionError",
+    "ActionRegistry",
+    "action_registry",
+]

--- a/wagtail/actions/base.py
+++ b/wagtail/actions/base.py
@@ -1,0 +1,90 @@
+from django.core.exceptions import PermissionDenied
+from django.utils.functional import cached_property
+
+
+class BaseAction:
+    """
+    Base class for actions.
+
+    An action encapsulates a single mutation of a model instance (creating,
+    editing, deleting, publishing, and so on) along with its permission checks,
+    audit logging, and signals. This keeps the business logic in one place so
+    that admin views, the API, and code calling into Wagtail programmatically
+    all behave identically.
+
+    Subclasses set the :attr:`action_name` and :attr:`permission_policy_action`
+    attributes and implement :meth:`execute`.
+    """
+
+    action_name: str | None = None
+    """
+    The name the action is registered under in the action registry, e.g.
+    ``"create"``. Used by :class:`~wagtail.actions.registry.ActionRegistry`.
+    """
+
+    permission_policy_action: str | None = None
+    """
+    The action string passed to the permission policy, e.g. ``"add"``,
+    ``"change"`` or ``"delete"``.
+    """
+
+    permission_error_class = PermissionDenied
+    """
+    The :class:`~django.core.exceptions.PermissionDenied` subclass raised by
+    ``check()`` when the permission check fails.
+    """
+
+    def __init__(self, instance, user=None):
+        self.instance = instance
+        self.user = user
+
+    @cached_property
+    def permission_policy(self):
+        """
+        The permission policy used to check permissions for the instance.
+
+        By default, it is retrieved from the permission policy registry, before
+        falling back to a plain
+        ``wagtail.permission_policies.ModelPermissionPolicy`` for models
+        that have not registered one.
+        """
+        from wagtail.permission_policies import ModelPermissionPolicy
+
+        # FIXME: use the registry when it's implemented.
+        # from wagtail.permissions import policies_registry
+        # permission_policy = policies_registry.get(self.instance)
+        permission_policy = ModelPermissionPolicy(type(self.instance))
+
+        return permission_policy
+
+    def user_has_permission(self):
+        """
+        Return whether ``self.user`` is allowed to perform the action.
+
+        The default implementation checks ``permission_policy_action`` against
+        the instance. Subclasses may override this to perform a model-level
+        check (for actions such as "create" where there is no existing
+        instance to check against) or to combine multiple checks.
+        """
+        return self.permission_policy.user_has_permission_for_instance(
+            self.user, self.permission_policy_action, self.instance
+        )
+
+    def check(self, skip_permission_checks=False):
+        """
+        Raise a :class:`~django.core.exceptions.PermissionDenied` subclass if
+        the user is not allowed to perform the action. This is a no-op when no
+        user is given or ``skip_permission_checks`` is ``True``.
+        """
+        if self.user and not skip_permission_checks and not self.user_has_permission():
+            raise self.permission_error_class(
+                f"You do not have permission to perform the "
+                f"'{self.action_name}' action on this object."
+            )
+
+    def execute(self, skip_permission_checks=False):
+        """
+        Run :meth:`check` and then perform the action, returning the affected
+        instance.
+        """
+        raise NotImplementedError

--- a/wagtail/actions/create.py
+++ b/wagtail/actions/create.py
@@ -1,0 +1,109 @@
+from django.core.exceptions import PermissionDenied
+
+from wagtail.actions.base import BaseAction
+from wagtail.log_actions import log
+
+
+class CreatePermissionError(PermissionDenied):
+    """
+    Raised when creating an object is not permitted.
+    """
+
+    pass
+
+
+class CreateAction(BaseAction):
+    """
+    Save a new object to the database, creating a revision if the model is
+    revisable, and log a ``wagtail.create`` action.
+
+    :param instance: the (unsaved) object to create.
+    :param user: the user performing the action.
+    :param log_action: pass a string to override the default ``"wagtail.create"``
+        log action code, or ``False``/``None`` to skip logging.
+    :param content_changed: whether the log entry should mark the content as
+        changed.
+    :param publish: whether to publish the object. Only applies to models using
+        ``DraftStateMixin``; the created revision is published, making the
+        object live. When ``False`` (the default), the object is created as a
+        draft.
+    """
+
+    action_name = "create"
+    permission_policy_action = "add"
+    permission_error_class = CreatePermissionError
+
+    def __init__(
+        self,
+        instance,
+        user=None,
+        *,
+        log_action="wagtail.create",
+        content_changed=True,
+        publish=False,
+    ):
+        super().__init__(instance, user=user)
+        self.log_action = log_action
+        self.content_changed = content_changed
+        self.publish = publish
+
+    def user_has_permission(self):
+        # "add" is a model-level permission: there is no existing instance to
+        # check against.
+        return self.permission_policy.user_has_permission(
+            self.user, self.permission_policy_action
+        )
+
+    def _create(self, skip_permission_checks=False):
+        from wagtail.models import DraftStateMixin, RevisionMixin
+        from wagtail.models.orderable import set_max_order
+
+        revision_enabled = isinstance(self.instance, RevisionMixin)
+        draftstate_enabled = isinstance(self.instance, DraftStateMixin)
+
+        # If DraftStateMixin is applied, make sure the object is not live when
+        # first created. Making it live is done by publishing a revision below.
+        if draftstate_enabled:
+            self.instance.live = False
+
+        self.instance.save()
+
+        # If the model declares a sort order field (e.g. via the Orderable
+        # mixin) and no value was set, place the object last.
+        sort_order_field = getattr(self.instance, "sort_order_field", None)
+        if sort_order_field and getattr(self.instance, sort_order_field) is None:
+            set_max_order(self.instance, sort_order_field)
+
+        revision = None
+        if revision_enabled:
+            revision = self.instance.save_revision(
+                user=self.user,
+                changed=self.content_changed,
+                clean=self.publish,
+                log_action=False,
+            )
+
+        if self.log_action:
+            log(
+                instance=self.instance,
+                action=self.log_action,
+                user=self.user,
+                revision=revision,
+                content_changed=self.content_changed,
+            )
+
+        # Publish the new revision to make the object live. This emits its own
+        # wagtail.publish log entry and the published signal, and runs its own
+        # permission check (for the "publish" permission).
+        if self.publish and draftstate_enabled:
+            revision.publish(
+                user=self.user,
+                changed=self.content_changed,
+                skip_permission_checks=skip_permission_checks,
+            )
+
+        return self.instance
+
+    def execute(self, skip_permission_checks=False):
+        self.check(skip_permission_checks=skip_permission_checks)
+        return self._create(skip_permission_checks=skip_permission_checks)

--- a/wagtail/actions/delete.py
+++ b/wagtail/actions/delete.py
@@ -1,0 +1,48 @@
+from django.core.exceptions import PermissionDenied
+from django.db import transaction
+
+from wagtail.actions.base import BaseAction
+from wagtail.log_actions import log
+
+
+class DeletePermissionError(PermissionDenied):
+    """
+    Raised when deleting an object is not permitted.
+    """
+
+    pass
+
+
+class DeleteAction(BaseAction):
+    """
+    Delete an object from the database and log a ``wagtail.delete`` action.
+
+    :param instance: the object to delete.
+    :param user: the user performing the action.
+    :param log_action: pass a string to override the default ``"wagtail.delete"``
+        log action code, or ``False``/``None`` to skip logging.
+    """
+
+    action_name = "delete"
+    permission_policy_action = "delete"
+    permission_error_class = DeletePermissionError
+
+    def __init__(self, instance, user=None, *, log_action="wagtail.delete"):
+        super().__init__(instance, user=user)
+        self.log_action = log_action
+
+    def _delete(self):
+        with transaction.atomic():
+            if self.log_action:
+                # Log before deleting, while the object still exists.
+                log(
+                    instance=self.instance,
+                    action=self.log_action,
+                    user=self.user,
+                    deleted=True,
+                )
+            return self.instance.delete()
+
+    def execute(self, skip_permission_checks=False):
+        self.check(skip_permission_checks=skip_permission_checks)
+        return self._delete()

--- a/wagtail/actions/edit.py
+++ b/wagtail/actions/edit.py
@@ -1,0 +1,99 @@
+from django.core.exceptions import PermissionDenied
+
+from wagtail.actions.base import BaseAction
+from wagtail.log_actions import log
+
+
+class EditPermissionError(PermissionDenied):
+    """
+    Raised when editing an object is not permitted.
+    """
+
+    pass
+
+
+class EditAction(BaseAction):
+    """
+    Save changes to an existing object, creating a revision if the model is
+    revisable, and log a ``wagtail.edit`` action.
+
+    :param instance: the object to edit, with its changes already applied.
+    :param user: the user performing the action.
+    :param log_action: pass a string to override the default ``"wagtail.edit"``
+        log action code, or ``False``/``None`` to skip logging.
+    :param content_changed: whether the log entry should mark the content as
+        changed.
+    :param publish: whether to publish the object. Only applies to models using
+        ``DraftStateMixin``; the new revision is published, making the object
+        live. When ``False`` (the default), the changes are saved as a draft.
+    :param previous_revision: when reverting, the revision being reverted to.
+    :param overwrite_revision: when overwriting the latest revision instead of
+        creating a new one, the revision to overwrite.
+    """
+
+    action_name = "edit"
+    permission_policy_action = "change"
+    permission_error_class = EditPermissionError
+
+    def __init__(
+        self,
+        instance,
+        user=None,
+        *,
+        log_action="wagtail.edit",
+        content_changed=True,
+        publish=False,
+        previous_revision=None,
+        overwrite_revision=None,
+    ):
+        super().__init__(instance, user=user)
+        self.log_action = log_action
+        self.content_changed = content_changed
+        self.publish = publish
+        self.previous_revision = previous_revision
+        self.overwrite_revision = overwrite_revision
+
+    def _edit(self, skip_permission_checks=False):
+        from wagtail.models import DraftStateMixin, RevisionMixin
+
+        revision_enabled = isinstance(self.instance, RevisionMixin)
+        draftstate_enabled = isinstance(self.instance, DraftStateMixin)
+
+        self.instance.save()
+
+        revision = None
+        if revision_enabled:
+            revision = self.instance.save_revision(
+                user=self.user,
+                changed=self.content_changed,
+                clean=self.publish,
+                previous_revision=self.previous_revision,
+                overwrite_revision=self.overwrite_revision,
+                log_action=False,
+            )
+
+        if self.log_action:
+            log(
+                instance=self.instance,
+                action=self.log_action,
+                user=self.user,
+                revision=revision,
+                content_changed=self.content_changed,
+            )
+
+        # Publish the new revision to make the object live. This emits its own
+        # wagtail.publish log entry and the published signal, and runs its own
+        # permission check (for the "publish" permission).
+        if self.publish and draftstate_enabled:
+            revision.publish(
+                user=self.user,
+                changed=self.content_changed,
+                previous_revision=self.previous_revision,
+                skip_permission_checks=skip_permission_checks,
+            )
+
+        return self.instance
+
+    def execute(self, skip_permission_checks=False):
+        self.check(skip_permission_checks=skip_permission_checks)
+        return self._edit(skip_permission_checks=skip_permission_checks)

--- a/wagtail/actions/registry.py
+++ b/wagtail/actions/registry.py
@@ -1,0 +1,70 @@
+from django.core.exceptions import ImproperlyConfigured
+
+from wagtail import hooks
+from wagtail.actions.base import BaseAction
+
+
+class ActionRegistry:
+    """
+    A registry mapping model classes to the actions available for them.
+
+    Registration is opt-in: a model only gets the actions that are explicitly
+    registered for it, either directly via :meth:`register` or through the
+    ``register_actions`` hook.
+
+    Lookups walk the model's inheritance chain (MRO), so an action registered
+    against a base class is inherited by its subclasses, and a subclass may add
+    further actions on top.
+    """
+
+    def __init__(self):
+        # {model_class: {action_name: action_class}}
+        self.actions = {}
+        self.has_scanned_for_actions = False
+
+    def register(self, model, action_class):
+        """
+        Register ``action_class`` as available for ``model``.
+        """
+        if not (
+            isinstance(action_class, type) and issubclass(action_class, BaseAction)
+        ):
+            raise TypeError(
+                f"{action_class!r} is not a subclass of {BaseAction.__name__}"
+            )
+        if not action_class.action_name:
+            raise ImproperlyConfigured(
+                f"{action_class.__name__} must define an 'action_name' to be registered"
+            )
+        self.actions.setdefault(model, {})[action_class.action_name] = action_class
+        return action_class
+
+    def _scan_for_actions(self):
+        if not self.has_scanned_for_actions:
+            for fn in hooks.get_hooks("register_actions"):
+                fn(self)
+            self.has_scanned_for_actions = True
+
+    def get_actions_for_model(self, model):
+        """
+        Return a dict of ``{action_name: action_class}`` for the given model,
+        merging actions registered against every class in its MRO. More specific
+        (subclass) registrations take precedence over those on base classes.
+        """
+        self._scan_for_actions()
+        actions = {}
+        # Walk the MRO from the most generic to the most specific class, so that
+        # more specific registrations override less specific ones.
+        for klass in reversed(model.mro()):
+            actions.update(self.actions.get(klass, {}))
+        return actions
+
+    def get_action_class(self, model, action_name):
+        """
+        Return the action class registered under ``action_name`` for ``model``,
+        or ``None`` if there is no such action.
+        """
+        return self.get_actions_for_model(model).get(action_name)
+
+
+action_registry = ActionRegistry()

--- a/wagtail/tests/actions/test_create.py
+++ b/wagtail/tests/actions/test_create.py
@@ -1,0 +1,178 @@
+from unittest import mock
+
+from django.contrib.auth.models import Permission
+from django.test import TestCase
+
+from wagtail.actions.create import CreateAction, CreatePermissionError
+from wagtail.log_actions import registry as log_registry
+from wagtail.models import Revision
+from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.signals import published
+from wagtail.test.testapp.models import (
+    Advert,
+    DraftStateModel,
+    FullFeaturedSnippet,
+    RevisableModel,
+)
+from wagtail.test.utils import WagtailTestUtils
+
+
+class TestCreateAction(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.user = self.create_superuser(username="admin")
+
+    def test_create_plain_model(self):
+        advert = Advert(text="Test advert", url="https://example.com")
+        result = CreateAction(advert, user=self.user).execute()
+
+        self.assertEqual(result, advert)
+        self.assertIsNotNone(advert.pk)
+        self.assertTrue(Advert.objects.filter(pk=advert.pk).exists())
+
+        # Exactly one log entry, with no revision.
+        entries = log_registry.get_logs_for_instance(advert).filter(
+            action="wagtail.create"
+        )
+        self.assertEqual(entries.count(), 1)
+        self.assertIsNone(entries.first().revision)
+
+    def test_create_revisable_model(self):
+        # RevisableModel has no registered permission policy, so the action
+        # should fall back to ModelPermissionPolicy.
+        action = CreateAction(RevisableModel(text="Hello"), user=self.user)
+        self.assertIsInstance(action.permission_policy, ModelPermissionPolicy)
+
+        instance = action.execute()
+        self.assertIsNotNone(instance.pk)
+
+        # A revision is created and referenced by the log entry.
+        self.assertEqual(Revision.objects.for_instance(instance).count(), 1)
+        entries = log_registry.get_logs_for_instance(instance).filter(
+            action="wagtail.create"
+        )
+        self.assertEqual(entries.count(), 1)
+        self.assertIsNotNone(entries.first().revision)
+
+    def test_create_draftstate_model_as_draft(self):
+        instance = DraftStateModel(text="Draft")
+        CreateAction(instance, user=self.user).execute()
+
+        # Created as a draft: not live, but has a revision.
+        self.assertFalse(instance.live)
+        self.assertIsNotNone(instance.latest_revision)
+        self.assertIsNone(instance.live_revision)
+
+        # Only a create log entry, no publish.
+        self.assertEqual(
+            log_registry.get_logs_for_instance(instance)
+            .filter(action="wagtail.create")
+            .count(),
+            1,
+        )
+        self.assertEqual(
+            log_registry.get_logs_for_instance(instance)
+            .filter(action="wagtail.publish")
+            .count(),
+            0,
+        )
+
+    def test_create_draftstate_model_and_publish(self):
+        instance = DraftStateModel(text="Published")
+        mock_handler = mock.MagicMock()
+        published.connect(mock_handler)
+        self.addCleanup(published.disconnect, mock_handler)
+        CreateAction(instance, user=self.user, publish=True).execute()
+
+        instance.refresh_from_db()
+        self.assertTrue(instance.live)
+        self.assertIsNotNone(instance.live_revision)
+
+        # Both a create entry and a publish entry are written.
+        self.assertEqual(
+            log_registry.get_logs_for_instance(instance)
+            .filter(action="wagtail.create")
+            .count(),
+            1,
+        )
+        self.assertEqual(
+            log_registry.get_logs_for_instance(instance)
+            .filter(action="wagtail.publish")
+            .count(),
+            1,
+        )
+
+        # The published signal fired once.
+        self.assertEqual(mock_handler.call_count, 1)
+        self.assertEqual(mock_handler.call_args.kwargs["instance"], instance)
+
+    def test_create_orderable_model_sets_sort_order(self):
+        first = FullFeaturedSnippet(text="First")
+        CreateAction(first, user=self.user).execute()
+        second = FullFeaturedSnippet(text="Second")
+        CreateAction(second, user=self.user).execute()
+
+        self.assertIsNotNone(first.sort_order)
+        self.assertIsNotNone(second.sort_order)
+        self.assertGreater(second.sort_order, first.sort_order)
+
+    def test_create_orderable_model_keeps_explicit_sort_order(self):
+        instance = FullFeaturedSnippet(text="Explicit", sort_order=42)
+        CreateAction(instance, user=self.user).execute()
+        self.assertEqual(instance.sort_order, 42)
+
+    def test_log_action_override(self):
+        advert = Advert(text="Custom log", url="https://example.com")
+        CreateAction(advert, user=self.user, log_action="wagtail.copy").execute()
+        self.assertEqual(
+            log_registry.get_logs_for_instance(advert)
+            .filter(action="wagtail.copy")
+            .count(),
+            1,
+        )
+        self.assertEqual(
+            log_registry.get_logs_for_instance(advert)
+            .filter(action="wagtail.create")
+            .count(),
+            0,
+        )
+
+    def test_log_action_disabled(self):
+        advert = Advert(text="No log", url="https://example.com")
+        CreateAction(advert, user=self.user, log_action=False).execute()
+        self.assertEqual(log_registry.get_logs_for_instance(advert).count(), 0)
+        # The object is still created.
+        self.assertIsNotNone(advert.pk)
+
+    def test_permission_denied(self):
+        user = self.create_user(username="editor")
+        user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="tests", codename="change_advert"
+            )
+        )
+        advert = Advert(text="Denied", url="https://example.com")
+        with self.assertRaises(CreatePermissionError):
+            CreateAction(advert, user=user).execute()
+        self.assertIsNone(advert.pk)
+
+    def test_permission_granted(self):
+        user = self.create_user(username="adder")
+        user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="tests", codename="add_advert"
+            )
+        )
+        advert = Advert(text="Allowed", url="https://example.com")
+        CreateAction(advert, user=user).execute()
+        self.assertIsNotNone(advert.pk)
+
+    def test_skip_permission_checks(self):
+        user = self.create_user(username="powerless")
+        advert = Advert(text="Bypass", url="https://example.com")
+        CreateAction(advert, user=user).execute(skip_permission_checks=True)
+        self.assertIsNotNone(advert.pk)
+
+    def test_no_user_skips_permission_checks(self):
+        advert = Advert(text="No user", url="https://example.com")
+        CreateAction(advert).execute()
+        self.assertIsNotNone(advert.pk)

--- a/wagtail/tests/actions/test_delete.py
+++ b/wagtail/tests/actions/test_delete.py
@@ -1,0 +1,93 @@
+from django.contrib.auth.models import Permission
+from django.test import TestCase
+
+from wagtail.actions.delete import DeleteAction, DeletePermissionError
+from wagtail.log_actions import registry as log_registry
+from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.test.testapp.models import Advert, DraftStateModel, RevisableModel
+from wagtail.test.utils import WagtailTestUtils
+
+
+class TestDeleteAction(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.user = self.create_superuser(username="admin")
+
+    def test_delete_plain_model(self):
+        advert = Advert.objects.create(text="To delete", url="https://example.com")
+        pk = advert.pk
+        DeleteAction(advert, user=self.user).execute()
+
+        self.assertFalse(Advert.objects.filter(pk=pk).exists())
+
+        # Deleting clears the in-memory pk; restore it to look up the log entry.
+        advert.pk = pk
+        # The log entry is written and marked as deleted (so it survives the
+        # object being removed).
+        entries = log_registry.get_logs_for_instance(advert).filter(
+            action="wagtail.delete"
+        )
+        self.assertEqual(entries.count(), 1)
+        self.assertTrue(entries.first().deleted)
+
+    def test_delete_revisable_model(self):
+        # RevisableModel has no registered permission policy -> falls back to
+        # ModelPermissionPolicy.
+        instance = RevisableModel.objects.create(text="To delete")
+        action = DeleteAction(instance, user=self.user)
+        self.assertIsInstance(action.permission_policy, ModelPermissionPolicy)
+        pk = instance.pk
+        action.execute()
+        self.assertFalse(RevisableModel.objects.filter(pk=pk).exists())
+
+    def test_delete_draftstate_model(self):
+        instance = DraftStateModel.objects.create(text="To delete")
+        pk = instance.pk
+        DeleteAction(instance, user=self.user).execute()
+        self.assertFalse(DraftStateModel.objects.filter(pk=pk).exists())
+
+    def test_log_action_override(self):
+        advert = Advert.objects.create(text="To delete", url="https://example.com")
+        pk = advert.pk
+        DeleteAction(advert, user=self.user, log_action="wagtail.copy").execute()
+        advert.pk = pk
+        entries = log_registry.get_logs_for_instance(advert)
+        self.assertEqual(entries.filter(action="wagtail.copy").count(), 1)
+        self.assertEqual(entries.filter(action="wagtail.delete").count(), 0)
+
+    def test_log_action_disabled(self):
+        advert = Advert.objects.create(text="To delete", url="https://example.com")
+        pk = advert.pk
+        DeleteAction(advert, user=self.user, log_action=False).execute()
+        self.assertFalse(Advert.objects.filter(pk=pk).exists())
+        advert.pk = pk
+        self.assertEqual(log_registry.get_logs_for_instance(advert).count(), 0)
+
+    def test_permission_denied(self):
+        advert = Advert.objects.create(text="Keep", url="https://example.com")
+        user = self.create_user(username="editor")
+        user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="tests", codename="change_advert"
+            )
+        )
+        with self.assertRaises(DeletePermissionError):
+            DeleteAction(advert, user=user).execute()
+        # The object is not deleted.
+        self.assertTrue(Advert.objects.filter(pk=advert.pk).exists())
+
+    def test_permission_granted(self):
+        advert = Advert.objects.create(text="Delete me", url="https://example.com")
+        user = self.create_user(username="deleter")
+        user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="tests", codename="delete_advert"
+            )
+        )
+        DeleteAction(advert, user=user).execute()
+        self.assertFalse(Advert.objects.filter(pk=advert.pk).exists())
+
+    def test_skip_permission_checks(self):
+        advert = Advert.objects.create(text="Delete me", url="https://example.com")
+        user = self.create_user(username="powerless")
+        DeleteAction(advert, user=user).execute(skip_permission_checks=True)
+        self.assertFalse(Advert.objects.filter(pk=advert.pk).exists())

--- a/wagtail/tests/actions/test_edit.py
+++ b/wagtail/tests/actions/test_edit.py
@@ -1,0 +1,173 @@
+from unittest import mock
+
+from django.contrib.auth.models import Permission
+from django.test import TestCase
+
+from wagtail.actions.edit import EditAction, EditPermissionError
+from wagtail.log_actions import registry as log_registry
+from wagtail.models import Revision
+from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.signals import published
+from wagtail.test.testapp.models import Advert, DraftStateModel, RevisableModel
+from wagtail.test.utils import WagtailTestUtils
+
+
+class TestEditAction(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.user = self.create_superuser(username="admin")
+
+    def test_edit_plain_model(self):
+        advert = Advert.objects.create(text="Original", url="https://example.com")
+        advert.text = "Edited"
+        result = EditAction(advert, user=self.user).execute()
+
+        self.assertEqual(result, advert)
+        advert.refresh_from_db()
+        self.assertEqual(advert.text, "Edited")
+
+        entries = log_registry.get_logs_for_instance(advert).filter(
+            action="wagtail.edit"
+        )
+        self.assertEqual(entries.count(), 1)
+        self.assertIsNone(entries.first().revision)
+
+    def test_edit_revisable_model(self):
+        instance = RevisableModel.objects.create(text="Original")
+        instance.text = "Edited"
+        action = EditAction(instance, user=self.user)
+        # No registered permission policy -> ModelPermissionPolicy fallback.
+        self.assertIsInstance(action.permission_policy, ModelPermissionPolicy)
+        action.execute()
+
+        self.assertEqual(Revision.objects.for_instance(instance).count(), 1)
+        entries = log_registry.get_logs_for_instance(instance).filter(
+            action="wagtail.edit"
+        )
+        self.assertEqual(entries.count(), 1)
+        self.assertIsNotNone(entries.first().revision)
+
+    def test_edit_draftstate_model_as_draft(self):
+        # Create an unpublished draft to edit.
+        instance = DraftStateModel.objects.create(text="Original", live=False)
+        instance.text = "Draft edit"
+        EditAction(instance, user=self.user).execute()
+
+        # Editing as a draft does not publish the object.
+        instance.refresh_from_db()
+        self.assertFalse(instance.live)
+        self.assertEqual(
+            log_registry.get_logs_for_instance(instance)
+            .filter(action="wagtail.edit")
+            .count(),
+            1,
+        )
+        self.assertEqual(
+            log_registry.get_logs_for_instance(instance)
+            .filter(action="wagtail.publish")
+            .count(),
+            0,
+        )
+        # The new content lives in the latest revision, not the live object.
+        self.assertEqual(
+            instance.latest_revision.content["text"],
+            "Draft edit",
+        )
+
+    def test_edit_draftstate_model_and_publish(self):
+        instance = DraftStateModel.objects.create(text="Original")
+        instance.text = "Published edit"
+        mock_handler = mock.MagicMock()
+        published.connect(mock_handler)
+        self.addCleanup(published.disconnect, mock_handler)
+        EditAction(instance, user=self.user, publish=True).execute()
+
+        instance.refresh_from_db()
+        self.assertTrue(instance.live)
+        self.assertEqual(instance.text, "Published edit")
+        self.assertEqual(
+            log_registry.get_logs_for_instance(instance)
+            .filter(action="wagtail.edit")
+            .count(),
+            1,
+        )
+        self.assertEqual(
+            log_registry.get_logs_for_instance(instance)
+            .filter(action="wagtail.publish")
+            .count(),
+            1,
+        )
+        self.assertEqual(mock_handler.call_count, 1)
+
+    def test_edit_with_overwrite_revision(self):
+        instance = RevisableModel.objects.create(text="Original")
+        instance.text = "First revision"
+        EditAction(instance, user=self.user).execute()
+        first_revision = instance.latest_revision
+
+        instance.text = "Overwritten"
+        EditAction(
+            instance, user=self.user, overwrite_revision=first_revision
+        ).execute()
+
+        # The revision was overwritten rather than a new one created.
+        self.assertEqual(Revision.objects.for_instance(instance).count(), 1)
+        instance.refresh_from_db()
+        self.assertEqual(instance.latest_revision.content["text"], "Overwritten")
+
+    def test_log_action_override(self):
+        advert = Advert.objects.create(text="Original", url="https://example.com")
+        advert.text = "Renamed"
+        EditAction(advert, user=self.user, log_action="wagtail.rename").execute()
+        self.assertEqual(
+            log_registry.get_logs_for_instance(advert)
+            .filter(action="wagtail.rename")
+            .count(),
+            1,
+        )
+        self.assertEqual(
+            log_registry.get_logs_for_instance(advert)
+            .filter(action="wagtail.edit")
+            .count(),
+            0,
+        )
+
+    def test_log_action_disabled(self):
+        advert = Advert.objects.create(text="Original", url="https://example.com")
+        advert.text = "No log"
+        EditAction(advert, user=self.user, log_action=False).execute()
+        self.assertEqual(log_registry.get_logs_for_instance(advert).count(), 0)
+        advert.refresh_from_db()
+        self.assertEqual(advert.text, "No log")
+
+    def test_permission_denied(self):
+        advert = Advert.objects.create(text="Original", url="https://example.com")
+        user = self.create_user(username="adder")
+        user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="tests", codename="add_advert"
+            )
+        )
+        advert.text = "Denied"
+        with self.assertRaises(EditPermissionError):
+            EditAction(advert, user=user).execute()
+
+    def test_permission_granted(self):
+        advert = Advert.objects.create(text="Original", url="https://example.com")
+        user = self.create_user(username="editor")
+        user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="tests", codename="change_advert"
+            )
+        )
+        advert.text = "Allowed"
+        EditAction(advert, user=user).execute()
+        advert.refresh_from_db()
+        self.assertEqual(advert.text, "Allowed")
+
+    def test_skip_permission_checks(self):
+        advert = Advert.objects.create(text="Original", url="https://example.com")
+        user = self.create_user(username="powerless")
+        advert.text = "Bypass"
+        EditAction(advert, user=user).execute(skip_permission_checks=True)
+        advert.refresh_from_db()
+        self.assertEqual(advert.text, "Bypass")

--- a/wagtail/tests/actions/test_registry.py
+++ b/wagtail/tests/actions/test_registry.py
@@ -1,0 +1,97 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase
+
+from wagtail import hooks
+from wagtail.actions.base import BaseAction
+from wagtail.actions.registry import ActionRegistry
+from wagtail.test.testapp.models import (
+    Advert,
+    RevisableChildModel,
+    RevisableModel,
+)
+
+
+class DummyAction(BaseAction):
+    action_name = "dummy"
+    permission_policy_action = "change"
+
+    def execute(self, skip_permission_checks=False):
+        return self.instance
+
+
+class UnavailableAction(BaseAction):
+    action_name = "unavailable"
+    permission_policy_action = "change"
+
+    @classmethod
+    def is_available_for_instance(cls, instance):
+        return False
+
+    def execute(self, skip_permission_checks=False):
+        return self.instance
+
+
+class TestActionRegistry(TestCase):
+    def setUp(self):
+        self.registry = ActionRegistry()
+
+    def test_register_and_get(self):
+        self.registry.register(RevisableModel, DummyAction)
+        self.assertEqual(
+            self.registry.get_action_class(RevisableModel, "dummy"),
+            DummyAction,
+        )
+        self.assertEqual(
+            self.registry.get_actions_for_model(RevisableModel),
+            {"dummy": DummyAction},
+        )
+
+    def test_get_unknown_action_returns_none(self):
+        self.assertIsNone(self.registry.get_action_class(RevisableModel, "nope"))
+
+    def test_mro_inheritance(self):
+        # An action registered against a base class is inherited by subclasses.
+        self.registry.register(RevisableModel, DummyAction)
+        self.assertEqual(
+            self.registry.get_action_class(RevisableChildModel, "dummy"),
+            DummyAction,
+        )
+
+    def test_mro_merging(self):
+        # A subclass inherits base-class actions and adds its own.
+        self.registry.register(RevisableModel, DummyAction)
+        self.registry.register(RevisableChildModel, UnavailableAction)
+        actions = self.registry.get_actions_for_model(RevisableChildModel)
+        self.assertEqual(set(actions), {"dummy", "unavailable"})
+        # The base class only has its own action.
+        self.assertEqual(
+            set(self.registry.get_actions_for_model(RevisableModel)),
+            {"dummy"},
+        )
+
+    def test_register_rejects_non_action(self):
+        class NotAnAction:
+            action_name = "x"
+
+        with self.assertRaises(TypeError):
+            self.registry.register(RevisableModel, NotAnAction)
+
+    def test_register_rejects_missing_action_name(self):
+        class NamelessAction(BaseAction):
+            def execute(self, skip_permission_checks=False):
+                return self.instance
+
+        with self.assertRaises(ImproperlyConfigured):
+            self.registry.register(RevisableModel, NamelessAction)
+
+
+class TestRegisterActionsHook(TestCase):
+    def test_hook_registers_actions(self):
+        registry = ActionRegistry()
+
+        def register_dummy(reg):
+            reg.register(Advert, DummyAction)
+
+        with hooks.register_temporarily("register_actions", register_dummy):
+            actions = registry.get_actions_for_model(Advert)
+        self.assertEqual(actions, {"dummy": DummyAction})


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Basics for https://github.com/wagtail/wagtail/issues/14297

### Description

<!-- Please describe the problem you're fixing. -->

This just adds a barebones implementation of create/edit/delete action classes based on our existing `wagtail.actions` module.

There is also a registry for the actions, but I haven't hooked up anything for it in this PR. The idea in #14297 (and the Write API RFC) is to allow external code/packages to register their own actions, which can then be exposed in the API.

This PR is addition-only at the moment. I have another branch on top of this that actually refactors the generic models' views to make use of these actions classes, but I'll open a separate PR for that so it's clearer to see how this is shaping up.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Claude Code with Claude Sonnet (? I don't remember) was used to write the code based on the issue, but I trimmed it down quite a bit to remove parts that are still unclear if they'd be useful.

I've reviewed the code, but I have to admit I didn't look into the tests very much.