### PR TITLE
Refactor generic create/edit/delete views to use action classes

### DIFF
--- a/wagtail/actions/__init__.py
+++ b/wagtail/actions/__init__.py
@@ -1,3 +1,5 @@
+from django.db import models
+
 from wagtail.actions.base import BaseAction
 from wagtail.actions.create import CreateAction, CreatePermissionError
 from wagtail.actions.delete import DeleteAction, DeletePermissionError
@@ -15,3 +17,9 @@ __all__ = [
     "ActionRegistry",
     "action_registry",
 ]
+
+
+def register_default_actions():
+    action_registry.register(models.Model, CreateAction)
+    action_registry.register(models.Model, EditAction)
+    action_registry.register(models.Model, DeleteAction)

--- a/wagtail/actions/create.py
+++ b/wagtail/actions/create.py
@@ -29,8 +29,6 @@ class CreateAction(BaseAction):
         the instance directly.
     :param log_action: pass a string to override the default ``"wagtail.create"``
         log action code, or ``False``/``None`` to skip logging.
-    :param content_changed: whether the log entry should mark the content as
-        changed.
     :param publish: whether to publish the object. Only applies to models using
         ``DraftStateMixin``; the created revision is published, making the
         object live. When ``False`` (the default), the object is created as a
@@ -52,7 +50,6 @@ class CreateAction(BaseAction):
         *,
         form=None,
         log_action="wagtail.create",
-        content_changed=True,
         publish=False,
         sort_order_field=UNSET,
     ):
@@ -61,7 +58,6 @@ class CreateAction(BaseAction):
         super().__init__(instance, user=user)
         self.form = form
         self.log_action = log_action
-        self.content_changed = content_changed
         self.publish = publish
         self.sort_order_field = sort_order_field
         self.revision_enabled = isinstance(instance, RevisionMixin)
@@ -104,7 +100,6 @@ class CreateAction(BaseAction):
         if self.revision_enabled:
             revision = self.instance.save_revision(
                 user=self.user,
-                changed=self.content_changed,
                 clean=self.publish,
                 log_action=False,
             )
@@ -115,7 +110,7 @@ class CreateAction(BaseAction):
                 action=self.log_action,
                 user=self.user,
                 revision=revision,
-                content_changed=self.content_changed,
+                content_changed=True,
             )
 
         # Publish the new revision to make the object live. This emits its own
@@ -124,7 +119,6 @@ class CreateAction(BaseAction):
         if self.publish and self.draftstate_enabled:
             revision.publish(
                 user=self.user,
-                changed=self.content_changed,
                 skip_permission_checks=skip_permission_checks,
             )
 

--- a/wagtail/actions/create.py
+++ b/wagtail/actions/create.py
@@ -3,6 +3,10 @@ from django.core.exceptions import PermissionDenied
 from wagtail.actions.base import BaseAction
 from wagtail.log_actions import log
 
+# Sentinel for "auto-detect the sort order field from the model", distinct from
+# an explicit None which means "do not set a sort order".
+UNSET = object()
+
 
 class CreatePermissionError(PermissionDenied):
     """
@@ -19,6 +23,10 @@ class CreateAction(BaseAction):
 
     :param instance: the (unsaved) object to create.
     :param user: the user performing the action.
+    :param form: an optional bound, validated model form for the instance. When
+        given, the action saves the instance through the form (preserving any
+        custom form save logic and saving many-to-many data); otherwise it saves
+        the instance directly.
     :param log_action: pass a string to override the default ``"wagtail.create"``
         log action code, or ``False``/``None`` to skip logging.
     :param content_changed: whether the log entry should mark the content as
@@ -27,6 +35,10 @@ class CreateAction(BaseAction):
         ``DraftStateMixin``; the created revision is published, making the
         object live. When ``False`` (the default), the object is created as a
         draft.
+    :param sort_order_field: the name of the field to use for ordering. If not
+        given, it is read from the model's ``sort_order_field`` attribute (e.g.
+        from the ``Orderable`` mixin). Pass ``None`` explicitly to disable
+        setting a sort order.
     """
 
     action_name = "create"
@@ -38,14 +50,22 @@ class CreateAction(BaseAction):
         instance,
         user=None,
         *,
+        form=None,
         log_action="wagtail.create",
         content_changed=True,
         publish=False,
+        sort_order_field=UNSET,
     ):
+        from wagtail.models import DraftStateMixin, RevisionMixin
+
         super().__init__(instance, user=user)
+        self.form = form
         self.log_action = log_action
         self.content_changed = content_changed
         self.publish = publish
