### PR TITLE
Add API v3 router for Sites

### DIFF
--- a/wagtail/actions/create.py
+++ b/wagtail/actions/create.py
@@ -82,6 +82,14 @@ class CreateAction(BaseAction):
             self.user, self.permission_policy_action
         )
 
+    def _clean_instance(self):
+        if self.form:
+            # Use is_valid() instead of full_clean() to avoid re-validating the
+            # form if it has already been validated.
+            self.form.is_valid()
+        else:
+            self.instance.full_clean()
+
     def _save_instance(self):
         # If DraftStateMixin is applied, make sure the object is not live when
         # first created. Making it live is done by publishing a revision below.
@@ -95,6 +103,9 @@ class CreateAction(BaseAction):
 
     def _create(self, skip_permission_checks=False):
         from wagtail.models.orderable import set_max_order
+
+        if self.clean:
+            self._clean_instance()
 
         self._save_instance()
 

--- a/wagtail/actions/create.py
+++ b/wagtail/actions/create.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 
 from wagtail.actions.base import BaseAction
 from wagtail.log_actions import log
@@ -84,9 +84,8 @@ class CreateAction(BaseAction):
 
     def _clean_instance(self):
         if self.form:
-            # Use is_valid() instead of full_clean() to avoid re-validating the
-            # form if it has already been validated.
-            self.form.is_valid()
+            if not self.form.is_valid():
+                raise ValidationError(self.form.errors.get_json_data())
         else:
             self.instance.full_clean()
 

--- a/wagtail/actions/edit.py
+++ b/wagtail/actions/edit.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 
 from wagtail.actions.base import BaseAction
 from wagtail.log_actions import log
@@ -76,9 +76,8 @@ class EditAction(BaseAction):
 
     def _clean_instance(self):
         if self.form:
-            # Use is_valid() instead of full_clean() to avoid re-validating the
-            # form if it has already been validated.
-            self.form.is_valid()
+            if not self.form.is_valid():
+                raise ValidationError(self.form.errors.get_json_data())
         else:
             self.instance.full_clean()
 

--- a/wagtail/actions/edit.py
+++ b/wagtail/actions/edit.py
@@ -74,6 +74,14 @@ class EditAction(BaseAction):
         # The revision created by execute(), if any.
         self.revision = None
 
+    def _clean_instance(self):
+        if self.form:
+            # Use is_valid() instead of full_clean() to avoid re-validating the
+            # form if it has already been validated.
+            self.form.is_valid()
+        else:
+            self.instance.full_clean()
+
     def _save_instance(self):
         if self.draftstate_enabled and self.instance.live:
             # Do not update the instance if it's a live DraftStateMixin object.
@@ -91,6 +99,9 @@ class EditAction(BaseAction):
                 self.instance.save()
 
     def _edit(self, skip_permission_checks=False):
+        if self.clean:
+            self._clean_instance()
+
         self._save_instance()
 
         if self.revision_enabled:

--- a/wagtail/api/v3/api.py
+++ b/wagtail/api/v3/api.py
@@ -3,6 +3,7 @@ from ninja import NinjaAPI
 from wagtail.api.v3.errors import register_exception_handlers
 from wagtail.api.v3.routers.pages import router as pages_router
 from wagtail.api.v3.routers.schema import router as schema_router
