### PR TITLE
Add extension blocks for image and document stats

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changelog
  * Stop converting AVIF and WebP images to PNG by default (Thibaud Colas)
  * Add rich text serializing to HTML support in the v2 API (Thibaud Colas)
  * Expose the block `id` as a template context variable when rendering children of `StreamBlock` and `ListBlock` (Sage Abdullah)
+ * Add extension blocks for image and document stats in the edit view templates (Preeti Singh)
  * Fix: Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
  * Fix: Prevent an error when approving a workflow that has been cancelled in a different session (Kailesh)
  * Fix: Accommodate multilingual sites in skipping the "choose parent" step when creating a new page from a flat page listing (Amrinder Singh)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -989,6 +989,7 @@
 * Jack Whitworth
 * Thomas Herman
 * Joey Jurjens
+* Preeti Singh
 
 ## Translators
 

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -41,6 +41,7 @@ For more details, refer to the [](permissions_reference) reference documentation
  * Stop converting AVIF and WebP images to PNG by default (Thibaud Colas)
  * Add rich text [serializing to HTML](api_v2_rich_text) support in the v2 API (Thibaud Colas)
  * Expose the block `id` [as a template context variable](streamfield_block_id_context_variable) when rendering children of `StreamBlock` and `ListBlock` (Sage Abdullah)
+ * Add extension blocks for image and document stats in the edit view templates (Preeti Singh)
 
 ### Bug fixes
 

--- a/wagtail/documents/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/edit.html
@@ -15,17 +15,18 @@
                 {% endif %}
             {% endfor %}
         </div>
+        {% block document_stats %}
+            <dl>
+                {% if document.file %}
+                    <dt>{% trans "Filesize" %}</dt>
+                    <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found"%}{% endif %}</dd>
+                {% endif %}
 
-        <dl>
-            {% if document.file %}
-                <dt>{% trans "Filesize" %}</dt>
-                <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
-            {% endif %}
-
-            <dt>{% trans "Usage" %}</dt>
-            <dd>
-                <a href="{{ document.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
-            </dd>
-        </dl>
+                <dt>{% trans "Usage" %}</dt>
+                <dd>
+                    <a href="{{ document.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                </dd>
+            </dl>
+        {% endblock %}
     </div>
 {% endblock %}

--- a/wagtail/documents/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/edit.html
@@ -16,16 +16,18 @@
             {% endfor %}
         </div>
 
-        <dl>
-            {% if document.file %}
-                <dt>{% trans "Filesize" %}</dt>
-                <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
-            {% endif %}
+        {% block stats %}
+            <dl>
+                {% if document.file %}
+                    <dt>{% trans "Filesize" %}</dt>
+                    <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found"%}{% endif %}</dd>
+                {% endif %}
 
-            <dt>{% trans "Usage" %}</dt>
-            <dd>
-                <a href="{{ document.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
-            </dd>
-        </dl>
+                <dt>{% trans "Usage" %}</dt>
+                <dd>
+                    <a href="{{ document.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                </dd>
+            </dl>
+        {% endblock %}
     </div>
 {% endblock %}

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -55,18 +55,19 @@
                 </div>
                 <div class="w-col-span-1">
                     {% image image original as original_image %}
+                    {% block image_stats %}
+                        <dl>
+                            <dt>{% trans "Max dimensions" %}</dt>
+                            <dd>{{ original_image.width|unlocalize }}x{{ original_image.height|unlocalize }}</dd>
+                            <dt>{% trans "Filesize" %}</dt>
+                            <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
 
-                    <dl>
-                        <dt>{% trans "Max dimensions" %}</dt>
-                        <dd>{{ original_image.width|unlocalize }}x{{ original_image.height|unlocalize }}</dd>
-                        <dt>{% trans "Filesize" %}</dt>
-                        <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
-
-                        <dt>{% trans "Usage" %}</dt>
-                        <dd>
-                            <a href="{{ image.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
-                        </dd>
-                    </dl>
+                            <dt>{% trans "Usage" %}</dt>
+                            <dd>
+                                <a href="{{ image.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                            </dd>
+                        </dl>
+                    {% endblock %}
                 </div>
             </div>
         </div>

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -56,17 +56,19 @@
                 <div class="w-col-span-1">
                     {% image image original as original_image %}
 
-                    <dl>
-                        <dt>{% trans "Max dimensions" %}</dt>
-                        <dd>{{ original_image.width|unlocalize }}x{{ original_image.height|unlocalize }}</dd>
-                        <dt>{% trans "Filesize" %}</dt>
-                        <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
+                    {% block stats %}
+                        <dl>
+                            <dt>{% trans "Max dimensions" %}</dt>
+                            <dd>{{ original_image.width|unlocalize }}x{{ original_image.height|unlocalize }}</dd>
+                            <dt>{% trans "Filesize" %}</dt>
+                            <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
 
-                        <dt>{% trans "Usage" %}</dt>
-                        <dd>
-                            <a href="{{ image.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
-                        </dd>
-                    </dl>
+                            <dt>{% trans "Usage" %}</dt>
+                            <dd>
+                                <a href="{{ image.usage_url }}">{% blocktrans trimmed with usage_count=usage_count_val|intcomma count usage_count_val=usage_count_val %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                            </dd>
+                        </dl>
+                    {% endblock %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

Adds dedicated template blocks around the metadata/stats sections in the image and document edit templates.

Fixes #14356

### Changes

- Added `document_stats` block in `wagtaildocs/documents/edit.html`
- Added `image_stats` block in `wagtailimages/images/edit.html`

This allows downstream projects to extend the stats section without overriding the entire template.

### Testing

- Verified the document edit page loads correctly.
- Verified the image edit page loads correctly.
- Existing behaviour remains unchanged.