### PR TITLE
Fix Page.DoesNotExist crash in bulk action when childOf page does not…

### DIFF
--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_publish.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_publish.py
@@ -104,6 +104,16 @@ class TestBulkPublish(WagtailTestUtils, TestCase):
         # Check that the user received a 404 response
         self.assertEqual(response.status_code, 404)
 
+    def test_publish_view_invalid_child_of(self):
+        response = self.client.get(
+            reverse(
+                "wagtail_bulk_action",
+                args=("wagtailcore", "page", "publish"),
+            )
+            + "?id=all&childOf=99999"
+        )
+        self.assertEqual(response.status_code, 404)
+
     def test_publish_view_bad_permissions(self):
         """
         This tests that the publish view doesn't allow users without publish permissions

--- a/wagtail/admin/views/pages/bulk_actions/page_bulk_action.py
+++ b/wagtail/admin/views/pages/bulk_actions/page_bulk_action.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.shortcuts import get_object_or_404
 from django.utils.translation import ngettext
 
 from wagtail.admin.views.bulk_action import BulkAction
@@ -22,7 +23,7 @@ class PageBulkAction(BulkAction):
             q = self.request.GET.get("q", "")
 
         if parent_id is not None:
-            listing_objects = listing_objects.get(id=parent_id)
+            listing_objects = get_object_or_404(self.model, id=parent_id)
             # If we're searching, include the descendants as well.
             # Otherwise, just include the direct children.
             if q:


### PR DESCRIPTION
Fixes #14388

### Description

When performing a bulk action with "Select all in listing", the URL
contains `id=all&childOf=<page_id>`. If the page referenced by `childOf`
no longer exists (e.g. deleted by another admin while the listing was open),
the view crashes with an unhandled `Page.DoesNotExist` (500 error).

Replaced the unguarded `.get()` call with `get_object_or_404()`, consistent
with how all other page views in the codebase handle this case.

### AI usage

Assist me while writing the unit tests