### PR TITLE
Replaced uses of AccessibilityItem with ContentCheckerItem. Fixes the Checks side panel

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,6 +53,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~~
 
  * Fix: Ensure models with a UUID primary key can be previewed when creating a new instance (Sébastien Corbin)
+ * Fix: Ensure the checks side panel recognises custom `ContentCheckerItem` subclasses (Robert Rollins)
  * Maintenance: Update base managers for Page and Collection to avoid warnings from django-treebeard 5.3 (Samir Shah)
 
 

--- a/docs/releases/7.4.3.md
+++ b/docs/releases/7.4.3.md
@@ -14,6 +14,7 @@ depth: 1
 ### Bug fixes
 
  * Ensure models with a UUID primary key can be previewed when creating a new instance (Sébastien Corbin)
+ * Ensure the checks side panel recognises custom `ContentCheckerItem` subclasses (Robert Rollins)
 
 ### Maintenance
 

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -10,6 +10,7 @@ from django.utils.translation import gettext
 from wagtail import hooks
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.ui.components import Component
+from wagtail.admin.ui.side_panels import ChecksSidePanel
 from wagtail.admin.userbar import AccessibilityItem, ContentCheckerItem, Userbar
 from wagtail.coreutils import get_dummy_request
 from wagtail.models import PAGE_TEMPLATE_VAR, Locale, Site
@@ -353,6 +354,32 @@ class TestContentCheckerConfig(WagtailTestUtils, TestCase):
                     },
                 },
             )
+
+    def test_checks_side_panel_respects_custom_config(self):
+        class CustomMessageContentCheckerItem(ContentCheckerItem):
+            axe_messages = {
+                "empty-heading": {
+                    "error_name": "Headings should not be empty!",
+                    "help_text": "Use meaningful text!",
+                },
+            }
+
+        with hooks.register_temporarily(
+            "construct_wagtail_userbar",
+            self.get_hook(CustomMessageContentCheckerItem),
+        ):
+            panel = ChecksSidePanel(object=Page.objects.get(id=2), request=self.request)
+            config = panel.get_axe_configuration()
+
+        self.assertEqual(
+            config["messages"],
+            {
+                "empty-heading": {
+                    "error_name": "Headings should not be empty!",
+                    "help_text": "Use meaningful text!",
+                },
+            },
+        )
 
     def test_unset_run_only(self):
         class UnsetRunOnlyContentCheckerItem(ContentCheckerItem):

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -4,7 +4,11 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy, ngettext
 
 from wagtail.admin.ui.components import Component
-from wagtail.admin.userbar import AccessibilityItem, ContentCheckerItem, apply_userbar_hooks
+from wagtail.admin.userbar import (
+    AccessibilityItem,
+    ContentCheckerItem,
+    apply_userbar_hooks,
+)
 from wagtail.models import DraftStateMixin, LockableMixin, Page, ReferenceIndex
 from wagtail.models.view_restrictions import BaseViewRestriction
 

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -4,7 +4,7 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy, ngettext
 
 from wagtail.admin.ui.components import Component
-from wagtail.admin.userbar import AccessibilityItem, apply_userbar_hooks
+from wagtail.admin.userbar import ContentCheckerItem, apply_userbar_hooks
 from wagtail.models import DraftStateMixin, LockableMixin, Page, ReferenceIndex
 from wagtail.models.view_restrictions import BaseViewRestriction
 
@@ -334,12 +334,12 @@ class ChecksSidePanel(BaseSidePanel):
 
     def get_axe_configuration(self):
         # Retrieve the Axe configuration from the userbar.
-        userbar_items = [AccessibilityItem(in_editor=True)]
+        userbar_items = [ContentCheckerItem(in_editor=True)]
         page = self.object if issubclass(self.model, Page) else None
         apply_userbar_hooks(self.request, userbar_items, page)
 
         for item in userbar_items:
-            if isinstance(item, AccessibilityItem):
+            if isinstance(item, ContentCheckerItem):
                 return item.get_axe_configuration(self.request)
 
     def get_context_data(self, parent_context):

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -4,7 +4,7 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy, ngettext
 
 from wagtail.admin.ui.components import Component
-from wagtail.admin.userbar import ContentCheckerItem, apply_userbar_hooks
+from wagtail.admin.userbar import AccessibilityItem, ContentCheckerItem, apply_userbar_hooks
 from wagtail.models import DraftStateMixin, LockableMixin, Page, ReferenceIndex
 from wagtail.models.view_restrictions import BaseViewRestriction
 
