### PR TITLE
 Create a registry for permission policies (take N)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~~~~~
 
  * Support for custom base page models (Matt Westcott)
+ * Create a global registry for permission policies (Sage Abdullah)
  * Add customizability for all remaining page views to `PageViewSet` (Sage Abdullah)
  * Set `FieldPanel(required_on_save=True)` for `AbstractFormField`'s `field_type` field (Alex Tomkins)
  * Handle pasting of multiple tags separated by newlines or commas (Matthias Brück)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -440,6 +440,7 @@ def setup(app):
         indextemplate="pair: %s; field lookup type",
     )
 
+    from django.db.models import Model
     from django.http import HttpRequest
 
     from wagtail.admin.ui.components import Component
@@ -448,6 +449,7 @@ def setup(app):
         # Stop Sphinx from looking in the wrong place for HttpRequest when resolving
         # type annotations - see https://github.com/wagtail/wagtail/pull/12777
         HttpRequest: "django.http",
+        Model: "django.db.models",
         # Document `Component` as part of our own API instead of Laces for
         # cross-linking, as the latter does not use Sphinx for docs.
         Component: "wagtail.admin.ui.components",

--- a/docs/extending/generic_views.md
+++ b/docs/extending/generic_views.md
@@ -44,25 +44,17 @@ class PersonViewSet(ModelViewSet):
 person_viewset = PersonViewSet("person")  # defines /admin/person/ as the base URL
 ```
 
-Before enabling the viewset, the model must be registered to Wagtail's permission system using {func}`~wagtail.permissions.register_permission_policy`. Then, the viewset can be registered with the Wagtail admin to make it available under the URL `/admin/person/`. To do so, add the following to `wagtail_hooks.py`:
+This viewset can then be registered with the Wagtail admin to make it available under the URL `/admin/person/`, by adding the following to `wagtail_hooks.py`:
 
 ```python
 from wagtail import hooks
-from wagtail.permissions import register_permission_policy
 
-from .models import Person
 from .views import person_viewset
-
-register_permission_policy(Person)
 
 
 @hooks.register("register_admin_viewset")
 def register_viewset():
     return person_viewset
-```
-
-```{versionchanged} 8.0
-Models registered with `ModelViewSet` must also be registered to Wagtail's permission system.
 ```
 
 The viewset can be further customized by overriding other attributes and methods.
@@ -257,16 +249,12 @@ class PersonChooserViewSet(ChooserViewSet):
 person_chooser_viewset = PersonChooserViewSet("person_chooser")
 ```
 
-After registering the model to Wagtail's permission system using {func}`~wagtail.permissions.register_permission_policy`, the chooser viewset can be registered with the `register_admin_viewset` hook:
+Again this can be registered with the `register_admin_viewset` hook:
 
 ```python
 from wagtail import hooks
-from wagtail.permissions import register_permission_policy
 
-from .models import Person
 from .views import person_chooser_viewset
-
-register_permission_policy(Person)  # If not already done
 
 
 @hooks.register("register_admin_viewset")

--- a/docs/extending/generic_views.md
+++ b/docs/extending/generic_views.md
@@ -44,17 +44,25 @@ class PersonViewSet(ModelViewSet):
 person_viewset = PersonViewSet("person")  # defines /admin/person/ as the base URL
 ```
 
-This viewset can then be registered with the Wagtail admin to make it available under the URL `/admin/person/`, by adding the following to `wagtail_hooks.py`:
+Before enabling the viewset, the model must be registered to Wagtail's permission system using {func}`~wagtail.permissions.register_permission_policy`. Then, the viewset can be registered with the Wagtail admin to make it available under the URL `/admin/person/`. To do so, add the following to `wagtail_hooks.py`:
 
 ```python
 from wagtail import hooks
+from wagtail.permissions import register_permission_policy
 
+from .models import Person
 from .views import person_viewset
+
+register_permission_policy(Person)
 
 
 @hooks.register("register_admin_viewset")
 def register_viewset():
     return person_viewset
+```
+
+```{versionchanged} 8.0
+Models registered with `ModelViewSet` must also be registered to Wagtail's permission system.
 ```
 
 The viewset can be further customized by overriding other attributes and methods.
@@ -249,12 +257,16 @@ class PersonChooserViewSet(ChooserViewSet):
 person_chooser_viewset = PersonChooserViewSet("person_chooser")
 ```
 
-Again this can be registered with the `register_admin_viewset` hook:
+After registering the model to Wagtail's permission system using {func}`~wagtail.permissions.register_permission_policy`, the chooser viewset can be registered with the `register_admin_viewset` hook:
 
 ```python
 from wagtail import hooks
+from wagtail.permissions import register_permission_policy
 
+from .models import Person
 from .views import person_chooser_viewset
+
+register_permission_policy(Person)  # If not already done
 
 
 @hooks.register("register_admin_viewset")

--- a/docs/reference/contrib/settings.md
+++ b/docs/reference/contrib/settings.md
@@ -1,3 +1,5 @@
+(settings_models)=
+
 # Settings models
 
 The `wagtail.contrib.settings` module allows you to define models that hold

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -16,6 +16,7 @@ hooks
 signals
 settings
 project_template
+permissions
 jinja2
 panels
 viewsets

--- a/docs/reference/permissions.md
+++ b/docs/reference/permissions.md
@@ -1,0 +1,109 @@
+(permissions_reference)=
+
+# Permissions
+
+```{note}
+This document covers the internals of Wagtail's permissions system. You should read about [how Wagtail makes use of Django's permissions system](permissions_overview) first.
+
+Please note that aside from the {func}`~wagtail.permissions.register_permission_policy` function, the APIs described in this document are considered internal and thus are not subject to our [](deprecation_policy).
+```
+
+At the basic level, Wagtail's permission system is implemented using a set of classes called "permission policies" that define the permission rules for a given Django model. Whenever a permission test is performed, a global registry is consulted to determine the permission policy instance to use for a given Django model. As such, any model managed within Wagtail should register a corresponding permission policy instance to the global registry.
+
+Other supporting code (not documented here) is used by pages and snippets to cater for more specific permission checks needed by features such as publishing, locking, and workflows. As a result, the following should not be considered a comprehensive documentation of how Wagtail does permission checks.
+
+## Permission policies
+
+```{eval-rst}
+.. autoclass:: wagtail.permission_policies.BasePermissionPolicy
+
+   .. automethod:: get_all_permissions_for_user
+   .. automethod:: get_cached_permissions_for_user
+   .. automethod:: user_has_permission
+   .. automethod:: user_has_any_permission
+   .. automethod:: users_with_any_permission
+   .. automethod:: users_with_permission
+   .. automethod:: user_has_permission_for_instance
+   .. automethod:: user_has_any_permission_for_instance
+   .. automethod:: instances_user_has_any_permission_for
+   .. automethod:: instances_user_has_permission_for
+   .. automethod:: users_with_any_permission_for_instance
+   .. automethod:: users_with_permission_for_instance
+
+.. autoclass:: wagtail.permission_policies.BaseDjangoAuthPermissionPolicy
+
+.. autoclass:: wagtail.permission_policies.ModelPermissionPolicy
+
+.. autoclass:: wagtail.permission_policies.OwnershipPermissionPolicy
+
+.. autoclass:: wagtail.permission_policies.collections.CollectionPermissionPolicy
+
+.. autoclass:: wagtail.permission_policies.collections.CollectionOwnershipPermissionPolicy
+
+.. autoclass:: wagtail.permission_policies.collections.CollectionManagementPermissionPolicy
+
+.. autoclass:: wagtail.permission_policies.pages.PagePermissionPolicy
+
+.. autoclass:: wagtail.permission_policies.sites.SitePermissionPolicy
+```
+
+## Permission policy registry
+
+```{eval-rst}
+.. autoclass:: wagtail.permissions.PolicyRegistry
+
+   .. automethod:: get_by_type
+   .. automethod:: get
+
+.. autodata:: wagtail.permissions.policies_registry
+```
+
+Retrieving a permission policy for a given Django model class or instance can be done as below.
+
+```py
+from wagtail.permissions import policies_registry
+from .models import MyModel
+
+# With the model class
+policies_registry.get_by_type(MyModel)
+# With a model instance
+policies_registry.get(MyModel.objects.first())
+```
+
+```{eval-rst}
+.. autofunction:: wagtail.permissions.register_permission_policy
+```
+
+To register a permission policy for a model, call this function at the top of
+the model app's `wagtail_hooks.py`.
+
+```py
+# wagtail_hooks.py
+from wagtail.permissions import register_permission_policy
+from .models import MyModel
+
+
+register_permission_policy(MyModel)
+...  # More customizations
+```
+
+Alternatively, you can also call the function from the
+[`AppConfig.ready()`](django.apps.AppConfig.ready) method.
+
+```py
+# apps.py
+class MyAppConfig(AppConfig):
+    ...
+
+    def ready(self):
+        from wagtail.permissions import register_permission_policy
+        from .models import MyModel
+
+        register_permission_policy(MyModel)
+```
+
+```{note}
+Currently, `register_permission_policy(MyModel)` is the only officially supported use case of this function.
+
+While it is possible to register a custom permission policy instance for any model (including Wagtail's built-in models), we cannot guarantee that a custom permissions implementation would always be respected by Wagtail. We intend to support this in the future. Refer to our issue tracker for [supporting custom permission behavior](https://github.com/wagtail/wagtail/issues/2907) for more details.
+```

--- a/docs/reference/permissions.md
+++ b/docs/reference/permissions.md
@@ -55,19 +55,19 @@ Other supporting code (not documented here) is used by pages and snippets to cat
    .. automethod:: get_by_type
    .. automethod:: get
 
-.. autodata:: wagtail.permissions.policies_registry
+.. autodata:: wagtail.permissions.policy_registry
 ```
 
 Retrieving a permission policy for a given Django model class or instance can be done as below.
 
 ```py
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from .models import MyModel
 
 # With the model class
-policies_registry.get_by_type(MyModel)
+policy_registry.get_by_type(MyModel)
 # With a model instance
-policies_registry.get(MyModel.objects.first())
+policy_registry.get(MyModel.objects.first())
 ```
 
 ```{eval-rst}

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -82,6 +82,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. automethod:: get_form_class
    .. automethod:: get_edit_handler
    .. automethod:: get_permissions_to_register
+   .. autoattribute:: permission_policy
 
    .. autoattribute:: menu_label
 
@@ -94,13 +95,13 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: sort_order_field
    .. autoattribute:: list_per_page
    .. autoattribute:: list_display
-   
+
         This list will be passed to the ``list_display`` attribute of the index
         view. If left unset, the ``list_display`` attribute of the index view
         will be used instead, which by default is defined as a list containing
         ``"__str__"``, :class:`LocaleColumn() <wagtail.admin.ui.tables.LocaleColumn>`,
         and :class:`UpdatedAtColumn() <wagtail.admin.ui.tables.UpdatedAtColumn>`.
-    
+
         Note that the ``LocaleColumn`` is only included if the model is translatable.
    .. autoattribute:: list_export
    .. autoattribute:: list_filter
@@ -152,6 +153,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    Required; the model class that this viewset will work with.
 
    .. autoattribute:: icon
+   .. autoattribute:: permission_policy
    .. autoattribute:: choose_one_text
    .. autoattribute:: page_title
    .. autoattribute:: choose_another_text

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -114,6 +114,39 @@ Support for older versions will be dropped in a future release.
 
 Reusable apps that work with the `Page` model are likely to require updating in order to be usable on projects that use the new custom base page model feature. This process is detailed at [](reusable_app_base_page).
 