+        self.sort_order_field = sort_order_field
+        self.revision_enabled = isinstance(instance, RevisionMixin)
+        self.draftstate_enabled = isinstance(instance, DraftStateMixin)
 
     def user_has_permission(self):
         # "add" is a model-level permission: there is no existing instance to
@@ -54,28 +74,34 @@ class CreateAction(BaseAction):
             self.user, self.permission_policy_action
         )
 
-    def _create(self, skip_permission_checks=False):
-        from wagtail.models import DraftStateMixin, RevisionMixin
-        from wagtail.models.orderable import set_max_order
-
-        revision_enabled = isinstance(self.instance, RevisionMixin)
-        draftstate_enabled = isinstance(self.instance, DraftStateMixin)
-
+    def _save_instance(self):
         # If DraftStateMixin is applied, make sure the object is not live when
         # first created. Making it live is done by publishing a revision below.
-        if draftstate_enabled:
+        if self.draftstate_enabled:
             self.instance.live = False
 
-        self.instance.save()
+        if self.form:
+            self.instance = self.form.save()
+        else:
+            self.instance.save()
+
+    def _create(self, skip_permission_checks=False):
+        from wagtail.models.orderable import set_max_order
+
+        self._save_instance()
 
         # If the model declares a sort order field (e.g. via the Orderable
-        # mixin) and no value was set, place the object last.
-        sort_order_field = getattr(self.instance, "sort_order_field", None)
+        # mixin) and no value was set, place the object last. An explicit
+        # sort_order_field of None disables this.
+        if self.sort_order_field is UNSET:
+            sort_order_field = getattr(self.instance, "sort_order_field", None)
+        else:
+            sort_order_field = self.sort_order_field
         if sort_order_field and getattr(self.instance, sort_order_field) is None:
             set_max_order(self.instance, sort_order_field)
 
         revision = None