+from wagtail.api.v3.routers.sites import router as sites_router
 
 api = NinjaAPI(
     title="Wagtail API",
@@ -17,3 +18,4 @@ register_exception_handlers(api)
 
 api.add_router("/pages/", pages_router)
 api.add_router("/schema/", schema_router)
+api.add_router("/sites/", sites_router)

--- a/wagtail/api/v3/errors.py
+++ b/wagtail/api/v3/errors.py
@@ -1,9 +1,12 @@
 from http import HTTPStatus
 from typing import Any
 
+from django.core.exceptions import PermissionDenied
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.http import Http404, HttpRequest, HttpResponse
 from ninja import Schema
-from ninja.errors import HttpError, ValidationError
+from ninja.errors import HttpError
+from ninja.errors import ValidationError as NinjaValidationError
 
 PROBLEM_JSON = "application/problem+json"
 DEFAULT_PROBLEM_TYPE = "about:blank"
@@ -70,13 +73,26 @@ def register_exception_handlers(api):
     RFC 7807 choice for request validation failures.
     """
 
-    @api.exception_handler(ValidationError)
-    def validation_error_handler(request: HttpRequest, exc: ValidationError):
+    @api.exception_handler(NinjaValidationError)
+    @api.exception_handler(DjangoValidationError)
+    def validation_error_handler(
+        request: HttpRequest, exc: DjangoValidationError | NinjaValidationError
+    ):
+        if isinstance(exc, DjangoValidationError):
+            errors = [{"message": msg} for msg in exc.messages]
+        else:
+            errors = exc.errors
         return problem_response(
             status=422,
             detail="Validation failed",
-            errors=exc.errors,
+            errors=errors,
         )
+
+    @api.exception_handler(PermissionDenied)
+    def permission_denied_handler(request: HttpRequest, exc: PermissionDenied):
+        if not request.user.is_authenticated:
+            return problem_response(status=401, detail="Authentication required")
+        return problem_response(status=403, detail="Permission denied")
 
     @api.exception_handler(Http404)
     def not_found_handler(request: HttpRequest, exc: Http404):

--- a/wagtail/api/v3/permissions.py
+++ b/wagtail/api/v3/permissions.py
@@ -1,0 +1,34 @@
+import functools
+
+from django.core.exceptions import PermissionDenied
+
+from wagtail.permission_policies import ModelPermissionPolicy
+
+
+def require_any_permission(model, actions=("add", "change", "delete", "view")):
+    """
+    Decorator factory that gates a view behind authentication and any of the
+    given permission actions for *model*, looked up via ``policies_registry``.
+
+    Usage::
+
+        @router.get("/")
+        @require_any_permission(Site, ["add", "change", "delete", "view"])
+        def list_sites(request):
+            ...
+    """
+
+    def decorator(view_func):
+        @functools.wraps(view_func)
+        def wrapper(request, *args, **kwargs):
+            # FIXME: use the registry when it's implemented.
+            # from wagtail.permissions import policies_registry
+            # permission_policy = policies_registry.get(model)
+            permission_policy = ModelPermissionPolicy(model)
+            if not permission_policy.user_has_any_permission(request.user, actions):
+                raise PermissionDenied
+            return view_func(request, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/wagtail/api/v3/routers/sites.py
+++ b/wagtail/api/v3/routers/sites.py
@@ -1,0 +1,91 @@
+from django.http import HttpRequest
+from django.shortcuts import get_object_or_404
+from ninja import Router, Status
+from ninja.pagination import paginate
+
+from wagtail.actions.create import CreateAction
+from wagtail.actions.delete import DeleteAction
+from wagtail.actions.edit import EditAction
+from wagtail.api.v3.pagination import WagtailLimitOffsetPagination
+from wagtail.api.v3.permissions import require_any_permission
+from wagtail.api.v3.schemas import SiteInputSchema, SiteSchema
+from wagtail.models import Site
+from wagtail.permissions import site_permission_policy
+
+router = Router(tags=["sites"])
+
+
+@router.get(
+    "/",
+    response=list[SiteSchema],
+    url_name="list_sites",
+    summary="List sites",
+    operation_id="sites_list",
+)
+@paginate(WagtailLimitOffsetPagination)
+@require_any_permission(Site)
+def list_sites(request: HttpRequest):
+    return site_permission_policy.instances_user_has_any_permission_for(
+        request.user,
+        ("add", "change", "delete", "view"),
+    )
+
+
+@router.get(
+    "/{site_id}/",
+    response=SiteSchema,
+    url_name="detail_site",
+    summary="Site detail",
+    operation_id="sites_detail",
+)
+@require_any_permission(Site)
+def get_site(request: HttpRequest, site_id: int):
+    return get_object_or_404(
+        site_permission_policy.instances_user_has_any_permission_for(
+            request.user,
+            ("add", "change", "delete", "view"),
+        ),
+        pk=site_id,
+    )
+
+
+@router.post(
+    "/",
+    response={201: SiteSchema},
+    url_name="create_site",
+    summary="Create site",
+    operation_id="sites_create",
+)
+@require_any_permission(Site, ("add",))
+def create_site(request: HttpRequest, data: SiteInputSchema):
+    site = Site(**data.dict())
+    CreateAction(site, user=request.user).execute(skip_permission_checks=True)
+    return Status(201, site)
+
+
+@router.put(
+    "/{site_id}/",
+    response=SiteSchema,
+    url_name="update_site",
+    summary="Update site",
+    operation_id="sites_update",
+)
+def update_site(request: HttpRequest, site_id: int, data: SiteInputSchema):
+    site = get_object_or_404(Site, pk=site_id)
+    for field, value in data.dict().items():
+        setattr(site, field, value)
+    EditAction(site, user=request.user).execute()
+    return site
+
+
+@router.delete(
+    "/{site_id}/",
+    response={204: None},
+    url_name="delete_site",
+    summary="Delete site",
+    operation_id="sites_delete",
+)
+def delete_site(request: HttpRequest, site_id: int):
+    site = get_object_or_404(Site, pk=site_id)
+    DeleteAction(site, user=request.user).execute()
+    return Status(204, None)

--- a/wagtail/api/v3/routers/sites.py
+++ b/wagtail/api/v3/routers/sites.py
@@ -11,6 +11,7 @@ from wagtail.api.v3.permissions import require_any_permission
 from wagtail.api.v3.schemas import SiteInputSchema, SiteSchema
 from wagtail.models import Site
 from wagtail.permissions import site_permission_policy
+from wagtail.sites.forms import SiteForm
 
 router = Router(tags=["sites"])
 
@@ -58,9 +59,11 @@ def get_site(request: HttpRequest, site_id: int):
 )
 @require_any_permission(Site, ("add",))
 def create_site(request: HttpRequest, data: SiteInputSchema):
-    site = Site(**data.dict())
-    CreateAction(site, user=request.user).execute(skip_permission_checks=True)
-    return Status(201, site)
+    form = SiteForm(data.dict())
+    CreateAction(form.instance, user=request.user, form=form).execute(
+        skip_permission_checks=True
+    )
+    return Status(201, form.instance)
 
 
 @router.put(
@@ -72,10 +75,9 @@ def create_site(request: HttpRequest, data: SiteInputSchema):
 )
 def update_site(request: HttpRequest, site_id: int, data: SiteInputSchema):
     site = get_object_or_404(Site, pk=site_id)
-    for field, value in data.dict().items():
-        setattr(site, field, value)
-    EditAction(site, user=request.user).execute()
-    return site
+    form = SiteForm(data.dict(), instance=site)
+    EditAction(form.instance, user=request.user, form=form).execute()
+    return form.instance
 
 
 @router.delete(

--- a/wagtail/api/v3/schemas.py
+++ b/wagtail/api/v3/schemas.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
-from ninja import Schema
+from ninja import Field, Schema
 
 from wagtail.api.v2.utils import get_full_url
 from wagtail.models import Page
@@ -58,7 +58,9 @@ class SiteInputSchema(Schema):
     hostname: str
     port: int = 80
     site_name: str = ""
-    root_page_id: int
+    # Accept root_page_id in the input schema for consistency with the output,
+    # but use root_page so it can be accepted by ModelForm.
+    root_page: int = Field(..., alias="root_page_id")
     is_default_site: bool = False
 
 

--- a/wagtail/api/v3/schemas.py
+++ b/wagtail/api/v3/schemas.py
@@ -45,6 +45,23 @@ class PageListingSchema(Schema):
         )
 
 
+class SiteSchema(Schema):
+    id: int
+    hostname: str
+    port: int
+    site_name: str
+    root_page_id: int
+    is_default_site: bool
+
+
+class SiteInputSchema(Schema):
+    hostname: str
+    port: int = 80
+    site_name: str = ""
+    root_page_id: int
+    is_default_site: bool = False
+
+
 class ContentTypeSummarySchema(Schema):
     name: str
     label: str

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -140,6 +140,24 @@
         "title": "PagedPageListingSchema",
         "type": "object"
       },
+      "PagedSiteSchema": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SiteSchema"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": ["items", "count"],
+        "title": "PagedSiteSchema",
+        "type": "object"
+      },
       "SchemaDetailResponse": {
         "properties": {
           "create": {
@@ -180,6 +198,74 @@
           }
         },
         "title": "SchemaDetailResponse",
+        "type": "object"
+      },
+      "SiteInputSchema": {
+        "properties": {
+          "hostname": {
+            "title": "Hostname",
+            "type": "string"
+          },
+          "is_default_site": {
+            "default": false,
+            "title": "Is Default Site",
+            "type": "boolean"
+          },
+          "port": {
+            "default": 80,
+            "title": "Port",
+            "type": "integer"
+          },
+          "root_page_id": {
+            "title": "Root Page Id",
+            "type": "integer"
+          },
+          "site_name": {
+            "default": "",
+            "title": "Site Name",
+            "type": "string"
+          }
+        },
+        "required": ["hostname", "root_page_id"],
+        "title": "SiteInputSchema",
+        "type": "object"
+      },
+      "SiteSchema": {
+        "properties": {
+          "hostname": {
+            "title": "Hostname",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_default_site": {
+            "title": "Is Default Site",
+            "type": "boolean"
+          },
+          "port": {
+            "title": "Port",
+            "type": "integer"
+          },
+          "root_page_id": {
+            "title": "Root Page Id",
+            "type": "integer"
+          },
+          "site_name": {
+            "title": "Site Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "hostname",
+          "port",
+          "site_name",
+          "root_page_id",
+          "is_default_site"
+        ],
+        "title": "SiteSchema",
         "type": "object"
       }
     }
@@ -312,6 +398,166 @@
         },
         "summary": "Schemas for a content type",
         "tags": ["schema"]
+      }
+    },
+    "/api/v3/sites/": {
+      "get": {
+        "operationId": "sites_list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedSiteSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List sites",
+        "tags": ["sites"]
+      },
+      "post": {
+        "operationId": "sites_create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SiteInputSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteSchema"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create site",
+        "tags": ["sites"]
+      }
+    },
+    "/api/v3/sites/{site_id}/": {
+      "delete": {
+        "operationId": "sites_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete site",
+        "tags": ["sites"]
+      },
+      "get": {
+        "operationId": "sites_detail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Site detail",
+        "tags": ["sites"]
+      },
+      "put": {
+        "operationId": "sites_update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SiteInputSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Update site",
+        "tags": ["sites"]
       }
     }
   },

--- a/wagtail/api/v3/tests/test_sites.py
+++ b/wagtail/api/v3/tests/test_sites.py
@@ -1,0 +1,347 @@
+import json
+
+from django.contrib.auth.models import Permission
+from django.core.cache import cache
+from django.test import TestCase
+from django.urls import reverse
+
+from wagtail.api.v3.tests.base import TestV3Base
+from wagtail.models import Page, Site
+from wagtail.models.sites import (
+    SITE_ROOT_PATHS_CACHE_KEY,
+    SITE_ROOT_PATHS_CACHE_VERSION,
+)
+from wagtail.test.utils import WagtailTestUtils
+
+SITE_FIELDS = {"id", "hostname", "port", "site_name", "root_page_id", "is_default_site"}
+
+
+class TestV3SiteListing(TestV3Base, WagtailTestUtils, TestCase):
+    fixtures = ["demosite.json"]
+
+    def get_response(self, **params):
+        return self.client.get(reverse("wagtailapi_v3:list_sites"), params)
+
+    def test_anonymous_returns_401(self):
+        response = self.get_response()
+        self.assert_problem_response(response, status_code=401)
+
+    def test_authenticated_returns_200(self):
+        self.login()
+        response = self.get_response()
+        self.assertEqual(response.status_code, 200)
+
+    def test_response_fields(self):
+        self.login()
+        content = self.get_response().json()
+        self.assertIn("count", content)
+        self.assertIn("items", content)
+        for site in content["items"]:
+            self.assertEqual(set(site.keys()), SITE_FIELDS)
+
+    def test_count_matches_database(self):
+        self.login()
+        content = self.get_response().json()
+        self.assertEqual(content["count"], Site.objects.count())
+
+    def test_default_limit_is_20(self):
+        self.login()
+        content = self.get_response().json()
+        self.assertLessEqual(len(content["items"]), 20)
+
+    def test_user_with_any_site_permission_can_list(self):
+        user = self.create_user(username="viewer", password="password")
+        user.user_permissions.add(Permission.objects.get(codename="view_site"))
+        self.login(username="viewer", password="password")
+        response = self.get_response()
+        self.assertEqual(response.status_code, 200)
+
+    def test_user_without_any_site_permission_gets_403(self):
+        self.create_user(username="noperms", password="password")
+        self.login(username="noperms", password="password")
+        response = self.get_response()
+        self.assert_problem_response(response, status_code=403)
+
+
+class TestV3SiteDetail(TestV3Base, WagtailTestUtils, TestCase):
+    fixtures = ["demosite.json"]
+
+    def get_response(self, site_id):
+        return self.client.get(
+            reverse("wagtailapi_v3:detail_site", kwargs={"site_id": site_id})
+        )
+
+    def test_anonymous_returns_401(self):
+        site = Site.objects.get(is_default_site=True)
+        response = self.get_response(site.pk)
+        self.assert_problem_response(response, status_code=401)
+
+    def test_detail_returns_correct_fields(self):
+        self.login()
+        site = Site.objects.get(is_default_site=True)
+        response = self.get_response(site.pk)
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertEqual(set(content.keys()), SITE_FIELDS)
+        self.assertEqual(content["id"], site.pk)
+        self.assertEqual(content["hostname"], site.hostname)
+        self.assertEqual(content["port"], site.port)
+        self.assertEqual(content["root_page_id"], site.root_page_id)
+        self.assertEqual(content["is_default_site"], True)
+
+    def test_user_without_any_site_permission_gets_403(self):
+        self.create_user(username="noperms", password="password")
+        self.login(username="noperms", password="password")
+        site = Site.objects.get(is_default_site=True)
+        response = self.get_response(site.pk)
+        self.assert_problem_response(response, status_code=403)
+
+    def test_unknown_id_returns_404(self):
+        self.login()
+        response = self.get_response(999999)
+        self.assert_problem_response(response, status_code=404)
+
+
+class TestV3SiteCreate(TestV3Base, WagtailTestUtils, TestCase):
+    fixtures = ["demosite.json"]
+
+    def setUp(self):
+        super().setUp()
+        self.root_page = Page.objects.get(depth=1)
+        self.valid_payload = {
+            "hostname": "new.example.com",
+            "port": 80,
+            "site_name": "New Site",
+            "root_page_id": self.root_page.pk,
+            "is_default_site": False,
+        }
+
+    def post(self, data):
+        return self.client.post(
+            reverse("wagtailapi_v3:create_site"),
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+
+    def test_anonymous_returns_401(self):
+        response = self.post(self.valid_payload)
+        self.assert_problem_response(response, status_code=401)
+
+    def test_superuser_can_create(self):
+        self.login()
+        initial_count = Site.objects.count()
+        response = self.post(self.valid_payload)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(Site.objects.count(), initial_count + 1)
+        content = response.json()
+        self.assertEqual(set(content.keys()), SITE_FIELDS)
+        self.assertEqual(content["hostname"], "new.example.com")
+
+    def test_user_without_add_permission_gets_403(self):
+        user = self.create_user(username="noperms", password="password")
+        self.login(user)
+        response = self.post(self.valid_payload)
+        self.assert_problem_response(response, status_code=403)
+
+    def test_user_with_add_permission_can_create(self):
+        user = self.create_user(username="adder", password="password")
+        user.user_permissions.add(Permission.objects.get(codename="add_site"))
+        self.login(user)
+        response = self.post(self.valid_payload)
+        self.assertEqual(response.status_code, 201)
+
+    def test_duplicate_hostname_port_returns_422(self):
+        self.login()
+        existing = Site.objects.get(is_default_site=True)
+        payload = dict(self.valid_payload)
+        payload["hostname"] = existing.hostname
+        payload["port"] = existing.port
+        response = self.post(payload)
+        self.assert_problem_response(response, status_code=422)
+
+    def test_two_default_sites_returns_422(self):
+        self.login()
+        payload = dict(self.valid_payload)
+        payload["is_default_site"] = True
+        response = self.post(payload)
+        self.assert_problem_response(response, status_code=422)
+
+    def test_invalid_root_page_id_returns_422(self):
+        self.login()
+        payload = dict(self.valid_payload)
+        payload["root_page_id"] = 999999
+        response = self.post(payload)
+        self.assert_problem_response(response, status_code=422)
+
+    def test_create_invalidates_site_root_paths_cache(self):
+        self.login()
+        # Warm the cache.
+        Site.get_site_root_paths()
+
+        self.assertIsNotNone(
+            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
+        )
+        self.post(self.valid_payload)
+        self.assertIsNone(
+            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
+        )
+
+    def test_hostname_is_lowercased(self):
+        self.login()
+        payload = dict(self.valid_payload)
+        payload["hostname"] = "UPPER.Example.COM"
+        response = self.post(payload)
+        self.assertEqual(response.status_code, 201)
+        content = response.json()
+        self.assertEqual(content["hostname"], "upper.example.com")
+
+
+class TestV3SiteUpdate(TestV3Base, WagtailTestUtils, TestCase):
+    fixtures = ["demosite.json"]
+
+    def setUp(self):
+        super().setUp()
+        self.site = Site.objects.get(is_default_site=True)
+        self.root_page = Page.objects.get(depth=1)
+        self.valid_payload = {
+            "hostname": "updated.example.com",
+            "port": 80,
+            "site_name": "Updated",
+            "root_page_id": self.site.root_page_id,
+            "is_default_site": True,
+        }
+
+    def put(self, site_id, data):
+        return self.client.put(
+            reverse("wagtailapi_v3:update_site", kwargs={"site_id": site_id}),
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+
+    def test_anonymous_returns_401(self):
+        response = self.put(self.site.pk, self.valid_payload)
+        self.assert_problem_response(response, status_code=401)
+
+    def test_superuser_can_update(self):
+        self.login()
+        response = self.put(self.site.pk, self.valid_payload)
+        self.assertEqual(response.status_code, 200)
+        self.site.refresh_from_db()
+        self.assertEqual(self.site.hostname, "updated.example.com")
+
+    def test_user_without_change_permission_gets_403(self):
+        user = self.create_user(username="noperms", password="password")
+        self.login(user)
+        response = self.put(self.site.pk, self.valid_payload)
+        self.assert_problem_response(response, status_code=403)
+
+    def test_user_with_change_permission_can_update(self):
+        user = self.create_user(username="changer", password="password")
+        user.user_permissions.add(Permission.objects.get(codename="change_site"))
+        self.login(username="changer", password="password")
+        response = self.put(self.site.pk, self.valid_payload)
+        self.assertEqual(response.status_code, 200)
+
+    def test_unknown_id_returns_404(self):
+        self.login()
+        response = self.put(999999, self.valid_payload)
+        self.assert_problem_response(response, status_code=404)
+
+    def test_is_default_site_conflict_returns_422(self):
+        # Create a second non-default site, then try to make it default
+        # while the first is still default.
+        second = Site.objects.create(
+            hostname="second.example.com",
+            port=80,
+            root_page=self.root_page,
+            is_default_site=False,
+        )
+        self.login()
+        payload = {
+            "hostname": "second.example.com",
+            "port": 80,
+            "site_name": "",
+            "root_page_id": self.root_page.pk,
+            "is_default_site": True,
+        }
+        response = self.put(second.pk, payload)
+        self.assert_problem_response(response, status_code=422)
+
+    def test_update_invalidates_site_root_paths_cache(self):
+        self.login()
+        Site.get_site_root_paths()
+
+        self.assertIsNotNone(
+            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
+        )
+        self.put(self.site.pk, self.valid_payload)
+        self.assertIsNone(
+            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
+        )
+
+    def test_response_fields(self):
+        self.login()
+        response = self.put(self.site.pk, self.valid_payload)
+        content = response.json()
+        self.assertEqual(set(content.keys()), SITE_FIELDS)
+
+
+class TestV3SiteDelete(TestV3Base, WagtailTestUtils, TestCase):
+    fixtures = ["demosite.json"]
+
+    def setUp(self):
+        super().setUp()
+        root_page = Page.objects.get(depth=1)
+        self.site_to_delete = Site.objects.create(
+            hostname="todelete.example.com",
+            port=80,
+            site_name="To Delete",
+            root_page=root_page,
+            is_default_site=False,
+        )
+
+    def delete(self, site_id):
+        return self.client.delete(
+            reverse("wagtailapi_v3:delete_site", kwargs={"site_id": site_id})
+        )
+
+    def test_anonymous_returns_401(self):
+        response = self.delete(self.site_to_delete.pk)
+        self.assert_problem_response(response, status_code=401)
+
+    def test_superuser_can_delete(self):
+        self.login()
+        pk = self.site_to_delete.pk
+        response = self.delete(pk)
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Site.objects.filter(pk=pk).exists())
+
+    def test_user_without_delete_permission_gets_403(self):
+        user = self.create_user(username="noperms", password="password")
+        self.login(user)
+        response = self.delete(self.site_to_delete.pk)
+        self.assert_problem_response(response, status_code=403)
+
+    def test_user_with_delete_permission_can_delete(self):
+        user = self.create_user(username="deleter", password="password")
+        user.user_permissions.add(Permission.objects.get(codename="delete_site"))
+        self.login(user)
+        response = self.delete(self.site_to_delete.pk)
+        self.assertEqual(response.status_code, 204)
+
+    def test_unknown_id_returns_404(self):
+        self.login()
+        response = self.delete(999999)
+        self.assert_problem_response(response, status_code=404)
+
+    def test_delete_invalidates_site_root_paths_cache(self):
+        self.login()
+        Site.get_site_root_paths()
+
+        self.assertIsNotNone(
+            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
+        )
+        self.delete(self.site_to_delete.pk)
+        self.assertIsNone(
+            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
+        )


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Built on #14360 and #14374.

### Description

<!-- Please describe the problem you're fixing. -->
This implements a Django Ninja router endpoints for managing the Site model.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Claude Code in VSCode with Claude Sonnet was used to generate the code, but I reviewed and refined the implementation manually. I didn't look very closely at the tests, but at a glance they seem to make sense.