+### Custom models managed in Wagtail must register a permission policy
+
+If you have a model registered with Wagtail, such as via {class}`~wagtail.admin.viewsets.model.ModelViewSet`, {class}`~wagtail.snippets.views.snippets.SnippetViewSet`, {class}`~wagtail.admin.viewsets.chooser.ChooserViewSet` (as described in [](generic_views)) or through other means, you must now register a corresponding permission policy for it.
+
+Registering a permission policy can be done by calling `wagtail.permissions.register_permission_policy(Model)` at the top of the model app's `wagtail_hooks.py`.
+
+```py
+# wagtail_hooks.py
+from wagtail.permissions import register_permission_policy
+from .models import MyModel
+
+
+register_permission_policy(MyModel)
+...  # More customizations
+```
+
+Alternatively, you can also put the registration in the app's `AppConfig`.
+
+```py
+# apps.py
+class MyAppConfig(AppConfig):
+    ...
+
+    def ready(self):
+        from wagtail.permissions import register_permission_policy
+        from .models import MyModel
+
+        register_permission_policy(MyModel)
+```
+
+If you do not register a permission policy, Wagtail will use a default policy as before (or the {attr}`~wagtail.admin.viewsets.model.ModelViewSet.permission_policy` if set on the viewset), and a deprecation warning will be raised. This support will be removed in a future release.
+
+
 ### `SnippetChooserViewSet.widget_class` is now a class
 
 The [`SnippetChooserViewSet.widget_class`](wagtail.snippets.views.chooser.SnippetChooserViewSet.widget_class) attribute now correctly returns a widget class instead of an instance, consistent with [`ChooserViewSet.widget_class`](wagtail.admin.viewsets.chooser.ChooserViewSet.widget_class). This change may require updates to any customizations that relied on the previous behavior, such as an override in a `SnippetChooserViewSet` subclass that uses `super().widget_class`.

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -19,6 +19,12 @@ Wagtail 8.0 introduces a new API transport layer at `/api/v3/`, built on [Django
 
 This release introduces [the ability to swap out the base `Page` model](custom_page_models) with a custom project-specific model. Any fields and methods defined on this model will be shared by all page types. This feature is only supported for newly-created projects, and certain add-on packages may not yet be compatible with it (see [](reusable_app_base_page)). This feature was developed by Matt Westcott.
 
+### Permission policy registry
+
+A permission policy for every model managed by Wagtail is now registered to a global permission policy registry. The registry allows you to retrieve the permission policy of a model from anywhere in the code, which can be useful for performing permission checks outside of a view's request-response cycle, such as in a background task. It can also be used to implement custom permission logic, including for Wagtail's built-in models.
+
+For more details, refer to the [](permissions_reference) reference documentation. This feature was developed by Sage Abdullah.
+
 ### Other features
 
  * Add customizability for all remaining page views to `PageViewSet` (Sage Abdullah)

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -118,7 +118,9 @@ Reusable apps that work with the `Page` model are likely to require updating in 
 
 If you have a model registered with Wagtail, such as via {class}`~wagtail.admin.viewsets.model.ModelViewSet`, {class}`~wagtail.snippets.views.snippets.SnippetViewSet`, {class}`~wagtail.admin.viewsets.chooser.ChooserViewSet` (as described in [](generic_views)) or through other means, you must now register a corresponding permission policy for it.
 
-Registering a permission policy can be done by calling `wagtail.permissions.register_permission_policy(Model)` at the top of the model app's `wagtail_hooks.py`.
+Registering a permission policy can be done by calling
+[`register_permission_policy(Model)`](wagtail.permissions.register_permission_policy)
+at the top of the model app's `wagtail_hooks.py`.
 
 ```py
 # wagtail_hooks.py
@@ -130,7 +132,8 @@ register_permission_policy(MyModel)
 ...  # More customizations
 ```
 
-Alternatively, you can also put the registration in the app's `AppConfig`.
+Alternatively, you can also put the registration in the app's
+[`AppConfig.ready()`](django.apps.AppConfig.ready).
 
 ```py
 # apps.py

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -114,12 +114,12 @@ Support for older versions will be dropped in a future release.
 
 Reusable apps that work with the `Page` model are likely to require updating in order to be usable on projects that use the new custom base page model feature. This process is detailed at [](reusable_app_base_page).
 
-### Custom models managed in Wagtail must register a permission policy
+### Custom permission policy in viewsets must be registered separately
 
-If you have a model registered with Wagtail, such as via {class}`~wagtail.admin.viewsets.model.ModelViewSet`, {class}`~wagtail.snippets.views.snippets.SnippetViewSet`, {class}`~wagtail.admin.viewsets.chooser.ChooserViewSet` (as described in [](generic_views)) or through other means, you must now register a corresponding permission policy for it.
+If you use the [](generic_views) and have a {class}`~wagtail.admin.viewsets.model.ModelViewSet`, {class}`~wagtail.snippets.views.snippets.SnippetViewSet`, or {class}`~wagtail.admin.viewsets.chooser.ChooserViewSet` that defines a custom value for the (previously-undocumented) {attr}`~wagtail.admin.viewsets.model.ModelViewSet.permission_policy`, you must now register the permission policy separately.
 
 Registering a permission policy can be done by calling
-[`register_permission_policy(Model)`](wagtail.permissions.register_permission_policy)
+[`register_permission_policy(Model, <policy_instance>)`](wagtail.permissions.register_permission_policy)
 at the top of the model app's `wagtail_hooks.py`.
 
 ```py
@@ -128,7 +128,7 @@ from wagtail.permissions import register_permission_policy
 from .models import MyModel
 
 
-register_permission_policy(MyModel)
+register_permission_policy(MyModel, my_custom_policy_instance)
 ...  # More customizations
 ```
 
@@ -144,10 +144,12 @@ class MyAppConfig(AppConfig):
         from wagtail.permissions import register_permission_policy
         from .models import MyModel
 
-        register_permission_policy(MyModel)
+        register_permission_policy(MyModel, my_custom_policy_instance)
 ```
 
-If you do not register a permission policy, Wagtail will use a default policy as before (or the {attr}`~wagtail.admin.viewsets.model.ModelViewSet.permission_policy` if set on the viewset), and a deprecation warning will be raised. This support will be removed in a future release.
+If you do not register the permission policy explicitly, Wagtail will automatically register the viewset's `permission_policy`, and a deprecation warning will be raised. This support will be removed in a future release.
+
+This change does not affect viewsets that do not have a custom `permission_policy`.
 
 
 ### `SnippetChooserViewSet.widget_class` is now a class

--- a/docs/topics/permissions.md
+++ b/docs/topics/permissions.md
@@ -4,6 +4,8 @@
 
 Wagtail adapts and extends [the Django permission system](inv:django#topic-authorization) to cater to the needs of website content creation, such as moderation workflows, and multiple teams working on different areas of a site (or multiple sites within the same Wagtail installation). Permissions can be configured through the 'Groups' area of the Wagtail admin interface, under 'Settings'.
 
+This document provides an introduction to the basics of how permissions can be configured in the Wagtail admin. For a more detailed look at how permissions are implemented in Wagtail, refer to [Permissions reference](permissions_reference).
+
 ```{note}
 Whilst Wagtail supports a number of user roles and permissions, the Wagtail Admin should still be restricted to trusted users.
 ```

--- a/docs/topics/snippets/registering.md
+++ b/docs/topics/snippets/registering.md
@@ -2,21 +2,7 @@
 
 # Registering snippets
 
-Before registering a snippet model for use in the admin, it must be registered with Wagtail's permission system using {func}`~wagtail.permissions.register_permission_policy`. This can be done by adding the following at the top of `wagtail_hooks.py`:
-
-```python
-from wagtail.permissions import register_permission_policy
-
-from .models import Advert
-
-register_permission_policy(Advert)
-```
-
-```{versionchanged} 8.0
-Snippets must also be registered to Wagtail's permission system.
-```
-
-Snippets can then be registered using `register_snippet` as a decorator or as a function. The latter is recommended, but the decorator is provided for convenience and backward compatibility.
+Snippets can be registered using `register_snippet` as a decorator or as a function. The latter is recommended, but the decorator is provided for convenience and backward compatibility.
 
 ## Using `@register_snippet` as a decorator
 

--- a/docs/topics/snippets/registering.md
+++ b/docs/topics/snippets/registering.md
@@ -2,7 +2,21 @@
 
 # Registering snippets
 
-Snippets can be registered using `register_snippet` as a decorator or as a function. The latter is recommended, but the decorator is provided for convenience and backward compatibility.
+Before registering a snippet model for use in the admin, it must be registered with Wagtail's permission system using {func}`~wagtail.permissions.register_permission_policy`. This can be done by adding the following at the top of `wagtail_hooks.py`:
+
+```python
+from wagtail.permissions import register_permission_policy
+
+from .models import Advert
+
+register_permission_policy(Advert)
+```
+
+```{versionchanged} 8.0
+Snippets must also be registered to Wagtail's permission system.
+```
+
+Snippets can then be registered using `register_snippet` as a decorator or as a function. The latter is recommended, but the decorator is provided for convenience and backward compatibility.
 
 ## Using `@register_snippet` as a decorator
 

--- a/wagtail/actions/base.py
+++ b/wagtail/actions/base.py
@@ -48,14 +48,9 @@ class BaseAction:
         ``wagtail.permission_policies.ModelPermissionPolicy`` for models
         that have not registered one.
         """
-        from wagtail.permission_policies import ModelPermissionPolicy
+        from wagtail.permissions import policies_registry
 
-        # FIXME: use the registry when it's implemented.
-        # from wagtail.permissions import policies_registry
-        # permission_policy = policies_registry.get(self.instance)
-        permission_policy = ModelPermissionPolicy(type(self.instance))
-
-        return permission_policy
+        return policies_registry.get(self.instance)
 
     def user_has_permission(self):
         """

--- a/wagtail/actions/base.py
+++ b/wagtail/actions/base.py
@@ -48,9 +48,9 @@ class BaseAction:
         ``wagtail.permission_policies.ModelPermissionPolicy`` for models
         that have not registered one.
         """
-        from wagtail.permissions import policies_registry
+        from wagtail.permissions import policy_registry
 
-        return policies_registry.get(self.instance)
+        return policy_registry.get(self.instance)
 
     def user_has_permission(self):
         """

--- a/wagtail/actions/create_page.py
+++ b/wagtail/actions/create_page.py
@@ -1,5 +1,4 @@
 from wagtail.actions.create import CreateAction
-from wagtail.permissions import page_permission_policy
 
 
 class CreatePageAction(CreateAction):
@@ -23,8 +22,6 @@ class CreatePageAction(CreateAction):
         # entry (via save_revision(log_action=True)) after creation.
         super().__init__(instance, user=user, log_action="wagtail.edit", **kwargs)
         self.parent = parent
-        # FIXME: use the registry
-        self.permission_policy = page_permission_policy
 
     def user_has_permission(self):
         if not super().user_has_permission():

--- a/wagtail/actions/edit_page.py
+++ b/wagtail/actions/edit_page.py
@@ -1,5 +1,4 @@
 from wagtail.actions.edit import EditAction
-from wagtail.permissions import page_permission_policy
 
 
 class EditPageAction(EditAction):
@@ -9,11 +8,6 @@ class EditPageAction(EditAction):
 
     See :class:`~wagtail.actions.edit.EditAction` for the parameters.
     """
-
-    def __init__(self, instance, user=None, **kwargs):
-        super().__init__(instance, user=user, **kwargs)
-        # FIXME: use the registry
-        self.permission_policy = page_permission_policy
 
     def user_has_permission(self):
         if not super().user_has_permission():

--- a/wagtail/actions/publish_revision.py
+++ b/wagtail/actions/publish_revision.py
@@ -48,11 +48,11 @@ class PublishRevisionAction:
         log_action: bool = True,
         previous_revision: Revision | None = None,
     ):
-        from wagtail.permissions import policies_registry
+        from wagtail.permissions import policy_registry
 
         self.revision = revision
         self.object = self.revision.as_object()
-        self.permission_policy = policies_registry.get(self.object)
+        self.permission_policy = policy_registry.get(self.object)
         self.user = user
         self.changed = changed
         self.log_action = log_action

--- a/wagtail/actions/publish_revision.py
+++ b/wagtail/actions/publish_revision.py
@@ -8,7 +8,6 @@ from django.core.exceptions import PermissionDenied
 from django.utils import timezone
 
 from wagtail.log_actions import log
-from wagtail.permission_policies.base import ModelPermissionPolicy
 from wagtail.signals import published
 from wagtail.utils.timestamps import ensure_utc
 
@@ -49,9 +48,11 @@ class PublishRevisionAction:
         log_action: bool = True,
         previous_revision: Revision | None = None,
     ):
+        from wagtail.permissions import policies_registry
+
         self.revision = revision
         self.object = self.revision.as_object()
-        self.permission_policy = ModelPermissionPolicy(type(self.object))
+        self.permission_policy = policies_registry.get(self.object)
         self.user = user
         self.changed = changed
         self.log_action = log_action

--- a/wagtail/admin/admin_url_finder.py
+++ b/wagtail/admin/admin_url_finder.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
 
 from wagtail.hooks import search_for_hooks
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.utils.registry import ObjectTypeRegistry
 
 """
@@ -53,7 +53,7 @@ class ModelAdminURLFinder:
         Return the edit URL for the given instance if one exists and the user has permission for it,
         or None otherwise.
         """
-        permission_policy = policies_registry.get(instance)
+        permission_policy = policy_registry.get(instance)
         if (
             self.user
             and permission_policy

--- a/wagtail/admin/admin_url_finder.py
+++ b/wagtail/admin/admin_url_finder.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
 
 from wagtail.hooks import search_for_hooks
+from wagtail.permissions import policies_registry
 from wagtail.utils.registry import ObjectTypeRegistry
 
 """
@@ -31,7 +32,6 @@ class ModelAdminURLFinder:
     """
 
     edit_url_name = None
-    permission_policy = None
 
     def __init__(self, user=None):
         self.user = user
@@ -53,10 +53,11 @@ class ModelAdminURLFinder:
         Return the edit URL for the given instance if one exists and the user has permission for it,
         or None otherwise.
         """
+        permission_policy = policies_registry.get(instance)
         if (
             self.user
-            and self.permission_policy
-            and not self.permission_policy.user_has_permission_for_instance(
+            and permission_policy
+            and not permission_policy.user_has_permission_for_instance(
                 self.user, "change", instance
             )
         ):

--- a/wagtail/admin/api/filters.py
+++ b/wagtail/admin/api/filters.py
@@ -3,7 +3,7 @@ from rest_framework.filters import BaseFilterBackend
 
 from wagtail import hooks
 from wagtail.api.v2.utils import BadRequestError, parse_boolean
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 Page = swapper.load_model("wagtailcore", "Page")
 
@@ -42,7 +42,7 @@ class ForExplorerFilter(BaseFilterBackend):
                 queryset = hook(parent_page, queryset, request)
 
             queryset = (
-                policies_registry.get_by_type(Page).explorable_instances(request.user)
+                policy_registry.get_by_type(Page).explorable_instances(request.user)
                 & queryset
             )
 

--- a/wagtail/admin/api/filters.py
+++ b/wagtail/admin/api/filters.py
@@ -1,8 +1,11 @@
+import swapper
 from rest_framework.filters import BaseFilterBackend
 
 from wagtail import hooks
 from wagtail.api.v2.utils import BadRequestError, parse_boolean
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
+
+Page = swapper.load_model("wagtailcore", "Page")
 
 
 class HasChildrenFilter(BaseFilterBackend):
@@ -39,7 +42,8 @@ class ForExplorerFilter(BaseFilterBackend):
                 queryset = hook(parent_page, queryset, request)
 
             queryset = (
-                page_permission_policy.explorable_instances(request.user) & queryset
+                policies_registry.get_by_type(Page).explorable_instances(request.user)
+                & queryset
             )
 
         return queryset

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext as _
 from wagtail.admin import messages
 from wagtail.admin.localization import get_localized_response
 from wagtail.log_actions import LogContext
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 def permission_denied(request):
@@ -106,7 +106,7 @@ def user_has_any_page_permission(user):
     page.
     """
     Page = swapper.load_model("wagtailcore", "Page")
-    return policies_registry.get_by_type(Page).user_has_any_permission(
+    return policy_registry.get_by_type(Page).user_has_any_permission(
         user, {"add", "change", "publish", "bulk_delete", "lock", "unlock"}
     )
 

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -1,5 +1,6 @@
 from functools import wraps
 
+import swapper
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect
@@ -9,7 +10,7 @@ from django.utils.translation import gettext as _
 from wagtail.admin import messages
 from wagtail.admin.localization import get_localized_response
 from wagtail.log_actions import LogContext
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 
 def permission_denied(request):
@@ -104,7 +105,8 @@ def user_has_any_page_permission(user):
     Check if a user has any permission to add, edit, or otherwise manage any
     page.
     """
-    return page_permission_policy.user_has_any_permission(
+    Page = swapper.load_model("wagtailcore", "Page")
+    return policies_registry.get_by_type(Page).user_has_any_permission(
         user, {"add", "change", "publish", "bulk_delete", "lock", "unlock"}
     )
 

--- a/wagtail/admin/forms/account.py
+++ b/wagtail/admin/forms/account.py
@@ -2,6 +2,7 @@ import io
 import os
 import warnings
 
+import swapper
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -15,9 +16,10 @@ from wagtail.admin.localization import (
     get_available_admin_time_zones,
 )
 from wagtail.admin.widgets import SwitchInput
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 from wagtail.users.models import UserProfile
 
+Page = swapper.load_model("wagtailcore", "Page")
 User = get_user_model()
 
 
@@ -25,7 +27,7 @@ class NotificationPreferencesForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        permission_policy = page_permission_policy
+        permission_policy = policies_registry.get_by_type(Page)
         if not permission_policy.user_has_permission(self.instance.user, "publish"):
             del self.fields["submitted_notifications"]
         if not permission_policy.user_has_permission(self.instance.user, "change"):

--- a/wagtail/admin/forms/account.py
+++ b/wagtail/admin/forms/account.py
@@ -16,7 +16,7 @@ from wagtail.admin.localization import (
     get_available_admin_time_zones,
 )
 from wagtail.admin.widgets import SwitchInput
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.users.models import UserProfile
 
 Page = swapper.load_model("wagtailcore", "Page")
@@ -27,7 +27,7 @@ class NotificationPreferencesForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        permission_policy = policies_registry.get_by_type(Page)
+        permission_policy = policy_registry.get_by_type(Page)
         if not permission_policy.user_has_permission(self.instance.user, "publish"):
             del self.fields["submitted_notifications"]
         if not permission_policy.user_has_permission(self.instance.user, "change"):

--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -6,7 +6,7 @@ from django.utils.translation import ngettext
 
 from wagtail.admin import widgets
 from wagtail.models import PageViewRestriction
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 from .models import WagtailAdminModelForm
 from .view_restrictions import BaseViewRestrictionForm
@@ -19,7 +19,9 @@ class CopyForm(forms.Form):
         # CopyPage must be passed a 'page' kwarg indicating the page to be copied
         self.page = kwargs.pop("page")
         self.user = kwargs.pop("user")
-        can_publish = page_permission_policy.user_has_permission(self.user, "publish")
+        can_publish = policies_registry.get_by_type(Page).user_has_permission(
+            self.user, "publish"
+        )
 
         super().__init__(*args, **kwargs)
         self.fields["new_title"] = forms.CharField(

--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -6,7 +6,7 @@ from django.utils.translation import ngettext
 
 from wagtail.admin import widgets
 from wagtail.models import PageViewRestriction
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 from .models import WagtailAdminModelForm
 from .view_restrictions import BaseViewRestrictionForm
@@ -19,7 +19,7 @@ class CopyForm(forms.Form):
         # CopyPage must be passed a 'page' kwarg indicating the page to be copied
         self.page = kwargs.pop("page")
         self.user = kwargs.pop("user")
-        can_publish = policies_registry.get_by_type(Page).user_has_permission(
+        can_publish = policy_registry.get_by_type(Page).user_has_permission(
             self.user, "publish"
         )
 

--- a/wagtail/admin/navigation.py
+++ b/wagtail/admin/navigation.py
@@ -1,13 +1,13 @@
 import swapper
 from django.conf import settings
 
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 Page = swapper.load_model("wagtailcore", "Page")
 
 
 def get_site_for_user(user):
-    root_page = policies_registry.get_by_type(Page).explorable_root_instance(user)
+    root_page = policy_registry.get_by_type(Page).explorable_root_instance(user)
     if root_page:
         root_site = root_page.get_site()
     else:

--- a/wagtail/admin/navigation.py
+++ b/wagtail/admin/navigation.py
@@ -1,10 +1,13 @@
+import swapper
 from django.conf import settings
 
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
+
+Page = swapper.load_model("wagtailcore", "Page")
 
 
 def get_site_for_user(user):
-    root_page = page_permission_policy.explorable_root_instance(user)
+    root_page = policies_registry.get_by_type(Page).explorable_root_instance(user)
     if root_page:
         root_site = root_page.get_site()
     else:

--- a/wagtail/admin/tests/test_editing_sessions.py
+++ b/wagtail/admin/tests/test_editing_sessions.py
@@ -12,10 +12,10 @@ from freezegun import freeze_time
 
 from wagtail.admin.models import EditingSession
 from wagtail.models import GroupPagePermission, Workflow, WorkflowContentType
-from wagtail.models.pages import PageLogEntry
 from wagtail.test.testapp.models import (
     Advert,
     AdvertWithCustomPrimaryKey,
+    FeatureCompleteToy,
     FullFeaturedSnippet,
     SimplePage,
 )
@@ -122,19 +122,43 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_ping_non_page_non_snippet_model(self):
-        # PageLogEntry is not a model that has a permissions policy, so we
-        # cannot check permissions for editing it, thus cannot ping it either
-        log_entry = PageLogEntry.objects.first()
+        # FeatureCompleteToy is a model that was registered with a ModelViewSet.
+        # It is not a page nor a snippet, but we can still check for permissions
+        # and ping it to have an idle or is_editing state, if so desired.
+        toy = FeatureCompleteToy.objects.create(name="Buzz Lightyear")
         session = EditingSession.objects.create(
             user=self.user,
-            content_type=ContentType.objects.get_for_model(PageLogEntry),
-            object_id=log_entry.pk,
+            content_type=ContentType.objects.get_for_model(FeatureCompleteToy),
+            object_id=toy.pk,
             last_seen_at=TIMESTAMP_1,
         )
         response = self.client.post(
             reverse(
                 "wagtailadmin_editing_sessions:ping",
-                args=("wagtailcore", "pagelogentry", str(log_entry.pk), session.id),
+                args=("tests", "featurecompletetoy", quote(toy.pk), session.id),
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertEqual(response_json["session_id"], session.id)
+        self.assertEqual(response_json["other_sessions"], [])
+
+    def test_ping_non_page_non_snippet_model_no_permissions(self):
+        self.user.is_superuser = False
+        self.user.save()
+        editors = Group.objects.get(name="Editors")
+        self.user.groups.add(editors)
+        toy = FeatureCompleteToy.objects.create(name="Buzz Lightyear")
+        session = EditingSession.objects.create(
+            user=self.user,
+            content_type=ContentType.objects.get_for_model(FeatureCompleteToy),
+            object_id=toy.pk,
+            last_seen_at=TIMESTAMP_1,
+        )
+        response = self.client.post(
+            reverse(
+                "wagtailadmin_editing_sessions:ping",
+                args=("tests", "featurecompletetoy", quote(toy.pk), session.id),
             )
         )
         self.assertEqual(response.status_code, 404)

--- a/wagtail/admin/tests/test_editing_sessions.py
+++ b/wagtail/admin/tests/test_editing_sessions.py
@@ -12,6 +12,7 @@ from freezegun import freeze_time
 
 from wagtail.admin.models import EditingSession
 from wagtail.models import GroupPagePermission, Workflow, WorkflowContentType
+from wagtail.models.pages import PageLogEntry
 from wagtail.test.testapp.models import (
     Advert,
     AdvertWithCustomPrimaryKey,
@@ -121,17 +122,19 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_ping_non_page_non_snippet_model(self):
-        editors = Group.objects.get(name="Editors")
+        # PageLogEntry is not a model that has a permissions policy, so we
+        # cannot check permissions for editing it, thus cannot ping it either
+        log_entry = PageLogEntry.objects.first()
         session = EditingSession.objects.create(
             user=self.user,
-            content_type=ContentType.objects.get_for_model(Group),
-            object_id=editors.pk,
+            content_type=ContentType.objects.get_for_model(PageLogEntry),
+            object_id=log_entry.pk,
             last_seen_at=TIMESTAMP_1,
         )
         response = self.client.post(
             reverse(
                 "wagtailadmin_editing_sessions:ping",
-                args=("auth", "group", str(editors.pk), session.id),
+                args=("wagtailcore", "pagelogentry", str(log_entry.pk), session.id),
             )
         )
         self.assertEqual(response.status_code, 404)

--- a/wagtail/admin/tests/test_editing_sessions.py
+++ b/wagtail/admin/tests/test_editing_sessions.py
@@ -11,7 +11,12 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from wagtail.admin.models import EditingSession
-from wagtail.models import GroupPagePermission, Workflow, WorkflowContentType
+from wagtail.models import (
+    GroupPagePermission,
+    PageLogEntry,
+    Workflow,
+    WorkflowContentType,
+)
 from wagtail.test.testapp.models import (
     Advert,
     AdvertWithCustomPrimaryKey,
@@ -121,7 +126,7 @@ class TestPingView(WagtailTestUtils, TestCase):
         )
         self.assertEqual(response.status_code, 404)
 
-    def test_ping_non_page_non_snippet_model(self):
+    def test_ping_non_page_non_snippet_registered_model(self):
         # FeatureCompleteToy is a model that was registered with a ModelViewSet.
         # It is not a page nor a snippet, but we can still check for permissions
         # and ping it to have an idle or is_editing state, if so desired.
@@ -143,7 +148,7 @@ class TestPingView(WagtailTestUtils, TestCase):
         self.assertEqual(response_json["session_id"], session.id)
         self.assertEqual(response_json["other_sessions"], [])
 
-    def test_ping_non_page_non_snippet_model_no_permissions(self):
+    def test_ping_non_page_non_snippet_registered_model_no_permissions(self):
         self.user.is_superuser = False
         self.user.save()
         editors = Group.objects.get(name="Editors")
@@ -159,6 +164,24 @@ class TestPingView(WagtailTestUtils, TestCase):
             reverse(
                 "wagtailadmin_editing_sessions:ping",
                 args=("tests", "featurecompletetoy", quote(toy.pk), session.id),
+            )
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_ping_non_registered_model(self):
+        # PageLogEntry is not a model that was registered to the admin at all,
+        # so we cannot check edit permissions for it, thus cannot ping it either
+        log_entry = PageLogEntry.objects.first()
+        session = EditingSession.objects.create(
+            user=self.user,
+            content_type=ContentType.objects.get_for_model(PageLogEntry),
+            object_id=log_entry.pk,
+            last_seen_at=TIMESTAMP_1,
+        )
+        response = self.client.post(
+            reverse(
+                "wagtailadmin_editing_sessions:ping",
+                args=("wagtailcore", "pagelogentry", str(log_entry.pk), session.id),
             )
         )
         self.assertEqual(response.status_code, 404)

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -6,7 +6,9 @@ from django.contrib.admin.utils import quote
 from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
+from django.db import models
 from django.test import TestCase
+from django.test.utils import isolate_apps
 from django.urls import NoReverseMatch, reverse
 from django.utils.formats import date_format, localize
 from django.utils.html import escape
@@ -15,8 +17,11 @@ from openpyxl import load_workbook
 
 from wagtail import hooks
 from wagtail.admin.admin_url_finder import AdminURLFinder
+from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.log_actions import log
 from wagtail.models import ModelLogEntry
+from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permissions import policies_registry
 from wagtail.test.testapp.models import (
     FeatureCompleteToy,
     JSONStreamModel,
@@ -25,6 +30,7 @@ from wagtail.test.testapp.models import (
 )
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 from wagtail.test.utils.wagtail_tests import WagtailTestUtils
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
 
 class TestModelViewSetGroup(WagtailTestUtils, TestCase):
@@ -2168,3 +2174,30 @@ class TestReorderView(WagtailTestUtils, TestCase):
         # Check if obj1 is now the second item by taking obj2's sort_order
         # and decrementing sort_order of the other items before it by 1
         self.assertOrder([(self.obj2, 3), (self.obj1, 4), (self.obj3, 9)])
+
+
+class TestPermissionPolicyDeprecation(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.user = self.login()
+
+    @isolate_apps("wagtail")
+    def test_default_policy_registration(self):
+        class Toy(models.Model):
+            pass
+
+        class SomeToyViewSet(ModelViewSet):
+            model = Toy
+
+        self.assertIsNone(policies_registry.get_by_type(Toy))
+        viewset = SomeToyViewSet()
+        with self.assertWarnsMessage(
+            RemovedInWagtail90Warning,
+            "A permission policy for Toy was registered via SomeToyViewSet. "
+            "Please register the policy with "
+            "wagtail.permissions.register_permission_policy(Toy, <policy_instance>) "
+            "instead.",
+        ):
+            viewset.register_permissions()
+            policy = policies_registry.get_by_type(Toy)
+            self.assertIsInstance(policy, ModelPermissionPolicy)
+            self.assertIs(policy, viewset.permission_policy)

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -21,7 +21,7 @@ from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.log_actions import log
 from wagtail.models import ModelLogEntry
 from wagtail.permission_policies import ModelPermissionPolicy
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.test.testapp.models import (
     FeatureCompleteToy,
     JSONStreamModel,
@@ -2188,10 +2188,10 @@ class TestPermissionPolicyRegistration(WagtailTestUtils, TestCase):
         viewset = SomeToyViewSet()
         viewset.register_permissions()
         # Upon registration, the registry creates a fallback policy for the model
-        policy = policies_registry.get_by_type(Toy)
+        policy = policy_registry.get_by_type(Toy)
         self.assertIsInstance(policy, ModelPermissionPolicy)
         self.assertIs(policy, viewset.permission_policy)
-        self.assertIs(policies_registry.get_fallback_policy(Toy), policy)
+        self.assertIs(policy_registry.get_fallback_policy(Toy), policy)
 
     @isolate_apps("wagtail")
     def test_deprecated_policy_registration(self):
@@ -2213,8 +2213,8 @@ class TestPermissionPolicyRegistration(WagtailTestUtils, TestCase):
             "instead.",
         ):
             viewset.register_permissions()
-            policy = policies_registry.get_by_type(CustomToy)
+            policy = policy_registry.get_by_type(CustomToy)
             self.assertIsInstance(policy, ModelPermissionPolicy)
             self.assertEqual(policy.auth_model._meta.label, "wagtailadmin.Admin")
             self.assertIs(policy, viewset.permission_policy)
-            self.assertIsNone(policies_registry.get_fallback_policy(CustomToy))
+            self.assertIsNone(policy_registry.get_fallback_policy(CustomToy))

--- a/wagtail/admin/tests/viewsets/test_model_viewset.py
+++ b/wagtail/admin/tests/viewsets/test_model_viewset.py
@@ -2176,28 +2176,45 @@ class TestReorderView(WagtailTestUtils, TestCase):
         self.assertOrder([(self.obj2, 3), (self.obj1, 4), (self.obj3, 9)])
 
 
-class TestPermissionPolicyDeprecation(WagtailTestUtils, TestCase):
-    def setUp(self):
-        self.user = self.login()
-
+class TestPermissionPolicyRegistration(WagtailTestUtils, TestCase):
     @isolate_apps("wagtail")
-    def test_default_policy_registration(self):
+    def test_fallback_policy_registration(self):
         class Toy(models.Model):
             pass
 
         class SomeToyViewSet(ModelViewSet):
             model = Toy
 
-        self.assertIsNone(policies_registry.get_by_type(Toy))
         viewset = SomeToyViewSet()
+        viewset.register_permissions()
+        # Upon registration, the registry creates a fallback policy for the model
+        policy = policies_registry.get_by_type(Toy)
+        self.assertIsInstance(policy, ModelPermissionPolicy)
+        self.assertIs(policy, viewset.permission_policy)
+        self.assertIs(policies_registry.get_fallback_policy(Toy), policy)
+
+    @isolate_apps("wagtail")
+    def test_deprecated_policy_registration(self):
+        class CustomToy(models.Model):
+            pass
+
+        class CustomToyViewSet(ModelViewSet):
+            model = CustomToy
+            permission_policy = ModelPermissionPolicy(
+                CustomToy, auth_model="wagtailadmin.Admin"
+            )
+
+        viewset = CustomToyViewSet()
         with self.assertWarnsMessage(
             RemovedInWagtail90Warning,
-            "A permission policy for Toy was registered via SomeToyViewSet. "
+            "A permission policy for CustomToy was registered via CustomToyViewSet. "
             "Please register the policy with "
-            "wagtail.permissions.register_permission_policy(Toy, <policy_instance>) "
+            "wagtail.permissions.register_permission_policy(CustomToy, <policy_instance>) "
             "instead.",
         ):
             viewset.register_permissions()
-            policy = policies_registry.get_by_type(Toy)
+            policy = policies_registry.get_by_type(CustomToy)
             self.assertIsInstance(policy, ModelPermissionPolicy)
+            self.assertEqual(policy.auth_model._meta.label, "wagtailadmin.Admin")
             self.assertIs(policy, viewset.permission_policy)
+            self.assertIsNone(policies_registry.get_fallback_policy(CustomToy))

--- a/wagtail/admin/views/collection_privacy.py
+++ b/wagtail/admin/views/collection_privacy.py
@@ -5,12 +5,14 @@ from django.urls import reverse
 from wagtail.admin.forms.collections import CollectionViewRestrictionForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.models import Collection, CollectionViewRestriction
-from wagtail.permissions import collection_permission_policy
+from wagtail.permissions import policies_registry
 
 
 def set_privacy(request, collection_id):
     collection = get_object_or_404(Collection, id=collection_id)
-    if not collection_permission_policy.user_has_permission(request.user, "change"):
+    if not policies_registry.get_by_type(Collection).user_has_permission(
+        request.user, "change"
+    ):
         raise PermissionDenied
 
     # fetch restriction records in depth order so that ancestors appear first

--- a/wagtail/admin/views/collection_privacy.py
+++ b/wagtail/admin/views/collection_privacy.py
@@ -5,12 +5,12 @@ from django.urls import reverse
 from wagtail.admin.forms.collections import CollectionViewRestrictionForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.models import Collection, CollectionViewRestriction
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 def set_privacy(request, collection_id):
     collection = get_object_or_404(Collection, id=collection_id)
-    if not policies_registry.get_by_type(Collection).user_has_permission(
+    if not policy_registry.get_by_type(Collection).user_has_permission(
         request.user, "change"
     ):
         raise PermissionDenied

--- a/wagtail/admin/views/collections.py
+++ b/wagtail/admin/views/collections.py
@@ -8,11 +8,9 @@ from wagtail.admin.forms.collections import CollectionForm
 from wagtail.admin.ui.tables import TitleColumn
 from wagtail.admin.views.generic import CreateView, DeleteView, EditView, IndexView
 from wagtail.models import Collection
-from wagtail.permissions import collection_permission_policy
 
 
 class Index(IndexView):
-    permission_policy = collection_permission_policy
     model = Collection
     context_object_name = "collections"
     results_template_name = "wagtailadmin/collections/index_results.html"
@@ -41,7 +39,6 @@ class Index(IndexView):
 
 
 class Create(CreateView):
-    permission_policy = collection_permission_policy
     model = Collection
     form_class = CollectionForm
     page_title = gettext_lazy("Add collection")
@@ -68,7 +65,6 @@ class Create(CreateView):
 
 
 class Edit(EditView):
-    permission_policy = collection_permission_policy
     model = Collection
     form_class = CollectionForm
     template_name = "wagtailadmin/collections/edit.html"
@@ -136,7 +132,6 @@ class Edit(EditView):
 
 
 class Delete(DeleteView):
-    permission_policy = collection_permission_policy
     model = Collection
     success_message = gettext_lazy("Collection '%(object)s' deleted.")
     index_url_name = "wagtailadmin_collections:index"

--- a/wagtail/admin/views/editing_sessions.py
+++ b/wagtail/admin/views/editing_sessions.py
@@ -32,7 +32,11 @@ def ping(request, app_label, model_name, object_id, session_id):
     if isinstance(obj, AbstractPage):
         can_edit = obj.permissions_for_user(request.user).can_edit()
     else:
-        permission_policy = policy_registry.get_by_type(model)
+        permission_policy = policy_registry.get_by_type(model, fallback=False)
+        if not permission_policy:
+            # Model likely was not registered with Wagtail
+            raise Http404
+
         can_edit = permission_policy.user_has_permission_for_instance(
             request.user, "change", obj
         )

--- a/wagtail/admin/views/editing_sessions.py
+++ b/wagtail/admin/views/editing_sessions.py
@@ -14,6 +14,7 @@ from wagtail.admin.models import EditingSession
 from wagtail.admin.ui.editing_sessions import EditingSessionsList
 from wagtail.admin.utils import get_user_display_name
 from wagtail.models import AbstractPage, Revision, RevisionMixin, WorkflowMixin
+from wagtail.permissions import policies_registry
 
 
 @require_POST
@@ -31,11 +32,9 @@ def ping(request, app_label, model_name, object_id, session_id):
     if isinstance(obj, AbstractPage):
         can_edit = obj.permissions_for_user(request.user).can_edit()
     else:
-        try:
-            permission_policy = model.snippet_viewset.permission_policy
-        except AttributeError as e:
-            # model is neither a Page nor a snippet
-            raise Http404 from e
+        if not (permission_policy := policies_registry.get_by_type(model)):
+            # Model likely was not registered with Wagtail
+            raise Http404
 
         can_edit = permission_policy.user_has_permission_for_instance(
             request.user, "change", obj

--- a/wagtail/admin/views/editing_sessions.py
+++ b/wagtail/admin/views/editing_sessions.py
@@ -32,10 +32,7 @@ def ping(request, app_label, model_name, object_id, session_id):
     if isinstance(obj, AbstractPage):
         can_edit = obj.permissions_for_user(request.user).can_edit()
     else:
-        if not (permission_policy := policies_registry.get_by_type(model)):
-            # Model likely was not registered with Wagtail
-            raise Http404
-
+        permission_policy = policies_registry.get_by_type(model)
         can_edit = permission_policy.user_has_permission_for_instance(
             request.user, "change", obj
         )

--- a/wagtail/admin/views/editing_sessions.py
+++ b/wagtail/admin/views/editing_sessions.py
@@ -14,7 +14,7 @@ from wagtail.admin.models import EditingSession
 from wagtail.admin.ui.editing_sessions import EditingSessionsList
 from wagtail.admin.utils import get_user_display_name
 from wagtail.models import AbstractPage, Revision, RevisionMixin, WorkflowMixin
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 @require_POST
@@ -32,7 +32,7 @@ def ping(request, app_label, model_name, object_id, session_id):
     if isinstance(obj, AbstractPage):
         can_edit = obj.permissions_for_user(request.user).can_edit()
     else:
-        permission_policy = policies_registry.get_by_type(model)
+        permission_policy = policy_registry.get_by_type(model)
         can_edit = permission_policy.user_has_permission_for_instance(
             request.user, "change", obj
         )

--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -33,6 +33,7 @@ from wagtail.admin.ui.tables import Column, LocaleColumn, Table, TitleColumn
 from wagtail.coreutils import resolve_model_string
 from wagtail.models import CollectionMember, TranslatableMixin
 from wagtail.permission_policies import BlanketPermissionPolicy, ModelPermissionPolicy
+from wagtail.permissions import policies_registry
 from wagtail.search.index import class_is_indexed
 
 
@@ -319,7 +320,10 @@ class CreationFormMixin(ModelLookupMixin, PreserveURLParametersMixin):
     create_action_label = _("Create")
     create_action_clicked_label = None
     create_url_name = None
-    permission_policy = None
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model_class)
 
     def get_permission_policy(self):
         if self.permission_policy:

--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -33,7 +33,7 @@ from wagtail.admin.ui.tables import Column, LocaleColumn, Table, TitleColumn
 from wagtail.coreutils import resolve_model_string
 from wagtail.models import CollectionMember, TranslatableMixin
 from wagtail.permission_policies import BlanketPermissionPolicy, ModelPermissionPolicy
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.search.index import class_is_indexed
 
 
@@ -323,7 +323,7 @@ class CreationFormMixin(ModelLookupMixin, PreserveURLParametersMixin):
 
     @cached_property
     def permission_policy(self):
-        return policies_registry.get_by_type(self.model_class)
+        return policy_registry.get_by_type(self.model_class)
 
     def get_permission_policy(self):
         if self.permission_policy:

--- a/wagtail/admin/views/generic/multiple_upload.py
+++ b/wagtail/admin/views/generic/multiple_upload.py
@@ -16,7 +16,7 @@ from wagtail.models import UploadedFile
 
 class AddView(PermissionCheckedMixin, TemplateView):
     # subclasses need to provide:
-    # - permission_policy
+    # - permission_policy (if one does not exist in the registry for the model)
     # - template_name
 
     # - edit_object_url_name
@@ -195,9 +195,9 @@ class AddView(PermissionCheckedMixin, TemplateView):
         return context
 
 
-class EditView(View):
+class EditView(PermissionCheckedMixin, View):
     # subclasses need to provide:
-    # - permission_policy
+    # - permission_policy (if one does not exist in the registry for the model)
     # - pk_url_kwarg
     # - edit_object_form_prefix
     # - context_object_name
@@ -265,9 +265,9 @@ class EditView(View):
             )
 
 
-class DeleteView(View):
+class DeleteView(PermissionCheckedMixin, View):
     # subclasses need to provide:
-    # - permission_policy
+    # - permission_policy (if one does not exist in the registry for the model)
     # - pk_url_kwarg
     # - context_object_id_name
 

--- a/wagtail/admin/views/generic/permissions.py
+++ b/wagtail/admin/views/generic/permissions.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import PermissionDenied
 from django.utils.functional import cached_property
 
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 class PermissionCheckedMixin:
@@ -33,9 +33,7 @@ class PermissionCheckedMixin:
 
     @cached_property
     def permission_policy(self):
-        return getattr(self, "model", None) and policies_registry.get_by_type(
-            self.model
-        )
+        return getattr(self, "model", None) and policy_registry.get_by_type(self.model)
 
     def user_has_permission(self, permission):
         return not self.permission_policy or (

--- a/wagtail/admin/views/generic/permissions.py
+++ b/wagtail/admin/views/generic/permissions.py
@@ -1,4 +1,7 @@
 from django.core.exceptions import PermissionDenied
+from django.utils.functional import cached_property
+
+from wagtail.permissions import policies_registry
 
 
 class PermissionCheckedMixin:
@@ -14,7 +17,6 @@ class PermissionCheckedMixin:
       one or more of those permissions)
     """
 
-    permission_policy = None
     permission_required = None
     any_permission_required = None
 
@@ -28,6 +30,12 @@ class PermissionCheckedMixin:
                 raise PermissionDenied
 
         return super().dispatch(request, *args, **kwargs)
+
+    @cached_property
+    def permission_policy(self):
+        return getattr(self, "model", None) and policies_registry.get_by_type(
+            self.model
+        )
 
     def user_has_permission(self, permission):
         return not self.permission_policy or (

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -9,6 +9,7 @@ from django.db.models import Exists, IntegerField, Max, OuterRef, Q
 from django.db.models.functions import Cast
 from django.forms import Media
 from django.http import Http404, HttpResponse
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import TemplateView
 
@@ -26,7 +27,7 @@ from wagtail.models import (
     WorkflowState,
     get_default_page_content_type,
 )
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 User = get_user_model()
 Page = swapper.load_model("wagtailcore", "Page")
@@ -237,6 +238,7 @@ class LockedPagesPanel(Component):
     def get_context_data(self, parent_context):
         request = parent_context["request"]
         context = super().get_context_data(parent_context)
+        permissions_policy = policies_registry.get_by_type(Page)
         context.update(
             {
                 "locked_pages": Page.objects.filter(
@@ -245,7 +247,7 @@ class LockedPagesPanel(Component):
                 )
                 .order_by("-locked_at", "-latest_revision_created_at", "-pk")
                 .specific(defer=True),
-                "can_remove_locks": page_permission_policy.user_has_permission(
+                "can_remove_locks": permissions_policy.user_has_permission(
                     request.user, "unlock"
                 ),
                 "request": request,
@@ -296,7 +298,10 @@ class RecentEditsPanel(Component):
 class HomeView(WagtailAdminTemplateMixin, TemplateView):
     template_name = "wagtailadmin/home.html"
     page_title = _("Dashboard")
-    permission_policy = page_permission_policy
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Page)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -27,7 +27,7 @@ from wagtail.models import (
     WorkflowState,
     get_default_page_content_type,
 )
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 User = get_user_model()
 Page = swapper.load_model("wagtailcore", "Page")
@@ -238,7 +238,7 @@ class LockedPagesPanel(Component):
     def get_context_data(self, parent_context):
         request = parent_context["request"]
         context = super().get_context_data(parent_context)
-        permissions_policy = policies_registry.get_by_type(Page)
+        permissions_policy = policy_registry.get_by_type(Page)
         context.update(
             {
                 "locked_pages": Page.objects.filter(
@@ -301,7 +301,7 @@ class HomeView(WagtailAdminTemplateMixin, TemplateView):
 
     @cached_property
     def permission_policy(self):
-        return policies_registry.get_by_type(Page)
+        return policy_registry.get_by_type(Page)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/wagtail/admin/views/pages/choose_parent.py
+++ b/wagtail/admin/views/pages/choose_parent.py
@@ -12,7 +12,7 @@ from django.views.generic import FormView
 from wagtail.admin.forms.pages import ParentChooserForm
 from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
 from wagtail.admin.views.generic.mixins import LocaleMixin
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 Page = swapper.load_model("wagtailcore", "Page")
 
@@ -22,6 +22,10 @@ class ChooseParentView(LocaleMixin, WagtailAdminTemplateMixin, FormView):
     model = Page
     index_url_name = None
     page_title = gettext_lazy("Choose parent")
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_valid_parent_pages(self, user):
         """
@@ -52,7 +56,7 @@ class ChooseParentView(LocaleMixin, WagtailAdminTemplateMixin, FormView):
 
             perms = {
                 perm
-                for perm in page_permission_policy.get_cached_permissions_for_user(user)
+                for perm in self.permission_policy.get_cached_permissions_for_user(user)
                 if perm.permission.codename == Page.PERMISSION_CODENAMES.ADD
             }
 

--- a/wagtail/admin/views/pages/choose_parent.py
+++ b/wagtail/admin/views/pages/choose_parent.py
@@ -12,7 +12,7 @@ from django.views.generic import FormView
 from wagtail.admin.forms.pages import ParentChooserForm
 from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
 from wagtail.admin.views.generic.mixins import LocaleMixin
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 Page = swapper.load_model("wagtailcore", "Page")
 
@@ -25,7 +25,7 @@ class ChooseParentView(LocaleMixin, WagtailAdminTemplateMixin, FormView):
 
     @cached_property
     def permission_policy(self):
-        return policies_registry.get_by_type(self.model)
+        return policy_registry.get_by_type(self.model)
 
     def get_valid_parent_pages(self, user):
         """

--- a/wagtail/admin/views/pages/history.py
+++ b/wagtail/admin/views/pages/history.py
@@ -11,7 +11,6 @@ from wagtail.admin.views.pages.utils import (
 )
 from wagtail.admin.widgets import BooleanRadioSelect
 from wagtail.models import PageLogEntry
-from wagtail.permissions import page_permission_policy
 
 Page = swapper.load_model("wagtailcore", "Page")
 
@@ -72,7 +71,6 @@ class PageHistoryView(GenericPageBreadcrumbsMixin, history.HistoryView):
     filterset_class = PageHistoryFilterSet
     model = Page
     pk_url_kwarg = "page_id"
-    permission_policy = page_permission_policy
     history_url_name = "wagtailadmin_pages:history"
     history_results_url_name = "wagtailadmin_pages:history_results"
     edit_url_name = "wagtailadmin_pages:edit"

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -38,7 +38,6 @@ from wagtail.admin.ui.tables.pages import (
 from wagtail.admin.views import generic
 from wagtail.admin.widgets.button import HeaderButton
 from wagtail.models import PageLogEntry, Site, get_page_content_types
-from wagtail.permissions import page_permission_policy
 
 Page = swapper.load_model("wagtailcore", "Page")
 
@@ -271,7 +270,6 @@ class PageListingMixin:
 
 
 class IndexView(PageListingMixin, generic.IndexView):
-    permission_policy = page_permission_policy
     any_permission_required = {
         "add",
         "change",
@@ -306,7 +304,7 @@ class IndexView(PageListingMixin, generic.IndexView):
             settings, "WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS", True
         ):
             pages = pages.filter(
-                pk__in=page_permission_policy.explorable_instances(
+                pk__in=self.permission_policy.explorable_instances(
                     self.request.user
                 ).values_list("pk", flat=True)
             )
@@ -429,7 +427,7 @@ class ExplorableIndexView(IndexView):
             settings, "WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS", True
         ):
             pages = pages.filter(
-                pk__in=page_permission_policy.explorable_instances(
+                pk__in=self.permission_policy.explorable_instances(
                     self.request.user
                 ).values_list("pk", flat=True)
             )

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -14,7 +14,6 @@ from wagtail.admin.ui.tables.pages import (
 from wagtail.admin.views.generic.base import BaseListingView
 from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
 from wagtail.admin.views.pages.listing import PageListingMixin
-from wagtail.permissions import page_permission_policy
 from wagtail.search.query import MATCH_ALL
 from wagtail.search.utils import parse_query_string
 
@@ -47,7 +46,6 @@ def page_filter_search(q, pages, all_pages=None, ordering=None):
 
 
 class SearchView(PageListingMixin, PermissionCheckedMixin, BaseListingView):
-    permission_policy = page_permission_policy
     any_permission_required = {
         "add",
         "change",
@@ -114,7 +112,7 @@ class SearchView(PageListingMixin, PermissionCheckedMixin, BaseListingView):
 
         if getattr(settings, "WAGTAILADMIN_PAGE_SEARCH_FILTER_BY_PERMISSIONS", True):
             self.all_pages = self.all_pages.filter(
-                pk__in=page_permission_policy.explorable_instances(
+                pk__in=self.permission_policy.explorable_instances(
                     self.request.user
                 ).values_list("pk", flat=True)
             )

--- a/wagtail/admin/views/pages/utils.py
+++ b/wagtail/admin/views/pages/utils.py
@@ -1,3 +1,4 @@
+import swapper
 from django.conf import settings
 from django.urls import reverse
 from django.utils.functional import cached_property
@@ -9,7 +10,7 @@ from wagtail.admin.utils import (  # noqa: F401
     get_latest_str,
     get_valid_next_url_from_request,
 )
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 
 def get_breadcrumbs_items_for_page(
@@ -20,9 +21,10 @@ def get_breadcrumbs_items_for_page(
     include_self=True,
     querystring_value="",
 ):
+    Page = swapper.load_model("wagtailcore", "Page")
     # find the closest common ancestor of the pages that this user has direct explore permission
     # (i.e. add/edit/publish/lock) over; this will be the root of the breadcrumb
-    cca = page_permission_policy.explorable_root_instance(user)
+    cca = policies_registry.get_by_type(Page).explorable_root_instance(user)
     if not cca:
         return []
 

--- a/wagtail/admin/views/pages/utils.py
+++ b/wagtail/admin/views/pages/utils.py
@@ -10,7 +10,7 @@ from wagtail.admin.utils import (  # noqa: F401
     get_latest_str,
     get_valid_next_url_from_request,
 )
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 def get_breadcrumbs_items_for_page(
@@ -24,7 +24,7 @@ def get_breadcrumbs_items_for_page(
     Page = swapper.load_model("wagtailcore", "Page")
     # find the closest common ancestor of the pages that this user has direct explore permission
     # (i.e. add/edit/publish/lock) over; this will be the root of the breadcrumb
-    cca = policies_registry.get_by_type(Page).explorable_root_instance(user)
+    cca = policy_registry.get_by_type(Page).explorable_root_instance(user)
     if not cca:
         return []
 

--- a/wagtail/admin/views/reports/aging_pages.py
+++ b/wagtail/admin/views/reports/aging_pages.py
@@ -9,7 +9,6 @@ from wagtail.admin.filters import ContentTypeFilter, WagtailFilterSet
 from wagtail.admin.widgets import AdminDateInput
 from wagtail.coreutils import get_content_type_label
 from wagtail.models import PageLogEntry, get_page_content_types
-from wagtail.permissions import page_permission_policy
 from wagtail.users.utils import get_deleted_user_display_name
 
 from .base import PageReportView
@@ -102,7 +101,7 @@ class AgingPagesView(PageReportView):
             page=OuterRef("pk"), action__exact="wagtail.publish"
         )
         self.queryset = (
-            page_permission_policy.instances_user_has_permission_for(
+            self.permission_policy.instances_user_has_permission_for(
                 self.request.user, "publish"
             )
             .exclude(last_published_at__isnull=True)

--- a/wagtail/admin/views/reports/base.py
+++ b/wagtail/admin/views/reports/base.py
@@ -1,8 +1,10 @@
+import swapper
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.views.generic import BaseListingView, PermissionCheckedMixin
 from wagtail.admin.views.mixins import SpreadsheetExportMixin
-from wagtail.permissions import page_permission_policy
+
+Page = swapper.load_model("wagtailcore", "Page")
 
 
 class ReportView(SpreadsheetExportMixin, PermissionCheckedMixin, BaseListingView):
@@ -50,4 +52,4 @@ class PageReportView(ReportView):
         "content_type.model_class._meta.verbose_name.title",
     ]
     context_object_name = "pages"
-    permission_policy = page_permission_policy
+    model = Page

--- a/wagtail/admin/views/reports/locked_pages.py
+++ b/wagtail/admin/views/reports/locked_pages.py
@@ -7,7 +7,6 @@ from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.filters import DateRangePickerWidget, WagtailFilterSet
-from wagtail.permissions import page_permission_policy
 
 from .base import PageReportView
 
@@ -61,7 +60,7 @@ class LockedPagesView(PageReportView):
     def get_queryset(self):
         pages = (
             (
-                page_permission_policy.instances_user_has_permission_for(
+                self.permission_policy.instances_user_has_permission_for(
                     self.request.user, "change"
                 )
                 | Page.objects.filter(locked_by=self.request.user)

--- a/wagtail/admin/views/reports/page_types_usage.py
+++ b/wagtail/admin/views/reports/page_types_usage.py
@@ -10,7 +10,7 @@ from wagtail.admin.filters import WagtailFilterSet
 from wagtail.admin.views.reports import ReportView
 from wagtail.coreutils import get_content_languages
 from wagtail.models import Site, get_page_models
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 Page = swapper.load_model("wagtailcore", "Page")
 
@@ -112,7 +112,7 @@ class PageTypesUsageReportView(ReportView):
     def permission_policy(self):
         # This view lists ContentType objects, but we want to check permissions
         # against the Page model.
-        return policies_registry.get_by_type(Page)
+        return policy_registry.get_by_type(Page)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/wagtail/admin/views/reports/page_types_usage.py
+++ b/wagtail/admin/views/reports/page_types_usage.py
@@ -3,13 +3,14 @@ import swapper
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, F, OuterRef, Q, Subquery
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.filters import WagtailFilterSet
 from wagtail.admin.views.reports import ReportView
 from wagtail.coreutils import get_content_languages
 from wagtail.models import Site, get_page_models
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 Page = swapper.load_model("wagtailcore", "Page")
 
@@ -105,8 +106,13 @@ class PageTypesUsageReportView(ReportView):
     filterset_class = PageTypesUsageReportFilterSet
     index_url_name = "wagtailadmin_reports:page_types_usage"
     index_results_url_name = "wagtailadmin_reports:page_types_usage_results"
-    permission_policy = page_permission_policy
     any_permission_required = ["add", "change", "publish"]
+
+    @cached_property
+    def permission_policy(self):
+        # This view lists ContentType objects, but we want to check permissions
+        # against the Page model.
+        return policies_registry.get_by_type(Page)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/wagtail/admin/views/reports/workflows.py
+++ b/wagtail/admin/views/reports/workflows.py
@@ -27,7 +27,7 @@ from wagtail.models import (
     WorkflowState,
     get_default_page_content_type,
 )
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.snippets.models import get_editable_models
 
 from .base import ReportView
@@ -43,7 +43,7 @@ def get_requested_by_queryset(request):
 
 
 def get_editable_page_ids_query(request):
-    pages = policies_registry.get_by_type(Page).instances_user_has_permission_for(
+    pages = policy_registry.get_by_type(Page).instances_user_has_permission_for(
         request.user, "change"
     )
     # Need to cast the page ids to string because Postgres doesn't support
@@ -170,7 +170,7 @@ class WorkflowView(ReportView):
     def permission_policy(self):
         # This view lists WorkflowState objects, but we want to check permissions
         # against the Page model.
-        return policies_registry.get_by_type(Page)
+        return policy_registry.get_by_type(Page)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -256,7 +256,7 @@ class WorkflowTasksView(ReportView):
     def permission_policy(self):
         # This view lists TaskState objects, but we want to check permissions
         # against the Page model.
-        return policies_registry.get_by_type(Page)
+        return policy_registry.get_by_type(Page)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/wagtail/admin/views/reports/workflows.py
+++ b/wagtail/admin/views/reports/workflows.py
@@ -1,6 +1,7 @@
 import datetime
 
 import django_filters
+import swapper
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
@@ -26,10 +27,12 @@ from wagtail.models import (
     WorkflowState,
     get_default_page_content_type,
 )
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 from wagtail.snippets.models import get_editable_models
 
 from .base import ReportView
+
+Page = swapper.load_model("wagtailcore", "Page")
 
 
 def get_requested_by_queryset(request):
@@ -40,7 +43,7 @@ def get_requested_by_queryset(request):
 
 
 def get_editable_page_ids_query(request):
-    pages = page_permission_policy.instances_user_has_permission_for(
+    pages = policies_registry.get_by_type(Page).instances_user_has_permission_for(
         request.user, "change"
     )
     # Need to cast the page ids to string because Postgres doesn't support
@@ -144,7 +147,6 @@ class WorkflowView(ReportView):
     filterset_class = WorkflowReportFilterSet
     index_url_name = "wagtailadmin_reports:workflow"
     index_results_url_name = "wagtailadmin_reports:workflow_results"
-    permission_policy = page_permission_policy
     any_permission_required = ["add", "change", "publish"]
 
     export_headings = {
@@ -163,6 +165,12 @@ class WorkflowView(ReportView):
         "requested_by",
         "created_at",
     ]
+
+    @cached_property
+    def permission_policy(self):
+        # This view lists WorkflowState objects, but we want to check permissions
+        # against the Page model.
+        return policies_registry.get_by_type(Page)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -223,7 +231,6 @@ class WorkflowTasksView(ReportView):
     filterset_class = WorkflowTasksReportFilterSet
     index_url_name = "wagtailadmin_reports:workflow_tasks"
     index_results_url_name = "wagtailadmin_reports:workflow_tasks_results"
-    permission_policy = page_permission_policy
     any_permission_required = ["add", "change", "publish"]
 
     export_headings = {
@@ -244,6 +251,12 @@ class WorkflowTasksView(ReportView):
         "finished_at",
         "finished_by",
     ]
+
+    @cached_property
+    def permission_policy(self):
+        # This view lists TaskState objects, but we want to check permissions
+        # against the Page model.
+        return policies_registry.get_by_type(Page)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -45,7 +45,7 @@ from wagtail.models import (
     WorkflowState,
     WorkflowTask,
 )
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.snippets.models import get_workflow_enabled_models
 from wagtail.workflows import get_task_types
 
@@ -423,7 +423,7 @@ class WorkflowUsageView(PageListingMixin, PermissionCheckedMixin, BaseListingVie
     def permission_policy(self):
         # This view lists Page objects, but we want to check permissions
         # against the Workflow model.
-        return policies_registry.get_by_type(Workflow)
+        return policy_registry.get_by_type(Workflow)
 
     def dispatch(self, request, *args, **kwargs):
         self.object = self.get_object()
@@ -431,7 +431,7 @@ class WorkflowUsageView(PageListingMixin, PermissionCheckedMixin, BaseListingVie
         # We set Workflow's permission_policy as the main permission policy for this view
         # for consistency with the other workflow views. However, since we are listing
         # page objects in this view, we want to ensure the user has a page permission.
-        if not policies_registry.get_by_type(Page).user_has_any_permission(
+        if not policy_registry.get_by_type(Page).user_has_any_permission(
             request.user,
             {"add", "change", "publish", "bulk_delete", "lock", "unlock"},
         ):
@@ -468,7 +468,7 @@ class WorkflowUsageView(PageListingMixin, PermissionCheckedMixin, BaseListingVie
 
     def get_base_queryset(self):
         editable_pages = (
-            policies_registry.get_by_type(Page)
+            policy_registry.get_by_type(Page)
             .instances_user_has_permission_for(self.request.user, "change")
             .filter(depth__gt=1)
         )
@@ -483,7 +483,7 @@ def enable_workflow(request, pk):
     workflow = get_object_or_404(Workflow, id=pk)
 
     # Check permissions
-    if not policies_registry.get_by_type(Workflow).user_has_permission(
+    if not policy_registry.get_by_type(Workflow).user_has_permission(
         request.user, "add"
     ):
         raise PermissionDenied
@@ -515,7 +515,7 @@ def remove_workflow(request, page_pk, workflow_pk=None):
     page = get_object_or_404(Page, id=page_pk)
 
     # Check permissions
-    if not policies_registry.get_by_type(Workflow).user_has_permission(
+    if not policy_registry.get_by_type(Workflow).user_has_permission(
         request.user, "change"
     ):
         raise PermissionDenied
@@ -624,7 +624,7 @@ class TaskIndex(IndexView):
 
 
 def select_task_type(request):
-    if not policies_registry.get_by_type(Task).user_has_permission(request.user, "add"):
+    if not policy_registry.get_by_type(Task).user_has_permission(request.user, "add"):
         raise PermissionDenied
 
     task_types = [
@@ -814,7 +814,7 @@ def enable_task(request, pk):
     task = get_object_or_404(Task, id=pk)
 
     # Check permissions
-    if not policies_registry.get_by_type(Task).user_has_permission(request.user, "add"):
+    if not policy_registry.get_by_type(Task).user_has_permission(request.user, "add"):
         raise PermissionDenied
 
     # Set workflow to active if inactive
@@ -857,7 +857,7 @@ class BaseTaskChooserView(TemplateView):
     def dispatch(self, request):
         self.task_models = get_task_types()
         self.can_create = (
-            policies_registry.get_by_type(Task).user_has_permission(request.user, "add")
+            policy_registry.get_by_type(Task).user_has_permission(request.user, "add")
             and len(self.task_models) != 0
         )
         return super().dispatch(request)

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -20,7 +20,6 @@ from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
 
 from wagtail.admin import messages
-from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.filters import (
     MultipleContentTypeFilter,
     WagtailFilterSet,
@@ -46,17 +45,11 @@ from wagtail.models import (
     WorkflowState,
     WorkflowTask,
 )
-from wagtail.permissions import (
-    page_permission_policy,
-    task_permission_policy,
-    workflow_permission_policy,
-)
+from wagtail.permissions import policies_registry
 from wagtail.snippets.models import get_workflow_enabled_models
 from wagtail.workflows import get_task_types
 
 Page = swapper.load_model("wagtailcore", "Page")
-
-task_permission_checker = PermissionPolicyChecker(task_permission_policy)
 
 
 class WorkflowTitleColumn(TitleColumn):
@@ -114,7 +107,6 @@ class WorkflowFilterSet(BaseWorkflowFilterSet):
 
 
 class Index(IndexView):
-    permission_policy = workflow_permission_policy
     model = Workflow
     context_object_name = "workflows"
     template_name = "wagtailadmin/workflows/index.html"
@@ -167,7 +159,6 @@ class Index(IndexView):
 
 
 class Create(CreateView):
-    permission_policy = workflow_permission_policy
     model = Workflow
     page_title = _("New workflow")
     template_name = "wagtailadmin/workflows/create.html"
@@ -259,7 +250,6 @@ class Create(CreateView):
 
 
 class Edit(EditView):
-    permission_policy = workflow_permission_policy
     model = Workflow
     page_title = _("Editing workflow")
     template_name = "wagtailadmin/workflows/edit.html"
@@ -386,7 +376,6 @@ class Edit(EditView):
 
 
 class Disable(DeleteView):
-    permission_policy = workflow_permission_policy
     model = Workflow
     page_title = _("Disable workflow")
     template_name = "wagtailadmin/workflows/confirm_disable.html"
@@ -421,7 +410,6 @@ class Disable(DeleteView):
 
 
 class WorkflowUsageView(PageListingMixin, PermissionCheckedMixin, BaseListingView):
-    permission_policy = workflow_permission_policy
     any_permission_required = {"add", "change", "delete", "view"}
     pk_url_kwarg = "pk"
     index_url_name = "wagtailadmin_workflows:usage"
@@ -431,13 +419,19 @@ class WorkflowUsageView(PageListingMixin, PermissionCheckedMixin, BaseListingVie
     page_title = _("Usage")
     filterset_class = GenericPageFilterSet
 
+    @cached_property
+    def permission_policy(self):
+        # This view lists Page objects, but we want to check permissions
+        # against the Workflow model.
+        return policies_registry.get_by_type(Workflow)
+
     def dispatch(self, request, *args, **kwargs):
         self.object = self.get_object()
 
-        # We set workflow_permission_policy as the main permission policy for this view
+        # We set Workflow's permission_policy as the main permission policy for this view
         # for consistency with the other workflow views. However, since we are listing
         # page objects in this view, we want to ensure the user has a page permission.
-        if not page_permission_policy.user_has_any_permission(
+        if not policies_registry.get_by_type(Page).user_has_any_permission(
             request.user,
             {"add", "change", "publish", "bulk_delete", "lock", "unlock"},
         ):
@@ -473,9 +467,11 @@ class WorkflowUsageView(PageListingMixin, PermissionCheckedMixin, BaseListingVie
         return get_object_or_404(Workflow, id=self.kwargs.get(self.pk_url_kwarg))
 
     def get_base_queryset(self):
-        editable_pages = page_permission_policy.instances_user_has_permission_for(
-            self.request.user, "change"
-        ).filter(depth__gt=1)
+        editable_pages = (
+            policies_registry.get_by_type(Page)
+            .instances_user_has_permission_for(self.request.user, "change")
+            .filter(depth__gt=1)
+        )
         pages = self.object.all_pages() & editable_pages
         pages = self.annotate_queryset(pages)
         return pages
@@ -487,7 +483,9 @@ def enable_workflow(request, pk):
     workflow = get_object_or_404(Workflow, id=pk)
 
     # Check permissions
-    if not workflow_permission_policy.user_has_permission(request.user, "add"):
+    if not policies_registry.get_by_type(Workflow).user_has_permission(
+        request.user, "add"
+    ):
         raise PermissionDenied
 
     # Set workflow to active if inactive
@@ -517,7 +515,9 @@ def remove_workflow(request, page_pk, workflow_pk=None):
     page = get_object_or_404(Page, id=page_pk)
 
     # Check permissions
-    if not workflow_permission_policy.user_has_permission(request.user, "change"):
+    if not policies_registry.get_by_type(Workflow).user_has_permission(
+        request.user, "change"
+    ):
         raise PermissionDenied
 
     if hasattr(page, "workflowpage"):
@@ -570,7 +570,6 @@ class TaskFilterSet(BaseWorkflowFilterSet):
 
 
 class TaskIndex(IndexView):
-    permission_policy = task_permission_policy
     model = Task
     context_object_name = "tasks"
     template_name = "wagtailadmin/workflows/task_index.html"
@@ -625,7 +624,7 @@ class TaskIndex(IndexView):
 
 
 def select_task_type(request):
-    if not task_permission_policy.user_has_permission(request.user, "add"):
+    if not policies_registry.get_by_type(Task).user_has_permission(request.user, "add"):
         raise PermissionDenied
 
     task_types = [
@@ -658,7 +657,6 @@ def select_task_type(request):
 
 
 class CreateTask(CreateView):
-    permission_policy = task_permission_policy
     page_title = _("New workflow task")
     template_name = "wagtailadmin/workflows/create_task.html"
     success_message = _("Task '%(object)s' created.")
@@ -714,7 +712,6 @@ class CreateTask(CreateView):
 
 
 class EditTask(EditView):
-    permission_policy = task_permission_policy
     template_name = "wagtailadmin/workflows/edit_task.html"
     success_message = _("Task '%(object)s' updated.")
     add_url_name = "wagtailadmin_workflows:select_task_type"
@@ -778,7 +775,6 @@ class EditTask(EditView):
 
 
 class DisableTask(DeleteView):
-    permission_policy = task_permission_policy
     model = Task
     page_title = _("Disable task")
     template_name = "wagtailadmin/workflows/confirm_disable_task.html"
@@ -818,7 +814,7 @@ def enable_task(request, pk):
     task = get_object_or_404(Task, id=pk)
 
     # Check permissions
-    if not task_permission_policy.user_has_permission(request.user, "add"):
+    if not policies_registry.get_by_type(Task).user_has_permission(request.user, "add"):
         raise PermissionDenied
 
     # Set workflow to active if inactive
@@ -861,7 +857,7 @@ class BaseTaskChooserView(TemplateView):
     def dispatch(self, request):
         self.task_models = get_task_types()
         self.can_create = (
-            task_permission_policy.user_has_permission(request.user, "add")
+            policies_registry.get_by_type(Task).user_has_permission(request.user, "add")
             and len(self.task_models) != 0
         )
         return super().dispatch(request)

--- a/wagtail/admin/viewsets/chooser.py
+++ b/wagtail/admin/viewsets/chooser.py
@@ -10,7 +10,6 @@ from wagtail.admin.telepath import register as register_telepath_adapter
 from wagtail.admin.views.generic import chooser as chooser_views
 from wagtail.admin.widgets.chooser import BaseChooser
 from wagtail.blocks import ChooserBlock
-from wagtail.permissions import policies_registry
 from wagtail.utils.deprecation import RemovedInWagtail90Warning
 from wagtail.utils.registry import resolve_model_string
 
@@ -251,14 +250,7 @@ class ChooserViewSet(ViewSet):
                 register_telepath_adapter(adapter, self.widget_class)
 
         model = resolve_model_string(self.model)
-        # When ChooserViewSet.permission_policy is removed in Wagtail 9.0, we may
-        # want to raise a RuntimeWarning or ImproperlyConfigured to ensure developers
-        # do not forget to register the permission policy for their model.
-        if (
-            self.permission_policy
-            and self.permission_policy is not self.UNDEFINED
-            and not policies_registry.get_by_type(model)
-        ):
+        if self.permission_policy and self.permission_policy is not self.UNDEFINED:
             warnings.warn(
                 f"A permission policy for {model.__name__} was set via "
                 f"{self.__class__.__name__}. Please register the policy with "

--- a/wagtail/admin/viewsets/chooser.py
+++ b/wagtail/admin/viewsets/chooser.py
@@ -84,7 +84,8 @@ class ChooserViewSet(ViewSet):
     create_action_clicked_label = None  #: Alternative text to display on the submit button after it has been clicked
     creation_tab_label = None  #: Label for the 'create' tab in the chooser modal (defaults to the same as create_action_label)
 
-    permission_policy = None
+    # Let the views consult the registry at request time by default.
+    permission_policy = ViewSet.UNDEFINED
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/wagtail/admin/viewsets/chooser.py
+++ b/wagtail/admin/viewsets/chooser.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.db.models import ForeignKey
 from django.urls import path
 from django.utils.functional import cached_property
@@ -8,6 +10,9 @@ from wagtail.admin.telepath import register as register_telepath_adapter
 from wagtail.admin.views.generic import chooser as chooser_views
 from wagtail.admin.widgets.chooser import BaseChooser
 from wagtail.blocks import ChooserBlock
+from wagtail.permissions import policies_registry
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
+from wagtail.utils.registry import resolve_model_string
 
 from .base import ViewSet
 
@@ -86,6 +91,15 @@ class ChooserViewSet(ViewSet):
 
     # Let the views consult the registry at request time by default.
     permission_policy = ViewSet.UNDEFINED
+    """
+    The permission policy for the model.
+
+    .. versionchanged:: 8.0
+
+        This property is deprecated and will be removed in a future release.
+        Register the permission policy for the model via
+        ``wagtail.permissions.register_permission_policy()`` instead.
+    """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -96,6 +110,8 @@ class ChooserViewSet(ViewSet):
         return super().get_common_view_kwargs(
             **{
                 "model": self.model,
+                # RemovedInWagtail90Warning: remove in favour of registering the
+                # policy via the registry.
                 "permission_policy": self.permission_policy,
                 "preserve_url_parameters": self.preserve_url_parameters,
                 "url_filter_parameters": self.url_filter_parameters,
@@ -233,3 +249,20 @@ class ChooserViewSet(ViewSet):
             if self.widget_telepath_adapter_class:
                 adapter = self.widget_telepath_adapter_class()
                 register_telepath_adapter(adapter, self.widget_class)
+
+        model = resolve_model_string(self.model)
+        # When ChooserViewSet.permission_policy is removed in Wagtail 9.0, we may
+        # want to raise a RuntimeWarning or ImproperlyConfigured to ensure developers
+        # do not forget to register the permission policy for their model.
+        if (
+            self.permission_policy
+            and self.permission_policy is not self.UNDEFINED
+            and not policies_registry.get_by_type(model)
+        ):
+            warnings.warn(
+                f"A permission policy for {model.__name__} was set via "
+                f"{self.__class__.__name__}. Please register the policy with "
+                f"wagtail.permissions.register_permission_policy("
+                f"{model.__name__}, <policy_instance>) instead.",
+                RemovedInWagtail90Warning,
+            )

--- a/wagtail/admin/viewsets/chooser.py
+++ b/wagtail/admin/viewsets/chooser.py
@@ -98,7 +98,7 @@ class ChooserViewSet(ViewSet):
 
         This property is deprecated and will be removed in a future release.
         Register the permission policy for the model via
-        ``wagtail.permissions.register_permission_policy()`` instead.
+        :func:`wagtail.permissions.register_permission_policy()` instead.
     """
 
     def __init__(self, *args, **kwargs):

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -21,7 +21,7 @@ from wagtail.admin.views import generic
 from wagtail.admin.views.generic import history, usage
 from wagtail.admin.viewsets.listing import ListingViewSetMixin
 from wagtail.models import ReferenceIndex
-from wagtail.permissions import policies_registry, register_permission_policy
+from wagtail.permissions import policy_registry, register_permission_policy
 from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
 from .base import ViewSet, ViewSetGroup
@@ -136,7 +136,7 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
         """
         # Upon access, this will either return an explicitly registered policy
         # for the model, or create and register a fallback policy for the model.
-        return policies_registry.get_by_type(self.model)
+        return policy_registry.get_by_type(self.model)
 
     @cached_property
     def pk_path_converter(self):
@@ -476,7 +476,7 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
         from wagtail.admin.menu import MenuItem
 
         def is_shown(_self, request):
-            permission_policy = policies_registry.get_by_type(self.model)
+            permission_policy = policy_registry.get_by_type(self.model)
             return permission_policy.user_has_any_permission(
                 request.user, self.index_view_class.any_permission_required
             )
@@ -595,7 +595,7 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
     def register_permissions(self):
         hooks.register("register_permissions", self.get_permissions_to_register)
 
-        registered_policy = policies_registry.get_by_type(self.model, fallback=False)
+        registered_policy = policy_registry.get_by_type(self.model, fallback=False)
         if not registered_policy:
             # If no explicit policy was registered by now, accessing
             # self.permission_policy will create and register a fallback policy
@@ -604,8 +604,7 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
             # unless the cached property was overridden with a custom one, thus
             # it is not the same as the fallback policy for the model.
             has_custom_policy = (
-                permission_policy
-                is not policies_registry.get_fallback_policy(self.model)
+                permission_policy is not policy_registry.get_fallback_policy(self.model)
             )
 
             if has_custom_policy:

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -475,7 +475,8 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
         from wagtail.admin.menu import MenuItem
 
         def is_shown(_self, request):
-            return self.permission_policy.user_has_any_permission(
+            permission_policy = policies_registry.get_by_type(self.model)
+            return permission_policy.user_has_any_permission(
                 request.user, self.index_view_class.any_permission_required
             )
 

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -168,7 +168,6 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
         view_kwargs = super().get_common_view_kwargs(
             **{
                 "model": self.model,
-                "permission_policy": self.permission_policy,
                 "index_url_name": self.get_url_name("index"),
                 "index_results_url_name": self.get_url_name("index_results"),
                 "history_url_name": self.get_url_name("history"),

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -133,7 +133,7 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
 
             This property is deprecated and will be removed in a future release.
             Register the permission policy for the model via
-            ``wagtail.permissions.register_permission_policy()`` instead.
+            :func:`wagtail.permissions.register_permission_policy()` instead.
         """
         return ModelPermissionPolicy(self.model)
 

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -21,7 +21,6 @@ from wagtail.admin.views import generic
 from wagtail.admin.views.generic import history, usage
 from wagtail.admin.viewsets.listing import ListingViewSetMixin
 from wagtail.models import ReferenceIndex
-from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.permissions import policies_registry, register_permission_policy
 from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
@@ -135,7 +134,9 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
             Register the permission policy for the model via
             :func:`wagtail.permissions.register_permission_policy()` instead.
         """
-        return ModelPermissionPolicy(self.model)
+        # Upon access, this will either return an explicitly registered policy
+        # for the model, or create and register a fallback policy for the model.
+        return policies_registry.get_by_type(self.model)
 
     @cached_property
     def pk_path_converter(self):
@@ -593,27 +594,38 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
 
     def register_permissions(self):
         hooks.register("register_permissions", self.get_permissions_to_register)
-        if not policies_registry.get_by_type(self.model):
-            register_permission_policy(
-                self.model,
-                self.permission_policy,
-                # Use exact_class so that subclasses of the model don't inherit
-                # the ModelPermissionPolicy of its parents, as each concrete
-                # model has its own set of Permission records, and historically
-                # we've created a ModelPermissionPolicy for each concrete model.
-                exact_class=True,
+
+        registered_policy = policies_registry.get_by_type(self.model, fallback=False)
+        if not registered_policy:
+            # If no explicit policy was registered by now, accessing
+            # self.permission_policy will create and register a fallback policy
+            # for the model...
+            permission_policy = self.permission_policy
+            # unless the cached property was overridden with a custom one, thus
+            # it is not the same as the fallback policy for the model.
+            has_custom_policy = (
+                permission_policy
+                is not policies_registry.get_fallback_policy(self.model)
             )
 
-            # When the registration is removed in Wagtail 9.0, we may want to
-            # raise a RuntimeWarning or ImproperlyConfigured to ensure developers
-            # do not forget to register the permission policy for their model.
-            warnings.warn(
-                f"A permission policy for {self.model.__name__} was registered "
-                f"via {self.__class__.__name__}. Please register the policy with "
-                f"wagtail.permissions.register_permission_policy("
-                f"{self.model.__name__}, <policy_instance>) instead.",
-                RemovedInWagtail90Warning,
-            )
+            if has_custom_policy:
+                register_permission_policy(
+                    self.model,
+                    self.permission_policy,
+                    # Use exact_class so that subclasses of the model don't inherit
+                    # the ModelPermissionPolicy of its parents, as each concrete
+                    # model has its own set of Permission records, and historically
+                    # we've created a ModelPermissionPolicy for each concrete model.
+                    exact_class=True,
+                )
+
+                warnings.warn(
+                    f"A permission policy for {self.model.__name__} was registered "
+                    f"via {self.__class__.__name__}. Please register the policy with "
+                    f"wagtail.permissions.register_permission_policy("
+                    f"{self.model.__name__}, <policy_instance>) instead.",
+                    RemovedInWagtail90Warning,
+                )
 
     def get_urlpatterns(self):
         conv = self.pk_path_converter

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -562,7 +562,6 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
             "_ModelAdminURLFinder",
             (ModelAdminURLFinder,),
             {
-                "permission_policy": self.permission_policy,
                 "edit_url_name": self.get_url_name("edit"),
             },
         )

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
@@ -19,7 +21,9 @@ from wagtail.admin.views import generic
 from wagtail.admin.views.generic import history, usage
 from wagtail.admin.viewsets.listing import ListingViewSetMixin
 from wagtail.models import ReferenceIndex
-from wagtail.permissions import ModelPermissionPolicy
+from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permissions import policies_registry, register_permission_policy
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
 from .base import ViewSet, ViewSetGroup
 
@@ -120,8 +124,17 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
         ):
             self.sort_order_field = self.model.sort_order_field
 
-    @property
+    @cached_property
     def permission_policy(self):
+        """
+        The permission policy for the model.
+
+        .. versionchanged:: 8.0
+
+            This property is deprecated and will be removed in a future release.
+            Register the permission policy for the model via
+            ``wagtail.permissions.register_permission_policy()`` instead.
+        """
         return ModelPermissionPolicy(self.model)
 
     @cached_property
@@ -581,6 +594,27 @@ class ModelViewSet(ListingViewSetMixin, ViewSet):
 
     def register_permissions(self):
         hooks.register("register_permissions", self.get_permissions_to_register)
+        if not policies_registry.get_by_type(self.model):
+            register_permission_policy(
+                self.model,
+                self.permission_policy,
+                # Use exact_class so that subclasses of the model don't inherit
+                # the ModelPermissionPolicy of its parents, as each concrete
+                # model has its own set of Permission records, and historically
+                # we've created a ModelPermissionPolicy for each concrete model.
+                exact_class=True,
+            )
+
+            # When the registration is removed in Wagtail 9.0, we may want to
+            # raise a RuntimeWarning or ImproperlyConfigured to ensure developers
+            # do not forget to register the permission policy for their model.
+            warnings.warn(
+                f"A permission policy for {self.model.__name__} was registered "
+                f"via {self.__class__.__name__}. Please register the policy with "
+                f"wagtail.permissions.register_permission_policy("
+                f"{self.model.__name__}, <policy_instance>) instead.",
+                RemovedInWagtail90Warning,
+            )
 
     def get_urlpatterns(self):
         conv = self.pk_path_converter

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -56,12 +56,7 @@ from wagtail.admin.viewsets import viewsets
 from wagtail.admin.viewsets.pages import base_page_viewset
 from wagtail.admin.widgets import ButtonWithDropdownFromHook
 from wagtail.models import Collection, Task, Workflow
-from wagtail.permissions import (
-    collection_permission_policy,
-    page_permission_policy,
-    task_permission_policy,
-    workflow_permission_policy,
-)
+from wagtail.permissions import policies_registry
 from wagtail.templatetags.wagtailcore_tags import (
     wagtail_feature_release_editor_guide_link,
     wagtail_feature_release_whats_new_link,
@@ -83,7 +78,9 @@ class ExplorerMenuItem(MenuItem):
 
     def get_context(self, request):
         context = super().get_context(request)
-        start_page = page_permission_policy.explorable_root_instance(request.user)
+        start_page = policies_registry.get_by_type(Page).explorable_root_instance(
+            request.user
+        )
 
         if start_page:
             context["start_page_id"] = start_page.id
@@ -91,7 +88,9 @@ class ExplorerMenuItem(MenuItem):
         return context
 
     def render_component(self, request):
-        start_page = page_permission_policy.explorable_root_instance(request.user)
+        start_page = policies_registry.get_by_type(Page).explorable_root_instance(
+            request.user
+        )
 
         if start_page:
             return PageExplorerMenuItemComponent(
@@ -173,7 +172,7 @@ def register_collection_permissions_panel():
 
 class CollectionsMenuItem(MenuItem):
     def is_shown(self, request):
-        return collection_permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Collection).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -194,7 +193,7 @@ class WorkflowsMenuItem(MenuItem):
         if not getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True):
             return False
 
-        return workflow_permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Workflow).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -204,7 +203,7 @@ class WorkflowTasksMenuItem(MenuItem):
         if not getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True):
             return False
 
-        return task_permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Task).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -845,35 +844,40 @@ def register_core_features(features):
 
 class LockedPagesMenuItem(MenuItem):
     def is_shown(self, request):
-        return page_permission_policy.user_has_permission(request.user, "unlock")
+        return policies_registry.get_by_type(Page).user_has_permission(
+            request.user, "unlock"
+        )
 
 
 class WorkflowReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return getattr(
-            settings, "WAGTAIL_WORKFLOW_ENABLED", True
-        ) and page_permission_policy.user_has_any_permission(
-            request.user, ["add", "change", "publish"]
+        return getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True) and (
+            policies_registry.get_by_type(Page).user_has_any_permission(
+                request.user, ["add", "change", "publish"]
+            )
         )
 
 
 class SiteHistoryReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return page_permission_policy.explorable_root_instance(request.user) is not None
+        return (
+            policies_registry.get_by_type(Page).explorable_root_instance(request.user)
+            is not None
+        )
 
 
 class AgingPagesReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return getattr(
-            settings, "WAGTAIL_AGING_PAGES_ENABLED", True
-        ) and page_permission_policy.user_has_any_permission(
-            request.user, ["add", "change", "publish"]
+        return getattr(settings, "WAGTAIL_AGING_PAGES_ENABLED", True) and (
+            policies_registry.get_by_type(Page).user_has_any_permission(
+                request.user, ["add", "change", "publish"]
+            )
         )
 
 
 class PageTypesReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return page_permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Page).user_has_any_permission(
             request.user, ["add", "change", "publish"]
         )
 
@@ -1160,24 +1164,33 @@ register_admin_url_finder(Page, PageAdminURLFinder)
 
 
 class CollectionAdminURLFinder(ModelAdminURLFinder):
-    permission_policy = collection_permission_policy
     edit_url_name = "wagtailadmin_collections:edit"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Collection)
 
 
 register_admin_url_finder(Collection, CollectionAdminURLFinder)
 
 
 class WorkflowAdminURLFinder(ModelAdminURLFinder):
-    permission_policy = workflow_permission_policy
     edit_url_name = "wagtailadmin_workflows:edit"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Workflow)
 
 
 register_admin_url_finder(Workflow, WorkflowAdminURLFinder)
 
 
 class WorkflowTaskAdminURLFinder(ModelAdminURLFinder):
-    permission_policy = task_permission_policy
     edit_url_name = "wagtailadmin_workflows:edit_task"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Task)
 
 
 register_admin_url_finder(Task, WorkflowTaskAdminURLFinder)

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -56,7 +56,7 @@ from wagtail.admin.viewsets import viewsets
 from wagtail.admin.viewsets.pages import base_page_viewset
 from wagtail.admin.widgets import ButtonWithDropdownFromHook
 from wagtail.models import Collection, Task, Workflow
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.templatetags.wagtailcore_tags import (
     wagtail_feature_release_editor_guide_link,
     wagtail_feature_release_whats_new_link,
@@ -78,7 +78,7 @@ class ExplorerMenuItem(MenuItem):
 
     def get_context(self, request):
         context = super().get_context(request)
-        start_page = policies_registry.get_by_type(Page).explorable_root_instance(
+        start_page = policy_registry.get_by_type(Page).explorable_root_instance(
             request.user
         )
 
@@ -88,7 +88,7 @@ class ExplorerMenuItem(MenuItem):
         return context
 
     def render_component(self, request):
-        start_page = policies_registry.get_by_type(Page).explorable_root_instance(
+        start_page = policy_registry.get_by_type(Page).explorable_root_instance(
             request.user
         )
 
@@ -172,7 +172,7 @@ def register_collection_permissions_panel():
 
 class CollectionsMenuItem(MenuItem):
     def is_shown(self, request):
-        return policies_registry.get_by_type(Collection).user_has_any_permission(
+        return policy_registry.get_by_type(Collection).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -193,7 +193,7 @@ class WorkflowsMenuItem(MenuItem):
         if not getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True):
             return False
 
-        return policies_registry.get_by_type(Workflow).user_has_any_permission(
+        return policy_registry.get_by_type(Workflow).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -203,7 +203,7 @@ class WorkflowTasksMenuItem(MenuItem):
         if not getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True):
             return False
 
-        return policies_registry.get_by_type(Task).user_has_any_permission(
+        return policy_registry.get_by_type(Task).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -844,7 +844,7 @@ def register_core_features(features):
 
 class LockedPagesMenuItem(MenuItem):
     def is_shown(self, request):
-        return policies_registry.get_by_type(Page).user_has_permission(
+        return policy_registry.get_by_type(Page).user_has_permission(
             request.user, "unlock"
         )
 
@@ -852,7 +852,7 @@ class LockedPagesMenuItem(MenuItem):
 class WorkflowReportMenuItem(MenuItem):
     def is_shown(self, request):
         return getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True) and (
-            policies_registry.get_by_type(Page).user_has_any_permission(
+            policy_registry.get_by_type(Page).user_has_any_permission(
                 request.user, ["add", "change", "publish"]
             )
         )
@@ -861,7 +861,7 @@ class WorkflowReportMenuItem(MenuItem):
 class SiteHistoryReportMenuItem(MenuItem):
     def is_shown(self, request):
         return (
-            policies_registry.get_by_type(Page).explorable_root_instance(request.user)
+            policy_registry.get_by_type(Page).explorable_root_instance(request.user)
             is not None
         )
 
@@ -869,7 +869,7 @@ class SiteHistoryReportMenuItem(MenuItem):
 class AgingPagesReportMenuItem(MenuItem):
     def is_shown(self, request):
         return getattr(settings, "WAGTAIL_AGING_PAGES_ENABLED", True) and (
-            policies_registry.get_by_type(Page).user_has_any_permission(
+            policy_registry.get_by_type(Page).user_has_any_permission(
                 request.user, ["add", "change", "publish"]
             )
         )
@@ -877,7 +877,7 @@ class AgingPagesReportMenuItem(MenuItem):
 
 class PageTypesReportMenuItem(MenuItem):
     def is_shown(self, request):
-        return policies_registry.get_by_type(Page).user_has_any_permission(
+        return policy_registry.get_by_type(Page).user_has_any_permission(
             request.user, ["add", "change", "publish"]
         )
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -1166,10 +1166,6 @@ register_admin_url_finder(Page, PageAdminURLFinder)
 class CollectionAdminURLFinder(ModelAdminURLFinder):
     edit_url_name = "wagtailadmin_collections:edit"
 
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(Collection)
-
 
 register_admin_url_finder(Collection, CollectionAdminURLFinder)
 
@@ -1177,20 +1173,12 @@ register_admin_url_finder(Collection, CollectionAdminURLFinder)
 class WorkflowAdminURLFinder(ModelAdminURLFinder):
     edit_url_name = "wagtailadmin_workflows:edit"
 
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(Workflow)
-
 
 register_admin_url_finder(Workflow, WorkflowAdminURLFinder)
 
 
 class WorkflowTaskAdminURLFinder(ModelAdminURLFinder):
     edit_url_name = "wagtailadmin_workflows:edit_task"
-
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(Task)
 
 
 register_admin_url_finder(Task, WorkflowTaskAdminURLFinder)

--- a/wagtail/api/v3/permissions.py
+++ b/wagtail/api/v3/permissions.py
@@ -2,13 +2,13 @@ import functools
 
 from django.core.exceptions import PermissionDenied
 
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 def require_any_permission(model, actions=("add", "change", "delete", "view")):
     """
     Decorator factory that gates a view behind authentication and any of the
-    given permission actions for *model*, looked up via ``policies_registry``.
+    given permission actions for *model*, looked up via ``policy_registry``.
 
     Usage::
 
@@ -21,7 +21,7 @@ def require_any_permission(model, actions=("add", "change", "delete", "view")):
     def decorator(view_func):
         @functools.wraps(view_func)
         def wrapper(request, *args, **kwargs):
-            permission_policy = policies_registry.get_by_type(model)
+            permission_policy = policy_registry.get_by_type(model)
             if not permission_policy.user_has_any_permission(request.user, actions):
                 raise PermissionDenied
             return view_func(request, *args, **kwargs)

--- a/wagtail/api/v3/permissions.py
+++ b/wagtail/api/v3/permissions.py
@@ -1,12 +1,8 @@
 import functools
 
-import swapper
 from django.core.exceptions import PermissionDenied
 
-from wagtail.permission_policies import ModelPermissionPolicy
-from wagtail.permissions import page_permission_policy
-
-Page = swapper.load_model("wagtailcore", "Page")
+from wagtail.permissions import policies_registry
 
 
 def require_any_permission(model, actions=("add", "change", "delete", "view")):
@@ -25,13 +21,7 @@ def require_any_permission(model, actions=("add", "change", "delete", "view")):
     def decorator(view_func):
         @functools.wraps(view_func)
         def wrapper(request, *args, **kwargs):
-            # FIXME: use the registry when it's implemented.
-            # from wagtail.permissions import policies_registry
-            # permission_policy = policies_registry.get(model)
-            if issubclass(model, Page):
-                permission_policy = page_permission_policy
-            else:
-                permission_policy = ModelPermissionPolicy(model)
+            permission_policy = policies_registry.get_by_type(model)
             if not permission_policy.user_has_any_permission(request.user, actions):
                 raise PermissionDenied
             return view_func(request, *args, **kwargs)

--- a/wagtail/api/v3/querysets.py
+++ b/wagtail/api/v3/querysets.py
@@ -3,7 +3,8 @@ from enum import Enum
 from django.http import HttpRequest
 
 from wagtail.api.v2.querysets import get_public_pages_queryset
-from wagtail.permissions import page_permission_policy
+from wagtail.models import Page
+from wagtail.permissions import policies_registry
 
 
 class AccessTier(str, Enum):
@@ -23,4 +24,4 @@ def get_pages_queryset(request: HttpRequest, tier: AccessTier = AccessTier.PUBLI
         return get_public_pages_queryset(request)
 
     if tier == AccessTier.AUTHENTICATED:
-        return page_permission_policy.explorable_instances(getattr(request, "user"))
+        return policies_registry.get_by_type(Page).explorable_instances(request.user)

--- a/wagtail/api/v3/querysets.py
+++ b/wagtail/api/v3/querysets.py
@@ -1,9 +1,11 @@
 from enum import Enum
+from typing import cast
 
 import swapper
 from django.http import HttpRequest
 
 from wagtail.api.v2.querysets import get_public_pages_queryset
+from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.permissions import policies_registry
 
 Page = swapper.load_model("wagtailcore", "Page")
@@ -26,4 +28,8 @@ def get_pages_queryset(request: HttpRequest, tier: AccessTier = AccessTier.PUBLI
         return get_public_pages_queryset(request)
 
     if tier == AccessTier.AUTHENTICATED:
-        return policies_registry.get_by_type(Page).explorable_instances(request.user)
+        permission_policy = cast(
+            PagePermissionPolicy,
+            policies_registry.get_by_type(Page),
+        )
+        return permission_policy.explorable_instances(request.user)

--- a/wagtail/api/v3/querysets.py
+++ b/wagtail/api/v3/querysets.py
@@ -1,10 +1,12 @@
 from enum import Enum
 
+import swapper
 from django.http import HttpRequest
 
 from wagtail.api.v2.querysets import get_public_pages_queryset
-from wagtail.models import Page
 from wagtail.permissions import policies_registry
+
+Page = swapper.load_model("wagtailcore", "Page")
 
 
 class AccessTier(str, Enum):

--- a/wagtail/api/v3/querysets.py
+++ b/wagtail/api/v3/querysets.py
@@ -6,7 +6,7 @@ from django.http import HttpRequest
 
 from wagtail.api.v2.querysets import get_public_pages_queryset
 from wagtail.permission_policies.pages import PagePermissionPolicy
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 Page = swapper.load_model("wagtailcore", "Page")
 
@@ -30,6 +30,6 @@ def get_pages_queryset(request: HttpRequest, tier: AccessTier = AccessTier.PUBLI
     if tier == AccessTier.AUTHENTICATED:
         permission_policy = cast(
             PagePermissionPolicy,
-            policies_registry.get_by_type(Page),
+            policy_registry.get_by_type(Page),
         )
         return permission_policy.explorable_instances(request.user)

--- a/wagtail/api/v3/routers/sites.py
+++ b/wagtail/api/v3/routers/sites.py
@@ -10,7 +10,7 @@ from wagtail.api.v3.pagination import WagtailLimitOffsetPagination
 from wagtail.api.v3.permissions import require_any_permission
 from wagtail.api.v3.schemas import SiteInputSchema, SiteSchema
 from wagtail.models import Site
-from wagtail.permissions import site_permission_policy
+from wagtail.permissions import policies_registry
 from wagtail.sites.forms import SiteForm
 
 router = Router(tags=["sites"])
@@ -26,7 +26,7 @@ router = Router(tags=["sites"])
 @paginate(WagtailLimitOffsetPagination)
 @require_any_permission(Site)
 def list_sites(request: HttpRequest):
-    return site_permission_policy.instances_user_has_any_permission_for(
+    return policies_registry.get_by_type(Site).instances_user_has_any_permission_for(
         request.user,
         ("add", "change", "delete", "view"),
     )
@@ -42,7 +42,7 @@ def list_sites(request: HttpRequest):
 @require_any_permission(Site)
 def get_site(request: HttpRequest, site_id: int):
     return get_object_or_404(
-        site_permission_policy.instances_user_has_any_permission_for(
+        policies_registry.get_by_type(Site).instances_user_has_any_permission_for(
             request.user,
             ("add", "change", "delete", "view"),
         ),

--- a/wagtail/api/v3/routers/sites.py
+++ b/wagtail/api/v3/routers/sites.py
@@ -10,7 +10,7 @@ from wagtail.api.v3.pagination import WagtailLimitOffsetPagination
 from wagtail.api.v3.permissions import require_any_permission
 from wagtail.api.v3.schemas import SiteInputSchema, SiteSchema
 from wagtail.models import Site
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.sites.forms import SiteForm
 
 router = Router(tags=["sites"])
@@ -26,7 +26,7 @@ router = Router(tags=["sites"])
 @paginate(WagtailLimitOffsetPagination)
 @require_any_permission(Site)
 def list_sites(request: HttpRequest):
-    return policies_registry.get_by_type(Site).instances_user_has_any_permission_for(
+    return policy_registry.get_by_type(Site).instances_user_has_any_permission_for(
         request.user,
         ("add", "change", "delete", "view"),
     )
@@ -42,7 +42,7 @@ def list_sites(request: HttpRequest):
 @require_any_permission(Site)
 def get_site(request: HttpRequest, site_id: int):
     return get_object_or_404(
-        policies_registry.get_by_type(Site).instances_user_has_any_permission_for(
+        policy_registry.get_by_type(Site).instances_user_has_any_permission_for(
             request.user,
             ("add", "change", "delete", "view"),
         ),

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -1,11 +1,12 @@
 from functools import lru_cache
 
+import swapper
 from django.contrib.contenttypes.models import ContentType
 
 from wagtail import hooks
 from wagtail.coreutils import safe_snake_case
 from wagtail.models import get_page_models
-from wagtail.permissions import page_permission_policy
+from wagtail.permissions import policies_registry
 
 
 def get_field_clean_name(label):
@@ -29,9 +30,9 @@ def get_forms_for_user(user):
     """
     Return a queryset of form pages that this user is allowed to access the submissions for
     """
-    editable_forms = page_permission_policy.instances_user_has_permission_for(
-        user, "change"
-    )
+    Page = swapper.load_model("wagtailcore", "Page")
+    permission_policy = policies_registry.get_by_type(Page)
+    editable_forms = permission_policy.instances_user_has_permission_for(user, "change")
     editable_forms = editable_forms.filter(content_type__in=get_form_types())
 
     # Apply hooks

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -6,7 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from wagtail import hooks
 from wagtail.coreutils import safe_snake_case
 from wagtail.models import get_page_models
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 def get_field_clean_name(label):
@@ -31,7 +31,7 @@ def get_forms_for_user(user):
     Return a queryset of form pages that this user is allowed to access the submissions for
     """
     Page = swapper.load_model("wagtailcore", "Page")
-    permission_policy = policies_registry.get_by_type(Page)
+    permission_policy = policy_registry.get_by_type(Page)
     editable_forms = permission_policy.instances_user_has_permission_for(user, "change")
     editable_forms = editable_forms.filter(content_type__in=get_form_types())
 

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -28,7 +28,6 @@ from wagtail.admin.views.mixins import SpreadsheetExportMixin
 from wagtail.admin.views.pages.listing import PageFilterSet, PageListingMixin
 from wagtail.contrib.forms.models import FormMixin
 from wagtail.contrib.forms.utils import get_form_types, get_forms_for_user
-from wagtail.permissions import page_permission_policy
 
 Page = swapper.load_model("wagtailcore", "Page")
 
@@ -68,7 +67,6 @@ class FormPageFilterSet(PageFilterSet):
 class FormPagesListView(PageListingMixin, PermissionCheckedMixin, BaseListingView):
     """Lists the available form pages for the current user"""
 
-    permission_policy = page_permission_policy
     any_permission_required = {
         "add",
         "change",

--- a/wagtail/contrib/redirects/api.py
+++ b/wagtail/contrib/redirects/api.py
@@ -17,7 +17,7 @@ from wagtail.api.v3.permissions import require_any_permission
 from wagtail.contrib.redirects.forms import RedirectForm
 from wagtail.contrib.redirects.middleware import get_redirect
 from wagtail.contrib.redirects.models import Redirect
-from wagtail.contrib.redirects.permissions import permission_policy
+from wagtail.permissions import policies_registry
 
 router = Router(tags=["redirects"])
 
@@ -55,6 +55,7 @@ class RedirectInputSchema(Schema):
 @paginate(WagtailLimitOffsetPagination)
 @require_any_permission(Redirect)
 def list_redirects(request: HttpRequest):
+    permission_policy = policies_registry.get_by_type(Redirect)
     return permission_policy.instances_user_has_any_permission_for(
         request.user,
         ("add", "change", "delete", "view"),
@@ -70,6 +71,7 @@ def list_redirects(request: HttpRequest):
 )
 @require_any_permission(Redirect)
 def get_redirect_detail(request: HttpRequest, redirect_id: int):
+    permission_policy = policies_registry.get_by_type(Redirect)
     return get_object_or_404(
         permission_policy.instances_user_has_any_permission_for(
             request.user,

--- a/wagtail/contrib/redirects/api.py
+++ b/wagtail/contrib/redirects/api.py
@@ -17,7 +17,7 @@ from wagtail.api.v3.permissions import require_any_permission
 from wagtail.contrib.redirects.forms import RedirectForm
 from wagtail.contrib.redirects.middleware import get_redirect
 from wagtail.contrib.redirects.models import Redirect
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 router = Router(tags=["redirects"])
 
@@ -55,7 +55,7 @@ class RedirectInputSchema(Schema):
 @paginate(WagtailLimitOffsetPagination)
 @require_any_permission(Redirect)
 def list_redirects(request: HttpRequest):
-    permission_policy = policies_registry.get_by_type(Redirect)
+    permission_policy = policy_registry.get_by_type(Redirect)
     return permission_policy.instances_user_has_any_permission_for(
         request.user,
         ("add", "change", "delete", "view"),
@@ -71,7 +71,7 @@ def list_redirects(request: HttpRequest):
 )
 @require_any_permission(Redirect)
 def get_redirect_detail(request: HttpRequest, redirect_id: int):
-    permission_policy = policies_registry.get_by_type(Redirect)
+    permission_policy = policy_registry.get_by_type(Redirect)
     return get_object_or_404(
         permission_policy.instances_user_has_any_permission_for(
             request.user,

--- a/wagtail/contrib/redirects/apps.py
+++ b/wagtail/contrib/redirects/apps.py
@@ -9,6 +9,12 @@ class WagtailRedirectsAppConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
+        from wagtail.permissions import register_permission_policy
+
+        from .models import Redirect
+
+        register_permission_policy(Redirect)
+
         from wagtail.signals import page_slug_changed, post_page_move
 
         from .signal_handlers import (

--- a/wagtail/contrib/redirects/permissions.py
+++ b/wagtail/contrib/redirects/permissions.py
@@ -1,4 +1,12 @@
-from wagtail.contrib.redirects.models import Redirect
-from wagtail.permission_policies import ModelPermissionPolicy
+import warnings
 
-permission_policy = ModelPermissionPolicy(Redirect)
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.permissions import policies_registry
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
+
+warnings.warn(
+    "wagtail.contrib.redirects.permissions.permission_policy is deprecated. "
+    "Use wagtail.permissions.policies_registry.get_by_type(Redirect) instead.",
+    RemovedInWagtail90Warning,
+)
+permission_policy = policies_registry.get_by_type(Redirect)

--- a/wagtail/contrib/redirects/permissions.py
+++ b/wagtail/contrib/redirects/permissions.py
@@ -1,12 +1,12 @@
 import warnings
 
 from wagtail.contrib.redirects.models import Redirect
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
 warnings.warn(
     "wagtail.contrib.redirects.permissions.permission_policy is deprecated. "
-    "Use wagtail.permissions.policies_registry.get_by_type(Redirect) instead.",
+    "Use wagtail.permissions.policy_registry.get_by_type(Redirect) instead.",
     RemovedInWagtail90Warning,
 )
-permission_policy = policies_registry.get_by_type(Redirect)
+permission_policy = policy_registry.get_by_type(Redirect)

--- a/wagtail/contrib/redirects/tests/test_permissions.py
+++ b/wagtail/contrib/redirects/tests/test_permissions.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from wagtail.contrib.redirects.models import Redirect
 from wagtail.permission_policies import ModelPermissionPolicy
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
 
@@ -11,7 +11,7 @@ class TestRedirectPermissions(TestCase):
         with self.assertWarnsMessage(
             RemovedInWagtail90Warning,
             "wagtail.contrib.redirects.permissions.permission_policy is deprecated. "
-            "Use wagtail.permissions.policies_registry.get_by_type(Redirect) instead.",
+            "Use wagtail.permissions.policy_registry.get_by_type(Redirect) instead.",
         ):
             from wagtail.contrib.redirects.permissions import permission_policy
 
@@ -19,6 +19,6 @@ class TestRedirectPermissions(TestCase):
             self.assertIs(permission_policy.model, Redirect)
 
     def test_get_from_registry(self):
-        permission_policy = policies_registry.get_by_type(Redirect)
+        permission_policy = policy_registry.get_by_type(Redirect)
         self.assertIsInstance(permission_policy, ModelPermissionPolicy)
         self.assertIs(permission_policy.model, Redirect)

--- a/wagtail/contrib/redirects/tests/test_permissions.py
+++ b/wagtail/contrib/redirects/tests/test_permissions.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permissions import policies_registry
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
+
+
+class TestRedirectPermissions(TestCase):
+    def test_permissions_direct_import_deprecated(self):
+        with self.assertWarnsMessage(
+            RemovedInWagtail90Warning,
+            "wagtail.contrib.redirects.permissions.permission_policy is deprecated. "
+            "Use wagtail.permissions.policies_registry.get_by_type(Redirect) instead.",
+        ):
+            from wagtail.contrib.redirects.permissions import permission_policy
+
+            self.assertIsInstance(permission_policy, ModelPermissionPolicy)
+            self.assertIs(permission_policy.model, Redirect)
+
+    def test_get_from_registry(self):
+        permission_policy = policies_registry.get_by_type(Redirect)
+        self.assertIsInstance(permission_policy, ModelPermissionPolicy)
+        self.assertIs(permission_policy.model, Redirect)

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -25,7 +25,6 @@ from wagtail.contrib.redirects.forms import (
     RedirectForm,
 )
 from wagtail.contrib.redirects.models import Redirect
-from wagtail.contrib.redirects.permissions import permission_policy
 from wagtail.contrib.redirects.utils import (
     get_file_storage,
     get_format_cls_by_extension,
@@ -35,8 +34,21 @@ from wagtail.contrib.redirects.utils import (
 )
 from wagtail.log_actions import log
 from wagtail.models import Site
+from wagtail.permissions import policies_registry
 
-permission_checker = PermissionPolicyChecker(permission_policy)
+
+class RedirectPermissionPolicyChecker(PermissionPolicyChecker):
+    def __init__(self):
+        # Provide policy via a cached property so we can retrieve it from the
+        # registry at runtime, rather than at import time.
+        pass
+
+    @cached_property
+    def policy(self):
+        return policies_registry.get_by_type(Redirect)
+
+
+permission_checker = RedirectPermissionPolicyChecker()
 
 
 class RedirectTargetColumn(Column):
@@ -62,7 +74,6 @@ class RedirectTargetColumn(Column):
 class IndexView(generic.IndexView):
     template_name = "wagtailredirects/index.html"
     results_template_name = "wagtailredirects/index_results.html"
-    permission_policy = permission_policy
     model = Redirect
     header_icon = "redirect"
     add_item_label = gettext_lazy("Add redirect")
@@ -137,7 +148,6 @@ class IndexView(generic.IndexView):
 class EditView(generic.EditView):
     model = Redirect
     form_class = RedirectForm
-    permission_policy = permission_policy
     template_name = "wagtailredirects/edit.html"
     index_url_name = "wagtailredirects:index"
     edit_url_name = "wagtailredirects:edit"
@@ -169,7 +179,6 @@ class EditView(generic.EditView):
 class DeleteView(generic.DeleteView):
     model = Redirect
     pk_url_kwarg = "redirect_id"
-    permission_policy = permission_policy
     template_name = "wagtailredirects/confirm_delete.html"
     index_url_name = "wagtailredirects:index"
     delete_url_name = "wagtailredirects:delete"
@@ -188,7 +197,6 @@ class DeleteView(generic.DeleteView):
 class CreateView(generic.CreateView):
     model = Redirect
     form_class = RedirectForm
-    permission_policy = permission_policy
     template_name = "wagtailredirects/add.html"
     add_url_name = "wagtailredirects:add"
     index_url_name = "wagtailredirects:index"

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -34,7 +34,7 @@ from wagtail.contrib.redirects.utils import (
 )
 from wagtail.log_actions import log
 from wagtail.models import Site
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 class RedirectPermissionPolicyChecker(PermissionPolicyChecker):
@@ -45,7 +45,7 @@ class RedirectPermissionPolicyChecker(PermissionPolicyChecker):
 
     @cached_property
     def policy(self):
-        return policies_registry.get_by_type(Redirect)
+        return policy_registry.get_by_type(Redirect)
 
 
 permission_checker = RedirectPermissionPolicyChecker()

--- a/wagtail/contrib/redirects/wagtail_hooks.py
+++ b/wagtail/contrib/redirects/wagtail_hooks.py
@@ -9,7 +9,7 @@ from wagtail.admin.admin_url_finder import (
 )
 from wagtail.admin.menu import MenuItem
 from wagtail.contrib.redirects import urls
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 from .models import Redirect
 
@@ -23,7 +23,7 @@ def register_admin_urls():
 
 class RedirectsMenuItem(MenuItem):
     def is_shown(self, request):
-        return policies_registry.get_by_type(Redirect).user_has_any_permission(
+        return policy_registry.get_by_type(Redirect).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 

--- a/wagtail/contrib/redirects/wagtail_hooks.py
+++ b/wagtail/contrib/redirects/wagtail_hooks.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.models import Permission
 from django.urls import include, path, reverse
-from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
@@ -50,10 +49,6 @@ def register_permissions():
 
 class RedirectAdminURLFinder(ModelAdminURLFinder):
     edit_url_name = "wagtailredirects:edit"
-
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(Redirect)
 
 
 register_admin_url_finder(Redirect, RedirectAdminURLFinder)

--- a/wagtail/contrib/redirects/wagtail_hooks.py
+++ b/wagtail/contrib/redirects/wagtail_hooks.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import Permission
 from django.urls import include, path, reverse
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
@@ -9,7 +10,7 @@ from wagtail.admin.admin_url_finder import (
 )
 from wagtail.admin.menu import MenuItem
 from wagtail.contrib.redirects import urls
-from wagtail.contrib.redirects.permissions import permission_policy
+from wagtail.permissions import policies_registry
 
 from .models import Redirect
 
@@ -23,7 +24,7 @@ def register_admin_urls():
 
 class RedirectsMenuItem(MenuItem):
     def is_shown(self, request):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Redirect).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -49,7 +50,10 @@ def register_permissions():
 
 class RedirectAdminURLFinder(ModelAdminURLFinder):
     edit_url_name = "wagtailredirects:edit"
-    permission_policy = permission_policy
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Redirect)
 
 
 register_admin_url_finder(Redirect, RedirectAdminURLFinder)

--- a/wagtail/contrib/search_promotions/views/settings.py
+++ b/wagtail/contrib/search_promotions/views/settings.py
@@ -19,7 +19,7 @@ from wagtail.admin.views import generic
 from wagtail.contrib.search_promotions import forms, models
 from wagtail.contrib.search_promotions.models import Query, SearchPromotion
 from wagtail.log_actions import log
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.search.utils import normalise_query_string
 
 
@@ -66,7 +66,7 @@ class IndexView(generic.IndexView):
     def permission_policy(self):
         # This view works with Query objects, but we want to check permissions
         # against the SearchPromotion model.
-        return policies_registry.get_by_type(SearchPromotion)
+        return policy_registry.get_by_type(SearchPromotion)
 
     def get_base_queryset(self):
         # Use a subquery to filter out the Query objects that do not have a
@@ -101,7 +101,7 @@ class SearchPromotionCreateEditMixin:
     def permission_policy(self):
         # This view works with Query objects, but we want to check permissions
         # against the SearchPromotion model.
-        return policies_registry.get_by_type(SearchPromotion)
+        return policy_registry.get_by_type(SearchPromotion)
 
     def get_success_message(self, instance=None):
         return self.success_message % {"query": instance}
@@ -218,7 +218,7 @@ class DeleteView(generic.DeleteView):
     def permission_policy(self):
         # This view works with Query objects, but we want to check permissions
         # against the SearchPromotion model.
-        return policies_registry.get_by_type(SearchPromotion)
+        return policy_registry.get_by_type(SearchPromotion)
 
     def delete_action(self):
         editors_picks = self.object.editors_picks.all()

--- a/wagtail/contrib/search_promotions/views/settings.py
+++ b/wagtail/contrib/search_promotions/views/settings.py
@@ -19,7 +19,7 @@ from wagtail.admin.views import generic
 from wagtail.contrib.search_promotions import forms, models
 from wagtail.contrib.search_promotions.models import Query, SearchPromotion
 from wagtail.log_actions import log
-from wagtail.permission_policies.base import ModelPermissionPolicy
+from wagtail.permissions import policies_registry
 from wagtail.search.utils import normalise_query_string
 
 
@@ -35,7 +35,6 @@ class IndexView(generic.IndexView):
     page_title = gettext_lazy("Promoted search results")
     header_icon = "pick"
     paginate_by = 20
-    permission_policy = ModelPermissionPolicy(SearchPromotion)
     index_url_name = "wagtailsearchpromotions:index"
     index_results_url_name = "wagtailsearchpromotions:index_results"
     search_fields = ["query_string"]
@@ -63,6 +62,12 @@ class IndexView(generic.IndexView):
         ),
     ]
 
+    @cached_property
+    def permission_policy(self):
+        # This view works with Query objects, but we want to check permissions
+        # against the SearchPromotion model.
+        return policies_registry.get_by_type(SearchPromotion)
+
     def get_base_queryset(self):
         # Use a subquery to filter out the Query objects that do not have a
         # SearchPromotion instead of using .filter(editors_picks__isnull=False).
@@ -86,12 +91,17 @@ class IndexView(generic.IndexView):
 
 class SearchPromotionCreateEditMixin:
     model = Query
-    permission_policy = ModelPermissionPolicy(SearchPromotion)
     index_url_name = "wagtailsearchpromotions:index"
     edit_url_name = "wagtailsearchpromotions:edit"
     form_class = forms.QueryForm
     header_icon = "pick"
     page_subtitle = gettext_lazy("Promoted search result")
+
+    @cached_property
+    def permission_policy(self):
+        # This view works with Query objects, but we want to check permissions
+        # against the SearchPromotion model.
+        return policies_registry.get_by_type(SearchPromotion)
 
     def get_success_message(self, instance=None):
         return self.success_message % {"query": instance}
@@ -196,7 +206,6 @@ class EditView(SearchPromotionCreateEditMixin, generic.EditView):
 
 class DeleteView(generic.DeleteView):
     model = Query
-    permission_policy = ModelPermissionPolicy(SearchPromotion)
     pk_url_kwarg = "query_id"
     context_object_name = "query"
     success_message = gettext_lazy("Editor's picks deleted.")
@@ -204,6 +213,12 @@ class DeleteView(generic.DeleteView):
     delete_url_name = "wagtailsearchpromotions:delete"
     header_icon = "pick"
     template_name = "wagtailsearchpromotions/confirm_delete.html"
+
+    @cached_property
+    def permission_policy(self):
+        # This view works with Query objects, but we want to check permissions
+        # against the SearchPromotion model.
+        return policies_registry.get_by_type(SearchPromotion)
 
     def delete_action(self):
         editors_picks = self.object.editors_picks.all()

--- a/wagtail/contrib/search_promotions/wagtail_hooks.py
+++ b/wagtail/contrib/search_promotions/wagtail_hooks.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import Permission
 from django.urls import include, path, reverse
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
@@ -9,9 +10,11 @@ from wagtail.admin.admin_url_finder import (
 )
 from wagtail.admin.menu import AdminOnlyMenuItem, MenuItem
 from wagtail.contrib.search_promotions import admin_urls
-from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permissions import policies_registry, register_permission_policy
 
 from .models import SearchPromotion
+
+register_permission_policy(SearchPromotion)
 
 
 @hooks.register("register_admin_urls")
@@ -65,7 +68,9 @@ def register_permissions():
 
 
 class SearchPromotionAdminURLFinder(ModelAdminURLFinder):
-    permission_policy = ModelPermissionPolicy(SearchPromotion)
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(SearchPromotion)
 
     def construct_edit_url(self, instance):
         return reverse("wagtailsearchpromotions:edit", args=(instance.query.id,))

--- a/wagtail/contrib/search_promotions/wagtail_hooks.py
+++ b/wagtail/contrib/search_promotions/wagtail_hooks.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.models import Permission
 from django.urls import include, path, reverse
-from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
@@ -10,7 +9,7 @@ from wagtail.admin.admin_url_finder import (
 )
 from wagtail.admin.menu import AdminOnlyMenuItem, MenuItem
 from wagtail.contrib.search_promotions import admin_urls
-from wagtail.permissions import policies_registry, register_permission_policy
+from wagtail.permissions import register_permission_policy
 
 from .models import SearchPromotion
 
@@ -68,10 +67,6 @@ def register_permissions():
 
 
 class SearchPromotionAdminURLFinder(ModelAdminURLFinder):
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(SearchPromotion)
-
     def construct_edit_url(self, instance):
         return reverse("wagtailsearchpromotions:edit", args=(instance.query.id,))
 

--- a/wagtail/contrib/settings/registry.py
+++ b/wagtail/contrib/settings/registry.py
@@ -9,7 +9,7 @@ from wagtail.admin.admin_url_finder import (
     register_admin_url_finder,
 )
 from wagtail.admin.menu import MenuItem
-from wagtail.permissions import policies_registry, register_permission_policy
+from wagtail.permissions import policy_registry, register_permission_policy
 
 from .forms import SitePermissionForm
 
@@ -29,7 +29,7 @@ class SettingMenuItem(MenuItem):
         )
 
     def is_shown(self, request):
-        permission_policy = policies_registry.get_by_type(self.model)
+        permission_policy = policy_registry.get_by_type(self.model)
         return permission_policy.user_has_permission(request.user, "change")
 
 

--- a/wagtail/contrib/settings/registry.py
+++ b/wagtail/contrib/settings/registry.py
@@ -9,6 +9,7 @@ from wagtail.admin.admin_url_finder import (
     register_admin_url_finder,
 )
 from wagtail.admin.menu import MenuItem
+from wagtail.permissions import policies_registry, register_permission_policy
 
 from .forms import SitePermissionForm
 
@@ -16,7 +17,7 @@ from .forms import SitePermissionForm
 class SettingMenuItem(MenuItem):
     def __init__(self, model, icon="cog", classname="", **kwargs):
         self.model = model
-        self.permission_policy = self.model.get_permission_policy()
+        self.permission_policy = policies_registry.get_by_type(model)
         super().__init__(
             label=capfirst(model._meta.verbose_name),
             url=reverse(
@@ -98,6 +99,7 @@ class Registry(list):
 
         # Register an admin URL finder
         permission_policy = model.get_permission_policy()
+        register_permission_policy(model, permission_policy)
 
         if issubclass(model, BaseSiteSetting):
             finder_class = type(

--- a/wagtail/contrib/settings/registry.py
+++ b/wagtail/contrib/settings/registry.py
@@ -105,13 +105,13 @@ class Registry(list):
             finder_class = type(
                 "_SiteSettingAdminURLFinder",
                 (SiteSettingAdminURLFinder,),
-                {"model": model, "permission_policy": permission_policy},
+                {"model": model},
             )
         elif issubclass(model, BaseGenericSetting):
             finder_class = type(
                 "_GenericSettingAdminURLFinder",
                 (GenericSettingAdminURLFinder,),
-                {"model": model, "permission_policy": permission_policy},
+                {"model": model},
             )
         else:
             raise NotImplementedError

--- a/wagtail/contrib/settings/registry.py
+++ b/wagtail/contrib/settings/registry.py
@@ -17,7 +17,6 @@ from .forms import SitePermissionForm
 class SettingMenuItem(MenuItem):
     def __init__(self, model, icon="cog", classname="", **kwargs):
         self.model = model
-        self.permission_policy = policies_registry.get_by_type(model)
         super().__init__(
             label=capfirst(model._meta.verbose_name),
             url=reverse(
@@ -30,7 +29,8 @@ class SettingMenuItem(MenuItem):
         )
 
     def is_shown(self, request):
-        return self.permission_policy.user_has_permission(request.user, "change")
+        permission_policy = policies_registry.get_by_type(self.model)
+        return permission_policy.user_has_permission(request.user, "change")
 
 
 class SiteSettingAdminURLFinder(ModelAdminURLFinder):

--- a/wagtail/contrib/settings/tests/generic/test_model.py
+++ b/wagtail/contrib/settings/tests/generic/test_model.py
@@ -1,6 +1,8 @@
 from django.test import TestCase, override_settings
 
 from wagtail.models import Site
+from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permissions import policies_registry
 from wagtail.test.testapp.models import ImportantPagesGenericSetting
 
 from .base import GenericSettingsTestMixin
@@ -121,3 +123,14 @@ class GenericSettingModelTestCase(GenericSettingsTestMixin, TestCase):
             str(ImportantPagesGenericSetting.load()),
             "important pages settings",
         )
+
+    def test_permission_policy_registered(self):
+        self.assertIsInstance(
+            ImportantPagesGenericSetting.get_permission_policy(),
+            ModelPermissionPolicy,
+        )
+        registered = policies_registry.get_by_type(ImportantPagesGenericSetting)
+        # get_permission_policy() creates a new instance each time, so we can't
+        # assertIs, but we can check that they are similar
+        self.assertIsInstance(registered, ModelPermissionPolicy)
+        self.assertIs(registered.model, ImportantPagesGenericSetting)

--- a/wagtail/contrib/settings/tests/generic/test_model.py
+++ b/wagtail/contrib/settings/tests/generic/test_model.py
@@ -2,7 +2,7 @@ from django.test import TestCase, override_settings
 
 from wagtail.models import Site
 from wagtail.permission_policies import ModelPermissionPolicy
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.test.testapp.models import ImportantPagesGenericSetting
 
 from .base import GenericSettingsTestMixin
@@ -129,7 +129,7 @@ class GenericSettingModelTestCase(GenericSettingsTestMixin, TestCase):
             ImportantPagesGenericSetting.get_permission_policy(),
             ModelPermissionPolicy,
         )
-        registered = policies_registry.get_by_type(ImportantPagesGenericSetting)
+        registered = policy_registry.get_by_type(ImportantPagesGenericSetting)
         # get_permission_policy() creates a new instance each time, so we can't
         # assertIs, but we can check that they are similar
         self.assertIsInstance(registered, ModelPermissionPolicy)

--- a/wagtail/contrib/settings/tests/site_specific/test_model.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_model.py
@@ -4,7 +4,7 @@ from django.test import RequestFactory, TestCase, override_settings
 
 from wagtail.models import Site
 from wagtail.permission_policies.sites import SitePermissionPolicy
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.test.testapp.models import ImportantPagesSiteSetting, TestSiteSetting
 
 from .base import SiteSettingsTestMixin
@@ -231,7 +231,7 @@ class SettingModelTestCase(SiteSettingsTestMixin, TestCase):
             ImportantPagesSiteSetting.get_permission_policy(),
             SitePermissionPolicy,
         )
-        registered = policies_registry.get_by_type(ImportantPagesSiteSetting)
+        registered = policy_registry.get_by_type(ImportantPagesSiteSetting)
         # get_permission_policy() creates a new instance each time, so we can't
         # assertIs, but we can check that they are similar
         self.assertIsInstance(registered, SitePermissionPolicy)

--- a/wagtail/contrib/settings/tests/site_specific/test_model.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_model.py
@@ -3,6 +3,8 @@ import pickle
 from django.test import RequestFactory, TestCase, override_settings
 
 from wagtail.models import Site
+from wagtail.permission_policies.sites import SitePermissionPolicy
+from wagtail.permissions import policies_registry
 from wagtail.test.testapp.models import ImportantPagesSiteSetting, TestSiteSetting
 
 from .base import SiteSettingsTestMixin
@@ -223,3 +225,14 @@ class SettingModelTestCase(SiteSettingsTestMixin, TestCase):
                 self.assertEqual(settings.get_page_url("test_attribute"), "")
                 # when called indirectly via shortcut
                 self.assertEqual(settings.page_url.test_attribute, "")
+
+    def test_permission_policy_registered(self):
+        self.assertIsInstance(
+            ImportantPagesSiteSetting.get_permission_policy(),
+            SitePermissionPolicy,
+        )
+        registered = policies_registry.get_by_type(ImportantPagesSiteSetting)
+        # get_permission_policy() creates a new instance each time, so we can't
+        # assertIs, but we can check that they are similar
+        self.assertIsInstance(registered, SitePermissionPolicy)
+        self.assertIs(registered.model, ImportantPagesSiteSetting)

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -17,6 +17,7 @@ from wagtail.admin.ui.side_panels import ChecksSidePanel, PreviewSidePanel
 from wagtail.admin.views import generic
 from wagtail.admin.views.generic import preview
 from wagtail.models import PreviewableMixin, Site
+from wagtail.permissions import policies_registry
 
 from .forms import SiteSwitchForm
 from .models import BaseGenericSetting, BaseSiteSetting
@@ -57,7 +58,7 @@ def redirect_to_relevant_instance(request, app_name, model_name):
         # Redirect the user to the edit page for the current site
         # (or the current request does not correspond to a site, the first site in the list)
         site = Site.find_for_request(request)
-        permission_policy = model.get_permission_policy()
+        permission_policy = policies_registry.get_by_type(model)
         if not site or not permission_policy.user_has_permission_for_instance(
             request.user, "change", site
         ):
@@ -109,7 +110,6 @@ class EditView(generic.EditView):
         self.app_name = app_name
         self.model_name = model_name
         self.model = get_model_from_url_params(app_name, model_name)
-        self.permission_policy = self.model.get_permission_policy()
         self.pk = kwargs.get(self.pk_url_kwarg)
         super().setup(request, app_name, model_name, *args, **kwargs)
         self.object = self.get_object()
@@ -205,7 +205,6 @@ class PreviewOnEdit(preview.PreviewOnEdit):
         self.app_name = app_name
         self.model_name = model_name
         self.model = get_model_from_url_params(app_name, model_name)
-        self.permission_policy = self.model.get_permission_policy()
         self.pk = kwargs.get("pk")
         super().setup(request, app_name, model_name, *args, **kwargs)
 

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -17,7 +17,7 @@ from wagtail.admin.ui.side_panels import ChecksSidePanel, PreviewSidePanel
 from wagtail.admin.views import generic
 from wagtail.admin.views.generic import preview
 from wagtail.models import PreviewableMixin, Site
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 from .forms import SiteSwitchForm
 from .models import BaseGenericSetting, BaseSiteSetting
@@ -58,7 +58,7 @@ def redirect_to_relevant_instance(request, app_name, model_name):
         # Redirect the user to the edit page for the current site
         # (or the current request does not correspond to a site, the first site in the list)
         site = Site.find_for_request(request)
-        permission_policy = policies_registry.get_by_type(model)
+        permission_policy = policy_registry.get_by_type(model)
         if not site or not permission_policy.user_has_permission_for_instance(
             request.user, "change", site
         ):

--- a/wagtail/contrib/simple_translation/views.py
+++ b/wagtail/contrib/simple_translation/views.py
@@ -13,6 +13,7 @@ from django.views.generic.detail import SingleObjectMixin
 from wagtail.actions.copy_for_translation import CopyPageForTranslationAction
 from wagtail.admin import messages
 from wagtail.models import DraftStateMixin, TranslatableMixin
+from wagtail.permissions import policies_registry
 from wagtail.snippets.views.snippets import get_snippet_model_from_url_params
 
 from .forms import SubmitTranslationForm
@@ -148,7 +149,7 @@ class SubmitSnippetTranslationView(SubmitTranslationView):
         if isinstance(object, DraftStateMixin):
             object = object.get_latest_revision_as_object()
 
-        if not model.snippet_viewset.permission_policy.user_has_permission_for_instance(
+        if not policies_registry.get_by_type(model).user_has_permission_for_instance(
             self.request.user, "change", object
         ):
             raise PermissionDenied

--- a/wagtail/contrib/simple_translation/views.py
+++ b/wagtail/contrib/simple_translation/views.py
@@ -13,7 +13,7 @@ from django.views.generic.detail import SingleObjectMixin
 from wagtail.actions.copy_for_translation import CopyPageForTranslationAction
 from wagtail.admin import messages
 from wagtail.models import DraftStateMixin, TranslatableMixin
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.snippets.views.snippets import get_snippet_model_from_url_params
 
 from .forms import SubmitTranslationForm
@@ -149,7 +149,7 @@ class SubmitSnippetTranslationView(SubmitTranslationView):
         if isinstance(object, DraftStateMixin):
             object = object.get_latest_revision_as_object()
 
-        if not policies_registry.get_by_type(model).user_has_permission_for_instance(
+        if not policy_registry.get_by_type(model).user_has_permission_for_instance(
             self.request.user, "change", object
         ):
             raise PermissionDenied

--- a/wagtail/documents/__init__.py
+++ b/wagtail/documents/__init__.py
@@ -31,3 +31,15 @@ def get_document_model():
             "WAGTAILDOCS_DOCUMENT_MODEL refers to model '%s' that has not been installed"
             % model_string
         ) from e
+
+
+def get_permission_policy():
+    from wagtail.permission_policies.collections import (
+        CollectionOwnershipPermissionPolicy,
+    )
+
+    return CollectionOwnershipPermissionPolicy(
+        get_document_model_string(),
+        auth_model="wagtaildocs.Document",
+        owner_field_name="uploaded_by_user",
+    )

--- a/wagtail/documents/apps.py
+++ b/wagtail/documents/apps.py
@@ -27,3 +27,12 @@ class WagtailDocsAppConfig(AppConfig):
         from wagtail.models.reference_index import ReferenceIndex
 
         ReferenceIndex.register_model(Document)
+
+        from wagtail.permissions import register_permission_policy
+
+        from . import get_permission_policy
+        from .models import AbstractDocument
+
+        # Register the default permission policy with the abstract model to ease
+        # testing when a custom model is applied via @override_settings.
+        register_permission_policy(AbstractDocument, get_permission_policy())

--- a/wagtail/documents/apps.py
+++ b/wagtail/documents/apps.py
@@ -31,8 +31,5 @@ class WagtailDocsAppConfig(AppConfig):
         from wagtail.permissions import register_permission_policy
 
         from . import get_permission_policy
-        from .models import AbstractDocument
 
-        # Register the default permission policy with the abstract model to ease
-        # testing when a custom model is applied via @override_settings.
-        register_permission_policy(AbstractDocument, get_permission_policy())
+        register_permission_policy(Document, get_permission_policy())

--- a/wagtail/documents/forms.py
+++ b/wagtail/documents/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.conf import settings
 from django.forms.models import modelform_factory
+from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
 
@@ -11,12 +12,11 @@ from wagtail.admin.forms.collections import (
 )
 from wagtail.admin.forms.tags import validate_tag_length
 from wagtail.admin.widgets import AdminTagWidget
+from wagtail.documents import get_document_model
 from wagtail.documents.fields import WagtailDocumentField
 from wagtail.documents.models import Document
-from wagtail.documents.permissions import (
-    permission_policy as documents_permission_policy,
-)
 from wagtail.models import Collection
+from wagtail.permissions import policies_registry
 from wagtail.search import index as search_index
 
 
@@ -37,8 +37,6 @@ def formfield_for_dbfield(db_field, **kwargs):
 
 
 class BaseDocumentForm(BaseCollectionMemberForm):
-    permission_policy = documents_permission_policy
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.original_file = self.instance.file
@@ -48,6 +46,10 @@ class BaseDocumentForm(BaseCollectionMemberForm):
             self.fields["file"].widget.attrs["data-w-sync-target-value"] = (
                 f"#{self['title'].id_for_label}"
             )
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_document_model())
 
     def save(self, commit=True):
         if "file" in self.changed_data:

--- a/wagtail/documents/forms.py
+++ b/wagtail/documents/forms.py
@@ -16,7 +16,7 @@ from wagtail.documents import get_document_model
 from wagtail.documents.fields import WagtailDocumentField
 from wagtail.documents.models import Document
 from wagtail.models import Collection
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.search import index as search_index
 
 
@@ -49,7 +49,7 @@ class BaseDocumentForm(BaseCollectionMemberForm):
 
     @cached_property
     def permission_policy(self):
-        return policies_registry.get_by_type(get_document_model())
+        return policy_registry.get_by_type(get_document_model())
 
     def save(self, commit=True):
         if "file" in self.changed_data:

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -13,7 +13,7 @@ from django.utils.translation import gettext_lazy as _
 from taggit.managers import TaggableManager
 
 from wagtail.models import CollectionMember, ReferenceIndex
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
 from wagtail.utils.file import hash_filelike
@@ -182,7 +182,7 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
     def is_editable_by_user(self, user):
         from wagtail.documents import get_document_model
 
-        return policies_registry.get_by_type(
+        return policy_registry.get_by_type(
             get_document_model()
         ).user_has_permission_for_instance(user, "change", self)
 

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -13,6 +13,7 @@ from django.utils.translation import gettext_lazy as _
 from taggit.managers import TaggableManager
 
 from wagtail.models import CollectionMember, ReferenceIndex
+from wagtail.permissions import policies_registry
 from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
 from wagtail.utils.file import hash_filelike
@@ -179,9 +180,11 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
         return reverse("wagtaildocs:document_usage", args=(self.id,))
 
     def is_editable_by_user(self, user):
-        from wagtail.documents.permissions import permission_policy
+        from wagtail.documents import get_document_model
 
-        return permission_policy.user_has_permission_for_instance(user, "change", self)
+        return policies_registry.get_by_type(
+            get_document_model()
+        ).user_has_permission_for_instance(user, "change", self)
 
     @property
     def content_type(self):

--- a/wagtail/documents/permissions.py
+++ b/wagtail/documents/permissions.py
@@ -1,12 +1,12 @@
 import warnings
 
 from wagtail.documents import get_document_model
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
 warnings.warn(
     "wagtail.documents.permissions.permission_policy is deprecated. "
-    "Use wagtail.permissions.policies_registry.get_by_type(get_document_model()) instead.",
+    "Use wagtail.permissions.policy_registry.get_by_type(get_document_model()) instead.",
     RemovedInWagtail90Warning,
 )
-permission_policy = policies_registry.get_by_type(get_document_model())
+permission_policy = policy_registry.get_by_type(get_document_model())

--- a/wagtail/documents/permissions.py
+++ b/wagtail/documents/permissions.py
@@ -1,8 +1,12 @@
-from wagtail.documents import get_document_model_string
-from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
+import warnings
 
-permission_policy = CollectionOwnershipPermissionPolicy(
-    get_document_model_string(),
-    auth_model="wagtaildocs.Document",
-    owner_field_name="uploaded_by_user",
+from wagtail.documents import get_document_model
+from wagtail.permissions import policies_registry
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
+
+warnings.warn(
+    "wagtail.documents.permissions.permission_policy is deprecated. "
+    "Use wagtail.permissions.policies_registry.get_by_type(get_document_model()) instead.",
+    RemovedInWagtail90Warning,
 )
+permission_policy = policies_registry.get_by_type(get_document_model())

--- a/wagtail/documents/tests/__init__.py
+++ b/wagtail/documents/tests/__init__.py
@@ -1,0 +1,18 @@
+from django.test.signals import setting_changed
+
+from wagtail.documents import get_document_model, get_permission_policy
+from wagtail.permissions import register_permission_policy
+
+
+def update_permission_policy(signal, sender, setting, **kwargs):
+    """
+    Register the permission policy when the `WAGTAILDOCS_DOCUMENT_MODEL` setting changes.
+    This is useful in tests where we override the document model setting and expect the
+    permission policy to have changed accordingly.
+    """
+
+    if setting == "WAGTAILDOCS_DOCUMENT_MODEL":
+        register_permission_policy(get_document_model(), get_permission_policy())
+
+
+setting_changed.connect(update_permission_policy)

--- a/wagtail/documents/tests/test_models.py
+++ b/wagtail/documents/tests/test_models.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.files.base import ContentFile
 from django.db import transaction
 from django.test import TestCase, TransactionTestCase, tag
+from django.test.signals import setting_changed
 from django.test.utils import override_settings
 
 from wagtail.documents import (
@@ -12,10 +13,12 @@ from wagtail.documents import (
     models,
     signal_handlers,
 )
+from wagtail.documents.tests import update_permission_policy
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.models import Collection, GroupCollectionPermission
 from wagtail.test.testapp.models import CustomDocument, ReimportedDocumentModel
 from wagtail.test.utils import PageFixturesMixin, WagtailTestUtils
+from wagtail.test.utils.decorators import disconnect_signal_receiver
 
 
 @tag("transaction")
@@ -299,12 +302,18 @@ class TestGetDocumentModel(WagtailTestUtils, TestCase):
         del settings.WAGTAILDOCS_DOCUMENT_MODEL
         self.assertEqual(get_document_model_string(), "wagtaildocs.Document")
 
+    @disconnect_signal_receiver(
+        signal=setting_changed, receiver=update_permission_policy
+    )
     @override_settings(WAGTAILDOCS_DOCUMENT_MODEL="tests.UnknownModel")
     def test_unknown_get_document_model(self):
         """Test get_document_model with an unknown model"""
         with self.assertRaises(ImproperlyConfigured):
             get_document_model()
 
+    @disconnect_signal_receiver(
+        signal=setting_changed, receiver=update_permission_policy
+    )
     @override_settings(WAGTAILDOCS_DOCUMENT_MODEL="invalid-string")
     def test_invalid_get_document_model(self):
         """Test get_document_model with an invalid model string"""

--- a/wagtail/documents/tests/test_permissions.py
+++ b/wagtail/documents/tests/test_permissions.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+
+from wagtail.documents import get_document_model
+from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
+from wagtail.permissions import policies_registry
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
+
+
+class TestDocumentPermissions(TestCase):
+    def test_permissions_direct_import_deprecated(self):
+        model = get_document_model()
+        with self.assertWarnsMessage(
+            RemovedInWagtail90Warning,
+            "wagtail.documents.permissions.permission_policy is deprecated. "
+            "Use wagtail.permissions.policies_registry.get_by_type(get_document_model()) instead.",
+        ):
+            from wagtail.documents.permissions import permission_policy
+
+            self.assertIsInstance(
+                permission_policy,
+                CollectionOwnershipPermissionPolicy,
+            )
+            self.assertIs(permission_policy.model, model)
+
+    def test_get_from_registry(self):
+        model = get_document_model()
+        permission_policy = policies_registry.get_by_type(model)
+        self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
+        self.assertIs(permission_policy.model, model)

--- a/wagtail/documents/tests/test_permissions.py
+++ b/wagtail/documents/tests/test_permissions.py
@@ -2,7 +2,7 @@ from django.test import TestCase, override_settings
 
 from wagtail.documents import get_document_model
 from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.test.testapp.models import CustomDocument
 from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
@@ -13,7 +13,7 @@ class TestDocumentPermissions(TestCase):
         with self.assertWarnsMessage(
             RemovedInWagtail90Warning,
             "wagtail.documents.permissions.permission_policy is deprecated. "
-            "Use wagtail.permissions.policies_registry.get_by_type(get_document_model()) instead.",
+            "Use wagtail.permissions.policy_registry.get_by_type(get_document_model()) instead.",
         ):
             from wagtail.documents.permissions import permission_policy
 
@@ -25,12 +25,12 @@ class TestDocumentPermissions(TestCase):
 
     def test_get_from_registry(self):
         model = get_document_model()
-        permission_policy = policies_registry.get_by_type(model)
+        permission_policy = policy_registry.get_by_type(model)
         self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
         self.assertIs(permission_policy.model, model)
 
     @override_settings(WAGTAILDOCS_DOCUMENT_MODEL="tests.CustomDocument")
     def test_get_from_registry_with_custom_model(self):
-        permission_policy = policies_registry.get_by_type(CustomDocument)
+        permission_policy = policy_registry.get_by_type(CustomDocument)
         self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
         self.assertIs(permission_policy.model, CustomDocument)

--- a/wagtail/documents/tests/test_permissions.py
+++ b/wagtail/documents/tests/test_permissions.py
@@ -1,8 +1,9 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from wagtail.documents import get_document_model
 from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
 from wagtail.permissions import policies_registry
+from wagtail.test.testapp.models import CustomDocument
 from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
 
@@ -27,3 +28,9 @@ class TestDocumentPermissions(TestCase):
         permission_policy = policies_registry.get_by_type(model)
         self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
         self.assertIs(permission_policy.model, model)
+
+    @override_settings(WAGTAILDOCS_DOCUMENT_MODEL="tests.CustomDocument")
+    def test_get_from_registry_with_custom_model(self):
+        permission_policy = policies_registry.get_by_type(CustomDocument)
+        self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
+        self.assertIs(permission_policy.model, CustomDocument)

--- a/wagtail/documents/views/bulk_actions/add_to_collection.py
+++ b/wagtail/documents/views/bulk_actions/add_to_collection.py
@@ -2,7 +2,9 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
+from wagtail.documents import get_document_model
 from wagtail.documents.views.bulk_actions.document_bulk_action import DocumentBulkAction
+from wagtail.permissions import policies_registry
 
 
 class CollectionForm(forms.Form):
@@ -11,9 +13,9 @@ class CollectionForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields["collection"] = forms.ModelChoiceField(
             label=_("Collection"),
-            queryset=DocumentBulkAction.permission_policy.collections_user_has_permission_for(
-                user, "add"
-            ),
+            queryset=policies_registry.get_by_type(
+                get_document_model()
+            ).collections_user_has_permission_for(user, "add"),
         )
 
 

--- a/wagtail/documents/views/bulk_actions/add_to_collection.py
+++ b/wagtail/documents/views/bulk_actions/add_to_collection.py
@@ -4,7 +4,7 @@ from django.utils.translation import ngettext
 
 from wagtail.documents import get_document_model
 from wagtail.documents.views.bulk_actions.document_bulk_action import DocumentBulkAction
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 class CollectionForm(forms.Form):
@@ -13,7 +13,7 @@ class CollectionForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields["collection"] = forms.ModelChoiceField(
             label=_("Collection"),
-            queryset=policies_registry.get_by_type(
+            queryset=policy_registry.get_by_type(
                 get_document_model()
             ).collections_user_has_permission_for(user, "add"),
         )

--- a/wagtail/documents/views/bulk_actions/document_bulk_action.py
+++ b/wagtail/documents/views/bulk_actions/document_bulk_action.py
@@ -1,13 +1,16 @@
+from django.utils.functional import cached_property
+
 from wagtail.admin.views.bulk_action import BulkAction
 from wagtail.documents import get_document_model
-from wagtail.documents.permissions import (
-    permission_policy as documents_permission_policy,
-)
+from wagtail.permissions import policies_registry
 
 
 class DocumentBulkAction(BulkAction):
-    permission_policy = documents_permission_policy
     models = [get_document_model()]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_all_objects_in_listing_query(self, parent_id):
         listing_objects = self.permission_policy.instances_user_has_permission_for(

--- a/wagtail/documents/views/bulk_actions/document_bulk_action.py
+++ b/wagtail/documents/views/bulk_actions/document_bulk_action.py
@@ -2,7 +2,7 @@ from django.utils.functional import cached_property
 
 from wagtail.admin.views.bulk_action import BulkAction
 from wagtail.documents import get_document_model
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 class DocumentBulkAction(BulkAction):
@@ -10,7 +10,7 @@ class DocumentBulkAction(BulkAction):
 
     @cached_property
     def permission_policy(self):
-        return policies_registry.get_by_type(self.model)
+        return policy_registry.get_by_type(self.model)
 
     def get_all_objects_in_listing_query(self, parent_id):
         listing_objects = self.permission_policy.instances_user_has_permission_for(

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -220,10 +220,6 @@ class DocumentChooserViewSet(ChooserViewSet):
     choose_another_text = _("Choose another document")
     edit_item_text = _("Edit this document")
 
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(get_document_model())
-
 
 viewset = DocumentChooserViewSet(
     "wagtaildocs_chooser",

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -21,7 +21,7 @@ from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.admin.widgets import BaseChooser, BaseChooserAdapter
 from wagtail.blocks import ChooserBlock
 from wagtail.documents import get_document_model, get_document_model_string
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 class DocumentChosenResponseMixin(ChosenResponseMixin):
@@ -122,7 +122,7 @@ class DocumentChooseResultsView(
 class DocumentChosenView(ChosenViewMixin, DocumentChosenResponseMixin, View):
     @cached_property
     def permission_policy(self):
-        return policies_registry.get_by_type(self.model)
+        return policy_registry.get_by_type(self.model)
 
     def get_object(self, pk):
         item = super().get_object(pk)
@@ -143,7 +143,7 @@ class DocumentChosenMultipleView(
 ):
     @cached_property
     def permission_policy(self):
-        return policies_registry.get_by_type(self.model)
+        return policy_registry.get_by_type(self.model)
 
     def get_objects(self, pks):
         return self.permission_policy.instances_user_has_any_permission_for(

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -21,7 +21,7 @@ from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.admin.widgets import BaseChooser, BaseChooserAdapter
 from wagtail.blocks import ChooserBlock
 from wagtail.documents import get_document_model, get_document_model_string
-from wagtail.documents.permissions import permission_policy
+from wagtail.permissions import policies_registry
 
 
 class DocumentChosenResponseMixin(ChosenResponseMixin):
@@ -120,10 +120,13 @@ class DocumentChooseResultsView(
 
 
 class DocumentChosenView(ChosenViewMixin, DocumentChosenResponseMixin, View):
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
+
     def get_object(self, pk):
         item = super().get_object(pk)
-
-        if not permission_policy.user_has_permission_for_instance(
+        if not self.permission_policy.user_has_permission_for_instance(
             self.request.user, "choose", item
         ):
             raise PermissionDenied
@@ -138,8 +141,12 @@ class DocumentChosenView(ChosenViewMixin, DocumentChosenResponseMixin, View):
 class DocumentChosenMultipleView(
     ChosenMultipleViewMixin, DocumentChosenResponseMixin, View
 ):
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
+
     def get_objects(self, pks):
-        return permission_policy.instances_user_has_any_permission_for(
+        return self.permission_policy.instances_user_has_any_permission_for(
             self.request.user, ["choose"]
         ).filter(pk__in=pks)
 
@@ -205,7 +212,6 @@ class DocumentChooserViewSet(ChooserViewSet):
     base_widget_class = BaseAdminDocumentChooser
     widget_telepath_adapter_class = DocumentChooserAdapter
     base_block_class = BaseDocumentChooserBlock
-    permission_policy = permission_policy
 
     icon = "doc-full-inverse"
     choose_one_text = _("Choose a document")
@@ -213,6 +219,10 @@ class DocumentChooserViewSet(ChooserViewSet):
     create_action_clicked_label = _("Uploading…")
     choose_another_text = _("Choose another document")
     edit_item_text = _("Edit this document")
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_document_model())
 
 
 viewset = DocumentChooserViewSet(

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -24,7 +24,7 @@ from wagtail.admin.views import generic
 from wagtail.documents import get_document_model
 from wagtail.documents.forms import get_document_form
 from wagtail.models import ReferenceIndex
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 Document = get_document_model()
 
@@ -51,7 +51,7 @@ class DocumentTable(Table):
 class DocumentsFilterSet(BaseMediaFilterSet):
     @cached_property
     def permission_policy(self):
-        return policies_registry.get_by_type(Document)
+        return policy_registry.get_by_type(Document)
 
     class Meta:
         model = Document

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -137,15 +137,6 @@ class IndexView(generic.IndexView):
             )
         return columns
 
-    @cached_property
-    def collections(self):
-        collections = policies_registry.get_by_type(
-            self.model
-        ).collections_user_has_any_permission_for(self.request.user, ["add", "change"])
-        if len(collections) < 2:
-            collections = None
-        return collections
-
     def get_next_url(self):
         next_url = self.index_url
         request_query_string = self.request.META.get("QUERY_STRING")

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -9,7 +9,6 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, ngettext
 
 from wagtail.admin import messages
-from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.filters import BaseMediaFilterSet
 from wagtail.admin.ui.tables import (
     BulkActionsCheckboxColumn,
@@ -24,10 +23,9 @@ from wagtail.admin.utils import get_valid_next_url_from_request, set_query_param
 from wagtail.admin.views import generic
 from wagtail.documents import get_document_model
 from wagtail.documents.forms import get_document_form
-from wagtail.documents.permissions import permission_policy
 from wagtail.models import ReferenceIndex
+from wagtail.permissions import policies_registry
 
-permission_checker = PermissionPolicyChecker(permission_policy)
 Document = get_document_model()
 
 
@@ -51,7 +49,9 @@ class DocumentTable(Table):
 
 
 class DocumentsFilterSet(BaseMediaFilterSet):
-    permission_policy = permission_policy
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Document)
 
     class Meta:
         model = Document
@@ -59,7 +59,6 @@ class DocumentsFilterSet(BaseMediaFilterSet):
 
 
 class IndexView(generic.IndexView):
-    permission_policy = permission_policy
     any_permission_required = ["add", "change", "delete"]
     context_object_name = "documents"
     page_title = gettext_lazy("Documents")
@@ -140,9 +139,9 @@ class IndexView(generic.IndexView):
 
     @cached_property
     def collections(self):
-        collections = permission_policy.collections_user_has_any_permission_for(
-            self.request.user, ["add", "change"]
-        )
+        collections = policies_registry.get_by_type(
+            self.model
+        ).collections_user_has_any_permission_for(self.request.user, ["add", "change"])
         if len(collections) < 2:
             collections = None
         return collections
@@ -195,7 +194,6 @@ class IndexView(generic.IndexView):
 
 
 class CreateView(generic.CreateView):
-    permission_policy = permission_policy
     index_url_name = "wagtaildocs:index"
     add_url_name = "wagtaildocs:add"
     edit_url_name = "wagtaildocs:edit"
@@ -227,7 +225,6 @@ class CreateView(generic.CreateView):
 
 
 class EditView(generic.EditView):
-    permission_policy = permission_policy
     pk_url_kwarg = "document_id"
     error_message = gettext_lazy("The document could not be saved due to errors.")
     template_name = "wagtaildocs/documents/edit.html"
@@ -300,7 +297,6 @@ class EditView(generic.EditView):
 class DeleteView(generic.DeleteView):
     model = get_document_model()
     pk_url_kwarg = "document_id"
-    permission_policy = permission_policy
     permission_required = "delete"
     header_icon = "doc-full-inverse"
     usage_url_name = "wagtaildocs:document_usage"
@@ -332,7 +328,6 @@ class DeleteView(generic.DeleteView):
 class UsageView(generic.UsageView):
     model = get_document_model()
     pk_url_kwarg = "document_id"
-    permission_policy = permission_policy
     permission_required = "change"
     header_icon = "doc-full-inverse"
     index_url_name = "wagtaildocs:index"

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -1,7 +1,6 @@
 import os.path
 
 from django.urls import reverse
-from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy
 
@@ -15,7 +14,6 @@ from wagtail.admin.views.generic.multiple_upload import (
 )
 from wagtail.admin.views.generic.multiple_upload import DeleteView as BaseDeleteView
 from wagtail.admin.views.generic.multiple_upload import EditView as BaseEditView
-from wagtail.permissions import policies_registry
 
 from .. import get_document_model
 from ..forms import get_document_form, get_document_multi_form
@@ -47,10 +45,6 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
             },
             {"url": "", "label": self.get_page_title()},
         ]
-
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(self.model)
 
     def get_model(self):
         return get_document_model()
@@ -93,10 +87,6 @@ class EditView(BaseEditView):
     edit_object_url_name = "wagtaildocs:edit_multiple"
     delete_object_url_name = "wagtaildocs:delete_multiple"
 
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(self.model)
-
     def get_model(self):
         return get_document_model()
 
@@ -107,10 +97,6 @@ class EditView(BaseEditView):
 class DeleteView(BaseDeleteView):
     pk_url_kwarg = "doc_id"
     context_object_id_name = "doc_id"
-
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(self.model)
 
     def get_model(self):
         return get_document_model()

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -1,6 +1,7 @@
 import os.path
 
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy
 
@@ -14,14 +15,13 @@ from wagtail.admin.views.generic.multiple_upload import (
 )
 from wagtail.admin.views.generic.multiple_upload import DeleteView as BaseDeleteView
 from wagtail.admin.views.generic.multiple_upload import EditView as BaseEditView
+from wagtail.permissions import policies_registry
 
 from .. import get_document_model
 from ..forms import get_document_form, get_document_multi_form
-from ..permissions import permission_policy
 
 
 class AddView(WagtailAdminTemplateMixin, BaseAddView):
-    permission_policy = permission_policy
     template_name = "wagtaildocs/multiple/add.html"
     header_icon = "doc-full-inverse"
     page_title = gettext_lazy("Add documents")
@@ -47,6 +47,10 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
             },
             {"url": "", "label": self.get_page_title()},
         ]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_model(self):
         return get_document_model()
@@ -82,13 +86,16 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
 
 
 class EditView(BaseEditView):
-    permission_policy = permission_policy
     pk_url_kwarg = "doc_id"
     edit_object_form_prefix = "doc"
     context_object_name = "doc"
     context_object_id_name = "doc_id"
     edit_object_url_name = "wagtaildocs:edit_multiple"
     delete_object_url_name = "wagtaildocs:delete_multiple"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_model(self):
         return get_document_model()
@@ -98,9 +105,12 @@ class EditView(BaseEditView):
 
 
 class DeleteView(BaseDeleteView):
-    permission_policy = permission_policy
     pk_url_kwarg = "doc_id"
     context_object_id_name = "doc_id"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_model(self):
         return get_document_model()

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.template.response import TemplateResponse
 from django.urls import include, path, reverse, reverse_lazy
 from django.utils.cache import add_never_cache_headers
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
@@ -18,7 +19,6 @@ from wagtail.admin.site_summary import SummaryItem
 from wagtail.documents import admin_urls, get_document_model
 from wagtail.documents.api.admin.views import DocumentsAdminAPIViewSet
 from wagtail.documents.forms import GroupDocumentPermissionFormSet
-from wagtail.documents.permissions import permission_policy
 from wagtail.documents.rich_text import DocumentLinkHandler
 from wagtail.documents.rich_text.contentstate import (
     ContentstateDocumentLinkConversionRule,
@@ -31,7 +31,10 @@ from wagtail.documents.views.bulk_actions import (
 )
 from wagtail.documents.views.chooser import viewset as chooser_viewset
 from wagtail.models import BaseViewRestriction
+from wagtail.permissions import policies_registry
 from wagtail.wagtail_hooks import require_wagtail_login
+
+Document = get_document_model()
 
 
 @hooks.register("register_admin_urls")
@@ -48,7 +51,7 @@ def construct_admin_api(router):
 
 class DocumentsMenuItem(MenuItem):
     def is_shown(self, request):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Document).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -102,14 +105,16 @@ class DocumentsSummaryItem(SummaryItem):
         site_name = get_site_for_user(self.request.user)["site_name"]
 
         return {
-            "total_docs": permission_policy.instances_user_has_any_permission_for(
+            "total_docs": policies_registry.get_by_type(Document)
+            .instances_user_has_any_permission_for(
                 self.request.user, {"add", "change", "delete", "choose"}
-            ).count(),
+            )
+            .count(),
             "site_name": site_name,
         }
 
     def is_shown(self):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Document).user_has_any_permission(
             self.request.user, ["add", "change", "delete"]
         )
 
@@ -121,7 +126,7 @@ def add_documents_summary_item(request, items):
 
 class DocsSearchArea(SearchArea):
     def is_shown(self, request):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Document).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -201,7 +206,10 @@ def check_view_restrictions(document, request):
 
 class DocumentAdminURLFinder(ModelAdminURLFinder):
     edit_url_name = "wagtaildocs:edit"
-    permission_policy = permission_policy
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Document)
 
 
 register_admin_url_finder(get_document_model(), DocumentAdminURLFinder)

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.template.response import TemplateResponse
 from django.urls import include, path, reverse, reverse_lazy
 from django.utils.cache import add_never_cache_headers
-from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
@@ -206,10 +205,6 @@ def check_view_restrictions(document, request):
 
 class DocumentAdminURLFinder(ModelAdminURLFinder):
     edit_url_name = "wagtaildocs:edit"
-
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(Document)
 
 
 register_admin_url_finder(get_document_model(), DocumentAdminURLFinder)

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -30,7 +30,7 @@ from wagtail.documents.views.bulk_actions import (
 )
 from wagtail.documents.views.chooser import viewset as chooser_viewset
 from wagtail.models import BaseViewRestriction
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.wagtail_hooks import require_wagtail_login
 
 Document = get_document_model()
@@ -50,7 +50,7 @@ def construct_admin_api(router):
 
 class DocumentsMenuItem(MenuItem):
     def is_shown(self, request):
-        return policies_registry.get_by_type(Document).user_has_any_permission(
+        return policy_registry.get_by_type(Document).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -104,7 +104,7 @@ class DocumentsSummaryItem(SummaryItem):
         site_name = get_site_for_user(self.request.user)["site_name"]
 
         return {
-            "total_docs": policies_registry.get_by_type(Document)
+            "total_docs": policy_registry.get_by_type(Document)
             .instances_user_has_any_permission_for(
                 self.request.user, {"add", "change", "delete", "choose"}
             )
@@ -113,7 +113,7 @@ class DocumentsSummaryItem(SummaryItem):
         }
 
     def is_shown(self):
-        return policies_registry.get_by_type(Document).user_has_any_permission(
+        return policy_registry.get_by_type(Document).user_has_any_permission(
             self.request.user, ["add", "change", "delete"]
         )
 
@@ -125,7 +125,7 @@ def add_documents_summary_item(request, items):
 
 class DocsSearchArea(SearchArea):
     def is_shown(self, request):
-        return policies_registry.get_by_type(Document).user_has_any_permission(
+        return policy_registry.get_by_type(Document).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 

--- a/wagtail/images/__init__.py
+++ b/wagtail/images/__init__.py
@@ -32,3 +32,15 @@ def get_image_model():
             "WAGTAILIMAGES_IMAGE_MODEL refers to model '%s' that has not been installed"
             % model_string
         ) from e
+
+
+def get_permission_policy():
+    from wagtail.permission_policies.collections import (
+        CollectionOwnershipPermissionPolicy,
+    )
+
+    return CollectionOwnershipPermissionPolicy(
+        get_image_model(),
+        auth_model="wagtailimages.Image",
+        owner_field_name="uploaded_by_user",
+    )

--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -46,3 +46,9 @@ class WagtailImagesAppConfig(AppConfig):
         from wagtail.models.reference_index import ReferenceIndex
 
         ReferenceIndex.register_model(Image)
+
+        from wagtail.permissions import register_permission_policy
+
+        from . import get_permission_policy
+
+        register_permission_policy(Image, get_permission_policy())

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -20,7 +20,7 @@ from wagtail.images.fields import WagtailImageField
 from wagtail.images.formats import get_image_formats
 from wagtail.images.models import Image
 from wagtail.models import Collection
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.search import index as search_index
 
 
@@ -54,7 +54,7 @@ class BaseImageForm(BaseCollectionMemberForm):
 
     @cached_property
     def permission_policy(self):
-        return policies_registry.get_by_type(get_image_model())
+        return policy_registry.get_by_type(get_image_model())
 
     def save(self, commit=True):
         if "file" in self.changed_data:

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -4,6 +4,7 @@ from django import forms
 from django.conf import settings
 from django.db import models
 from django.forms.models import modelform_factory
+from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext as _
 
@@ -14,11 +15,12 @@ from wagtail.admin.forms.collections import (
 )
 from wagtail.admin.forms.tags import validate_tag_length
 from wagtail.admin.widgets import AdminTagWidget
+from wagtail.images import get_image_model
 from wagtail.images.fields import WagtailImageField
 from wagtail.images.formats import get_image_formats
 from wagtail.images.models import Image
-from wagtail.images.permissions import permission_policy as images_permission_policy
 from wagtail.models import Collection
+from wagtail.permissions import policies_registry
 from wagtail.search import index as search_index
 
 
@@ -40,8 +42,6 @@ def formfield_for_dbfield(db_field, **kwargs):
 
 
 class BaseImageForm(BaseCollectionMemberForm):
-    permission_policy = images_permission_policy
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.original_file = self.instance.file
@@ -51,6 +51,10 @@ class BaseImageForm(BaseCollectionMemberForm):
             self.fields["file"].widget.attrs["data-w-sync-target-value"] = (
                 f"#{self['title'].id_for_label}"
             )
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
     def save(self, commit=True):
         if "file" in self.changed_data:

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -35,6 +35,7 @@ from taggit.managers import TaggableManager
 
 from wagtail import hooks
 from wagtail.coreutils import string_to_ascii
+from wagtail.images import get_image_model
 from wagtail.images.exceptions import (
     InvalidFilterSpecError,
     UnknownOutputImageFormatError,
@@ -48,6 +49,7 @@ from wagtail.images.image_operations import (
 from wagtail.images.rect import Rect
 from wagtail.images.utils import to_svg_safe_spec
 from wagtail.models import CollectionMember, ReferenceIndex
+from wagtail.permissions import policies_registry
 from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
 from wagtail.utils.file import hash_filelike
@@ -915,8 +917,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         return getattr(self, "description", None) or self.title
 
     def is_editable_by_user(self, user):
-        from wagtail.images.permissions import permission_policy
-
+        permission_policy = policies_registry.get_by_type(get_image_model())
         return permission_policy.user_has_permission_for_instance(user, "change", self)
 
     class Meta:

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -49,7 +49,7 @@ from wagtail.images.image_operations import (
 from wagtail.images.rect import Rect
 from wagtail.images.utils import to_svg_safe_spec
 from wagtail.models import CollectionMember, ReferenceIndex
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
 from wagtail.utils.file import hash_filelike
@@ -917,7 +917,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         return getattr(self, "description", None) or self.title
 
     def is_editable_by_user(self, user):
-        permission_policy = policies_registry.get_by_type(get_image_model())
+        permission_policy = policy_registry.get_by_type(get_image_model())
         return permission_policy.user_has_permission_for_instance(user, "change", self)
 
     class Meta:

--- a/wagtail/images/permissions.py
+++ b/wagtail/images/permissions.py
@@ -1,46 +1,12 @@
-from django.dispatch import receiver
-from django.test.signals import setting_changed
+import warnings
 
 from wagtail.images import get_image_model
-from wagtail.images.models import Image
-from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
+from wagtail.permissions import policies_registry
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
-permission_policy = None
-
-
-class ImagesPermissionPolicyGetter:
-    """
-    A helper to retrieve the current permission policy dynamically.
-    Following the descriptor protocol, this should be used as a class attribute::
-
-        class MyImageView(PermissionCheckedMixin, ...):
-            permission_policy = ImagesPermissionPolicyGetter()
-    """
-
-    def __get__(self, obj, objtype=None):
-        return permission_policy
-
-
-def set_permission_policy():
-    """Sets the permission policy for the current image model."""
-
-    global permission_policy
-    permission_policy = CollectionOwnershipPermissionPolicy(
-        get_image_model(), auth_model=Image, owner_field_name="uploaded_by_user"
-    )
-
-
-@receiver(setting_changed)
-def update_permission_policy(signal, sender, setting, **kwargs):
-    """
-    Updates the permission policy when the `WAGTAILIMAGES_IMAGE_MODEL` setting changes.
-    This is useful in tests where we override the base image model and expect the
-    permission policy to have changed accordingly.
-    """
-
-    if setting == "WAGTAILIMAGES_IMAGE_MODEL":
-        set_permission_policy()
-
-
-# Set the permission policy for the first time.
-set_permission_policy()
+warnings.warn(
+    "wagtail.images.permissions.permission_policy is deprecated. "
+    "Use wagtail.permissions.policies_registry.get_by_type(get_image_model()) instead.",
+    RemovedInWagtail90Warning,
+)
+permission_policy = policies_registry.get_by_type(get_image_model())

--- a/wagtail/images/permissions.py
+++ b/wagtail/images/permissions.py
@@ -1,12 +1,12 @@
 import warnings
 
 from wagtail.images import get_image_model
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
 warnings.warn(
     "wagtail.images.permissions.permission_policy is deprecated. "
-    "Use wagtail.permissions.policies_registry.get_by_type(get_image_model()) instead.",
+    "Use wagtail.permissions.policy_registry.get_by_type(get_image_model()) instead.",
     RemovedInWagtail90Warning,
 )
-permission_policy = policies_registry.get_by_type(get_image_model())
+permission_policy = policy_registry.get_by_type(get_image_model())

--- a/wagtail/images/tests/__init__.py
+++ b/wagtail/images/tests/__init__.py
@@ -1,0 +1,18 @@
+from django.test.signals import setting_changed
+
+from wagtail.images import get_image_model, get_permission_policy
+from wagtail.permissions import register_permission_policy
+
+
+def update_permission_policy(signal, sender, setting, **kwargs):
+    """
+    Register the permission policy when the `WAGTAILIMAGES_IMAGE_MODEL` setting changes.
+    This is useful in tests where we override the image model setting and expect the
+    permission policy to have changed accordingly.
+    """
+
+    if setting == "WAGTAILIMAGES_IMAGE_MODEL":
+        register_permission_policy(get_image_model(), get_permission_policy())
+
+
+setting_changed.connect(update_permission_policy)

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 from unittest.mock import patch
 
 from django.conf import settings
+from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import SimpleUploadedFile, TemporaryUploadedFile
@@ -4321,6 +4322,32 @@ class TestURLGeneratorViewOutput(WagtailTestUtils, TestCase):
         )
         self.assertEqual(preview_url, expected_preview_url)
 
+    def test_get_no_collection_permissions(self):
+        # Remove privileges from user
+        self.user.is_superuser = False
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            ),
+            Permission.objects.get(
+                content_type__app_label="wagtailimages",
+                codename=get_permission_codename("change", Image._meta),
+            ),
+        )
+        self.user.save()
+
+        # With only admin access and model-level permissions, the user gets
+        # redirected to the home page due to insufficient permissions to view
+        # the image URL generator at all
+        response = self.client.get(
+            reverse(
+                "wagtailimages:url_generator_output",
+                args=(self.image.id,),
+            )
+            + "?filter_method=fill&width=800&height=600"
+        )
+        self.assertRedirects(response, reverse("wagtailadmin_home"))
+
     def test_get_bad_permissions(self):
         """
         This tests that the view gives a 403 if a user without correct permissions attempts to access it
@@ -4332,6 +4359,20 @@ class TestURLGeneratorViewOutput(WagtailTestUtils, TestCase):
                 content_type__app_label="wagtailadmin", codename="access_admin"
             )
         )
+        image_changers_group = Group.objects.create(name="Image changers")
+        change_permission = Permission.objects.get(
+            content_type__app_label="wagtailimages", codename="change_image"
+        )
+        root_collection = Collection.get_first_root_node()
+        new_collection = root_collection.add_child(
+            instance=Collection(name="New collection")
+        )
+        GroupCollectionPermission.objects.create(
+            group=image_changers_group,
+            collection=new_collection,
+            permission=change_permission,
+        )
+        self.user.groups.add(image_changers_group)
         self.user.save()
 
         # Get
@@ -4345,6 +4386,9 @@ class TestURLGeneratorViewOutput(WagtailTestUtils, TestCase):
 
         # Check response
         self.assertEqual(response.status_code, 403)
+        # With admin access, model-level image permission, but only permissions
+        # for a different collection, the user should get an image-specific
+        # error message
         self.assertEqual(
             response.content.decode(),
             "You do not have permission to generate a URL for this image.",

--- a/wagtail/images/tests/test_permissions.py
+++ b/wagtail/images/tests/test_permissions.py
@@ -2,7 +2,7 @@ from django.test import TestCase, override_settings
 
 from wagtail.images import get_image_model
 from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.test.testapp.models import CustomImage
 from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
@@ -13,7 +13,7 @@ class TestImagePermissions(TestCase):
         with self.assertWarnsMessage(
             RemovedInWagtail90Warning,
             "wagtail.images.permissions.permission_policy is deprecated. "
-            "Use wagtail.permissions.policies_registry.get_by_type(get_image_model()) instead.",
+            "Use wagtail.permissions.policy_registry.get_by_type(get_image_model()) instead.",
         ):
             from wagtail.images.permissions import permission_policy
 
@@ -25,12 +25,12 @@ class TestImagePermissions(TestCase):
 
     def test_get_from_registry(self):
         model = get_image_model()
-        permission_policy = policies_registry.get_by_type(model)
+        permission_policy = policy_registry.get_by_type(model)
         self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
         self.assertIs(permission_policy.model, model)
 
     @override_settings(WAGTAILIMAGES_IMAGE_MODEL="tests.CustomImage")
     def test_get_from_registry_with_custom_model(self):
-        permission_policy = policies_registry.get_by_type(CustomImage)
+        permission_policy = policy_registry.get_by_type(CustomImage)
         self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
         self.assertIs(permission_policy.model, CustomImage)

--- a/wagtail/images/tests/test_permissions.py
+++ b/wagtail/images/tests/test_permissions.py
@@ -1,0 +1,36 @@
+from django.test import TestCase, override_settings
+
+from wagtail.images import get_image_model
+from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
+from wagtail.permissions import policies_registry
+from wagtail.test.testapp.models import CustomImage
+from wagtail.utils.deprecation import RemovedInWagtail90Warning
+
+
+class TestImagePermissions(TestCase):
+    def test_permissions_direct_import_deprecated(self):
+        model = get_image_model()
+        with self.assertWarnsMessage(
+            RemovedInWagtail90Warning,
+            "wagtail.images.permissions.permission_policy is deprecated. "
+            "Use wagtail.permissions.policies_registry.get_by_type(get_image_model()) instead.",
+        ):
+            from wagtail.images.permissions import permission_policy
+
+            self.assertIsInstance(
+                permission_policy,
+                CollectionOwnershipPermissionPolicy,
+            )
+            self.assertIs(permission_policy.model, model)
+
+    def test_get_from_registry(self):
+        model = get_image_model()
+        permission_policy = policies_registry.get_by_type(model)
+        self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
+        self.assertIs(permission_policy.model, model)
+
+    @override_settings(WAGTAILIMAGES_IMAGE_MODEL="tests.CustomImage")
+    def test_get_from_registry_with_custom_model(self):
+        permission_policy = policies_registry.get_by_type(CustomImage)
+        self.assertIsInstance(permission_policy, CollectionOwnershipPermissionPolicy)
+        self.assertIs(permission_policy.model, CustomImage)

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -23,8 +23,8 @@ from wagtail.images.fields import WagtailImageField
 from wagtail.images.formats import Format, get_image_format, register_image_format
 from wagtail.images.forms import get_image_form
 from wagtail.images.models import Image as WagtailImage
-from wagtail.images.permissions import update_permission_policy
 from wagtail.images.rect import Rect, Vector
+from wagtail.images.tests import update_permission_policy
 from wagtail.images.utils import generate_signature, verify_signature
 from wagtail.images.views.serve import ServeView
 from wagtail.test.testapp.models import CustomImage, CustomImageFilePath

--- a/wagtail/images/views/bulk_actions/add_to_collection.py
+++ b/wagtail/images/views/bulk_actions/add_to_collection.py
@@ -4,14 +4,14 @@ from django.utils.translation import ngettext
 
 from wagtail.images import get_image_model
 from wagtail.images.views.bulk_actions.image_bulk_action import ImageBulkAction
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 class CollectionForm(forms.Form):
     def __init__(self, *args, **kwargs):
         user = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
-        permission_policy = policies_registry.get_by_type(get_image_model())
+        permission_policy = policy_registry.get_by_type(get_image_model())
         self.fields["collection"] = forms.ModelChoiceField(
             label=_("Collection"),
             queryset=permission_policy.collections_user_has_permission_for(user, "add"),

--- a/wagtail/images/views/bulk_actions/add_to_collection.py
+++ b/wagtail/images/views/bulk_actions/add_to_collection.py
@@ -2,18 +2,19 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
+from wagtail.images import get_image_model
 from wagtail.images.views.bulk_actions.image_bulk_action import ImageBulkAction
+from wagtail.permissions import policies_registry
 
 
 class CollectionForm(forms.Form):
     def __init__(self, *args, **kwargs):
         user = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
+        permission_policy = policies_registry.get_by_type(get_image_model())
         self.fields["collection"] = forms.ModelChoiceField(
             label=_("Collection"),
-            queryset=ImageBulkAction.permission_policy.collections_user_has_permission_for(
-                user, "add"
-            ),
+            queryset=permission_policy.collections_user_has_permission_for(user, "add"),
         )
 
 

--- a/wagtail/images/views/bulk_actions/image_bulk_action.py
+++ b/wagtail/images/views/bulk_actions/image_bulk_action.py
@@ -1,11 +1,16 @@
+from django.utils.functional import cached_property
+
 from wagtail.admin.views.bulk_action import BulkAction
 from wagtail.images import get_image_model
-from wagtail.images.permissions import permission_policy as images_permission_policy
+from wagtail.permissions import policies_registry
 
 
 class ImageBulkAction(BulkAction):
-    permission_policy = images_permission_policy
     models = [get_image_model()]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def get_all_objects_in_listing_query(self, parent_id):
         listing_objects = self.permission_policy.instances_user_has_permission_for(

--- a/wagtail/images/views/bulk_actions/image_bulk_action.py
+++ b/wagtail/images/views/bulk_actions/image_bulk_action.py
@@ -2,7 +2,7 @@ from django.utils.functional import cached_property
 
 from wagtail.admin.views.bulk_action import BulkAction
 from wagtail.images import get_image_model
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 class ImageBulkAction(BulkAction):
@@ -10,7 +10,7 @@ class ImageBulkAction(BulkAction):
 
     @cached_property
     def permission_policy(self):
-        return policies_registry.get_by_type(self.model)
+        return policy_registry.get_by_type(self.model)
 
     def get_all_objects_in_listing_query(self, parent_id):
         listing_objects = self.permission_policy.instances_user_has_permission_for(

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -8,7 +8,6 @@ from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import View
 
-from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.models import popular_tags_for_model
 from wagtail.admin.ui.tables import (
@@ -33,11 +32,9 @@ from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.images import get_image_model
 from wagtail.images.formats import get_image_format
 from wagtail.images.forms import ImageInsertionForm, get_image_form
-from wagtail.images.permissions import permission_policy
 from wagtail.images.utils import find_image_duplicates
 from wagtail.models import ReferenceIndex
-
-permission_checker = PermissionPolicyChecker(permission_policy)
+from wagtail.permissions import policies_registry
 
 
 class ImageChosenResponseMixin(ChosenResponseMixin):
@@ -60,7 +57,10 @@ class ImageCreationFormMixin(CreationFormMixin):
     creation_tab_id = "upload"
     create_action_label = _("Upload")
     create_action_clicked_label = _("Uploading…")
-    permission_policy = permission_policy
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
     def get_creation_form_class(self):
         return get_image_form(self.model)
@@ -94,9 +94,8 @@ class BaseImageChooseView(BaseChooseView):
     def get_object_list(self):
         # Get images (filtered by user permission)
         images = (
-            permission_policy.instances_user_has_any_permission_for(
-                self.request.user, ["choose"]
-            )
+            policies_registry.get_by_type(get_image_model())
+            .instances_user_has_any_permission_for(self.request.user, ["choose"])
             .select_related("collection")
             .prefetch_renditions("max-165x165")
         )
@@ -222,7 +221,7 @@ class ImageChooseResultsView(
 class ImageChosenView(ChosenViewMixin, ImageChosenResponseMixin, View):
     def get_object(self, pk):
         item = super().get_object(pk)
-
+        permission_policy = policies_registry.get_by_type(self.model)
         if not permission_policy.user_has_permission_for_instance(
             self.request.user, "choose", item
         ):
@@ -236,8 +235,12 @@ class ImageChosenView(ChosenViewMixin, ImageChosenResponseMixin, View):
 
 
 class ImageChosenMultipleView(ChosenMultipleViewMixin, ImageChosenResponseMixin, View):
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
+
     def get_objects(self, pks):
-        return permission_policy.instances_user_has_any_permission_for(
+        return self.permission_policy.instances_user_has_any_permission_for(
             self.request.user, ["choose"]
         ).filter(pk__in=pks)
 
@@ -275,7 +278,7 @@ class ImageUploadViewMixin(SelectFormatResponseMixin, CreateViewMixin):
             duplicates = find_image_duplicates(
                 image=image,
                 user=request.user,
-                permission_policy=permission_policy,
+                permission_policy=self.permission_policy,
             )
             existing_image = duplicates.first()
             if existing_image:
@@ -392,7 +395,6 @@ class ImageChooserViewSet(ChooserViewSet):
     chosen_multiple_view_class = ImageChosenMultipleView
     create_view_class = ImageUploadView
     select_format_view_class = ImageSelectFormatView
-    permission_policy = permission_policy
     register_widget = False
     preserve_url_parameters = ChooserViewSet.preserve_url_parameters + [
         "select_format",
@@ -405,6 +407,10 @@ class ImageChooserViewSet(ChooserViewSet):
     create_action_clicked_label = _("Uploading…")
     choose_another_text = _("Choose another image")
     edit_item_text = _("Edit this image")
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
     @property
     def select_format_view(self):

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -58,10 +58,6 @@ class ImageCreationFormMixin(CreationFormMixin):
     create_action_label = _("Upload")
     create_action_clicked_label = _("Uploading…")
 
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(get_image_model())
-
     def get_creation_form_class(self):
         return get_image_form(self.model)
 
@@ -407,10 +403,6 @@ class ImageChooserViewSet(ChooserViewSet):
     create_action_clicked_label = _("Uploading…")
     choose_another_text = _("Choose another image")
     edit_item_text = _("Edit this image")
-
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(get_image_model())
 
     @property
     def select_format_view(self):

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -34,7 +34,7 @@ from wagtail.images.formats import get_image_format
 from wagtail.images.forms import ImageInsertionForm, get_image_form
 from wagtail.images.utils import find_image_duplicates
 from wagtail.models import ReferenceIndex
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 class ImageChosenResponseMixin(ChosenResponseMixin):
@@ -90,7 +90,7 @@ class BaseImageChooseView(BaseChooseView):
     def get_object_list(self):
         # Get images (filtered by user permission)
         images = (
-            policies_registry.get_by_type(get_image_model())
+            policy_registry.get_by_type(get_image_model())
             .instances_user_has_any_permission_for(self.request.user, ["choose"])
             .select_related("collection")
             .prefetch_renditions("max-165x165")
@@ -217,7 +217,7 @@ class ImageChooseResultsView(
 class ImageChosenView(ChosenViewMixin, ImageChosenResponseMixin, View):
     def get_object(self, pk):
         item = super().get_object(pk)
-        permission_policy = policies_registry.get_by_type(self.model)
+        permission_policy = policy_registry.get_by_type(self.model)
         if not permission_policy.user_has_permission_for_instance(
             self.request.user, "choose", item
         ):
@@ -233,7 +233,7 @@ class ImageChosenView(ChosenViewMixin, ImageChosenResponseMixin, View):
 class ImageChosenMultipleView(ChosenMultipleViewMixin, ImageChosenResponseMixin, View):
     @cached_property
     def permission_policy(self):
-        return policies_registry.get_by_type(self.model)
+        return policy_registry.get_by_type(self.model)
 
     def get_objects(self, pks):
         return self.permission_policy.instances_user_has_any_permission_for(

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -36,7 +36,7 @@ from wagtail.images.forms import URLGeneratorForm, get_image_form
 from wagtail.images.models import Filter, SourceImageIOError
 from wagtail.images.utils import generate_signature
 from wagtail.models import ReferenceIndex, Site
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 Image = get_image_model()
 
@@ -46,7 +46,7 @@ USAGE_PAGE_SIZE = getattr(settings, "WAGTAILIMAGES_USAGE_PAGE_SIZE", 20)
 class ImagesFilterSet(BaseMediaFilterSet):
     @cached_property
     def permission_policy(self):
-        return policies_registry.get_by_type(Image)
+        return policy_registry.get_by_type(Image)
 
     class Meta:
         model = Image
@@ -434,7 +434,7 @@ def preview(request, image_id, filter_spec):
     model = get_image_model()
     image = get_object_or_404(model, id=image_id)
 
-    if not policies_registry.get_by_type(model).user_has_permission_for_instance(
+    if not policy_registry.get_by_type(model).user_has_permission_for_instance(
         request.user, "change", image
     ):
         raise PermissionDenied

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -19,7 +19,6 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, ngettext
 
 from wagtail.admin import messages
-from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.filters import BaseMediaFilterSet
 from wagtail.admin.ui.tables import (
     BaseColumn,
@@ -35,11 +34,9 @@ from wagtail.images import get_image_model
 from wagtail.images.exceptions import InvalidFilterSpecError
 from wagtail.images.forms import URLGeneratorForm, get_image_form
 from wagtail.images.models import Filter, SourceImageIOError
-from wagtail.images.permissions import permission_policy
 from wagtail.images.utils import generate_signature
 from wagtail.models import ReferenceIndex, Site
-
-permission_checker = PermissionPolicyChecker(permission_policy)
+from wagtail.permissions import policies_registry
 
 Image = get_image_model()
 
@@ -47,7 +44,9 @@ USAGE_PAGE_SIZE = getattr(settings, "WAGTAILIMAGES_USAGE_PAGE_SIZE", 20)
 
 
 class ImagesFilterSet(BaseMediaFilterSet):
-    permission_policy = permission_policy
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(Image)
 
     class Meta:
         model = Image
@@ -67,7 +66,6 @@ class IndexView(generic.IndexView):
     }
     default_ordering = "-created_at"
     context_object_name = "images"
-    permission_policy = permission_policy
     any_permission_required = ["add", "change", "delete"]
     model = Image
     filterset_class = ImagesFilterSet
@@ -97,7 +95,7 @@ class IndexView(generic.IndexView):
     def get_base_queryset(self):
         # Get images (filtered by user permission)
         images = (
-            permission_policy.instances_user_has_any_permission_for(
+            self.permission_policy.instances_user_has_any_permission_for(
                 self.request.user, ["change", "delete"]
             )
             .select_related("collection")
@@ -237,7 +235,6 @@ class TitleColumnWithFilename(TitleColumn):
 
 
 class EditView(generic.EditView):
-    permission_policy = permission_policy
     pk_url_kwarg = "image_id"
     error_message = gettext_lazy("The image could not be saved due to errors.")
     template_name = "wagtailimages/images/edit.html"
@@ -262,7 +259,7 @@ class EditView(generic.EditView):
 
     def get_object(self, queryset=None):
         obj = super().get_object(queryset)
-        if not permission_policy.user_has_permission_for_instance(
+        if not self.permission_policy.user_has_permission_for_instance(
             self.request.user, "change", obj
         ):
             raise PermissionDenied
@@ -351,7 +348,7 @@ class URLGeneratorView(generic.InspectView):
 
         self.object = get_object_or_404(self.model, id=image_id)
 
-        if not permission_policy.user_has_permission_for_instance(
+        if not self.permission_policy.user_has_permission_for_instance(
             request.user, "change", self.object
         ):
             if self.output_only:
@@ -434,9 +431,10 @@ class URLGeneratorView(generic.InspectView):
 
 
 def preview(request, image_id, filter_spec):
-    image = get_object_or_404(get_image_model(), id=image_id)
+    model = get_image_model()
+    image = get_object_or_404(model, id=image_id)
 
-    if not permission_policy.user_has_permission_for_instance(
+    if not policies_registry.get_by_type(model).user_has_permission_for_instance(
         request.user, "change", image
     ):
         raise PermissionDenied
@@ -468,7 +466,6 @@ def preview(request, image_id, filter_spec):
 class DeleteView(generic.DeleteView):
     model = get_image_model()
     pk_url_kwarg = "image_id"
-    permission_policy = permission_policy
     permission_required = "delete"
     header_icon = "image"
     template_name = "wagtailimages/images/confirm_delete.html"
@@ -499,7 +496,6 @@ class DeleteView(generic.DeleteView):
 
 
 class CreateView(generic.CreateView):
-    permission_policy = permission_policy
     index_url_name = "wagtailimages:index"
     add_url_name = "wagtailimages:add"
     edit_url_name = "wagtailimages:edit"
@@ -530,7 +526,6 @@ class UsageView(generic.UsageView):
     model = get_image_model()
     paginate_by = USAGE_PAGE_SIZE
     pk_url_kwarg = "image_id"
-    permission_policy = permission_policy
     permission_required = "change"
     header_icon = "image"
     index_url_name = "wagtailimages:index"

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -2,7 +2,6 @@ import os.path
 
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy
 
@@ -23,7 +22,6 @@ from wagtail.images.utils import (
     get_accept_attributes,
     get_allowed_image_extensions,
 )
-from wagtail.permissions import policies_registry
 
 
 class AddView(WagtailAdminTemplateMixin, BaseAddView):
@@ -52,10 +50,6 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
             },
             {"url": "", "label": self.get_page_title()},
         ]
-
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(get_image_model())
 
     def get_model(self):
         return get_image_model()
@@ -132,10 +126,6 @@ class EditView(BaseEditView):
     edit_object_url_name = "wagtailimages:edit_multiple"
     delete_object_url_name = "wagtailimages:delete_multiple"
 
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(get_image_model())
-
     def get_model(self):
         return get_image_model()
 
@@ -146,10 +136,6 @@ class EditView(BaseEditView):
 class DeleteView(BaseDeleteView):
     pk_url_kwarg = "image_id"
     context_object_id_name = "image_id"
-
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(get_image_model())
 
     def get_model(self):
         return get_image_model()

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -2,6 +2,7 @@ import os.path
 
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy
 
@@ -17,16 +18,15 @@ from wagtail.admin.views.generic.multiple_upload import DeleteView as BaseDelete
 from wagtail.admin.views.generic.multiple_upload import EditView as BaseEditView
 from wagtail.images import get_image_model
 from wagtail.images.forms import get_image_form, get_image_multi_form
-from wagtail.images.permissions import ImagesPermissionPolicyGetter, permission_policy
 from wagtail.images.utils import (
     find_image_duplicates,
     get_accept_attributes,
     get_allowed_image_extensions,
 )
+from wagtail.permissions import policies_registry
 
 
 class AddView(WagtailAdminTemplateMixin, BaseAddView):
-    permission_policy = ImagesPermissionPolicyGetter()
     template_name = "wagtailimages/multiple/add.html"
     header_icon = "image"
     page_title = gettext_lazy("Add images")
@@ -52,6 +52,10 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
             },
             {"url": "", "label": self.get_page_title()},
         ]
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
     def get_model(self):
         return get_image_model()
@@ -121,13 +125,16 @@ class AddView(WagtailAdminTemplateMixin, BaseAddView):
 
 
 class EditView(BaseEditView):
-    permission_policy = permission_policy
     pk_url_kwarg = "image_id"
     edit_object_form_prefix = "image"
     context_object_name = "image"
     context_object_id_name = "image_id"
     edit_object_url_name = "wagtailimages:edit_multiple"
     delete_object_url_name = "wagtailimages:delete_multiple"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
     def get_model(self):
         return get_image_model()
@@ -137,9 +144,12 @@ class EditView(BaseEditView):
 
 
 class DeleteView(BaseDeleteView):
-    permission_policy = permission_policy
     pk_url_kwarg = "image_id"
     context_object_id_name = "image_id"
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
     def get_model(self):
         return get_image_model()

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -1,5 +1,4 @@
 from django.urls import include, path, reverse, reverse_lazy
-from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
@@ -188,10 +187,6 @@ def describe_collection_docs(collection):
 
 class ImageAdminURLFinder(ModelAdminURLFinder):
     edit_url_name = "wagtailimages:edit"
-
-    @cached_property
-    def permission_policy(self):
-        return policies_registry.get_by_type(get_image_model())
 
 
 register_admin_url_finder(get_image_model(), ImageAdminURLFinder)

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -24,7 +24,7 @@ from wagtail.images.views.bulk_actions import (
     DeleteBulkAction,
 )
 from wagtail.images.views.chooser import viewset as chooser_viewset
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 @hooks.register("register_admin_urls")
@@ -41,7 +41,7 @@ def construct_admin_api(router):
 
 class ImagesMenuItem(MenuItem):
     def is_shown(self, request):
-        return policies_registry.get_by_type(get_image_model()).user_has_any_permission(
+        return policy_registry.get_by_type(get_image_model()).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -130,7 +130,7 @@ class ImagesSummaryItem(SummaryItem):
         site_name = get_site_for_user(self.request.user)["site_name"]
 
         return {
-            "total_images": policies_registry.get_by_type(get_image_model())
+            "total_images": policy_registry.get_by_type(get_image_model())
             .instances_user_has_any_permission_for(
                 self.request.user, {"add", "change", "delete", "choose"}
             )
@@ -139,7 +139,7 @@ class ImagesSummaryItem(SummaryItem):
         }
 
     def is_shown(self):
-        return policies_registry.get_by_type(get_image_model()).user_has_any_permission(
+        return policy_registry.get_by_type(get_image_model()).user_has_any_permission(
             self.request.user, ["add", "change", "delete"]
         )
 
@@ -151,7 +151,7 @@ def add_images_summary_item(request, items):
 
 class ImagesSearchArea(SearchArea):
     def is_shown(self, request):
-        return policies_registry.get_by_type(get_image_model()).user_has_any_permission(
+        return policy_registry.get_by_type(get_image_model()).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -1,4 +1,5 @@
 from django.urls import include, path, reverse, reverse_lazy
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
@@ -15,7 +16,6 @@ from wagtail.admin.site_summary import SummaryItem
 from wagtail.images import admin_urls, get_image_model, image_operations
 from wagtail.images.api.admin.views import ImagesAdminAPIViewSet
 from wagtail.images.forms import GroupImagePermissionFormSet
-from wagtail.images.permissions import permission_policy
 from wagtail.images.rich_text import ImageEmbedHandler
 from wagtail.images.rich_text.contentstate import ContentstateImageConversionRule
 from wagtail.images.rich_text.editor_html import EditorHTMLImageConversionRule
@@ -25,6 +25,7 @@ from wagtail.images.views.bulk_actions import (
     DeleteBulkAction,
 )
 from wagtail.images.views.chooser import viewset as chooser_viewset
+from wagtail.permissions import policies_registry
 
 
 @hooks.register("register_admin_urls")
@@ -41,7 +42,7 @@ def construct_admin_api(router):
 
 class ImagesMenuItem(MenuItem):
     def is_shown(self, request):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(get_image_model()).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -130,14 +131,16 @@ class ImagesSummaryItem(SummaryItem):
         site_name = get_site_for_user(self.request.user)["site_name"]
 
         return {
-            "total_images": permission_policy.instances_user_has_any_permission_for(
+            "total_images": policies_registry.get_by_type(get_image_model())
+            .instances_user_has_any_permission_for(
                 self.request.user, {"add", "change", "delete", "choose"}
-            ).count(),
+            )
+            .count(),
             "site_name": site_name,
         }
 
     def is_shown(self):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(get_image_model()).user_has_any_permission(
             self.request.user, ["add", "change", "delete"]
         )
 
@@ -149,7 +152,7 @@ def add_images_summary_item(request, items):
 
 class ImagesSearchArea(SearchArea):
     def is_shown(self, request):
-        return permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(get_image_model()).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 
@@ -185,7 +188,10 @@ def describe_collection_docs(collection):
 
 class ImageAdminURLFinder(ModelAdminURLFinder):
     edit_url_name = "wagtailimages:edit"
-    permission_policy = permission_policy
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(get_image_model())
 
 
 register_admin_url_finder(get_image_model(), ImageAdminURLFinder)

--- a/wagtail/locales/views.py
+++ b/wagtail/locales/views.py
@@ -9,7 +9,6 @@ from wagtail.admin.views import generic
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.coreutils import get_content_languages
 from wagtail.models import Locale
-from wagtail.permissions import locale_permission_policy
 
 from .forms import LocaleForm
 from .utils import get_locale_usage
@@ -127,7 +126,6 @@ class DeleteView(generic.DeleteView):
 class LocaleViewSet(ModelViewSet):
     icon = "site"
     model = Locale
-    permission_policy = locale_permission_policy
     add_to_reference_index = False
 
     index_view_class = IndexView

--- a/wagtail/locales/wagtail_hooks.py
+++ b/wagtail/locales/wagtail_hooks.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 from wagtail.models import Site
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 from .views import LocaleViewSet
 
@@ -16,7 +16,7 @@ def register_viewset():
 
 class LocalesMenuItem(MenuItem):
     def is_shown(self, request):
-        return policies_registry.get_by_type(Site).user_has_any_permission(
+        return policy_registry.get_by_type(Site).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 

--- a/wagtail/locales/wagtail_hooks.py
+++ b/wagtail/locales/wagtail_hooks.py
@@ -3,7 +3,8 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
-from wagtail.permissions import site_permission_policy
+from wagtail.models import Site
+from wagtail.permissions import policies_registry
 
 from .views import LocaleViewSet
 
@@ -15,7 +16,7 @@ def register_viewset():
 
 class LocalesMenuItem(MenuItem):
     def is_shown(self, request):
-        return site_permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Site).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -2322,10 +2322,10 @@ class GroupPagePermission(models.Model):
 
 class PagePermissionTester:
     def __init__(self, user, page):
-        from wagtail.permissions import policies_registry
+        from wagtail.permissions import policy_registry
 
         self.user = user
-        self.permission_policy = policies_registry.get(page)
+        self.permission_policy = policy_registry.get(page)
         self.page = page
         self.page_is_root = page.depth == 1  # Equivalent to page.is_root()
 
@@ -2739,11 +2739,11 @@ class PageLogEntryManager(BaseLogEntryManager):
         return super().log_action(instance, action, **kwargs)
 
     def viewable_by_user(self, user):
-        from wagtail.permissions import policies_registry
+        from wagtail.permissions import policy_registry
 
         Page = swapper.load_model("wagtailcore", "Page")
 
-        permission_policy = policies_registry.get_by_type(Page)
+        permission_policy = policy_registry.get_by_type(Page)
         explorable_instances = permission_policy.explorable_instances(user)
         q = Q(page__in=explorable_instances.values_list("pk", flat=True))
 

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -2322,10 +2322,10 @@ class GroupPagePermission(models.Model):
 
 class PagePermissionTester:
     def __init__(self, user, page):
-        from wagtail.permissions import page_permission_policy
+        from wagtail.permissions import policies_registry
 
         self.user = user
-        self.permission_policy = page_permission_policy
+        self.permission_policy = policies_registry.get(page)
         self.page = page
         self.page_is_root = page.depth == 1  # Equivalent to page.is_root()
 
@@ -2739,11 +2739,12 @@ class PageLogEntryManager(BaseLogEntryManager):
         return super().log_action(instance, action, **kwargs)
 
     def viewable_by_user(self, user):
-        from wagtail.permissions import page_permission_policy
+        from wagtail.permissions import policies_registry
 
         Page = swapper.load_model("wagtailcore", "Page")
 
-        explorable_instances = page_permission_policy.explorable_instances(user)
+        permission_policy = policies_registry.get_by_type(Page)
+        explorable_instances = permission_policy.explorable_instances(user)
         q = Q(page__in=explorable_instances.values_list("pk", flat=True))
 
         root_page_permissions = Page.get_first_root_node().permissions_for_user(user)

--- a/wagtail/permission_policies/base.py
+++ b/wagtail/permission_policies/base.py
@@ -12,21 +12,30 @@ class BasePermissionPolicy:
     """
     A 'permission policy' is an object that handles all decisions about the actions
     users are allowed to perform on a given model. The mechanism by which it does this
-    is arbitrary, and may or may not involve the django.contrib.auth Permission model;
+    is arbitrary, and may or may not involve the ``django.contrib.auth``
+    :class:`~django.contrib.auth.models.Permission` model;
     it could be as simple as "allow all users to do everything".
 
     In this way, admin apps can change their permission-handling logic just by swapping
     to a different policy object, rather than having that logic spread across numerous
     view functions.
 
-    BasePermissionPolicy is an abstract class that all permission policies inherit from.
-    The only method that subclasses need to implement is users_with_any_permission;
+    ``BasePermissionPolicy`` is an abstract class that all permission policies inherit from.
+    The only method that subclasses need to implement is :meth:`users_with_any_permission`;
     all other methods can be derived from that (but in practice, subclasses will probably
     want to override additional methods, either for efficiency or to implement more
     fine-grained permission logic).
+
+
+    :param model: The model class that this permission policy applies to.
+        This may be a model class or a string in the form of ``app_label.model_name``.
     """
 
     permission_cache_name = ""
+    """
+    Attribute name on the user object to use for caching permissions information.
+    If empty, no caching will be performed.
+    """
 
     def __init__(self, model):
         self._model_or_name = model
@@ -47,8 +56,8 @@ class BasePermissionPolicy:
         """
         Return a set of all permissions that the given user has on this model.
 
-        They may be instances of django.contrib.auth.Permission, or custom
-        permission objects defined by the policy, which are not necessarily
+        They may be instances of :class:`~django.contrib.auth.models.Permission`,
+        or custom permission objects defined by the policy, which are not necessarily
         model instances.
         """
         return set()
@@ -76,14 +85,14 @@ class BasePermissionPolicy:
     def user_has_permission(self, user, action):
         """
         Return whether the given user has permission to perform the given action
-        on some or all instances of this model
+        on some or all instances of this model.
         """
         return user in self.users_with_permission(action)
 
     def user_has_any_permission(self, user, actions):
         """
         Return whether the given user has permission to perform any of the given actions
-        on some or all instances of this model
+        on some or all instances of this model.
         """
         return any(self.user_has_permission(user, action) for action in actions)
 
@@ -93,14 +102,14 @@ class BasePermissionPolicy:
     def users_with_any_permission(self, actions):
         """
         Return a queryset of users who have permission to perform any of the given actions
-        on some or all instances of this model
+        on some or all instances of this model.
         """
         raise NotImplementedError
 
     def users_with_permission(self, action):
         """
         Return a queryset of users who have permission to perform the given action on
-        some or all instances of this model
+        some or all instances of this model.
         """
         return self.users_with_any_permission([action])
 
@@ -115,14 +124,14 @@ class BasePermissionPolicy:
     def user_has_permission_for_instance(self, user, action, instance):
         """
         Return whether the given user has permission to perform the given action on the
-        given model instance
+        given model instance.
         """
         return self.user_has_permission(user, action)
 
     def user_has_any_permission_for_instance(self, user, actions, instance):
         """
         Return whether the given user has permission to perform any of the given actions
-        on the given model instance
+        on the given model instance.
         """
         return any(
             self.user_has_permission_for_instance(user, action, instance)
@@ -132,7 +141,7 @@ class BasePermissionPolicy:
     def instances_user_has_any_permission_for(self, user, actions):
         """
         Return a queryset of all instances of this model for which the given user has
-        permission to perform any of the given actions
+        permission to perform any of the given actions.
         """
         if self.user_has_any_permission(user, actions):
             return self.model._default_manager.all()
@@ -142,18 +151,22 @@ class BasePermissionPolicy:
     def instances_user_has_permission_for(self, user, action):
         """
         Return a queryset of all instances of this model for which the given user has
-        permission to perform the given action
+        permission to perform the given action.
         """
         return self.instances_user_has_any_permission_for(user, [action])
 
     def users_with_any_permission_for_instance(self, actions, instance):
         """
         Return a queryset of all users who have permission to perform any of the given
-        actions on the given model instance
+        actions on the given model instance.
         """
         return self.users_with_any_permission(actions)
 
     def users_with_permission_for_instance(self, action, instance):
+        """
+        Return a queryset of all users who have permission to perform the given
+        action on the given model instance.
+        """
         return self.users_with_any_permission_for_instance([action], instance)
 
 
@@ -205,17 +218,22 @@ class AuthenticationOnlyPermissionPolicy(BasePermissionPolicy):
 
 class BaseDjangoAuthPermissionPolicy(BasePermissionPolicy):
     """
-    Extends BasePermissionPolicy with helper methods useful for policies that need to
-    perform lookups against the django.contrib.auth permission model
+    Extends :class:`~wagtail.permission_policies.BasePermissionPolicy` with
+    helper methods useful for policies that need to perform lookups against the
+    :class:`~django.contrib.auth.models.Permission` model.
+
+    :param model: The model class that this permission policy applies to.
+        This may be a model class or a string in the form of ``app_label.model_name``.
+    :param auth_model: The model class (or a string in the form of
+        ``app_label.model_name``) to use for permission record lookups.
+        Usually this will match ``model`` (which specifies the type of instances that
+        :meth:`~wagtail.permission_policies.BasePermissionPolicy.instances_user_has_permission_for` will return),
+        but this may differ when swappable models are in use - for example, an
+        interface for editing user records might use a custom ``User`` model but will
+        typically still refer to the permission records for ``auth.User``.
     """
 
     def __init__(self, model, auth_model=None):
-        # `auth_model` specifies the model to be used for permission record lookups;
-        # usually this will match `model` (which specifies the type of instances that
-        # `instances_user_has_permission_for` will return), but this may differ when
-        # swappable models are in use - for example, an interface for editing user
-        # records might use a custom User model but will typically still refer to the
-        # permission records for auth.user.
         super().__init__(model)
         self._auth_model_or_name = auth_model or model
 
@@ -288,7 +306,7 @@ class BaseDjangoAuthPermissionPolicy(BasePermissionPolicy):
 class ModelPermissionPolicy(BaseDjangoAuthPermissionPolicy):
     """
     A permission policy that enforces permissions at the model level, by consulting
-    the standard django.contrib.auth permission model directly
+    the standard :class:`~django.contrib.auth.models.Permission` model directly.
     """
 
     def user_has_permission(self, user, action):
@@ -305,15 +323,15 @@ class OwnershipPermissionPolicy(BaseDjangoAuthPermissionPolicy):
     A permission policy for objects that support a concept of 'ownership', where
     the owner is typically the user who created the object.
 
-    This policy piggybacks off 'add' and 'change' permissions defined through the
-    django.contrib.auth Permission model, as follows:
+    This policy piggybacks off ``add`` and ``change`` permissions defined through the
+    :class:`~django.contrib.auth.models.Permission` model, as follows:
 
-    * any user with 'add' permission can create instances, and ALSO edit instances
-    that they own
-    * any user with 'change' permission can edit instances regardless of ownership
+    * any user with ``add`` permission can create instances, and ALSO edit instances
+      that they own
+    * any user with ``change`` permission can edit instances regardless of ownership
     * ability to edit also implies ability to delete
 
-    Besides 'add', 'change' and 'delete', no other actions are recognised or permitted
+    Besides ``add``, ``change`` and ``delete``, no other actions are recognised or permitted
     (unless the user is an active superuser, in which case they can do everything).
     """
 

--- a/wagtail/permission_policies/base.py
+++ b/wagtail/permission_policies/base.py
@@ -253,18 +253,18 @@ class BaseDjangoAuthPermissionPolicy(BasePermissionPolicy):
     def _content_type(self):
         return ContentType.objects.get_for_model(self.auth_model)
 
+    def _get_permission_codename(self, action):
+        return get_permission_codename(action, self.auth_model._meta)
+
     def _get_permission_codenames(self, actions):
-        return {get_permission_codename(action, self.model._meta) for action in actions}
+        return {self._get_permission_codename(action) for action in actions}
 
     def _get_permission_name(self, action):
         """
         Get the full app-label-qualified permission name (as required by
         user.has_perm(...) ) for the given action on this model
         """
-        return "{}.{}".format(
-            self.app_label,
-            get_permission_codename(action, self.model._meta),
-        )
+        return "{}.{}".format(self.app_label, self._get_permission_codename(action))
 
     def _get_permission_objects_for_actions(self, actions):
         """

--- a/wagtail/permission_policies/collections.py
+++ b/wagtail/permission_policies/collections.py
@@ -140,10 +140,10 @@ class CollectionPermissionPolicy(
     CollectionPermissionLookupMixin, BaseDjangoAuthPermissionPolicy
 ):
     """
-    A permission policy for objects that are assigned locations in the Collection tree.
+    A permission policy for objects that are assigned locations in the ``Collection`` tree.
     Permissions may be defined at any node of the hierarchy, through the
-    GroupCollectionPermission model, and propagate downwards. These permissions are
-    applied to objects according to the standard django.contrib.auth permission model.
+    ``GroupCollectionPermission`` model, and propagate downwards. These permissions are
+    applied to objects according to the standard :class:`~django.contrib.auth.models.Permission` model.
     """
 
     def user_has_permission(self, user, action):
@@ -210,9 +210,9 @@ class CollectionOwnershipPermissionPolicy(
     """
     A permission policy for objects that are assigned locations in the Collection tree.
     Permissions may be defined at any node of the hierarchy, through the
-    GroupCollectionPermission model, and propagate downwards. These permissions are
+    ``GroupCollectionPermission`` model, and propagate downwards. These permissions are
     applied to objects according to the 'ownership' permission model
-    (see permission_policies.base.OwnershipPermissionPolicy)
+    (see :class:`~wagtail.permission_policies.OwnershipPermissionPolicy`).
     """
 
     def __init__(self, model, auth_model=None, owner_field_name="owner"):
@@ -391,10 +391,15 @@ class CollectionOwnershipPermissionPolicy(
 class CollectionManagementPermissionPolicy(
     CollectionPermissionLookupMixin, BaseDjangoAuthPermissionPolicy
 ):
+    """
+    A permission policy for managing collections themselves, rather than objects
+    assigned to collections.
+    """
+
     def _descendants_with_perm(self, user, action):
         """
         Return a queryset of collections descended from a collection on which this user has
-        a GroupCollectionPermission record for this action. Used for actions, like edit and
+        a ``GroupCollectionPermission`` record for this action. Used for actions, like edit and
         delete where the user cannot modify the collection where they are granted permission.
         """
         # Get the permission object corresponding to this action

--- a/wagtail/permission_policies/pages.py
+++ b/wagtail/permission_policies/pages.py
@@ -7,6 +7,14 @@ from wagtail.permission_policies.base import OwnershipPermissionPolicy
 
 
 class PagePermissionPolicy(OwnershipPermissionPolicy):
+    """
+    A permission policy for page objects, which are arranged in a tree structure.
+    Permissions may be defined at any node of the tree, through the
+    ``GroupPagePermission`` model, and propagate downwards. These permissions are
+    applied to objects according to the 'ownership' permission model (see
+    :class:`~wagtail.permission_policies.OwnershipPermissionPolicy`).
+    """
+
     permission_cache_name = "_page_permission_cache"
     _explorable_root_instance_cache_name = "_explorable_root_page_cache"
 

--- a/wagtail/permission_policies/pages.py
+++ b/wagtail/permission_policies/pages.py
@@ -1,5 +1,5 @@
 import swapper
-from django.contrib.auth import get_permission_codename, get_user_model
+from django.contrib.auth import get_user_model
 from django.db.models import Q
 
 from wagtail.models import GroupPagePermission
@@ -19,9 +19,10 @@ class PagePermissionPolicy(OwnershipPermissionPolicy):
     _explorable_root_instance_cache_name = "_explorable_root_page_cache"
 
     def __init__(self, model=None):
+        Page = swapper.get_model_name("wagtailcore", "Page")
         if model is None:
-            model = swapper.load_model("wagtailcore", "Page")
-        super().__init__(model=model)
+            model = Page
+        super().__init__(model=model, auth_model=Page)
 
     def get_all_permissions_for_user(self, user):
         if not user.is_active or user.is_anonymous or user.is_superuser:
@@ -100,11 +101,10 @@ class PagePermissionPolicy(OwnershipPermissionPolicy):
             if instance.pk == perm.page_id or instance.is_descendant_of(perm.page):
                 permissions.add(perm.permission.codename)
                 if (
-                    perm.permission.codename
-                    == get_permission_codename("add", self.model._meta)
+                    perm.permission.codename == self._get_permission_codename("add")
                     and instance.owner_id == user.pk
                 ):
-                    permissions.add(get_permission_codename("change", self.model._meta))
+                    permissions.add(self._get_permission_codename("change"))
 
         return bool(self._get_permission_codenames(actions) & permissions)
 
@@ -116,8 +116,7 @@ class PagePermissionPolicy(OwnershipPermissionPolicy):
         pages = self.model._default_manager.none()
         for perm in self.get_cached_permissions_for_user(user):
             if (
-                perm.permission.codename
-                == get_permission_codename("add", self.model._meta)
+                perm.permission.codename == self._get_permission_codename("add")
                 and "add" not in actions
                 and "change" in actions
             ):
@@ -150,7 +149,7 @@ class PagePermissionPolicy(OwnershipPermissionPolicy):
         # owner of the instance
         if "change" in actions and "add" not in actions:
             add_groups = GroupPagePermission.objects.filter(
-                permission__codename=get_permission_codename("add", self.model._meta),
+                permission__codename=self._get_permission_codename("add"),
                 page__in=ancestors,
             ).values_list("group", flat=True)
 
@@ -218,7 +217,7 @@ class PagePermissionPolicy(OwnershipPermissionPolicy):
             perm.page for perm in self.get_cached_permissions_for_user(user)
         ]
         for page in page_permissions:
-            explorable_pages |= page.get_ancestors()
+            explorable_pages |= self.model._default_manager.ancestor_of(page)
 
         # Remove unnecessary top-level ancestors that the user has no access to
         fca_page = self.model.base_page_model.objects.first_common_ancestor_of(

--- a/wagtail/permission_policies/sites.py
+++ b/wagtail/permission_policies/sites.py
@@ -9,9 +9,11 @@ from .base import BaseDjangoAuthPermissionPolicy
 class SitePermissionPolicy(BaseDjangoAuthPermissionPolicy):
     """
     A permission policy for objects that are associated with site records, such as
-    wagtail.contrib.settings.models.BaseSiteSetting subclasses. Permissions may be
-    assigned globally through standard django.contrib.auth permissions, or for
-    individual sites through wagtail.models.GroupSitePermission records.
+    ``wagtail.contrib.settings.models.BaseSiteSetting`` subclasses (see
+    :ref:`settings_models`). Permissions may be
+    assigned globally through standard
+    :class:`~django.contrib.auth.models.Permission` objects, or for
+    individual sites through ``wagtail.models.GroupSitePermission`` records.
     """
 
     permission_cache_name = "_site_permission_cache"

--- a/wagtail/permissions.py
+++ b/wagtail/permissions.py
@@ -1,9 +1,19 @@
 import swapper
 
-from wagtail.models import Collection, Locale, Site, Task, Workflow
+from wagtail.models import AbstractPage, Collection, Locale, Site, Task, Workflow
 from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.permission_policies.collections import CollectionManagementPermissionPolicy
 from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.utils.registry import ObjectTypeRegistry
+
+policies_registry = ObjectTypeRegistry()
+
+
+def register_permission_policy(model, policy=None, exact_class=False):
+    if policy is None:
+        policy = ModelPermissionPolicy(model)
+    policies_registry.register(model, value=policy, exact_class=exact_class)
+
 
 page_permission_policy = PagePermissionPolicy(
     swapper.get_model_name("wagtailcore", "Page")
@@ -13,3 +23,10 @@ collection_permission_policy = CollectionManagementPermissionPolicy(Collection)
 task_permission_policy = ModelPermissionPolicy(Task)
 workflow_permission_policy = ModelPermissionPolicy(Workflow)
 locale_permission_policy = ModelPermissionPolicy(Locale)
+
+register_permission_policy(AbstractPage, page_permission_policy)
+register_permission_policy(Site, site_permission_policy)
+register_permission_policy(Collection, collection_permission_policy)
+register_permission_policy(Task, task_permission_policy)
+register_permission_policy(Workflow, workflow_permission_policy)
+register_permission_policy(Locale, locale_permission_policy)

--- a/wagtail/permissions.py
+++ b/wagtail/permissions.py
@@ -48,7 +48,7 @@ class PolicyRegistry(ObjectTypeRegistry):
         Otherwise, return ``None``.
         """
         if not (policy := super().get_by_type(cls)):
-            if fallback and not (policy := self.get_fallback_policy(cls)):
+            if (not (policy := self.get_fallback_policy(cls))) and fallback:
                 self.fallback_policies[cls] = policy = ModelPermissionPolicy(cls)
         return policy
 

--- a/wagtail/permissions.py
+++ b/wagtail/permissions.py
@@ -19,15 +19,37 @@ class PolicyRegistry(ObjectTypeRegistry):
     :func:`~wagtail.permissions.register_permission_policy` function instead.
     """
 
-    def get_by_type(self, cls: type[Model]) -> BasePermissionPolicy:
+    def __init__(self):
+        super().__init__()
+        self.fallback_policies = {}
+        """
+        A dict that stores fallback permission policies for models that have not
+        registered a custom permission policy. Having this as a separate dict
+        allows us to ensure custom permission policies are registered before any
+        code attempts to retrieve them from the registry.
+        """
+
+    def get_fallback_policy(self, cls: type[Model]) -> BasePermissionPolicy | None:
+        """
+        Get the fallback permission policy for a given model class,
+        if a fallback was registered.
+        """
+        return self.fallback_policies.get(cls)
+
+    def get_by_type(self, cls: type[Model], fallback=True) -> BasePermissionPolicy:
         """
         Get the permission policy for a given model class.
         If a matching policy was registered with ``exact_class=True``, it will be
         returned. Otherwise, the policy registered with ``exact_class=False`` for
         the given class or its nearest ancestor class will be returned. If no policy
-        can be found, ``None`` will be returned.
+        can be found and ``fallback`` is True, a default fallback
+        :class:`~wagtail.permission_policies.ModelPermissionPolicy` will be used.
+        Otherwise, return ``None``.
         """
-        return super().get_by_type(cls)
+        if not (policy := super().get_by_type(cls)):
+            if fallback and not (policy := self.get_fallback_policy(cls)):
+                self.fallback_policies[cls] = policy = ModelPermissionPolicy(cls)
+        return policy
 
     def get(self, obj: Model) -> BasePermissionPolicy:
         """

--- a/wagtail/permissions.py
+++ b/wagtail/permissions.py
@@ -16,7 +16,7 @@ class PolicyRegistry(ObjectTypeRegistry):
     given model class.
 
     Instead of using this class directly, use the global
-    :obj:`~wagtail.permissions.policies_registry` instance and the
+    :obj:`~wagtail.permissions.policy_registry` instance and the
     :func:`~wagtail.permissions.register_permission_policy` function instead.
     """
 
@@ -69,7 +69,7 @@ class PolicyRegistry(ObjectTypeRegistry):
         return super().register(cls, value, exact_class)
 
 
-policies_registry = PolicyRegistry()
+policy_registry = PolicyRegistry()
 """
 A global instance of :class:`~wagtail.permissions.PolicyRegistry` used to
 register and look up permission policies for models managed by Wagtail.
@@ -92,7 +92,7 @@ def register_permission_policy(
     """
     if policy is None:
         policy = ModelPermissionPolicy(model)
-    policies_registry.register(model, value=policy, exact_class=exact_class)
+    policy_registry.register(model, value=policy, exact_class=exact_class)
 
 
 page_permission_policy = PagePermissionPolicy(

--- a/wagtail/permissions.py
+++ b/wagtail/permissions.py
@@ -1,7 +1,8 @@
 import swapper
+from django.db.models import Model
 
 from wagtail.models import AbstractPage, Collection, Locale, Site, Task, Workflow
-from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permission_policies import BasePermissionPolicy, ModelPermissionPolicy
 from wagtail.permission_policies.collections import CollectionManagementPermissionPolicy
 from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.utils.registry import ObjectTypeRegistry
@@ -18,7 +19,7 @@ class PolicyRegistry(ObjectTypeRegistry):
     :func:`~wagtail.permissions.register_permission_policy` function instead.
     """
 
-    def get_by_type(self, cls):
+    def get_by_type(self, cls: type[Model]) -> BasePermissionPolicy:
         """
         Get the permission policy for a given model class.
         If a matching policy was registered with ``exact_class=True``, it will be
@@ -28,7 +29,7 @@ class PolicyRegistry(ObjectTypeRegistry):
         """
         return super().get_by_type(cls)
 
-    def get(self, obj):
+    def get(self, obj: Model) -> BasePermissionPolicy:
         """
         Get the permission policy for a given model instance based on its class.
         """
@@ -42,7 +43,11 @@ register and look up permission policies for models managed by Wagtail.
 """
 
 
-def register_permission_policy(model, policy=None, exact_class=False):
+def register_permission_policy(
+    model: type[Model],
+    policy: BasePermissionPolicy = None,
+    exact_class=False,
+):
     """
     Register a permission policy for a given model class.
 

--- a/wagtail/permissions.py
+++ b/wagtail/permissions.py
@@ -1,4 +1,5 @@
 import swapper
+from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model
 
 from wagtail.models import AbstractPage, Collection, Locale, Site, Task, Workflow
@@ -56,6 +57,16 @@ class PolicyRegistry(ObjectTypeRegistry):
         Get the permission policy for a given model instance based on its class.
         """
         return super().get(obj)
+
+    def register(self, cls, value=None, exact_class=False):
+        if self.get_fallback_policy(cls):
+            raise ImproperlyConfigured(
+                f"A fallback permission policy has already been created for "
+                f"{cls._meta.label}. Please ensure your custom "
+                f"{value.__class__.__name__} is registered earlier on, such as "
+                f"at the top of wagtail_hooks.py or in your AppConfig.ready()."
+            )
+        return super().register(cls, value, exact_class)
 
 
 policies_registry = PolicyRegistry()

--- a/wagtail/permissions.py
+++ b/wagtail/permissions.py
@@ -6,10 +6,52 @@ from wagtail.permission_policies.collections import CollectionManagementPermissi
 from wagtail.permission_policies.pages import PagePermissionPolicy
 from wagtail.utils.registry import ObjectTypeRegistry
 
-policies_registry = ObjectTypeRegistry()
+
+class PolicyRegistry(ObjectTypeRegistry):
+    """
+    A registry that maps model classes to their permission policy instances.
+    This is used by Wagtail to determine which permission policy to use for a
+    given model class.
+
+    Instead of using this class directly, use the global
+    :obj:`~wagtail.permissions.policies_registry` instance and the
+    :func:`~wagtail.permissions.register_permission_policy` function instead.
+    """
+
+    def get_by_type(self, cls):
+        """
+        Get the permission policy for a given model class.
+        If a matching policy was registered with ``exact_class=True``, it will be
+        returned. Otherwise, the policy registered with ``exact_class=False`` for
+        the given class or its nearest ancestor class will be returned. If no policy
+        can be found, ``None`` will be returned.
+        """
+        return super().get_by_type(cls)
+
+    def get(self, obj):
+        """
+        Get the permission policy for a given model instance based on its class.
+        """
+        return super().get(obj)
+
+
+policies_registry = PolicyRegistry()
+"""
+A global instance of :class:`~wagtail.permissions.PolicyRegistry` used to
+register and look up permission policies for models managed by Wagtail.
+"""
 
 
 def register_permission_policy(model, policy=None, exact_class=False):
+    """
+    Register a permission policy for a given model class.
+
+    If no policy is provided, a default
+    :class:`~wagtail.permission_policies.ModelPermissionPolicy` will be created.
+    If ``exact_class`` is set to True, the policy will only be used for the
+    exact model class, otherwise it will also be used for subclasses of the
+    model class.
+    """
     if policy is None:
         policy = ModelPermissionPolicy(model)
     policies_registry.register(model, value=policy, exact_class=exact_class)

--- a/wagtail/sites/views.py
+++ b/wagtail/sites/views.py
@@ -4,7 +4,6 @@ from wagtail.admin.ui.tables import Column, StatusFlagColumn, TitleColumn
 from wagtail.admin.views import generic
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.models import Site
-from wagtail.permissions import site_permission_policy
 from wagtail.sites.forms import SiteForm
 
 
@@ -53,7 +52,6 @@ class DeleteView(generic.DeleteView):
 class SiteViewSet(ModelViewSet):
     icon = "site"
     model = Site
-    permission_policy = site_permission_policy
     add_to_reference_index = False
 
     index_view_class = IndexView

--- a/wagtail/sites/wagtail_hooks.py
+++ b/wagtail/sites/wagtail_hooks.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 from wagtail.models import Site
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 from .views import SiteViewSet
 
@@ -16,7 +16,7 @@ def register_viewset():
 
 class SitesMenuItem(MenuItem):
     def is_shown(self, request):
-        return policies_registry.get_by_type(Site).user_has_any_permission(
+        return policy_registry.get_by_type(Site).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 

--- a/wagtail/sites/wagtail_hooks.py
+++ b/wagtail/sites/wagtail_hooks.py
@@ -3,7 +3,8 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
-from wagtail.permissions import site_permission_policy
+from wagtail.models import Site
+from wagtail.permissions import policies_registry
 
 from .views import SiteViewSet
 
@@ -15,7 +16,7 @@ def register_viewset():
 
 class SitesMenuItem(MenuItem):
     def is_shown(self, request):
-        return site_permission_policy.user_has_any_permission(
+        return policies_registry.get_by_type(Site).user_has_any_permission(
             request.user, ["add", "change", "delete"]
         )
 

--- a/wagtail/snippets/bulk_actions/delete.py
+++ b/wagtail/snippets/bulk_actions/delete.py
@@ -8,7 +8,6 @@ from django.utils.translation import ngettext
 from wagtail.admin.views.bulk_action.mixins import ReferenceIndexMixin
 from wagtail.admin.views.generic import BeforeAfterHookMixin
 from wagtail.snippets.bulk_actions.snippet_bulk_action import SnippetBulkAction
-from wagtail.snippets.permissions import get_permission_name
 
 
 class DeleteBulkAction(BeforeAfterHookMixin, ReferenceIndexMixin, SnippetBulkAction):
@@ -50,12 +49,9 @@ class DeleteBulkAction(BeforeAfterHookMixin, ReferenceIndexMixin, SnippetBulkAct
         return self.run_hook("after_delete_snippet", self.request, objects)
 
     def check_perm(self, snippet):
-        if getattr(self, "can_delete_items", None) is None:
-            # since snippets permissions are not enforced per object, makes sense to just check once per model request
-            self.can_delete_items = self.request.user.has_perm(
-                get_permission_name("delete", self.model)
-            )
-        return self.can_delete_items
+        return self.permission_policy.user_has_permission_for_instance(
+            self.request.user, "delete", snippet
+        )
 
     @classmethod
     def execute_action(cls, objects, user=None, **kwargs):

--- a/wagtail/snippets/bulk_actions/snippet_bulk_action.py
+++ b/wagtail/snippets/bulk_actions/snippet_bulk_action.py
@@ -2,7 +2,7 @@ from django.utils.functional import cached_property, classproperty
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.views.bulk_action import BulkAction
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.snippets.models import get_snippet_models
 
 
@@ -21,7 +21,7 @@ class SnippetBulkAction(BulkAction):
 
     @cached_property
     def permission_policy(self):
-        return policies_registry.get_by_type(self.model)
+        return policy_registry.get_by_type(self.model)
 
     def object_context(self, snippet):
         return {

--- a/wagtail/snippets/bulk_actions/snippet_bulk_action.py
+++ b/wagtail/snippets/bulk_actions/snippet_bulk_action.py
@@ -1,7 +1,8 @@
-from django.utils.functional import classproperty
+from django.utils.functional import cached_property, classproperty
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.views.bulk_action import BulkAction
+from wagtail.permissions import policies_registry
 from wagtail.snippets.models import get_snippet_models
 
 
@@ -17,6 +18,10 @@ class SnippetBulkAction(BulkAction):
         # get_snippet_models() at import time could result in either a circular
         # import or an incomplete list of models.
         return get_snippet_models()
+
+    @cached_property
+    def permission_policy(self):
+        return policies_registry.get_by_type(self.model)
 
     def object_context(self, snippet):
         return {

--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -1,14 +1,13 @@
 from functools import lru_cache
 
 from django.apps import apps as global_apps
-from django.contrib.admin.utils import quote
 from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db import DEFAULT_DB_ALIAS, models, router
-from django.urls import reverse
 from django.utils.module_loading import import_string
 
+from wagtail.admin.admin_url_finder import ModelAdminURLFinder
 from wagtail.admin.viewsets import viewsets
 from wagtail.hooks import search_for_hooks
 from wagtail.models import DraftStateMixin, LockableMixin, WorkflowMixin
@@ -49,25 +48,8 @@ def get_editable_models(user):
     ]
 
 
-class SnippetAdminURLFinder:
-    # subclasses should define a 'model' attribute
-    def __init__(self, user=None):
-        if user:
-            from wagtail.snippets.permissions import get_permission_name
-
-            self.user_can_edit = user.has_perm(
-                get_permission_name("change", self.model)
-            )
-        else:
-            # skip permission checks
-            self.user_can_edit = True
-
-    def get_edit_url(self, instance):
-        if self.user_can_edit:
-            return reverse(
-                instance.snippet_viewset.get_url_name("edit"),
-                args=[quote(instance.pk)],
-            )
+class SnippetAdminURLFinder(ModelAdminURLFinder):
+    pass
 
 
 def register_snippet(registerable, viewset=None):

--- a/wagtail/snippets/permissions.py
+++ b/wagtail/snippets/permissions.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_permission_codename
 
+from wagtail.permissions import policies_registry
 from wagtail.snippets.models import get_snippet_models
 
 
@@ -29,7 +30,7 @@ def user_can_access_snippets(user, models=None):
         models = get_snippet_models()
 
     for model in models:
-        if model.snippet_viewset.permission_policy.user_has_any_permission(
+        if policies_registry.get_by_type(model).user_has_any_permission(
             user, {"add", "change", "delete", "view"}
         ):
             return True

--- a/wagtail/snippets/permissions.py
+++ b/wagtail/snippets/permissions.py
@@ -1,6 +1,6 @@
 from django.contrib.auth import get_permission_codename
 
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.snippets.models import get_snippet_models
 
 
@@ -30,7 +30,7 @@ def user_can_access_snippets(user, models=None):
         models = get_snippet_models()
 
     for model in models:
-        if policies_registry.get_by_type(model).user_has_any_permission(
+        if policy_registry.get_by_type(model).user_has_any_permission(
             user, {"add", "change", "delete", "view"}
         ):
             return True

--- a/wagtail/snippets/tests/test_bulk_actions/test_bulk_delete.py
+++ b/wagtail/snippets/tests/test_bulk_actions/test_bulk_delete.py
@@ -119,6 +119,31 @@ class TestSnippetDeleteView(WagtailTestUtils, TestCase):
         for snippet in self.test_snippets:
             self.assertTrue(self.snippet_model.objects.filter(pk=snippet.pk).exists())
 
+    def test_delete_with_custom_permissions(self):
+        self.user.first_name = "[FORBIDDEN]"
+        self.user.last_name = "Joe"
+        self.user.save()
+
+        response = self.client.get(self.get_url())
+        self.assertEqual(response.status_code, 200)
+
+        html = response.content.decode()
+        self.assertInHTML(
+            "<p>You don't have permission to delete these full-featured snippets</p>",
+            html,
+        )
+
+        for snippet in self.test_snippets:
+            self.assertInHTML(f"<li>{snippet.text}</li>", html)
+
+        response = self.client.post(self.get_url())
+        # User should be redirected back to the index
+        self.assertEqual(response.status_code, 302)
+
+        # Snippets should not be deleted
+        for snippet in self.test_snippets:
+            self.assertTrue(self.snippet_model.objects.filter(pk=snippet.pk).exists())
+
     def test_before_bulk_action_hook_get(self):
         with self.register_hook(
             "before_bulk_action", lambda *args: HttpResponse("Overridden!")

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -1814,7 +1814,6 @@ class TestCustomPermissionPolicy(BaseSnippetViewSetTests):
     def test_registered_policy(self):
         permission_policy = policies_registry.get_by_type(self.model)
         self.assertIsInstance(permission_policy, FullFeaturedPermissionPolicy)
-        self.assertIs(permission_policy, self.model.snippet_viewset.permission_policy)
 
 
 class TestSnippetIndexViewBreadcrumbs(SimpleTestCase):

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -1814,6 +1814,7 @@ class TestCustomPermissionPolicy(BaseSnippetViewSetTests):
     def test_registered_policy(self):
         permission_policy = policies_registry.get_by_type(self.model)
         self.assertIsInstance(permission_policy, FullFeaturedPermissionPolicy)
+        self.assertIs(permission_policy, self.model.snippet_viewset.permission_policy)
 
 
 class TestSnippetIndexViewBreadcrumbs(SimpleTestCase):

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -33,7 +33,7 @@ from wagtail.documents.tests.utils import get_test_document_file
 from wagtail.images import get_image_model
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.models import Locale, Workflow, WorkflowContentType
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.snippets.blocks import SnippetChooserBlock
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet
@@ -1812,7 +1812,7 @@ class TestCustomPermissionPolicy(BaseSnippetViewSetTests):
         self.assertRedirects(response, reverse("wagtailadmin_home"))
 
     def test_registered_policy(self):
-        permission_policy = policies_registry.get_by_type(self.model)
+        permission_policy = policy_registry.get_by_type(self.model)
         self.assertIsInstance(permission_policy, FullFeaturedPermissionPolicy)
         self.assertIs(permission_policy, self.model.snippet_viewset.permission_policy)
 

--- a/wagtail/snippets/tests/test_viewset.py
+++ b/wagtail/snippets/tests/test_viewset.py
@@ -33,6 +33,7 @@ from wagtail.documents.tests.utils import get_test_document_file
 from wagtail.images import get_image_model
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.models import Locale, Workflow, WorkflowContentType
+from wagtail.permissions import policies_registry
 from wagtail.snippets.blocks import SnippetChooserBlock
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet
@@ -49,6 +50,7 @@ from wagtail.test.testapp.models import (
     SnippetChooserModel,
     VariousOnDeleteModel,
 )
+from wagtail.test.testapp.wagtail_hooks import FullFeaturedPermissionPolicy
 from wagtail.test.utils import PageFixturesMixin, WagtailTestUtils
 from wagtail.test.utils.template_tests import AdminTemplateTestUtils
 from wagtail.utils.timestamps import render_timestamp
@@ -1808,6 +1810,11 @@ class TestCustomPermissionPolicy(BaseSnippetViewSetTests):
         self.assertEqual(self.user.get_full_name(), "[FORBIDDEN] Joe")
         response = self.client.get(self.get_url("edit", args=(quote(self.object.pk),)))
         self.assertRedirects(response, reverse("wagtailadmin_home"))
+
+    def test_registered_policy(self):
+        permission_policy = policies_registry.get_by_type(self.model)
+        self.assertIsInstance(permission_policy, FullFeaturedPermissionPolicy)
+        self.assertIs(permission_policy, self.model.snippet_viewset.permission_policy)
 
 
 class TestSnippetIndexViewBreadcrumbs(SimpleTestCase):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -43,6 +43,7 @@ from wagtail.models import (
     RevisionMixin,
     WorkflowMixin,
 )
+from wagtail.permissions import policies_registry
 from wagtail.snippets.action_menu import SnippetActionMenu
 from wagtail.snippets.models import SnippetAdminURLFinder, get_snippet_models
 from wagtail.snippets.side_panels import SnippetStatusSidePanel
@@ -110,7 +111,7 @@ class ModelIndexView(generic.BaseListingView):
         return super().dispatch(request, *args, **kwargs)
 
     def get_list_url(self, model):
-        if model.snippet_viewset.permission_policy.user_has_any_permission(
+        if policies_registry.get_by_type(model).user_has_any_permission(
             self.request.user,
             {"add", "change", "delete", "view"},
         ):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -43,7 +43,7 @@ from wagtail.models import (
     RevisionMixin,
     WorkflowMixin,
 )
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.snippets.action_menu import SnippetActionMenu
 from wagtail.snippets.models import SnippetAdminURLFinder, get_snippet_models
 from wagtail.snippets.side_panels import SnippetStatusSidePanel
@@ -111,7 +111,7 @@ class ModelIndexView(generic.BaseListingView):
         return super().dispatch(request, *args, **kwargs)
 
     def get_list_url(self, model):
-        if policies_registry.get_by_type(model).user_has_any_permission(
+        if policy_registry.get_by_type(model).user_has_any_permission(
             self.request.user,
             {"add", "change", "delete", "view"},
         ):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -1082,7 +1082,12 @@ class SnippetViewSet(ModelViewSet):
     @property
     def url_finder_class(self):
         return type(
-            "_SnippetAdminURLFinder", (SnippetAdminURLFinder,), {"model": self.model}
+            "_SnippetAdminURLFinder",
+            (SnippetAdminURLFinder,),
+            {
+                "model": self.model,
+                "edit_url_name": self.get_url_name("edit"),
+            },
         )
 
     def get_urlpatterns(self):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -43,7 +43,6 @@ from wagtail.models import (
     RevisionMixin,
     WorkflowMixin,
 )
-from wagtail.permissions import ModelPermissionPolicy
 from wagtail.snippets.action_menu import SnippetActionMenu
 from wagtail.snippets.models import SnippetAdminURLFinder, get_snippet_models
 from wagtail.snippets.side_panels import SnippetStatusSidePanel
@@ -660,10 +659,6 @@ class SnippetViewSet(ModelViewSet):
             {"view_name": "revisions_revert"},
         )
         return revisions_revert_view_class
-
-    @property
-    def permission_policy(self):
-        return ModelPermissionPolicy(self.model)
 
     def get_common_view_kwargs(self, **kwargs):
         return super().get_common_view_kwargs(

--- a/wagtail/test/snippets/apps.py
+++ b/wagtail/test/snippets/apps.py
@@ -14,26 +14,6 @@ class WagtailSnippetsTestsAppConfig(AppConfig):
         # Invoking `register` from `ready` confirms that it does not perform any database queries -
         # if it did, it would fail (on a standard test run without --keepdb at least) because the
         # test database hasn't been migrated yet.
-        from wagtail.permissions import register_permission_policy
         from wagtail.users.permission_order import register
 
-        from . import models
-
         register("snippetstests.fancysnippet", order=999)
-
-        models_for_permissions = [
-            models.AlphaSnippet,
-            models.ZuluSnippet,
-            models.RegisterFunction,
-            models.RegisterDecorator,
-            models.SearchableSnippet,
-            models.NonAutocompleteSearchableSnippet,
-            models.StandardSnippet,
-            models.FancySnippet,
-            models.FileUploadSnippet,
-            models.MultiSectionRichTextSnippet,
-            models.StandardSnippetWithCustomPrimaryKey,
-            models.TranslatableSnippet,
-        ]
-        for model in models_for_permissions:
-            register_permission_policy(model)

--- a/wagtail/test/snippets/apps.py
+++ b/wagtail/test/snippets/apps.py
@@ -14,6 +14,26 @@ class WagtailSnippetsTestsAppConfig(AppConfig):
         # Invoking `register` from `ready` confirms that it does not perform any database queries -
         # if it did, it would fail (on a standard test run without --keepdb at least) because the
         # test database hasn't been migrated yet.
+        from wagtail.permissions import register_permission_policy
         from wagtail.users.permission_order import register
 
+        from . import models
+
         register("snippetstests.fancysnippet", order=999)
+
+        models_for_permissions = [
+            models.AlphaSnippet,
+            models.ZuluSnippet,
+            models.RegisterFunction,
+            models.RegisterDecorator,
+            models.SearchableSnippet,
+            models.NonAutocompleteSearchableSnippet,
+            models.StandardSnippet,
+            models.FancySnippet,
+            models.FileUploadSnippet,
+            models.MultiSectionRichTextSnippet,
+            models.StandardSnippetWithCustomPrimaryKey,
+            models.TranslatableSnippet,
+        ]
+        for model in models_for_permissions:
+            register_permission_policy(model)

--- a/wagtail/test/testapp/apps.py
+++ b/wagtail/test/testapp/apps.py
@@ -10,7 +10,38 @@ class WagtailTestsAppConfig(AppConfig):
 
     def ready(self):
         from wagtail.models.reference_index import ReferenceIndex
+        from wagtail.permissions import register_permission_policy
 
-        from .models import PageChooserModel
+        from . import models
 
-        ReferenceIndex.register_model(PageChooserModel)
+        ReferenceIndex.register_model(models.PageChooserModel)
+        models_with_default_permissions = [
+            # Snippets
+            models.Advert,
+            models.AdvertWithCustomPrimaryKey,
+            models.AdvertWithCustomUUIDPrimaryKey,
+            models.AdvertWithTabbedInterface,
+            models.ModelWithCustomManager,
+            models.DraftStateCustomPrimaryKeyModel,
+            models.PreviewableModel,
+            models.CustomPreviewSizesModel,
+            models.MultiPreviewModesModel,
+            models.NonPreviewableModel,
+            models.LockableModel,
+            models.RevisableCluster,
+            models.CustomPermissionModel,
+            models.DraftStateModel,
+            models.ModeratedModel,
+            models.RevisableModel,
+            models.RevisableChildModel,
+            models.VariousOnDeleteModel,
+            models.SnippetChooserModel,
+            # Models registered with ModelViewSet
+            models.JSONStreamModel,
+            models.JSONMinMaxCountStreamModel,
+            models.JSONBlockCountsStreamModel,
+            models.FeatureCompleteToy,
+            models.SearchTestModel,
+        ]
+        for model in models_with_default_permissions:
+            register_permission_policy(model)

--- a/wagtail/test/testapp/apps.py
+++ b/wagtail/test/testapp/apps.py
@@ -10,38 +10,7 @@ class WagtailTestsAppConfig(AppConfig):
 
     def ready(self):
         from wagtail.models.reference_index import ReferenceIndex
-        from wagtail.permissions import register_permission_policy
 
-        from . import models
+        from .models import PageChooserModel
 
-        ReferenceIndex.register_model(models.PageChooserModel)
-        models_with_default_permissions = [
-            # Snippets
-            models.Advert,
-            models.AdvertWithCustomPrimaryKey,
-            models.AdvertWithCustomUUIDPrimaryKey,
-            models.AdvertWithTabbedInterface,
-            models.ModelWithCustomManager,
-            models.DraftStateCustomPrimaryKeyModel,
-            models.PreviewableModel,
-            models.CustomPreviewSizesModel,
-            models.MultiPreviewModesModel,
-            models.NonPreviewableModel,
-            models.LockableModel,
-            models.RevisableCluster,
-            models.CustomPermissionModel,
-            models.DraftStateModel,
-            models.ModeratedModel,
-            models.RevisableModel,
-            models.RevisableChildModel,
-            models.VariousOnDeleteModel,
-            models.SnippetChooserModel,
-            # Models registered with ModelViewSet
-            models.JSONStreamModel,
-            models.JSONMinMaxCountStreamModel,
-            models.JSONBlockCountsStreamModel,
-            models.FeatureCompleteToy,
-            models.SearchTestModel,
-        ]
-        for model in models_with_default_permissions:
-            register_permission_policy(model)
+        ReferenceIndex.register_model(PageChooserModel)

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -70,6 +70,7 @@ class CustomSubmissionsListView(SubmissionsListView):
 
 class TestIndexView(IndexView):
     model = ModelWithStringTypePrimaryKey
+    permission_policy = None
     index_url_name = "testapp_generic_index"
     template_name = "tests/generic_view_templates/index.html"
     paginate_by = 20
@@ -97,6 +98,7 @@ class TestCreateView(CreateView):
 
 class TestEditView(EditView):
     model = ModelWithStringTypePrimaryKey
+    permission_policy = None
     context_object_name = "test_object"
     template_name = "tests/generic_view_templates/edit.html"
     index_url_name = "testapp_generic_index"
@@ -110,6 +112,7 @@ class TestEditView(EditView):
 
 class TestDeleteView(DeleteView):
     model = ModelWithStringTypePrimaryKey
+    permission_policy = None
     context_object_name = "test_object"
     template_name = "tests/generic_view_templates/delete.html"
     index_url_name = "testapp_generic_index"

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -24,7 +24,7 @@ from wagtail.admin.ui.tables import BooleanColumn, UpdatedAtColumn
 from wagtail.admin.utils import set_query_params
 from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail.admin.widgets import Button
-from wagtail.permission_policies.base import ModelPermissionPolicy
+from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.snippets.bulk_actions.snippet_bulk_action import SnippetBulkAction
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.chooser import SnippetChooserViewSet

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -25,6 +25,7 @@ from wagtail.admin.utils import set_query_params
 from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail.admin.widgets import Button
 from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permissions import register_permission_policy
 from wagtail.snippets.bulk_actions.snippet_bulk_action import SnippetBulkAction
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.chooser import SnippetChooserViewSet
@@ -334,7 +335,6 @@ class FullFeaturedSnippetViewSet(SnippetViewSet):
     # Ensure that the menu item is placed last
     menu_order = 999999
     inspect_view_enabled = True
-    permission_policy = FullFeaturedPermissionPolicy(FullFeaturedSnippet)
 
     class IndexView(SnippetViewSet.index_view_class):
         def get_add_url(self):
@@ -430,6 +430,18 @@ class SnippetChooserModelViewSet(SnippetViewSet):
     exclude_form_fields = []
 
 
+# Ensure custom permission policies are registered before the snippet models are
+# registered, so that the viewsets do not try to register a default viewset.
+# This can also be done in the app's AppConfig.ready() method, but having it
+# alongside the viewset registration makes the order more explicit.
+# RemovedInWagtail90Warning: Remove this comment. The default permission policy
+# for a snippet will no longer be registered automatically in Wagtail 9.0. The
+# policy will be retrieved at request time from the policies registry, so the
+# ordering of registration will no longer be important.
+register_permission_policy(
+    FullFeaturedSnippet,
+    FullFeaturedPermissionPolicy(FullFeaturedSnippet),
+)
 register_snippet(FullFeaturedSnippet, viewset=FullFeaturedSnippetViewSet)
 register_snippet(DraftStateModel, viewset=DraftStateModelViewSet)
 # Works with both classes and instances

--- a/wagtail/tests/test_page_permissions.py
+++ b/wagtail/tests/test_page_permissions.py
@@ -30,6 +30,8 @@ from wagtail.test.utils import Page, PageFixturesMixin
 
 class TestPagePermission(PageFixturesMixin, TestCase):
     fixtures = ["test.json"]
+    model = Page
+    policy_class = PagePermissionPolicy
 
     def create_workflow_and_task(self):
         workflow = Workflow.objects.create(name="test_workflow")
@@ -553,7 +555,7 @@ class TestPagePermission(PageFixturesMixin, TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        policy = PagePermissionPolicy()
+        policy = self.policy_class(self.model)
 
         editable_pages = policy.instances_user_has_permission_for(
             event_editor, "change"
@@ -593,7 +595,7 @@ class TestPagePermission(PageFixturesMixin, TestCase):
         )
         about_us_page = Page.objects.get(url_path="/home/about-us/")
 
-        policy = PagePermissionPolicy()
+        policy = self.policy_class(self.model)
         explorable_pages = policy.explorable_instances(event_editor)
 
         # Verify all pages below /home/events/ are explorable
@@ -630,7 +632,7 @@ class TestPagePermission(PageFixturesMixin, TestCase):
             email="corporateeditor@example.com"
         )
 
-        policy = PagePermissionPolicy()
+        policy = self.policy_class(self.model)
 
         about_us_page = Page.objects.get(url_path="/home/about-us/")
         businessy_events = Page.objects.get(url_path="/home/events/businessy-events/")
@@ -638,9 +640,15 @@ class TestPagePermission(PageFixturesMixin, TestCase):
 
         explorable_pages = policy.explorable_instances(corporate_editor)
 
-        self.assertTrue(explorable_pages.filter(id=about_us_page.id).exists())
-        self.assertTrue(explorable_pages.filter(id=businessy_events.id).exists())
-        self.assertTrue(explorable_pages.filter(id=events_page.id).exists())
+        pages = [about_us_page, businessy_events, events_page]
+        for page in pages:
+            # If the policy is for a specific model, then the result should only
+            # include pages of that model type (or its subclasses).
+            page_matches_policy_model = issubclass(page.specific_class, self.model)
+            self.assertIs(
+                explorable_pages.filter(id=page.id).exists(),
+                page_matches_policy_model,
+            )
 
     def test_editable_pages_for_user_with_edit_permission(self):
         event_moderator = get_user_model().objects.get(
@@ -655,7 +663,7 @@ class TestPagePermission(PageFixturesMixin, TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        policy = PagePermissionPolicy()
+        policy = self.policy_class(self.model)
 
         editable_pages = policy.instances_user_has_permission_for(
             event_moderator, "change"
@@ -693,7 +701,7 @@ class TestPagePermission(PageFixturesMixin, TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        policy = PagePermissionPolicy()
+        policy = self.policy_class(self.model)
 
         editable_pages = policy.instances_user_has_permission_for(user, "change")
         can_edit_pages = policy.user_has_permission(user, "change")
@@ -729,27 +737,33 @@ class TestPagePermission(PageFixturesMixin, TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        policy = PagePermissionPolicy()
+        policy = self.policy_class(self.model)
 
         editable_pages = policy.instances_user_has_permission_for(user, "change")
         can_edit_pages = policy.user_has_permission(user, "change")
         publishable_pages = policy.instances_user_has_permission_for(user, "publish")
         can_publish_pages = policy.user_has_permission(user, "publish")
 
-        self.assertTrue(editable_pages.filter(id=homepage.id).exists())
-        self.assertTrue(editable_pages.filter(id=christmas_page.id).exists())
-        self.assertTrue(editable_pages.filter(id=unpublished_event_page.id).exists())
-        self.assertTrue(editable_pages.filter(id=someone_elses_event_page.id).exists())
+        pages = [
+            homepage,
+            christmas_page,
+            unpublished_event_page,
+            someone_elses_event_page,
+        ]
+        for page in pages:
+            # If the policy is for a specific model, then the result should only
+            # include pages of that model type (or its subclasses).
+            page_matches_policy_model = issubclass(page.specific_class, self.model)
+            self.assertIs(
+                editable_pages.filter(id=page.id).exists(),
+                page_matches_policy_model,
+            )
+            self.assertIs(
+                publishable_pages.filter(id=page.id).exists(),
+                page_matches_policy_model,
+            )
 
         self.assertTrue(can_edit_pages)
-
-        self.assertTrue(publishable_pages.filter(id=homepage.id).exists())
-        self.assertTrue(publishable_pages.filter(id=christmas_page.id).exists())
-        self.assertTrue(publishable_pages.filter(id=unpublished_event_page.id).exists())
-        self.assertTrue(
-            publishable_pages.filter(id=someone_elses_event_page.id).exists()
-        )
-
         self.assertTrue(can_publish_pages)
 
     def test_editable_pages_for_non_editing_user(self):
@@ -763,7 +777,7 @@ class TestPagePermission(PageFixturesMixin, TestCase):
             url_path="/home/events/someone-elses-event/"
         )
 
-        policy = PagePermissionPolicy()
+        policy = self.policy_class(self.model)
 
         editable_pages = policy.instances_user_has_permission_for(user, "change")
         can_edit_pages = policy.user_has_permission(user, "change")
@@ -991,6 +1005,10 @@ class TestPagePermission(PageFixturesMixin, TestCase):
         page = Page.objects.get(pk=instance.pk)
         user = get_user_model().objects.get(email="eventeditor@example.com")
         self.assertIsInstance(page.permissions_for_user(user), CustomPermissionTester)
+
+
+class TestSpecificPagePermission(TestPagePermission):
+    model = EventPage
 
 
 class TestPagePermissionTesterCanCopyTo(PageFixturesMixin, TestCase):

--- a/wagtail/tests/test_permissions.py
+++ b/wagtail/tests/test_permissions.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 
 from wagtail.models import Collection, Locale, Site, Task, Workflow
@@ -76,6 +77,18 @@ class TestPolicyRegistry(TestCase):
         instance = Advert(text="test")
         self.assertIs(self.registry.get(instance), policy)
 
+    def test_register_raises_if_fallback_already_created(self):
+        self.registry.get_by_type(Advert)  # creates and caches a fallback policy
+        policy = ModelPermissionPolicy(Advert)
+        with self.assertRaisesMessage(
+            ImproperlyConfigured,
+            "A fallback permission policy has already been created for "
+            "tests.Advert. Please ensure your custom ModelPermissionPolicy is "
+            "registered earlier on, such as at the top of wagtail_hooks.py or "
+            "in your AppConfig.ready().",
+        ):
+            self.registry.register(Advert, policy)
+
     def test_register_succeeds_if_no_fallback_created(self):
         policy = ModelPermissionPolicy(Advert)
         self.registry.register(Advert, policy)
@@ -107,6 +120,17 @@ class TestRegisterPermissionPolicy(TestCase):
         register_permission_policy(RevisableModel, policy, exact_class=True)
         self.assertIs(self.registry.get_by_type(RevisableModel), policy)
         self.assertIsNot(self.registry.get_by_type(RevisableChildModel), policy)
+
+    def test_raises_if_fallback_already_created_for_model(self):
+        self.registry.get_by_type(Advert)  # creates a fallback policy
+        with self.assertRaisesMessage(
+            ImproperlyConfigured,
+            "A fallback permission policy has already been created for "
+            "tests.Advert. Please ensure your custom ModelPermissionPolicy is "
+            "registered earlier on, such as at the top of wagtail_hooks.py or "
+            "in your AppConfig.ready().",
+        ):
+            register_permission_policy(Advert)
 
 
 class TestDefaultPermissionPolicies(TestCase):
@@ -162,3 +186,17 @@ class TestDefaultPermissionPolicies(TestCase):
         self.assertEqual(policy.model, Advert)
         # The fallback is cached, so a second lookup returns the same instance.
         self.assertIs(policies_registry.get_by_type(Advert), policy)
+
+    def test_registering_a_policy_for_a_model_with_existing_fallback_raises(self):
+        self.addCleanup(self._clear_fallback_policy, Advert)
+        # Once a fallback policy has been created for a model, the registry
+        # protects against a custom policy being registered too late.
+        policies_registry.get_by_type(Advert)
+        with self.assertRaisesMessage(
+            ImproperlyConfigured,
+            "A fallback permission policy has already been created for "
+            "tests.Advert. Please ensure your custom ModelPermissionPolicy is "
+            "registered earlier on, such as at the top of wagtail_hooks.py or "
+            "in your AppConfig.ready().",
+        ):
+            register_permission_policy(Advert, ModelPermissionPolicy(Advert))

--- a/wagtail/tests/test_permissions.py
+++ b/wagtail/tests/test_permissions.py
@@ -1,0 +1,164 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from wagtail.models import Collection, Locale, Site, Task, Workflow
+from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permission_policies.collections import CollectionManagementPermissionPolicy
+from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.permissions import (
+    PolicyRegistry,
+    collection_permission_policy,
+    locale_permission_policy,
+    page_permission_policy,
+    policies_registry,
+    register_permission_policy,
+    site_permission_policy,
+    task_permission_policy,
+    workflow_permission_policy,
+)
+from wagtail.test.testapp.models import (
+    Advert,
+    RevisableChildModel,
+    RevisableModel,
+    SimplePage,
+)
+from wagtail.test.utils import Page
+
+
+class TestPolicyRegistry(TestCase):
+    def setUp(self):
+        self.registry = PolicyRegistry()
+
+    def test_get_fallback_policy_returns_none_if_not_created(self):
+        self.assertIsNone(self.registry.get_fallback_policy(Advert))
+
+    def test_get_by_type_with_no_policy_and_fallback_false_returns_none(self):
+        self.assertIsNone(self.registry.get_by_type(Advert, fallback=False))
+        self.assertIsNone(self.registry.get_fallback_policy(Advert))
+
+    def test_get_by_type_with_no_policy_creates_fallback_policy(self):
+        policy = self.registry.get_by_type(Advert)
+        self.assertIsInstance(policy, ModelPermissionPolicy)
+        self.assertEqual(policy.model, Advert)
+        self.assertIs(self.registry.get_fallback_policy(Advert), policy)
+
+    def test_get_by_type_returns_same_fallback_instance_on_repeated_calls(self):
+        first = self.registry.get_by_type(Advert)
+        second = self.registry.get_by_type(Advert)
+        self.assertIs(first, second)
+
+    def test_get_by_type_returns_registered_policy_over_fallback(self):
+        policy = ModelPermissionPolicy(Advert)
+        self.registry.register(Advert, policy)
+        self.assertIs(self.registry.get_by_type(Advert), policy)
+        # No fallback should have been created.
+        self.assertIsNone(self.registry.get_fallback_policy(Advert))
+
+    def test_get_by_type_mro_inheritance(self):
+        policy = ModelPermissionPolicy(RevisableModel)
+        self.registry.register(RevisableModel, policy)
+        self.assertIs(self.registry.get_by_type(RevisableChildModel), policy)
+
+    def test_get_by_type_exact_class_only_matches_exact_class(self):
+        policy = ModelPermissionPolicy(RevisableModel)
+        self.registry.register(RevisableModel, policy, exact_class=True)
+        self.assertIs(self.registry.get_by_type(RevisableModel), policy)
+        # A subclass doesn't match an exact_class registration, so a fallback
+        # policy is created for it instead.
+        fallback = self.registry.get_by_type(RevisableChildModel)
+        self.assertIsNot(fallback, policy)
+        self.assertIsInstance(fallback, ModelPermissionPolicy)
+
+    def test_get_returns_policy_for_instance_class(self):
+        policy = ModelPermissionPolicy(Advert)
+        self.registry.register(Advert, policy)
+        instance = Advert(text="test")
+        self.assertIs(self.registry.get(instance), policy)
+
+    def test_register_succeeds_if_no_fallback_created(self):
+        policy = ModelPermissionPolicy(Advert)
+        self.registry.register(Advert, policy)
+        self.assertIs(self.registry.get_by_type(Advert), policy)
+
+
+class TestRegisterPermissionPolicy(TestCase):
+    def setUp(self):
+        self.registry = PolicyRegistry()
+        # register_permission_policy() delegates to the module-level global,
+        # so patch it to point at an isolated registry for these tests.
+        patcher = mock.patch("wagtail.permissions.policies_registry", self.registry)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_registers_default_model_permission_policy_when_none_provided(self):
+        register_permission_policy(Advert)
+        policy = self.registry.get_by_type(Advert)
+        self.assertIsInstance(policy, ModelPermissionPolicy)
+        self.assertEqual(policy.model, Advert)
+
+    def test_registers_provided_policy(self):
+        policy = ModelPermissionPolicy(Advert)
+        register_permission_policy(Advert, policy)
+        self.assertIs(self.registry.get_by_type(Advert), policy)
+
+    def test_respects_exact_class_argument(self):
+        policy = ModelPermissionPolicy(RevisableModel)
+        register_permission_policy(RevisableModel, policy, exact_class=True)
+        self.assertIs(self.registry.get_by_type(RevisableModel), policy)
+        self.assertIsNot(self.registry.get_by_type(RevisableChildModel), policy)
+
+
+class TestDefaultPermissionPolicies(TestCase):
+    """
+    The global policies_registry is pre-populated with policies for
+    Wagtail's own models.
+    """
+
+    def test_page_uses_page_permission_policy(self):
+        policy = policies_registry.get_by_type(Page)
+        self.assertIs(policy, page_permission_policy)
+        self.assertIsInstance(policy, PagePermissionPolicy)
+
+    def test_site_uses_model_permission_policy(self):
+        policy = policies_registry.get_by_type(Site)
+        self.assertIs(policy, site_permission_policy)
+        self.assertIsInstance(policy, ModelPermissionPolicy)
+
+    def test_collection_uses_collection_management_permission_policy(self):
+        policy = policies_registry.get_by_type(Collection)
+        self.assertIs(policy, collection_permission_policy)
+        self.assertIsInstance(policy, CollectionManagementPermissionPolicy)
+
+    def test_task_uses_model_permission_policy(self):
+        policy = policies_registry.get_by_type(Task)
+        self.assertIs(policy, task_permission_policy)
+        self.assertIsInstance(policy, ModelPermissionPolicy)
+
+    def test_workflow_uses_model_permission_policy(self):
+        policy = policies_registry.get_by_type(Workflow)
+        self.assertIs(policy, workflow_permission_policy)
+        self.assertIsInstance(policy, ModelPermissionPolicy)
+
+    def test_locale_uses_model_permission_policy(self):
+        policy = policies_registry.get_by_type(Locale)
+        self.assertIs(policy, locale_permission_policy)
+        self.assertIsInstance(policy, ModelPermissionPolicy)
+
+    def test_page_subclass_inherits_page_permission_policy(self):
+        self.assertIs(policies_registry.get_by_type(SimplePage), page_permission_policy)
+
+    def _clear_fallback_policy(self, model):
+        # fallback_policies is a class attribute shared by every PolicyRegistry
+        # instance, including the global policies_registry, so any fallback
+        # created for a test-only model must be cleaned up afterwards to avoid
+        # leaking state into other tests.
+        policies_registry.fallback_policies.pop(model, None)
+
+    def test_unregistered_model_gets_a_fallback_model_permission_policy(self):
+        self.addCleanup(self._clear_fallback_policy, Advert)
+        policy = policies_registry.get_by_type(Advert)
+        self.assertIsInstance(policy, ModelPermissionPolicy)
+        self.assertEqual(policy.model, Advert)
+        # The fallback is cached, so a second lookup returns the same instance.
+        self.assertIs(policies_registry.get_by_type(Advert), policy)

--- a/wagtail/tests/test_permissions.py
+++ b/wagtail/tests/test_permissions.py
@@ -12,7 +12,7 @@ from wagtail.permissions import (
     collection_permission_policy,
     locale_permission_policy,
     page_permission_policy,
-    policies_registry,
+    policy_registry,
     register_permission_policy,
     site_permission_policy,
     task_permission_policy,
@@ -100,7 +100,7 @@ class TestRegisterPermissionPolicy(TestCase):
         self.registry = PolicyRegistry()
         # register_permission_policy() delegates to the module-level global,
         # so patch it to point at an isolated registry for these tests.
-        patcher = mock.patch("wagtail.permissions.policies_registry", self.registry)
+        patcher = mock.patch("wagtail.permissions.policy_registry", self.registry)
         patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -135,63 +135,63 @@ class TestRegisterPermissionPolicy(TestCase):
 
 class TestDefaultPermissionPolicies(TestCase):
     """
-    The global policies_registry is pre-populated with policies for
+    The global policy_registry is pre-populated with policies for
     Wagtail's own models.
     """
 
     def test_page_uses_page_permission_policy(self):
-        policy = policies_registry.get_by_type(Page)
+        policy = policy_registry.get_by_type(Page)
         self.assertIs(policy, page_permission_policy)
         self.assertIsInstance(policy, PagePermissionPolicy)
 
     def test_site_uses_model_permission_policy(self):
-        policy = policies_registry.get_by_type(Site)
+        policy = policy_registry.get_by_type(Site)
         self.assertIs(policy, site_permission_policy)
         self.assertIsInstance(policy, ModelPermissionPolicy)
 
     def test_collection_uses_collection_management_permission_policy(self):
-        policy = policies_registry.get_by_type(Collection)
+        policy = policy_registry.get_by_type(Collection)
         self.assertIs(policy, collection_permission_policy)
         self.assertIsInstance(policy, CollectionManagementPermissionPolicy)
 
     def test_task_uses_model_permission_policy(self):
-        policy = policies_registry.get_by_type(Task)
+        policy = policy_registry.get_by_type(Task)
         self.assertIs(policy, task_permission_policy)
         self.assertIsInstance(policy, ModelPermissionPolicy)
 
     def test_workflow_uses_model_permission_policy(self):
-        policy = policies_registry.get_by_type(Workflow)
+        policy = policy_registry.get_by_type(Workflow)
         self.assertIs(policy, workflow_permission_policy)
         self.assertIsInstance(policy, ModelPermissionPolicy)
 
     def test_locale_uses_model_permission_policy(self):
-        policy = policies_registry.get_by_type(Locale)
+        policy = policy_registry.get_by_type(Locale)
         self.assertIs(policy, locale_permission_policy)
         self.assertIsInstance(policy, ModelPermissionPolicy)
 
     def test_page_subclass_inherits_page_permission_policy(self):
-        self.assertIs(policies_registry.get_by_type(SimplePage), page_permission_policy)
+        self.assertIs(policy_registry.get_by_type(SimplePage), page_permission_policy)
 
     def _clear_fallback_policy(self, model):
         # fallback_policies is a class attribute shared by every PolicyRegistry
-        # instance, including the global policies_registry, so any fallback
+        # instance, including the global policy_registry, so any fallback
         # created for a test-only model must be cleaned up afterwards to avoid
         # leaking state into other tests.
-        policies_registry.fallback_policies.pop(model, None)
+        policy_registry.fallback_policies.pop(model, None)
 
     def test_unregistered_model_gets_a_fallback_model_permission_policy(self):
         self.addCleanup(self._clear_fallback_policy, Advert)
-        policy = policies_registry.get_by_type(Advert)
+        policy = policy_registry.get_by_type(Advert)
         self.assertIsInstance(policy, ModelPermissionPolicy)
         self.assertEqual(policy.model, Advert)
         # The fallback is cached, so a second lookup returns the same instance.
-        self.assertIs(policies_registry.get_by_type(Advert), policy)
+        self.assertIs(policy_registry.get_by_type(Advert), policy)
 
     def test_registering_a_policy_for_a_model_with_existing_fallback_raises(self):
         self.addCleanup(self._clear_fallback_policy, Advert)
         # Once a fallback policy has been created for a model, the registry
         # protects against a custom policy being registered too late.
-        policies_registry.get_by_type(Advert)
+        policy_registry.get_by_type(Advert)
         with self.assertRaisesMessage(
             ImproperlyConfigured,
             "A fallback permission policy has already been created for "

--- a/wagtail/users/apps.py
+++ b/wagtail/users/apps.py
@@ -9,3 +9,13 @@ class WagtailUsersAppConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
     group_viewset = "wagtail.users.views.groups.GroupViewSet"
     user_viewset = "wagtail.users.views.users.UserViewSet"
+
+    def ready(self):
+        from django.contrib.auth import get_user_model
+        from django.contrib.auth.models import Group
+
+        from wagtail.permissions import register_permission_policy
+
+        User = get_user_model()
+        register_permission_policy(User)
+        register_permission_policy(Group)

--- a/wagtail/users/tests/test_permissions.py
+++ b/wagtail/users/tests/test_permissions.py
@@ -3,17 +3,17 @@ from django.contrib.auth.models import Group
 from django.test import TestCase
 
 from wagtail.permission_policies import ModelPermissionPolicy
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 
 
 class TestPermissions(TestCase):
     def test_get_user_permission_policy_from_registry(self):
         User = get_user_model()
-        permission_policy = policies_registry.get_by_type(User)
+        permission_policy = policy_registry.get_by_type(User)
         self.assertIsInstance(permission_policy, ModelPermissionPolicy)
         self.assertIs(permission_policy.model, User)
 
     def test_get_group_permission_policy_from_registry(self):
-        permission_policy = policies_registry.get_by_type(Group)
+        permission_policy = policy_registry.get_by_type(Group)
         self.assertIsInstance(permission_policy, ModelPermissionPolicy)
         self.assertIs(permission_policy.model, Group)

--- a/wagtail/users/tests/test_permissions.py
+++ b/wagtail/users/tests/test_permissions.py
@@ -1,0 +1,19 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.test import TestCase
+
+from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.permissions import policies_registry
+
+
+class TestPermissions(TestCase):
+    def test_get_user_permission_policy_from_registry(self):
+        User = get_user_model()
+        permission_policy = policies_registry.get_by_type(User)
+        self.assertIsInstance(permission_policy, ModelPermissionPolicy)
+        self.assertIs(permission_policy.model, User)
+
+    def test_get_group_permission_policy_from_registry(self):
+        permission_policy = policies_registry.get_by_type(Group)
+        self.assertIsInstance(permission_policy, ModelPermissionPolicy)
+        self.assertIs(permission_policy.model, Group)

--- a/wagtail/users/views/bulk_actions/user_bulk_action.py
+++ b/wagtail/users/views/bulk_actions/user_bulk_action.py
@@ -3,7 +3,6 @@ from django.db.models import Q
 
 from wagtail.admin.views.bulk_action import BulkAction
 from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
-from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
 
@@ -12,7 +11,6 @@ User = get_user_model()
 
 class UserBulkAction(PermissionCheckedMixin, BulkAction):
     models = [User]
-    permission_policy = ModelPermissionPolicy(User)
     any_permission_required = ["add", "change", "delete"]
 
     def get_all_objects_in_listing_query(self, parent_id):

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -36,6 +36,7 @@ from wagtail.admin.widgets.button import (
     ButtonWithDropdown,
 )
 from wagtail.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
+from wagtail.permissions import policies_registry
 from wagtail.search import index
 from wagtail.users.forms import UserCreationForm, UserEditForm
 from wagtail.users.utils import user_can_delete_user
@@ -370,7 +371,7 @@ class UserViewSet(ModelViewSet):
     def search_area_class(self):
         class UsersSearchArea(SearchArea):
             def is_shown(search_area, request):
-                return self.permission_policy.user_has_any_permission(
+                return policies_registry.get_by_type(User).user_has_any_permission(
                     request.user, {"add", "change", "delete"}
                 )
 

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -36,7 +36,7 @@ from wagtail.admin.widgets.button import (
     ButtonWithDropdown,
 )
 from wagtail.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
-from wagtail.permissions import policies_registry
+from wagtail.permissions import policy_registry
 from wagtail.search import index
 from wagtail.users.forms import UserCreationForm, UserEditForm
 from wagtail.users.utils import user_can_delete_user
@@ -371,7 +371,7 @@ class UserViewSet(ModelViewSet):
     def search_area_class(self):
         class UsersSearchArea(SearchArea):
             def is_shown(search_area, request):
-                return policies_registry.get_by_type(User).user_has_any_permission(
+                return policy_registry.get_by_type(User).user_has_any_permission(
                     request.user, {"add", "change", "delete"}
                 )
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->
I lost track of which take we are at at this point…

<!-- Insert the issue number that you're fixing here, if any -->
Rebase of #11268 and rework of #14258, minimal implementation of https://github.com/wagtail/rfcs/pull/102 that doesn't try to answer the questions around `PagePermissionTester` (i.e. that class is still page-specific).

Fixes #13859. ~~Fixes (maybe) #2907?~~ Probably not, still to do on actually making use of `_for_instance()` permission checks in the views…

### Description

<!-- Please describe the problem you're fixing. -->
This adds a `policy_registry` to `wagtail.permissions`, which is an instance of `PolicyRegistry` (an `ObjectTypeRegistry` subclass) that maps a model to a permission policy instance.

Instead of instantiating permission policies in various places and/or importing them from specific modules e.g. `wagtail.images.permissions`, we register the default permission policies for our built-in models to the registry. We also do the same for user-registered models such as snippets and models in `ModelViewSet`s.

Then, every time a permission policy for any model is needed, we can get them from the registry at request time anywhere in the codebase, instead of having to know the model in advance and importing the default policy instance at startup. This allows the permission policies to be overridable, even for built-in models. It also helps in enforcing consistent permission policies throughout Wagtail where the "canonical" permission policy may be otherwise difficult to obtain, e.g. to fix issues like #13859.

## Resolved questions

### Should there be a default registration?


- Should we remove, or keep the step of registering policies from `ModelViewSet`, as it's questionable whether it belongs there, being more a model-level concern than a view-level concern? But then developers will have to do that manually when registering models.
  - For snippets, we could automatically register the policy in `register_snippet`, as you can argue `register_snippet` is a higher abstraction on the model rather than being view-specific. Although, doing so would add another gap between `ModelViewSet` and snippets.
- Have `ModelViewSet` fall back to a local unregistered `ModelPermissionPolicy(model)` when nothing is found in the registry, perhaps?
  - Problem: `ModelViewSet` is not the only place that looks for a policy. A similar fallback would have to be done everywhere that is not part of the viewset's mechanism, e.g. `wagtail.actions`, `wagtail.api`.
  - Also, putting this in the viewset means the permission policy must be resolved at startup, rather than at request time, making it more sensitive to registration order.
- More radically, have the registry return a fallback of `ModelPermissionPolicy(model)` for any models that don't have an explicit policy registered?
  - If this fallback is silent, this would become a foot-gun when customisations come into play. If users have registered a policy but for whatever reason it didn't get picked up in some places (e.g. due to import/registration order), the fallback might give a false sense of security by being "good enough" to pass as expected in simple scenarios, giving the impression that the custom policy was applied when it wasn't.
  - If the fallback is loud, then developers will still need to register the policy, which kind of defeats point of having a fallback.

**Answer (implemented):**

Maybe the registry's fallback should be somewhat smarter? For example: if the registry provides a fallback for a model, and then later on there is code that tries to register a new policy for the same model, **only then** it raises a warning or improperly configured error. So if you are happy with `ModelPermissionPolicy(model)`, you don't have to do anything. Then, if you have a custom policy but forgot to register it (or registered it in the wrong order), you'll get ~~a warning~~ an error.

In addition, any `ModelViewSet.permission_policy` override should be respected (and thus registered) during the 8.x cycle, but raise a deprecation warning.

## Open questions

- Naming: `policies_registry` vs. `policy_registry` vs. `permission(s)_registry` vs. `registry` (let importers rename if they wish)
  - I added a commit that renamed `policies_registry` to `policy_registry`, since `permission_policy` is the more common term so far…
- Does `register_permission_policy()` need to exist, or should we just expose `policies_registry.register()` directly?
  - FWIW I'm just following the pattern for other `ObjectTypeRegistry`-based registries, such as [`register_form_field_override`](https://github.com/wagtail/wagtail/blob/c820283780f045965e89eb36bbc128d34947b122/wagtail/admin/forms/models.py#L30-L32), [`register_filter_adapter_class`](https://github.com/wagtail/wagtail/blob/c820283780f045965e89eb36bbc128d34947b122/wagtail/admin/active_filters.py#L166), [`register_admin_url_finder`](https://github.com/wagtail/wagtail/blob/c820283780f045965e89eb36bbc128d34947b122/wagtail/admin/admin_url_finder.py#L83), [`register_comparison_class`](https://github.com/wagtail/wagtail/blob/c820283780f045965e89eb36bbc128d34947b122/wagtail/admin/compare.py#L20-L22), [`register_display_class`](https://github.com/wagtail/wagtail/blob/c820283780f045965e89eb36bbc128d34947b122/wagtail/admin/ui/fields.py#L10)
  - Although in the case of permissions, reading from the registry is done more often than writing to it (at least in our own code). If we were to document that as well, then we'd either have to document `policies_registry.get(_by_type)` or expose a new function e.g. `get_permission_registry`. If we expose the registry itself, we might as well expose `policies_registry.register()` directly and get rid of `register_permission_policy()`?
  - For now, I'm keeping `register_permission_policy` while also documenting the `policy_registry` itself (and its getter methods, but not `register()`). Let me know if you wish to change this.




### AI usage

GitHub Copilot for autocompletion. Claude Code with Claude Sonnet 5 was used to write `wagtail.tests.test_permissions`, but nothing else. All in VSCode.