### PR TITLE
Add API v3 router for Redirects

### DIFF
--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -140,6 +140,24 @@
         "title": "PagedPageListingSchema",
         "type": "object"
       },
+      "PagedRedirectSchema": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RedirectSchema"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": ["items", "count"],
+        "title": "PagedRedirectSchema",
+        "type": "object"
+      },
       "PagedSiteSchema": {
         "properties": {
           "count": {
@@ -156,6 +174,129 @@
         },
         "required": ["items", "count"],
         "title": "PagedSiteSchema",
+        "type": "object"
+      },
+      "RedirectInputSchema": {
+        "properties": {
+          "is_permanent": {
+            "default": true,
+            "title": "Is Permanent",
+            "type": "boolean"
+          },
+          "old_path": {
+            "title": "Old Path",
+            "type": "string"
+          },
+          "redirect_link": {
+            "default": "",
+            "title": "Redirect Link",
+            "type": "string"
+          },
+          "redirect_page_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Redirect Page Id"
+          },
+          "redirect_page_route_path": {
+            "default": "",
+            "title": "Redirect Page Route Path",
+            "type": "string"
+          },
+          "site": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Site"
+          }
+        },
+        "required": ["old_path"],
+        "title": "RedirectInputSchema",
+        "type": "object"
+      },
+      "RedirectSchema": {
+        "properties": {
+          "automatically_created": {
+            "title": "Automatically Created",
+            "type": "boolean"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_permanent": {
+            "title": "Is Permanent",
+            "type": "boolean"
+          },
+          "old_path": {
+            "title": "Old Path",
+            "type": "string"
+          },
+          "redirect_link": {
+            "title": "Redirect Link",
+            "type": "string"
+          },
+          "redirect_page_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Redirect Page Id"
+          },
+          "redirect_page_route_path": {
+            "title": "Redirect Page Route Path",
+            "type": "string"
+          },
+          "site_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Site Id"
+          }
+        },
+        "required": [
+          "id",
+          "old_path",
+          "site_id",
+          "is_permanent",
+          "redirect_page_id",
+          "redirect_page_route_path",
+          "redirect_link",
+          "automatically_created",
+          "created_at"
+        ],
+        "title": "RedirectSchema",
         "type": "object"
       },
       "SchemaDetailResponse": {
@@ -348,6 +489,166 @@
         },
         "summary": "Page detail",
         "tags": ["pages"]
