### PR TITLE
Fix AttributeError when no sites exist in URLGeneratorView

### DIFF
--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -39,6 +39,7 @@ from wagtail.models import (
     Collection,
     GroupCollectionPermission,
     Page,
+    Site,
     UploadedFile,
     get_root_collection_id,
 )
@@ -4253,6 +4254,23 @@ class TestURLGeneratorView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         self.assertEqual(len(messages), 1)
         self.assertIn(
             "The filter options you have selected are not valid.", messages[0]
+        )
+
+    def test_get_with_no_sites(self):
+        """
+        This tests that the view does not crash with an AttributeError when no
+        sites exist. The result_url should be a relative path (no domain prefix).
+        """
+        Site.objects.all().delete()
+
+        response = self.client.get(
+            reverse("wagtailimages:url_generator", args=(self.image.id,))
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["result_url"].startswith("http"))
+        self.assertTrue(
+            response.context["result_url"].endswith(f"/{self.image.id}/original/")
         )
 
 

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -399,7 +399,8 @@ class URLGeneratorView(generic.InspectView):
         try:
             site_root_url = Site.objects.get(is_default_site=True).root_url
         except Site.DoesNotExist:
-            site_root_url = Site.objects.first().root_url
+            first_site = Site.objects.first()
+            site_root_url = first_site.root_url if first_site else ""
 
         # Generate preview url
         preview_url = reverse("wagtailimages:preview", args=(image_id, filter_spec))


### PR DESCRIPTION
Fixes #14384

### Description

When no sites are configured, `Site.objects.first()` returns `None` and
calling `.root_url` on it causes an `AttributeError`. Added a None check
so `site_root_url` falls back to an empty string, returning a relative URL
instead of crashing.

### AI usage

For writing the unit test case 