@@ -334,7 +334,7 @@ class ChecksSidePanel(BaseSidePanel):
 
     def get_axe_configuration(self):
         # Retrieve the Axe configuration from the userbar.
-        userbar_items = [ContentCheckerItem(in_editor=True)]
+        userbar_items = [AccessibilityItem(in_editor=True)]
         page = self.object if issubclass(self.model, Page) else None
         apply_userbar_hooks(self.request, userbar_items, page)
 

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -5,7 +5,11 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy, ngettext
 
 from wagtail.admin.ui.components import Component
-from wagtail.admin.userbar import AccessibilityItem, apply_userbar_hooks
+from wagtail.admin.userbar import (
+    AccessibilityItem,
+    ContentCheckerItem,
+    apply_userbar_hooks,
+)
 from wagtail.models import AbstractPage, DraftStateMixin, LockableMixin, ReferenceIndex
 from wagtail.models.view_restrictions import BaseViewRestriction
 
@@ -343,7 +347,7 @@ class ChecksSidePanel(BaseSidePanel):
         apply_userbar_hooks(self.request, userbar_items, page)
 
         for item in userbar_items:
-            if isinstance(item, AccessibilityItem):
+            if isinstance(item, ContentCheckerItem):
                 return item.get_axe_configuration(self.request)
 
     def get_context_data(self, parent_context):

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -356,7 +356,7 @@ class Userbar(Component):
 
             if in_preview_panel:
                 items = [
-                    ContentCheckerItem(),
+                    AccessibilityItem(),
                 ]
             elif isinstance(self.object, Page) and self.object.pk:
                 if revision_id:
@@ -365,7 +365,7 @@ class Userbar(Component):
                         AdminItem(),
                         ExplorePageItem(revision.content_object),
                         EditPageItem(revision.content_object),
-                        ContentCheckerItem(),
+                        AccessibilityItem(),
                     ]
                 else:
                     # Not a revision
@@ -374,13 +374,13 @@ class Userbar(Component):
                         ExplorePageItem(self.object),
                         EditPageItem(self.object),
                         AddPageItem(self.object),
-                        ContentCheckerItem(),
+                        AccessibilityItem(),
                     ]
             else:
                 # Not a page.
                 items = [
                     AdminItem(),
-                    ContentCheckerItem(),
+                    AccessibilityItem(),
                 ]
 
             apply_userbar_hooks(request, items, self.object)

--- a/wagtail/admin/userbar.py
+++ b/wagtail/admin/userbar.py
@@ -356,7 +356,7 @@ class Userbar(Component):
 
             if in_preview_panel:
                 items = [
-                    AccessibilityItem(),
+                    ContentCheckerItem(),
                 ]
             elif isinstance(self.object, Page) and self.object.pk:
                 if revision_id:
@@ -365,7 +365,7 @@ class Userbar(Component):
                         AdminItem(),
                         ExplorePageItem(revision.content_object),
                         EditPageItem(revision.content_object),
-                        AccessibilityItem(),
+                        ContentCheckerItem(),
                     ]
                 else:
                     # Not a revision
@@ -374,13 +374,13 @@ class Userbar(Component):
                         ExplorePageItem(self.object),
                         EditPageItem(self.object),
                         AddPageItem(self.object),
-                        AccessibilityItem(),
+                        ContentCheckerItem(),
                     ]
             else:
                 # Not a page.
                 items = [
                     AdminItem(),
-                    AccessibilityItem(),
+                    ContentCheckerItem(),
                 ]
 
             apply_userbar_hooks(request, items, self.object)


### PR DESCRIPTION
ContentCheckerItem replaced AccessibilityItem in 7.4, but some code that had been referencing AccessibilityItem still uses the old class. This causes mismatches with properly updated user code that derives from ContentCheckerItem.

In particular, it breaks ChecksSidePanel.get_axe_configuration(), which incorrectly checks for AccessibilityItem before running item.get_axe_configuration(). This causes subclasses of ContentCheckerItem to have their method calls skipped, which breaks the Checks side panel, causing it to render blank metrics and display "0 accessibility issues" even when there are actual issues.

This change does not affect any tests, and since AccessibilityItem is a subclass of ContentCheckerItem, the behavior in ChecksSidePanel.get_axe_configuration() doesn't change, except to fix the bug that makes it ignore actual ContentCheckerItems.

### AI usage

None