### PR TITLE
Fix nested submenu labels in slim sidebar

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
  * Fix: Allow `ChooserBlock.bulk_to_python()` to resolve records with primary keys that need converting to their native type, such as UUIDs (Saksham Chawla)
  * Fix: Prevent error when accessing the sitemap via an unknown host and no default site is configured (Jawad Khan)
  * Fix: Prevent excessive memory usage when copying a page with many revisions (Taras Panasiuk)
+ * Fix: Prevent nested submenu labels from becoming invisible when using the slim sidebar (Neda Gilanian, Sage Abdullah)
  * Docs: Fix broken links to Cloudflare and Handsontable documentation (Roshan Ramani)
  * Maintenance: Drop support for Python 3.10
  * Maintenance: Remove obsolete use of `USE_L10N` setting (DresdenGman)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1002,6 +1002,7 @@
 * Roshan Ramani
 * Jawad Khan
 * Taras Panasiuk
+* Neda Gilanian
 
 ## Translators
 

--- a/client/src/components/Sidebar/SidebarPanel.scss
+++ b/client/src/components/Sidebar/SidebarPanel.scss
@@ -57,7 +57,7 @@
 
       // Don't apply this to nested submenus though
       @at-root .sidebar--slim .sidebar-panel #{&} {
-        inset-inline-start: $menu-width-slim;
+        inset-inline-start: $menu-width;
         transform: translateX(0);
       }
     }

--- a/client/src/components/Sidebar/menu/SubMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/SubMenuItem.tsx
@@ -84,10 +84,13 @@ export const SubMenuItem: React.FunctionComponent<SubMenuItemProps> = ({
     }
   };
 
+  const isInSubMenu = path.split('.').length > 2;
+
   const className =
     'sidebar-menu-item sidebar-sub-menu-item' +
     (isActive ? ' sidebar-menu-item--active' : '') +
-    (isOpen ? ' sidebar-sub-menu-item--open' : '');
+    (isOpen ? ' sidebar-sub-menu-item--open' : '') +
+    (isInSubMenu ? ' sidebar-menu-item--in-sub-menu' : '');
 
   const sidebarTriggerIconClassName =
     'sidebar-sub-menu-trigger-icon' +

--- a/client/src/components/Sidebar/menu/SubMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/SubMenuItem.tsx
@@ -84,10 +84,13 @@ export const SubMenuItem: React.FunctionComponent<SubMenuItemProps> = ({
     }
   };
 
-  const className =
-    'sidebar-menu-item sidebar-sub-menu-item' +
-    (isActive ? ' sidebar-menu-item--active' : '') +
-    (isOpen ? ' sidebar-sub-menu-item--open' : '');
+const isInSubMenu = path.split('.').length > 2;
+
+const className =
+  'sidebar-menu-item sidebar-sub-menu-item' +
+  (isActive ? ' sidebar-menu-item--active' : '') +
+  (isOpen ? ' sidebar-sub-menu-item--open' : '') +
+  (isInSubMenu ? ' sidebar-menu-item--in-sub-menu' : '');
 
   const sidebarTriggerIconClassName =
     'sidebar-sub-menu-trigger-icon' +

--- a/docs/releases/8.1.md
+++ b/docs/releases/8.1.md
@@ -22,6 +22,7 @@ depth: 1
  * Allow `ChooserBlock.bulk_to_python()` to resolve records with primary keys that need converting to their native type, such as UUIDs (Saksham Chawla)
  * Prevent error when accessing the sitemap via an unknown host and no default site is configured (Jawad Khan)
  * Fix excessive memory usage when copying a page with many revisions (Taras Panasiuk)
+ * Prevent nested submenu labels from becoming invisible when using the slim sidebar (Neda Gilanian, Sage Abdullah)
 
 ### Documentation
 

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -189,6 +189,8 @@ class MiscellaneousViewSetGroup(ViewSetGroup):
     items = (CalendarViewSet, GreetingsViewSet)
     menu_label = "Miscellaneous"
     submenu_hook = "register_submenu_greetings"
+    add_to_admin_menu = False
+    add_to_settings_menu = True
 
 
 class SubmenuHookGreetingsViewSet(ViewSet):


### PR DESCRIPTION
Fixes #14375

## What does this PR do?

Fixes the missing label issue for nested submenu items when the sidebar is collapsed to slim mode.

The issue occurs because nested `SubMenuItem` instances do not receive the
`sidebar-menu-item--in-sub-menu` CSS class automatically. This PR detects
nested submenu items and applies the class so their labels are rendered
correctly in the slim sidebar.

## How to test

1. Create a nested submenu structure as described in #14375.
2. Collapse the sidebar to slim mode.
3. Open the parent submenu and then the nested submenu.
4. Verify that the nested submenu label is visible.

## AI disclosure

I used ChatGPT to help understand the issue and navigate the contribution process.
The code changes were implemented and reviewed by me.