### PR TITLE
Fix float truncation in Vector and Rect __repr__

### DIFF
--- a/wagtail/images/rect.py
+++ b/wagtail/images/rect.py
@@ -16,7 +16,7 @@ class Vector:
         return tuple(self) == tuple(other)
 
     def __repr__(self):
-        return "Vector(x: %d, y: %d)" % (self.x, self.y)
+        return f"Vector(x: {self.x}, y: {self.y})"
 
 
 class Rect:
@@ -185,12 +185,7 @@ class Rect:
         return tuple(self) == tuple(other)
 
     def __repr__(self):
-        return "Rect(left: %d, top: %d, right: %d, bottom: %d)" % (
-            self.left,
-            self.top,
-            self.right,
-            self.bottom,
-        )
+        return f"Rect(left: {self.left}, top: {self.top}, right: {self.right}, bottom: {self.bottom})"
 
     @classmethod
     def from_point(cls, x, y, width, height):

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -712,6 +712,15 @@ class TestRect(TestCase):
             repr(rect), "Rect(left: 100, top: 150, right: 200, bottom: 250)"
         )
 
+    def test_repr_float_coords(self):
+        rect = Rect(0, 0, 10, 10)
+        rect.size = Vector(7, 7)
+        self.assertIn("1.5", repr(rect))
+
+    def test_vector_repr(self):
+        self.assertEqual(repr(Vector(100, 200)), "Vector(x: 100, y: 200)")
+        self.assertEqual(repr(Vector(1.7, 3.9)), "Vector(x: 1.7, y: 3.9)")
+
     def test_from_point(self):
         rect = Rect.from_point(100, 200, 50, 20)
         self.assertEqual(rect, Rect(75, 190, 125, 210))


### PR DESCRIPTION
Fixes #14382

### Description

`Vector.__repr__` and `Rect.__repr__` in `wagtail/images/rect.py` used `%d`
formatting which silently truncates float coordinates to integers. Coordinates
can be floats after operations like `_set_size()` and `_set_centroid()`, so
`repr()` was returning misleading output during debugging.

Updated both methods to use f-strings, consistent with the rest of the codebase.
Added tests to cover float coordinate cases.


### AI usage

to write the unit test cases 