+      }
+    },
+    "/api/v3/redirects/": {
+      "get": {
+        "operationId": "redirects_list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedRedirectSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List redirects",
+        "tags": ["redirects"]
+      },
+      "post": {
+        "operationId": "redirects_create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RedirectInputSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RedirectSchema"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create redirect",
+        "tags": ["redirects"]
+      }
+    },
+    "/api/v3/redirects/{redirect_id}/": {
+      "delete": {
+        "operationId": "redirects_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "redirect_id",
+            "required": true,
+            "schema": {
+              "title": "Redirect Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete redirect",
+        "tags": ["redirects"]
+      },
+      "get": {
+        "operationId": "redirects_detail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "redirect_id",
+            "required": true,
+            "schema": {
+              "title": "Redirect Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RedirectSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Redirect detail",
+        "tags": ["redirects"]
+      },
+      "put": {
+        "operationId": "redirects_update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "redirect_id",
+            "required": true,
+            "schema": {
+              "title": "Redirect Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RedirectInputSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RedirectSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Update redirect",
+        "tags": ["redirects"]
       }
     },
     "/api/v3/schema/": {

--- a/wagtail/contrib/redirects/api.py
+++ b/wagtail/contrib/redirects/api.py
@@ -1,11 +1,128 @@
-from django.http import Http404
+from datetime import datetime
+
+from django.http import Http404, HttpRequest
+from django.shortcuts import get_object_or_404
+from ninja import Field, Router, Schema, Status
+from ninja.pagination import paginate
 from rest_framework import serializers
 
+from wagtail.actions.create import CreateAction
+from wagtail.actions.delete import DeleteAction
+from wagtail.actions.edit import EditAction
 from wagtail.api.v2.filters import FieldsFilter, OrderingFilter, SearchFilter
 from wagtail.api.v2.serializers import BaseSerializer
 from wagtail.api.v2.views import BaseAPIViewSet
+from wagtail.api.v3.pagination import WagtailLimitOffsetPagination
+from wagtail.api.v3.permissions import require_any_permission
+from wagtail.contrib.redirects.forms import RedirectForm
 from wagtail.contrib.redirects.middleware import get_redirect
 from wagtail.contrib.redirects.models import Redirect
+from wagtail.contrib.redirects.permissions import permission_policy
+
+router = Router(tags=["redirects"])
+
+
+class RedirectSchema(Schema):
+    id: int
+    old_path: str
+    site_id: int | None
+    is_permanent: bool
+    redirect_page_id: int | None
+    redirect_page_route_path: str
+    redirect_link: str
+    automatically_created: bool
+    created_at: datetime | None
+
+
+class RedirectInputSchema(Schema):
+    old_path: str
+    site: int | None = None
+    is_permanent: bool = True
+    # Accept redirect_page_id in the input schema for consistency with the output,
+    # but use redirect_page so it can be accepted by ModelForm.
+    redirect_page: int | None = Field(None, alias="redirect_page_id")
+    redirect_page_route_path: str = ""
+    redirect_link: str = ""
+
+
+@router.get(
+    "/",
+    response=list[RedirectSchema],
+    url_name="list_redirects",
+    summary="List redirects",
+    operation_id="redirects_list",
+)
+@paginate(WagtailLimitOffsetPagination)
+@require_any_permission(Redirect)
+def list_redirects(request: HttpRequest):
+    return permission_policy.instances_user_has_any_permission_for(
+        request.user,
+        ("add", "change", "delete", "view"),
+    )
+
+
+@router.get(
+    "/{redirect_id}/",
+    response=RedirectSchema,
+    url_name="detail_redirect",
+    summary="Redirect detail",
+    operation_id="redirects_detail",
+)
+@require_any_permission(Redirect)
+def get_redirect_detail(request: HttpRequest, redirect_id: int):
+    return get_object_or_404(
+        permission_policy.instances_user_has_any_permission_for(
+            request.user,
+            ("add", "change", "delete", "view"),
+        ),
+        pk=redirect_id,
+    )
+
+
+@router.post(
+    "/",
+    response={201: RedirectSchema},
+    url_name="create_redirect",
+    summary="Create redirect",
+    operation_id="redirects_create",
+)
+@require_any_permission(Redirect, ("add",))
+def create_redirect(request: HttpRequest, data: RedirectInputSchema):
+    form = RedirectForm(data.dict())
+    CreateAction(form.instance, user=request.user, form=form).execute(
+        skip_permission_checks=True
+    )
+    return Status(201, form.instance)
+
+
+@router.put(
+    "/{redirect_id}/",
+    response=RedirectSchema,
+    url_name="update_redirect",
+    summary="Update redirect",
+    operation_id="redirects_update",
+)
+def update_redirect(request: HttpRequest, redirect_id: int, data: RedirectInputSchema):
+    redirect = get_object_or_404(Redirect, pk=redirect_id)
+    form = RedirectForm(data.dict(), instance=redirect)
+    EditAction(form.instance, user=request.user, form=form).execute()
+    return form.instance
+
+
+@router.delete(
+    "/{redirect_id}/",
+    response={204: None},
+    url_name="delete_redirect",
+    summary="Delete redirect",
+    operation_id="redirects_delete",
+)
+def delete_redirect(request: HttpRequest, redirect_id: int):
+    redirect = get_object_or_404(Redirect, pk=redirect_id)
+    DeleteAction(redirect, user=request.user).execute()
+    return Status(204, None)
+
+
+# Legacy API v2
 
 
 class RedirectSerializer(BaseSerializer):

--- a/wagtail/contrib/redirects/apps.py
+++ b/wagtail/contrib/redirects/apps.py
@@ -18,3 +18,9 @@ class WagtailRedirectsAppConfig(AppConfig):
 
         post_page_move.connect(autocreate_redirects_on_page_move)
         page_slug_changed.connect(autocreate_redirects_on_slug_change)
+
+        from wagtail.api.v3.api import api
+
+        from .api import router
+
+        api.add_router("/redirects/", router)

--- a/wagtail/contrib/redirects/tests/test_v3_api.py
+++ b/wagtail/contrib/redirects/tests/test_v3_api.py
@@ -1,0 +1,314 @@
+import json
+
+from django.contrib.auth.models import Permission
+from django.test import TestCase
+from django.urls import reverse
+
+from wagtail.api.v3.tests.base import TestV3Base
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.models import Page, Site
+from wagtail.test.utils import WagtailTestUtils
+
+REDIRECT_FIELDS = {
+    "id",
+    "old_path",
+    "site_id",
+    "is_permanent",
+    "redirect_page_id",
+    "redirect_page_route_path",
+    "redirect_link",
+    "automatically_created",
+    "created_at",
+}
+
+
+def make_redirect(**kwargs):
+    defaults = {
+        "old_path": "/test",
+        "redirect_link": "https://example.com/",
+    }
+    defaults.update(kwargs)
+    return Redirect.objects.create(**defaults)
+
+
+class TestV3RedirectListing(TestV3Base, WagtailTestUtils, TestCase):
+    def setUp(self):
+        super().setUp()
+        make_redirect(old_path="/one", redirect_link="https://example.com/one/")
+        make_redirect(old_path="/two", redirect_link="https://example.com/two/")
+
+    def get_response(self, **params):
+        return self.client.get(reverse("wagtailapi_v3:list_redirects"), params)
+
+    def test_anonymous_returns_401(self):
+        response = self.get_response()
+        self.assert_problem_response(response, status_code=401)
+
+    def test_authenticated_returns_200(self):
+        self.login()
+        response = self.get_response()
+        self.assertEqual(response.status_code, 200)
+
+    def test_response_fields(self):
+        self.login()
+        content = self.get_response().json()
+        self.assertIn("count", content)
+        self.assertIn("items", content)
+        for item in content["items"]:
+            self.assertEqual(set(item.keys()), REDIRECT_FIELDS)
+
+    def test_count_matches_database(self):
+        self.login()
+        content = self.get_response().json()
+        self.assertEqual(content["count"], Redirect.objects.count())
+
+    def test_default_limit_is_20(self):
+        self.login()
+        content = self.get_response().json()
+        self.assertLessEqual(len(content["items"]), 20)
+
+    def test_user_with_any_redirect_permission_can_list(self):
+        user = self.create_user(username="viewer", password="password")
+        user.user_permissions.add(Permission.objects.get(codename="view_redirect"))
+        self.login(username="viewer", password="password")
+        response = self.get_response()
+        self.assertEqual(response.status_code, 200)
+
+    def test_user_without_any_redirect_permission_gets_403(self):
+        self.create_user(username="noperms", password="password")
+        self.login(username="noperms", password="password")
+        response = self.get_response()
+        self.assert_problem_response(response, status_code=403)
+
+
+class TestV3RedirectDetail(TestV3Base, WagtailTestUtils, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.redirect = make_redirect(
+            old_path="/old", redirect_link="https://example.com/"
+        )
+
+    def get_response(self, redirect_id):
+        return self.client.get(
+            reverse(
+                "wagtailapi_v3:detail_redirect", kwargs={"redirect_id": redirect_id}
+            )
+        )
+
+    def test_anonymous_returns_401(self):
+        response = self.get_response(self.redirect.pk)
+        self.assert_problem_response(response, status_code=401)
+
+    def test_detail_returns_correct_fields(self):
+        self.login()
+        response = self.get_response(self.redirect.pk)
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertEqual(set(content.keys()), REDIRECT_FIELDS)
+        self.assertEqual(content["id"], self.redirect.pk)
+        self.assertEqual(content["old_path"], "/old")
+        self.assertEqual(content["redirect_link"], "https://example.com/")
+        self.assertIsNone(content["site_id"])
+        self.assertTrue(content["is_permanent"])
+
+    def test_user_without_any_redirect_permission_gets_403(self):
+        self.create_user(username="noperms", password="password")
+        self.login(username="noperms", password="password")
+        response = self.get_response(self.redirect.pk)
+        self.assert_problem_response(response, status_code=403)
+
+    def test_unknown_id_returns_404(self):
+        self.login()
+        response = self.get_response(999999)
+        self.assert_problem_response(response, status_code=404)
+
+
+class TestV3RedirectCreate(TestV3Base, WagtailTestUtils, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.valid_payload = {
+            "old_path": "/new-old-path",
+            "redirect_link": "https://example.com/target/",
+            "is_permanent": True,
+        }
+
+    def post(self, data):
+        return self.client.post(
+            reverse("wagtailapi_v3:create_redirect"),
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+
+    def test_anonymous_returns_401(self):
+        response = self.post(self.valid_payload)
+        self.assert_problem_response(response, status_code=401)
+
+    def test_superuser_can_create(self):
+        self.login()
+        initial_count = Redirect.objects.count()
+        response = self.post(self.valid_payload)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(Redirect.objects.count(), initial_count + 1)
+        content = response.json()
+        self.assertEqual(set(content.keys()), REDIRECT_FIELDS)
+        self.assertEqual(content["old_path"], "/new-old-path")
+        self.assertEqual(content["redirect_link"], "https://example.com/target/")
+
+    def test_user_without_add_permission_gets_403(self):
+        user = self.create_user(username="noperms", password="password")
+        self.login(user)
+        response = self.post(self.valid_payload)
+        self.assert_problem_response(response, status_code=403)
+
+    def test_user_with_add_permission_can_create(self):
+        user = self.create_user(username="adder", password="password")
+        user.user_permissions.add(Permission.objects.get(codename="add_redirect"))
+        self.login(user)
+        response = self.post(self.valid_payload)
+        self.assertEqual(response.status_code, 201)
+
+    def test_old_path_is_normalised(self):
+        self.login()
+        payload = dict(self.valid_payload)
+        payload["old_path"] = "  /foo/bar/  "
+        response = self.post(payload)
+        self.assertEqual(response.status_code, 201)
+        content = response.json()
+        self.assertEqual(content["old_path"], "/foo/bar")
+
+    def test_duplicate_old_path_and_site_returns_422(self):
+        self.login()
+        make_redirect(old_path="/new-old-path")
+        response = self.post(self.valid_payload)
+        self.assert_problem_response(response, status_code=422)
+
+    def test_create_with_page_redirect(self):
+        self.login()
+        page = Page.objects.filter(depth__gt=1).first()
+        payload = {"old_path": "/to-page", "redirect_page_id": page.pk}
+        response = self.post(payload)
+        self.assertEqual(response.status_code, 201)
+        content = response.json()
+        self.assertEqual(content["redirect_page_id"], page.pk)
+
+    def test_create_with_site(self):
+        self.login()
+        site = Site.objects.first()
+        payload = dict(self.valid_payload)
+        payload["old_path"] = "/site-specific"
+        payload["site"] = site.pk
+        response = self.post(payload)
+        self.assertEqual(response.status_code, 201)
+        content = response.json()
+        self.assertEqual(content["site_id"], site.pk)
+
+
+class TestV3RedirectUpdate(TestV3Base, WagtailTestUtils, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.redirect = make_redirect(
+            old_path="/original", redirect_link="https://example.com/"
+        )
+        self.valid_payload = {
+            "old_path": "/updated",
+            "redirect_link": "https://example.com/updated/",
+            "is_permanent": False,
+        }
+
+    def put(self, redirect_id, data):
+        return self.client.put(
+            reverse(
+                "wagtailapi_v3:update_redirect", kwargs={"redirect_id": redirect_id}
+            ),
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+
+    def test_anonymous_returns_401(self):
+        response = self.put(self.redirect.pk, self.valid_payload)
+        self.assert_problem_response(response, status_code=401)
+
+    def test_superuser_can_update(self):
+        self.login()
+        response = self.put(self.redirect.pk, self.valid_payload)
+        self.assertEqual(response.status_code, 200)
+        self.redirect.refresh_from_db()
+        self.assertEqual(self.redirect.old_path, "/updated")
+        self.assertFalse(self.redirect.is_permanent)
+
+    def test_user_without_change_permission_gets_403(self):
+        user = self.create_user(username="noperms", password="password")
+        self.login(user)
+        response = self.put(self.redirect.pk, self.valid_payload)
+        self.assert_problem_response(response, status_code=403)
+
+    def test_user_with_change_permission_can_update(self):
+        user = self.create_user(username="changer", password="password")
+        user.user_permissions.add(Permission.objects.get(codename="change_redirect"))
+        self.login(username="changer", password="password")
+        response = self.put(self.redirect.pk, self.valid_payload)
+        self.assertEqual(response.status_code, 200)
+
+    def test_unknown_id_returns_404(self):
+        self.login()
+        response = self.put(999999, self.valid_payload)
+        self.assert_problem_response(response, status_code=404)
+
+    def test_response_fields(self):
+        self.login()
+        response = self.put(self.redirect.pk, self.valid_payload)
+        content = response.json()
+        self.assertEqual(set(content.keys()), REDIRECT_FIELDS)
+
+    def test_old_path_is_normalised_on_update(self):
+        self.login()
+        payload = dict(self.valid_payload)
+        payload["old_path"] = "  /needs/normalising/  "
+        response = self.put(self.redirect.pk, payload)
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertEqual(content["old_path"], "/needs/normalising")
+
+
+class TestV3RedirectDelete(TestV3Base, WagtailTestUtils, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.redirect = make_redirect(
+            old_path="/to-delete", redirect_link="https://example.com/"
+        )
+
+    def delete(self, redirect_id):
+        return self.client.delete(
+            reverse(
+                "wagtailapi_v3:delete_redirect", kwargs={"redirect_id": redirect_id}
+            )
+        )
+
+    def test_anonymous_returns_401(self):
+        response = self.delete(self.redirect.pk)
+        self.assert_problem_response(response, status_code=401)
+
+    def test_superuser_can_delete(self):
+        self.login()
+        pk = self.redirect.pk
+        response = self.delete(pk)
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Redirect.objects.filter(pk=pk).exists())
+
+    def test_user_without_delete_permission_gets_403(self):
+        user = self.create_user(username="noperms", password="password")
+        self.login(user)
+        response = self.delete(self.redirect.pk)
+        self.assert_problem_response(response, status_code=403)
+
+    def test_user_with_delete_permission_can_delete(self):
+        user = self.create_user(username="deleter", password="password")
+        user.user_permissions.add(Permission.objects.get(codename="delete_redirect"))
+        self.login(user)
+        response = self.delete(self.redirect.pk)
+        self.assertEqual(response.status_code, 204)
+
+    def test_unknown_id_returns_404(self):
+        self.login()
+        response = self.delete(999999)
+        self.assert_problem_response(response, status_code=404)


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Built on https://github.com/wagtail/wagtail/pull/14376, https://github.com/wagtail/wagtail/pull/14360, and https://github.com/wagtail/wagtail/pull/14374.

### Description

<!-- Please describe the problem you're fixing. -->

This implements a Django Ninja router endpoints for managing the Redirect model.



### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Claude Code in VSCode with Claude Sonnet was used to generate the code, but I reviewed and refined the implementation manually. I didn't look very closely at the tests, but at a glance they seem to make sense.