### PR TITLE
Fix ValueError and InvalidPage crash in workflow edit view for invalid page number

### DIFF
--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -736,6 +736,14 @@ class TestWorkflowsEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
             row.find(id="id_pages-0-DELETE").attrs["data-w-formset-target"],
         )
 
+    def test_get_with_invalid_page_number(self):
+        response = self.get({"p": "abc"})
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_with_out_of_range_page_number(self):
+        response = self.get({"p": "99999"})
+        self.assertEqual(response.status_code, 200)
+
     def test_post(self):
         response = self.post(
             {

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -2,7 +2,7 @@ import django_filters
 from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
-from django.core.paginator import Paginator
+from django.core.paginator import InvalidPage, Paginator
 from django.db import transaction
 from django.db.models import Count, Prefetch
 from django.db.models.functions import Lower
@@ -300,8 +300,11 @@ class Edit(EditView):
         # Get the (paginated) list of Pages to which this Workflow is assigned.
         pages = Page.objects.filter(workflowpage__workflow=self.get_object())
         pages.paginator = Paginator(pages, self.MAX_PAGES)
-        page_number = int(self.request.GET.get("p", 1))
-        paginated_pages = pages.paginator.page(page_number)
+        try:
+            page_number = int(self.request.GET.get("p", 1))
+            paginated_pages = pages.paginator.page(page_number)
+        except (ValueError, InvalidPage):
+            paginated_pages = pages.paginator.page(1)
         return paginated_pages
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Fixes #14386

### Description

When an invalid value is provided for the `p` query parameter in the
workflow edit view, the view crashes with either a `ValueError` (non-numeric
input like `?p=abc`) or `InvalidPage` (out-of-range number like `?p=99999`).

Added a try/except to fall back to page 1 on invalid input. The same
pattern is already handled correctly in `ordering.py`.

### AI usage

Assists me while writing the unit tests 