-        if revision_enabled:
+        if self.revision_enabled:
             revision = self.instance.save_revision(
                 user=self.user,
                 changed=self.content_changed,
@@ -95,7 +121,7 @@ class CreateAction(BaseAction):
         # Publish the new revision to make the object live. This emits its own
         # wagtail.publish log entry and the published signal, and runs its own
         # permission check (for the "publish" permission).
-        if self.publish and draftstate_enabled:
+        if self.publish and self.draftstate_enabled:
             revision.publish(
                 user=self.user,
                 changed=self.content_changed,

--- a/wagtail/actions/create.py
+++ b/wagtail/actions/create.py
@@ -37,6 +37,10 @@ class CreateAction(BaseAction):
         given, it is read from the model's ``sort_order_field`` attribute (e.g.
         from the ``Orderable`` mixin). Pass ``None`` explicitly to disable
         setting a sort order.
+    :param clean: whether to validate the instance when creating its revision.
+        By default the revision is validated unless saving a draft of a
+        draft-enabled object. Pass an explicit value to override this, e.g. when
+        publishing happens in a separate later step.
     """
 
     action_name = "create"
@@ -52,6 +56,7 @@ class CreateAction(BaseAction):
         log_action="wagtail.create",
         publish=False,
         sort_order_field=UNSET,
+        clean=None,
     ):
         from wagtail.models import DraftStateMixin, RevisionMixin
 
@@ -62,6 +67,13 @@ class CreateAction(BaseAction):
         self.sort_order_field = sort_order_field
         self.revision_enabled = isinstance(instance, RevisionMixin)
         self.draftstate_enabled = isinstance(instance, DraftStateMixin)
+        # Validate the revision unless we're saving a draft of a draft-enabled
+        # object (where incomplete content is allowed).
+        if clean is None:
+            clean = self.publish or not self.draftstate_enabled
+        self.clean = clean
+        # The revision created by execute(), if any.
+        self.revision = None
 
     def user_has_permission(self):
         # "add" is a model-level permission: there is no existing instance to
@@ -96,11 +108,10 @@ class CreateAction(BaseAction):
         if sort_order_field and getattr(self.instance, sort_order_field) is None:
             set_max_order(self.instance, sort_order_field)
 
-        revision = None
         if self.revision_enabled:
-            revision = self.instance.save_revision(
+            self.revision = self.instance.save_revision(
                 user=self.user,
-                clean=self.publish,
+                clean=self.clean,
                 log_action=False,
             )
 
@@ -109,7 +120,7 @@ class CreateAction(BaseAction):
                 instance=self.instance,
                 action=self.log_action,
                 user=self.user,
-                revision=revision,
+                revision=self.revision,
                 content_changed=True,
             )
 
@@ -117,7 +128,7 @@ class CreateAction(BaseAction):
         # wagtail.publish log entry and the published signal, and runs its own
         # permission check (for the "publish" permission).
         if self.publish and self.draftstate_enabled:
-            revision.publish(
+            self.revision.publish(
                 user=self.user,
                 skip_permission_checks=skip_permission_checks,
             )

--- a/wagtail/actions/edit.py
+++ b/wagtail/actions/edit.py
@@ -25,8 +25,6 @@ class EditAction(BaseAction):
         the instance directly.
     :param log_action: pass a string to override the default ``"wagtail.edit"``
         log action code, or ``False``/``None`` to skip logging.
-    :param content_changed: whether the log entry should mark the content as
-        changed.
     :param publish: whether to publish the object. Only applies to models using
         ``DraftStateMixin``; the new revision is published, making the object
         live. When ``False`` (the default), the changes are saved as a draft.
@@ -46,7 +44,6 @@ class EditAction(BaseAction):
         *,
         form=None,
         log_action="wagtail.edit",
-        content_changed=True,
         publish=False,
         previous_revision=None,
         overwrite_revision=None,
@@ -56,12 +53,14 @@ class EditAction(BaseAction):
         super().__init__(instance, user=user)
         self.form = form
         self.log_action = log_action
-        self.content_changed = content_changed
         self.publish = publish
         self.previous_revision = previous_revision
         self.overwrite_revision = overwrite_revision
         self.revision_enabled = isinstance(instance, RevisionMixin)
         self.draftstate_enabled = isinstance(instance, DraftStateMixin)
+        # Content is considered changed if the form reports changes; without a
+        # form (e.g. a programmatic edit), assume the content has changed.
+        self.content_changed = form.has_changed() if form is not None else True
 
     def _save_instance(self):
         if self.draftstate_enabled and self.instance.live:

--- a/wagtail/actions/edit.py
+++ b/wagtail/actions/edit.py
@@ -31,6 +31,10 @@ class EditAction(BaseAction):
     :param previous_revision: when reverting, the revision being reverted to.
     :param overwrite_revision: when overwriting the latest revision instead of
         creating a new one, the revision to overwrite.
+    :param clean: whether to validate the instance when creating its revision.
+        By default the revision is validated unless saving a draft of a
+        draft-enabled object. Pass an explicit value to override this, e.g. when
+        publishing happens in a separate later step.
     """
 
     action_name = "edit"
@@ -47,6 +51,7 @@ class EditAction(BaseAction):
         publish=False,
         previous_revision=None,
         overwrite_revision=None,
+        clean=None,
     ):
         from wagtail.models import DraftStateMixin, RevisionMixin
 
@@ -61,6 +66,13 @@ class EditAction(BaseAction):
         # Content is considered changed if the form reports changes; without a
         # form (e.g. a programmatic edit), assume the content has changed.
         self.content_changed = form.has_changed() if form is not None else True
+        # Validate the revision unless we're saving a draft of a draft-enabled
+        # object (where incomplete content is allowed).
+        if clean is None:
+            clean = self.publish or not self.draftstate_enabled
+        self.clean = clean
+        # The revision created by execute(), if any.
+        self.revision = None
 
     def _save_instance(self):
         if self.draftstate_enabled and self.instance.live:
@@ -81,12 +93,11 @@ class EditAction(BaseAction):
     def _edit(self, skip_permission_checks=False):
         self._save_instance()
 
-        revision = None
         if self.revision_enabled:
-            revision = self.instance.save_revision(
+            self.revision = self.instance.save_revision(
                 user=self.user,
                 changed=self.content_changed,
-                clean=self.publish,
+                clean=self.clean,
                 previous_revision=self.previous_revision,
                 overwrite_revision=self.overwrite_revision,
                 log_action=False,
@@ -97,7 +108,7 @@ class EditAction(BaseAction):
                 instance=self.instance,
                 action=self.log_action,
                 user=self.user,
-                revision=revision,
+                revision=self.revision,
                 content_changed=self.content_changed,
             )
 
@@ -105,7 +116,7 @@ class EditAction(BaseAction):
         # wagtail.publish log entry and the published signal, and runs its own
         # permission check (for the "publish" permission).
         if self.publish and self.draftstate_enabled:
-            revision.publish(
+            self.revision.publish(
                 user=self.user,
                 changed=self.content_changed,
                 previous_revision=self.previous_revision,

--- a/wagtail/actions/edit.py
+++ b/wagtail/actions/edit.py
@@ -19,6 +19,10 @@ class EditAction(BaseAction):
 
     :param instance: the object to edit, with its changes already applied.
     :param user: the user performing the action.
+    :param form: an optional bound, validated model form for the instance. When
+        given, the action saves the instance through the form (preserving any
+        custom form save logic and saving many-to-many data); otherwise it saves
+        the instance directly.
     :param log_action: pass a string to override the default ``"wagtail.edit"``
         log action code, or ``False``/``None`` to skip logging.
     :param content_changed: whether the log entry should mark the content as
@@ -40,29 +44,46 @@ class EditAction(BaseAction):
         instance,
         user=None,
         *,
+        form=None,
         log_action="wagtail.edit",
         content_changed=True,
         publish=False,
         previous_revision=None,
         overwrite_revision=None,
     ):
+        from wagtail.models import DraftStateMixin, RevisionMixin
+
         super().__init__(instance, user=user)
+        self.form = form
         self.log_action = log_action
         self.content_changed = content_changed
         self.publish = publish
         self.previous_revision = previous_revision
         self.overwrite_revision = overwrite_revision
+        self.revision_enabled = isinstance(instance, RevisionMixin)
+        self.draftstate_enabled = isinstance(instance, DraftStateMixin)
+
+    def _save_instance(self):
+        if self.draftstate_enabled and self.instance.live:
+            # Do not update the instance if it's a live DraftStateMixin object.
+            # Edits will be saved as a revision, and the live object will be updated
+            # when the revision is published.
+            if self.form:
+                # Ensure any custom form.save() logic is run, but do not save
+                # the instance to the database.
+                self.instance = self.form.save(commit=False)
+            # No form is given, leave the instance as-is.
+        else:
+            if self.form:
+                self.instance = self.form.save()
+            else:
+                self.instance.save()
 
     def _edit(self, skip_permission_checks=False):
-        from wagtail.models import DraftStateMixin, RevisionMixin
-
-        revision_enabled = isinstance(self.instance, RevisionMixin)
-        draftstate_enabled = isinstance(self.instance, DraftStateMixin)
-
-        self.instance.save()
+        self._save_instance()
 
         revision = None
-        if revision_enabled:
+        if self.revision_enabled:
             revision = self.instance.save_revision(
                 user=self.user,
                 changed=self.content_changed,
@@ -84,7 +105,7 @@ class EditAction(BaseAction):
         # Publish the new revision to make the object live. This emits its own
         # wagtail.publish log entry and the published signal, and runs its own
         # permission check (for the "publish" permission).
-        if self.publish and draftstate_enabled:
+        if self.publish and self.draftstate_enabled:
             revision.publish(
                 user=self.user,
                 changed=self.content_changed,

--- a/wagtail/admin/tests/test_views_generic.py
+++ b/wagtail/admin/tests/test_views_generic.py
@@ -41,6 +41,9 @@ class TestGenericIndexViewWithoutModel(WagtailTestUtils, TestCase):
 class TestGenericCreateView(WagtailTestUtils, TestCase):
     fixtures = ["test.json"]
 
+    def setUp(self):
+        self.user = self.login()
+
     def get(self, params=None):
         return self.client.get(reverse("testapp_generic_create"), params)
 

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -28,7 +28,6 @@ from wagtail.admin.ui.editing_sessions import EditingSessionsModule
 from wagtail.admin.ui.tables import LiveStatusTagColumn, TitleColumn
 from wagtail.admin.utils import get_latest_str, set_query_params
 from wagtail.locks import BasicLock, ScheduledForPublishLock, WorkflowLock
-from wagtail.log_actions import log
 from wagtail.log_actions import registry as log_registry
 from wagtail.models import (
     DraftStateMixin,
@@ -41,7 +40,6 @@ from wagtail.models import (
     WorkflowMixin,
     WorkflowState,
 )
-from wagtail.models.orderable import set_max_order
 from wagtail.utils.timestamps import render_timestamp
 
 
@@ -516,61 +514,44 @@ class CreateEditViewOptionalFeaturesMixin:
         Called after the form is successfully validated - saves the object to the db
         and returns the new object. Override this to implement custom save logic.
         """
-        if self.draftstate_enabled:
-            instance = self.form.save(
-                commit=self.view_name == "edit" and not self.object.live
-            )
-
-            # If DraftStateMixin is applied, only save to the database in CreateView,
-            # and make sure the live field is set to False.
-            if self.view_name == "create":
-                instance.live = False
-                instance.save()
-                self.form.save_m2m()
-        else:
-            instance = self.form.save()
-
-        # Apply max order number if the model uses custom ordering and the
-        # sort_order_field is not set.
-        if (
-            self.view_name == "create"
-            and self.sort_order_field
-            and getattr(instance, self.sort_order_field) is None
-        ):
-            set_max_order(instance, self.sort_order_field)
-
-        self.has_content_changes = self.view_name == "create" or self.form.has_changed()
-
-        # Save revision if the model inherits from RevisionMixin
-        self.new_revision = None
-        if self.revision_enabled:
-            overwrite_revision_id = self.request.POST.get("overwrite_revision_id")
-            if overwrite_revision_id:
-                try:
-                    overwrite_revision = instance.revisions.get(
-                        pk=overwrite_revision_id
-                    )
-                except Revision.DoesNotExist as e:
-                    raise PermissionDenied(
-                        "Cannot overwrite a revision that does not exist"
-                    ) from e
-            else:
-                overwrite_revision = None
-
-            self.new_revision = instance.save_revision(
+        # Publishing, if any, happens separately in publish_action (after this),
+        # so the action never publishes here; clean reflects whether we're saving
+        # a draft. Permission is already checked by the view.
+        if self.view_name == "create":
+            action = self.action_class(
+                self.form.instance,
                 user=self.request.user,
+                form=self.form,
+                sort_order_field=self.sort_order_field,
                 clean=not self.saving_as_draft,
-                overwrite_revision=overwrite_revision,
+            )
+        else:
+            action = self.action_class(
+                self.form.instance,
+                user=self.request.user,
+                form=self.form,
+                overwrite_revision=self.overwrite_revision,
+                clean=not self.saving_as_draft,
             )
 
-        log(
-            instance=instance,
-            action="wagtail.create" if self.view_name == "create" else "wagtail.edit",
-            revision=self.new_revision,
-            content_changed=self.has_content_changes,
-        )
+        instance = action.execute(skip_permission_checks=True)
+        self.new_revision = action.revision
 
         return instance
+
+    @cached_property
+    def overwrite_revision(self):
+        if not self.revision_enabled:
+            return None
+        overwrite_revision_id = self.request.POST.get("overwrite_revision_id")
+        if not overwrite_revision_id:
+            return None
+        try:
+            return self.object.revisions.get(pk=overwrite_revision_id)
+        except Revision.DoesNotExist as e:
+            raise PermissionDenied(
+                "Cannot overwrite a revision that does not exist"
+            ) from e
 
     def publish_action(self):
         hook_response = self.run_hook("before_publish", self.request, self.object)

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -1015,14 +1015,11 @@ class EditView(
         Called after the form is successfully validated - saves the object to the db.
         Override this to implement custom save logic.
         """
-        self.has_content_changes = self.form.has_changed()
-
         # Permission is already checked by PermissionCheckedMixin.
         self.action_class(
             self.form.instance,
             user=self.request.user,
             form=self.form,
-            content_changed=self.has_content_changes,
         ).execute(skip_permission_checks=True)
 
         return self.form.instance

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -22,6 +22,7 @@ from django.views.generic.edit import (
     BaseUpdateView,
 )
 
+from wagtail.actions.delete import DeleteAction
 from wagtail.actions.unpublish import UnpublishAction
 from wagtail.admin import messages
 from wagtail.admin.filters import WagtailFilterSet
@@ -1232,9 +1233,10 @@ class DeleteView(
         )
 
     def delete_action(self):
-        with transaction.atomic():
-            log(instance=self.object, action="wagtail.delete")
-            self.object.delete()
+        # Permission is already checked by PermissionCheckedMixin.
+        DeleteAction(self.object, user=self.request.user).execute(
+            skip_permission_checks=True
+        )
 
     def form_valid(self, form):
         if self.usage and self.usage.is_protected:

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -22,7 +22,7 @@ from django.views.generic.edit import (
     BaseUpdateView,
 )
 
-from wagtail.actions.delete import DeleteAction
+from wagtail.actions import action_registry
 from wagtail.actions.unpublish import UnpublishAction
 from wagtail.admin import messages
 from wagtail.admin.filters import WagtailFilterSet
@@ -53,11 +53,9 @@ from wagtail.admin.widgets.button import (
     ButtonWithDropdown,
     HeaderButton,
 )
-from wagtail.log_actions import log
 from wagtail.log_actions import registry as log_registry
 from wagtail.models import DraftStateMixin, Locale, ReferenceIndex
 from wagtail.models.audit_log import ModelLogEntry
-from wagtail.models.orderable import set_max_order
 from wagtail.search.index import class_is_indexed
 
 from .base import BaseListingView, WagtailAdminTemplateMixin
@@ -552,6 +550,10 @@ class CreateView(
             self.produced_error_message = self.get_error_message()
         return result
 
+    @cached_property
+    def action_class(self):
+        return action_registry.get_action_class(self.model, "create")
+
     def get_action(self, request):
         for action in self.get_available_actions():
             if request.POST.get(f"action-{action}"):
@@ -705,13 +707,14 @@ class CreateView(
         Called after the form is successfully validated - saves the object to the db
         and returns the new object. Override this to implement custom save logic.
         """
-        instance = self.form.save()
-        # Apply max order number if the model uses custom ordering and the
-        # sort_order_field is not set.
-        if self.sort_order_field and getattr(instance, self.sort_order_field) is None:
-            set_max_order(instance, self.sort_order_field)
-        log(instance=instance, action="wagtail.create", content_changed=True)
-        return instance
+        # Permission is already checked by PermissionCheckedMixin.
+        self.action_class(
+            self.form.instance,
+            user=self.request.user,
+            form=self.form,
+            sort_order_field=self.sort_order_field,
+        ).execute(skip_permission_checks=True)
+        return self.form.instance
 
     def get_success_json(self):
         edit_url = self.get_edit_url()
@@ -855,6 +858,10 @@ class EditView(
         except KeyError:
             quoted_pk = self.args[0]
         return unquote(str(quoted_pk))
+
+    @cached_property
+    def action_class(self):
+        return action_registry.get_action_class(self.model, "edit")
 
     def get_action(self, request):
         for action in self.get_available_actions():
@@ -1008,17 +1015,17 @@ class EditView(
         Called after the form is successfully validated - saves the object to the db.
         Override this to implement custom save logic.
         """
-        instance = self.form.save()
-
         self.has_content_changes = self.form.has_changed()
 
-        log(
-            instance=instance,
-            action="wagtail.edit",
+        # Permission is already checked by PermissionCheckedMixin.
+        self.action_class(
+            self.form.instance,
+            user=self.request.user,
+            form=self.form,
             content_changed=self.has_content_changes,
-        )
+        ).execute(skip_permission_checks=True)
 
-        return instance
+        return self.form.instance
 
     def get_success_json(self):
         result = {
@@ -1177,6 +1184,10 @@ class DeleteView(
 
         return super().get_object(queryset)
 
+    @cached_property
+    def action_class(self):
+        return action_registry.get_action_class(self.model, "delete")
+
     def get_usage(self):
         if not self.usage_url:
             return None
@@ -1234,7 +1245,7 @@ class DeleteView(
 
     def delete_action(self):
         # Permission is already checked by PermissionCheckedMixin.
-        DeleteAction(self.object, user=self.request.user).execute(
+        self.action_class(self.object, user=self.request.user).execute(
             skip_permission_checks=True
         )
 

--- a/wagtail/apps.py
+++ b/wagtail/apps.py
@@ -11,6 +11,10 @@ class WagtailAppConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
+        from wagtail.actions import register_default_actions
+
+        register_default_actions()
+
         from wagtail.models import AbstractPage
         from wagtail.models.reference_index import ReferenceIndex
 

--- a/wagtail/tests/actions/test_create.py
+++ b/wagtail/tests/actions/test_create.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from django.contrib.auth.models import Permission
+from django.forms.models import modelform_factory
 from django.test import TestCase
 
 from wagtail.actions.create import CreateAction, CreatePermissionError
@@ -15,6 +16,9 @@ from wagtail.test.testapp.models import (
     RevisableModel,
 )
 from wagtail.test.utils import WagtailTestUtils
+
+AdvertForm = modelform_factory(Advert, fields=["text", "url", "tags"])
+DraftStateModelForm = modelform_factory(DraftStateModel, fields=["text"])
 
 
 class TestCreateAction(WagtailTestUtils, TestCase):
@@ -119,6 +123,67 @@ class TestCreateAction(WagtailTestUtils, TestCase):
         instance = FullFeaturedSnippet(text="Explicit", sort_order=42)
         CreateAction(instance, user=self.user).execute()
         self.assertEqual(instance.sort_order, 42)
+
+    def test_create_with_form_saves_instance_and_m2m(self):
+        form = AdvertForm(
+            {"text": "From form", "url": "https://example.com", "tags": "alpha, beta"}
+        )
+        self.assertTrue(form.is_valid())
+
+        action = CreateAction(form.instance, user=self.user, form=form)
+        instance = action.execute()
+
+        self.assertIsNotNone(instance.pk)
+        instance.refresh_from_db()
+        self.assertEqual(instance.text, "From form")
+        # Many-to-many data is saved via the form.
+        self.assertEqual(
+            sorted(instance.tags.values_list("name", flat=True)),
+            ["alpha", "beta"],
+        )
+
+    def test_create_draftstate_with_form_is_not_live(self):
+        form = DraftStateModelForm({"text": "Draft from form"})
+        self.assertTrue(form.is_valid())
+
+        action = CreateAction(form.instance, user=self.user, form=form)
+        instance = action.execute()
+
+        instance.refresh_from_db()
+        self.assertFalse(instance.live)
+        self.assertEqual(instance.text, "Draft from form")
+        self.assertIsNotNone(instance.latest_revision)
+
+    def test_sort_order_field_none_disables_ordering(self):
+        instance = FullFeaturedSnippet(text="No order")
+        CreateAction(instance, user=self.user, sort_order_field=None).execute()
+        self.assertIsNone(instance.sort_order)
+
+    def test_sort_order_field_explicit_override(self):
+        instance = FullFeaturedSnippet(text="Explicit field")
+        CreateAction(instance, user=self.user, sort_order_field="sort_order").execute()
+        self.assertIsNotNone(instance.sort_order)
+
+    def test_revision_exposed_on_action(self):
+        action = CreateAction(RevisableModel(text="Hello"), user=self.user)
+        self.assertIsNone(action.revision)
+        action.execute()
+        self.assertIsNotNone(action.revision)
+        self.assertEqual(action.revision, action.instance.latest_revision)
+
+    def test_clean_defaults(self):
+        # Non-draftstate: validated by default.
+        self.assertTrue(CreateAction(RevisableModel(text="x"), user=self.user).clean)
+        # Draftstate without publishing: not validated (drafts may be incomplete).
+        self.assertFalse(CreateAction(DraftStateModel(text="x"), user=self.user).clean)
+        # Draftstate with publishing: validated.
+        self.assertTrue(
+            CreateAction(DraftStateModel(text="x"), user=self.user, publish=True).clean
+        )
+        # Explicit override wins.
+        self.assertTrue(
+            CreateAction(DraftStateModel(text="x"), user=self.user, clean=True).clean
+        )
 
     def test_log_action_override(self):
         advert = Advert(text="Custom log", url="https://example.com")

--- a/wagtail/tests/actions/test_edit.py
+++ b/wagtail/tests/actions/test_edit.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from django.contrib.auth.models import Permission
+from django.forms.models import modelform_factory
 from django.test import TestCase
 
 from wagtail.actions.edit import EditAction, EditPermissionError
@@ -10,6 +11,9 @@ from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.signals import published
 from wagtail.test.testapp.models import Advert, DraftStateModel, RevisableModel
 from wagtail.test.utils import WagtailTestUtils
+
+AdvertForm = modelform_factory(Advert, fields=["text", "url", "tags"])
+DraftStateModelForm = modelform_factory(DraftStateModel, fields=["text"])
 
 
 class TestEditAction(WagtailTestUtils, TestCase):
@@ -113,6 +117,83 @@ class TestEditAction(WagtailTestUtils, TestCase):
         self.assertEqual(Revision.objects.for_instance(instance).count(), 1)
         instance.refresh_from_db()
         self.assertEqual(instance.latest_revision.content["text"], "Overwritten")
+
+    def test_edit_with_form_saves_instance_and_m2m(self):
+        advert = Advert.objects.create(text="Original", url="https://example.com")
+        form = AdvertForm(
+            {"text": "Edited", "url": "https://example.com", "tags": "alpha, beta"},
+            instance=advert,
+        )
+        self.assertTrue(form.is_valid())
+
+        EditAction(advert, user=self.user, form=form).execute()
+
+        advert.refresh_from_db()
+        self.assertEqual(advert.text, "Edited")
+        self.assertEqual(
+            sorted(advert.tags.values_list("name", flat=True)),
+            ["alpha", "beta"],
+        )
+
+    def test_edit_live_draftstate_with_form_leaves_live_version_untouched(self):
+        instance = DraftStateModel.objects.create(text="Live", live=True)
+        form = DraftStateModelForm({"text": "Draft edit"}, instance=instance)
+        self.assertTrue(form.is_valid())
+
+        EditAction(instance, user=self.user, form=form).execute()
+
+        # The live row is unchanged; the edit only created a new revision.
+        instance.refresh_from_db()
+        self.assertTrue(instance.live)
+        self.assertEqual(instance.text, "Live")
+        self.assertEqual(instance.latest_revision.content["text"], "Draft edit")
+
+    def test_content_changed_derived_from_form(self):
+        advert = Advert.objects.create(text="Original", url="https://example.com")
+        # An unchanged form -> content_changed is False.
+        unchanged = AdvertForm(
+            {"text": "Original", "url": "https://example.com"}, instance=advert
+        )
+        self.assertTrue(unchanged.is_valid())
+        self.assertFalse(
+            EditAction(advert, user=self.user, form=unchanged).content_changed
+        )
+
+        # A changed form -> content_changed is True.
+        changed = AdvertForm(
+            {"text": "Different", "url": "https://example.com"}, instance=advert
+        )
+        self.assertTrue(changed.is_valid())
+        self.assertTrue(
+            EditAction(advert, user=self.user, form=changed).content_changed
+        )
+
+    def test_content_changed_without_form_assumes_changed(self):
+        advert = Advert.objects.create(text="Original", url="https://example.com")
+        self.assertTrue(EditAction(advert, user=self.user).content_changed)
+
+    def test_revision_exposed_on_action(self):
+        instance = RevisableModel.objects.create(text="Original")
+        instance.text = "Edited"
+        action = EditAction(instance, user=self.user)
+        self.assertIsNone(action.revision)
+        action.execute()
+        self.assertIsNotNone(action.revision)
+        self.assertEqual(action.revision, instance.latest_revision)
+
+    def test_clean_defaults(self):
+        # Non-draftstate: validated by default.
+        self.assertTrue(EditAction(RevisableModel(text="x"), user=self.user).clean)
+        # Draftstate without publishing: not validated.
+        self.assertFalse(EditAction(DraftStateModel(text="x"), user=self.user).clean)
+        # Draftstate with publishing: validated.
+        self.assertTrue(
+            EditAction(DraftStateModel(text="x"), user=self.user, publish=True).clean
+        )
+        # Explicit override wins.
+        self.assertFalse(
+            EditAction(RevisableModel(text="x"), user=self.user, clean=False).clean
+        )
 
     def test_log_action_override(self):
         advert = Advert.objects.create(text="Original", url="https://example.com")

--- a/wagtail/tests/actions/test_registry.py
+++ b/wagtail/tests/actions/test_registry.py
@@ -1,11 +1,15 @@
 from django.core.exceptions import ImproperlyConfigured
+from django.db import models
 from django.test import TestCase
 
 from wagtail import hooks
+from wagtail.actions import CreateAction, DeleteAction, EditAction
 from wagtail.actions.base import BaseAction
-from wagtail.actions.registry import ActionRegistry
+from wagtail.actions.registry import ActionRegistry, action_registry
 from wagtail.test.testapp.models import (
     Advert,
+    DraftStateModel,
+    FullFeaturedSnippet,
     RevisableChildModel,
     RevisableModel,
 )
@@ -95,3 +99,25 @@ class TestRegisterActionsHook(TestCase):
         with hooks.register_temporarily("register_actions", register_dummy):
             actions = registry.get_actions_for_model(Advert)
         self.assertEqual(actions, {"dummy": DummyAction})
+
+
+class TestDefaultActions(TestCase):
+    """The global registry is populated with default actions for all models."""
+
+    def test_base_model_has_default_actions(self):
+        self.assertEqual(
+            action_registry.get_actions_for_model(models.Model),
+            {"create": CreateAction, "edit": EditAction, "delete": DeleteAction},
+        )
+
+    def test_custom_models_have_default_actions(self):
+        for model in (Advert, DraftStateModel, FullFeaturedSnippet):
+            with self.subTest(model=model):
+                self.assertEqual(
+                    action_registry.get_actions_for_model(model),
+                    {
+                        "create": CreateAction,
+                        "edit": EditAction,
+                        "delete": DeleteAction,
+                    },
+                )


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #14297 (?), built on #14373

### Description

This is a more concrete implementation of the action classes, proven to work by refactoring our generic create/edit/delete views (and the snippets' optional features view mixin) to use them.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Claude Code within VSCode (with Claude Sonnet?) was used to help write the code and polish the rough edges when battle-testing with the views. I reviewed the code as Claude made the edits, and then did another review afterwards.